### PR TITLE
feat: replace user profile dropdown with modal dialog

### DIFF
--- a/frontend/src/components/auth/UserProfile.tsx
+++ b/frontend/src/components/auth/UserProfile.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { User, LogIn, LogOut, ChevronUp } from "lucide-react";
+import { User, LogIn, LogOut, X, ShieldCheck } from "lucide-react";
 import { useAuth } from "../../auth/useAuth";
 import { useMockAuth, shouldUseMockAuth } from "../../auth/mockAuth";
 
@@ -12,21 +12,13 @@ const UserProfile: React.FC<UserProfileProps> = ({
   compact = false,
   menuPosition = "above",
 }) => {
-  // Use mock auth in development if enabled
   const realAuth = useAuth();
   const mockAuth = useMockAuth();
 
   const auth = shouldUseMockAuth() ? mockAuth : realAuth;
-  const {
-    isAuthenticated,
-    login,
-    logout,
-    getUserInfo,
-    getStoredUserInfo,
-    inProgress,
-  } = auth;
+  const { isAuthenticated, login, logout, getUserInfo, getStoredUserInfo, inProgress } = auth;
 
-  const [showMenu, setShowMenu] = useState(false);
+  const [showModal, setShowModal] = useState(false);
   const userInfo = getUserInfo();
   const storedUserInfo = getStoredUserInfo();
 
@@ -41,7 +33,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
   const handleLogout = async () => {
     try {
       await logout();
-      setShowMenu(false);
+      setShowModal(false);
     } catch (error) {
       console.error("Logout error:", error);
     }
@@ -49,9 +41,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
 
   if (inProgress === "login" || inProgress === "logout") {
     return (
-      <div
-        className={`flex items-center ${compact ? "justify-center" : "justify-center p-2"}`}
-      >
+      <div className={`flex items-center ${compact ? "justify-center" : "justify-center p-2"}`}>
         <div className="w-8 h-8 bg-gray-300 rounded-full animate-pulse"></div>
       </div>
     );
@@ -80,9 +70,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
           <User className="h-4 w-4 text-white" />
         </div>
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-gray-700 group-hover:text-gray-900">
-            Sign in
-          </p>
+          <p className="text-sm font-medium text-gray-700 group-hover:text-gray-900">Sign in</p>
           <p className="text-xs text-gray-500">Click to authenticate</p>
         </div>
         <LogIn className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
@@ -90,140 +78,113 @@ const UserProfile: React.FC<UserProfileProps> = ({
     );
   }
 
-  if (compact) {
-    return (
-      <div className="relative">
-        <button
-          onClick={() => setShowMenu(!showMenu)}
-          className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center hover:bg-accent-blue-bright transition-colors"
-          title={`${userInfo?.name} (${userInfo?.email})`}
-        >
-          <span className="text-white text-sm font-medium">
-            {userInfo?.initials || "U"}
-          </span>
-        </button>
-
-        {/* Compact User Menu */}
-        {showMenu && (
-          <div
-            className={`absolute left-1/2 transform -translate-x-1/2 bg-primary-white border border-border-light rounded-xl shadow-hover py-1 min-w-48 z-50 ${
-              menuPosition === "below"
-                ? "top-full mt-2"
-                : "bottom-full mb-2"
-            }`}
-          >
-            <div className="px-4 py-2 border-b border-gray-100">
-              <p className="text-sm font-medium text-neutral-slate">
-                {userInfo?.name}
-              </p>
-              <p className="text-xs text-gray-500">{userInfo?.email}</p>
-              {storedUserInfo?.lastLogin && (
-                <p className="text-xs text-gray-400 mt-1">
-                  Last login:{" "}
-                  {new Date(storedUserInfo.lastLogin).toLocaleString()}
-                </p>
-              )}
-              {userInfo?.roles && userInfo.roles.length > 0 && (
-                <div className="mt-2">
-                  {userInfo.roles.map((role) => (
-                    <span
-                      key={role}
-                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue mr-1"
-                    >
-                      {role}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-            <button
-              onClick={handleLogout}
-              className="flex items-center space-x-2 px-4 py-2 text-sm text-neutral-slate hover:bg-secondary-blue-pale/50 w-full text-left"
-            >
-              <LogOut className="h-4 w-4" />
-              <span>Sign out</span>
-            </button>
-          </div>
-        )}
+  const triggerButton = compact ? (
+    <button
+      onClick={() => setShowModal(true)}
+      className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center hover:bg-accent-blue-bright transition-colors"
+      title={`${userInfo?.name} (${userInfo?.email})`}
+    >
+      <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
+    </button>
+  ) : (
+    <button
+      onClick={() => setShowModal(true)}
+      className="flex items-center space-x-3 p-2 w-full text-left hover:bg-secondary-blue-pale/50 rounded-md transition-colors group"
+    >
+      <div className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center">
+        <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
       </div>
-    );
-  }
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-neutral-slate group-hover:text-neutral-slate truncate">
+          {userInfo?.name || "User"}
+        </p>
+        <p className="text-xs text-gray-500 truncate">{userInfo?.email || "user@example.com"}</p>
+      </div>
+    </button>
+  );
 
   return (
-    <div className="relative">
-      <button
-        onClick={() => setShowMenu(!showMenu)}
-        className="flex items-center space-x-3 p-2 w-full text-left hover:bg-secondary-blue-pale/50 rounded-md transition-colors group"
-      >
-        <div className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center">
-          <span className="text-white text-sm font-medium">
-            {userInfo?.initials || "U"}
-          </span>
-        </div>
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-neutral-slate group-hover:text-neutral-slate truncate">
-            {userInfo?.name || "User"}
-          </p>
-          <p className="text-xs text-gray-500 truncate">
-            {userInfo?.email || "user@example.com"}
-          </p>
-        </div>
-        <ChevronUp
-          className={`h-4 w-4 text-gray-400 group-hover:text-gray-600 transition-transform ${
-            menuPosition === "below"
-              ? showMenu
-                ? ""
-                : "rotate-180"
-              : showMenu
-                ? "rotate-180"
-                : ""
-          }`}
-        />
-      </button>
+    <>
+      {triggerButton}
 
-      {/* User Menu */}
-      {showMenu && (
-        <div
-          className={`absolute left-0 right-0 bg-primary-white border border-border-light rounded-xl shadow-hover py-1 z-50 ${
-            menuPosition === "below"
-              ? "top-full mt-2"
-              : "bottom-full mb-2"
-          }`}
-        >
-          <div className="px-4 py-2 border-b border-gray-100">
-            <p className="text-sm font-medium text-neutral-slate">
-              {userInfo?.name}
-            </p>
-            <p className="text-xs text-gray-500">{userInfo?.email}</p>
-            {storedUserInfo?.lastLogin && (
-              <p className="text-xs text-gray-400 mt-1">
-                Last login:{" "}
-                {new Date(storedUserInfo.lastLogin).toLocaleString()}
-              </p>
-            )}
-            {userInfo?.roles && userInfo.roles.length > 0 && (
-              <div className="mt-2">
-                {userInfo.roles.map((role) => (
-                  <span
-                    key={role}
-                    className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue mr-1"
-                  >
-                    {role}
-                  </span>
-                ))}
+      {showModal && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div
+            className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+            onClick={() => setShowModal(false)}
+          />
+
+          <div className="flex min-h-full items-center justify-center p-4">
+            <div className="relative bg-primary-white rounded-xl shadow-xl max-w-sm w-full">
+              {/* Header */}
+              <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+                <h3 className="text-base font-semibold text-neutral-slate">Uživatel</h3>
+                <button
+                  onClick={() => setShowModal(false)}
+                  className="text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  <X className="h-5 w-5" />
+                </button>
               </div>
-            )}
+
+              {/* User identity */}
+              <div className="px-5 py-5 flex items-center space-x-4 border-b border-gray-100">
+                <div className="w-12 h-12 bg-primary-blue rounded-full flex items-center justify-center shrink-0">
+                  <span className="text-white text-lg font-semibold">
+                    {userInfo?.initials || "U"}
+                  </span>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-neutral-slate truncate">
+                    {userInfo?.name}
+                  </p>
+                  <p className="text-xs text-gray-500 truncate">{userInfo?.email}</p>
+                  {storedUserInfo?.lastLogin && (
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      Poslední přihlášení:{" "}
+                      {new Date(storedUserInfo.lastLogin).toLocaleString("cs-CZ")}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* Roles */}
+              {userInfo?.roles && userInfo.roles.length > 0 && (
+                <div className="px-5 py-4 border-b border-gray-100">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <ShieldCheck className="h-4 w-4 text-primary-blue" />
+                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      Role
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {userInfo.roles.map((role) => (
+                      <span
+                        key={role}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
+                      >
+                        {role}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Footer */}
+              <div className="px-5 py-4">
+                <button
+                  onClick={handleLogout}
+                  className="flex items-center justify-center space-x-2 w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                >
+                  <LogOut className="h-4 w-4" />
+                  <span>Odhlásit se</span>
+                </button>
+              </div>
+            </div>
           </div>
-          <button
-            onClick={handleLogout}
-            className="flex items-center space-x-2 px-4 py-2 text-sm text-neutral-slate hover:bg-secondary-blue-pale/50 w-full text-left"
-          >
-            <LogOut className="h-4 w-4" />
-            <span>Sign out</span>
-          </button>
         </div>
       )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Clicking the user avatar in the bottom-left sidebar now opens a centered modal dialog instead of an inline dropdown. The modal displays the user's avatar, name, email, last login, and role badges in clearly separated sections with a sign-out button in the footer. Both the compact (icon-only) and full sidebar variants share the same modal. Backdrop click and the X button close the modal.