### PR TITLE
feat: allow direct InTransit to Completed purchase order transition

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
@@ -178,6 +178,7 @@ public class PurchaseOrder : IEntity<int>
         {
             (PurchaseOrderStatus.Draft, PurchaseOrderStatus.InTransit) => true,
             (PurchaseOrderStatus.InTransit, PurchaseOrderStatus.Received) => true,
+            (PurchaseOrderStatus.InTransit, PurchaseOrderStatus.Completed) => true,
             (PurchaseOrderStatus.Received, PurchaseOrderStatus.Completed) => true,
             _ => false
         };

--- a/backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs
@@ -320,6 +320,26 @@ public class PurchaseOrderTests
         statusChangeEntry.ChangedBy.Should().Be(changedBy);
     }
 
+    [Fact]
+    public void ChangeStatus_FromInTransitToCompleted_ShouldUpdateStatusAndHistory()
+    {
+        var purchaseOrder = CreateValidPurchaseOrder();
+        purchaseOrder.ChangeStatus(PurchaseOrderStatus.InTransit, ValidCreatedBy);
+        const string changedBy = "completer@example.com";
+
+        purchaseOrder.ChangeStatus(PurchaseOrderStatus.Completed, changedBy);
+
+        purchaseOrder.Status.Should().Be(PurchaseOrderStatus.Completed);
+        purchaseOrder.UpdatedBy.Should().Be(changedBy);
+        purchaseOrder.History.Should().HaveCount(3);
+
+        var statusChangeEntry = purchaseOrder.History.Last();
+        statusChangeEntry.Action.Should().Contain("Status changed");
+        statusChangeEntry.OldValue.Should().Be("InTransit");
+        statusChangeEntry.NewValue.Should().Be("Completed");
+        statusChangeEntry.ChangedBy.Should().Be(changedBy);
+    }
+
     [Theory]
     [InlineData(PurchaseOrderStatus.Draft, PurchaseOrderStatus.Completed)]
     [InlineData(PurchaseOrderStatus.InTransit, PurchaseOrderStatus.Draft)]

--- a/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderStatusHandlerTests.cs
@@ -356,7 +356,7 @@ public class UpdatePurchaseOrderStatusHandlerTests
     }
 
     [Fact]
-    public async Task Handle_TransitionFromInTransitToCompleted_ShouldReturnError()
+    public async Task Handle_TransitionFromInTransitToCompleted_Succeeds()
     {
         var request = new UpdatePurchaseOrderStatusRequest(ValidOrderId, "Completed");
         var purchaseOrder = CreateDraftPurchaseOrder();
@@ -366,11 +366,20 @@ public class UpdatePurchaseOrderStatusHandlerTests
             .Setup(x => x.GetByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(purchaseOrder);
 
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<PurchaseOrder>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
         var result = await _handler.Handle(request, CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.Success.Should().BeFalse();
-        result.ErrorCode.Should().Be(ErrorCodes.StatusTransitionNotAllowed);
+        result!.Success.Should().BeTrue();
+        result.Status.Should().Be("Completed");
+        purchaseOrder.Status.Should().Be(PurchaseOrderStatus.Completed);
     }
 
     private static PurchaseOrder CreateDraftPurchaseOrder()


### PR DESCRIPTION
Adds `InTransit → Completed` as a valid purchase order state transition so the action the UI already offers (`getNextStatus("InTransit")` returns `"Completed"`) no longer fails with `StatusTransitionNotAllowed`. The existing path through `Received` remains valid, so nothing is removed. Covered by a new domain test; build, `dotnet format`, and all `PurchaseOrderTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)