### PR TITLE
feat: Relocate Journal Repositories to Correct Persistence Folder

### DIFF
--- a/artifacts/feat-arch-review-journal-repository-implement/arch-review.r1.md
+++ b/artifacts/feat-arch-review-journal-repository-implement/arch-review.r1.md
@@ -1,0 +1,147 @@
+# Architecture Review: Relocate Journal Repositories to Correct Persistence Folder
+
+## Skip Design: true
+
+Backend-only namespace and file-move refactor. No UI components, screens, or visual changes are introduced or affected.
+
+## Architectural Fit Assessment
+
+This change brings the Journal module into compliance with the canonical Persistence layout documented in `docs/architecture/filesystem.md` (lines 40–47, 160–168): feature-specific persistence code lives under `Anela.Heblo.Persistence/{Feature}/`. Every other module that has been added since (`Persistence/KnowledgeBase/`, `Persistence/Features/Article/`, `Persistence/Features/Bank/`, `Persistence/Purchase/PurchaseOrders/`, `Persistence/GridLayouts/`, etc.) follows this convention. Only the `Catalog/` siblings (`Inventory/`, `Stock/`, `ManufactureDifficulty/`) legitimately belong under Catalog because they reference `Anela.Heblo.Domain.Features.Catalog.*` types. `Journal` does not — it consumes only `Anela.Heblo.Domain.Features.Journal.*`, confirming the misplacement.
+
+Integration points:
+- **DI registration**: `Application/Features/Journal/JournalModule.cs:4` is the runtime consumer.
+- **EF Core configuration discovery**: `ApplicationDbContext.cs:170` uses `ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly)`. Configuration discovery is by assembly scan, **not** by namespace — moving the files is therefore safe at runtime. No `OnModelCreating` change is needed, and no migration is added or modified.
+- **Tests**: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs:3` directly imports the old namespace. This consumer is **not listed in spec FR-4** and must be included.
+- **Coexisting issue #2513**: would move the `AddScoped<IJournalRepository, JournalRepository>()` calls from `JournalModule.cs` to `PersistenceModule.cs`. The two changes are orthogonal — whichever merges first dictates which file the `using` lives in at completion.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before:                                          After:
+Anela.Heblo.Persistence/                         Anela.Heblo.Persistence/
+├── Catalog/                                     ├── Catalog/
+│   ├── Inventory/    (keep)                     │   ├── Inventory/    (unchanged)
+│   ├── Stock/        (keep)                     │   ├── Stock/        (unchanged)
+│   ├── ManufactureDifficulty/ (keep)            │   ├── ManufactureDifficulty/ (unchanged)
+│   └── Journal/  ← MOVE OUT                     │   └── (Journal removed)
+│       ├── JournalRepository.cs                 └── Journal/  ← NEW
+│       ├── JournalTagRepository.cs                  ├── JournalRepository.cs
+│       ├── JournalEntryConfiguration.cs             ├── JournalTagRepository.cs
+│       ├── JournalEntryProductConfiguration.cs      ├── JournalEntryConfiguration.cs
+│       ├── JournalEntryTagConfiguration.cs          ├── JournalEntryProductConfiguration.cs
+│       └── JournalEntryTagAssignmentConfiguration  ├── JournalEntryTagConfiguration.cs
+│                                                   └── JournalEntryTagAssignmentConfiguration.cs
+
+namespace Anela.Heblo.Persistence.Catalog.Journal  →  namespace Anela.Heblo.Persistence.Journal
+```
+
+The full Journal folder contains **six** files (two repositories + four EF Core entity configurations), not just the two referenced in the spec summary. All six share the same misplaced namespace and must move together — this is already required by spec FR-3, but worth surfacing explicitly because the summary mentions only the two repositories.
+
+`Persistence/Catalog/` **must remain** after the move because `Inventory/`, `Stock/`, and `ManufactureDifficulty/` continue to live there. Spec FR-1's conditional ("if Catalog becomes empty…") correctly leaves the folder in place, but the check itself is unnecessary here — it will not become empty.
+
+### Key Design Decisions
+
+#### Decision 1: Preserve git history via `git mv`
+**Options considered:**
+- (a) `git mv` each file then update the namespace in a follow-up commit.
+- (b) Delete + re-create files (loses history).
+- (c) Single commit combining `git mv` and namespace edit.
+
+**Chosen approach:** (c) — perform `git mv` and namespace edits in a **single commit** per file (or as a single batch). Git's rename detection (`git log --follow`) will still recognize moves with small content edits because the move-plus-namespace-change diff stays well above git's similarity threshold (>95% unchanged).
+
+**Rationale:** Spec FR-1 mandates history preservation. A single commit keeps the move atomic; reviewers see the move and the namespace edit together. Splitting into two commits is unnecessary churn for a six-file refactor.
+
+#### Decision 2: Keep block-scoped namespace style in moved files
+**Options considered:**
+- (a) Convert to file-scoped namespace (`namespace X;`), matching the neighboring `LotRepository.cs` style.
+- (b) Preserve the existing block-scoped namespace (`namespace X { ... }`) used in the current Journal files.
+
+**Chosen approach:** (b) — keep block-scoped.
+
+**Rationale:** Spec NFR-4 and the project-level "surgical changes" rule (`CLAUDE.md`) explicitly forbid reformatting adjacent lines or changing style during a structural move. Style alignment with neighbors is a separate concern and out of scope for this change. Implementers must **not** let `dotnet format` rewrite the namespace block style. If `dotnet format` does want to change it, configure or skip the affected files for this PR — but flagging that this stylistic inconsistency exists is worthwhile (see Specification Amendments).
+
+#### Decision 3: Update DI `using` in `JournalModule.cs` regardless of issue #2513 status
+**Options considered:**
+- (a) Wait for #2513 to merge first.
+- (b) Update `JournalModule.cs` now; let #2513 reconcile via merge or rebase.
+- (c) Update `PersistenceModule.cs` preemptively even if #2513 hasn't merged.
+
+**Chosen approach:** (b) — update wherever the registration **currently** lives. If #2513 merges first, this PR rebases and updates `PersistenceModule.cs` instead. If this PR merges first, #2513 carries the updated `using` forward when it moves the registration.
+
+**Rationale:** The two PRs are mechanically independent. Coupling them sequencing-wise is unnecessary friction. The `using` edit is one line and trivially reconciled in either order.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create new folder: `backend/src/Anela.Heblo.Persistence/Journal/`
+
+Move (via `git mv`) and update the namespace in:
+| File | Old path | New path |
+|------|----------|----------|
+| `JournalRepository.cs` | `Persistence/Catalog/Journal/` | `Persistence/Journal/` |
+| `JournalTagRepository.cs` | `Persistence/Catalog/Journal/` | `Persistence/Journal/` |
+| `JournalEntryConfiguration.cs` | `Persistence/Catalog/Journal/` | `Persistence/Journal/` |
+| `JournalEntryProductConfiguration.cs` | `Persistence/Catalog/Journal/` | `Persistence/Journal/` |
+| `JournalEntryTagConfiguration.cs` | `Persistence/Catalog/Journal/` | `Persistence/Journal/` |
+| `JournalEntryTagAssignmentConfiguration.cs` | `Persistence/Catalog/Journal/` | `Persistence/Journal/` |
+
+Delete the now-empty `Persistence/Catalog/Journal/` folder. Do **not** touch `Persistence/Catalog/` — its other subfolders remain valid.
+
+### Interfaces and Contracts
+
+No interface changes. The contracts (`IJournalRepository`, `IJournalTagRepository`) live in `Anela.Heblo.Domain.Features.Journal` and are unaffected.
+
+The only contract-level change is the **internal** namespace of the implementations:
+
+| Type | Before | After |
+|------|--------|-------|
+| `JournalRepository` | `Anela.Heblo.Persistence.Catalog.Journal` | `Anela.Heblo.Persistence.Journal` |
+| `JournalTagRepository` | `Anela.Heblo.Persistence.Catalog.Journal` | `Anela.Heblo.Persistence.Journal` |
+| `JournalEntryConfiguration` | `Anela.Heblo.Persistence.Catalog.Journal` | `Anela.Heblo.Persistence.Journal` |
+| `JournalEntryProductConfiguration` | `Anela.Heblo.Persistence.Catalog.Journal` | `Anela.Heblo.Persistence.Journal` |
+| `JournalEntryTagConfiguration` | `Anela.Heblo.Persistence.Catalog.Journal` | `Anela.Heblo.Persistence.Journal` |
+| `JournalEntryTagAssignmentConfiguration` | `Anela.Heblo.Persistence.Catalog.Journal` | `Anela.Heblo.Persistence.Journal` |
+
+### Data Flow
+
+No data flow changes. Runtime sequence:
+1. `JournalController` (API) sends MediatR request.
+2. `Get/Create/UpdateJournalEntryHandler` (Application) calls `IJournalRepository` / `IJournalTagRepository`.
+3. DI resolves to `JournalRepository` / `JournalTagRepository` (Persistence) — only the namespace from which DI imports the concrete type changes.
+4. EF Core applies the entity configurations via `ApplyConfigurationsFromAssembly` — assembly scan finds them at the new namespace without code change in `ApplicationDbContext`.
+
+### Consumers to Update (complete list)
+
+The spec lists only `JournalModule.cs`. The full set of `using Anela.Heblo.Persistence.Catalog.Journal;` references in the repository is:
+
+1. `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs:4` — production DI registration.
+2. `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs:3` — integration test directly instantiates `JournalRepository`.
+
+Both must be updated. Post-change verification command: `grep -rn "Anela\.Heblo\.Persistence\.Catalog\.Journal" backend/` must return zero results (FR-4 acceptance criterion).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec FR-4 lists only `JournalModule.cs`; the integration test reference is missed and silently breaks the test build. | Medium | Treat the repo-wide grep (FR-4 acceptance) as authoritative, not the "Known consumer" list. Add an explicit step to update `JournalRepositoryIntegrationTests.cs`. |
+| `dotnet format` rewrites block-scoped namespace to file-scoped, violating NFR-4 surgical-changes rule. | Low | After the move, run `dotnet format` first to confirm it doesn't touch the namespace style; if it does, exclude the moved files from this formatting pass or run `dotnet format --verify-no-changes` on the touched files before committing. |
+| Merge conflict with issue #2513 if both PRs touch `JournalModule.cs` `using` and DI lines. | Low | Resolve by accepting #2513's structural move and keeping the new `using Anela.Heblo.Persistence.Journal;` form. Whichever merges second rebases. |
+| Git rename detection fails because both the path **and** namespace line change, splitting the move into delete+add in some tooling views. | Low | Acceptable. Default git rename detection (50% similarity) easily clears this — content is >95% unchanged. Reviewers using GitHub web UI may need to enable "show rename" but `git log --follow` works. |
+| Hidden `csproj` or `.editorconfig` reference to the old folder path. | Low | `Anela.Heblo.Persistence.csproj` is an SDK-style project that includes `**/*.cs` by glob — no per-file references exist. Verified by inspection of repo conventions. Repo-wide grep across `.csproj` and `.json` per FR-4 acceptance covers any unexpected reference. |
+
+## Specification Amendments
+
+1. **FR-4 must include the integration test consumer.** Add `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs` to the known-consumers list. The spec's "Known consumer: `JournalModule.cs`" wording is incomplete; the test file is the second production-affecting consumer and missing it will break `dotnet test`.
+
+2. **FR-1 "Catalog becomes empty" check is dead code.** `Persistence/Catalog/` contains `Inventory/`, `Stock/`, and `ManufactureDifficulty/`, all of which legitimately belong there. The conditional cleanup of `Persistence/Catalog/` can be removed from the spec as it will never trigger. Keep the cleanup of `Persistence/Catalog/Journal/` itself.
+
+3. **Clarify file count.** The spec summary mentions only `JournalRepository.cs` and `JournalTagRepository.cs`; FR-3 covers "any other Journal-related files" generically. The concrete inventory is six files (two repositories + four EF Core entity configurations: `JournalEntryConfiguration`, `JournalEntryProductConfiguration`, `JournalEntryTagConfiguration`, `JournalEntryTagAssignmentConfiguration`). Listing them explicitly in FR-3 removes any ambiguity for the implementer.
+
+4. **Add explicit non-goal: do not change namespace style.** Existing Journal files use block-scoped namespaces while neighboring Persistence files (e.g. `LotRepository.cs`) use file-scoped. NFR-4 implicitly forbids changing this, but stating it explicitly prevents an implementer from "fixing" it during the move and inflating the diff.
+
+## Prerequisites
+
+None. This refactor requires no migration, no infrastructure change, no configuration, and no coordination with other in-flight work beyond the soft dependency on #2513 (handled by merge order, not blocking). It can begin immediately.

--- a/artifacts/feat-arch-review-journal-repository-implement/brief.md
+++ b/artifacts/feat-arch-review-journal-repository-implement/brief.md
@@ -1,0 +1,33 @@
+## Module
+Journal
+
+## Finding
+The Journal repository implementations are stored inside a `Catalog` sub-folder of the Persistence layer:
+
+```
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalRepository.cs
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalTagRepository.cs
+```
+
+Their namespace reflects this: `namespace Anela.Heblo.Persistence.Catalog.Journal`.
+
+Per `docs/architecture/filesystem.md`, the Persistence layer layout is:
+```
+Anela.Heblo.Persistence/
+└── {Feature}/          ← feature-specific persistence (e.g. Journal/)
+    ├── {Entity}Configuration.cs
+    └── {Entity}Repository.cs
+```
+
+Journal is an independent module with no structural relationship to Catalog. The correct path is `Persistence/Journal/`.
+
+## Why it matters
+- Any developer looking for Journal's persistence code will search `Persistence/Journal/` and not find it.
+- The `JournalModule.cs` DI registration already imports `Anela.Heblo.Persistence.Catalog.Journal`, propagating the wrong namespace into the Application layer.
+- It implies a historical artifact (Journal may have been scaffolded inside Catalog) that was never cleaned up, creating a false coupling visible in every `using` statement.
+
+## Suggested fix
+Move both files to `backend/src/Anela.Heblo.Persistence/Journal/`, update their namespace to `Anela.Heblo.Persistence.Journal`, and fix the `using` in `JournalModule.cs` (or, better, do this as part of fixing issue #2513 which moves those registrations to `PersistenceModule.cs`).
+
+---
+_Filed by daily arch-review routine on 2026-06-04._

--- a/artifacts/feat-arch-review-journal-repository-implement/impl/main.r1.md
+++ b/artifacts/feat-arch-review-journal-repository-implement/impl/main.r1.md
@@ -1,0 +1,67 @@
+All verification complete. Here is the output summary:
+
+---
+
+# Implementation: Relocate Journal Repositories to Correct Persistence Folder
+
+## What was implemented
+
+Moved all six Journal module persistence files from `Persistence/Catalog/Journal/` to `Persistence/Journal/`, updated namespaces from `Anela.Heblo.Persistence.Catalog.Journal` to `Anela.Heblo.Persistence.Journal`, fixed both consumer `using` statements, and removed the now-empty `Catalog/Journal/` subfolder. Pure structural cleanup with zero behavior change.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Persistence/Journal/JournalRepository.cs` — moved from `Catalog/Journal/`, namespace updated
+- `backend/src/Anela.Heblo.Persistence/Journal/JournalTagRepository.cs` — moved from `Catalog/Journal/`, namespace updated
+- `backend/src/Anela.Heblo.Persistence/Journal/JournalEntryConfiguration.cs` — moved from `Catalog/Journal/`, namespace updated
+- `backend/src/Anela.Heblo.Persistence/Journal/JournalEntryProductConfiguration.cs` — moved from `Catalog/Journal/`, namespace updated
+- `backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagConfiguration.cs` — moved from `Catalog/Journal/`, namespace updated
+- `backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagAssignmentConfiguration.cs` — moved from `Catalog/Journal/`, namespace updated
+- `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs` — `using` directive updated on line 4
+- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs` — `using` directive updated on line 3
+- `docs/superpowers/plans/2026-06-04-relocate-journal-persistence.md` — plan document added
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Features/Journal/` — 55 Journal tests, all pass (same as baseline)
+- Full suite: 38 pre-existing failures in `Bank` and `Purchase` integration tests (require live DB, unrelated to this change); all Journal tests green
+
+## How to verify
+
+```bash
+# Confirm zero old namespace references
+grep -rn "Anela\.Heblo\.Persistence\.Catalog\.Journal" backend/ --include="*.cs"
+
+# Confirm new location has all six files
+ls backend/src/Anela.Heblo.Persistence/Journal/
+
+# Confirm old folder is gone, Catalog siblings intact
+ls backend/src/Anela.Heblo.Persistence/Catalog/
+
+# Run Journal tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"
+
+# Build
+dotnet build Anela.Heblo.sln
+```
+
+## Notes
+
+- Block-scoped namespace style (`namespace X { }`) preserved in all moved files per NFR-4 / arch-review Decision 2. `dotnet format --verify-no-changes` exits 0 confirming no violations.
+- Git rename similarity scores ranged 92–99%, all above the 50% threshold; `git log --follow` correctly walks history through the rename.
+- 38 test failures in `Bank`/`Flexi`/`Purchase` integration tests are pre-existing and require a live PostgreSQL connection — they were failing identically before this change. No Journal tests are affected.
+- Issue #2513 (move DI registrations to `PersistenceModule.cs`) was not yet merged; `JournalModule.cs` updated as planned. When #2513 merges, it should pick up the updated `using Anela.Heblo.Persistence.Journal;` line without conflict.
+
+## PR Summary
+
+Relocate six Journal persistence files from the incorrect `Persistence/Catalog/Journal/` path to their canonical `Persistence/Journal/` location per `docs/architecture/filesystem.md`. The Journal module has no dependency on Catalog; this was a scaffolding artifact.
+
+Namespace changed from `Anela.Heblo.Persistence.Catalog.Journal` to `Anela.Heblo.Persistence.Journal`. EF Core configuration discovery uses assembly scan, so no `ApplicationDbContext` change and no migration is needed. Both consumers updated: `JournalModule.cs` (DI) and `JournalRepositoryIntegrationTests.cs`.
+
+### Changes
+- `backend/src/Anela.Heblo.Persistence/Journal/` — new folder with all six files (moved via `git mv` from `Catalog/Journal/`, history preserved)
+- `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs` — `using` updated to new namespace
+- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs` — `using` updated to new namespace
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-journal-repository-implement/spec.r1.md
+++ b/artifacts/feat-arch-review-journal-repository-implement/spec.r1.md
@@ -1,0 +1,111 @@
+# Specification: Relocate Journal Repositories to Correct Persistence Folder
+
+## Summary
+Move the Journal module's repository implementations out of the misleading `Persistence/Catalog/Journal/` sub-folder into their proper location at `Persistence/Journal/`, update namespaces accordingly, and fix all dependent `using` statements. This is a structural cleanup with no behavior change.
+
+## Background
+The Journal module is an independent feature with no structural relationship to Catalog, yet its persistence code currently lives inside `backend/src/Anela.Heblo.Persistence/Catalog/Journal/`. This violates the documented Persistence layer layout (`docs/architecture/filesystem.md`), which mandates `Persistence/{Feature}/` as the root for feature-specific persistence code.
+
+The misplacement causes three concrete problems:
+1. Developers searching `Persistence/Journal/` for Journal persistence code do not find it.
+2. The namespace `Anela.Heblo.Persistence.Catalog.Journal` propagates into the Application layer via `JournalModule.cs` DI registration, falsely implying a Catalog dependency in every `using` statement.
+3. It is a stale scaffolding artifact (Journal was likely created under Catalog and never cleaned up).
+
+This issue was filed by the daily arch-review routine on 2026-06-04 and is related to issue #2513, which moves DI registrations from feature modules to `PersistenceModule.cs`.
+
+## Functional Requirements
+
+### FR-1: Relocate Repository Files
+Move both files to the correct Persistence folder layout.
+
+**Files to move:**
+- `backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalRepository.cs` → `backend/src/Anela.Heblo.Persistence/Journal/JournalRepository.cs`
+- `backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalTagRepository.cs` → `backend/src/Anela.Heblo.Persistence/Journal/JournalTagRepository.cs`
+
+**Acceptance criteria:**
+- Both files exist at the new path `backend/src/Anela.Heblo.Persistence/Journal/`.
+- Both files are deleted from `backend/src/Anela.Heblo.Persistence/Catalog/Journal/`.
+- If the now-empty `backend/src/Anela.Heblo.Persistence/Catalog/Journal/` folder remains, it is removed.
+- If `backend/src/Anela.Heblo.Persistence/Catalog/` becomes empty as a result, it is also removed; otherwise it is left untouched.
+- Git history for the moved files is preserved (use `git mv` rather than delete + create).
+
+### FR-2: Update Namespaces in Moved Files
+Update the `namespace` declaration in both moved files to match the new folder location.
+
+**Acceptance criteria:**
+- `JournalRepository.cs` declares `namespace Anela.Heblo.Persistence.Journal`.
+- `JournalTagRepository.cs` declares `namespace Anela.Heblo.Persistence.Journal`.
+- No file in the repository still declares `namespace Anela.Heblo.Persistence.Catalog.Journal`.
+
+### FR-3: Update Other Persistence Configuration/Entity Files (if any)
+Audit the `Persistence/Catalog/Journal/` folder for any other Journal-related files (e.g., `JournalConfiguration.cs`, `JournalTagConfiguration.cs`, entity-related code) and move them alongside the repositories using the same rules as FR-1 and FR-2.
+
+**Acceptance criteria:**
+- After the move, `backend/src/Anela.Heblo.Persistence/Catalog/Journal/` contains no Journal-related code.
+- All Journal persistence files (repositories, EF Core configurations, etc.) live under `backend/src/Anela.Heblo.Persistence/Journal/` and declare `namespace Anela.Heblo.Persistence.Journal`.
+
+### FR-4: Fix Dependent `using` Statements
+Update every consumer of the old namespace `Anela.Heblo.Persistence.Catalog.Journal` to use `Anela.Heblo.Persistence.Journal`.
+
+**Known consumer:** `JournalModule.cs` (DI registration in the Application layer).
+
+**Acceptance criteria:**
+- A repository-wide search confirms zero occurrences of the string `Anela.Heblo.Persistence.Catalog.Journal` in `.cs`, `.csproj`, `.json`, or any other text files.
+- All previously dependent files compile and import the new namespace.
+- If issue #2513 has already moved DI registrations to `PersistenceModule.cs`, the `using` is updated there instead; if not, it is updated in `JournalModule.cs` as a minimum, with a note in the PR linking to #2513.
+
+### FR-5: Verify Build and Tests
+The refactor must not change behavior. The full backend build and test suite must pass.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds with zero new warnings or errors attributable to the change.
+- `dotnet format` reports no formatting violations in the moved/changed files.
+- All existing Journal-related unit and integration tests pass without modification (other than namespace updates in `using` statements if tests reference the old namespace).
+- No EF Core migrations are added or modified.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance impact. This is a compile-time/source-organization change only.
+
+### NFR-2: Security
+No security impact. No changes to authentication, authorization, data access, or input handling.
+
+### NFR-3: Backward Compatibility
+- No public HTTP API or contract changes.
+- No database schema changes.
+- No changes to OpenAPI client generation output.
+- Internal namespace change is acceptable because the Persistence layer is not a publicly consumed API surface.
+
+### NFR-4: Code Quality
+- Match existing code style in the moved files exactly; do not reformat unrelated lines.
+- Do not modify the contents of repository methods, only the `namespace` declaration and the file location.
+- Do not "improve" adjacent code (per CLAUDE.md surgical-changes rule).
+
+## Data Model
+No data model changes. Entity classes and EF Core configurations retain their existing schemas and mappings.
+
+## API / Interface Design
+No public API changes.
+
+**Internal namespace change:**
+| Before | After |
+|---|---|
+| `Anela.Heblo.Persistence.Catalog.Journal.JournalRepository` | `Anela.Heblo.Persistence.Journal.JournalRepository` |
+| `Anela.Heblo.Persistence.Catalog.Journal.JournalTagRepository` | `Anela.Heblo.Persistence.Journal.JournalTagRepository` |
+
+## Dependencies
+- **Issue #2513** — moves DI registrations from per-feature modules to `PersistenceModule.cs`. If this issue is merged first, FR-4 should update `PersistenceModule.cs` instead of `JournalModule.cs`. The two changes are compatible in either order; coordinate the merge to avoid conflicts.
+- **`docs/architecture/filesystem.md`** — defines the canonical Persistence layout this change conforms to.
+
+## Out of Scope
+- Refactoring DI registration location (covered by issue #2513).
+- Any change to Journal domain logic, entities, DTOs, or API endpoints.
+- Renaming or restructuring other modules that may have similar issues (audit only Journal as part of this work).
+- Database schema or migration changes.
+- Documentation updates beyond what is required to keep references accurate (no new docs needed; `filesystem.md` is already correct).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-journal-repository-implement/task-plan.r1.md
+++ b/artifacts/feat-arch-review-journal-repository-implement/task-plan.r1.md
@@ -1,0 +1,14 @@
+Plan saved to `docs/superpowers/plans/2026-06-04-relocate-journal-persistence.md`.
+
+**Self-review against spec — all clean:**
+
+- **Spec coverage:** All five FRs and four NFRs map to specific steps; the arch-review amendments (integration test consumer, six-file inventory, no style change, dead "Catalog becomes empty" check) are all reflected.
+- **Placeholder scan:** No TBDs, no "implement later," every code/grep step has the exact command and the exact expected output, the commit message is provided in full.
+- **Type consistency:** Only namespace and folder paths change; consistent across all 16 steps in Task 2.
+
+**Plan structure:**
+- **Task 1 — Baseline** (5 steps): verify file inventory, target absent, grep matches 8 known references, build green, Journal tests pass.
+- **Task 2 — Atomic refactor** (16 steps, single commit): `git mv` × 6 → namespace edit × 6 → consumer `using` swap × 2 → folder cleanup → repo-wide grep returns zero → build → Journal tests → staged-diff inspection → conventional commit. Intermediate states don't compile, so the entire refactor is one commit by design.
+- **Task 3 — Final sweep** (8 steps): wider grep, folder state checks, `git log --follow` rename detection, `dotnet format --verify-no-changes`, full test suite, full build, and a tick-off checklist mapping each spec acceptance criterion to its verification step.
+
+Critical guardrails surfaced in the plan: keep block-scoped namespaces (don't let `dotnet format` rewrite them), don't touch `Persistence/Catalog/`, don't run a separate format pass on the moved files in Task 2, and an explicit note for coordinating with issue #2513 if it has already merged the DI registration to `PersistenceModule.cs`.

--- a/backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Anela.Heblo.Application.Features.Journal.Contracts;
 using Anela.Heblo.Domain.Features.Journal;
-using Anela.Heblo.Persistence.Catalog.Journal;
+using Anela.Heblo.Persistence.Journal;
 
 namespace Anela.Heblo.Application.Features.Journal
 {

--- a/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryConfiguration.cs
@@ -3,7 +3,7 @@ using Anela.Heblo.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace Anela.Heblo.Persistence.Catalog.Journal
+namespace Anela.Heblo.Persistence.Journal
 {
     public class JournalEntryConfiguration : IEntityTypeConfiguration<JournalEntry>
     {

--- a/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryProductConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryProductConfiguration.cs
@@ -3,7 +3,7 @@ using Anela.Heblo.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace Anela.Heblo.Persistence.Catalog.Journal
+namespace Anela.Heblo.Persistence.Journal
 {
     public class JournalEntryProductConfiguration : IEntityTypeConfiguration<JournalEntryProduct>
     {

--- a/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagAssignmentConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagAssignmentConfiguration.cs
@@ -3,7 +3,7 @@ using Anela.Heblo.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace Anela.Heblo.Persistence.Catalog.Journal
+namespace Anela.Heblo.Persistence.Journal
 {
     public class JournalEntryTagAssignmentConfiguration : IEntityTypeConfiguration<JournalEntryTagAssignment>
     {

--- a/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagConfiguration.cs
@@ -3,7 +3,7 @@ using Anela.Heblo.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace Anela.Heblo.Persistence.Catalog.Journal
+namespace Anela.Heblo.Persistence.Journal
 {
     public class JournalEntryTagConfiguration : IEntityTypeConfiguration<JournalEntryTag>
     {

--- a/backend/src/Anela.Heblo.Persistence/Journal/JournalRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Journal/JournalRepository.cs
@@ -4,7 +4,7 @@ using Anela.Heblo.Xcc.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace Anela.Heblo.Persistence.Catalog.Journal
+namespace Anela.Heblo.Persistence.Journal
 {
     public class JournalRepository : BaseRepository<JournalEntry, int>, IJournalRepository
     {

--- a/backend/src/Anela.Heblo.Persistence/Journal/JournalTagRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Journal/JournalTagRepository.cs
@@ -2,7 +2,7 @@ using Anela.Heblo.Domain.Features.Journal;
 using Anela.Heblo.Persistence.Repositories;
 using Microsoft.EntityFrameworkCore;
 
-namespace Anela.Heblo.Persistence.Catalog.Journal
+namespace Anela.Heblo.Persistence.Journal
 {
     public class JournalTagRepository : BaseRepository<JournalEntryTag, int>, IJournalTagRepository
     {

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs
@@ -1,6 +1,6 @@
 using Anela.Heblo.Domain.Features.Journal;
 using Anela.Heblo.Persistence;
-using Anela.Heblo.Persistence.Catalog.Journal;
+using Anela.Heblo.Persistence.Journal;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/docs/superpowers/plans/2026-06-04-relocate-journal-persistence.md
+++ b/docs/superpowers/plans/2026-06-04-relocate-journal-persistence.md
@@ -1,0 +1,557 @@
+# Relocate Journal Repositories to Correct Persistence Folder — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the Journal module's six persistence files out of `Persistence/Catalog/Journal/` to their canonical location `Persistence/Journal/`, update the namespace from `Anela.Heblo.Persistence.Catalog.Journal` to `Anela.Heblo.Persistence.Journal`, and fix the two consumers that import the old namespace. Pure structural cleanup — zero behavior change, zero migrations.
+
+**Architecture:** All six files (two repositories + four EF Core entity configurations) move together as a single atomic refactor commit. `git mv` preserves history. EF Core configuration discovery uses assembly scan (`ApplyConfigurationsFromAssembly` at `ApplicationDbContext.cs:170`), so the namespace move is runtime-safe with no `OnModelCreating` change. Block-scoped namespace style is **preserved verbatim** (no file-scoped conversion) per the spec NFR-4 "surgical changes" rule. `Persistence/Catalog/` itself stays — only the `Journal/` subfolder is removed.
+
+**Tech Stack:** .NET 8, C#, EF Core, MediatR, xUnit + FluentAssertions + Moq, `git mv`, `dotnet build`, `dotnet format`, `dotnet test`.
+
+---
+
+## File Inventory
+
+### Files to move (6 files, all from `backend/src/Anela.Heblo.Persistence/Catalog/Journal/` → `backend/src/Anela.Heblo.Persistence/Journal/`)
+
+| File | Lines | Current namespace declaration |
+|------|-------|-------------------------------|
+| `JournalRepository.cs` | ~250 | `namespace Anela.Heblo.Persistence.Catalog.Journal` (line 7) |
+| `JournalTagRepository.cs` | 21 | `namespace Anela.Heblo.Persistence.Catalog.Journal` (line 5) |
+| `JournalEntryConfiguration.cs` | ~60 | `namespace Anela.Heblo.Persistence.Catalog.Journal` (line 6) |
+| `JournalEntryProductConfiguration.cs` | ~25 | `namespace Anela.Heblo.Persistence.Catalog.Journal` (line 6) |
+| `JournalEntryTagConfiguration.cs` | ~30 | `namespace Anela.Heblo.Persistence.Catalog.Journal` (line 6) |
+| `JournalEntryTagAssignmentConfiguration.cs` | 22 | `namespace Anela.Heblo.Persistence.Catalog.Journal` (line 6) |
+
+### Consumer files to update (2 files)
+
+| File | Line | Change |
+|------|------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs` | 4 | `using Anela.Heblo.Persistence.Catalog.Journal;` → `using Anela.Heblo.Persistence.Journal;` |
+| `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs` | 3 | `using Anela.Heblo.Persistence.Catalog.Journal;` → `using Anela.Heblo.Persistence.Journal;` |
+
+### Files NOT to touch
+- `docs/superpowers/plans/2026-05-12-remove-journal-family-entries.md` — historical plan document, references are textual artifacts of an old change. Spec FR-4 acceptance criterion targets `.cs`, `.csproj`, `.json` only; markdown notes are out of scope.
+- `Persistence/Catalog/` parent folder — `Inventory/`, `Stock/`, `ManufactureDifficulty/` legitimately belong under Catalog and remain unchanged.
+- `ApplicationDbContext.cs` — uses assembly-scan configuration discovery; needs no code change.
+
+---
+
+## Decomposition Rationale
+
+This is one atomic refactor. The build is **broken** in any state where some files have moved but consumers still reference the old namespace, or vice versa. Therefore the move + namespace edit + consumer update **must land in a single commit**. Task 2 below performs the entire refactor as one commit. Task 1 captures a green baseline; Task 3 performs the final validation grep + build + test sweep.
+
+Within Task 2, individual steps are bite-sized (each `git mv` and each namespace edit is its own step) but they share one final commit, because intermediate states do not compile.
+
+---
+
+## Task 1: Establish Green Baseline
+
+**Files:** none modified — verification only.
+
+**Purpose:** Confirm the current state matches the spec's "before" picture and that Journal-related tests pass on `main` before we touch anything. If anything is already broken, we want to know now, not after the refactor.
+
+- [ ] **Step 1: Verify the six source files exist at the old path**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.Persistence/Catalog/Journal/
+```
+
+Expected output (exactly these six files):
+```
+JournalEntryConfiguration.cs
+JournalEntryProductConfiguration.cs
+JournalEntryTagAssignmentConfiguration.cs
+JournalEntryTagConfiguration.cs
+JournalRepository.cs
+JournalTagRepository.cs
+```
+
+If any file is missing or extra files appear, **stop** and reconcile with the spec before proceeding.
+
+- [ ] **Step 2: Verify the target folder does not yet exist**
+
+Run:
+```bash
+test -d backend/src/Anela.Heblo.Persistence/Journal && echo "EXISTS - investigate" || echo "OK - target absent"
+```
+
+Expected: `OK - target absent`.
+
+If `EXISTS - investigate`, stop and check whether someone else already started this work.
+
+- [ ] **Step 3: Capture baseline grep of old namespace references**
+
+Run:
+```bash
+grep -rn "Anela\.Heblo\.Persistence\.Catalog\.Journal" backend/ --include="*.cs" --include="*.csproj" --include="*.json"
+```
+
+Expected output — exactly these eight lines (six file declarations + two consumer `using` directives):
+```
+backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs:4:using Anela.Heblo.Persistence.Catalog.Journal;
+backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs:3:using Anela.Heblo.Persistence.Catalog.Journal;
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryConfiguration.cs:6:namespace Anela.Heblo.Persistence.Catalog.Journal
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryProductConfiguration.cs:6:namespace Anela.Heblo.Persistence.Catalog.Journal
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryTagAssignmentConfiguration.cs:6:namespace Anela.Heblo.Persistence.Catalog.Journal
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryTagConfiguration.cs:6:namespace Anela.Heblo.Persistence.Catalog.Journal
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalRepository.cs:7:namespace Anela.Heblo.Persistence.Catalog.Journal
+backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalTagRepository.cs:5:namespace Anela.Heblo.Persistence.Catalog.Journal
+```
+
+If you see more lines, an additional consumer exists that the spec did not list. Add it to your mental checklist for Task 2 (use the same `using` swap pattern).
+
+- [ ] **Step 4: Confirm baseline build is green**
+
+Run from repo root:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`.
+
+If the build is already red on `main` (or your starting branch), **stop** and resolve before refactoring.
+
+- [ ] **Step 5: Confirm baseline Journal tests pass**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal" --no-build
+```
+
+Expected: `Passed!` with all Journal-related tests green.
+
+If any Journal test is already failing on baseline, **stop** — do not start the refactor on top of a red test suite.
+
+---
+
+## Task 2: Atomic Move + Namespace Update + Consumer Fix (single commit)
+
+**Files:**
+- Move (via `git mv`): six files from `backend/src/Anela.Heblo.Persistence/Catalog/Journal/` to `backend/src/Anela.Heblo.Persistence/Journal/`
+- Modify (namespace edit): all six moved files
+- Modify (using directive swap):
+  - `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs:4`
+  - `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs:3`
+- Delete: empty folder `backend/src/Anela.Heblo.Persistence/Catalog/Journal/`
+
+**Critical constraints:**
+- **Keep block-scoped namespace** in every moved file (`namespace X { ... }`). Do **not** convert to file-scoped (`namespace X;`) even if neighboring files use the file-scoped form. Spec NFR-4 and arch-review Decision 2 require this.
+- **Do not edit any line** in the moved files other than the single `namespace …` declaration line.
+- **Do not run `dotnet format`** on the moved files in this task — if it rewrites block-scoped to file-scoped, you'll violate NFR-4. Format verification happens in Task 3 and must report no changes.
+
+- [ ] **Step 1: Create the new target folder**
+
+Run:
+```bash
+mkdir -p backend/src/Anela.Heblo.Persistence/Journal
+```
+
+(No expected output. Verify it exists with `ls -d backend/src/Anela.Heblo.Persistence/Journal/`.)
+
+- [ ] **Step 2: `git mv` the six files**
+
+Run:
+```bash
+git mv backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalRepository.cs                      backend/src/Anela.Heblo.Persistence/Journal/JournalRepository.cs
+git mv backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalTagRepository.cs                   backend/src/Anela.Heblo.Persistence/Journal/JournalTagRepository.cs
+git mv backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryConfiguration.cs              backend/src/Anela.Heblo.Persistence/Journal/JournalEntryConfiguration.cs
+git mv backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryProductConfiguration.cs       backend/src/Anela.Heblo.Persistence/Journal/JournalEntryProductConfiguration.cs
+git mv backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryTagConfiguration.cs           backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagConfiguration.cs
+git mv backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryTagAssignmentConfiguration.cs backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagAssignmentConfiguration.cs
+```
+
+Verify with:
+```bash
+git status --short
+```
+
+Expected: six `R` (rename) entries, each from `Catalog/Journal/…` to `Journal/…`. No other modifications yet.
+
+- [ ] **Step 3: Update namespace in `JournalRepository.cs`**
+
+Find the single line `namespace Anela.Heblo.Persistence.Catalog.Journal` (at line 7) and change to:
+```csharp
+namespace Anela.Heblo.Persistence.Journal
+```
+
+Keep the opening `{` on the next line untouched. Do **not** add `;`. Do **not** change anything else in the file.
+
+Verify:
+```bash
+grep -n "^namespace " backend/src/Anela.Heblo.Persistence/Journal/JournalRepository.cs
+```
+Expected: `7:namespace Anela.Heblo.Persistence.Journal`
+
+- [ ] **Step 4: Update namespace in `JournalTagRepository.cs`**
+
+Change line 5 from `namespace Anela.Heblo.Persistence.Catalog.Journal` to:
+```csharp
+namespace Anela.Heblo.Persistence.Journal
+```
+
+Verify:
+```bash
+grep -n "^namespace " backend/src/Anela.Heblo.Persistence/Journal/JournalTagRepository.cs
+```
+Expected: `5:namespace Anela.Heblo.Persistence.Journal`
+
+- [ ] **Step 5: Update namespace in `JournalEntryConfiguration.cs`**
+
+Change line 6 from `namespace Anela.Heblo.Persistence.Catalog.Journal` to:
+```csharp
+namespace Anela.Heblo.Persistence.Journal
+```
+
+Verify:
+```bash
+grep -n "^namespace " backend/src/Anela.Heblo.Persistence/Journal/JournalEntryConfiguration.cs
+```
+Expected: `6:namespace Anela.Heblo.Persistence.Journal`
+
+- [ ] **Step 6: Update namespace in `JournalEntryProductConfiguration.cs`**
+
+Change line 6 from `namespace Anela.Heblo.Persistence.Catalog.Journal` to:
+```csharp
+namespace Anela.Heblo.Persistence.Journal
+```
+
+Verify:
+```bash
+grep -n "^namespace " backend/src/Anela.Heblo.Persistence/Journal/JournalEntryProductConfiguration.cs
+```
+Expected: `6:namespace Anela.Heblo.Persistence.Journal`
+
+- [ ] **Step 7: Update namespace in `JournalEntryTagConfiguration.cs`**
+
+Change line 6 from `namespace Anela.Heblo.Persistence.Catalog.Journal` to:
+```csharp
+namespace Anela.Heblo.Persistence.Journal
+```
+
+Verify:
+```bash
+grep -n "^namespace " backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagConfiguration.cs
+```
+Expected: `6:namespace Anela.Heblo.Persistence.Journal`
+
+- [ ] **Step 8: Update namespace in `JournalEntryTagAssignmentConfiguration.cs`**
+
+Change line 6 from `namespace Anela.Heblo.Persistence.Catalog.Journal` to:
+```csharp
+namespace Anela.Heblo.Persistence.Journal
+```
+
+Verify:
+```bash
+grep -n "^namespace " backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagAssignmentConfiguration.cs
+```
+Expected: `6:namespace Anela.Heblo.Persistence.Journal`
+
+- [ ] **Step 9: Update consumer `using` in `JournalModule.cs`**
+
+In `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs`, change line 4 from:
+```csharp
+using Anela.Heblo.Persistence.Catalog.Journal;
+```
+to:
+```csharp
+using Anela.Heblo.Persistence.Journal;
+```
+
+Touch no other line in this file. Do not reorder or sort `using` directives.
+
+Verify:
+```bash
+sed -n '1,6p' backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs
+```
+Expected line 4: `using Anela.Heblo.Persistence.Journal;`
+
+> Note on coordination with issue #2513: if that PR has already merged on your starting branch, the `AddScoped<IJournalRepository, …>` registrations may have moved to `backend/src/Anela.Heblo.Persistence/PersistenceModule.cs` instead. Detect with `grep -n "JournalRepository" backend/src/Anela.Heblo.Persistence/PersistenceModule.cs`. If a match is found there, update the `using` in `PersistenceModule.cs` using the same pattern, and **drop** the `JournalModule.cs` edit if its `using Anela.Heblo.Persistence.Catalog.Journal;` line is also gone. The acceptance criterion is "zero hits of the old namespace string anywhere in `backend/`," not "edit a specific file" — Step 12 below enforces that.
+
+- [ ] **Step 10: Update consumer `using` in `JournalRepositoryIntegrationTests.cs`**
+
+In `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs`, change line 3 from:
+```csharp
+using Anela.Heblo.Persistence.Catalog.Journal;
+```
+to:
+```csharp
+using Anela.Heblo.Persistence.Journal;
+```
+
+Touch no other line in this file. Do not reorder `using` directives.
+
+Verify:
+```bash
+sed -n '1,5p' backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs
+```
+Expected line 3: `using Anela.Heblo.Persistence.Journal;`
+
+- [ ] **Step 11: Remove the now-empty source folder**
+
+The `git mv` operations already removed the files from the index. Verify the directory is empty and delete it:
+```bash
+ls backend/src/Anela.Heblo.Persistence/Catalog/Journal/ 2>/dev/null
+```
+
+Expected output: empty (nothing printed) or `No such file or directory`. If anything is listed, **stop** and investigate — a file was missed in Step 2.
+
+Then remove the empty directory (git will not track empty directories, so this is a filesystem-only cleanup):
+```bash
+rmdir backend/src/Anela.Heblo.Persistence/Catalog/Journal/ 2>/dev/null || true
+```
+
+(The `|| true` handles the case where the directory was already removed because `git mv` cleaned it up.)
+
+Verify the directory is gone:
+```bash
+test -d backend/src/Anela.Heblo.Persistence/Catalog/Journal && echo "FAIL: still exists" || echo "OK: removed"
+```
+Expected: `OK: removed`
+
+Also verify the Catalog parent still exists with its three legitimate siblings:
+```bash
+ls backend/src/Anela.Heblo.Persistence/Catalog/
+```
+Expected:
+```
+Inventory
+ManufactureDifficulty
+Stock
+```
+
+- [ ] **Step 12: Repo-wide grep for the old namespace (must be zero in `.cs`/`.csproj`/`.json`)**
+
+Run:
+```bash
+grep -rn "Anela\.Heblo\.Persistence\.Catalog\.Journal" backend/ --include="*.cs" --include="*.csproj" --include="*.json"
+```
+
+Expected: **no output** (exit code 1). This is the FR-4 acceptance criterion.
+
+If any line is printed, fix it before continuing. The fix is the same `using` swap pattern as Steps 9–10.
+
+- [ ] **Step 13: Build the backend**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`. Warning count must not increase compared to the Task 1 Step 4 baseline.
+
+If the build fails, the most likely cause is a missed consumer. Re-run the grep from Step 12 and patch any survivors.
+
+- [ ] **Step 14: Run Journal-targeted tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal" --no-build
+```
+
+Expected: `Passed!` with the same pass count as the Task 1 Step 5 baseline. No tests should be skipped or excluded that were not skipped at baseline.
+
+If any Journal test fails, the most likely causes are:
+- A consumer namespace was missed (re-check Step 12).
+- The block-scoped namespace's closing `}` was accidentally deleted while editing the opening line.
+
+- [ ] **Step 15: Stage and inspect the diff**
+
+Run:
+```bash
+git add -A
+git status --short
+```
+
+Expected `git status --short` output:
+```
+R  backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryConfiguration.cs              -> backend/src/Anela.Heblo.Persistence/Journal/JournalEntryConfiguration.cs
+R  backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryProductConfiguration.cs       -> backend/src/Anela.Heblo.Persistence/Journal/JournalEntryProductConfiguration.cs
+R  backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryTagAssignmentConfiguration.cs -> backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagAssignmentConfiguration.cs
+R  backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalEntryTagConfiguration.cs           -> backend/src/Anela.Heblo.Persistence/Journal/JournalEntryTagConfiguration.cs
+R  backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalRepository.cs                      -> backend/src/Anela.Heblo.Persistence/Journal/JournalRepository.cs
+R  backend/src/Anela.Heblo.Persistence/Catalog/Journal/JournalTagRepository.cs                   -> backend/src/Anela.Heblo.Persistence/Journal/JournalTagRepository.cs
+M  backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs
+M  backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs
+```
+
+Confirm with:
+```bash
+git diff --staged --stat
+```
+The six renamed files should each show a 1-line change (the `namespace` edit). The two `M` files should each show a 1-line change (the `using` swap).
+
+If any file shows more than ~2 lines changed, **stop** — you've accidentally formatted or edited unrelated lines. Revert the offending file and redo just the targeted edit.
+
+- [ ] **Step 16: Commit**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: move Journal repositories from Persistence/Catalog/Journal to Persistence/Journal
+
+Relocate the Journal module's six persistence files (two repositories and four EF Core
+entity configurations) from Persistence/Catalog/Journal/ to Persistence/Journal/, where
+they belong per docs/architecture/filesystem.md. The Journal module has no structural
+relationship to Catalog; the previous location was a scaffolding artifact.
+
+Namespace changes from Anela.Heblo.Persistence.Catalog.Journal to
+Anela.Heblo.Persistence.Journal. Both consumers (JournalModule DI registration and
+JournalRepositoryIntegrationTests) updated to import the new namespace.
+
+EF Core configuration discovery uses ApplyConfigurationsFromAssembly (assembly scan),
+so the move is runtime-safe with no ApplicationDbContext change and no migration.
+Block-scoped namespace style preserved per surgical-changes rule.
+
+Related: #2513
+EOF
+)"
+```
+
+Verify the commit landed cleanly:
+```bash
+git log -1 --stat
+```
+
+Expected: one commit; the eight files listed; no other files. Each renamed file shows `1 +/- 1` (one line added, one removed — the namespace declaration). Each consumer shows `1 +/- 1` (one line added, one removed — the `using`).
+
+---
+
+## Task 3: Final Verification Sweep
+
+**Files:** none modified — verification only. If any of these steps reveal a problem, fix it inline and add a separate commit only if a code change is required (e.g., `dotnet format` insists on a change that does NOT touch the block-scoped namespace style).
+
+- [ ] **Step 1: Repo-wide grep across all text types**
+
+Spec FR-4 specifies `.cs`, `.csproj`, `.json` "or any other text files." Cast the net wider than Task 2 Step 12, this time including markdown but excluding historical plan documents and build artifacts:
+
+```bash
+grep -rn "Anela\.Heblo\.Persistence\.Catalog\.Journal" backend/ frontend/ docs/ \
+  --include="*.cs" --include="*.csproj" --include="*.json" --include="*.props" --include="*.targets" \
+  --exclude-dir=bin --exclude-dir=obj --exclude-dir=node_modules
+```
+
+Expected: **no output**. (Markdown plan documents under `docs/superpowers/plans/` are deliberately excluded by the absence of `--include="*.md"`; they are historical artifacts, not live references.)
+
+If output appears, identify whether it is a live reference (code, config) or a historical document. Patch live references with the same `using` swap; leave historical documents alone.
+
+- [ ] **Step 2: Confirm no `Persistence.Catalog.Journal` folder remains**
+
+```bash
+test -d backend/src/Anela.Heblo.Persistence/Catalog/Journal && echo "FAIL" || echo "OK"
+```
+
+Expected: `OK`
+
+```bash
+ls backend/src/Anela.Heblo.Persistence/Catalog/
+```
+
+Expected (unchanged from Task 2 Step 11):
+```
+Inventory
+ManufactureDifficulty
+Stock
+```
+
+- [ ] **Step 3: Confirm the new folder has all six files**
+
+```bash
+ls backend/src/Anela.Heblo.Persistence/Journal/
+```
+
+Expected:
+```
+JournalEntryConfiguration.cs
+JournalEntryProductConfiguration.cs
+JournalEntryTagAssignmentConfiguration.cs
+JournalEntryTagConfiguration.cs
+JournalRepository.cs
+JournalTagRepository.cs
+```
+
+- [ ] **Step 4: Verify git history is preserved for each moved file**
+
+For each of the six files, confirm `git log --follow` walks back through the rename:
+
+```bash
+for f in JournalRepository.cs JournalTagRepository.cs JournalEntryConfiguration.cs JournalEntryProductConfiguration.cs JournalEntryTagConfiguration.cs JournalEntryTagAssignmentConfiguration.cs; do
+  echo "--- $f ---"
+  git log --follow --oneline -3 backend/src/Anela.Heblo.Persistence/Journal/$f
+done
+```
+
+Expected: for each file, more than just the single refactor commit appears (the original creation commit + any intermediate edits are visible). If only the refactor commit appears, rename detection failed — investigate, but note that GitHub web UI may still show this as a rename via its own similarity heuristic, and `git log --follow` is the authoritative source.
+
+- [ ] **Step 5: Run `dotnet format` in verify-only mode**
+
+Spec NFR-4 / FR-5 require no formatting violations and no incidental reformatting.
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes --verbosity diagnostic
+```
+
+Expected exit code: `0` (no formatting changes needed).
+
+If `dotnet format` reports needed changes:
+- If they are inside the six moved files and would convert block-scoped to file-scoped namespace, **do not apply them**. The block-scoped style is a deliberate decision (arch-review Decision 2); the inconsistency with neighboring files is acknowledged and out of scope. Note the discrepancy in the PR description but ship as-is.
+- If they are anywhere else (whitespace, unused `using` reordering in `JournalModule.cs` or the integration test), the formatter is right and the prior edit was sloppy. Apply the fix (`dotnet format`) and add a separate small commit `chore: dotnet format` so review history is clear.
+
+- [ ] **Step 6: Run the full backend test suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: `Passed!` with the same total count and no new failures or skips relative to baseline.
+
+If integration tests requiring a real database are skipped in your environment (e.g., no PostgreSQL container running), confirm the same skip pattern was present in the Task 1 baseline. Do not mark the task complete if Journal-specific integration tests are failing.
+
+- [ ] **Step 7: Confirm full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.`, `0 Error(s)`, warning count equal to baseline.
+
+- [ ] **Step 8: Spec acceptance criteria checklist**
+
+Walk the spec and tick off each acceptance criterion against the verification results above:
+
+- [ ] FR-1: Both repository files at new path ✓ (Task 3 Step 3)
+- [ ] FR-1: Both repository files removed from old path ✓ (Task 3 Step 2)
+- [ ] FR-1: Empty `Persistence/Catalog/Journal/` removed ✓ (Task 3 Step 2)
+- [ ] FR-1: `Persistence/Catalog/` left intact with `Inventory/`, `Stock/`, `ManufactureDifficulty/` ✓ (Task 3 Step 2)
+- [ ] FR-1: Git history preserved via `git mv` ✓ (Task 3 Step 4)
+- [ ] FR-2: Both repositories declare `namespace Anela.Heblo.Persistence.Journal` ✓ (Task 2 Steps 3–4 verification greps)
+- [ ] FR-2: No file declares the old namespace ✓ (Task 3 Step 1)
+- [ ] FR-3: All EF configuration files moved alongside repositories ✓ (Task 3 Step 3)
+- [ ] FR-3: All Journal persistence files under `Persistence/Journal/` with new namespace ✓ (Task 3 Steps 1, 3)
+- [ ] FR-4: Repo-wide search confirms zero occurrences of old namespace string ✓ (Task 3 Step 1)
+- [ ] FR-4: All dependent files compile ✓ (Task 3 Step 7)
+- [ ] FR-4: Integration test consumer (`JournalRepositoryIntegrationTests.cs`) updated — added per arch-review amendment ✓ (Task 2 Step 10)
+- [ ] FR-5: `dotnet build` succeeds with zero new warnings/errors ✓ (Task 3 Step 7)
+- [ ] FR-5: `dotnet format` reports no formatting violations ✓ (Task 3 Step 5)
+- [ ] FR-5: All existing Journal-related tests pass ✓ (Task 3 Step 6)
+- [ ] FR-5: No EF Core migrations added or modified ✓ (Task 2 Step 15 stat shows only the eight expected files)
+- [ ] NFR-1, NFR-2, NFR-3: No runtime, security, or contract impact (structural change only) ✓
+- [ ] NFR-4: Surgical changes — only `namespace` and `using` lines edited; block-scoped style preserved ✓ (Task 2 Step 15 stat shows 1 +/- 1 per file)
+
+If any item cannot be ticked, do not close the task — fix it.
+
+---
+
+## Out of Scope (do not do)
+
+- Do **not** move DI registrations between modules. That is issue #2513.
+- Do **not** convert block-scoped namespaces to file-scoped, even if neighbors use the latter.
+- Do **not** reformat, reorder, or sort `using` directives in `JournalModule.cs` or `JournalRepositoryIntegrationTests.cs`.
+- Do **not** edit any line in the moved files other than the `namespace` declaration.
+- Do **not** touch `Persistence/Catalog/Inventory/`, `Persistence/Catalog/Stock/`, or `Persistence/Catalog/ManufactureDifficulty/`.
+- Do **not** add, modify, or remove EF Core migrations.
+- Do **not** edit `ApplicationDbContext.cs` — configuration discovery is by assembly scan, no code change is needed.
+- Do **not** audit or refactor other modules with similar issues — scope is Journal only.
+- Do **not** update historical plan documents under `docs/superpowers/plans/` even if they reference the old namespace.


### PR DESCRIPTION

Relocate six Journal persistence files from the incorrect `Persistence/Catalog/Journal/` path to their canonical `Persistence/Journal/` location per `docs/architecture/filesystem.md`. The Journal module has no dependency on Catalog; this was a scaffolding artifact.

Namespace changed from `Anela.Heblo.Persistence.Catalog.Journal` to `Anela.Heblo.Persistence.Journal`. EF Core configuration discovery uses assembly scan, so no `ApplicationDbContext` change and no migration is needed. Both consumers updated: `JournalModule.cs` (DI) and `JournalRepositoryIntegrationTests.cs`.

### Changes
- `backend/src/Anela.Heblo.Persistence/Journal/` — new folder with all six files (moved via `git mv` from `Catalog/Journal/`, history preserved)
- `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs` — `using` updated to new namespace
- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalRepositoryIntegrationTests.cs` — `using` updated to new namespace

---

Closes #2514

### Tokens used
7185821
