### PR TITLE
refactor: consolidate repository DI bindings into feature modules

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
@@ -5,6 +5,7 @@ using Anela.Heblo.Application.Features.Analytics.UseCases.GetMarginReport;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginAnalysis;
 using Anela.Heblo.Application.Features.Analytics.Validators;
 using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Persistence.Features.Analytics;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using FluentValidation;
 using MediatR;
@@ -21,6 +22,9 @@ public static class AnalyticsModule
     public static IServiceCollection AddAnalyticsModule(this IServiceCollection services)
     {
         // MediatR handlers are automatically registered by AddMediatR scan
+
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IAnalyticsRepository, AnalyticsRepository>();
 
         // Register refactored services for clean separation of concerns
         // Note: IMarginCalculationService is registered by CatalogModule and injected here

--- a/backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs
@@ -1,5 +1,7 @@
 using Anela.Heblo.Application.Features.Article.UseCases.Generate;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+using Anela.Heblo.Domain.Features.Article;
+using Anela.Heblo.Persistence.Features.Article;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +17,10 @@ public static class ArticleModule
             .Bind(configuration.GetSection(ArticleOptions.SectionName))
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        // Repositories (implementations live in the Persistence layer)
+        services.AddScoped<IArticleRepository, ArticleRepository>();
+        services.AddScoped<IArticleAdminRepository, ArticleAdminRepository>();
 
         services.AddScoped<PipelineStepRecorder>();
         services.AddScoped<PlanQueriesStep>();

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/BackgroundJobsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/BackgroundJobsModule.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.BackgroundJobs.DashboardTiles;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Persistence.BackgroundJobs;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,7 +11,8 @@ public static class BackgroundJobsModule
     public static IServiceCollection AddBackgroundJobsModule(this IServiceCollection services)
     {
         // MediatR handlers are automatically registered by MediatR scan
-        // Repository is registered in PersistenceModule
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IRecurringJobConfigurationRepository, RecurringJobConfigurationRepository>();
         // Hangfire adapter implementations (IHangfireJobEnqueuer, IHangfireRecurringJobScheduler)
         // are registered in Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices
         // because their implementations live in the API project (Clean Architecture dependency rule).

--- a/backend/src/Anela.Heblo.Application/Features/Bank/BankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/BankModule.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.Application.Features.Bank.Infrastructure;
 using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementList;
 using Anela.Heblo.Application.Features.Bank.Validators;
 using Anela.Heblo.Domain.Features.Bank;
+using Anela.Heblo.Persistence.Features.Bank;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.Configuration;
@@ -16,6 +17,9 @@ public static class BankModule
     {
         services.AddTransient<IBankClientFactory, BankClientFactory>();
         services.Configure<BankAccountSettings>(configuration.GetSection(BankAccountSettings.ConfigurationKey));
+
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IBankStatementImportRepository, BankStatementImportRepository>();
 
         services.AddScoped<IValidator<GetBankStatementListRequest>, GetBankStatementListRequestValidator>();
         services.AddScoped<

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -27,6 +27,7 @@ using Anela.Heblo.Domain.Features.Catalog.Services;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
 using Anela.Heblo.Persistence.Catalog.ManufactureDifficulty;
+using Anela.Heblo.Persistence.Catalog.Stock;
 using Anela.Heblo.Persistence.Repositories;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using FluentValidation;
@@ -45,6 +46,8 @@ public static class CatalogModule
         // Register default implementations - tests can override these
         services.AddTransient<ICatalogRepository, CatalogRepository>();
         services.AddTransient<IManufactureDifficultyRepository, ManufactureDifficultyRepository>();
+        // Stock is a Catalog subdomain; its repository implementation lives in the Persistence layer
+        services.AddScoped<IStockUpOperationRepository, StockUpOperationRepository>();
         // Register adapter to expose catalog services to Purchase module
         services.AddScoped<IMaterialCatalogService, PurchaseMaterialCatalogAdapter>();
         services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceRecalculationAdapter>();

--- a/backend/src/Anela.Heblo.Application/Features/Dashboard/DashboardModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Dashboard/DashboardModule.cs
@@ -1,4 +1,6 @@
 using Anela.Heblo.Application.Features.Dashboard.Infrastructure;
+using Anela.Heblo.Domain.Features.Dashboard;
+using Anela.Heblo.Persistence.Dashboard;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using Hangfire;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,6 +12,9 @@ public static class DashboardModule
     public static IServiceCollection AddDashboardModule(this IServiceCollection services)
     {
         // MediatR handlers are automatically registered by the ApplicationModule
+
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IUserDashboardSettingsRepository, UserDashboardSettingsRepository>();
 
         // Hangfire storage singleton — resolved lazily after Hangfire is configured
         services.AddSingleton(_ => JobStorage.Current);

--- a/backend/src/Anela.Heblo.Application/Features/FeatureFlags/FeatureFlagsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FeatureFlags/FeatureFlagsModule.cs
@@ -1,4 +1,6 @@
 using Anela.Heblo.Application.Features.FeatureFlags.Infrastructure;
+using Anela.Heblo.Domain.Features.FeatureFlags;
+using Anela.Heblo.Persistence.FeatureFlags;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,6 +22,9 @@ public static class FeatureFlagsModule
         // Re-created per scope to allow future per-request EvaluationContext injection.
         services.AddScoped<IFeatureClient>(_ => Api.Instance.GetClient());
         services.AddScoped<IFeatureFlagChecker, FeatureFlagChecker>();
+
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IFeatureFlagOverrideRepository, FeatureFlagOverrideRepository>();
         return services;
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutsModule.cs
@@ -1,3 +1,5 @@
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence.GridLayouts;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Anela.Heblo.Application.Features.GridLayouts;
@@ -6,6 +8,9 @@ public static class GridLayoutsModule
 {
     public static IServiceCollection AddGridLayoutsModule(this IServiceCollection services)
     {
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IGridLayoutRepository, GridLayoutRepository>();
+
         // MediatR handlers are auto-registered via assembly scanning.
         return services;
     }

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Anela.Heblo.Application.Features.InvoiceClassification.Services;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
 using Anela.Heblo.Domain.Features.InvoiceClassification.Rules;
+using Anela.Heblo.Persistence.InvoiceClassification;
 
 namespace Anela.Heblo.Application.Features.InvoiceClassification;
 
@@ -11,6 +12,10 @@ public static class InvoiceClassificationModule
     {
         services.AddScoped<IInvoiceClassificationService, InvoiceClassificationService>();
         services.AddScoped<IRuleEvaluationEngine, RuleEvaluationEngine>();
+
+        // Repositories (implementations live in the Persistence layer)
+        services.AddScoped<IClassificationRuleRepository, ClassificationRuleRepository>();
+        services.AddScoped<IClassificationHistoryRepository, ClassificationHistoryRepository>();
 
         // Register all classification rule implementations
         services.AddScoped<IClassificationRule, VatClassificationRule>();

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
@@ -7,6 +7,8 @@ using Microsoft.Identity.Web;
 using Anela.Heblo.Application.Features.KnowledgeBase.Services.DocumentExtractors;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.AskQuestion;
 using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Features.KnowledgeBase;
+using Anela.Heblo.Persistence.KnowledgeBase;
 using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,7 +49,8 @@ public static class KnowledgeBaseModule
         // Scoped to match existing Article contract bindings above.
         services.AddScoped<IArticleKnowledgeSource, KnowledgeBaseArticleKnowledgeSource>();
 
-        // IKnowledgeBaseRepository is registered in PersistenceModule (real EF Core implementation)
+        // Repository (real EF Core implementation lives in the Persistence layer)
+        services.AddScoped<IKnowledgeBaseRepository, KnowledgeBaseRepository>();
 
         // OneDrive service — use real Graph service only when SharePoint drives are configured
         // AND real authentication is active. Mock auth has no Azure AD token so Graph calls

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
@@ -1,6 +1,8 @@
 using Anela.Heblo.Application.Features.Leaflet.Pipeline;
 using Anela.Heblo.Application.Features.Leaflet.Services;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Persistence.Features.Leaflet;
 using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,8 +27,11 @@ public static class LeafletModule
             IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
             LeafletGenerationPersistenceBehavior>();
 
+        // Repositories (implementations live in the Persistence layer)
+        services.AddScoped<ILeafletDocumentRepository, LeafletDocumentRepository>();
+        services.AddScoped<ILeafletGenerationRepository, LeafletGenerationRepository>();
+
         // LeafletIngestionJob is auto-discovered via IRecurringJob assembly scan in AddRecurringJobs()
-        // ILeafletDocumentRepository and ILeafletGenerationRepository are registered in PersistenceModule
         // MediatR handlers are auto-registered via AddApplicationServices() assembly scan
 
         return services;

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs
@@ -1,5 +1,7 @@
 using Anela.Heblo.Application.Features.MeetingTasks.Services;
 using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using Anela.Heblo.Persistence.MeetingTasks;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,8 +47,10 @@ public static class MeetingTasksModule
         services.AddSingleton<IMeetingUserDirectory, MeetingUserDirectory>();
         services.AddScoped<IMeetingAccessGuard, MeetingAccessGuard>();
 
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IMeetingTranscriptRepository, MeetingTranscriptRepository>();
+
         // PlaudPollingJob is auto-discovered via IRecurringJob assembly scan in AddRecurringJobs().
-        // IMeetingTranscriptRepository is registered in PersistenceModule (subtask 1).
         // MediatR handlers are auto-registered by the MediatR assembly scan in ApplicationModule.
         return services;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/PackagingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/PackagingModule.cs
@@ -2,6 +2,8 @@ using Anela.Heblo.Application.Common.Behaviors;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackages;
 using Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
 using Anela.Heblo.Application.Features.Packaging.Validators;
+using Anela.Heblo.Domain.Features.Packaging;
+using Anela.Heblo.Persistence.Repositories.Packaging;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +14,9 @@ public static class PackagingModule
 {
     public static IServiceCollection AddPackagingModule(this IServiceCollection services)
     {
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IPackageRepository, PackageRepository>();
+
         services.AddScoped<IValidator<ScanPackingOrderRequest>, ScanPackingOrderRequestValidator>();
         services.AddScoped<
             IPipelineBehavior<ScanPackingOrderRequest, ScanPackingOrderResponse>,

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs
@@ -5,6 +5,7 @@ using Anela.Heblo.Application.Features.Purchase.Services;
 using Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
 using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
 using Anela.Heblo.Domain.Features.Purchase;
+using Anela.Heblo.Persistence.Purchase.PurchaseOrders;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,6 +17,9 @@ public static class PurchaseModule
     public static IServiceCollection AddPurchaseModule(this IServiceCollection services)
     {
         services.AddScoped<IPurchaseOrderNumberGenerator, PurchaseOrderNumberGenerator>();
+
+        // Repository (implementation lives in the Persistence layer)
+        services.AddScoped<IPurchaseOrderRepository, PurchaseOrderRepository>();
 
         // Register stock severity calculator
         services.AddScoped<IStockSeverityCalculator, StockSeverityCalculator>();

--- a/backend/src/Anela.Heblo.Persistence/FeatureFlags/FeatureFlagOverrideRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/FeatureFlags/FeatureFlagOverrideRepository.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Anela.Heblo.Persistence.FeatureFlags;
 
-internal sealed class FeatureFlagOverrideRepository : IFeatureFlagOverrideRepository
+public sealed class FeatureFlagOverrideRepository : IFeatureFlagOverrideRepository
 {
     private readonly ApplicationDbContext _ctx;
 

--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -1,36 +1,6 @@
-using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Article;
-using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Anela.Heblo.Domain.Features.FeatureFlags;
-using Anela.Heblo.Persistence.FeatureFlags;
-using Anela.Heblo.Domain.Features.DataQuality;
-using Anela.Heblo.Domain.Features.Bank;
-using Anela.Heblo.Domain.Features.Packaging;
-using Anela.Heblo.Domain.Features.Purchase;
-using Anela.Heblo.Domain.Features.GridLayouts;
-using Anela.Heblo.Persistence.GridLayouts;
 using Anela.Heblo.Domain.Features.Catalog.Inventory;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
-using Anela.Heblo.Domain.Features.InvoiceClassification;
 using Anela.Heblo.Persistence.Catalog.Inventory;
-using Anela.Heblo.Domain.Features.KnowledgeBase;
-using Anela.Heblo.Domain.Features.MeetingTasks;
-using Anela.Heblo.Domain.Features.Leaflet;
-using Anela.Heblo.Persistence.BackgroundJobs;
-using Anela.Heblo.Persistence.DataQuality;
-using Anela.Heblo.Persistence.Catalog.Stock;
-using Anela.Heblo.Persistence.Dashboard;
-using Anela.Heblo.Persistence.Features.Analytics;
-using Anela.Heblo.Persistence.Features.Bank;
 using Anela.Heblo.Persistence.Infrastructure;
-using Anela.Heblo.Persistence.InvoiceClassification;
-using Anela.Heblo.Persistence.Features.Article;
-using Anela.Heblo.Persistence.Features.Leaflet;
-using Anela.Heblo.Persistence.KnowledgeBase;
-using Anela.Heblo.Persistence.Purchase.PurchaseOrders;
-using Anela.Heblo.Persistence.Repositories.Packaging;
-using Anela.Heblo.Persistence.MeetingTasks;
-using Anela.Heblo.Domain.Features.Dashboard;
 using Anela.Heblo.Xcc.Telemetry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -130,51 +100,10 @@ public static class PersistenceModule
         // Register telemetry services
         services.AddScoped<ITelemetryService, NoOpTelemetryService>(); // Default to NoOp, can be overridden by API layer
 
-        // Register repositories
-        services.AddScoped<IAnalyticsRepository, AnalyticsRepository>();
-        services.AddScoped<IUserDashboardSettingsRepository, UserDashboardSettingsRepository>();
-
-        // Bank repositories
-        services.AddScoped<IBankStatementImportRepository, BankStatementImportRepository>();
-
-        // Invoice Classification repositories
-        services.AddScoped<IClassificationRuleRepository, ClassificationRuleRepository>();
-        services.AddScoped<IClassificationHistoryRepository, ClassificationHistoryRepository>();
-
-        // Stock repositories
-        services.AddScoped<IStockUpOperationRepository, StockUpOperationRepository>();
-
-        // Background Jobs repositories
-        services.AddScoped<IRecurringJobConfigurationRepository, RecurringJobConfigurationRepository>();
-
-        // KnowledgeBase repositories
-        services.AddScoped<IKnowledgeBaseRepository, KnowledgeBaseRepository>();
-
-        // Meeting Tasks repositories
-        services.AddScoped<IMeetingTranscriptRepository, MeetingTranscriptRepository>();
-
-        // Leaflet repositories
-        services.AddScoped<ILeafletDocumentRepository, LeafletDocumentRepository>();
-        services.AddScoped<ILeafletGenerationRepository, LeafletGenerationRepository>();
-
-        // Article repositories
-        services.AddScoped<IArticleRepository, ArticleRepository>();
-        services.AddScoped<IArticleAdminRepository, ArticleAdminRepository>();
-
-        // Grid Layouts repositories
-        services.AddScoped<IGridLayoutRepository, GridLayoutRepository>();
-
-        // Data Quality repositories
-        services.AddScoped<IDqtRunRepository, DqtRunRepository>();
-
-        // Feature Flags repositories
-        services.AddScoped<IFeatureFlagOverrideRepository, FeatureFlagOverrideRepository>();
-
-        // Purchase repositories
-        services.AddScoped<IPurchaseOrderRepository, PurchaseOrderRepository>();
-
-        // Packaging repositories
-        services.AddScoped<IPackageRepository, PackageRepository>();
+        // NOTE: Repository bindings live in each module's {Feature}Module.cs (vertical-slice
+        // composition), not here. PersistenceModule owns only shared infrastructure: the
+        // DbContext, NpgsqlDataSource, interceptors, telemetry, and the code generator.
+        // See docs/architecture/development_guidelines.md (§Dependency Injection Patterns).
 
         return services;
     }

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletModuleIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletModuleIntegrationTests.cs
@@ -29,10 +29,14 @@ public class LeafletModuleIntegrationTests
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddSingleton(Mock.Of<IEmbeddingGenerator<string, Embedding<float>>>());
         services.AddSingleton(Mock.Of<IChatClient>());
-        services.AddSingleton(Mock.Of<ILeafletDocumentRepository>());
-        services.AddSingleton(Mock.Of<ILeafletGenerationRepository>());
         services.AddScoped<IWordWindowChunker, WordWindowChunker>();
         services.AddLeafletModule(configuration);
+
+        // AddLeafletModule now registers the real repository implementations (vertical-slice
+        // composition). Override them with mocks AFTER the module call so the mocks win
+        // resolution — this wiring test validates the module's services without a database.
+        services.AddSingleton(Mock.Of<ILeafletDocumentRepository>());
+        services.AddSingleton(Mock.Of<ILeafletGenerationRepository>());
         return services;
     }
 

--- a/backend/test/Anela.Heblo.Tests/Persistence/PersistenceModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Persistence/PersistenceModuleTests.cs
@@ -186,6 +186,44 @@ public class PersistenceModuleTests
             "Database:ConnectionPruningInterval must be applied to control how often idle connections are pruned");
     }
 
+    /// <summary>
+    /// Architecture guard: PersistenceModule must NOT register any repository bindings.
+    ///
+    /// Repository DI bindings belong to each feature's {Feature}Module.cs (vertical-slice
+    /// composition), not the central Persistence composition root. Registering repos here
+    /// splits a slice's wiring across two layers and previously caused a duplicate
+    /// registration of IDqtRunRepository. See docs/architecture/development_guidelines.md
+    /// (§Dependency Injection Patterns). This test prevents the pattern from returning.
+    /// </summary>
+    [Fact]
+    public void AddPersistenceServices_RegistersNoRepositoryBindings()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["UseInMemoryDatabase"] = "true",
+                ["ConnectionStrings:Test"] = "InMemory"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Act
+        services.AddPersistenceServices(configuration, new FakeHostEnvironment("Test"));
+
+        // Assert
+        var repositoryRegistrations = services
+            .Where(d => d.ServiceType.Name.EndsWith("Repository", StringComparison.Ordinal))
+            .Select(d => d.ServiceType.Name)
+            .ToList();
+
+        repositoryRegistrations.Should().BeEmpty(
+            "repository bindings must live in their owning {Feature}Module.cs, not in PersistenceModule; " +
+            "PersistenceModule owns only shared infrastructure (DbContext, NpgsqlDataSource, interceptors, telemetry)");
+    }
+
     private sealed class FakeHostEnvironment : IHostEnvironment
     {
         public FakeHostEnvironment(string environmentName)

--- a/docs/architecture/development_guidelines.md
+++ b/docs/architecture/development_guidelines.md
@@ -116,6 +116,19 @@ public static class OrdersModule
 }
 ```
 
+### Repository bindings belong to the slice, never to `PersistenceModule`
+
+A repository's **implementation** lives in `Anela.Heblo.Persistence` (single `ApplicationDbContext`,
+Phase 1 — see ADR-001), but its **DI binding** must be written in the owning module's
+`{Feature}Module.cs`, exactly like the `IOrderRepository` line above. `PersistenceModule.cs` owns
+**only shared infrastructure**: the `DbContext`, `NpgsqlDataSource`, interceptors, telemetry, and the
+material-container code generator.
+
+Registering a repo centrally in `PersistenceModule.cs` splits one slice's wiring across two layers,
+turns `PersistenceModule` into a multi-module coupling/merge-conflict hotspot, and has already caused
+a duplicate registration (`IDqtRunRepository`). The rule is enforced by
+`PersistenceModuleTests.AddPersistenceServices_RegistersNoRepositoryBindings`.
+
 ### API Composition (Program.cs):
 ```csharp
 // Aggregate all modules
@@ -228,6 +241,31 @@ When module A needs **read-only access** to data in module B, the dependency mus
 - **Context**: Need clean separation between HTTP layer and business logic
 - **Decision**: Use standard ASP.NET Core Controllers with MediatR for request handling
 - **Consequences**: Clean architecture, testable handlers, standard /api/{controller} endpoints
+
+### ADR-004: Repository DI Bindings Live in the Feature Module, Not `PersistenceModule`
+- **Status**: Accepted (2026-06-05)
+- **Context**: Repository **implementations** live in `Anela.Heblo.Persistence` because of the single
+  shared `ApplicationDbContext` (ADR-001). But the **DI binding**
+  (`services.AddScoped<IRepo, RepoImpl>()`) was written in two different places depending on the
+  module: some feature modules registered their own repos in `{Feature}Module.cs` (correct), while
+  ~15 modules had their repos registered centrally in `Anela.Heblo.Persistence/PersistenceModule.cs`.
+  This split a single vertical slice's wiring across two layers, turned `PersistenceModule` into a
+  multi-module coupling/merge-conflict hotspot, contradicted the documented DI pattern, and had
+  already produced a duplicate registration (`IDqtRunRepository`).
+- **Decision**: A repository's DI binding is **always** declared in its owning module's
+  `{Feature}Module.cs`. `PersistenceModule.cs` registers **only shared infrastructure**: the
+  `DbContext`, `NpgsqlDataSource`, interceptors, telemetry, and the material-container code generator
+  — never a repository. Repository implementation classes are `public` so the Application-layer module
+  can bind them. The implementation file still lives under `Persistence/{Feature}/`.
+- **Consequences**:
+  - Each vertical slice owns its full wiring in one file; adding a feature touches one module, not two.
+  - `PersistenceModule` stays small and stable (no per-feature churn).
+  - Enforced by `PersistenceModuleTests.AddPersistenceServices_RegistersNoRepositoryBindings`, which
+    fails CI if any `*Repository` binding reappears in `PersistenceModule`.
+  - Module-wiring tests that mock a repository must register the mock **after** the
+    `Add{Feature}Module` call so the mock overrides the module's real binding.
+- **Supersedes**: the previous mixed convention where `PersistenceModule` centrally registered
+  repositories. All future implementations must follow this pattern.
 
 ---
 

--- a/memory/decisions/repository-di-in-feature-module.md
+++ b/memory/decisions/repository-di-in-feature-module.md
@@ -1,0 +1,22 @@
+# Decision: Repository DI Bindings Live in the Feature Module, Not PersistenceModule
+
+**Decision:** A repository's DI binding (`services.AddScoped<IRepo, RepoImpl>()`) is always declared
+in its owning `{Feature}Module.cs`. `PersistenceModule.cs` registers only shared infrastructure
+(DbContext, NpgsqlDataSource, interceptors, telemetry, material-container code generator) — never a
+repository. (ADR-004 in `docs/architecture/development_guidelines.md`.)
+
+**Why:** Repository *implementations* must live in `Anela.Heblo.Persistence` because of the single
+shared `ApplicationDbContext` (ADR-001), but their DI *binding* used to be split — ~15 modules
+registered repos centrally in `PersistenceModule.cs` while others self-registered. That scattered a
+vertical slice's wiring across two layers, made `PersistenceModule` a coupling/merge-conflict hotspot,
+contradicted the documented DI pattern, and caused a duplicate `IDqtRunRepository` registration.
+
+**How to apply:**
+- New repo: write `services.AddScoped<IXxxRepository, XxxRepository>()` in `Features/Xxx/XxxModule.cs`,
+  with `using Anela.Heblo.Persistence.<impl-ns>;`. The impl class must be `public`.
+- Never add a repository binding to `PersistenceModule.cs`.
+- Guard test: `PersistenceModuleTests.AddPersistenceServices_RegistersNoRepositoryBindings` fails CI
+  if a `*Repository` binding reappears there.
+- Module-wiring tests that mock a repository must register the mock **after** `AddXxxModule(...)` so
+  the mock overrides the module's real binding (DI = last registration wins).
+- Stock is a Catalog subdomain → its repo lives in `CatalogModule`. UserDashboardSettings → `DashboardModule`.


### PR DESCRIPTION
Unifies how repository DI bindings are registered: every `AddScoped<IRepo, RepoImpl>()` now lives in its owning `{Feature}Module.cs` (vertical-slice composition), so `PersistenceModule.cs` registers only shared infrastructure (DbContext, NpgsqlDataSource, interceptors, telemetry, code generator). This removes the previous split where ~15 modules were registered centrally in `PersistenceModule`, which broke slice self-containment and had already caused a duplicate `IDqtRunRepository` registration. Also makes `FeatureFlagOverrideRepository` public so its feature module can bind it, and fixes `LeafletModuleIntegrationTests` to mock repositories after `AddLeafletModule`. A new guard test (`AddPersistenceServices_RegistersNoRepositoryBindings`) fails CI if any repository binding reappears in `PersistenceModule`, and the rule is recorded as ADR-004. Verified with `dotnet build` (0 errors), `dotnet format`, and the full test suite (4375 pass; only Docker-dependent Testcontainers tests fail in this sandbox).