### PR TITLE
docs: define canonical user identity resolution pattern (ADR-004)

### DIFF
--- a/docs/architecture/development_guidelines.md
+++ b/docs/architecture/development_guidelines.md
@@ -60,6 +60,24 @@ public class OrderDto { } // Never in API or Xcc!
 - **Frontend owns routing**: URL construction happens in frontend based on its routing structure
 - **Backward compatibility**: Support both new filter-based and legacy URL approaches during transition
 
+### User Identity Resolution
+
+There is exactly **one** way to obtain the current user. See **ADR-004** for the full decision.
+
+| Concern | Lives in |
+| --- | --- |
+| `ICurrentUserService` interface | `Anela.Heblo.Domain/Features/Users/` |
+| `CurrentUserService` implementation (depends on `IHttpContextAccessor`) | `Anela.Heblo.API/Features/Users/` (outer ring, **not** Application) |
+| DI registration | `Anela.Heblo.API/Features/Users/UsersModule.cs` (`AddUsersModule()`) |
+| Resolution call-site | **inside MediatR handlers** that inject `ICurrentUserService` |
+
+**Rules:**
+- **Resolve identity inside the handler**, not the controller. Handlers inject `ICurrentUserService`.
+- **Controllers never resolve identity** — no `GetCurrentUserId()` helper, no `ICurrentUserService` injection, no stamping `UserId`/`ModifiedBy` onto requests.
+- **Request DTOs must not carry client-settable `UserId` / `ModifiedBy`** — these are server-resolved, never trusted from the client (spoofing hole).
+- **Never inject `IHttpContextAccessor` into a handler** — always go through `ICurrentUserService`.
+- When a GUID audit value is needed, use `Guid.TryParse(user.Id, out var id) ? id : null` — nullable, **no sentinel GUID** (see the `TransportBox` pattern in `CreateNewTransportBoxHandler`). Do **not** add a shared `UserIdResolver` helper unless a real consumer exists.
+
 ### Testing
 - Unit tests for domain logic
 - Integration tests for use cases
@@ -229,6 +247,12 @@ When module A needs **read-only access** to data in module B, the dependency mus
 - **Decision**: Use standard ASP.NET Core Controllers with MediatR for request handling
 - **Consequences**: Clean architecture, testable handlers, standard /api/{controller} endpoints
 
+### ADR-004: User Identity Resolution
+- **Status**: Accepted
+- **Context**: Identity resolution had drifted into two coexisting patterns — a `BaseApiController.GetCurrentUserId()` helper that duplicated `CurrentUserService`'s claim-priority chain (used by `Dashboard`, `CarrierCooling`, `GiftSettings`), alongside the handler-side `ICurrentUserService` pattern used by 60+ other handlers. A daily arch-review routine kept re-filing fragments of the same concern (impl location, missing `UsersModule`, dead controller injections, direct `IHttpContextAccessor` use) because the canonical rule was written down nowhere.
+- **Decision**: There is exactly one way to obtain the current user. The `ICurrentUserService` interface lives in `Domain/Features/Users/`; the `CurrentUserService` implementation lives in `API/Features/Users/` (outer ring, since it depends on the web-only `IHttpContextAccessor`); DI is wired in `UsersModule.cs`. **Identity is resolved inside MediatR handlers** via injected `ICurrentUserService` — never in controllers, never via a controller helper, never via direct `IHttpContextAccessor`. Request DTOs carry no client-settable `UserId`/`ModifiedBy`. GUID audit values use `Guid.TryParse(user.Id, out var id) ? id : null` with no sentinel. See the *User Identity Resolution* practices section above.
+- **Consequences**: `BaseApiController.GetCurrentUserId()`, the three outlier controllers' identity assignments, and the spoofable DTO fields are removed (PR #2602, the final convergence of five arch-review findings). This ADR is the single source of truth — arch-review should treat any controller-side identity resolution or handler-side `IHttpContextAccessor` use as a violation of an accepted decision, not a new finding.
+
 ---
 
 ## ⚠️ Common Pitfalls to Avoid
@@ -240,6 +264,7 @@ When module A needs **read-only access** to data in module B, the dependency mus
 5. **Don't bypass contracts** - Always communicate through interfaces
 6. **Don't create anemic domain models** - Put behavior in entities
 7. **Don't ignore module boundaries** - Respect the architecture
+8. **Don't resolve user identity in controllers** - No `GetCurrentUserId()` helper, no `IHttpContextAccessor` in handlers; resolve via `ICurrentUserService` inside the handler (ADR-004)
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10974,16 +10974,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -22254,7 +22244,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/memory/decisions/logistics-no-userid-resolver.md
+++ b/memory/decisions/logistics-no-userid-resolver.md
@@ -12,4 +12,4 @@
 - Populate it inside `GiftPackageManufactureService` (next to the existing `_currentUserService` usage), not in a handler or a shared resolver.
 - Use the existing `TransportBox` pattern: `Guid.TryParse(user.Id, out var userId) ? userId : null` — nullable, no sentinel. See `CreateNewTransportBoxHandler.cs:43` and `OpenOrResumeBoxByCodeHandler.cs:72`.
 
-**Out of scope (still latent):** `DashboardController` has the same dead-code shape. Same delete-and-simplify treatment will apply when it is touched.
+**Resolved:** `DashboardController` had the same dead-code shape; PR #2602 applied the same delete-and-simplify treatment (handler-side resolution via `ICurrentUserService`, DTO `UserId` fields removed) to it and the `CarrierCooling`/`GiftSettings` controllers. The canonical pattern is now codified — see [user-identity-resolution.md](user-identity-resolution.md) and ADR-004.

--- a/memory/decisions/user-identity-resolution.md
+++ b/memory/decisions/user-identity-resolution.md
@@ -1,0 +1,26 @@
+# Decision: One Canonical Way to Resolve the Current User
+
+**Date:** 2026-06-05
+**Status:** Accepted — see `docs/architecture/development_guidelines.md` ADR-004.
+
+**Decision:** User identity is resolved in exactly one place and one way.
+
+- `ICurrentUserService` **interface** → `Anela.Heblo.Domain/Features/Users/`
+- `CurrentUserService` **implementation** (depends on `IHttpContextAccessor`, a web type) → `Anela.Heblo.API/Features/Users/` (outer ring, **not** Application)
+- **DI registration** → `Anela.Heblo.API/Features/Users/UsersModule.cs` (`AddUsersModule()`)
+- **Resolution happens inside MediatR handlers**, which inject `ICurrentUserService`.
+
+**Rules:**
+- Controllers never resolve identity — no `GetCurrentUserId()` helper, no `ICurrentUserService` injection, no stamping `UserId`/`ModifiedBy` onto requests.
+- Request DTOs carry no client-settable `UserId`/`ModifiedBy` (spoofing hole).
+- Handlers never inject `IHttpContextAccessor` — always go through `ICurrentUserService`.
+- GUID audit values: `Guid.TryParse(user.Id, out var id) ? id : null` — nullable, no sentinel GUID. No shared `UserIdResolver` helper unless a real consumer exists. See `CreateNewTransportBoxHandler.cs` and `OpenOrResumeBoxByCodeHandler.cs`, and the related decision [logistics-no-userid-resolver.md](logistics-no-userid-resolver.md).
+
+**Why this exists:** The rule was written down nowhere, so a daily arch-review routine kept re-discovering fragments of the same concern as separate findings — which felt like the code was "moving back and forth." It was not: every step pushed the same direction. ADR-004 + the guidelines section are the single source of truth so the loop stops.
+
+**Convergence history (five arch-review features, all the same direction):**
+- `feat-arch-review-users-currentuserservice-liv` — move impl Application → API. *(merged)*
+- `feat-arch-review-users-missing-usersmodule-cs` — add `UsersModule.cs`. *(merged)*
+- `feat-arch-review-users-gridlayoutscontroller-` — drop unused `ICurrentUserService` from controller. *(merged)*
+- `feat-arch-review-users-updatemanufactureorder` — replace direct `IHttpContextAccessor` with `ICurrentUserService`.
+- `feat-arch-review-users-baseapicontroller-getc` = **PR #2602** — remove `BaseApiController.GetCurrentUserId()` and migrate the last 3 outlier controllers (`Dashboard`, `CarrierCooling`, `GiftSettings`) to handler-side resolution. The final convergence step.


### PR DESCRIPTION
Codifies where the current user is resolved so the canonical pattern sticks once and for all and the daily arch-review routine stops re-filing fragments of the same concern (the churn behind PR #2602's apparent "back and forth"). Adds **ADR-004** plus a *User Identity Resolution* practices section and pitfall bullet to `development_guidelines.md`, establishing one rule: interface in Domain, `CurrentUserService` impl in the API layer, DI in `UsersModule.cs`, and identity resolved inside MediatR handlers via `ICurrentUserService` — never in controllers or via `IHttpContextAccessor`, with no client-settable `UserId`/`ModifiedBy` on DTOs. Adds `memory/decisions/user-identity-resolution.md` capturing the pattern and the five-feature convergence history, and closes the now-resolved "latent DashboardController" note in `logistics-no-userid-resolver.md`. Also includes a minor `frontend/package-lock.json` lockfile sync that was already present in the workspace. Documentation only — no production code changes.