### PR TITLE
feat: Separate Internal `PackingOrderItem` from Public API DTO

### DIFF
--- a/artifacts/feat-arch-review-shoptetorders-packingorderit/arch-review.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packingorderit/arch-review.r1.md
@@ -1,0 +1,232 @@
+I have all the context I need. Verified the codebase matches the spec, including filesystem conventions, existing test patterns, and that no frontend consumer reads `weightGrams`.
+
+```markdown
+# Architecture Review: Separate Internal `PackingOrderItem` from Public API DTO
+
+## Skip Design: true
+
+Backend refactor with a public-API contract reduction — no UI components, screens, or visual decisions involved. The frontend's hand-written `PackingOrderItem` interface (`useScanPackingOrder.ts:11`) already excludes `weightGrams`, so no rendered surface changes.
+
+## Architectural Fit Assessment
+
+**Excellent fit.** The proposed split exactly applies three rules already in force:
+
+1. **DTO isolation rule** (`docs/architecture/development_guidelines.md` §"Contracts and DTOs Rules"): "DTO objects for API live in `contracts/` of the specific module" and "DTOs are never shared or global." The current `PackingOrderItem` violates both — it is reused as the API DTO across two modules (`ShoptetOrders` and `Packaging`).
+2. **Adapter-contract precedent** (same file): `PackingOrder` already carries the wording "Internal contract — not an API DTO" (`IPackingOrderClient.cs:17`). `PackingOrderItem` is the only line type that did not get the same treatment when the contract was tightened — applying it now restores consistency.
+3. **OpenAPI class-not-record rule** (`CLAUDE.md`): both new DTOs are classes, matching the rule and matching the existing 60+ DTOs in the codebase (e.g. `ArticleListItemDto`, `JournalEntryDto`, `GiftPackageDto`).
+
+**Integration points:**
+- Adapter contract (`IPackingOrderClient`) — unchanged shape, only doc-comment tightened.
+- Two handlers (`GetPackingOrderHandler`, `ScanPackingOrderHandler`) — gain one explicit projection each.
+- Two response types (`GetPackingOrderResponse`, `ScanOrderData`) — switch element type.
+- OpenAPI regeneration cascades to `frontend/src/api/generated/api-client.ts` automatically.
+
+The Packaging-module handlers continue to consume the `IPackingOrderClient` contract owned by ShoptetOrders. This is the documented "Cross-Module Communication" pattern (`development_guidelines.md` §"Cross-Module Communication Example"): the consumer module imports the provider's contract. Nothing changes there.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+                       ┌──────────────────────────────────────────┐
+                       │ Adapters/Anela.Heblo.Adapters.ShoptetApi │
+                       │ ShoptetApiPackingOrderClient             │
+                       │  └─ builds PackingOrder + PackingOrderItem (incl. WeightGrams)
+                       └──────────────────────────────────────────┘
+                                       │ implements
+                                       ▼
+        ┌──────────────────────────────────────────────────────────────┐
+        │ Application/Features/ShoptetOrders                           │
+        │  IPackingOrderClient (contract)                              │
+        │  PackingOrder         ← internal Application contract        │
+        │  PackingOrderItem     ← internal Application contract        │
+        │                         (Name, Quantity, ImageUrl, SetName,  │
+        │                          WeightGrams)                        │
+        └──────────────────────────────────────────────────────────────┘
+              │ consumed by                       │ consumed by
+              ▼                                   ▼
+ ┌──────────────────────────────┐   ┌──────────────────────────────────┐
+ │ ShoptetOrders/UseCases/      │   │ Packaging/UseCases/              │
+ │ GetPackingOrder              │   │ ScanPackingOrder + ResetOrderShip │
+ │                              │   │                                  │
+ │  GetPackingOrderHandler      │   │  ScanPackingOrderHandler         │
+ │   projects → PackingOrderItemDto │   │   uses i.WeightGrams (internal)  │
+ │                              │   │   projects → ScanPackingOrderItemDto │
+ │  GetPackingOrderResponse     │   │                                  │
+ │   .Items: List<PackingOrderItemDto>│ │  ScanOrderData               │
+ │                              │   │   .Items: List<ScanPackingOrderItemDto>│
+ │  ── PUBLIC API ──            │   │  ── PUBLIC API ──                │
+ └──────────────────────────────┘   └──────────────────────────────────┘
+              │                                   │
+              ▼                                   ▼
+                  ┌──────────────────────────────────────┐
+                  │ OpenAPI Spec ──► api-client.ts       │
+                  │ (no weightGrams on either DTO)       │
+                  └──────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Two structurally-identical module-local DTOs (not one shared DTO)
+
+**Options considered:**
+- (A) One shared `PackingOrderItemDto` in a cross-module location (e.g. `Application/Shared/`).
+- (B) Two module-local DTOs (`PackingOrderItemDto` in ShoptetOrders, `ScanPackingOrderItemDto` in Packaging).
+- (C) One DTO in ShoptetOrders, re-used from Packaging via cross-module import.
+
+**Chosen approach:** (B). Each owning use case gets its own DTO in its own folder.
+
+**Rationale:** Option (A) is explicitly forbidden ("DTOs are never shared or global", `development_guidelines.md`). Option (C) re-creates the original problem at smaller scale: any field added to satisfy GetPackingOrder leaks into ScanPackingOrder and vice versa, and renames force coordinated changes across modules. The DTOs are intentionally allowed to drift; today they happen to be field-identical, tomorrow ScanPackingOrder may add packaging-specific fields. The minor duplication of four fields buys real module autonomy — the kind of duplication the project rules explicitly accept.
+
+#### Decision 2: DTO location inside the use-case folder, not a `Contracts/` folder
+
+**Options considered:**
+- (A) Place `PackingOrderItemDto` in `ShoptetOrders/UseCases/GetPackingOrder/` next to `GetPackingOrderResponse.cs`.
+- (B) Place it in `ShoptetOrders/Contracts/` for symmetry with the brief's "or a `Contracts/` folder if the module grows" remark.
+
+**Chosen approach:** (A). DTO lives in the use-case folder.
+
+**Rationale:** `docs/architecture/filesystem.md` distinguishes Simple Features from Complex Features. ShoptetOrders has two use cases (`GetPackingOrder`, `BlockOrderProcessing`); Packaging has five. Neither has a `Contracts/` folder today, and the existing precedent for use-case-local DTOs is strong (`Article/UseCases/ListArticles/ArticleListItemDto.cs`, `Catalog/UseCases/GetProductComposition/IngredientDto.cs`, `Smartsupp/UseCases/ListWebhookAudit/WebhookAuditSummaryDto.cs`). Introducing a `Contracts/` folder for a single DTO would be premature structure. The spec already chose this placement — confirming it as correct.
+
+#### Decision 3: Hand-written projection, no AutoMapper
+
+**Options considered:**
+- (A) Inline `Select(i => new PackingOrderItemDto { ... })` in each handler.
+- (B) Add a static extension `ToDto(this PackingOrderItem item)` per module.
+- (C) Introduce AutoMapper / Mapster.
+
+**Chosen approach:** (A). Inline projection.
+
+**Rationale:** Four fields, two call sites. (B) is a single layer of indirection for zero re-use beyond what (A) gives you. (C) violates the "surgical changes" rule in `CLAUDE.md` and would add a profile, a registration, and a runtime dependency for an O(n) `Select`. (A) is the lightest change that satisfies the requirement.
+
+#### Decision 4: `sealed class` over `class`
+
+**Options considered:**
+- (A) `public class PackingOrderItemDto { ... }`.
+- (B) `public sealed class PackingOrderItemDto { ... }`.
+
+**Chosen approach:** (B) `sealed class`.
+
+**Rationale:** Every use-case-local DTO in the codebase that I found uses `sealed` (e.g. `ArticleListItemDto.cs:5`). The spec says "public classes with public get/set properties" without specifying `sealed`. Match the codebase precedent.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Two new files, no folder changes:
+
+```
+backend/src/Anela.Heblo.Application/Features/
+├── ShoptetOrders/
+│   ├── IPackingOrderClient.cs                    (edit: tighten XML doc on PackingOrderItem)
+│   └── UseCases/GetPackingOrder/
+│       ├── GetPackingOrderHandler.cs             (edit: project Items)
+│       ├── GetPackingOrderResponse.cs            (edit: change List<T>)
+│       └── PackingOrderItemDto.cs                ← NEW
+└── Packaging/UseCases/ScanPackingOrder/
+    ├── ScanPackingOrderHandler.cs                (edit: project Items)
+    ├── ScanPackingOrderResponse.cs               (edit: change List<T>, drop unused using)
+    └── ScanPackingOrderItemDto.cs                ← NEW
+
+backend/test/Anela.Heblo.Tests/Application/
+├── ShoptetOrders/GetPackingOrderHandlerTests.cs  (edit + add reflection assertion)
+└── Packaging/ScanPackingOrderHandlerTests.cs     (edit + add reflection assertion)
+```
+
+`ResetOrderShipmentHandler.cs` is **not** touched — it never returns `PackingOrderItem` in its response (`ResetOrderShipmentResponse` uses `ResetShipmentData`/`ResetShipmentPackage`). It only reads `i.WeightGrams` from the internal contract for its own weight math (`ResetOrderShipmentHandler.cs:58`). That stays valid.
+
+### Interfaces and Contracts
+
+**New (both files):**
+```csharp
+namespace Anela.Heblo.Application.Features.ShoptetOrders.UseCases.GetPackingOrder;
+
+public sealed class PackingOrderItemDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public string? ImageUrl { get; set; }
+    public string? SetName { get; set; }
+}
+```
+
+```csharp
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
+
+public sealed class ScanPackingOrderItemDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public string? ImageUrl { get; set; }
+    public string? SetName { get; set; }
+}
+```
+
+**Internal contract (existing, doc tightened):**
+```csharp
+/// <summary>A single line on a packing order. Internal contract — not an API DTO.</summary>
+public class PackingOrderItem
+{
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public string? ImageUrl { get; set; }
+    public string? SetName { get; set; }
+    public int WeightGrams { get; set; }
+}
+```
+
+### Data Flow
+
+**GET packing order (read path):**
+```
+HTTP GET → Controller → GetPackingOrderRequest
+  → GetPackingOrderHandler
+      → IPackingOrderClient.GetPackingOrderAsync()  [ShoptetApi adapter builds PackingOrder + PackingOrderItem incl. WeightGrams]
+      → Project: order.Items.Select(i => new PackingOrderItemDto { Name, Quantity, ImageUrl, SetName }).ToList()
+      → GetPackingOrderResponse { Items: List<PackingOrderItemDto> }    ← WeightGrams dropped at projection boundary
+  → JSON serialization → HTTP
+```
+
+**POST scan packing order (write path):**
+```
+HTTP POST → Controller → ScanPackingOrderRequest
+  → ScanPackingOrderHandler
+      → IPackingOrderClient.GetPackingOrderAsync()  [PackingOrderItem incl. WeightGrams]
+      → uses order.Items[i].WeightGrams * Quantity for shipment weight (internal calc, unchanged)
+      → Project: order.Items.Select(i => new ScanPackingOrderItemDto { Name, Quantity, ImageUrl, SetName }).ToList()
+      → ScanOrderData { Items: List<ScanPackingOrderItemDto> }          ← WeightGrams dropped at projection boundary
+      → carrier + label work continues
+  → ScanPackingOrderResponse → JSON → HTTP
+```
+
+The weight-calculation logic in `ScanPackingOrderHandler.cs:102` (`order.Items.Sum(i => i.WeightGrams * i.Quantity)`) continues to read from `order.Items` (internal `PackingOrderItem`) — not from `orderData.Items` (now DTO). The projection happens once, into `orderData.Items`, and is independent of the math. Verify ordering in the edited handler: build `orderData` last (after weight math), or be careful to project into a local first.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Future developer adds field to internal `PackingOrderItem` expecting it to flow through to API (the very mistake this fixes) | High | FR-7 reflection tests fail CI if `WeightGrams` (or any property beyond the four) appears on either DTO. Keep test wording explicit so the failure message points at the cause. |
+| Backward-compat break: a client reads `.weightGrams` from the JSON response | Low | Verified: no consumer in `frontend/src/` reads `.weightGrams` outside the generated client. Hand-written FE interface (`useScanPackingOrder.ts:11`) already omits it. OQ-1 in the spec is therefore resolved as "safe to remove." |
+| `ScanPackingOrderHandler` projection placed before the weight calculation reads from the wrong collection | Medium | Implementation guidance: place the `.ToList()` projection into `orderData.Items` only after, or independent of, the weight math at line 102. The existing test that exercises the weight-eligibility path (`MinPackageWeightGrams = 100`) covers this — its expectation must continue to pass. |
+| OpenAPI client regeneration not picked up by local dev | Low | `docs/development/api-client-generation.md` states the client is auto-regenerated on backend build. Spec requires `npm run build` + `npm run lint` to pass — that catches a stale client. |
+| Other tests construct `PackingOrderItem` to set up the `IPackingOrderClient` mock and would not need changes | Low | Confirmed: `ResetOrderShipmentHandlerTests.cs:37`, `CreateOrderShipmentHandlerTests.cs:36`, `ScanPackingOrderHandlerPackagePersistenceTests.cs:77` use `PackingOrderItem` only on the mock-input side — they are unaffected. Spec FR-7 bullet 3 already calls this out. |
+| Cross-module coupling between Packaging and ShoptetOrders is reinforced (Packaging keeps importing `PackingOrderItem`) | Low (accepted) | Already the existing arrangement and documented as the cross-module pattern. Not in scope; future audit (per spec "Out of Scope" §2) may address whether Packaging should own its own minimal adapter contract. |
+
+## Specification Amendments
+
+**Amendment 1 (cosmetic):** Use `sealed class` rather than `class` for both new DTOs, matching the precedent in `ArticleListItemDto.cs:5`, `IngredientDto.cs`, `WebhookAuditSummaryDto.cs`, and every other use-case-local DTO inspected. Update FR-1's acceptance criteria to read "Both are public **sealed** classes with public get/set properties."
+
+**Amendment 2 (clarification):** FR-4's instruction for `ScanPackingOrderHandler` should explicitly state: *the projection into `ScanPackingOrderItemDto` must use `order.Items` (the internal collection), and must not replace the internal collection used by the weight calculation at line 102.* As worded, the spec implies this; making it explicit prevents an accidental "single mutation" implementation that breaks weight math.
+
+**Amendment 3 (resolves OQ-1, which the spec already lists as `None` but the NFR-3 paragraph leaves implicit):** A grep over `frontend/src/**/*.ts{,x}` excluding `generated/api-client.ts` returned zero matches for `weightGrams` or `WeightGrams`. The removal is safe. Add an explicit one-line note to NFR-3: "Verified 2026-06-05: no consumer of `weightGrams` exists in the frontend source outside the generated client."
+
+**Amendment 4 (test-hygiene):** Add a fourth required test in FR-7: a reflection assertion that `PackingOrderItem` (the internal type) still **does** have `WeightGrams` — this anchors the symmetric guarantee and would catch an over-eager future cleanup that drops it from the internal contract and silently regresses the shipment weight calc.
+
+No structural amendments. The spec is sound.
+
+## Prerequisites
+
+None. This change is purely additive (two new files) plus four small edits and test updates. No DB migration, no config, no infrastructure work, no new packages, no new DI registrations. Build-time OpenAPI regeneration is already wired (`docs/development/api-client-generation.md`).
+
+Validation gates per `CLAUDE.md`: `dotnet build` + `dotnet format`, all touched tests pass under `dotnet test`, `npm run build` + `npm run lint` in `frontend/`. E2E suite is nightly and out-of-band — not required for this change.
+```

--- a/artifacts/feat-arch-review-shoptetorders-packingorderit/brief.md
+++ b/artifacts/feat-arch-review-shoptetorders-packingorderit/brief.md
@@ -1,0 +1,42 @@
+## Module
+ShoptetOrders
+
+## Finding
+`PackingOrderItem` is defined in `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs` (lines 48–60) as part of the `IPackingOrderClient` contract — an Application-layer service interface. The class carries an explicit comment:
+
+> "A single line on the packing screen. **Also serialized in the API response.**"
+
+`GetPackingOrderResponse` (line 25 of `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderResponse.cs`) declares:
+
+```csharp
+public List<PackingOrderItem> Items { get; set; } = new();
+```
+
+This means the same type serves two distinct roles:
+
+1. Internal contract between `IPackingOrderClient` implementations and the application handler.
+2. External API DTO serialized to JSON and exposed to clients (confirmed in generated TypeScript client `PackingOrderItem` at `frontend/src/api/generated/api-client.ts` line 30113, including the `weightGrams` field).
+
+The `WeightGrams` property is an example of leakage: it was added to support backend packing-weight calculations but is now part of the public API surface. The frontend `PackingOrderItem` interface in `useScanPackingOrder.ts` (line 12) does **not** include a weight field — it has its own separately maintained type — which means the two clients of packing-order items are already diverging.
+
+## Why it matters
+Per `development_guidelines.md`: DTOs live in `contracts/` of the specific module and must not be shared. The double role violates this rule: any field added to the internal contract automatically becomes part of the public API, and any change to the public API forces changes to the internal contract. The types cannot evolve independently.
+
+## Suggested fix
+Introduce a dedicated `PackingOrderItemDto` in `UseCases/GetPackingOrder/` (or a `Contracts/` folder if the module grows):
+
+```csharp
+public class PackingOrderItemDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public string? ImageUrl { get; set; }
+    public string? SetName { get; set; }
+    // WeightGrams is intentionally omitted — internal detail only
+}
+```
+
+Change `GetPackingOrderResponse.Items` to `List<PackingOrderItemDto>` and map in the handler. Remove the "Also serialized in the API response" comment from `PackingOrderItem`.
+
+---
+_Filed by daily arch-review routine on 2026-06-05._

--- a/artifacts/feat-arch-review-shoptetorders-packingorderit/impl/main.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packingorderit/impl/main.r1.md
@@ -1,0 +1,69 @@
+All 5 tasks complete. Writing the output summary.
+
+---
+
+# Implementation: Separate Internal `PackingOrderItem` from Public API DTO
+
+## What was implemented
+
+Split the dual-role `PackingOrderItem` class (formerly both an internal adapter contract and a public API DTO) into three clearly scoped types:
+- Internal: `PackingOrderItem` (keeps `WeightGrams`) — adapter contract only
+- Public: `PackingOrderItemDto` — GetPackingOrder use case
+- Public: `ScanPackingOrderItemDto` — ScanPackingOrder use case
+
+Both handlers now project at the response boundary (dropping `WeightGrams`). The weight calculation in `ScanPackingOrderHandler:102` continues reading from `order.Items` (internal collection). Reflection-based tests lock the API surface so future field leakage fails CI.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs` — doc comment tightened: "Internal contract — not an API DTO"
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/PackingOrderItemDto.cs` — new `sealed class`, 4 fields (Name, Quantity, ImageUrl, SetName)
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderResponse.cs` — `Items` type changed to `List<PackingOrderItemDto>`
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs` — `Items` assignment replaced with `.Select()` projection
+- `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderItemDto.cs` — new `sealed class`, 4 fields
+- `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderResponse.cs` — `ScanOrderData.Items` type changed; unused `using` removed
+- `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` — `Items` assignment projected; weight-calc line unchanged
+- `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs` — reflection test added
+- `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs` — 2 reflection tests added (DTO shape + symmetric WeightGrams guarantee)
+- `frontend/src/api/generated/api-client.ts` — auto-regenerated; `weightGrams` absent from both DTO types
+
+## Tests
+
+- `GetPackingOrderHandlerTests.cs`: added `PackingOrderItemDto_HasExactlyTheFourPublicFields_AndNoWeightGrams`
+- `ScanPackingOrderHandlerTests.cs`: added `ScanPackingOrderItemDto_HasExactlyTheFourPublicFields_AndNoWeightGrams` and `InternalPackingOrderItem_StillExposesWeightGrams_ForShipmentMath`
+- All 4,456 backend tests pass (3 skipped); existing weight-eligibility tests pass unchanged
+
+## How to verify
+
+```bash
+cd backend && dotnet build && dotnet test
+cd frontend && npm run build
+grep -n "weightGrams" frontend/src/api/generated/api-client.ts || echo "OK: absent"
+grep -rn "List<PackingOrderItem>" backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/
+```
+Expected: all tests green; `weightGrams` absent from client; boundary grep returns zero matches.
+
+## Notes
+
+- Pre-existing frontend lint errors in 144 test files (unrelated to this change) — those existed before the branch and are out of scope per spec.
+- NSwag required explicit invocation (`dotnet nswag run nswag.frontend.json`) rather than auto post-build, but the result is equivalent.
+- All 4 arch-review amendments applied: `sealed class` on both DTOs, explicit projection-vs-weight-calc ordering in ScanPackingOrderHandler, OQ-1 resolved (no frontend consumer of `weightGrams`), symmetric reflection test anchoring `PackingOrderItem.WeightGrams`.
+
+## PR Summary
+
+Split `PackingOrderItem` — previously both an internal adapter contract and a public API DTO — into three clearly scoped types. The internal type retains `WeightGrams` for shipment-weight calculations; the two new module-local DTOs (`PackingOrderItemDto`, `ScanPackingOrderItemDto`) expose only the four public fields to API clients.
+
+This prevents internal fields from leaking into the public contract: `WeightGrams` was already being serialized to the frontend (visible in the generated client), even though no frontend consumer used it. Both handlers now project explicitly at the response boundary. Reflection-based tests lock the API surface so any future internal field would fail CI before reaching clients.
+
+### Changes
+- `IPackingOrderClient.cs` — tightened doc on `PackingOrderItem` to declare it an internal contract
+- `PackingOrderItemDto.cs` — new sealed DTO (4 fields) for GetPackingOrder use case
+- `GetPackingOrderResponse.cs` — `Items` now `List<PackingOrderItemDto>`
+- `GetPackingOrderHandler.cs` — explicit projection from internal → DTO
+- `ScanPackingOrderItemDto.cs` — new sealed DTO (4 fields) for ScanPackingOrder use case
+- `ScanPackingOrderResponse.cs` — `ScanOrderData.Items` now `List<ScanPackingOrderItemDto>`; unused `using` removed
+- `ScanPackingOrderHandler.cs` — explicit projection; weight-calc line reads from internal collection unchanged
+- `GetPackingOrderHandlerTests.cs` / `ScanPackingOrderHandlerTests.cs` — reflection tests lock DTO shape
+- `api-client.ts` — regenerated; `weightGrams` absent from both packing-order DTO types
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-shoptetorders-packingorderit/spec.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packingorderit/spec.r1.md
@@ -1,0 +1,181 @@
+# Specification: Separate Internal `PackingOrderItem` from Public API DTO
+
+## Summary
+The `PackingOrderItem` class in `IPackingOrderClient.cs` serves dual roles: an internal Application-layer contract between client adapters and handlers, and a public API DTO serialized to JSON. This conflation violates the project's DTO isolation rule and has already caused leakage of internal fields (`WeightGrams`) into the public API. This work splits the type so the internal contract and the public DTO can evolve independently.
+
+## Background
+Per `docs/architecture/development_guidelines.md`, DTOs live in the `contracts/` (or use-case) folder of their owning module and must not be shared across module or layer boundaries. The current implementation breaks this rule in two places:
+
+1. `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs` (lines 47–60) declares `PackingOrderItem` as the return shape of the `IPackingOrderClient` adapter contract. The class carries the comment "A single line on the packing screen. Also serialized in the API response."
+2. `GetPackingOrderResponse.Items` (`Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderResponse.cs:25`) directly references the same type, exposing it via the public REST contract.
+3. `ScanOrderData.Items` (`Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderResponse.cs:37`) — a different module — also re-uses the same `PackingOrderItem`, expanding the coupling across module boundaries.
+
+Concrete evidence of leakage:
+- `PackingOrderItem.WeightGrams` was added for backend shipment-weight calculations (`ScanPackingOrderHandler.cs:102`, `ResetOrderShipmentHandler.cs:58`). It is now serialized to clients (`frontend/src/api/generated/api-client.ts:30127` exposes `weightGrams?: number`).
+- The frontend already maintains a divergent hand-written `PackingOrderItem` in `frontend/src/api/hooks/useScanPackingOrder.ts:11` that **excludes** the weight field. The two clients of the type have already drifted.
+
+Without separation, any future internal field (e.g. cost basis, internal supplier code, stock IDs) automatically becomes part of the public API, and any public-API rename forces a churn on every adapter implementation.
+
+## Functional Requirements
+
+### FR-1: Introduce module-local API DTOs
+
+Introduce dedicated DTOs that represent the public API shape of a packing-order line item. Each use case owns its own DTO — DTOs must not be shared across modules, per `development_guidelines.md`.
+
+**Required new types:**
+
+1. `PackingOrderItemDto` in `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/`, with fields:
+   - `string Name`
+   - `int Quantity`
+   - `string? ImageUrl`
+   - `string? SetName`
+2. `ScanPackingOrderItemDto` in `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/`, with the same four fields.
+
+Both DTOs MUST be C# `class`es (not records) per the project rule that OpenAPI-generated DTOs cannot use C# `record` (see `CLAUDE.md`).
+
+**Acceptance criteria:**
+- `PackingOrderItemDto` exists in the GetPackingOrder use-case folder and contains only the four fields above.
+- `ScanPackingOrderItemDto` exists in the ScanPackingOrder use-case folder and contains only the four fields above.
+- Neither DTO contains `WeightGrams` nor any other internal field.
+- Both are public classes with public get/set properties.
+- Both files compile under `dotnet build`.
+
+### FR-2: Keep internal `PackingOrderItem` as the adapter contract
+
+The internal `PackingOrderItem` (in `IPackingOrderClient.cs`) MUST continue to carry `WeightGrams` because it is consumed by `ScanPackingOrderHandler` (`ScanPackingOrderHandler.cs:102`) and `ResetOrderShipmentHandler` (`ResetOrderShipmentHandler.cs:58`) for shipment-weight calculations. Its visibility scope shrinks: it is now strictly an Application-layer adapter contract, not an API surface.
+
+**Acceptance criteria:**
+- `PackingOrderItem` remains in `Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs`.
+- `PackingOrderItem.WeightGrams` is retained.
+- The XML doc comment on `PackingOrderItem` is updated to remove the "Also serialized in the API response" sentence and is reworded to state it is an internal Application contract only (mirroring the existing wording on `PackingOrder`: "Internal contract — not an API DTO").
+- No file outside the backend Application/Adapter assemblies references `PackingOrderItem`.
+
+### FR-3: Replace public-DTO references in response types
+
+Both response types must reference the new DTOs instead of the internal `PackingOrderItem`.
+
+**Required edits:**
+- `GetPackingOrderResponse.cs:25`: change `List<PackingOrderItem> Items` to `List<PackingOrderItemDto> Items`.
+- `ScanPackingOrderResponse.cs:37`: change `List<PackingOrderItem> Items` to `List<ScanPackingOrderItemDto> Items` (on the `ScanOrderData` class).
+- Remove now-unused `using Anela.Heblo.Application.Features.ShoptetOrders;` import from `ScanPackingOrderResponse.cs` if no other reference remains.
+
+**Acceptance criteria:**
+- Neither `GetPackingOrderResponse` nor `ScanOrderData` references the internal `PackingOrderItem` type.
+- `dotnet build` succeeds with no warnings about unused imports.
+
+### FR-4: Map internal → DTO in handlers
+
+Each handler that returns one of the public responses MUST perform an explicit mapping from `PackingOrderItem` to its module-local DTO. The mapping drops `WeightGrams` and copies the remaining four fields verbatim.
+
+**Required edits:**
+- `GetPackingOrderHandler.cs:56`: replace `Items = order.Items` with a projection: `Items = order.Items.Select(i => new PackingOrderItemDto { Name = i.Name, Quantity = i.Quantity, ImageUrl = i.ImageUrl, SetName = i.SetName }).ToList()`.
+- `ScanPackingOrderHandler` (the call site that builds `ScanOrderData.Items`): apply the same projection to `ScanPackingOrderItemDto`. The handler MUST continue to use `order.Items[i].WeightGrams` for the existing weight-calculation logic at `ScanPackingOrderHandler.cs:102` — only the output projection changes.
+
+**Acceptance criteria:**
+- Both handlers compile and produce response objects whose `Items` collections contain DTO instances (not internal `PackingOrderItem`).
+- Weight calculations in `ScanPackingOrderHandler` and `ResetOrderShipmentHandler` are functionally unchanged.
+- An xUnit test for each handler asserts that `WeightGrams` does NOT appear on the serialized response (see FR-7).
+
+### FR-5: Regenerate the OpenAPI TypeScript client
+
+The frontend OpenAPI-generated client (`frontend/src/api/generated/api-client.ts`) is auto-generated on build (per `docs/development/api-client-generation.md`). After backend changes, the generated `PackingOrderItem` TypeScript class MUST no longer contain `weightGrams`.
+
+**Acceptance criteria:**
+- After running the standard build, `frontend/src/api/generated/api-client.ts` no longer contains a `weightGrams` field on any `PackingOrderItem`-related class.
+- `npm run build` and `npm run lint` succeed in `frontend/`.
+
+### FR-6: Reconcile the hand-written frontend type
+
+`frontend/src/api/hooks/useScanPackingOrder.ts:11` defines a hand-written `PackingOrderItem` interface that already excludes weight. Its shape now matches the generated DTO exactly, so the hand-written interface should be considered for removal in favor of the generated one — but this is out of scope (see Out of Scope §1) because the hook intentionally uses a custom-fetch flow rather than the generated client.
+
+**Acceptance criteria:**
+- The hand-written interface in `useScanPackingOrder.ts` continues to compile and is not modified.
+- No new fields are introduced to it as part of this work.
+
+### FR-7: Tests assert API-surface boundary
+
+Add or update tests to lock in the contract boundary so future regressions are caught.
+
+**Required tests:**
+1. In `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs`: assert that `GetPackingOrderResponse.Items[0]` is of type `PackingOrderItemDto` and that the type does NOT have a `WeightGrams` property (use reflection: `typeof(PackingOrderItemDto).GetProperty("WeightGrams").Should().BeNull()`).
+2. In `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs`: same assertion for `ScanPackingOrderItemDto`.
+3. Existing tests in those files that construct or assert `PackingOrderItem` must be updated to use the new DTO types where they assert on response shape, and continue using the internal `PackingOrderItem` where they exercise the `IPackingOrderClient` mock.
+
+**Acceptance criteria:**
+- All affected test files compile and pass under `dotnet test`.
+- Each handler has at least one test that fails if `WeightGrams` (or any other field beyond the four allowed) is re-added to the public DTO.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact expected. The added projection is O(n) over the items list (typical order: <50 items), runs once per request, and replaces a reference assignment that the JSON serializer was already iterating.
+
+### NFR-2: Security
+Reducing the public API surface is a defensive improvement: internal fields like `WeightGrams` (and any future internal-only fields) cannot accidentally leak to clients. No new auth, validation, or input-handling code is introduced. Existing endpoint authorization is unchanged.
+
+### NFR-3: Backward compatibility
+The public API loses one field: `weightGrams` on each `PackingOrderItem` entry of `GET /api/.../packing-orders/{code}` and `POST /api/packaging/orders/{code}/scan` responses. The frontend's hand-written interface already does not consume this field (`useScanPackingOrder.ts:11`), and the only generated-client consumer would be the OpenAPI client — verify no production code path reads `.weightGrams` (Open Question OQ-1). All other field names, types, and nullability remain unchanged.
+
+### NFR-4: Code quality
+- All new DTOs follow `csharp-coding-style.md`: explicit access modifiers, nullable reference types, classes (not records) for OpenAPI compatibility per `CLAUDE.md`.
+- The internal `PackingOrderItem` comment is updated for accuracy.
+- No new abstractions or factory layers introduced — direct in-handler projection only, per the project's "surgical changes" principle.
+
+## Data Model
+
+Two layers, kept structurally identical except for the internal `WeightGrams` field:
+
+**Internal (adapter contract, unchanged shape):**
+```
+PackingOrderItem (Features/ShoptetOrders/IPackingOrderClient.cs)
+├── Name: string
+├── Quantity: int
+├── ImageUrl: string?
+├── SetName: string?
+└── WeightGrams: int          ← internal only, kept
+```
+
+**Public (module-local DTOs, new):**
+```
+PackingOrderItemDto (Features/ShoptetOrders/UseCases/GetPackingOrder/)
+├── Name: string
+├── Quantity: int
+├── ImageUrl: string?
+└── SetName: string?
+
+ScanPackingOrderItemDto (Features/Packaging/UseCases/ScanPackingOrder/)
+├── Name: string
+├── Quantity: int
+├── ImageUrl: string?
+└── SetName: string?
+```
+
+The two DTOs are intentionally structurally identical today but live in their owning modules and may evolve independently (e.g. ScanPackingOrder could later add packaging-specific fields).
+
+## API / Interface Design
+
+**No URL, verb, status code, or auth changes.**
+
+Affected endpoints (response payloads change shape only — one removed field):
+- `GET` GetPackingOrder endpoint → `GetPackingOrderResponse` (`Items` items lose `weightGrams`).
+- `POST /api/packaging/orders/{orderCode}/scan` → `ScanPackingOrderResponse.Order.Items` items lose `weightGrams`.
+
+The OpenAPI spec regenerates automatically from the response types. Verify the regenerated spec reflects the smaller object shape.
+
+## Dependencies
+- No new packages, services, or external dependencies.
+- Touches: `Features/ShoptetOrders/IPackingOrderClient.cs`, `Features/ShoptetOrders/UseCases/GetPackingOrder/*`, `Features/Packaging/UseCases/ScanPackingOrder/*`, related tests, and the auto-regenerated `frontend/src/api/generated/api-client.ts`.
+- The `ShoptetApiPackingOrderClient` adapter (`backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs`) is **not** modified — it continues to build internal `PackingOrderItem` instances with `WeightGrams`.
+
+## Out of Scope
+1. Refactoring the hand-written `PackingOrderItem` interface in `frontend/src/api/hooks/useScanPackingOrder.ts` to use the generated client. The hook uses a bespoke fetch path for reasons unrelated to this finding.
+2. Wider audit of other Application-layer types that may also dual-role (e.g. `PackingOrder` itself, `ScanShipmentPackage`). This spec is limited to `PackingOrderItem` as identified in the brief.
+3. Renaming, restructuring, or adding fields to either the internal type or the DTOs. The mapping is field-for-field with the single deliberate omission of `WeightGrams`.
+4. Introducing a generic mapper (AutoMapper / Mapster). The project favors hand-written projections per the surgical-changes principle.
+5. Migrating `PackingOrderItem` to a `Contracts/` folder. The brief allows this option "if the module grows" but is not requested now.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-shoptetorders-packingorderit/task-plan.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packingorderit/task-plan.r1.md
@@ -1,0 +1,11 @@
+Plan saved to `artifacts/feat-arch-review-shoptetorders-packingorderit/plan.r1.md`.
+
+**Summary:**
+- 5 tasks, ~30 bite-sized steps total, TDD flow throughout (reflection tests written first → confirm RED → implement → GREEN → commit).
+- Task 1: Tighten internal `PackingOrderItem` doc comment (1 file, 1 line).
+- Task 2: Introduce `PackingOrderItemDto` + wire `GetPackingOrderResponse` and `GetPackingOrderHandler`.
+- Task 3: Introduce `ScanPackingOrderItemDto` + wire `ScanOrderData` and `ScanPackingOrderHandler` — with explicit warning that the weight-calc at line 102 must keep reading from `order.Items` (internal contract), not the projected DTO list.
+- Task 4: Verify OpenAPI client regeneration drops `weightGrams`; `npm run build` + `npm run lint` succeed.
+- Task 5: End-to-end validation gates + final grep-based boundary checks.
+
+All four arch-review amendments are folded in: `sealed class` for DTOs, explicit projection-vs-weight-math separation in `ScanPackingOrderHandler`, the resolved OQ-1 noted in NFR-3, and the symmetric reflection test asserting internal `PackingOrderItem.WeightGrams` is retained. Self-review confirms every spec requirement maps to a task.

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
@@ -57,7 +57,15 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
             CustomerNote = order.CustomerNote,
             EshopNote = order.EshopNote,
             ShippingAddress = BuildShippingAddress(order),
-            Items = order.Items,
+            Items = order.Items
+                .Select(i => new ScanPackingOrderItemDto
+                {
+                    Name = i.Name,
+                    Quantity = i.Quantity,
+                    ImageUrl = i.ImageUrl,
+                    SetName = i.SetName,
+                })
+                .ToList(),
             Eligibility = new ScanOrderEligibility
             {
                 IsEligible = isEligible,

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderItemDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderItemDto.cs
@@ -1,0 +1,14 @@
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
+
+/// <summary>Public API DTO for a single packing-order line returned by ScanPackingOrder.</summary>
+public sealed class ScanPackingOrderItemDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+
+    /// <summary>Product image URL from the catalog; null when unavailable.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Parent set name when this item is a product-set component; null otherwise.</summary>
+    public string? SetName { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderResponse.cs
@@ -1,4 +1,3 @@
-using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Shared;
 
@@ -34,7 +33,7 @@ public class ScanOrderData
     public string? EshopNote { get; set; }
     public ShippingAddress? ShippingAddress { get; set; }
     public ScanOrderEligibility Eligibility { get; set; } = null!;
-    public List<PackingOrderItem> Items { get; set; } = [];
+    public List<ScanPackingOrderItemDto> Items { get; set; } = [];
 }
 
 public class ShippingAddress

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
@@ -44,7 +44,7 @@ public class PackingOrder
     public List<PackingOrderItem> Items { get; set; } = new();
 }
 
-/// <summary>A single line on the packing screen. Also serialized in the API response.</summary>
+/// <summary>A single line on a packing order. Internal contract — not an API DTO.</summary>
 public class PackingOrderItem
 {
     public string Name { get; set; } = string.Empty;

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs
@@ -53,7 +53,15 @@ public class GetPackingOrderHandler : IRequestHandler<GetPackingOrderRequest, Ge
                 },
                 CustomerNote = order.CustomerNote,
                 EshopNote = order.EshopNote,
-                Items = order.Items,
+                Items = order.Items
+                    .Select(i => new PackingOrderItemDto
+                    {
+                        Name = i.Name,
+                        Quantity = i.Quantity,
+                        ImageUrl = i.ImageUrl,
+                        SetName = i.SetName,
+                    })
+                    .ToList(),
             };
         }
         catch (Exception ex)

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderResponse.cs
@@ -22,5 +22,5 @@ public class GetPackingOrderResponse : BaseResponse
     public PackingEligibility Eligibility { get; set; } = new();
     public string? CustomerNote { get; set; }
     public string? EshopNote { get; set; }
-    public List<PackingOrderItem> Items { get; set; } = new();
+    public List<PackingOrderItemDto> Items { get; set; } = new();
 }

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/PackingOrderItemDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/PackingOrderItemDto.cs
@@ -1,0 +1,14 @@
+namespace Anela.Heblo.Application.Features.ShoptetOrders.UseCases.GetPackingOrder;
+
+/// <summary>Public API DTO for a single packing-order line returned by GetPackingOrder.</summary>
+public sealed class PackingOrderItemDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+
+    /// <summary>Product image URL from the catalog; null when unavailable.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Parent set name when this item is a product-set component; null otherwise.</summary>
+    public string? SetName { get; set; }
+}

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
@@ -444,4 +444,26 @@ public class ScanPackingOrderHandlerTests
             c => c.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    [Fact]
+    public void ScanPackingOrderItemDto_HasExactlyTheFourPublicFields_AndNoWeightGrams()
+    {
+        var properties = typeof(ScanPackingOrderItemDto)
+            .GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+            .Select(p => p.Name)
+            .ToHashSet();
+
+        properties.Should().BeEquivalentTo(new[] { "Name", "Quantity", "ImageUrl", "SetName" },
+            "ScanPackingOrderItemDto must not expose internal fields such as WeightGrams to API clients.");
+        typeof(ScanPackingOrderItemDto).GetProperty("WeightGrams").Should().BeNull();
+    }
+
+    [Fact]
+    public void InternalPackingOrderItem_StillExposesWeightGrams_ForShipmentMath()
+    {
+        // Anchor the symmetric guarantee: WeightGrams must remain on the internal adapter
+        // contract because ScanPackingOrderHandler and ResetOrderShipmentHandler depend on it.
+        typeof(PackingOrderItem).GetProperty("WeightGrams").Should().NotBeNull(
+            "PackingOrderItem is the internal Application contract and ScanPackingOrderHandler.cs:102 reads WeightGrams.");
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs
@@ -128,4 +128,17 @@ public class GetPackingOrderHandlerTests
         response.Success.Should().BeFalse();
         response.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
     }
+
+    [Fact]
+    public void PackingOrderItemDto_HasExactlyTheFourPublicFields_AndNoWeightGrams()
+    {
+        var properties = typeof(PackingOrderItemDto)
+            .GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+            .Select(p => p.Name)
+            .ToHashSet();
+
+        properties.Should().BeEquivalentTo(new[] { "Name", "Quantity", "ImageUrl", "SetName" },
+            "PackingOrderItemDto must not expose internal fields such as WeightGrams to API clients.");
+        typeof(PackingOrderItemDto).GetProperty("WeightGrams").Should().BeNull();
+    }
 }

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -29961,7 +29961,7 @@ export class ScanOrderData implements IScanOrderData {
     eshopNote?: string | undefined;
     shippingAddress?: ShippingAddress | undefined;
     eligibility?: ScanOrderEligibility;
-    items?: PackingOrderItem[];
+    items?: ScanPackingOrderItemDto[];
 
     constructor(data?: IScanOrderData) {
         if (data) {
@@ -29986,7 +29986,7 @@ export class ScanOrderData implements IScanOrderData {
             if (Array.isArray(_data["items"])) {
                 this.items = [] as any;
                 for (let item of _data["items"])
-                    this.items!.push(PackingOrderItem.fromJS(item));
+                    this.items!.push(ScanPackingOrderItemDto.fromJS(item));
             }
         }
     }
@@ -30028,7 +30028,7 @@ export interface IScanOrderData {
     eshopNote?: string | undefined;
     shippingAddress?: ShippingAddress | undefined;
     eligibility?: ScanOrderEligibility;
-    items?: PackingOrderItem[];
+    items?: ScanPackingOrderItemDto[];
 }
 
 export class ShippingAddress implements IShippingAddress {
@@ -30119,14 +30119,13 @@ export interface IScanOrderEligibility {
     warningBody?: string | undefined;
 }
 
-export class PackingOrderItem implements IPackingOrderItem {
+export class ScanPackingOrderItemDto implements IScanPackingOrderItemDto {
     name?: string;
     quantity?: number;
     imageUrl?: string | undefined;
     setName?: string | undefined;
-    weightGrams?: number;
 
-    constructor(data?: IPackingOrderItem) {
+    constructor(data?: IScanPackingOrderItemDto) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -30141,13 +30140,12 @@ export class PackingOrderItem implements IPackingOrderItem {
             this.quantity = _data["quantity"];
             this.imageUrl = _data["imageUrl"];
             this.setName = _data["setName"];
-            this.weightGrams = _data["weightGrams"];
         }
     }
 
-    static fromJS(data: any): PackingOrderItem {
+    static fromJS(data: any): ScanPackingOrderItemDto {
         data = typeof data === 'object' ? data : {};
-        let result = new PackingOrderItem();
+        let result = new ScanPackingOrderItemDto();
         result.init(data);
         return result;
     }
@@ -30158,17 +30156,15 @@ export class PackingOrderItem implements IPackingOrderItem {
         data["quantity"] = this.quantity;
         data["imageUrl"] = this.imageUrl;
         data["setName"] = this.setName;
-        data["weightGrams"] = this.weightGrams;
         return data;
     }
 }
 
-export interface IPackingOrderItem {
+export interface IScanPackingOrderItemDto {
     name?: string;
     quantity?: number;
     imageUrl?: string | undefined;
     setName?: string | undefined;
-    weightGrams?: number;
 }
 
 export class ScanShipmentData implements IScanShipmentData {
@@ -35076,7 +35072,7 @@ export class GetPackingOrderResponse extends BaseResponse implements IGetPacking
     eligibility?: PackingEligibility;
     customerNote?: string | undefined;
     eshopNote?: string | undefined;
-    items?: PackingOrderItem[];
+    items?: PackingOrderItemDto[];
 
     constructor(data?: IGetPackingOrderResponse) {
         super(data);
@@ -35096,7 +35092,7 @@ export class GetPackingOrderResponse extends BaseResponse implements IGetPacking
             if (Array.isArray(_data["items"])) {
                 this.items = [] as any;
                 for (let item of _data["items"])
-                    this.items!.push(PackingOrderItem.fromJS(item));
+                    this.items!.push(PackingOrderItemDto.fromJS(item));
             }
         }
     }
@@ -35137,7 +35133,7 @@ export interface IGetPackingOrderResponse extends IBaseResponse {
     eligibility?: PackingEligibility;
     customerNote?: string | undefined;
     eshopNote?: string | undefined;
-    items?: PackingOrderItem[];
+    items?: PackingOrderItemDto[];
 }
 
 export class PackingEligibility implements IPackingEligibility {
@@ -35182,6 +35178,54 @@ export interface IPackingEligibility {
     isEligible?: boolean;
     warningTitle?: string | undefined;
     warningBody?: string | undefined;
+}
+
+export class PackingOrderItemDto implements IPackingOrderItemDto {
+    name?: string;
+    quantity?: number;
+    imageUrl?: string | undefined;
+    setName?: string | undefined;
+
+    constructor(data?: IPackingOrderItemDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.name = _data["name"];
+            this.quantity = _data["quantity"];
+            this.imageUrl = _data["imageUrl"];
+            this.setName = _data["setName"];
+        }
+    }
+
+    static fromJS(data: any): PackingOrderItemDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackingOrderItemDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["name"] = this.name;
+        data["quantity"] = this.quantity;
+        data["imageUrl"] = this.imageUrl;
+        data["setName"] = this.setName;
+        return data;
+    }
+}
+
+export interface IPackingOrderItemDto {
+    name?: string;
+    quantity?: number;
+    imageUrl?: string | undefined;
+    setName?: string | undefined;
 }
 
 export class ListConversationsResponse extends BaseResponse implements IListConversationsResponse {


### PR DESCRIPTION

Split `PackingOrderItem` — previously both an internal adapter contract and a public API DTO — into three clearly scoped types. The internal type retains `WeightGrams` for shipment-weight calculations; the two new module-local DTOs (`PackingOrderItemDto`, `ScanPackingOrderItemDto`) expose only the four public fields to API clients.

This prevents internal fields from leaking into the public contract: `WeightGrams` was already being serialized to the frontend (visible in the generated client), even though no frontend consumer used it. Both handlers now project explicitly at the response boundary. Reflection-based tests lock the API surface so any future internal field would fail CI before reaching clients.

### Changes
- `IPackingOrderClient.cs` — tightened doc on `PackingOrderItem` to declare it an internal contract
- `PackingOrderItemDto.cs` — new sealed DTO (4 fields) for GetPackingOrder use case
- `GetPackingOrderResponse.cs` — `Items` now `List<PackingOrderItemDto>`
- `GetPackingOrderHandler.cs` — explicit projection from internal → DTO
- `ScanPackingOrderItemDto.cs` — new sealed DTO (4 fields) for ScanPackingOrder use case
- `ScanPackingOrderResponse.cs` — `ScanOrderData.Items` now `List<ScanPackingOrderItemDto>`; unused `using` removed
- `ScanPackingOrderHandler.cs` — explicit projection; weight-calc line reads from internal collection unchanged
- `GetPackingOrderHandlerTests.cs` / `ScanPackingOrderHandlerTests.cs` — reflection tests lock DTO shape
- `api-client.ts` — regenerated; `weightGrams` absent from both packing-order DTO types

---

Closes #2625

### Tokens used
17380599
