### PR TITLE
fix: stop DQT runs crashing on duplicate codes (failing dashboard tiles)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/InvoiceDqtComparer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/InvoiceDqtComparer.cs
@@ -31,8 +31,15 @@ public class InvoiceDqtComparer : IInvoiceDqtComparer
 
         var flexiInvoices = await _flexiClient.GetAllAsync(from, to, ct);
 
-        var shoptetByCode = shoptetInvoices.ToDictionary(i => i.Code);
-        var flexiByCode = flexiInvoices.ToDictionary(i => i.Code);
+        // Invoice codes are expected to be unique, but a source occasionally returns the same
+        // code twice (e.g. paginated batch overlap). That is itself a data-quality finding —
+        // group instead of ToDictionary so a duplicate is reported, not a fatal crash.
+        var shoptetGroups = shoptetInvoices.GroupBy(i => i.Code).ToList();
+        var flexiGroups = flexiInvoices.GroupBy(i => i.Code).ToList();
+        var shoptetByCode = shoptetGroups.ToDictionary(g => g.Key, g => g.First());
+        var flexiByCode = flexiGroups.ToDictionary(g => g.Key, g => g.First());
+        var shoptetDupCounts = shoptetGroups.Where(g => g.Count() > 1).ToDictionary(g => g.Key, g => g.Count());
+        var flexiDupCounts = flexiGroups.Where(g => g.Count() > 1).ToDictionary(g => g.Key, g => g.Count());
 
         var allCodes = shoptetByCode.Keys.Union(flexiByCode.Keys).ToHashSet();
         var mismatches = new List<InvoiceDqtMismatch>();
@@ -42,12 +49,16 @@ public class InvoiceDqtComparer : IInvoiceDqtComparer
             var inShoptet = shoptetByCode.TryGetValue(code, out var shoptetInvoice);
             var inFlexi = flexiByCode.TryGetValue(code, out var flexiInvoice);
 
+            var duplicateDetail = BuildDuplicateDetail(code, shoptetDupCounts, flexiDupCounts);
+            var duplicateFlag = duplicateDetail is null ? InvoiceMismatchType.None : InvoiceMismatchType.DuplicateInvoiceCode;
+
             if (inShoptet && !inFlexi)
             {
                 mismatches.Add(new InvoiceDqtMismatch
                 {
                     InvoiceCode = code,
-                    MismatchType = InvoiceMismatchType.MissingInFlexi
+                    MismatchType = InvoiceMismatchType.MissingInFlexi | duplicateFlag,
+                    Details = duplicateDetail
                 });
                 continue;
             }
@@ -57,16 +68,17 @@ public class InvoiceDqtComparer : IInvoiceDqtComparer
                 mismatches.Add(new InvoiceDqtMismatch
                 {
                     InvoiceCode = code,
-                    MismatchType = InvoiceMismatchType.MissingInShoptet
+                    MismatchType = InvoiceMismatchType.MissingInShoptet | duplicateFlag,
+                    Details = duplicateDetail
                 });
                 continue;
             }
 
             // Both exist — compare
-            var flags = InvoiceMismatchType.None;
+            var flags = duplicateFlag;
             string? shoptetVal = null;
             string? flexiVal = null;
-            string? details = null;
+            string? details = duplicateDetail;
 
             if (Math.Abs(shoptetInvoice!.Price.TotalWithVat - flexiInvoice!.Price.TotalWithVat) > Tolerance)
             {
@@ -86,7 +98,7 @@ public class InvoiceDqtComparer : IInvoiceDqtComparer
             if (itemDiff != null)
             {
                 flags |= InvoiceMismatchType.ItemsDiffer;
-                details = itemDiff;
+                details = details is null ? itemDiff : $"{details}; {itemDiff}";
             }
 
             if (flags != InvoiceMismatchType.None)
@@ -113,15 +125,26 @@ public class InvoiceDqtComparer : IInvoiceDqtComparer
     {
         // Items without a product code (unidentifiable shipping/billing/discount lines) cannot
         // be matched cross-system — skip them to avoid duplicate-key crashes.
-        var shoptetByCode = shoptetItems
+        var shoptetGroups = shoptetItems
             .Where(i => !string.IsNullOrEmpty(i.Code))
-            .ToDictionary(i => i.Code);
-        var flexiByCode = flexiItems
+            .GroupBy(i => i.Code)
+            .ToList();
+        var flexiGroups = flexiItems
             .Where(i => !string.IsNullOrEmpty(i.Code))
-            .ToDictionary(i => i.Code);
+            .GroupBy(i => i.Code)
+            .ToList();
+        var shoptetByCode = shoptetGroups.ToDictionary(g => g.Key, g => g.First());
+        var flexiByCode = flexiGroups.ToDictionary(g => g.Key, g => g.First());
         var allCodes = shoptetByCode.Keys.Union(flexiByCode.Keys);
 
         var diffs = new List<string>();
+
+        // A product code appearing more than once within one invoice is itself a finding —
+        // report it rather than letting ToDictionary throw.
+        foreach (var g in shoptetGroups.Where(g => g.Count() > 1))
+            diffs.Add($"Item {g.Key}: duplicated in shoptet (x{g.Count()})");
+        foreach (var g in flexiGroups.Where(g => g.Count() > 1))
+            diffs.Add($"Item {g.Key}: duplicated in flexi (x{g.Count()})");
 
         foreach (var code in allCodes)
         {
@@ -151,5 +174,19 @@ public class InvoiceDqtComparer : IInvoiceDqtComparer
         }
 
         return diffs.Count > 0 ? string.Join("; ", diffs) : null;
+    }
+
+    private static string? BuildDuplicateDetail(
+        string code,
+        IReadOnlyDictionary<string, int> shoptetDupCounts,
+        IReadOnlyDictionary<string, int> flexiDupCounts)
+    {
+        var parts = new List<string>();
+        if (shoptetDupCounts.TryGetValue(code, out var shoptetCount))
+            parts.Add($"shoptet (x{shoptetCount})");
+        if (flexiDupCounts.TryGetValue(code, out var flexiCount))
+            parts.Add($"flexi (x{flexiCount})");
+
+        return parts.Count > 0 ? $"Duplicate invoice code in {string.Join(", ", parts)}" : null;
     }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
@@ -8,5 +8,6 @@ public enum InvoiceMismatchType
     MissingInShoptet = 2,
     TotalWithVatDiffers = 4,
     TotalWithoutVatDiffers = 8,
-    ItemsDiffer = 16
+    ItemsDiffer = 16,
+    DuplicateInvoiceCode = 32
 }

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/InvoiceDqtComparerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/InvoiceDqtComparerTests.cs
@@ -230,4 +230,51 @@ public class InvoiceDqtComparerTests
         Assert.True(combined.MismatchType.HasFlag(InvoiceMismatchType.TotalWithVatDiffers));
         Assert.True(combined.MismatchType.HasFlag(InvoiceMismatchType.ItemsDiffer));
     }
+
+    [Fact]
+    public async Task DuplicateShoptetInvoiceCode_DoesNotThrow_AndFlagsDuplicate()
+    {
+        // Production crash: Shoptet returned invoice code 126013089 twice → ToDictionary threw.
+        SetupShoptet(MakeInvoice("126013089"), MakeInvoice("126013089"));
+        SetupFlexi(MakeInvoice("126013089"));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Equal(1, result.TotalChecked);
+        var mismatch = Assert.Single(result.Mismatches);
+        Assert.Equal("126013089", mismatch.InvoiceCode);
+        Assert.True(mismatch.MismatchType.HasFlag(InvoiceMismatchType.DuplicateInvoiceCode));
+        Assert.Contains("shoptet", mismatch.Details);
+    }
+
+    [Fact]
+    public async Task DuplicateFlexiInvoiceCode_DoesNotThrow_AndFlagsDuplicate()
+    {
+        SetupShoptet(MakeInvoice("INV-DUP"));
+        SetupFlexi(MakeInvoice("INV-DUP"), MakeInvoice("INV-DUP"));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        var mismatch = Assert.Single(result.Mismatches);
+        Assert.Equal("INV-DUP", mismatch.InvoiceCode);
+        Assert.True(mismatch.MismatchType.HasFlag(InvoiceMismatchType.DuplicateInvoiceCode));
+        Assert.Contains("flexi", mismatch.Details);
+    }
+
+    [Fact]
+    public async Task DuplicateItemCodeWithinInvoice_DoesNotThrow_AndReportsDuplicate()
+    {
+        // Production crash: duplicate product codes (e.g. BAL0005M) within an invoice → ToDictionary threw.
+        var shoptetItems = new List<IssuedInvoiceDetailItem> { MakeItem("BAL0005M"), MakeItem("BAL0005M") };
+        var flexiItems = new List<IssuedInvoiceDetailItem> { MakeItem("BAL0005M") };
+
+        SetupShoptet(MakeInvoice("INV-ITEMDUP", items: shoptetItems));
+        SetupFlexi(MakeInvoice("INV-ITEMDUP", items: flexiItems));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        var mismatch = Assert.Single(result.Mismatches);
+        Assert.True(mismatch.MismatchType.HasFlag(InvoiceMismatchType.ItemsDiffer));
+        Assert.Contains("BAL0005M", mismatch.Details);
+    }
 }

--- a/frontend/src/components/dashboard/tiles/DataQualityTile.tsx
+++ b/frontend/src/components/dashboard/tiles/DataQualityTile.tsx
@@ -40,7 +40,7 @@ export const DataQualityTile: React.FC<DataQualityTileProps> = ({ data }) => {
       <div className="h-full flex items-center justify-center text-center">
         <div>
           <XCircle className="h-10 w-10 text-red-500 mx-auto mb-2" />
-          <p className="text-red-600 text-sm">{data.error || 'Chyba při načítání dat'}</p>
+          <p className="text-red-600 text-sm">{data.error || 'Poslední DQT test selhal'}</p>
         </div>
       </div>
     );

--- a/frontend/src/components/dashboard/tiles/DqtYesterdayStatusTile.tsx
+++ b/frontend/src/components/dashboard/tiles/DqtYesterdayStatusTile.tsx
@@ -51,7 +51,7 @@ export const DqtYesterdayStatusTile: React.FC<DqtYesterdayStatusTileProps> = ({ 
       <div className="h-full flex items-center justify-center text-center">
         <div>
           <XCircle className="h-10 w-10 text-red-500 mx-auto mb-2" />
-          <p className="text-red-600 text-sm">Chyba při načítání dat</p>
+          <p className="text-red-600 text-sm">Poslední DQT test selhal</p>
         </div>
       </div>
     );

--- a/frontend/src/components/dashboard/tiles/__tests__/DqtYesterdayStatusTile.test.tsx
+++ b/frontend/src/components/dashboard/tiles/__tests__/DqtYesterdayStatusTile.test.tsx
@@ -37,7 +37,7 @@ describe('DqtYesterdayStatusTile', () => {
   it('renders error state and does not navigate on click', () => {
     renderTile({ status: 'error', data: null, drillDown });
 
-    expect(screen.getByText('Chyba při načítání dat')).toBeInTheDocument();
+    expect(screen.getByText('Poslední DQT test selhal')).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
The **Kvalita dat** and **DQT včera** dashboard tiles showed errors because the underlying `IssuedInvoiceComparison` DQT runs were crashing — `InvoiceDqtComparer` called `ToDictionary` on invoice and item codes that aren't guaranteed unique, so a single duplicate code (confirmed in production, e.g. invoice `126013089`) threw `ArgumentException` and failed the whole run. This change groups by code instead and reports duplicates as data-quality findings via a new `DuplicateInvoiceCode` mismatch flag, so runs complete and surface the anomaly rather than dying on it. The tile error wording is also corrected to "Poslední DQT test selhal", since a failed test run is not a tile load failure. Covered by new comparer tests (duplicate Shoptet/Flexi invoice codes and duplicate item codes) plus an updated tile test; backend build/format and frontend build/lint all pass.

Note: after deploy, a DQT re-run (`POST /api/data-quality/runs` for the affected date) is needed to replace the latest *Failed* run before the tiles turn green.