### PR TITLE
feat: Refactor `useUserManagement.ts` to Use Generated Typed Client

### DIFF
--- a/artifacts/feat-arch-review-usermanagement-useusermanage/arch-review.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-useusermanage/arch-review.r1.md
@@ -1,0 +1,186 @@
+# Architecture Review: Refactor `useUserManagement.ts` to Use Generated Typed Client
+
+## Skip Design: true
+
+No UI components, screens, or visual design changes. This is a pure transport-layer refactor inside a single hook file. The consumer (`ResponsiblePersonCombobox`) is untouched.
+
+## Architectural Fit Assessment
+
+The feature is a textbook conformance fix: one hook drifted from a project-wide convention, and this work restores conformance. Verified facts on disk:
+
+- **Pattern is universally established.** `useOrgChart.ts:13` and the rest of `frontend/src/api/hooks/` call `getAuthenticatedApiClient()` synchronously and invoke the generated method directly. `useUserManagement.ts:9-27` is the lone outlier.
+- **`getAuthenticatedApiClient()` is synchronous** (`frontend/src/api/client.ts:275`, returns `ApiClient`, not `Promise<ApiClient>`). The current `await` is dead-but-harmless.
+- **The generated method exists and already does the right things.** `api-client.ts:11660` builds the URL, `:11675` calls `this.http.fetch`, and `:11687` runs `GetGroupMembersResponse.fromJS(resultData200)`. It also throws on 400/401/non-2xx — meaning the manual `if (!response.ok) throw` in the current hook becomes redundant.
+- **Centralised cross-cutting concerns are inside `authenticatedHttp.fetch`** (`client.ts:281-365`): auth headers, E2E cookies, 401 redirect, global toast handling, 409-business-outcome suppression. Routing the call through the generated client *re-enters* this pipeline; the current manual fetch *already* re-enters it (it grabs `(apiClient as any).http.fetch`). Net behavioural change for error UX: **none**.
+
+Two corrections the spec did not catch:
+
+1. **Identifier mismatch.** Brief and spec call the hook `useGroupMembers`. The actual export is `useResponsiblePersonsQuery` (`useUserManagement.ts:5`). Implementation must preserve the real name; renaming would break `ResponsiblePersonCombobox.tsx:11` and the test file. Spec FR-3's code sample mentions `useGroupMembers` and must be read as illustrative only.
+2. **Existing tests are coupled to the old internals.** `__tests__/useUserManagement.test.tsx:7-17` mocks `getAuthenticatedApiClient` to return `{ baseUrl, http: { fetch } }` and stubs `global.fetch`. After the refactor, the mock shape must change to expose `userManagement_GetGroupMembers`. Spec NFR-3 ("existing unit tests must continue to pass") is **not** literally achievable — those tests *will* require an update. This needs to be acknowledged before work starts.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ResponsiblePersonCombobox.tsx
+        │  (uses)
+        ▼
+useResponsiblePersonsQuery  ◄────── React Query (cache, retry, enabled)
+        │
+        │  queryFn = () => apiClient.userManagement_GetGroupMembers(groupId)
+        ▼
+ApiClient (generated)                ◄── URL build, fromJS deserialization,
+        │                                typed error branches (400/401)
+        │  this.http.fetch(...)
+        ▼
+authenticatedHttp.fetch (in client.ts)
+        │
+        │  • buildAuthHeaders (token / E2E header)
+        │  • credentials policy
+        │  • 401 → clearTokenCache + globalAuthRedirectHandler
+        │  • global toast (with 409 suppression)
+        ▼
+window.fetch
+```
+
+The shape after refactor matches every other hook in the directory. No new layers, no new abstractions.
+
+### Key Design Decisions
+
+#### Decision 1: Use the generated method directly; do not introduce a wrapper
+
+**Options considered:**
+- (a) Call `apiClient.userManagement_GetGroupMembers(groupId)` directly inside `queryFn` (peer-hook pattern).
+- (b) Wrap the call in a thin module-private function for "future extensibility."
+- (c) Introduce a `UserManagement` repository/service abstraction.
+
+**Chosen approach:** (a).
+
+**Rationale:** Every existing hook uses (a). (b) and (c) violate YAGNI and create a third pattern in a codebase that already has exactly one. The goal of this refactor is to *remove* drift, not introduce a new abstraction.
+
+#### Decision 2: Drop the manual `if (!response.ok) throw` block
+
+**Options considered:**
+- (a) Remove it — the generated `processUserManagement_GetGroupMembers` already throws on non-2xx (`api-client.ts:11704-11707`).
+- (b) Keep an equivalent check wrapping the generated call.
+
+**Chosen approach:** (a).
+
+**Rationale:** The generated client throws `SwaggerException` (or the typed `ProblemDetails` branches for 400/401) before the promise resolves. React Query will mark the query as `isError`. Keeping a redundant check would be dead code. This is consistent with `useOrgChart.ts`, which has no such guard.
+
+#### Decision 3: Preserve `useResponsiblePersonsQuery` name, `queryKey` shape, and React Query options verbatim
+
+**Options considered:**
+- (a) Keep `queryKey: [...QUERY_KEYS.userManagement, 'group-members', groupId]`, `enabled: Boolean(groupId)`, `staleTime: 15 * 60 * 1000`, `retry: 2`, `retryDelay: 1000` exactly as today.
+- (b) "Tidy" any of the above to match `useOrgChart`'s shape.
+
+**Chosen approach:** (a).
+
+**Rationale:** Spec FR-2 mandates behavioural parity. The cache key, retry policy, and staleTime are observable behaviour for consumers and any persisted React Query cache. Changing them is out of scope and would silently invalidate the cache on deploy.
+
+#### Decision 4: Update the existing test file as part of this work
+
+**Options considered:**
+- (a) Update `__tests__/useUserManagement.test.tsx` so the `getAuthenticatedApiClient` mock returns `{ userManagement_GetGroupMembers: jest.fn() }` instead of `{ baseUrl, http }`.
+- (b) Leave the test file alone and rely on NFR-3 as written.
+
+**Chosen approach:** (a).
+
+**Rationale:** Option (b) is impossible — the existing mock provides `baseUrl` and `http.fetch`; after the refactor the hook calls `userManagement_GetGroupMembers`, which is `undefined` on the current mock and will throw. The spec must be amended (see "Specification Amendments") and the tests must be migrated to the new mocking shape. This is a small, mechanical change confined to the test file.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. All changes are confined to:
+
+- `frontend/src/api/hooks/useUserManagement.ts` — the hook itself.
+- `frontend/src/api/hooks/__tests__/useUserManagement.test.tsx` — mock shape and assertions.
+
+No changes to `client.ts`, the generated client, `ResponsiblePersonCombobox.tsx`, or any peer hook.
+
+### Interfaces and Contracts
+
+**Hook export (unchanged signature):**
+```ts
+export const useResponsiblePersonsQuery = (groupId: string): UseQueryResult<GetGroupMembersResponse, Error>
+```
+
+**Implementation shape (target):**
+```ts
+import { useQuery } from '@tanstack/react-query';
+import type { GetGroupMembersResponse } from '../generated/api-client';
+import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
+
+export const useResponsiblePersonsQuery = (groupId: string) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.userManagement, 'group-members', groupId],
+    enabled: Boolean(groupId),
+    queryFn: async (): Promise<GetGroupMembersResponse> => {
+      const apiClient = getAuthenticatedApiClient();
+      return apiClient.userManagement_GetGroupMembers(groupId);
+    },
+    staleTime: 15 * 60 * 1000,
+    retry: 2,
+    retryDelay: 1000,
+  });
+};
+```
+
+Note: `apiClient.userManagement_GetGroupMembers` takes `string | undefined` (`api-client.ts:11660`). Passing `groupId: string` satisfies this; the `enabled` gate prevents calls when `groupId` is empty.
+
+**Test mock shape (target):**
+```ts
+const mockUserManagement_GetGroupMembers = jest.fn();
+
+jest.mock('../../client', () => ({
+  getAuthenticatedApiClient: jest.fn(() => ({
+    userManagement_GetGroupMembers: mockUserManagement_GetGroupMembers,
+  })),
+  QUERY_KEYS: { userManagement: ['user-management'] },
+}));
+```
+
+Tests should `mockResolvedValue({ success: true, members: [] })` directly on `mockUserManagement_GetGroupMembers`, not on `global.fetch`. Remove `global.fetch` mocking and `response.json` plumbing from the test file.
+
+### Data Flow
+
+For the single read path:
+
+1. Consumer (`ResponsiblePersonCombobox`) renders with a `groupId`.
+2. `useResponsiblePersonsQuery(groupId)` is called; React Query checks cache under `['user-management', 'group-members', groupId]`.
+3. On cache miss and `Boolean(groupId) === true`, `queryFn` runs.
+4. `getAuthenticatedApiClient()` returns a new `ApiClient` instance wired with `authenticatedHttp` (synchronous).
+5. `apiClient.userManagement_GetGroupMembers(groupId)` builds `/api/UserManagement/group-members?groupId={...}` and calls `this.http.fetch`.
+6. `authenticatedHttp.fetch` attaches auth/E2E headers, calls `window.fetch`, applies 401 redirect and toast logic.
+7. Response is parsed via `GetGroupMembersResponse.fromJS(...)`. On 400/401, a `ProblemDetails` exception is thrown; on other non-2xx, `SwaggerException` is thrown.
+8. The thrown error surfaces as `isError === true` in the consumer; the deserialized object surfaces as `data`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing tests fail because they mock the old internals. | Medium | Update the test file in the same PR. Spec amendment required (see below). |
+| Subtle change in error object shape (`SwaggerException` vs. `Error("HTTP error! status: …")`). Any consumer doing `instanceof Error` checks or string-matching on the error message would break. | Low | Verified: `ResponsiblePersonCombobox.tsx` only reads `isError`/`isLoading`/`data` — never inspects the thrown error. No other consumers exist (`grep` confirmed). |
+| Response shape change: today the hook returns raw JSON; after the refactor it returns a `GetGroupMembersResponse` *class instance* produced by `fromJS`. The consumer accesses `response?.members` (line 46) and calls `.map(member => member.displayName ?? '', ...)` — works on both. | Low | Spot-check on PR: confirm `GetGroupMembersResponse.members` is exposed as a public property on the generated class. Tested implicitly by build + the existing combobox at runtime. |
+| `staleTime: 15 min` cache survives the deploy under the same key; if response shape diverges between deploys (raw JSON vs. class instance), already-cached entries could be plain objects without prototype methods. | Low | The consumer only uses property access (`.members`), no methods. Even if a stale plain-object entry exists, it still works. No mitigation required beyond awareness. |
+| Someone "tidies" the staleTime/retry/queryKey while doing the refactor, silently changing cache behaviour. | Low | Spec FR-2 already forbids this. Reviewer should diff the React Query options block. |
+
+## Specification Amendments
+
+1. **Hook name correction (spec FR-1, FR-3, summary, background).** All references to `useGroupMembers` must be read as `useResponsiblePersonsQuery`. The hook will not be renamed.
+2. **NFR-3 is unachievable as worded.** The existing test file (`frontend/src/api/hooks/__tests__/useUserManagement.test.tsx`) mocks the implementation details that this refactor removes. The acceptance criterion should be amended to: *"The existing test file is updated to mock `userManagement_GetGroupMembers` on the returned `ApiClient`. All tests under `useUserManagement.test.tsx` continue to pass after the update. No reduction in coverage of `useResponsiblePersonsQuery`."*
+3. **Error-handling block removal (clarification, not a contradiction).** The current hook's `if (!response.ok) throw ...` block must be deleted — keeping it is impossible because the generated method throws before returning. This is implied by FR-1 but worth stating explicitly so the reviewer doesn't ask for it back.
+4. **Out-of-scope clarification.** The `QUERY_KEYS.userManagement` constant in `client.ts:485` (value `["user-management"]`) is not touched, even though the query key spelling differs from the spec example (`'userManagement'`). Spec example wording is illustrative.
+
+## Prerequisites
+
+None. All required infrastructure already exists:
+
+- `apiClient.userManagement_GetGroupMembers` is generated (`api-client.ts:11660`).
+- `GetGroupMembersResponse` and its `fromJS` are generated.
+- `getAuthenticatedApiClient()` is exported synchronously (`client.ts:275`).
+- `QUERY_KEYS.userManagement` is defined (`client.ts:485`).
+
+No migrations, no config, no client regeneration, no backend changes.

--- a/artifacts/feat-arch-review-usermanagement-useusermanage/brief.md
+++ b/artifacts/feat-arch-review-usermanagement-useusermanage/brief.md
@@ -1,0 +1,53 @@
+## Module
+UserManagement
+
+## Finding
+`frontend/src/api/hooks/useUserManagement.ts:9-27` manually constructs a raw HTTP fetch call instead of using the generated typed client method.
+
+The generated client (`frontend/src/api/generated/api-client.ts:11643`) already exposes:
+```ts
+apiClient.userManagement_GetGroupMembers(groupId)
+```
+
+Instead, the hook does:
+```ts
+const apiClient = await getAuthenticatedApiClient();  // ← await on a sync function
+const relativeUrl = `/api/UserManagement/group-members?groupId=${encodeURIComponent(groupId)}`;
+const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;  // ← as any
+const response = await (apiClient as any).http.fetch(fullUrl, {  // ← as any
+  method: 'GET',
+  headers: { 'Content-Type': 'application/json' },
+});
+```
+
+Three concrete problems:
+1. `getAuthenticatedApiClient()` is synchronous; `await`-ing it is semantically wrong (works at runtime, signals a misunderstanding).
+2. Two `as any` casts bypass TypeScript's type system to access private internals.
+3. The raw `response.json()` call skips `GetGroupMembersResponse.fromJS(...)`, the generated deserialization / validation path.
+
+Every other hook in `frontend/src/api/hooks/` (e.g. `useOrgChart.ts:13`, `useArticles.ts`) calls the generated method directly:
+```ts
+const apiClient = getAuthenticatedApiClient();
+const response = await apiClient.userManagement_GetGroupMembers(groupId);
+return response;
+```
+
+## Why it matters
+- Drifts from the project's established hook pattern, making maintenance harder.
+- `as any` silently breaks if the generated client's internal shape changes.
+- Skipping `fromJS` means dates, enums, or nested objects would not be coerced to the right types if the contract ever grows.
+
+## Suggested fix
+Replace the manual fetch with the generated method:
+
+```ts
+queryFn: async (): Promise<GetGroupMembersResponse> => {
+  const apiClient = getAuthenticatedApiClient();
+  return apiClient.userManagement_GetGroupMembers(groupId);
+},
+```
+
+The authentication, base-URL construction, and response parsing are all handled by the generated client and `getAuthenticatedApiClient()` already.
+
+---
+_Filed by daily arch-review routine on 2026-06-05._

--- a/artifacts/feat-arch-review-usermanagement-useusermanage/impl/main.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-useusermanage/impl/main.r1.md
@@ -1,0 +1,44 @@
+Changes committed. Here's the output summary:
+
+---
+
+# Implementation: Refactor `useUserManagement.ts` to Use Generated Typed Client
+
+## What was implemented
+
+Replaced the manual raw-fetch implementation inside `useResponsiblePersonsQuery`'s `queryFn` with a direct call to the generated typed client method `apiClient.userManagement_GetGroupMembers(groupId)`. Updated the companion test file to mock the new method shape instead of the old `baseUrl`/`http.fetch` internals.
+
+## Files created/modified
+
+- `frontend/src/api/hooks/useUserManagement.ts` — removed 13 lines of raw fetch logic (URL building, header construction, `as any` casts, `response.ok` check, `response.json()`) and replaced with 2-line generated client call
+- `frontend/src/api/hooks/__tests__/useUserManagement.test.tsx` — updated mock factory from `{ baseUrl, http: { fetch } }` to `{ userManagement_GetGroupMembers: mockGetGroupMembers }`, removed `global.fetch` mocking, added default `mockResolvedValue` in `beforeEach`
+
+## Tests
+
+- `frontend/src/api/hooks/__tests__/useUserManagement.test.tsx` — 4 tests, all passing: loading state, initial state, hook structure, and cleanup
+
+## How to verify
+
+```bash
+cd frontend
+npm run build           # should compile cleanly
+npx eslint src/api/hooks/useUserManagement.ts src/api/hooks/__tests__/useUserManagement.test.tsx  # no output = clean
+npx react-scripts test --watchAll=false --testPathPattern="useUserManagement"  # 4 passed
+```
+
+## Notes
+
+- All pre-existing lint errors in other test files are unrelated and pre-date this change; the two modified files are clean.
+- The `node_modules` directory was installed via `npm install --legacy-peer-deps` because the worktree had no local install; `node_modules` is gitignored and not committed.
+- The spec's "NFR-3: existing tests must continue to pass" was amended per the arch-review (Decision 4): the test file was updated rather than left broken, since the old mocks targeted implementation details that no longer exist.
+
+## PR Summary
+
+Replaces the drift in `useResponsiblePersonsQuery` where a manual raw `fetch` call with `as any` casts bypassed the generated TypeScript client. The hook now calls `apiClient.userManagement_GetGroupMembers(groupId)` — the same pattern used by every other hook in `frontend/src/api/hooks/`. This restores type safety, re-enters the `authenticatedHttp` pipeline for auth headers and 401 handling, and enables `GetGroupMembersResponse.fromJS` deserialisation.
+
+### Changes
+- `frontend/src/api/hooks/useUserManagement.ts` — removed URL building, `as any` casts, manual header construction, `response.ok` check, and `response.json()` call; replaced with 2-line generated client invocation
+- `frontend/src/api/hooks/__tests__/useUserManagement.test.tsx` — migrated mock shape from `{ baseUrl, http.fetch }` to `{ userManagement_GetGroupMembers }` to match the refactored implementation
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-usermanagement-useusermanage/spec.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-useusermanage/spec.r1.md
@@ -1,0 +1,119 @@
+# Specification: Refactor `useUserManagement.ts` to Use Generated Typed Client
+
+## Summary
+The `useGroupMembers` hook in `frontend/src/api/hooks/useUserManagement.ts` bypasses the generated typed API client and constructs a raw HTTP fetch call with `as any` casts and an incorrect `await` on a synchronous function. This specification covers replacing the manual fetch with the established pattern used by all other hooks in `frontend/src/api/hooks/`, restoring type safety, response deserialization, and pattern consistency.
+
+## Background
+The project uses an auto-generated TypeScript API client (`frontend/src/api/generated/api-client.ts`) produced from the backend's OpenAPI schema on each build. Every other hook in `frontend/src/api/hooks/` (e.g., `useOrgChart.ts`, `useArticles.ts`) follows a consistent pattern: call `getAuthenticatedApiClient()` synchronously, then invoke the generated method directly. The generated client handles base URL construction, authentication headers, and response deserialization via `<Response>.fromJS(...)`.
+
+`useUserManagement.ts:9-27` diverges from this pattern for reasons that are not documented. The generated method `apiClient.userManagement_GetGroupMembers(groupId)` already exists at `api-client.ts:11643` and returns the correctly typed `GetGroupMembersResponse`. The current manual fetch:
+
+1. Awaits a synchronous function (`getAuthenticatedApiClient()`), which is semantically misleading even though it works at runtime.
+2. Uses two `as any` casts to reach into the client's private `baseUrl` and `http` fields, breaking type safety and creating a hidden coupling to the generated client's internal shape.
+3. Calls `response.json()` directly, skipping `GetGroupMembersResponse.fromJS(...)`, which means future contract additions (dates, enums, nested objects) would not be coerced into the correct runtime types.
+
+This is a small, isolated refactor with high signal: it aligns one hook with an established pattern, restores type safety, and removes drift.
+
+## Functional Requirements
+
+### FR-1: Replace manual fetch with generated client method
+Rewrite the `queryFn` in `useGroupMembers` to call `apiClient.userManagement_GetGroupMembers(groupId)` instead of constructing a raw fetch.
+
+**Acceptance criteria:**
+- `useUserManagement.ts` no longer contains any `as any` casts.
+- `useUserManagement.ts` no longer awaits `getAuthenticatedApiClient()` (the call is synchronous).
+- `useUserManagement.ts` no longer manually constructs URLs, headers, or calls `response.json()`.
+- The `queryFn` invokes `apiClient.userManagement_GetGroupMembers(groupId)` and returns its result.
+- The function signature, return type (`GetGroupMembersResponse`), and the hook's public API are unchanged.
+
+### FR-2: Preserve existing hook behavior
+The refactor is a like-for-like replacement of the transport mechanism. Query key, enabled condition, caching behavior, and error propagation must remain identical from the caller's perspective.
+
+**Acceptance criteria:**
+- Query key remains `['userManagement', 'groupMembers', groupId]` (or whatever the current key is — preserve verbatim).
+- The `enabled` predicate (e.g., `!!groupId`) is unchanged.
+- Any other React Query options currently passed (staleTime, retry, etc.) are unchanged.
+- Components consuming `useGroupMembers` require zero changes.
+
+### FR-3: Match the pattern used elsewhere in `frontend/src/api/hooks/`
+The final code shape should be visually consistent with peer hooks such as `useOrgChart.ts:13`.
+
+**Acceptance criteria:**
+- The hook structure mirrors the reference example in the brief:
+  ```ts
+  queryFn: async (): Promise<GetGroupMembersResponse> => {
+    const apiClient = getAuthenticatedApiClient();
+    return apiClient.userManagement_GetGroupMembers(groupId);
+  },
+  ```
+- No import of fetch utilities, no manual URL building, no header construction.
+
+## Non-Functional Requirements
+
+### NFR-1: Type Safety
+All `as any` casts in `useUserManagement.ts` must be eliminated. The file should pass `tsc --noEmit` with the project's existing strict settings and `npm run lint` with no new warnings.
+
+### NFR-2: Behavioral Parity
+Runtime behavior observed by callers must be identical: same response shape, same error handling semantics, same caching, same authentication flow. No regression in the UI or any consumer of `useGroupMembers`.
+
+### NFR-3: Test Coverage
+Any existing unit tests for `useUserManagement.ts` must continue to pass. If no tests currently exist for this hook, no new tests are required by this change (the brief describes a surgical refactor, not new functionality), but it should remain trivially testable via the same patterns used by other hooks.
+
+### NFR-4: Validation
+Before declaring done:
+- `npm run build` succeeds.
+- `npm run lint` passes with no new warnings.
+- Any tests touching `useUserManagement` pass.
+
+## Data Model
+No data model changes. The response type `GetGroupMembersResponse` is already defined by the generated client and is unchanged.
+
+## API / Interface Design
+
+**Affected file:** `frontend/src/api/hooks/useUserManagement.ts` (lines 9-27)
+
+**Before (current):**
+```ts
+queryFn: async (): Promise<GetGroupMembersResponse> => {
+  const apiClient = await getAuthenticatedApiClient();
+  const relativeUrl = `/api/UserManagement/group-members?groupId=${encodeURIComponent(groupId)}`;
+  const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+  const response = await (apiClient as any).http.fetch(fullUrl, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  const data = await response.json();
+  return data;
+},
+```
+
+**After (target):**
+```ts
+queryFn: async (): Promise<GetGroupMembersResponse> => {
+  const apiClient = getAuthenticatedApiClient();
+  return apiClient.userManagement_GetGroupMembers(groupId);
+},
+```
+
+**Backend endpoint:** No backend changes. The generated method `userManagement_GetGroupMembers` already calls `GET /api/UserManagement/group-members?groupId={groupId}` under the hood.
+
+## Dependencies
+- `frontend/src/api/generated/api-client.ts` — generated method `userManagement_GetGroupMembers` at line 11643 (already exists).
+- `frontend/src/api/client.ts` (or equivalent) — `getAuthenticatedApiClient()` factory (already exists, returns synchronously).
+- `@tanstack/react-query` — already in use by the hook.
+
+No new dependencies. No version bumps. No regeneration of the API client required.
+
+## Out of Scope
+- Refactoring other hooks in `frontend/src/api/hooks/` (they already follow the correct pattern).
+- Changes to the backend `UserManagement` controller, MediatR handlers, or DTOs.
+- Regenerating the OpenAPI client or modifying generation configuration.
+- Adding new unit tests for `useGroupMembers` beyond what already exists.
+- Changes to consumers of `useGroupMembers` (none should be needed).
+- Renaming, relocating, or restructuring `useUserManagement.ts`.
+- Addressing any other findings or refactors in the UserManagement module that weren't called out in the brief.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-usermanagement-useusermanage/task-plan.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-useusermanage/task-plan.r1.md
@@ -1,0 +1,9 @@
+Self-review against the spec:
+
+**Spec coverage** — FR-1 (use generated method) → Task 2.1; FR-2 (preserve queryKey/enabled/options + signature) → Task 2.1 explicit table, Definition of Done; FR-3 (match peer pattern) → Task 2.1 mirrors `useOrgChart.ts` exactly; NFR-1 (no `as any`, lint clean) → Task 3.2, DoD; NFR-2 (behavioural parity) → Task 2.1 table, DoD; NFR-3 (tests) → Task 1 (test migration), addresses arch-review Amendment 2; NFR-4 (build + lint) → Tasks 3.2 and 3.3. Arch-review amendments 1-4 all internalised in "Spec amendments to internalise".
+
+**Placeholder scan** — no TBDs, no "implement appropriate X", all code blocks complete.
+
+**Type consistency** — `useResponsiblePersonsQuery`, `GetGroupMembersResponse`, `userManagement_GetGroupMembers`, `QUERY_KEYS.userManagement` used consistently throughout.
+
+Plan saved to `artifacts/feat-arch-review-usermanagement-useusermanage/plan.r1.md`. It decomposes the refactor into three TDD-ordered tasks (failing tests first, refactor, validate) with exact file paths, full code, and explicit out-of-scope guardrails to keep the change surgical.

--- a/frontend/src/api/hooks/__tests__/useUserManagement.test.tsx
+++ b/frontend/src/api/hooks/__tests__/useUserManagement.test.tsx
@@ -3,13 +3,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
 import { useResponsiblePersonsQuery } from '../useUserManagement';
 
-// Mock the entire API client module
+const mockGetGroupMembers = jest.fn();
+
 jest.mock('../../client', () => ({
     getAuthenticatedApiClient: jest.fn(() => ({
-        baseUrl: 'http://localhost:5000',
-        http: {
-            fetch: jest.fn()
-        }
+        userManagement_GetGroupMembers: mockGetGroupMembers,
     })),
     QUERY_KEYS: {
         userManagement: ['user-management']
@@ -33,8 +31,7 @@ const createWrapper = () => {
 describe('useResponsiblePersonsQuery', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        // Mock fetch globally
-        global.fetch = jest.fn();
+        mockGetGroupMembers.mockResolvedValue({ success: true, members: [] });
     });
 
     afterEach(() => {
@@ -42,7 +39,7 @@ describe('useResponsiblePersonsQuery', () => {
     });
 
     it('should show loading state initially', () => {
-        (global.fetch as jest.Mock).mockImplementation(() => new Promise(() => {})); // Never resolves
+        mockGetGroupMembers.mockImplementation(() => new Promise(() => {})); // Never resolves
 
         const { result } = renderHook(() => useResponsiblePersonsQuery('test-group-id'), {
             wrapper: createWrapper(),
@@ -54,31 +51,19 @@ describe('useResponsiblePersonsQuery', () => {
     });
 
     it('should have correct initial state', () => {
-        (global.fetch as jest.Mock).mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ success: true, members: [] })
-        });
-
         const { result } = renderHook(() => useResponsiblePersonsQuery('test-group-id'), {
             wrapper: createWrapper(),
         });
 
-        // Check initial query state
         expect(result.current.failureCount).toBe(0);
         expect(result.current.dataUpdatedAt).toBeDefined();
     });
 
     it('should be a query hook with proper structure', () => {
-        (global.fetch as jest.Mock).mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ success: true, members: [] })
-        });
-
         const { result } = renderHook(() => useResponsiblePersonsQuery('test-group-id'), {
             wrapper: createWrapper(),
         });
 
-        // Check that it has the expected React Query structure
         expect(typeof result.current.isLoading).toBe('boolean');
         expect(typeof result.current.isError).toBe('boolean');
         expect(typeof result.current.isSuccess).toBe('boolean');
@@ -86,16 +71,10 @@ describe('useResponsiblePersonsQuery', () => {
     });
 
     it('should handle hook cleanup properly', () => {
-        (global.fetch as jest.Mock).mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ success: true, members: [] })
-        });
-
         const { unmount } = renderHook(() => useResponsiblePersonsQuery('test-group-id'), {
             wrapper: createWrapper(),
         });
 
-        // Test that unmounting doesn't throw errors
         expect(() => unmount()).not.toThrow();
     });
 });

--- a/frontend/src/api/hooks/useUserManagement.ts
+++ b/frontend/src/api/hooks/useUserManagement.ts
@@ -7,19 +7,8 @@ export const useResponsiblePersonsQuery = (groupId: string) => {
     queryKey: [...QUERY_KEYS.userManagement, 'group-members', groupId],
     enabled: Boolean(groupId),
     queryFn: async (): Promise<GetGroupMembersResponse> => {
-      const apiClient = await getAuthenticatedApiClient();
-      const relativeUrl = `/api/UserManagement/group-members?groupId=${encodeURIComponent(groupId)}`;
-      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
-      const response = await (apiClient as any).http.fetch(fullUrl, {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      return response.json();
+      const apiClient = getAuthenticatedApiClient();
+      return apiClient.userManagement_GetGroupMembers(groupId);
     },
     staleTime: 15 * 60 * 1000, // 15 minutes cache
     retry: 2,


### PR DESCRIPTION

Replaces the drift in `useResponsiblePersonsQuery` where a manual raw `fetch` call with `as any` casts bypassed the generated TypeScript client. The hook now calls `apiClient.userManagement_GetGroupMembers(groupId)` — the same pattern used by every other hook in `frontend/src/api/hooks/`. This restores type safety, re-enters the `authenticatedHttp` pipeline for auth headers and 401 handling, and enables `GetGroupMembersResponse.fromJS` deserialisation.

### Changes
- `frontend/src/api/hooks/useUserManagement.ts` — removed URL building, `as any` casts, manual header construction, `response.ok` check, and `response.json()` call; replaced with 2-line generated client invocation
- `frontend/src/api/hooks/__tests__/useUserManagement.test.tsx` — migrated mock shape from `{ baseUrl, http.fetch }` to `{ userManagement_GetGroupMembers }` to match the refactored implementation

---

Closes #2628

### Tokens used
3672950
