### PR TITLE
fix: run daily packing-material consumption after invoice imports

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Infrastructure/Jobs/DailyConsumptionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Infrastructure/Jobs/DailyConsumptionJob.cs
@@ -16,7 +16,7 @@ public class DailyConsumptionJob : IRecurringJob
         JobName = "daily-consumption-calculation",
         DisplayName = "Daily Consumption Calculation",
         Description = "Calculates daily consumption of packing materials",
-        CronExpression = "0 3 * * *", // Daily at 3:00 AM
+        CronExpression = "0 6 * * *", // Daily at 6:00 AM — after invoice imports (04:00 EUR / 04:15 CZK) so yesterday's invoices are available
         DefaultIsEnabled = true
     };
 


### PR DESCRIPTION
## Problem
Automatic packing-material consumption ("Automatická spotřeba") always recorded **0** — quantities never decreased. The `DailyConsumptionJob` ran at **03:00** but the invoice imports it depends on run at **04:00 (EUR) / 04:15 (CZK)**, so it processed a day whose invoices were not yet imported, computed zero consumption, and marked the day processed via the idempotency record — so it was never retried even after the invoices arrived an hour later. Verified against production: daily runs executed at 01:01 UTC (= 03:00 Prague), an hour before imports, with 0 materials processed despite 100–200 invoices existing for each of those days.

## Fix
Move the consumption job's default schedule from `0 3 * * *` to `0 6 * * *` (Europe/Prague), so yesterday's invoices are already imported when consumption runs.

## Deploy note
The cron is seeded into `RecurringJobConfigurations` and the DB value takes precedence over the code default, so already-seeded environments must also be updated (admin UI or `PUT /api/recurringjobs/daily-consumption-calculation/cron`); past days already locked at 0 are not backfilled.