### PR TITLE
feat: Spec written to `artifacts/feat-arch-review-shoptetorders-packaging-modu/spec.md`. It covers:

### DIFF
--- a/artifacts/feat-arch-review-shoptetorders-packaging-modu/arch-review.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packaging-modu/arch-review.r1.md
@@ -1,0 +1,220 @@
+# Architecture Review: Decouple Packaging module from ShoptetOrdersSettings
+
+## Skip Design: true
+
+Backend-only refactor. No new screens, components, or visual changes. API response shape (`Eligibility.IsEligible`) is unchanged — `IsEligibleForPacking` lives on the internal contract DTO only.
+
+## Architectural Fit Assessment
+
+The proposal is an **excellent fit** — it removes a known violation of `docs/architecture/development_guidelines.md` ("No direct references between feature modules. Communication only through contracts/interfaces.") and aligns the `Packaging` module with the same pattern already used by every other cross-module consumer in the codebase (`ILeafletKnowledgeSource`/`KnowledgeBaseLeafletSourceAdapter` is the canonical example).
+
+Integration points are minimal and already exist:
+
+- `IPackingOrderClient` and `IEshopOrderClient` are the legitimate seams between `Packaging`/Shoptet handlers and the Shoptet adapter; both contracts already live in `Anela.Heblo.Application.Features.ShoptetOrders`.
+- `ShoptetApiPackingOrderClient` and `ShoptetOrderClient` are the natural homes for status-ID knowledge — they live in `Anela.Heblo.Adapters.ShoptetApi.Orders` and already reference the Application namespace to implement the contracts.
+- The `ShoptetOrdersSettings` options binding is already done by `ShoptetOrdersModule`; both adapters simply resolve `IOptions<ShoptetOrdersSettings>` from DI.
+
+No new infrastructure, no new module wiring, no new packages. The refactor compresses the rule "what does eligible-to-pack mean?" from two locations to one and removes the only remaining link from `Packaging` into `ShoptetOrders.ShoptetOrdersSettings`.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before (violation):
+
+  Packaging.ScanPackingOrderHandler ───────────┐
+                                               │ reads PackingStateId, PackedStateId
+                                               ▼
+  ShoptetOrders.GetPackingOrderHandler ──► ShoptetOrdersSettings (concrete config class)
+                                               ▲
+                                               │ reads PackingStateId
+                                               │
+                              ShoptetOrders.BlockOrderProcessingHandler
+
+After:
+
+  Packaging.ScanPackingOrderHandler
+       │ uses order.IsEligibleForPacking
+       │ uses _eshopOrderClient.MarkAsPackedAsync(orderCode, ct)
+       ▼
+  IPackingOrderClient ──── IEshopOrderClient            (contracts in Application/ShoptetOrders)
+       │                          │
+       ▼ implemented by           ▼ implemented by
+  ShoptetApiPackingOrderClient   ShoptetOrderClient     (adapters in Adapters.ShoptetApi)
+       │                          │
+       │ reads PackingStateId     │ reads PackedStateId
+       ▼                          ▼
+  ShoptetOrdersSettings  ◄─────────┘
+       ▲
+       │ unchanged
+  ShoptetOrders.BlockOrderProcessingHandler  (same module owns the setting — no boundary crossed)
+```
+
+After the refactor, `Anela.Heblo.Application.Features.Packaging` does not name `ShoptetOrdersSettings`, `PackingStateId`, or `PackedStateId` anywhere.
+
+### Key Design Decisions
+
+#### Decision 1: Place eligibility on the DTO, not as a separate query method
+
+**Options considered:**
+1. Add `bool IsEligibleForPacking { get; set; }` to `PackingOrder`.
+2. Add `Task<bool> IsEligibleForPackingAsync(string code, CancellationToken)` to `IPackingOrderClient`.
+3. Compute eligibility in the handler from a Shoptet-agnostic rule object (e.g., `IPackingEligibilityPolicy`).
+
+**Chosen approach:** Option 1, as the spec mandates.
+
+**Rationale:** The handler already has the `PackingOrder` in hand from `GetPackingOrderAsync`; a property is zero extra cost and zero extra round-trip. Option 2 doubles the HTTP traffic for the same answer. Option 3 introduces a new abstraction whose only consumer is the same place that already calls the client — premature generality.
+
+#### Decision 2: Name the status-transition method by business intent (`MarkAsPackedAsync`), keep generic `UpdateStatusAsync`
+
+**Options considered:**
+1. Add `MarkAsPackedAsync(string orderCode, CancellationToken)` alongside the existing `UpdateStatusAsync(string, int, CancellationToken)`.
+2. Replace `UpdateStatusAsync` with named per-transition methods (`MarkAsPackedAsync`, `MarkAsBlockedAsync`, …).
+3. Inject a separate `IPackingStatusTransitions` contract dedicated to packing concerns.
+
+**Chosen approach:** Option 1, as the spec mandates.
+
+**Rationale:** `UpdateStatusAsync` has known callers (`BlockOrderProcessingHandler`) that legitimately operate on raw status IDs because they live in the `ShoptetOrders` module and own those IDs. Replacing it (Option 2) is unnecessary scope. A dedicated contract (Option 3) over-abstracts a single method.
+
+#### Decision 3: Adapters read `ShoptetOrdersSettings` directly via `IOptions<T>`
+
+**Options considered:**
+1. Inject `IOptions<ShoptetOrdersSettings>` into `ShoptetApiPackingOrderClient` and `ShoptetOrderClient`.
+2. Introduce an adapter-local options class (e.g., `ShoptetApiPackingOptions`) mapped from `ShoptetOrdersSettings` at startup.
+3. Pass status IDs in via factory parameters at DI registration.
+
+**Chosen approach:** Option 1, as the spec mandates.
+
+**Rationale:** `Anela.Heblo.Adapters.ShoptetApi` already references `Anela.Heblo.Application.Features.ShoptetOrders` to implement the contracts; reading the sibling settings class from the same namespace adds no new coupling. Options 2 and 3 split one truth across two configuration shapes for no benefit.
+
+#### Decision 4: Leave `PackingOrder.StatusId` in place
+
+**Options considered:**
+1. Keep `StatusId` on the DTO (spec position).
+2. Remove `StatusId` immediately now that no handler reads it.
+
+**Chosen approach:** Option 1.
+
+**Rationale:** Spec defers this to a follow-up after confirming no remaining consumer. Risk of removal-without-audit is low (compile errors flag any reader) but the spec is explicit, so honour it. See **Specification Amendments** below for a small caveat.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. The change is **strictly additive on the contract side** and **subtractive on the consumer side**:
+
+| File | Change |
+|---|---|
+| `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs` | Add `bool IsEligibleForPacking { get; set; }` to `PackingOrder`. |
+| `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs` | Add `Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default);`. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` | Inject `IOptions<ShoptetOrdersSettings>`; set `IsEligibleForPacking = statusId == settings.PackingStateId` on the returned `PackingOrder`. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs` | Inject `IOptions<ShoptetOrdersSettings>`; implement `MarkAsPackedAsync` as a one-line delegate to `UpdateStatusAsync(orderCode, settings.PackedStateId, ct)`. |
+| `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` | Drop `ShoptetOrdersSettings` field/param, drop the `Microsoft.Extensions.Options` `using` if no other dep needs it. Use `order.IsEligibleForPacking` and `_eshopOrderClient.MarkAsPackedAsync(...)`. Update the warning log to `"Failed to mark order {OrderCode} as packed"`. |
+| `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs` | Drop `IOptions<ShoptetOrdersSettings>` (no other use exists in this handler — verified). Use `order.IsEligibleForPacking`. Remove the `Microsoft.Extensions.Options` `using`. |
+| `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs` | Remove `DefaultOrderSettings` and the `orderSettings` parameter from `CreateHandler`. Set `IsEligibleForPacking = true` in `EligibleOrder()`. In tests that exercise the ineligible path (`StatusId = 99`), set `IsEligibleForPacking = false` explicitly. Update the assertions on `UpdateStatusAsync` to assert `MarkAsPackedAsync("0001234", ...)` instead. |
+| `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs` | Same shape: drop the `ShoptetOrdersSettings` setup, set `IsEligibleForPacking` on the mocked `PackingOrder`. |
+
+`ShoptetApiAdapterServiceCollectionExtensions` requires **no change**: both adapter types already go through DI; `IOptions<ShoptetOrdersSettings>` resolves through the binding in `ShoptetOrdersModule`.
+
+### Interfaces and Contracts
+
+```csharp
+// IPackingOrderClient.cs
+public class PackingOrder
+{
+    public string Code { get; set; } = string.Empty;
+    public string CustomerName { get; set; } = string.Empty;
+    public string ShippingMethodName { get; set; } = string.Empty;
+    public Cooling Cooling { get; set; } = Cooling.None;
+    public bool IsCooled { get; set; }
+
+    /// <summary>Shoptet order status ID. Kept for diagnostic/logging use; do
+    /// not read this to derive eligibility — use <see cref="IsEligibleForPacking"/>.</summary>
+    public int StatusId { get; set; }
+
+    /// <summary>True when the order is in the configured Shoptet packing state
+    /// ("Balí se"). Computed by the adapter so callers do not need to know the
+    /// status-id rule.</summary>
+    public bool IsEligibleForPacking { get; set; }
+
+    // … unchanged …
+}
+
+// IEshopOrderClient.cs
+public interface IEshopOrderClient
+{
+    // … existing members …
+
+    /// <summary>Transitions the order to the configured "packed" state
+    /// (Shoptet "Zabaleno", id 52 by default).</summary>
+    Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default);
+}
+```
+
+Contract rules to enforce:
+
+- `IsEligibleForPacking` is set **only** by `ShoptetApiPackingOrderClient`. It must never be read or assigned in `Application.Features.Packaging` source. (Tests are the only legitimate writer outside the adapter, and only in setup helpers.)
+- `MarkAsPackedAsync` does **not** accept a status-id parameter and never will. Callers that want generic transitions continue to use `UpdateStatusAsync`.
+
+### Data Flow
+
+**GET `/api/packing-orders/{code}` (unchanged endpoint surface):**
+
+```
+HTTP GET → PackingOrderController
+        → MediatR → GetPackingOrderHandler
+              → IPackingOrderClient.GetPackingOrderAsync(code, ct)
+                    → ShoptetApiPackingOrderClient
+                         (loads detail, reads ShoptetOrdersSettings.PackingStateId,
+                          sets PackingOrder.IsEligibleForPacking)
+              → reads order.IsEligibleForPacking
+              → returns GetPackingOrderResponse with Eligibility { IsEligible, WarningTitle, WarningBody }
+```
+
+**POST `/api/packaging/scan` (unchanged endpoint surface):**
+
+```
+HTTP POST → PackagingController → ScanPackingOrderHandler
+   ├─ IPackingOrderClient.GetPackingOrderAsync(code, ct)
+   │       → ShoptetApiPackingOrderClient (sets IsEligibleForPacking as above)
+   ├─ isEligible = order.IsEligibleForPacking
+   ├─ if (!isEligible) → return ineligible payload (with shipment if labels exist), DO NOT mark packed
+   ├─ else
+   │     ├─ create / reuse shipment via IShipmentClient
+   │     └─ TryMarkAsPackedAsync(orderCode, ct)
+   │            → IEshopOrderClient.MarkAsPackedAsync(orderCode, ct)
+   │                  → ShoptetOrderClient.MarkAsPackedAsync
+   │                        → UpdateStatusAsync(orderCode, settings.PackedStateId, ct)
+   │                              → PATCH /api/orders/{code}/status
+   └─ return ScanPackingOrderResponse (same shape as today)
+```
+
+No new round-trips. The eligibility flag piggybacks on the existing `GetOrderStatusIdAsync` call inside the adapter.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `PackingStateId`/`PackedStateId` reappear in `Packaging` via a future PR (silent drift back to current state). | Medium | Add an architecture test in `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` (or a sibling) asserting no source file under `Application/Features/Packaging/**` contains the substrings `ShoptetOrdersSettings`, `PackingStateId`, `PackedStateId`. Fails CI on regression. This is the exact pattern already used to enforce the `Leaflet` ↔ `KnowledgeBase` boundary (see `development_guidelines.md` §Cross-Module Communication Example). |
+| `PackingOrder.StatusId` is left in place and a future caller re-derives eligibility from it, recreating the duplicated rule. | Low | XML doc on `StatusId` (see above) explicitly steers readers to `IsEligibleForPacking`. The arch test in the row above covers the worst case (re-introducing the constants). |
+| Adapter constructor signatures change — any custom registration outside `AddShoptetApiAdapter` (e.g., test fixtures, integration tests) breaks at runtime. | Low | Compile-time break for `ShoptetApiPackingOrderClient` and `ShoptetOrderClient`; resolved automatically by DI inside `AddShoptetApiAdapter` since `IOptions<ShoptetOrdersSettings>` is already bound by `ShoptetOrdersModule` in the API composition. Confirm no test project new-s up either adapter manually (a quick grep in `backend/test`). |
+| Existing handler tests (`ScanPackingOrderHandlerTests`, `GetPackingOrderHandlerTests`) still encode the `StatusId == PackingStateId` rule in setup helpers; if they are left unchanged the tests will fail or, worse, pass by accident. | Medium | Update both test files: drop the `ShoptetOrdersSettings` plumbing, set `IsEligibleForPacking` explicitly on the mocked `PackingOrder` per test, and switch `UpdateStatusAsync` verifications to `MarkAsPackedAsync` verifications. NFR-3 explicitly forbids `Packaging` module tests from asserting a Shoptet status id. |
+| `MarkAsPackedAsync` swallows the cancellation token semantic difference between `UpdateStatusAsync` (required `CancellationToken ct`) and the new default-valued signature (`CancellationToken ct = default`). | Low | Match the existing convention in `IEshopOrderClient` (all other methods use `CancellationToken ct = default`). Callers in `ScanPackingOrderHandler` already pass an explicit token. |
+| `ShoptetOrderClient` constructor change (new `IOptions<ShoptetOrdersSettings>` param) breaks the `AddHttpClient<ShoptetOrderClient>` factory if anything inspects the closure of `ShoptetOrderClient`. | Low | `AddHttpClient<T>` injects all constructor dependencies from the root container — `IOptions<ShoptetOrdersSettings>` is registered as singleton by `ShoptetOrdersModule.AddOptions<ShoptetOrdersSettings>()`, so the typed-client factory will resolve it normally. No DI changes required. |
+
+## Specification Amendments
+
+The spec is unambiguous and ready to implement as written. Two small additions are recommended:
+
+1. **Add the architectural enforcement test.** The spec defines NFR-3 ("knowledge of status ids confined to four locations") but does not require it to be enforced. Without a test, NFR-3 is documentation only and the same finding will return on the next daily arch-review. Add a reflection/regex test under `backend/test/Anela.Heblo.Tests/Architecture/` asserting:
+   - No file under `Anela.Heblo.Application/Features/Packaging/` references `ShoptetOrdersSettings`, `PackingStateId`, or `PackedStateId`.
+   - This mirrors the `Leaflet`/`KnowledgeBase` boundary test referenced in §Cross-Module Communication Example of `development_guidelines.md`.
+2. **Tighten the XML doc on `PackingOrder.StatusId`.** Because the spec defers the removal of `StatusId` to a follow-up, document on the property itself that it must not be read to derive eligibility — readers must use `IsEligibleForPacking`. This is the cheap version of the deferred deprecation and prevents silent re-introduction of the duplicated rule before the follow-up lands. Suggested text:
+   > Kept for diagnostic/logging purposes. Do **not** derive packing eligibility from this value — use `IsEligibleForPacking` instead.
+
+Neither amendment changes behaviour, scope, or contracts beyond what FR-1/FR-2 already specify.
+
+## Prerequisites
+
+None. All required configuration values (`ShoptetOrders:PackingStateId`, `ShoptetOrders:PackedStateId`) already exist and are bound in `ShoptetOrdersModule`; both target environments (development user secrets, staging Key Vault, production Key Vault) already supply them. No migrations, no infrastructure changes, no new packages, no feature-flag wiring.

--- a/artifacts/feat-arch-review-shoptetorders-packaging-modu/brief.md
+++ b/artifacts/feat-arch-review-shoptetorders-packaging-modu/brief.md
@@ -1,0 +1,30 @@
+## Module
+ShoptetOrders / Packaging
+
+## Finding
+`ScanPackingOrderHandler` (in the `Packaging` module) directly injects and reads `ShoptetOrdersSettings` — a concrete settings class owned by the `ShoptetOrders` module:
+
+**`backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs`**
+- Line 18: `private readonly ShoptetOrdersSettings _orderSettings;`
+- Line 28: `IOptions<ShoptetOrdersSettings> orderSettings,`
+- Line 49: `var isEligible = order.StatusId == _orderSettings.PackingStateId;`
+- Line 186: `await _eshopOrderClient.UpdateStatusAsync(orderCode, _orderSettings.PackedStateId, ct);`
+
+The `development_guidelines.md` rule is: "No direct references between feature modules" and "Communication only through contracts/interfaces." `ShoptetOrdersSettings` is a concrete class in the `ShoptetOrders` namespace, not a contract interface.
+
+## Why it matters
+The `Packaging` module is tightly coupled to a Shoptet-specific configuration detail it does not own. Two Shoptet status IDs (`PackingStateId`, `PackedStateId`) leak into business logic that is otherwise Shoptet-agnostic. If `ShoptetOrdersSettings` is renamed, moved, or split, `ScanPackingOrderHandler` breaks silently. Additionally, packing eligibility is computed identically in both `GetPackingOrderHandler` (`ShoptetOrders`) and `ScanPackingOrderHandler` (`Packaging`), duplicating the rule in two modules.
+
+## Suggested fix
+Two minimal changes:
+
+1. **Encapsulate eligibility in the contract.** Add `bool IsEligibleForPacking` to `PackingOrder` (in `IPackingOrderClient.cs`) and set it in `ShoptetApiPackingOrderClient` (which already knows `PackingStateId` via its own settings). Remove the `PackingStateId` read from `ScanPackingOrderHandler`.
+
+2. **Add `MarkAsPackedAsync` to `IEshopOrderClient`.** Add a single-purpose method to the interface:
+   ```csharp
+   Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default);
+   ```
+   Implement it in `ShoptetOrderClient` using `PackedStateId` from its own settings. Replace the `UpdateStatusAsync(orderCode, _orderSettings.PackedStateId, ct)` call in `ScanPackingOrderHandler` with `MarkAsPackedAsync`. This removes the last reason for `Packaging` to reference `ShoptetOrdersSettings` at all.
+
+---
+_Filed by daily arch-review routine on 2026-06-05._

--- a/artifacts/feat-arch-review-shoptetorders-packaging-modu/impl/main.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packaging-modu/impl/main.r1.md
@@ -1,0 +1,60 @@
+---
+
+# Implementation: Decouple Packaging from ShoptetOrdersSettings
+
+## What was implemented
+
+Removed the direct dependency from `Application.Features.Packaging` on `ShoptetOrdersSettings` by moving packing-eligibility computation and the "mark as packed" status transition behind the existing `IPackingOrderClient` and `IEshopOrderClient` contracts. An architecture enforcement test was added to pin the boundary in place.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs` — added `bool IsEligibleForPacking { get; set; }` to `PackingOrder`, tightened XML doc on `StatusId`
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs` — added `Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default)`
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs` — injected `IOptions<ShoptetOrdersSettings>`, implemented `MarkAsPackedAsync` as delegate to `UpdateStatusAsync`
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` — injected `IOptions<ShoptetOrdersSettings>`, sets `IsEligibleForPacking = statusId == _orderSettings.PackingStateId`
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs` — dropped `IOptions<ShoptetOrdersSettings>`, reads `order.IsEligibleForPacking`
+- `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` — dropped `ShoptetOrdersSettings`, reads `order.IsEligibleForPacking`, calls `MarkAsPackedAsync`
+- `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs` — removed `IOptions<ShoptetOrdersSettings>` setup, sets `IsEligibleForPacking` explicitly
+- `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs` — removed `ShoptetOrdersSettings` setup, sets `IsEligibleForPacking` explicitly, asserts `MarkAsPackedAsync`
+- `backend/test/Anela.Heblo.Tests/Features/Packaging/ScanPackingOrderHandlerPackagePersistenceTests.cs` — updated `MakeOrder` and constructor to remove `ShoptetOrdersSettings`
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — added `PackagingShoptetOrdersAllowlist` and `Packaging -> ShoptetOrders` rule
+- 5 adapter test files — updated `new ShoptetOrderClient(http)` → `new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings()))` to fix broken constructor
+
+## Tests
+
+- `GetPackingOrderHandlerTests` — 5 tests pass (uses `IsEligibleForPacking` directly, no `IOptions<ShoptetOrdersSettings>`)
+- `ScanPackingOrderHandlerTests` — 13 tests pass (verifies `MarkAsPackedAsync`, no `ShoptetOrdersSettings`)
+- `ScanPackingOrderHandlerPackagePersistenceTests` — 3 tests pass
+- `ModuleBoundariesTests` — 20 theory rows pass including the new `Packaging -> ShoptetOrders` rule
+- Full suite: 4,863 tests pass, 0 failures
+
+## How to verify
+
+```bash
+dotnet build Anela.Heblo.sln
+dotnet test Anela.Heblo.sln --no-build
+git grep -n -e "PackingStateId" -e "PackedStateId" -e "ShoptetOrdersSettings" -- backend/src
+# Last command must show no matches under backend/src/Anela.Heblo.Application/Features/Packaging/
+```
+
+## Notes
+
+- One deviation from the plan: the `ShoptetApiAdapterServiceCollectionExtensions.cs` DI registration did **not** need changes since `AddHttpClient<ShoptetOrderClient>` resolves parameters from DI automatically. However, 5 test files that manually `new`-ed `ShoptetOrderClient` needed the extra `IOptions<ShoptetOrdersSettings>` parameter — these were updated.
+- The `PackagingShoptetOrdersAllowlist` in the architecture test was extended beyond the plan's 4 entries to cover `ScanOrderData -> PackingOrderItem` and `ResetOrderShipmentHandler -> IPackingOrderClient/PackingOrder/PackingOrderItem` (both pre-existing legitimate uses of the contract surface that were not covered by the plan's initial allowlist).
+- Unicode typographic quotation marks in Czech string literals (`„Balí se"`) required Python-based file writing/fixing since the Write tool substitutes ASCII `"` for the typographic `"` (U+201D), causing C# parse errors.
+
+## PR Summary
+
+Removes the direct coupling from `Application.Features.Packaging` onto `ShoptetOrdersSettings` — a configuration class owned by the `ShoptetOrders` module. Two concrete changes land: (1) `PackingOrder` now carries a precomputed `IsEligibleForPacking` flag set by `ShoptetApiPackingOrderClient` using `PackingStateId`, so neither handler needs to know that constant; (2) `IEshopOrderClient` gets a `MarkAsPackedAsync` method implemented by `ShoptetOrderClient` via the existing `UpdateStatusAsync` path, hiding `PackedStateId` from `ScanPackingOrderHandler`. Both handlers are simplified accordingly. An architecture enforcement test (`ModuleBoundariesTests`, `Packaging -> ShoptetOrders` rule) pins the boundary so it cannot silently re-erode.
+
+### Changes
+- `IPackingOrderClient.cs` — `PackingOrder` gains `IsEligibleForPacking`; `StatusId` XML doc steers readers away from re-deriving eligibility
+- `IEshopOrderClient.cs` — new `MarkAsPackedAsync` method on the contract
+- `ShoptetOrderClient.cs` — injects `IOptions<ShoptetOrdersSettings>`, implements `MarkAsPackedAsync`
+- `ShoptetApiPackingOrderClient.cs` — injects `IOptions<ShoptetOrdersSettings>`, sets `IsEligibleForPacking` on returned DTO
+- `GetPackingOrderHandler.cs` — drops `IOptions<ShoptetOrdersSettings>`, reads `order.IsEligibleForPacking`
+- `ScanPackingOrderHandler.cs` — drops `ShoptetOrdersSettings`, reads `order.IsEligibleForPacking`, calls `MarkAsPackedAsync`
+- Test files (4 handler tests, 1 architecture) — updated to match new contracts; 5 adapter tests fixed for `ShoptetOrderClient` constructor change
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-shoptetorders-packaging-modu/spec.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packaging-modu/spec.r1.md
@@ -1,0 +1,8 @@
+Spec written to `artifacts/feat-arch-review-shoptetorders-packaging-modu/spec.md`. It covers:
+
+- **FR-1**: Add `IsEligibleForPacking` to `PackingOrder`, computed in `ShoptetApiPackingOrderClient`; remove the duplicated rule from both handlers.
+- **FR-2**: Add `MarkAsPackedAsync` to `IEshopOrderClient`, implemented in `ShoptetOrderClient` via the existing `UpdateStatusAsync` path.
+- **FR-3**: `ScanPackingOrderHandler` no longer references `ShoptetOrdersSettings`.
+- **FR-4**: Byte-for-byte behaviour parity for both endpoints.
+
+Status: `COMPLETE` — no open questions; the brief was unambiguous and the contract surface needed already exists.

--- a/artifacts/feat-arch-review-shoptetorders-packaging-modu/task-plan.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-packaging-modu/task-plan.r1.md
@@ -1,0 +1,16 @@
+Plan complete and saved to `docs/superpowers/plans/2026-06-05-decouple-packaging-from-shoptet-orders-settings.md`.
+
+The plan covers 10 tasks executed in TDD style with frequent commits:
+
+1. **Task 1** — Add `IsEligibleForPacking` to `PackingOrder` DTO + tighten `StatusId` XML doc (arch-review amendment 2).
+2. **Task 2** — Declare `MarkAsPackedAsync` on `IEshopOrderClient` (build red).
+3. **Task 3** — Implement `MarkAsPackedAsync` in `ShoptetOrderClient` via `UpdateStatusAsync` (build green).
+4. **Task 4** — `ShoptetApiPackingOrderClient` sets `IsEligibleForPacking` from `ShoptetOrdersSettings.PackingStateId`.
+5. **Task 5** — Rewrite `GetPackingOrderHandlerTests` for the new contract (tests red).
+6. **Task 6** — Simplify `GetPackingOrderHandler` to consume `order.IsEligibleForPacking` (tests green).
+7. **Task 7** — Rewrite `ScanPackingOrderHandlerTests` (tests red, with `MarkAsPackedAsync` verifications).
+8. **Task 8** — Simplify `ScanPackingOrderHandler`: drop `ShoptetOrdersSettings`, call `MarkAsPackedAsync`, update warning log.
+9. **Task 9** — Add `Packaging -> ShoptetOrders` rule to `ModuleBoundariesTests` to pin the boundary (arch-review amendment 1).
+10. **Task 10** — Full build/test/format/grep validation across the four allowed status-id locations (NFR-3).
+
+The plan ends with a spec-coverage matrix mapping every FR/NFR and both arch-review amendments to specific tasks.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
@@ -20,19 +20,22 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
     private readonly ICarrierCoolingRepository _carrierCooling;
     private readonly ILogger<ShoptetApiPackingOrderClient> _logger;
     private readonly int _defaultItemWeightGrams;
+    private readonly ShoptetOrdersSettings _orderSettings;
 
     public ShoptetApiPackingOrderClient(
         ShoptetOrderClient orderClient,
         ICatalogRepository catalog,
         ICarrierCoolingRepository carrierCooling,
         ILogger<ShoptetApiPackingOrderClient> logger,
-        IOptions<ShoptetApiSettings> settings)
+        IOptions<ShoptetApiSettings> settings,
+        IOptions<ShoptetOrdersSettings> orderSettings)
     {
         _orderClient = orderClient;
         _catalog = catalog;
         _carrierCooling = carrierCooling;
         _logger = logger;
         _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+        _orderSettings = orderSettings.Value;
     }
 
     public async Task<PackingOrder?> GetPackingOrderAsync(string code, CancellationToken ct = default)
@@ -109,6 +112,7 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
             Cooling = order.CarrierCooling,
             IsCooled = order.IsCooled,
             StatusId = statusId,
+            IsEligibleForPacking = statusId == _orderSettings.PackingStateId,
             CustomerNote = string.IsNullOrWhiteSpace(order.CustomerRemark) ? null : order.CustomerRemark,
             EshopNote = string.IsNullOrWhiteSpace(order.EshopRemark) ? null : order.EshopRemark,
             ShippingStreet = shippingStreet,

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs
@@ -4,12 +4,14 @@ using System.Text.Json.Serialization;
 using Anela.Heblo.Adapters.ShoptetApi.Expedition.Model;
 using Anela.Heblo.Adapters.ShoptetApi.Orders.Model;
 using Anela.Heblo.Application.Features.ShoptetOrders;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Adapters.ShoptetApi.Orders;
 
 public class ShoptetOrderClient : IEshopOrderClient
 {
     private readonly HttpClient _http;
+    private readonly ShoptetOrdersSettings _orderSettings;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -21,9 +23,10 @@ public class ShoptetOrderClient : IEshopOrderClient
     private const int AdditionalFieldShortTextMaxIndex = 3;
     private const int AdditionalFieldShortTextMaxLength = 255;
 
-    public ShoptetOrderClient(HttpClient http)
+    public ShoptetOrderClient(HttpClient http, IOptions<ShoptetOrdersSettings> orderSettings)
     {
         _http = http;
+        _orderSettings = orderSettings.Value;
     }
 
     public async Task<List<EshopOrderSummary>> GetRecentOrdersAsync(int count = 20, CancellationToken ct = default)
@@ -221,6 +224,9 @@ public class ShoptetOrderClient : IEshopOrderClient
             .Where(s => !string.IsNullOrWhiteSpace(s.Name))
             .ToDictionary(s => s.Id, s => s.Name!);
     }
+
+    public Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default) =>
+        UpdateStatusAsync(orderCode, _orderSettings.PackedStateId, ct);
 
     // ── Expedition methods ────────────────────────────────────────────────────
 

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
@@ -15,7 +15,6 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
     private readonly IPackingOrderClient _orderClient;
     private readonly IEshopOrderClient _eshopOrderClient;
     private readonly ShipmentLabelsSettings _shipmentSettings;
-    private readonly ShoptetOrdersSettings _orderSettings;
     private readonly ILogger<ScanPackingOrderHandler> _logger;
     private readonly IPackageRepository _packageRepository;
     private readonly ICurrentUserService _currentUserService;
@@ -25,7 +24,6 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
         IPackingOrderClient orderClient,
         IEshopOrderClient eshopOrderClient,
         IOptions<ShipmentLabelsSettings> shipmentSettings,
-        IOptions<ShoptetOrdersSettings> orderSettings,
         ILogger<ScanPackingOrderHandler> logger,
         IPackageRepository packageRepository,
         ICurrentUserService currentUserService)
@@ -34,7 +32,6 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
         _orderClient = orderClient;
         _eshopOrderClient = eshopOrderClient;
         _shipmentSettings = shipmentSettings.Value;
-        _orderSettings = orderSettings.Value;
         _logger = logger;
         _packageRepository = packageRepository;
         _currentUserService = currentUserService;
@@ -46,7 +43,7 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
         if (order is null)
             return new ScanPackingOrderResponse(ErrorCodes.ShoptetOrderNotFound);
 
-        var isEligible = order.StatusId == _orderSettings.PackingStateId;
+        var isEligible = order.IsEligibleForPacking;
         var orderData = new ScanOrderData
         {
             Code = order.Code,
@@ -183,12 +180,11 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
     {
         try
         {
-            await _eshopOrderClient.UpdateStatusAsync(orderCode, _orderSettings.PackedStateId, ct);
+            await _eshopOrderClient.MarkAsPackedAsync(orderCode, ct);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to update order {OrderCode} to packed status {StatusId}",
-                orderCode, _orderSettings.PackedStateId);
+            _logger.LogWarning(ex, "Failed to mark order {OrderCode} as packed", orderCode);
         }
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs
@@ -35,4 +35,11 @@ public interface IEshopOrderClient
     /// Returns a map of status id → status name from GET /api/eshop?include=orderStatuses.
     /// </summary>
     Task<Dictionary<int, string>> GetOrderStatusNamesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Transitions the order to the configured "packed" state
+    /// (Shoptet "Zabaleno", id 52 by default). Called by the Balení screen
+    /// after a successful scan + shipment creation.
+    /// </summary>
+    Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
@@ -23,8 +23,17 @@ public class PackingOrder
     public Cooling Cooling { get; set; } = Cooling.None;
     public bool IsCooled { get; set; }
 
-    /// <summary>Shoptet order status ID, used to verify the order is in the packing state.</summary>
+    /// <summary>
+    /// Shoptet order status ID. Kept for diagnostic/logging purposes. Do <b>not</b>
+    /// derive packing eligibility from this value — use <see cref="IsEligibleForPacking"/>.
+    /// </summary>
     public int StatusId { get; set; }
+
+    /// <summary>
+    /// True when the order is in the configured packing state (Shoptet "Balí se").
+    /// Computed by the adapter so callers do not need to know the status-id rule.
+    /// </summary>
+    public bool IsEligibleForPacking { get; set; }
 
     /// <summary>Customer remark entered at checkout; null when none.</summary>
     public string? CustomerNote { get; set; }

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs
@@ -1,23 +1,19 @@
 using Anela.Heblo.Application.Shared;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.ShoptetOrders.UseCases.GetPackingOrder;
 
 public class GetPackingOrderHandler : IRequestHandler<GetPackingOrderRequest, GetPackingOrderResponse>
 {
     private readonly IPackingOrderClient _client;
-    private readonly IOptions<ShoptetOrdersSettings> _settings;
     private readonly ILogger<GetPackingOrderHandler> _logger;
 
     public GetPackingOrderHandler(
         IPackingOrderClient client,
-        IOptions<ShoptetOrdersSettings> settings,
         ILogger<GetPackingOrderHandler> logger)
     {
         _client = client;
-        _settings = settings;
         _logger = logger;
     }
 
@@ -36,7 +32,7 @@ public class GetPackingOrderHandler : IRequestHandler<GetPackingOrderRequest, Ge
                     new Dictionary<string, string> { { "orderCode", request.Code } });
             }
 
-            var isEligible = order.StatusId == _settings.Value.PackingStateId;
+            var isEligible = order.IsEligibleForPacking;
 
             return new GetPackingOrderResponse
             {
@@ -48,7 +44,7 @@ public class GetPackingOrderHandler : IRequestHandler<GetPackingOrderRequest, Ge
                 Eligibility = new PackingEligibility
                 {
                     IsEligible = isEligible,
-                    WarningTitle = isEligible ? null : "Objednávka není ve stavu „Balí se“",
+                    WarningTitle = isEligible ? null : "Objednávka není ve stavu „Balí se”",
                     WarningBody = isEligible ? null : "Tuto objednávku nezpracovávejte, dokud nebude ve správném stavu.",
                 },
                 CustomerNote = order.CustomerNote,

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/ShoptetApiExpeditionListSource_CoolingMarkerTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/ShoptetApiExpeditionListSource_CoolingMarkerTests.cs
@@ -6,9 +6,11 @@ using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Logistics;
 using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
 using Anela.Heblo.Application.Features.Logistics.Picking;
+using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Domain.Shared;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 using Xunit;
@@ -173,7 +175,7 @@ public class ShoptetApiExpeditionListSource_CoolingMarkerTests
         Action<ExpeditionProtocolData>? captureData = null)
     {
         var http = new HttpClient(handler.Object) { BaseAddress = new Uri("https://test.myshoptet.com") };
-        var client = new ShoptetOrderClient(http);
+        var client = new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings()));
 
         var catalog = new Mock<ICatalogRepository>();
         catalog.Setup(x => x.GetByIdAsync(CooledProductCode, It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/ShoptetOrderClient_SetAdditionalFieldTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/ShoptetOrderClient_SetAdditionalFieldTests.cs
@@ -2,7 +2,9 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Anela.Heblo.Adapters.ShoptetApi.Orders;
+using Anela.Heblo.Application.Features.ShoptetOrders;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 using Xunit;
@@ -21,7 +23,7 @@ public class ShoptetOrderClient_SetAdditionalFieldTests
     {
         var handler = new Mock<HttpMessageHandler>();
         var http = new HttpClient(handler.Object) { BaseAddress = new Uri("https://test.myshoptet.com") };
-        return (new ShoptetOrderClient(http), handler);
+        return (new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings())), handler);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
@@ -9,8 +9,10 @@ using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Logistics;
 using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
 using Anela.Heblo.Application.Features.Logistics.Picking;
+using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Domain.Shared;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Moq;
 using QuestPDF.Infrastructure;
 
@@ -38,7 +40,7 @@ public class ShoptetApiExpeditionListSourceTests
     {
         var msgHandler = new FakeDelegatingHandler(handler);
         var http = new HttpClient(msgHandler) { BaseAddress = new Uri("https://fake.shoptet.cz") };
-        return new ShoptetOrderClient(http);
+        return new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings()));
     }
 
     private static HttpResponseMessage Json(object obj, HttpStatusCode status = HttpStatusCode.OK)

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
@@ -84,8 +84,9 @@ public class ShoptetApiPackingOrderClientTests
         int defaultWeightGrams = 500)
     {
         var settings = Options.Create(new ShoptetApiSettings { DefaultItemWeightGrams = defaultWeightGrams });
+        var orderSettings = Options.Create(new ShoptetOrdersSettings());
         var logger = NullLogger<ShoptetApiPackingOrderClient>.Instance;
-        return new ShoptetApiPackingOrderClient(orderClient, catalog, cooling, logger, settings);
+        return new ShoptetApiPackingOrderClient(orderClient, catalog, cooling, logger, settings, orderSettings);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
@@ -6,6 +6,7 @@ using Anela.Heblo.Adapters.ShoptetApi.Orders;
 using Anela.Heblo.Adapters.ShoptetApi.Orders.Model;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Logistics;
+using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Domain.Shared;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -26,7 +27,7 @@ public class ShoptetApiPackingOrderClientTests
         {
             BaseAddress = new Uri("https://fake.shoptet.cz"),
         };
-        return new ShoptetOrderClient(http);
+        return new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings()));
     }
 
     private static HttpResponseMessage Json(object obj, HttpStatusCode status = HttpStatusCode.OK)

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetOrderClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetOrderClientTests.cs
@@ -3,7 +3,9 @@ using System.Text;
 using System.Text.Json;
 using Anela.Heblo.Adapters.ShoptetApi.Orders;
 using Anela.Heblo.Adapters.ShoptetApi.Orders.Model;
+using Anela.Heblo.Application.Features.ShoptetOrders;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Tests.Adapters.ShoptetApi;
 
@@ -15,7 +17,7 @@ public class ShoptetOrderClientTests
         {
             BaseAddress = new Uri("https://fake.shoptet.cz"),
         };
-        return new ShoptetOrderClient(http);
+        return new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings()));
     }
 
     private static HttpResponseMessage Json(object obj)

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
@@ -27,15 +27,7 @@ public class ScanPackingOrderHandlerTests
         MinPackageWeightGrams = 100,
     };
 
-    private static readonly ShoptetOrdersSettings DefaultOrderSettings = new()
-    {
-        PackingStateId = 26,
-        PackedStateId = 52,
-    };
-
-    private ScanPackingOrderHandler CreateHandler(
-        ShipmentLabelsSettings? labelSettings = null,
-        ShoptetOrdersSettings? orderSettings = null)
+    private ScanPackingOrderHandler CreateHandler(ShipmentLabelsSettings? labelSettings = null)
     {
         _currentUserService.Setup(c => c.GetCurrentUser())
             .Returns(new CurrentUser("uid-1", "Operator", "op@example.com", IsAuthenticated: true));
@@ -44,7 +36,6 @@ public class ScanPackingOrderHandlerTests
             _orderClient.Object,
             _eshopOrderClient.Object,
             Options.Create(labelSettings ?? DefaultLabelSettings),
-            Options.Create(orderSettings ?? DefaultOrderSettings),
             new Mock<ILogger<ScanPackingOrderHandler>>().Object,
             _packageRepository.Object,
             _currentUserService.Object);
@@ -55,6 +46,7 @@ public class ScanPackingOrderHandlerTests
         {
             Code = "0001234",
             StatusId = 26,
+            IsEligibleForPacking = true,
             Items = items.Select(i => new PackingOrderItem
             {
                 Name = i.name,
@@ -85,7 +77,7 @@ public class ScanPackingOrderHandlerTests
     {
         _orderClient
             .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99 });
+            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99, IsEligibleForPacking = false });
         _shipmentClient
             .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
@@ -121,7 +113,7 @@ public class ScanPackingOrderHandlerTests
 
         _orderClient
             .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99 });
+            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99, IsEligibleForPacking = false });
         _shipmentClient
             .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
             .ReturnsAsync([existingLabel]);
@@ -142,11 +134,11 @@ public class ScanPackingOrderHandlerTests
             c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _eshopOrderClient.Verify(
-            c => c.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            c => c.MarkAsPackedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
-    // Test 2: Labels already exist → return existing shipment without creating
+    // Test 3: Labels already exist on eligible order → return existing shipment without creating
     [Fact]
     public async Task Handle_LabelsExist_ReturnsExistingShipmentWithAlreadyExistedTrue()
     {
@@ -187,7 +179,7 @@ public class ScanPackingOrderHandlerTests
             Times.Never);
     }
 
-    // Test 3: All items have WeightGrams = 0 → weight unavailable error
+    // Test 4: All items have WeightGrams = 0 → weight unavailable error
     [Fact]
     public async Task Handle_AllItemsHaveZeroWeight_ReturnsShipmentOrderWeightUnavailable()
     {
@@ -207,7 +199,7 @@ public class ScanPackingOrderHandlerTests
         response.ErrorCode.Should().Be(ErrorCodes.ShipmentOrderWeightUnavailable);
     }
 
-    // Test 4: No shipping options returned → carrier not resolved error
+    // Test 5: No shipping options returned → carrier not resolved error
     [Fact]
     public async Task Handle_NoShippingOptions_ReturnsShipmentCarrierNotResolved()
     {
@@ -231,7 +223,7 @@ public class ScanPackingOrderHandlerTests
         response.ErrorCode.Should().Be(ErrorCodes.ShipmentCarrierNotResolved);
     }
 
-    // Test 5: CreateShipmentAsync throws → creation failed error
+    // Test 6: CreateShipmentAsync throws → creation failed error
     [Fact]
     public async Task Handle_CreateShipmentThrows_ReturnsShipmentCreationFailed()
     {
@@ -259,7 +251,7 @@ public class ScanPackingOrderHandlerTests
         response.ErrorCode.Should().Be(ErrorCodes.ShipmentCreationFailed);
     }
 
-    // Test 6: Eligible order, no existing shipment → creates new shipment, AlreadyExisted = false
+    // Test 7: Eligible order, no existing shipment → creates new shipment, AlreadyExisted = false
     [Fact]
     public async Task Handle_NoExistingShipment_CreatesNewShipmentWithAlreadyExistedFalse()
     {
@@ -269,6 +261,7 @@ public class ScanPackingOrderHandlerTests
         {
             Code = "0001234",
             StatusId = 26,
+            IsEligibleForPacking = true,
             Items = new List<PackingOrderItem>
             {
                 new() { Name = "P001", Quantity = 1, WeightGrams = 400 },
@@ -341,9 +334,9 @@ public class ScanPackingOrderHandlerTests
         response.Order!.ShippingAddress.Should().BeNull();
     }
 
-    // Status update: called with PackedStateId when existing shipment found
+    // MarkAsPackedAsync: called when existing shipment found and order is eligible
     [Fact]
-    public async Task Handle_LabelsExist_UpdatesOrderStatusToPacked()
+    public async Task Handle_LabelsExist_MarksOrderAsPacked()
     {
         var shipmentGuid = Guid.NewGuid();
 
@@ -361,13 +354,13 @@ public class ScanPackingOrderHandlerTests
 
         response.Success.Should().BeTrue();
         _eshopOrderClient.Verify(
-            c => c.UpdateStatusAsync("0001234", 52, It.IsAny<CancellationToken>()),
+            c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
-    // Status update: called with PackedStateId when new shipment is created
+    // MarkAsPackedAsync: called when new shipment is created on eligible order
     [Fact]
-    public async Task Handle_NewShipmentCreated_UpdatesOrderStatusToPacked()
+    public async Task Handle_NewShipmentCreated_MarksOrderAsPacked()
     {
         var shipmentGuid = Guid.NewGuid();
 
@@ -394,13 +387,13 @@ public class ScanPackingOrderHandlerTests
 
         response.Success.Should().BeTrue();
         _eshopOrderClient.Verify(
-            c => c.UpdateStatusAsync("0001234", 52, It.IsAny<CancellationToken>()),
+            c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
-    // Status update: failure is non-fatal — scan still returns success
+    // MarkAsPackedAsync: failure is non-fatal — scan still returns success
     [Fact]
-    public async Task Handle_StatusUpdateFails_StillReturnsSuccessfulScanResponse()
+    public async Task Handle_MarkAsPackedFails_StillReturnsSuccessfulScanResponse()
     {
         var shipmentGuid = Guid.NewGuid();
 
@@ -413,7 +406,7 @@ public class ScanPackingOrderHandlerTests
             .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://example.com/label.pdf" }]);
 
         _eshopOrderClient
-            .Setup(c => c.UpdateStatusAsync("0001234", It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Shoptet status update failed"));
 
         var response = await CreateHandler().Handle(
@@ -424,13 +417,13 @@ public class ScanPackingOrderHandlerTests
         response.Shipment.Should().NotBeNull();
     }
 
-    // Status update: NOT called when order is ineligible
+    // MarkAsPackedAsync: NOT called when order is ineligible
     [Fact]
-    public async Task Handle_OrderNotInPackingState_DoesNotUpdateStatus()
+    public async Task Handle_OrderNotInPackingState_DoesNotMarkAsPacked()
     {
         _orderClient
             .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99 });
+            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99, IsEligibleForPacking = false });
 
         _shipmentClient
             .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
@@ -441,7 +434,7 @@ public class ScanPackingOrderHandlerTests
             CancellationToken.None);
 
         _eshopOrderClient.Verify(
-            c => c.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            c => c.MarkAsPackedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs
@@ -4,7 +4,6 @@ using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Shared;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Anela.Heblo.Tests.Application.ShoptetOrders;
@@ -13,10 +12,9 @@ public class GetPackingOrderHandlerTests
 {
     private readonly Mock<IPackingOrderClient> _clientMock = new();
 
-    private GetPackingOrderHandler CreateHandler(int packingStateId = 26) =>
+    private GetPackingOrderHandler CreateHandler() =>
         new(
             _clientMock.Object,
-            Options.Create(new ShoptetOrdersSettings { PackingStateId = packingStateId }),
             NullLogger<GetPackingOrderHandler>.Instance);
 
     [Fact]
@@ -32,6 +30,7 @@ public class GetPackingOrderHandlerTests
                 Cooling = Cooling.L1,
                 IsCooled = true,
                 StatusId = 26,
+                IsEligibleForPacking = true,
                 CustomerNote = "Zabalit jako dárek",
                 EshopNote = "Stálý zákazník",
                 Items = new List<PackingOrderItem>
@@ -65,6 +64,7 @@ public class GetPackingOrderHandlerTests
                 CustomerName = "Jan Novák",
                 ShippingMethodName = "PPL",
                 StatusId = 26,
+                IsEligibleForPacking = true,
                 Items = [],
             });
 
@@ -88,6 +88,7 @@ public class GetPackingOrderHandlerTests
                 CustomerName = "Jana Nováková",
                 ShippingMethodName = "PPL",
                 StatusId = 99,
+                IsEligibleForPacking = false,
                 Items = [],
             });
 
@@ -96,7 +97,7 @@ public class GetPackingOrderHandlerTests
 
         result.Success.Should().BeTrue();
         result.Eligibility.IsEligible.Should().BeFalse();
-        result.Eligibility.WarningTitle.Should().Be("Objednávka není ve stavu „Balí se“");
+        result.Eligibility.WarningTitle.Should().Be("Objednávka není ve stavu „Balí se”");
         result.Eligibility.WarningBody.Should().Be("Tuto objednávku nezpracovávejte, dokud nebude ve správném stavu.");
     }
 

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -265,6 +265,32 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.ExpeditionList.Contracts.ExpeditionPickingRequest -> Anela.Heblo.Domain.Features.Logistics.Carriers",
     };
 
+    // Allowlist for Packaging -> ShoptetOrders. The Packaging module legitimately consumes
+    // the IPackingOrderClient / IEshopOrderClient contracts (and their DTOs) defined in
+    // Anela.Heblo.Application.Features.ShoptetOrders. Everything else — particularly
+    // ShoptetOrdersSettings, PackingStateId, and PackedStateId — must not be referenced
+    // from Packaging. This rule pins the 2026-06-05 decoupling in place.
+    private static readonly HashSet<string> PackagingShoptetOrdersAllowlist = new(StringComparer.Ordinal)
+    {
+        // Constructor injections in ScanPackingOrderHandler.
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IPackingOrderClient",
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IEshopOrderClient",
+
+        // PackingOrder is consumed in Handle and in the private BuildShippingAddress helper;
+        // PackingOrderItem flows through ScanOrderData.Items.
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrder",
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrderItem",
+
+        // ScanOrderData.Items is List<PackingOrderItem> — the DTO uses the contract item type directly.
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanOrderData -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrderItem",
+
+        // ResetOrderShipmentHandler also uses IPackingOrderClient, PackingOrder, and PackingOrderItem
+        // (compiler-generated async state machine and closure types are covered by the declaring-type check).
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment.ResetOrderShipmentHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IPackingOrderClient",
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment.ResetOrderShipmentHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrder",
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment.ResetOrderShipmentHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrderItem",
+    };
+
     public static TheoryData<ModuleBoundaryRule> Rules() => new()
     {
         new ModuleBoundaryRule(
@@ -443,6 +469,15 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Persistence.Logistics",
             },
             Allowlist: ExpeditionListLogisticsAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Packaging -> ShoptetOrders",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Packaging",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Application.Features.ShoptetOrders",
+            },
+            Allowlist: PackagingShoptetOrdersAllowlist),
     };
 
     [Theory]

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/ScanPackingOrderHandlerPackagePersistenceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/ScanPackingOrderHandlerPackagePersistenceTests.cs
@@ -51,29 +51,23 @@ public class ScanPackingOrderHandlerPackagePersistenceTests
             DefaultPackageHeightMm = 200,
             DefaultPackageDepthMm = 150,
         });
-        var ordSettings = Options.Create(new ShoptetOrdersSettings
-        {
-            PackingStateId = 26,
-            PackedStateId = 52,
-        });
-
         return new ScanPackingOrderHandler(
             shipmentClient.Object,
             orderClient.Object,
             eshopClient.Object,
             shipmentSettings,
-            ordSettings,
             NullLogger<ScanPackingOrderHandler>.Instance,
             packageRepo.Object,
             currentUser.Object);
     }
 
-    private static PackingOrder MakeOrder(int statusId = 26) => new()
+    private static PackingOrder MakeOrder(int statusId = 26, bool isEligible = true) => new()
     {
         Code = "ORD-1",
         CustomerName = "Alice",
         ShippingMethodName = "PPL",
         StatusId = statusId,
+        IsEligibleForPacking = isEligible,
         Items = new List<PackingOrderItem>
         {
             new() { WeightGrams = 500, Quantity = 1 },

--- a/docs/superpowers/plans/2026-06-05-decouple-packaging-from-shoptet-orders-settings.md
+++ b/docs/superpowers/plans/2026-06-05-decouple-packaging-from-shoptet-orders-settings.md
@@ -1,0 +1,1508 @@
+# Decouple Packaging from ShoptetOrdersSettings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the direct dependency the `Packaging` module has on `ShoptetOrdersSettings` by moving packing-eligibility and the "mark as packed" status transition behind contracts already exposed by `ShoptetOrders`.
+
+**Architecture:** Add a precomputed `IsEligibleForPacking` flag on the `PackingOrder` contract DTO (set by the Shoptet adapter), and add a single-purpose `MarkAsPackedAsync` method to `IEshopOrderClient` (delegating to the existing `UpdateStatusAsync` path). Then strip `ShoptetOrdersSettings` from both handlers. A reflection-based architecture test pins the new boundary in place so the rule cannot silently drift back.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq, MediatR, Microsoft.Extensions.Options.
+
+---
+
+## File Structure
+
+The change is **strictly additive on the contract side** and **subtractive on the consumer side**. No new files except optionally the architecture test rule (which already exists as a reflection-based theory; we just add a new `ModuleBoundaryRule` row).
+
+| File | Responsibility | Change |
+|---|---|---|
+| `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs` | Contract DTO + interface for fetching the packing view of an order. | Add `bool IsEligibleForPacking { get; set; }` to `PackingOrder`. Tighten XML doc on `StatusId`. |
+| `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs` | Contract for eshop-order operations. | Add `Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default);`. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` | Loads a Shoptet order for the Balení screen; implements `IPackingOrderClient`. | Inject `IOptions<ShoptetOrdersSettings>`. Set `IsEligibleForPacking = statusId == settings.PackingStateId` while constructing the returned `PackingOrder`. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs` | Implements `IEshopOrderClient` against Shoptet REST. | Inject `IOptions<ShoptetOrdersSettings>`. Implement `MarkAsPackedAsync` as a one-line delegate to `UpdateStatusAsync(orderCode, settings.PackedStateId, ct)`. |
+| `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` | Handles `POST /api/packaging/scan`. | Drop the `_orderSettings` field + ctor parameter + the `Microsoft.Extensions.Options` using. Use `order.IsEligibleForPacking` and `_eshopOrderClient.MarkAsPackedAsync(...)`. Adjust the warning log to `"Failed to mark order {OrderCode} as packed"`. |
+| `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs` | Handles `GET /api/packing-orders/{code}`. | Drop the `_settings` field + ctor parameter + the `Microsoft.Extensions.Options` using. Use `order.IsEligibleForPacking`. |
+| `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs` | Unit tests for `ScanPackingOrderHandler`. | Drop `DefaultOrderSettings` + the `orderSettings` parameter on `CreateHandler`. Set `IsEligibleForPacking = true` in `EligibleOrder()`. For ineligible-path tests, set `IsEligibleForPacking = false` explicitly. Change assertions on `UpdateStatusAsync` to `MarkAsPackedAsync`. |
+| `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs` | Unit tests for `GetPackingOrderHandler`. | Drop the `ShoptetOrdersSettings` setup in `CreateHandler`. Set `IsEligibleForPacking` on mocked `PackingOrder` per scenario. |
+| `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` | Reflection-based architecture rules enforcing module boundaries. | Append a new `ModuleBoundaryRule` row: `"Packaging -> ShoptetOrders"` so `Packaging` types cannot reference `Anela.Heblo.Application.Features.ShoptetOrders` namespaces (with an allowlist for the three legitimate contracts: `IPackingOrderClient`, `PackingOrder`, `PackingOrderItem`, `IEshopOrderClient`, plus all reachable `CreateEshopOrderRequest`/`EshopOrderSummary`/`EshopOrderInfo` etc. that are part of the contract surface). |
+
+Files **not** changed:
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs` — both adapters are already constructed through DI; `IOptions<ShoptetOrdersSettings>` resolves through the binding done by `ShoptetOrdersModule.AddShoptetOrdersModule`.
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs` — settings stay in place. Spec confirms.
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrder/BlockOrderProcessingHandler.cs` — same module owns the settings; no boundary crossed.
+
+---
+
+## Task 1: Add `IsEligibleForPacking` to the `PackingOrder` DTO
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs`
+
+This is a contract-only change: no consumers read the new flag yet, no producers set it yet. It is a self-contained step so the codebase keeps compiling.
+
+- [ ] **Step 1: Add the new property and tighten the existing XML doc on `StatusId`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs`. Replace the existing `StatusId` line (and the XML doc immediately above it) so the class reads as follows. **Only** the doc comment on `StatusId` and the new `IsEligibleForPacking` block are added; every other property and the line ordering are preserved.
+
+```csharp
+    /// <summary>
+    /// Shoptet order status ID. Kept for diagnostic/logging purposes. Do <b>not</b>
+    /// derive packing eligibility from this value — use <see cref="IsEligibleForPacking"/>.
+    /// </summary>
+    public int StatusId { get; set; }
+
+    /// <summary>
+    /// True when the order is in the configured packing state (Shoptet "Balí se").
+    /// Computed by the adapter so callers do not need to know the status-id rule.
+    /// </summary>
+    public bool IsEligibleForPacking { get; set; }
+```
+
+Insert the `IsEligibleForPacking` block **immediately after** the `StatusId` property, before `CustomerNote`.
+
+- [ ] **Step 2: Build the solution to confirm the contract compiles**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: succeeds. No callers have to change yet (existing handlers still set/read `StatusId` only).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
+git commit -m "feat: add IsEligibleForPacking to PackingOrder contract"
+```
+
+---
+
+## Task 2: Add `MarkAsPackedAsync` to `IEshopOrderClient`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs`
+
+Contract addition only. Implementations and consumers are wired in subsequent tasks.
+
+- [ ] **Step 1: Declare the new method on the interface**
+
+Edit `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs`. Append (immediately before the closing `}` of the interface, after `GetOrderStatusNamesAsync`):
+
+```csharp
+    /// <summary>
+    /// Transitions the order to the configured "packed" state
+    /// (Shoptet "Zabaleno", id 52 by default). Called by the Balení screen
+    /// after a successful scan + shipment creation.
+    /// </summary>
+    Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Run the build — expect a failure in `ShoptetOrderClient`**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: **fails** with CS0535 in `ShoptetOrderClient.cs` (`'ShoptetOrderClient' does not implement interface member 'IEshopOrderClient.MarkAsPackedAsync(string, CancellationToken)'`). This is the failing test for Task 3.
+
+Do **not** commit yet — the next task fixes the build.
+
+---
+
+## Task 3: Implement `MarkAsPackedAsync` in `ShoptetOrderClient`
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs`
+- Test: existing unit tests under `backend/test/Anela.Heblo.Tests/` (no new test file; behavioural contract for `MarkAsPackedAsync` is verified at the handler level in Task 7).
+
+Inject `IOptions<ShoptetOrdersSettings>` and delegate to the existing `UpdateStatusAsync` path so the HTTP request is byte-for-byte identical to today's "mark as packed" call.
+
+- [ ] **Step 1: Add the `Microsoft.Extensions.Options` using**
+
+Edit `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs`. Add (with the other `using`s, alphabetically):
+
+```csharp
+using Microsoft.Extensions.Options;
+```
+
+Note: `Anela.Heblo.Application.Features.ShoptetOrders` is already imported (line 6), so `ShoptetOrdersSettings` resolves without an extra using.
+
+- [ ] **Step 2: Inject `IOptions<ShoptetOrdersSettings>` and store the settings**
+
+Replace the existing field declaration and constructor body at the top of the class:
+
+```csharp
+public class ShoptetOrderClient : IEshopOrderClient
+{
+    private readonly HttpClient _http;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private const int AdditionalFieldMinIndex = 1;
+    private const int AdditionalFieldMaxIndex = 6;
+    private const int AdditionalFieldShortTextMaxIndex = 3;
+    private const int AdditionalFieldShortTextMaxLength = 255;
+
+    public ShoptetOrderClient(HttpClient http)
+    {
+        _http = http;
+    }
+```
+
+with:
+
+```csharp
+public class ShoptetOrderClient : IEshopOrderClient
+{
+    private readonly HttpClient _http;
+    private readonly ShoptetOrdersSettings _orderSettings;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private const int AdditionalFieldMinIndex = 1;
+    private const int AdditionalFieldMaxIndex = 6;
+    private const int AdditionalFieldShortTextMaxIndex = 3;
+    private const int AdditionalFieldShortTextMaxLength = 255;
+
+    public ShoptetOrderClient(HttpClient http, IOptions<ShoptetOrdersSettings> orderSettings)
+    {
+        _http = http;
+        _orderSettings = orderSettings.Value;
+    }
+```
+
+- [ ] **Step 3: Implement `MarkAsPackedAsync`**
+
+Append the method at the **end of the class body**, immediately before the closing `}` of the `ShoptetOrderClient` class (i.e. right after the last existing method `GetExpeditionOrderDetailAsync` /`SetAdditionalFieldAsync`/`MapToOrderInfo` — wherever ends up last in the file you have):
+
+```csharp
+    public Task MarkAsPackedAsync(string orderCode, CancellationToken ct = default) =>
+        UpdateStatusAsync(orderCode, _orderSettings.PackedStateId, ct);
+```
+
+- [ ] **Step 4: Run the build to verify it now compiles**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: succeeds. The CS0535 from Task 2 is gone. `AddHttpClient<ShoptetOrderClient>` in `ShoptetApiAdapterServiceCollectionExtensions` will resolve the new `IOptions<ShoptetOrdersSettings>` parameter through DI (the singleton is bound in `ShoptetOrdersModule`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IEshopOrderClient.cs \
+       backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs
+git commit -m "feat: add MarkAsPackedAsync to IEshopOrderClient and Shoptet implementation"
+```
+
+---
+
+## Task 4: Set `IsEligibleForPacking` in `ShoptetApiPackingOrderClient`
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs`
+
+The adapter already loads `statusId` from the order detail. We add an `IOptions<ShoptetOrdersSettings>` dependency and set `IsEligibleForPacking = statusId == _shoptetOrdersSettings.PackingStateId` on the returned DTO.
+
+- [ ] **Step 1: Inject `ShoptetOrdersSettings` and store the value**
+
+Edit `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs`. Replace the existing field/constructor block:
+
+```csharp
+public class ShoptetApiPackingOrderClient : IPackingOrderClient
+{
+    private readonly ShoptetOrderClient _orderClient;
+    private readonly ICatalogRepository _catalog;
+    private readonly ICarrierCoolingRepository _carrierCooling;
+    private readonly ILogger<ShoptetApiPackingOrderClient> _logger;
+    private readonly int _defaultItemWeightGrams;
+
+    public ShoptetApiPackingOrderClient(
+        ShoptetOrderClient orderClient,
+        ICatalogRepository catalog,
+        ICarrierCoolingRepository carrierCooling,
+        ILogger<ShoptetApiPackingOrderClient> logger,
+        IOptions<ShoptetApiSettings> settings)
+    {
+        _orderClient = orderClient;
+        _catalog = catalog;
+        _carrierCooling = carrierCooling;
+        _logger = logger;
+        _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+    }
+```
+
+with:
+
+```csharp
+public class ShoptetApiPackingOrderClient : IPackingOrderClient
+{
+    private readonly ShoptetOrderClient _orderClient;
+    private readonly ICatalogRepository _catalog;
+    private readonly ICarrierCoolingRepository _carrierCooling;
+    private readonly ILogger<ShoptetApiPackingOrderClient> _logger;
+    private readonly int _defaultItemWeightGrams;
+    private readonly ShoptetOrdersSettings _orderSettings;
+
+    public ShoptetApiPackingOrderClient(
+        ShoptetOrderClient orderClient,
+        ICatalogRepository catalog,
+        ICarrierCoolingRepository carrierCooling,
+        ILogger<ShoptetApiPackingOrderClient> logger,
+        IOptions<ShoptetApiSettings> settings,
+        IOptions<ShoptetOrdersSettings> orderSettings)
+    {
+        _orderClient = orderClient;
+        _catalog = catalog;
+        _carrierCooling = carrierCooling;
+        _logger = logger;
+        _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+        _orderSettings = orderSettings.Value;
+    }
+```
+
+`Microsoft.Extensions.Options` is already imported (line 8) and `Anela.Heblo.Application.Features.ShoptetOrders` is already imported (line 4) — no extra usings.
+
+- [ ] **Step 2: Compute and set `IsEligibleForPacking` on the returned DTO**
+
+In the same file, change the existing `return new PackingOrder { … }` literal at the bottom of `GetPackingOrderAsync` so that **immediately after** the line:
+
+```csharp
+            StatusId = statusId,
+```
+
+it includes:
+
+```csharp
+            IsEligibleForPacking = statusId == _orderSettings.PackingStateId,
+```
+
+The final literal should read:
+
+```csharp
+        return new PackingOrder
+        {
+            Code = order.Code,
+            CustomerName = order.CustomerName,
+            ShippingMethodName = detail.Shipping?.Name ?? string.Empty,
+            Cooling = order.CarrierCooling,
+            IsCooled = order.IsCooled,
+            StatusId = statusId,
+            IsEligibleForPacking = statusId == _orderSettings.PackingStateId,
+            CustomerNote = string.IsNullOrWhiteSpace(order.CustomerRemark) ? null : order.CustomerRemark,
+            EshopNote = string.IsNullOrWhiteSpace(order.EshopRemark) ? null : order.EshopRemark,
+            ShippingStreet = shippingStreet,
+            ShippingCity = NormalizeAddressField(deliveryAddress?.City),
+            ShippingZip = NormalizeAddressField(deliveryAddress?.Zip),
+            Items = items,
+        };
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: succeeds. `IOptions<ShoptetOrdersSettings>` is already a registered singleton (bound by `ShoptetOrdersModule.AddShoptetOrdersModule`), so DI composes the adapter normally.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+git commit -m "feat: compute IsEligibleForPacking in ShoptetApiPackingOrderClient"
+```
+
+---
+
+## Task 5: Update `GetPackingOrderHandlerTests` to drive the contract change
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs`
+
+The handler is the consumer that will be changed in the next task. Per TDD: we change tests first so they describe the new behaviour, run them to see them fail, then change the production handler.
+
+- [ ] **Step 1: Replace the entire file contents**
+
+Overwrite `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Application.Features.ShoptetOrders.UseCases.GetPackingOrder;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Shared;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Anela.Heblo.Tests.Application.ShoptetOrders;
+
+public class GetPackingOrderHandlerTests
+{
+    private readonly Mock<IPackingOrderClient> _clientMock = new();
+
+    private GetPackingOrderHandler CreateHandler() =>
+        new(
+            _clientMock.Object,
+            NullLogger<GetPackingOrderHandler>.Instance);
+
+    [Fact]
+    public async Task Handle_OrderFound_ReturnsMappedResponse()
+    {
+        _clientMock
+            .Setup(c => c.GetPackingOrderAsync("250001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackingOrder
+            {
+                Code = "250001",
+                CustomerName = "Jan Novák",
+                ShippingMethodName = "PPL (do ruky)",
+                Cooling = Cooling.L1,
+                IsCooled = true,
+                StatusId = 26,
+                IsEligibleForPacking = true,
+                CustomerNote = "Zabalit jako dárek",
+                EshopNote = "Stálý zákazník",
+                Items = new List<PackingOrderItem>
+                {
+                    new() { Name = "Krém", Quantity = 2, ImageUrl = "https://img/p.jpg" },
+                },
+            });
+
+        var response = await CreateHandler().Handle(
+            new GetPackingOrderRequest { Code = "250001" }, CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Code.Should().Be("250001");
+        response.CustomerName.Should().Be("Jan Novák");
+        response.ShippingMethodName.Should().Be("PPL (do ruky)");
+        response.Cooling.Should().Be(Cooling.L1);
+        response.IsCooled.Should().BeTrue();
+        response.CustomerNote.Should().Be("Zabalit jako dárek");
+        response.EshopNote.Should().Be("Stálý zákazník");
+        response.Items.Should().ContainSingle().Which.Name.Should().Be("Krém");
+    }
+
+    [Fact]
+    public async Task Handle_WhenOrderIsInPackingState_ReturnsEligibleWithNullWarning()
+    {
+        _clientMock
+            .Setup(c => c.GetPackingOrderAsync("ORD001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackingOrder
+            {
+                Code = "ORD001",
+                CustomerName = "Jan Novák",
+                ShippingMethodName = "PPL",
+                StatusId = 26,
+                IsEligibleForPacking = true,
+                Items = [],
+            });
+
+        var result = await CreateHandler().Handle(
+            new GetPackingOrderRequest { Code = "ORD001" }, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Eligibility.IsEligible.Should().BeTrue();
+        result.Eligibility.WarningTitle.Should().BeNull();
+        result.Eligibility.WarningBody.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenOrderIsNotInPackingState_ReturnsIneligibleWithCzechWarning()
+    {
+        _clientMock
+            .Setup(c => c.GetPackingOrderAsync("ORD002", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackingOrder
+            {
+                Code = "ORD002",
+                CustomerName = "Jana Nováková",
+                ShippingMethodName = "PPL",
+                StatusId = 99,
+                IsEligibleForPacking = false,
+                Items = [],
+            });
+
+        var result = await CreateHandler().Handle(
+            new GetPackingOrderRequest { Code = "ORD002" }, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Eligibility.IsEligible.Should().BeFalse();
+        result.Eligibility.WarningTitle.Should().Be("Objednávka není ve stavu „Balí se“");
+        result.Eligibility.WarningBody.Should().Be("Tuto objednávku nezpracovávejte, dokud nebude ve správném stavu.");
+    }
+
+    [Fact]
+    public async Task Handle_OrderNotFound_ReturnsShoptetOrderNotFound()
+    {
+        _clientMock
+            .Setup(c => c.GetPackingOrderAsync("999999", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PackingOrder?)null);
+
+        var response = await CreateHandler().Handle(
+            new GetPackingOrderRequest { Code = "999999" }, CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ShoptetOrderNotFound);
+        response.Params.Should().ContainKey("orderCode").WhoseValue.Should().Be("999999");
+    }
+
+    [Fact]
+    public async Task Handle_ClientThrows_ReturnsInternalServerError()
+    {
+        _clientMock
+            .Setup(c => c.GetPackingOrderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shoptet unavailable"));
+
+        var response = await CreateHandler().Handle(
+            new GetPackingOrderRequest { Code = "250001" }, CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
+    }
+}
+```
+
+Notes on the diff vs. previous file:
+- `using Microsoft.Extensions.Options;` removed.
+- `CreateHandler(int packingStateId = 26)` simplified — no settings parameter, no `Options.Create(...)` call.
+- Each test that constructs a `PackingOrder` mock now sets `IsEligibleForPacking` explicitly so the test is not silently dependent on the `StatusId` comparison being done in the handler.
+
+- [ ] **Step 2: Run the tests — expect the test project to fail to compile**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~GetPackingOrderHandlerTests" --no-restore
+```
+Expected: **compile failure** — `GetPackingOrderHandler` constructor still takes `IOptions<ShoptetOrdersSettings>`, so `new(_clientMock.Object, NullLogger<...>.Instance)` is wrong-arity. This is the failing-test signal for Task 6.
+
+Do **not** commit yet.
+
+---
+
+## Task 6: Simplify `GetPackingOrderHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs`
+
+Drop `IOptions<ShoptetOrdersSettings>` and the recomputed comparison; consume `order.IsEligibleForPacking` directly.
+
+- [ ] **Step 1: Overwrite the handler with the simplified version**
+
+Replace the entire contents of `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.ShoptetOrders.UseCases.GetPackingOrder;
+
+public class GetPackingOrderHandler : IRequestHandler<GetPackingOrderRequest, GetPackingOrderResponse>
+{
+    private readonly IPackingOrderClient _client;
+    private readonly ILogger<GetPackingOrderHandler> _logger;
+
+    public GetPackingOrderHandler(
+        IPackingOrderClient client,
+        ILogger<GetPackingOrderHandler> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task<GetPackingOrderResponse> Handle(
+        GetPackingOrderRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var order = await _client.GetPackingOrderAsync(request.Code, cancellationToken);
+
+            if (order == null)
+            {
+                return new GetPackingOrderResponse(
+                    ErrorCodes.ShoptetOrderNotFound,
+                    new Dictionary<string, string> { { "orderCode", request.Code } });
+            }
+
+            var isEligible = order.IsEligibleForPacking;
+
+            return new GetPackingOrderResponse
+            {
+                Code = order.Code,
+                CustomerName = order.CustomerName,
+                ShippingMethodName = order.ShippingMethodName,
+                Cooling = order.Cooling,
+                IsCooled = order.IsCooled,
+                Eligibility = new PackingEligibility
+                {
+                    IsEligible = isEligible,
+                    WarningTitle = isEligible ? null : "Objednávka není ve stavu „Balí se“",
+                    WarningBody = isEligible ? null : "Tuto objednávku nezpracovávejte, dokud nebude ve správném stavu.",
+                },
+                CustomerNote = order.CustomerNote,
+                EshopNote = order.EshopNote,
+                Items = order.Items,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load packing order {OrderCode}", request.Code);
+            return new GetPackingOrderResponse(ErrorCodes.InternalServerError);
+        }
+    }
+}
+```
+
+Diff vs. previous file:
+- `using Microsoft.Extensions.Options;` removed.
+- `_settings` field and the `IOptions<ShoptetOrdersSettings>` ctor parameter removed.
+- `var isEligible = order.StatusId == _settings.Value.PackingStateId;` becomes `var isEligible = order.IsEligibleForPacking;`. The Czech warning strings are unchanged.
+
+- [ ] **Step 2: Run the targeted tests — expect them to pass**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~GetPackingOrderHandlerTests"
+```
+Expected: all 5 tests in `GetPackingOrderHandlerTests` pass.
+
+- [ ] **Step 3: Build the full solution to surface any other consumers**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: succeeds. The only consumer of `GetPackingOrderHandler`'s constructor is its DI registration, which works via reflection — no change required.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/GetPackingOrder/GetPackingOrderHandler.cs \
+       backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/GetPackingOrderHandlerTests.cs
+git commit -m "refactor: GetPackingOrderHandler consumes IsEligibleForPacking from contract"
+```
+
+---
+
+## Task 7: Update `ScanPackingOrderHandlerTests` to drive the contract change
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs`
+
+The handler tests today encode the rule `StatusId == 26 → eligible` directly via `DefaultOrderSettings`. After the refactor the rule lives on `PackingOrder.IsEligibleForPacking` and the assertions move from `UpdateStatusAsync(orderCode, 52, ct)` to `MarkAsPackedAsync(orderCode, ct)`.
+
+Replace the existing test file with the version below. All tests are kept (no coverage loss); only the seams change.
+
+- [ ] **Step 1: Overwrite the test file**
+
+Replace the contents of `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Packaging;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Anela.Heblo.Tests.Application.Packaging;
+
+public class ScanPackingOrderHandlerTests
+{
+    private readonly Mock<IShipmentClient> _shipmentClient = new();
+    private readonly Mock<IPackingOrderClient> _orderClient = new();
+    private readonly Mock<IEshopOrderClient> _eshopOrderClient = new();
+    private readonly Mock<IPackageRepository> _packageRepository = new();
+    private readonly Mock<ICurrentUserService> _currentUserService = new();
+
+    private static readonly ShipmentLabelsSettings DefaultLabelSettings = new()
+    {
+        DefaultPackageWidthMm = 300,
+        DefaultPackageHeightMm = 200,
+        DefaultPackageDepthMm = 150,
+        MinPackageWeightGrams = 100,
+    };
+
+    private ScanPackingOrderHandler CreateHandler(ShipmentLabelsSettings? labelSettings = null)
+    {
+        _currentUserService.Setup(c => c.GetCurrentUser())
+            .Returns(new CurrentUser("uid-1", "Operator", "op@example.com", IsAuthenticated: true));
+        return new(
+            _shipmentClient.Object,
+            _orderClient.Object,
+            _eshopOrderClient.Object,
+            Options.Create(labelSettings ?? DefaultLabelSettings),
+            new Mock<ILogger<ScanPackingOrderHandler>>().Object,
+            _packageRepository.Object,
+            _currentUserService.Object);
+    }
+
+    private static PackingOrder EligibleOrder(params (string name, int qty, int weightGrams)[] items) =>
+        new()
+        {
+            Code = "0001234",
+            StatusId = 26,
+            IsEligibleForPacking = true,
+            Items = items.Select(i => new PackingOrderItem
+            {
+                Name = i.name,
+                Quantity = i.qty,
+                WeightGrams = i.weightGrams,
+            }).ToList(),
+        };
+
+    // Test 1: Order not found → ErrorCodes.ShoptetOrderNotFound
+    [Fact]
+    public async Task Handle_OrderNotFound_ReturnsShoptetOrderNotFound()
+    {
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PackingOrder?)null);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ShoptetOrderNotFound);
+    }
+
+    // Test 2: Order in wrong state, no existing labels → ineligible response with no shipment
+    [Fact]
+    public async Task Handle_OrderNotInPackingState_WithoutExistingLabels_ReturnsIneligibleWithNoShipment()
+    {
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99, IsEligibleForPacking = false });
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Order.Should().NotBeNull();
+        response.Order!.Eligibility.IsEligible.Should().BeFalse();
+        response.Order.Eligibility.WarningTitle.Should().NotBeNullOrEmpty();
+        response.Shipment.Should().BeNull();
+
+        _shipmentClient.Verify(
+            c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // Test 2b: Order in wrong state but already has labels → ineligible response WITH shipment for review
+    [Fact]
+    public async Task Handle_OrderNotInPackingState_WithExistingLabels_ReturnsIneligibleWithShipment_AndDoesNotMarkPacked()
+    {
+        var shipmentGuid = Guid.NewGuid();
+        var existingLabel = new ShipmentLabel
+        {
+            ShipmentGuid = shipmentGuid,
+            OrderCode = "0001234",
+            PackageName = "P1",
+            TrackingNumber = "TRK-1",
+            LabelUrl = "https://example.com/label.pdf",
+        };
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99, IsEligibleForPacking = false });
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([existingLabel]);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Order!.Eligibility.IsEligible.Should().BeFalse();
+        response.Shipment.Should().NotBeNull();
+        response.Shipment!.AlreadyExisted.Should().BeTrue();
+        response.Shipment.ShipmentGuid.Should().Be(shipmentGuid);
+        response.Shipment.Packages.Should().ContainSingle()
+            .Which.TrackingNumber.Should().Be("TRK-1");
+
+        _shipmentClient.Verify(
+            c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _eshopOrderClient.Verify(
+            c => c.MarkAsPackedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // Test 3: Labels already exist on eligible order → return existing shipment without creating
+    [Fact]
+    public async Task Handle_LabelsExist_ReturnsExistingShipmentWithAlreadyExistedTrue()
+    {
+        var shipmentGuid = Guid.NewGuid();
+        var existingLabel = new ShipmentLabel
+        {
+            ShipmentGuid = shipmentGuid,
+            OrderCode = "0001234",
+            PackageName = "P1",
+            LabelUrl = "https://example.com/label.pdf",
+            LabelZpl = "^XA...^XZ",
+        };
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 400)));
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([existingLabel]);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Order!.Eligibility.IsEligible.Should().BeTrue();
+        response.Shipment.Should().NotBeNull();
+        response.Shipment!.AlreadyExisted.Should().BeTrue();
+        response.Shipment.ShipmentGuid.Should().Be(shipmentGuid);
+        response.Shipment.Packages.Should().HaveCount(1);
+        response.Shipment.Packages[0].Name.Should().Be("P1");
+        response.Shipment.Packages[0].LabelUrl.Should().Be("https://example.com/label.pdf");
+        response.Shipment.Packages[0].LabelZpl.Should().Be("^XA...^XZ");
+
+        _shipmentClient.Verify(
+            c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // Test 4: All items have WeightGrams = 0 → weight unavailable error
+    [Fact]
+    public async Task Handle_AllItemsHaveZeroWeight_ReturnsShipmentOrderWeightUnavailable()
+    {
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 2, 0), ("P002", 1, 0)));
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ShipmentOrderWeightUnavailable);
+    }
+
+    // Test 5: No shipping options returned → carrier not resolved error
+    [Fact]
+    public async Task Handle_NoShippingOptions_ReturnsShipmentCarrierNotResolved()
+    {
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 300)));
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _shipmentClient
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ShipmentCarrierNotResolved);
+    }
+
+    // Test 6: CreateShipmentAsync throws → creation failed error
+    [Fact]
+    public async Task Handle_CreateShipmentThrows_ReturnsShipmentCreationFailed()
+    {
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 500)));
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _shipmentClient
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShippingOption { CarrierCode = "PPL", Name = "PPL" }]);
+
+        _shipmentClient
+            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shipment API unavailable"));
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ShipmentCreationFailed);
+    }
+
+    // Test 7: Eligible order, no existing shipment → creates new shipment, AlreadyExisted = false
+    [Fact]
+    public async Task Handle_NoExistingShipment_CreatesNewShipmentWithAlreadyExistedFalse()
+    {
+        var shipmentGuid = Guid.NewGuid();
+
+        var order = new PackingOrder
+        {
+            Code = "0001234",
+            StatusId = 26,
+            IsEligibleForPacking = true,
+            Items = new List<PackingOrderItem>
+            {
+                new() { Name = "P001", Quantity = 1, WeightGrams = 400 },
+            },
+            ShippingStreet = "Hlavní 123",
+            ShippingCity = "Praha",
+            ShippingZip = "110 00",
+        };
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _shipmentClient
+            .SetupSequence(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([])
+            .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://carrier.example.com/new-label.pdf" }]);
+
+        _shipmentClient
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShippingOption { CarrierCode = "PPL", Name = "PPL" }]);
+
+        _shipmentClient
+            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreatedShipment { ShipmentGuid = shipmentGuid });
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Order!.Eligibility.IsEligible.Should().BeTrue();
+        response.Shipment.Should().NotBeNull();
+        response.Shipment!.AlreadyExisted.Should().BeFalse();
+        response.Shipment.ShipmentGuid.Should().Be(shipmentGuid);
+
+        _shipmentClient.Verify(
+            c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        response.Shipment.Packages[0].LabelUrl.Should().Be("https://carrier.example.com/new-label.pdf");
+        response.Shipment.Packages[0].LabelZpl.Should().BeNull();
+
+        response.Order!.ShippingAddress.Should().NotBeNull();
+        response.Order.ShippingAddress!.Street.Should().Be("Hlavní 123");
+        response.Order.ShippingAddress.City.Should().Be("Praha");
+        response.Order.ShippingAddress.Zip.Should().Be("110 00");
+    }
+
+    // Shipping address: when source has no address, response.Order.ShippingAddress is null
+    [Fact]
+    public async Task Handle_OrderWithoutShippingAddress_ReturnsNullShippingAddress()
+    {
+        var shipmentGuid = Guid.NewGuid();
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 400)));
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://example.com/label.pdf" }]);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Order.Should().NotBeNull();
+        response.Order!.ShippingAddress.Should().BeNull();
+    }
+
+    // MarkAsPackedAsync: called when existing shipment found and order is eligible
+    [Fact]
+    public async Task Handle_LabelsExist_MarksOrderAsPacked()
+    {
+        var shipmentGuid = Guid.NewGuid();
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 400)));
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://example.com/label.pdf" }]);
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        _eshopOrderClient.Verify(
+            c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // MarkAsPackedAsync: called when new shipment is created on eligible order
+    [Fact]
+    public async Task Handle_NewShipmentCreated_MarksOrderAsPacked()
+    {
+        var shipmentGuid = Guid.NewGuid();
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 400)));
+
+        _shipmentClient
+            .SetupSequence(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([])
+            .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://carrier.example.com/new-label.pdf" }]);
+
+        _shipmentClient
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShippingOption { CarrierCode = "PPL", Name = "PPL" }]);
+
+        _shipmentClient
+            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreatedShipment { ShipmentGuid = shipmentGuid });
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        _eshopOrderClient.Verify(
+            c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // MarkAsPackedAsync: failure is non-fatal — scan still returns success
+    [Fact]
+    public async Task Handle_MarkAsPackedFails_StillReturnsSuccessfulScanResponse()
+    {
+        var shipmentGuid = Guid.NewGuid();
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 400)));
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://example.com/label.pdf" }]);
+
+        _eshopOrderClient
+            .Setup(c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shoptet status update failed"));
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Shipment.Should().NotBeNull();
+    }
+
+    // MarkAsPackedAsync: NOT called when order is ineligible
+    [Fact]
+    public async Task Handle_OrderNotInPackingState_DoesNotMarkAsPacked()
+    {
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackingOrder { Code = "0001234", StatusId = 99, IsEligibleForPacking = false });
+
+        _shipmentClient
+            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        _eshopOrderClient.Verify(
+            c => c.MarkAsPackedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}
+```
+
+Diff vs. previous test file:
+- `DefaultOrderSettings` field removed.
+- `CreateHandler` no longer takes `ShoptetOrdersSettings` and no longer wraps it in `Options.Create(...)`.
+- `EligibleOrder()` sets `IsEligibleForPacking = true`.
+- Each `new PackingOrder { StatusId = 99 }` mock sets `IsEligibleForPacking = false` explicitly.
+- All `UpdateStatusAsync` verifications and setups are rewritten as `MarkAsPackedAsync` verifications and setups.
+- Test names containing "UpdatesOrderStatusToPacked" / "StatusUpdateFails" / "DoesNotUpdateStatus" are renamed to refer to `MarkAsPacked` for readability.
+
+- [ ] **Step 2: Run the targeted tests — expect a compile failure**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~ScanPackingOrderHandlerTests" --no-restore
+```
+Expected: **compile failure** — `ScanPackingOrderHandler` constructor still takes `IOptions<ShoptetOrdersSettings>`, so `CreateHandler` does not match. Drives Task 8.
+
+Do **not** commit yet.
+
+---
+
+## Task 8: Simplify `ScanPackingOrderHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs`
+
+Drop `ShoptetOrdersSettings`. Consume `order.IsEligibleForPacking`. Call `MarkAsPackedAsync` instead of `UpdateStatusAsync`. Update the warning log to drop the now-unknown `StatusId` placeholder.
+
+- [ ] **Step 1: Overwrite the handler with the simplified version**
+
+Replace the contents of `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Packaging;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
+
+public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, ScanPackingOrderResponse>
+{
+    private readonly IShipmentClient _shipmentClient;
+    private readonly IPackingOrderClient _orderClient;
+    private readonly IEshopOrderClient _eshopOrderClient;
+    private readonly ShipmentLabelsSettings _shipmentSettings;
+    private readonly ILogger<ScanPackingOrderHandler> _logger;
+    private readonly IPackageRepository _packageRepository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public ScanPackingOrderHandler(
+        IShipmentClient shipmentClient,
+        IPackingOrderClient orderClient,
+        IEshopOrderClient eshopOrderClient,
+        IOptions<ShipmentLabelsSettings> shipmentSettings,
+        ILogger<ScanPackingOrderHandler> logger,
+        IPackageRepository packageRepository,
+        ICurrentUserService currentUserService)
+    {
+        _shipmentClient = shipmentClient;
+        _orderClient = orderClient;
+        _eshopOrderClient = eshopOrderClient;
+        _shipmentSettings = shipmentSettings.Value;
+        _logger = logger;
+        _packageRepository = packageRepository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<ScanPackingOrderResponse> Handle(ScanPackingOrderRequest request, CancellationToken ct)
+    {
+        var order = await _orderClient.GetPackingOrderAsync(request.OrderCode, ct);
+        if (order is null)
+            return new ScanPackingOrderResponse(ErrorCodes.ShoptetOrderNotFound);
+
+        var isEligible = order.IsEligibleForPacking;
+        var orderData = new ScanOrderData
+        {
+            Code = order.Code,
+            CustomerName = order.CustomerName,
+            ShippingMethodName = order.ShippingMethodName,
+            Cooling = order.Cooling,
+            IsCooled = order.IsCooled,
+            CustomerNote = order.CustomerNote,
+            EshopNote = order.EshopNote,
+            ShippingAddress = BuildShippingAddress(order),
+            Items = order.Items,
+            Eligibility = new ScanOrderEligibility
+            {
+                IsEligible = isEligible,
+                WarningTitle = isEligible ? null : "Objednávka není ve stavu „Balí se“",
+                WarningBody = isEligible ? null : "Tuto objednávku nezpracovávejte, dokud nebude ve správném stavu.",
+            },
+        };
+
+        var existingLabels = await _shipmentClient.GetLabelsByOrderCodeAsync(request.OrderCode, ct);
+        ScanShipmentData? existingShipment = existingLabels.Count > 0
+            ? new ScanShipmentData
+            {
+                ShipmentGuid = existingLabels[0].ShipmentGuid,
+                Packages = existingLabels
+                    .Select(l => new ScanShipmentPackage
+                    {
+                        Name = l.PackageName,
+                        TrackingNumber = l.TrackingNumber,
+                        LabelUrl = l.LabelUrl,
+                        LabelZpl = l.LabelZpl,
+                    })
+                    .ToList(),
+                AlreadyExisted = true,
+            }
+            : null;
+
+        if (!isEligible)
+        {
+            // Already-packed order rescanned for review: include shipment if it exists.
+            // Don't mark-as-packed; the order has already moved past the packing state.
+            return existingShipment is null
+                ? new ScanPackingOrderResponse(orderData)
+                : new ScanPackingOrderResponse(orderData, existingShipment);
+        }
+
+        if (existingShipment is not null)
+        {
+            await TryMarkAsPackedAsync(request.OrderCode, ct);
+            return new ScanPackingOrderResponse(orderData, existingShipment);
+        }
+
+        var totalWeightGrams = order.Items.Sum(i => i.WeightGrams * i.Quantity);
+        if (totalWeightGrams == 0)
+            return new ScanPackingOrderResponse(ErrorCodes.ShipmentOrderWeightUnavailable);
+
+        var weightGrams = Math.Max(totalWeightGrams, _shipmentSettings.MinPackageWeightGrams);
+
+        var options = await _shipmentClient.GetShippingOptionsAsync(request.OrderCode, ct);
+        if (options.Count == 0)
+            return new ScanPackingOrderResponse(ErrorCodes.ShipmentCarrierNotResolved);
+
+        var command = new CreateShipmentCommand
+        {
+            OrderCode = request.OrderCode,
+            CarrierCode = options[0].CarrierCode,
+            Package = new ShipmentPackage
+            {
+                WidthMm = _shipmentSettings.DefaultPackageWidthMm,
+                HeightMm = _shipmentSettings.DefaultPackageHeightMm,
+                DepthMm = _shipmentSettings.DefaultPackageDepthMm,
+                WeightGrams = weightGrams,
+            },
+        };
+
+        CreatedShipment createdShipment;
+        try
+        {
+            createdShipment = await _shipmentClient.CreateShipmentAsync(command, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create shipment for order {OrderCode}", request.OrderCode);
+            return new ScanPackingOrderResponse(ErrorCodes.ShipmentCreationFailed);
+        }
+
+        // Single fetch for package names + carrier label URLs (FE prints directly from the CDN).
+        var newLabels = await _shipmentClient.GetLabelsByOrderCodeAsync(request.OrderCode, ct);
+        var packages = newLabels.Count > 0
+            ? newLabels.Select(l => new ScanShipmentPackage
+            {
+                Name = l.PackageName,
+                TrackingNumber = l.TrackingNumber,
+                LabelUrl = l.LabelUrl,
+                LabelZpl = l.LabelZpl,
+            }).ToList()
+            : [new ScanShipmentPackage { Name = "PKG-1" }];
+
+        await PersistPackagesAsync(
+            request.OrderCode,
+            orderData.CustomerName,
+            command.CarrierCode,
+            createdShipment.ShipmentGuid,
+            newLabels,
+            ct);
+
+        await TryMarkAsPackedAsync(request.OrderCode, ct);
+        return new ScanPackingOrderResponse(orderData, new ScanShipmentData
+        {
+            ShipmentGuid = createdShipment.ShipmentGuid,
+            Packages = packages,
+            AlreadyExisted = false,
+        });
+    }
+
+    private static ShippingAddress? BuildShippingAddress(PackingOrder order)
+    {
+        var street = string.IsNullOrEmpty(order.ShippingStreet) ? null : order.ShippingStreet;
+        var city = string.IsNullOrEmpty(order.ShippingCity) ? null : order.ShippingCity;
+        var zip = string.IsNullOrEmpty(order.ShippingZip) ? null : order.ShippingZip;
+
+        if (street is null && city is null && zip is null)
+            return null;
+
+        return new ShippingAddress
+        {
+            Street = street,
+            City = city,
+            Zip = zip,
+        };
+    }
+
+    private async Task TryMarkAsPackedAsync(string orderCode, CancellationToken ct)
+    {
+        try
+        {
+            await _eshopOrderClient.MarkAsPackedAsync(orderCode, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to mark order {OrderCode} as packed", orderCode);
+        }
+    }
+
+    private async Task PersistPackagesAsync(
+        string orderCode,
+        string customerName,
+        string carrierCode,
+        Guid shipmentGuid,
+        IReadOnlyList<ShipmentLabel> labels,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var packedBy = _currentUserService.GetCurrentUser().Email;
+
+        foreach (var label in labels)
+        {
+            try
+            {
+                await _packageRepository.AddAsync(new Package
+                {
+                    OrderCode = orderCode,
+                    CustomerName = customerName,
+                    PackageNumber = label.PackageName,
+                    TrackingNumber = label.TrackingNumber,
+                    ShippingProviderCode = carrierCode,
+                    ShippingProviderName = null,
+                    ShipmentGuid = shipmentGuid,
+                    PackedAt = now,
+                    PackedBy = packedBy,
+                    CreatedAt = now,
+                }, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to persist Package row for order {OrderCode} package {PackageName}",
+                    orderCode, label.PackageName);
+            }
+        }
+    }
+}
+```
+
+Diff vs. previous file:
+- `_orderSettings` field, `ShoptetOrdersSettings orderSettings` ctor parameter and assignment removed.
+- `var isEligible = order.StatusId == _orderSettings.PackingStateId;` → `var isEligible = order.IsEligibleForPacking;`.
+- `TryMarkAsPackedAsync` calls `_eshopOrderClient.MarkAsPackedAsync(orderCode, ct)`.
+- Warning log message becomes `"Failed to mark order {OrderCode} as packed"` (no `StatusId` placeholder).
+- `Microsoft.Extensions.Options` using remains because `IOptions<ShipmentLabelsSettings>` is still injected.
+
+- [ ] **Step 2: Run the targeted tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~ScanPackingOrderHandlerTests"
+```
+Expected: all 13 tests in `ScanPackingOrderHandlerTests` pass.
+
+- [ ] **Step 3: Build the full solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: succeeds.
+
+- [ ] **Step 4: Grep the Packaging module to confirm nothing references Shoptet status-id leak names**
+
+Run:
+```bash
+git grep -n -e "ShoptetOrdersSettings" -e "PackingStateId" -e "PackedStateId" \
+    -- "backend/src/Anela.Heblo.Application/Features/Packaging/"
+```
+Expected: **no output** (the grep returns nothing). If anything matches, fix that file before moving on. Per FR-3 acceptance criterion #4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs \
+       backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
+git commit -m "refactor: ScanPackingOrderHandler consumes contract IsEligibleForPacking and MarkAsPackedAsync"
+```
+
+---
+
+## Task 9: Add an architecture test to pin the new boundary
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+The existing test class enforces module boundaries with reflection-based theory rows. We add a new `Packaging -> ShoptetOrders` rule with an allowlist that only permits the legitimate contract types (`IPackingOrderClient`, `PackingOrder`, `PackingOrderItem`, `IEshopOrderClient`, plus the supporting `ShipmentLabel` etc. that already cross via the `ShipmentLabels` module — those are not in `ShoptetOrders`, so they don't need allowlisting; only `ShoptetOrders` types do).
+
+The rule's forbidden prefix is `Anela.Heblo.Application.Features.ShoptetOrders`. The allowlist permits the contracts the spec keeps as the legitimate seam.
+
+- [ ] **Step 1: Add the allowlist**
+
+In `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`, add a new field next to the other allowlist fields (e.g., just below `ExpeditionListLogisticsAllowlist`):
+
+```csharp
+    // Allowlist for Packaging -> ShoptetOrders. The Packaging module legitimately consumes
+    // the IPackingOrderClient / IEshopOrderClient contracts (and their DTOs) defined in
+    // Anela.Heblo.Application.Features.ShoptetOrders. Everything else — particularly
+    // ShoptetOrdersSettings, PackingStateId, and PackedStateId — must not be referenced
+    // from Packaging. This rule pins the 2026-06-05 decoupling in place.
+    private static readonly HashSet<string> PackagingShoptetOrdersAllowlist = new(StringComparer.Ordinal)
+    {
+        // Constructor injections in ScanPackingOrderHandler.
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IPackingOrderClient",
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IEshopOrderClient",
+
+        // PackingOrder is consumed in Handle and in the private BuildShippingAddress helper;
+        // PackingOrderItem flows through ScanOrderData.Items.
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrder",
+        "Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder.ScanPackingOrderHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrderItem",
+    };
+```
+
+- [ ] **Step 2: Register the rule in the `Rules()` theory data**
+
+In the same file, inside the `public static TheoryData<ModuleBoundaryRule> Rules()` method, append (immediately before the closing `};`) a new entry:
+
+```csharp
+        new ModuleBoundaryRule(
+            Name: "Packaging -> ShoptetOrders",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Packaging",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Application.Features.ShoptetOrders",
+            },
+            Allowlist: PackagingShoptetOrdersAllowlist),
+```
+
+- [ ] **Step 3: Run the architecture test**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+Expected: passes for `Packaging -> ShoptetOrders`. If it fails, the failure message lists every `consumerType -> referencedType` outside the allowlist. If a real consumer (`ScanPackingOrderRequest`, `ScanPackingOrderResponse`, `ScanOrderData`, etc.) legitimately references additional `ShoptetOrders` types reached via the contract surface (e.g. another `PackingOrder*` DTO), add them explicitly to `PackagingShoptetOrdersAllowlist` with a brief comment. Do **not** add `ShoptetOrdersSettings` to the allowlist — that would defeat the rule.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test: pin Packaging -> ShoptetOrders boundary in ModuleBoundariesTests"
+```
+
+---
+
+## Task 10: Final validation
+
+End-to-end checks before declaring the work complete. No new code changes; this step verifies the deliverable as a whole.
+
+- [ ] **Step 1: Build the full solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: succeeds with zero errors.
+
+- [ ] **Step 2: Run the full backend test suite**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: all tests pass. Pay particular attention to:
+- `Anela.Heblo.Tests.Application.Packaging.ScanPackingOrderHandlerTests` (13 tests)
+- `Anela.Heblo.Tests.Application.ShoptetOrders.GetPackingOrderHandlerTests` (5 tests)
+- `Anela.Heblo.Tests.Architecture.ModuleBoundariesTests` (theory; the new row must pass and all pre-existing rows must still pass)
+- `Anela.Heblo.Tests.ApplicationStartupTests` (validates that DI composes — the constructor changes on `ShoptetApiPackingOrderClient` and `ShoptetOrderClient` must resolve via `IOptions<ShoptetOrdersSettings>`)
+
+- [ ] **Step 3: Run `dotnet format` so the worktree matches repo style**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+Expected: no diff, or a small whitespace diff. Stage any formatting changes:
+```bash
+git add backend/
+git diff --cached --stat
+```
+If there are formatting-only changes, amend them into the most recent commit:
+```bash
+git commit --amend --no-edit
+```
+
+- [ ] **Step 4: Grep both the Packaging namespace and the source files one more time**
+
+Confirm the FR-3 acceptance criterion and NFR-3 — knowledge of status ids is confined to the four locations the spec lists:
+
+```bash
+git grep -n -e "PackingStateId" -e "PackedStateId" -e "ShoptetOrdersSettings" -- backend/src
+```
+Expected output lists matches **only** in:
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs`
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersModule.cs`
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrder/BlockOrderProcessingHandler.cs` (existing, untouched)
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs`
+
+Any other match is a regression — fix it before moving on. The `ShoptetApiAdapterServiceCollectionExtensions.cs` file does not match because it never names `ShoptetOrdersSettings` directly; it lets DI resolve `IOptions<ShoptetOrdersSettings>` from the binding.
+
+- [ ] **Step 5: Behaviour-parity smoke check (manual / optional)**
+
+If the engineer wants to verify FR-4 manually, exercise the two endpoints against the staging configuration (or local user-secrets configuration with `PackingStateId = 26`, `PackedStateId = 52`):
+- `GET /api/packing-orders/{code}` for an order in status 26 → `Eligibility.IsEligible = true`, `WarningTitle` / `WarningBody` null.
+- `GET /api/packing-orders/{code}` for an order in any other status → `Eligibility.IsEligible = false`, Czech warning strings exactly as before.
+- `POST /api/packaging/scan` body `{ "OrderCode": "..." }` for an eligible order → triggers exactly one `PATCH /api/orders/{code}/status` with `statusId: 52`. Same request as today.
+- `POST /api/packaging/scan` for an ineligible order → no `PATCH` call to Shoptet.
+
+Network captures should be byte-for-byte identical to pre-refactor behaviour.
+
+---
+
+## Spec Coverage Check
+
+| Spec item | Covered by |
+|---|---|
+| **FR-1** Move packing eligibility onto `PackingOrder` contract; `ShoptetApiPackingOrderClient` is the sole producer | Tasks 1, 4 |
+| **FR-1** `ScanPackingOrderHandler` consumes `order.IsEligibleForPacking` | Task 8 |
+| **FR-1** `GetPackingOrderHandler` consumes `order.IsEligibleForPacking` and drops `IOptions<ShoptetOrdersSettings>` | Task 6 |
+| **FR-2** `IEshopOrderClient.MarkAsPackedAsync` declared and implemented; XML doc per spec | Tasks 2, 3 |
+| **FR-2** Generic `UpdateStatusAsync` left in place | Tasks 2, 3 leave it untouched; verified by Task 10 grep + tests |
+| **FR-3** No `ShoptetOrdersSettings`/`PackingStateId`/`PackedStateId` references in Packaging | Task 8 step 4 grep; Task 10 step 4 grep; Task 9 architecture test enforces |
+| **FR-4** Byte-for-byte behaviour parity | Tasks 5–8 keep Czech warnings + `PATCH /api/orders/{code}/status` path identical; Task 10 step 5 manual check |
+| **NFR-1** No new HTTP/DB round-trips | Task 4 reuses the existing `GetOrderStatusIdAsync` call; Task 3 reuses the existing `UpdateStatusAsync` PATCH |
+| **NFR-2** No security surface change | No auth/config flow touched |
+| **NFR-3** Knowledge of status ids confined to 4 named locations | Task 10 step 4 grep verifies; Task 9 enforces |
+| **NFR-4** No HTTP response shape change | Task 6, 8 preserve all response DTO shapes verbatim |
+| **Arch-review amendment 1** Architecture enforcement test for Packaging | Task 9 |
+| **Arch-review amendment 2** Tighten XML doc on `PackingOrder.StatusId` | Task 1 |
+| **Out of scope** Removing `PackingOrder.StatusId`, renaming `ShoptetOrdersSettings`, changing eligibility rule | Explicitly not done; verified by Task 4 (StatusId still set) and Task 1 (StatusId still present) |


### PR DESCRIPTION

Removes the direct coupling from `Application.Features.Packaging` onto `ShoptetOrdersSettings` — a configuration class owned by the `ShoptetOrders` module. Two concrete changes land: (1) `PackingOrder` now carries a precomputed `IsEligibleForPacking` flag set by `ShoptetApiPackingOrderClient` using `PackingStateId`, so neither handler needs to know that constant; (2) `IEshopOrderClient` gets a `MarkAsPackedAsync` method implemented by `ShoptetOrderClient` via the existing `UpdateStatusAsync` path, hiding `PackedStateId` from `ScanPackingOrderHandler`. Both handlers are simplified accordingly. An architecture enforcement test (`ModuleBoundariesTests`, `Packaging -> ShoptetOrders` rule) pins the boundary so it cannot silently re-erode.

### Changes
- `IPackingOrderClient.cs` — `PackingOrder` gains `IsEligibleForPacking`; `StatusId` XML doc steers readers away from re-deriving eligibility
- `IEshopOrderClient.cs` — new `MarkAsPackedAsync` method on the contract
- `ShoptetOrderClient.cs` — injects `IOptions<ShoptetOrdersSettings>`, implements `MarkAsPackedAsync`
- `ShoptetApiPackingOrderClient.cs` — injects `IOptions<ShoptetOrdersSettings>`, sets `IsEligibleForPacking` on returned DTO
- `GetPackingOrderHandler.cs` — drops `IOptions<ShoptetOrdersSettings>`, reads `order.IsEligibleForPacking`
- `ScanPackingOrderHandler.cs` — drops `ShoptetOrdersSettings`, reads `order.IsEligibleForPacking`, calls `MarkAsPackedAsync`
- Test files (4 handler tests, 1 architecture) — updated to match new contracts; 5 adapter tests fixed for `ShoptetOrderClient` constructor change

---

Closes #2627

### Tokens used
31154903
