### PR TITLE
docs: spike on in-app permission system to replace EntraID RBAC

### DIFF
--- a/docs/features/rbac-inapp-permissions-spike.md
+++ b/docs/features/rbac-inapp-permissions-spike.md
@@ -1,0 +1,334 @@
+# Spike: In-app Permission System (replacing EntraID-driven RBAC)
+
+**Status:** Spike / investigation — no implementation, decision pending
+**Date:** 2026-06-05
+**Branch:** `claude/rbac-inapp-permissions-spike-wHmHw`
+**Author:** AI-assisted spike
+
+---
+
+## 1. Goal
+
+Investigate moving the authorization model from **EntraID app-role driven RBAC** to an
+**in-app permission system** that the app itself owns:
+
+- **Permissions** — fine-grained, code-defined capability flags.
+- **Groups (roles)** — named bundles of permissions, editable by an admin at runtime.
+- **User → group** assignment, managed in-app.
+- **Group → group** nesting (a group inherits another group's permissions).
+
+Authentication stays on Entra ID (Microsoft Identity Web). Only the **authorization
+decision and its data** move into the application database.
+
+This document captures: the current state, the gap, candidate libraries (NuGet / OSS),
+a proposed design, a phased migration plan, and a recommendation.
+
+---
+
+## 2. Current state (as-is)
+
+The current model is **100% claim-based with zero database persistence of users, roles,
+or permissions**. Everything lives in Entra ID + code constants.
+
+### 2.1 Authentication
+- `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs`
+  - Real auth: `AddMicrosoftIdentityWebAppAuthentication` + `AddMicrosoftIdentityWebApiAuthentication` (dual web-app + web-API flow), `AddInMemoryTokenCaches`, OBO to Graph.
+  - Mock auth: `MockAuthenticationHandler` when `UseMockAuth=true` (grants all roles).
+  - E2E auth: cookie scheme `E2ETestCookies` in staging/dev.
+- Config keys: `AzureAd:*` (TenantId, ClientId, ClientSecret, Scopes), `DownstreamApi:*` (Graph).
+
+### 2.2 Authorization (roles)
+- Roles are **Entra ID app roles**, delivered in the JWT `roles` claim, validated via
+  `[Authorize(Roles = AccessRoles.X)]` on controller actions.
+- Default policy (`ConfigureAuthorizationPolicies`): `RequireAuthenticatedUser()` +
+  `RequireRole("heblo_user")`. **No named policies** — per-feature gating is purely
+  `[Authorize(Roles = …)]`.
+- The role catalogue is **code-first** and lives in the Domain layer:
+  - `Anela.Heblo.Domain/Features/Authorization/AccessMatrix.cs` — 30 features → ~52 roles
+    via the `{feature}.{read|write|admin}` convention; plus **10 predefined groups**
+    (`Spravce`, `Vedeni`, `Ucetni`, `Marketer`, `Nakupci`, `Vedouci_vyroby`,
+    `Pracovnik_vyroby`, `Vedouci_skladu`, `Skladnik`, `Poradenstvi`).
+  - `AccessModels.cs` — `AccessFeature`, `AccessRoleDefinition`, `AccessGroup` (records).
+  - `AuthorizationConstants.cs` — `AccessRoles` compile-time string constants used in
+    `[Authorize]` (+ a backward-compat `AuthorizationConstants.Roles` alias block).
+- The matrix is exported (`access-matrix.generated.json` via the `AccessMatrixGen` tool)
+  and used to populate the **Entra ID app manifest** and the frontend
+  `accessMatrix.generated.ts`.
+
+> **Key observation:** the codebase already models *features → levels → groups* cleanly.
+> The "group" concept (`AccessGroup`) exists today but is **static, code-defined, and
+> realised as Entra ID security groups**, not editable at runtime. The spike is largely
+> about making that existing matrix **dynamic and DB-backed** while keeping the same
+> permission vocabulary.
+
+### 2.3 Current user identity
+- `Domain/Features/Users/ICurrentUserService` → `GetCurrentUser()`, `IsInRole(string)`.
+- `API/Features/Users/CurrentUserService` reads from `ClaimsPrincipal` (no DB). ADR-005
+  mandates identity is resolved **inside MediatR handlers** via `ICurrentUserService`.
+- `CurrentUser(Id, Name, Email, IsAuthenticated)` — `Id` = Entra object id (NameIdentifier).
+
+### 2.4 Frontend
+- MSAL (`@azure/msal-browser`, `@azure/msal-react`), `frontend/src/auth/`.
+- Roles read from `idTokenClaims.roles` (`useAuth.ts`); `RequireAccess.tsx` gates routes;
+  `AuthGuard.tsx` enforces login; `accessMatrix.generated.ts` maps route → required role.
+
+### 2.5 What that means for a migration
+- **No DB schema** for users/roles/permissions exists → greenfield on the data side.
+- The **enforcement surface** is large but uniform: ~50+ `[Authorize(Roles = …)]`
+  attributes + 1 default policy + the frontend route map. A migration that keeps the
+  **same permission strings** can leave most attributes untouched.
+
+---
+
+## 3. The gap (why move at all)
+
+| Capability | Entra-role today | In-app permissions (target) |
+|---|---|---|
+| Add/rename a group, change which permissions it grants | Edit Entra groups + app manifest, redeploy/reassign | Admin UI, instant, no redeploy |
+| Group-to-group nesting / inheritance | Entra nested groups (token bloat, opaque) | First-class, in DB |
+| Assign user to group | Entra admin portal (separate system) | In-app admin screen |
+| Audit "who can do what / who changed access" | Scattered across Entra logs | App DB + app audit log |
+| Per-tenant / per-resource scoping (future) | Hard | Natural to model |
+| Onboarding a new employee | Entra group assignment by IT | Self-service in-app |
+| Token size | Grows with every role (Entra caps `roles`/`groups` in tokens) | Token stays small (just identity) |
+
+The Entra "groups in token" path also has hard limits (group overage claim when a user is
+in too many groups), and app-role assignment requires Entra admin rights — friction for a
+solo-operator business app.
+
+---
+
+## 4. Design options for the enforcement layer
+
+Regardless of which storage library we pick, ASP.NET Core needs the permission decision to
+flow through its authorization pipeline. Two viable hook points:
+
+### Option A — Claims transformation (recommended, lowest blast radius)
+Keep authentication on Entra. After token validation, an `IClaimsTransformation` (or a
+custom step) looks up the user (by Entra object id) in the app DB, expands their
+groups → permissions (resolving group→group nesting), and **adds the resulting permission
+strings as `Role` claims** on the `ClaimsPrincipal`.
+
+- **All existing `[Authorize(Roles = "catalog.read")]` keep working unchanged** — they just
+  read claims that now come from the DB instead of the token.
+- Cache the expansion per user (memory cache keyed by object id, short TTL + invalidate on
+  admin change) to avoid a DB hit per request.
+- `CurrentUserService.IsInRole` continues to work (still reads claims).
+
+This is the smallest, safest change and preserves ADR-005 and the whole `[Authorize]` surface.
+
+### Option B — Permission-based policy provider
+Switch from "roles" to true "permissions" using a dynamic `IAuthorizationPolicyProvider` +
+`AuthorizationHandler` (the classic "permission as policy" pattern, and what
+`AuthPermissions.AspNetCore` does internally). Attributes become
+`[HasPermission("catalog.read")]`.
+
+- Cleaner semantics, but requires touching every `[Authorize(Roles=…)]` site.
+- Better if we want permission **claims packed as a bitset/string** rather than many role
+  claims (avoids any claim-count concerns entirely).
+
+> **Recommendation:** start with **Option A** (claims transformation) so the migration is
+> data-only and reversible; optionally evolve to Option B later if the role-claim list
+> becomes unwieldy.
+
+---
+
+## 5. Library / OSS evaluation
+
+### Summary table
+
+| Option | Model | Group→group nesting | Runtime-editable | EF Core / Postgres | Deployment | License | Maturity | Fit |
+|---|---|---|---|---|---|---|---|---|
+| **AuthPermissions.AspNetCore** (JonPSmith) | Roles→permissions (enum flags), optional multi-tenant | Via roles + hierarchical tenants | ✅ admin services built-in | ✅ EF Core | In-proc library | MIT | v10, mature, well-documented | **High** |
+| **Casbin.NET** (Apache) | ACL/RBAC/ABAC, policy + model files | ✅ role-role mappings | ✅ runtime mgmt API | ✅ EF Core adapter | In-proc library | Apache-2.0 | 1.3k★, v2.20 (2026) | **Medium-High** |
+| **Roll-your-own** (DB tables + claims transformation) | Whatever we define | ✅ we model it | ✅ our admin UI | ✅ native ApplicationDbContext | In-proc | n/a | n/a | **High** (full control) |
+| **OpenFGA** (CNCF) | ReBAC / Zanzibar (relationship tuples) | ✅ very strong | ✅ | external store | **Separate service** (Docker) | Apache-2.0 | Mature, CNCF | Overkill |
+| **Permify** | ReBAC / Zanzibar | ✅ very strong | ✅ | external store | **Separate service** | Apache-2.0 | Mature | Overkill |
+| **Gatekeeper** (jchristn) | RBAC users/roles/resources | partial | ✅ | own store | In-proc library | MIT | Small/early | Low |
+| **OpenIddict / IdentityServer** | OAuth/OIDC token issuance | n/a | n/a | ✅ | In-proc | varies | Mature | **Wrong tool** (auth, not authz) |
+
+### Notes on the front-runners
+
+**AuthPermissions.AspNetCore (AuthP)** — purpose-built for exactly this scenario:
+*"an improved Role authorization system where the features a Role can access can be changed
+by an admin user (no redeploy)."* Permissions are a C# enum (flags), Roles bundle
+permissions, users get roles, all stored via EF Core with ready-made **admin services**
+(roles admin, user admin). It also supports JWT refresh and optional multi-tenant
+(hierarchical tenants = a form of group nesting). Permissions are packed into a **single
+claim** (no claim-count problem). MIT, actively maintained (v10).
+- **Pros:** least code to a working admin-editable system; battle-tested; matches our
+  feature/level vocabulary.
+- **Cons:** opinionated (its own DbContext/entities, its `[HasPermission]` attribute and
+  enum-based permissions) — means re-expressing our 52 string permissions as an enum and
+  adopting its policy provider (Option B). Some coupling to its conventions.
+
+**Casbin.NET** — flexible PERM-model engine; RBAC with role hierarchy (group→group) and a
+runtime management API; EF Core adapter for policy storage. Great if we want a pure policy
+engine and to keep our own user/group admin UI.
+- **Pros:** very flexible, supports ABAC later, mature.
+- **Cons:** model/policy CONF files are a new concept for the team; we'd still build the
+  admin UI and the user/group tables ourselves; the engine is more than we need for plain
+  RBAC.
+
+**Roll-your-own** — given the codebase already has a clean `AccessMatrix` (features →
+permissions → groups) and a Vertical-Slice + EF Core + MediatR setup, a small bespoke
+`Authorization` module is very achievable and keeps full architectural control (no foreign
+DbContext, no foreign attribute model, fits ADR rules). The "hard" parts (group→group
+expansion, caching, admin UI) are modest.
+- **Pros:** zero new coupling; reuses the existing permission vocabulary verbatim; works
+  with Option A so **no `[Authorize]` changes**; aligns with module-boundary ADRs.
+- **Cons:** we own it (testing, edge cases, admin UI from scratch).
+
+**OpenFGA / Permify (Zanzibar)** — extremely powerful relationship-based authorization,
+but they run as a **separate service** with their own datastore. That contradicts the
+project's single-Docker-image, single-Postgres, solo-dev simplicity. Only worth it if we
+foresee complex per-object sharing (e.g. "user X can edit *this* specific order"). Not the
+case today. **Park for the future.**
+
+---
+
+## 6. Proposed data model (roll-your-own / AuthP-agnostic)
+
+A new `Authorization` vertical slice in `Persistence` + `Application`. Permissions remain
+**code-defined** (the source of truth stays `AccessMatrix` — they are capabilities, not
+data); only **groups, nesting, and assignments** are data.
+
+```
+Permission            (code-defined, NOT a table — seeded/validated from AccessMatrix)
+  value: "catalog.read"
+
+PermissionGroup        (table)  -- "group" / "role" bundle
+  Id, Name, Description, IsSystem (seed-locked), CreatedAt/By
+
+GroupPermission        (table)  -- group → permission (many-to-many to code constants)
+  GroupId, PermissionValue
+
+GroupParent            (table)  -- group → group nesting (DAG; guard against cycles)
+  GroupId, ParentGroupId
+
+AppUser                (table)  -- materialised on first login from Entra claims
+  Id, EntraObjectId (unique), Email, DisplayName, IsActive, LastLoginAt
+
+UserGroup              (table)  -- user → group
+  UserId, GroupId
+```
+
+**Effective permissions(user)** = union of permissions of all groups reachable from the
+user's directly-assigned groups (transitive closure over `GroupParent`, cycle-guarded).
+
+The 10 existing `AccessMatrix.Groups` seed the `PermissionGroup` table as `IsSystem` rows
+on first migration, so day-one behaviour matches today exactly.
+
+### Enforcement wiring (Option A)
+- `PermissionClaimsTransformation : IClaimsTransformation`
+  - On each request (cached): resolve `AppUser` by Entra object id → compute effective
+    permissions → add each as a `Role` claim.
+  - Cache in `IMemoryCache` keyed by object id, TTL ~5 min, **invalidated** when an admin
+    edits any group/assignment (bump a version token).
+- Default policy unchanged (`heblo_user` becomes a seeded permission everyone gets, or a
+  separate "is active user" check).
+- `[Authorize(Roles = "catalog.read")]` everywhere → **no change**.
+
+### New admin surface (MediatR slices)
+- `Groups`: list/create/update/delete, set permissions, set parents.
+- `Users`: list, view effective permissions, assign/unassign groups.
+- Frontend: an Administration screen (the `administration` feature already exists in the
+  matrix) replacing reliance on the Entra portal.
+
+---
+
+## 7. Migration plan (phased, reversible)
+
+**Phase 0 — Spike (this doc).** Decide library vs roll-your-own and Option A vs B.
+
+**Phase 1 — Schema + seed (shadow mode).**
+- Add the `Authorization` slice, EF migration, seed system groups from `AccessMatrix`.
+- Materialise `AppUser` on login. **No enforcement change yet** — Entra roles still drive
+  `[Authorize]`. Validate that computed effective permissions == today's Entra roles for
+  real users.
+
+**Phase 2 — Switch enforcement to claims transformation (Option A).**
+- Enable `PermissionClaimsTransformation`. Behind a **feature flag**
+  (`IFeatureFlagChecker`) so we can fall back to token roles instantly.
+- Run both in parallel briefly; log diffs.
+
+**Phase 3 — Admin UI.** Ship the Groups/Users management screens; train the operator;
+stop maintaining Entra app-role assignments.
+
+**Phase 4 — Decommission Entra app roles** (optional). Remove app roles from the manifest;
+Entra keeps doing **authentication only**. Keep `accessMatrix.generated.ts` for the
+frontend route map (now driven by the in-app permission list returned from an API).
+
+**Rollback:** at any phase, the feature flag reverts to token-role enforcement; the DB
+tables are additive and harmless if unused.
+
+---
+
+## 8. Impact on existing architecture / ADRs
+
+- **ADR-005 (identity resolution):** unaffected — `ICurrentUserService` still resolves the
+  current user; we extend it (or add `IPermissionService`) for permission checks inside
+  handlers. Keep controllers free of identity logic.
+- **Module boundaries:** Authorization is a cross-cutting concern; the interface
+  (`IPermissionService`) belongs in `Domain/Features/Authorization`, the EF implementation
+  in `Persistence`, DI binding in an `AuthorizationModule.cs` (per ADR-004, repo bindings
+  live in the feature module, not `PersistenceModule`).
+- **Persistence:** single `ApplicationDbContext` (ADR-001) — add the new DbSets there.
+- **Frontend:** `RequireAccess` / `accessMatrix.generated.ts` stay; only the **source** of
+  the user's permission list changes from `idTokenClaims.roles` to a backend
+  `GET /api/auth/me` (or similar) returning effective permissions.
+- **Feature flags:** gate the enforcement switch (`docs/development/feature-flags.md`).
+
+---
+
+## 9. Risks & open questions
+
+1. **Per-request DB lookup cost** — mitigated by caching effective permissions per user;
+   need a clean cache-invalidation signal on admin edits.
+2. **Group→group cycles** — must validate the DAG on every parent edit (reject cycles).
+3. **First-login provisioning** — how does a brand-new Entra user get an initial group?
+   Options: default "no access" group, or auto-assign by Entra group/department claim
+   during Phase 1 shadow mapping.
+4. **Bootstrapping the first admin** — seed one super-admin (by email) so the admin UI is
+   reachable before any data exists.
+5. **Mock & E2E auth** — `MockAuthenticationHandler` and `E2ETestCookies` must seed/grant
+   permissions the same way (today mock grants all roles — keep that for tests).
+6. **AuthP vs roll-your-own** — AuthP is faster to a working product but introduces its own
+   conventions (enum permissions, its DbContext, `[HasPermission]` = Option B). Roll-your-own
+   reuses our exact vocabulary with Option A and zero `[Authorize]` churn but we own the code.
+7. **Is full ReBAC (per-object) ever needed?** If yes within ~12 months, evaluate OpenFGA
+   now rather than building twice. Current features are role/feature-level only → not needed.
+
+---
+
+## 10. Recommendation
+
+1. **Keep Entra ID for authentication.** Move **authorization data** in-app.
+2. **Enforce via claims transformation (Option A)** so the existing ~50 `[Authorize(Roles=…)]`
+   attributes and `CurrentUserService` keep working untouched.
+3. **Prefer a small roll-your-own `Authorization` slice** over a framework, because the
+   codebase already owns a clean permission matrix and the architectural conventions (VSA,
+   MediatR, single DbContext, module DI) make a bespoke module low-risk and zero-coupling.
+   - **Fallback / accelerator:** if time-to-market dominates, adopt
+     **AuthPermissions.AspNetCore** (MIT, purpose-built, admin services included) and accept
+     Option B (`[HasPermission]`) + its conventions.
+4. **Defer OpenFGA/Permify** unless per-object (ReBAC) sharing becomes a real requirement.
+5. Ship behind a **feature flag** in shadow mode first (Phase 1–2) to verify parity before
+   cutting over, with instant rollback to token roles.
+
+A follow-up implementation plan should pick: **(roll-your-own + Option A)** *or*
+**(AuthP + Option B)**, then proceed with Phase 1.
+
+---
+
+## Sources
+
+- [Casbin.NET (apache/casbin-Casbin.NET)](https://github.com/casbin/Casbin.NET)
+- [AuthPermissions.AspNetCore (JonPSmith)](https://github.com/JonPSmith/AuthPermissions.AspNetCore) · [Permissions wiki](https://github.com/JonPSmith/AuthPermissions.AspNetCore/wiki/Permissions-explained) · [Roles admin wiki](https://github.com/JonPSmith/AuthPermissions.AspNetCore/wiki/Roles-admin-service) · [NuGet](https://www.nuget.org/packages/AuthPermissions.AspNetCore)
+- [Permify — open-source authorization libraries](https://permify.co/post/open-source-authorization-libraries/) · [RBAC tools 2025](https://permify.co/post/rbac-tools/)
+- [WorkOS — best RBAC open-source solutions](https://workos.com/blog/rbac-open-source)
+- [Gatekeeper (jchristn)](https://github.com/jchristn/Gatekeeper)
+- [Microsoft Learn — implement RBAC for apps](https://learn.microsoft.com/en-us/entra/identity-platform/howto-implement-rbac-for-apps)
+- [Milan Jovanović — RBAC in ASP.NET Core](https://www.milanjovanovic.tech/blog/building-secure-apis-with-role-based-access-control-in-aspnetcore)
+</content>
+</invoke>

--- a/docs/superpowers/plans/2026-06-05-rbac-inapp-permissions-option-a.md
+++ b/docs/superpowers/plans/2026-06-05-rbac-inapp-permissions-option-a.md
@@ -1,0 +1,3810 @@
+# In-app Permission System (Option A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move authorization data (groups, group nesting, user assignments) into the app DB and enforce it via an ASP.NET Core `IClaimsTransformation`, keeping Entra ID for authentication and leaving every existing `[Authorize(Roles=…)]` attribute working.
+
+**Architecture:** A new `Authorization` vertical slice. Permissions stay code-defined in `AccessMatrix`; only groups/nesting/assignments are DB rows (5 tables). On each request, a claims transformation resolves the user's effective permissions (cached, group-closure) and injects them as `Role` claims. `super_user` is an Entra app role honored as a wildcard. A `/api/auth/me` endpoint feeds the React app its permission list. Admin CRUD via MediatR slices + an admin screen.
+
+**Tech Stack:** .NET 8, EF Core (PostgreSQL/Npgsql), MediatR, FluentValidation, xUnit + Moq + FluentAssertions, React + TanStack Query + Jest.
+
+**Source spec:** `docs/superpowers/specs/2026-06-05-rbac-inapp-permissions-option-a-design.md`
+
+**Conventions reused (verified in codebase):**
+- Entities: plain `class`, `Id` PK, `= null!` for required refs, `DateTimeOffset` timestamps. Domain layer `Anela.Heblo.Domain/Features/<Feature>/`.
+- EF config: `IEntityTypeConfiguration<T>` in `Anela.Heblo.Persistence/Features/<Feature>/`, auto-applied via `ApplyConfigurationsFromAssembly`.
+- Repo: concrete class injecting `ApplicationDbContext` directly (like `PackageRepository`), interface in Domain, **DI binding in the feature module** (ADR-004), impl `public` in Persistence.
+- MediatR: `Request : IRequest<Response>`, `Response : BaseResponse`, handler in same folder under `Application/Features/Authorization/UseCases/<UseCase>/`. Identity via injected `ICurrentUserService` inside handlers (ADR-005).
+- Controller: `BaseApiController`, `HandleResponse(response)`, `[Authorize(Roles = AccessRoles.X)]`.
+- Errors: `ErrorCodes` enum; reuse `ValidationError`, `ResourceNotFound`, `DuplicateEntry`; new `32xx` Authorization block (32 is a free prefix).
+- Migration: `dotnet ef migrations add <Name> --project backend/src/Anela.Heblo.Persistence --startup-project backend/src/Anela.Heblo.API`.
+
+**Validation commands (run from repo root unless noted):**
+- Backend build: `dotnet build`
+- Backend format check: `dotnet format --verify-no-changes`
+- Backend test (filter): `dotnet test --filter "FullyQualifiedName~Authorization"`
+- Frontend (from `frontend/`): `npm run build`, `npm run lint`, `npm test`
+
+---
+
+## Phase 1 — Domain: entities, interfaces, super_user constant
+
+### Task 1: Add the `super_user` role constant
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Authorization/AuthorizationConstants.cs:6`
+
+- [ ] **Step 1: Add the constant**
+
+In `public static class AccessRoles`, directly under `public const string Base = "heblo_user";` add:
+
+```csharp
+    /// <summary>Entra app role granting ALL permissions (wildcard / break-glass). Honored
+    /// directly from the token by the claims transformation, independent of any DB state.</summary>
+    public const string SuperUser = "super_user";
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Authorization/AuthorizationConstants.cs
+git commit -m "feat(authz): add super_user wildcard role constant"
+```
+
+---
+
+### Task 2: Authorization entities
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/AppUser.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/PermissionGroup.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/GroupPermission.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/GroupParent.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/UserGroup.cs`
+
+No test for plain entity classes (no behavior yet). These are POCOs.
+
+- [ ] **Step 1: Create `AppUser.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Authorization.Entities;
+
+/// <summary>An application user, materialized from Entra claims on first login.</summary>
+public class AppUser
+{
+    public Guid Id { get; set; }
+    public string EntraObjectId { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string DisplayName { get; set; } = null!;
+    public bool IsActive { get; set; } = true;
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? LastLoginAt { get; set; }
+
+    public ICollection<UserGroup> UserGroups { get; set; } = new List<UserGroup>();
+}
+```
+
+- [ ] **Step 2: Create `PermissionGroup.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Authorization.Entities;
+
+/// <summary>A named bundle of permissions ("group"/"role"), optionally nesting other groups.</summary>
+public class PermissionGroup
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    /// <summary>Seeded from AccessMatrix.Groups; read-only and re-synced on startup.</summary>
+    public bool IsSystem { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? CreatedBy { get; set; }
+
+    public ICollection<GroupPermission> Permissions { get; set; } = new List<GroupPermission>();
+    public ICollection<GroupParent> Parents { get; set; } = new List<GroupParent>();
+    public ICollection<UserGroup> UserGroups { get; set; } = new List<UserGroup>();
+}
+```
+
+- [ ] **Step 3: Create `GroupPermission.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Authorization.Entities;
+
+/// <summary>Grants one code-defined permission (AccessMatrix value) to a group.</summary>
+public class GroupPermission
+{
+    public Guid GroupId { get; set; }
+    public string PermissionValue { get; set; } = null!;
+
+    public PermissionGroup Group { get; set; } = null!;
+}
+```
+
+- [ ] **Step 4: Create `GroupParent.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Authorization.Entities;
+
+/// <summary>Nesting edge: GroupId inherits the permissions of ParentGroupId.</summary>
+public class GroupParent
+{
+    public Guid GroupId { get; set; }
+    public Guid ParentGroupId { get; set; }
+
+    public PermissionGroup Group { get; set; } = null!;
+    public PermissionGroup ParentGroup { get; set; } = null!;
+}
+```
+
+- [ ] **Step 5: Create `UserGroup.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Authorization.Entities;
+
+/// <summary>Assignment of a user to a group.</summary>
+public class UserGroup
+{
+    public Guid UserId { get; set; }
+    public Guid GroupId { get; set; }
+
+    public AppUser User { get; set; } = null!;
+    public PermissionGroup Group { get; set; } = null!;
+}
+```
+
+- [ ] **Step 6: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain`
+Expected: Build succeeded.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/
+git commit -m "feat(authz): add Authorization domain entities"
+```
+
+---
+
+### Task 3: Domain contracts (resolver + repository interfaces, result types)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/EffectivePermissions.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/IPermissionResolver.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Authorization/IAuthorizationRepository.cs`
+
+- [ ] **Step 1: Create `EffectivePermissions.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Authorization;
+
+/// <summary>The resolved authorization state for a user, as used by enforcement and /api/auth/me.</summary>
+public sealed record EffectivePermissions(
+    bool IsSuperUser,
+    IReadOnlyCollection<string> Permissions,
+    IReadOnlyCollection<string> Groups)
+{
+    public static EffectivePermissions Empty { get; } =
+        new(false, Array.Empty<string>(), Array.Empty<string>());
+}
+```
+
+- [ ] **Step 2: Create `IPermissionResolver.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Authorization;
+
+/// <summary>Resolves a user's effective permissions (group closure), with caching.
+/// super_user is handled by the caller (claims transformation) from the token, not here.</summary>
+public interface IPermissionResolver
+{
+    /// <summary>Resolves DB-derived effective permissions for an Entra object id.
+    /// Materializes the AppUser on first call. Returns empty for inactive/unknown users.</summary>
+    Task<EffectivePermissions> ResolveAsync(
+        string entraObjectId, string? email, string? displayName, CancellationToken ct = default);
+
+    /// <summary>Drops any cached entry for this Entra object id (used by admin writes).</summary>
+    void InvalidateCache(string entraObjectId);
+}
+```
+
+- [ ] **Step 3: Create `IAuthorizationRepository.cs`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+
+namespace Anela.Heblo.Domain.Features.Authorization;
+
+/// <summary>Data access for the Authorization slice (single ApplicationDbContext, ADR-001).</summary>
+public interface IAuthorizationRepository
+{
+    // Users
+    Task<AppUser?> GetUserByObjectIdAsync(string entraObjectId, CancellationToken ct = default);
+    Task<AppUser> AddUserAsync(AppUser user, CancellationToken ct = default);
+    Task<AppUser?> GetUserByIdAsync(Guid id, CancellationToken ct = default);
+    Task<List<AppUser>> GetAllUsersAsync(CancellationToken ct = default);
+
+    // Groups
+    Task<List<PermissionGroup>> GetAllGroupsAsync(CancellationToken ct = default);
+    Task<PermissionGroup?> GetGroupByIdAsync(Guid id, CancellationToken ct = default);
+    Task<PermissionGroup?> GetGroupByNameAsync(string name, CancellationToken ct = default);
+    Task<PermissionGroup> AddGroupAsync(PermissionGroup group, CancellationToken ct = default);
+    Task RemoveGroupAsync(PermissionGroup group, CancellationToken ct = default);
+
+    // Edges
+    Task<List<UserGroup>> GetUserGroupsAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>All group→permission and group→parent edges, for closure resolution.</summary>
+    Task<(List<GroupPermission> Permissions, List<GroupParent> Parents)> GetGroupGraphAsync(CancellationToken ct = default);
+
+    Task<int> SaveChangesAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain`
+Expected: Build succeeded.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Authorization/
+git commit -m "feat(authz): add resolver/repository contracts and EffectivePermissions"
+```
+
+---
+
+## Phase 2 — Persistence: EF config, migration, repository, seeder
+
+### Task 4: Add Authorization error codes
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` (append before `Exception = 0099` is NOT possible — add a new block at the end of the enum, before the closing brace)
+
+- [ ] **Step 1: Add the 32xx block**
+
+Add these members at the end of the `ErrorCodes` enum (prefix `32` is unused):
+
+```csharp
+    // Authorization module errors (32XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    AuthorizationGroupNotFound = 3201,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    AuthorizationUserNotFound = 3202,
+    [HttpStatusCode(HttpStatusCode.BadRequest)]
+    AuthorizationInvalidPermission = 3203,
+    [HttpStatusCode(HttpStatusCode.BadRequest)]
+    AuthorizationGroupCycleDetected = 3204,
+    [HttpStatusCode(HttpStatusCode.BadRequest)]
+    AuthorizationSystemGroupImmutable = 3205,
+    [HttpStatusCode(HttpStatusCode.Conflict)]
+    AuthorizationDuplicateGroupName = 3206,
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+git commit -m "feat(authz): add 32xx Authorization error codes"
+```
+
+---
+
+### Task 5: EF entity configurations
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/AppUserConfiguration.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/PermissionGroupConfiguration.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/GroupPermissionConfiguration.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/GroupParentConfiguration.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/UserGroupConfiguration.cs`
+
+These are auto-discovered by `ApplyConfigurationsFromAssembly` (no DbContext edit needed for discovery, but Task 6 adds DbSets for ergonomics).
+
+- [ ] **Step 1: Create `AppUserConfiguration.cs`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
+{
+    public void Configure(EntityTypeBuilder<AppUser> builder)
+    {
+        builder.ToTable("AppUsers", "public");
+        builder.HasKey(u => u.Id);
+        builder.Property(u => u.EntraObjectId).IsRequired().HasMaxLength(100);
+        builder.Property(u => u.Email).IsRequired().HasMaxLength(255);
+        builder.Property(u => u.DisplayName).IsRequired().HasMaxLength(255);
+        builder.Property(u => u.IsActive).IsRequired();
+        builder.Property(u => u.CreatedAt).IsRequired();
+        builder.HasIndex(u => u.EntraObjectId).IsUnique();
+        builder.HasMany(u => u.UserGroups).WithOne(ug => ug.User)
+            .HasForeignKey(ug => ug.UserId).OnDelete(DeleteBehavior.Cascade);
+    }
+}
+```
+
+- [ ] **Step 2: Create `PermissionGroupConfiguration.cs`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public class PermissionGroupConfiguration : IEntityTypeConfiguration<PermissionGroup>
+{
+    public void Configure(EntityTypeBuilder<PermissionGroup> builder)
+    {
+        builder.ToTable("PermissionGroups", "public");
+        builder.HasKey(g => g.Id);
+        builder.Property(g => g.Name).IsRequired().HasMaxLength(100);
+        builder.Property(g => g.Description).HasMaxLength(500);
+        builder.Property(g => g.IsSystem).IsRequired();
+        builder.Property(g => g.CreatedAt).IsRequired();
+        builder.Property(g => g.CreatedBy).HasMaxLength(255);
+        builder.HasIndex(g => g.Name).IsUnique();
+        builder.HasMany(g => g.Permissions).WithOne(p => p.Group)
+            .HasForeignKey(p => p.GroupId).OnDelete(DeleteBehavior.Cascade);
+        // Parents: GroupId is the child side; delete a group cascades its outgoing parent edges.
+        builder.HasMany(g => g.Parents).WithOne(gp => gp.Group)
+            .HasForeignKey(gp => gp.GroupId).OnDelete(DeleteBehavior.Cascade);
+    }
+}
+```
+
+- [ ] **Step 3: Create `GroupPermissionConfiguration.cs`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public class GroupPermissionConfiguration : IEntityTypeConfiguration<GroupPermission>
+{
+    public void Configure(EntityTypeBuilder<GroupPermission> builder)
+    {
+        builder.ToTable("GroupPermissions", "public");
+        builder.HasKey(p => new { p.GroupId, p.PermissionValue });
+        builder.Property(p => p.PermissionValue).IsRequired().HasMaxLength(100);
+    }
+}
+```
+
+- [ ] **Step 4: Create `GroupParentConfiguration.cs`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public class GroupParentConfiguration : IEntityTypeConfiguration<GroupParent>
+{
+    public void Configure(EntityTypeBuilder<GroupParent> builder)
+    {
+        builder.ToTable("GroupParents", "public");
+        builder.HasKey(gp => new { gp.GroupId, gp.ParentGroupId });
+        // ParentGroup navigation: restrict delete to avoid multiple cascade paths (Postgres rejects them).
+        builder.HasOne(gp => gp.ParentGroup).WithMany()
+            .HasForeignKey(gp => gp.ParentGroupId).OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+- [ ] **Step 5: Create `UserGroupConfiguration.cs`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public class UserGroupConfiguration : IEntityTypeConfiguration<UserGroup>
+{
+    public void Configure(EntityTypeBuilder<UserGroup> builder)
+    {
+        builder.ToTable("UserGroups", "public");
+        builder.HasKey(ug => new { ug.UserId, ug.GroupId });
+        builder.HasOne(ug => ug.Group).WithMany(g => g.UserGroups)
+            .HasForeignKey(ug => ug.GroupId).OnDelete(DeleteBehavior.Cascade);
+    }
+}
+```
+
+- [ ] **Step 6: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence`
+Expected: Build succeeded.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Authorization/
+git commit -m "feat(authz): add EF entity configurations for Authorization tables"
+```
+
+---
+
+### Task 6: Add DbSets to ApplicationDbContext
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs` (add DbSets near the other DbSet declarations)
+
+- [ ] **Step 1: Add DbSets**
+
+Add these properties alongside the existing `DbSet<...>` declarations:
+
+```csharp
+    // Authorization (in-app permissions)
+    public DbSet<Anela.Heblo.Domain.Features.Authorization.Entities.AppUser> AppUsers { get; set; } = null!;
+    public DbSet<Anela.Heblo.Domain.Features.Authorization.Entities.PermissionGroup> PermissionGroups { get; set; } = null!;
+    public DbSet<Anela.Heblo.Domain.Features.Authorization.Entities.GroupPermission> GroupPermissions { get; set; } = null!;
+    public DbSet<Anela.Heblo.Domain.Features.Authorization.Entities.GroupParent> GroupParents { get; set; } = null!;
+    public DbSet<Anela.Heblo.Domain.Features.Authorization.Entities.UserGroup> UserGroups { get; set; } = null!;
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+git commit -m "feat(authz): register Authorization DbSets"
+```
+
+---
+
+### Task 7: EF migration
+
+**Files:**
+- Create (generated): `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_AddAuthorizationTables.cs`
+
+- [ ] **Step 1: Generate the migration**
+
+Run:
+```bash
+dotnet ef migrations add AddAuthorizationTables \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+Expected: A new migration file under `Migrations/`. It should create tables `AppUsers`, `PermissionGroups`, `GroupPermissions`, `GroupParents`, `UserGroups`.
+
+- [ ] **Step 2: Inspect the generated `Up()`**
+
+Open the generated file and confirm: 5 `CreateTable` calls, unique indexes on `AppUsers.EntraObjectId` and `PermissionGroups.Name`, composite keys on the three join tables, and no accidental changes to unrelated tables. If unrelated model drift appears, STOP and report (do not hand-edit unrelated tables).
+
+- [ ] **Step 3: Verify build (migration compiles)**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Migrations/
+git commit -m "feat(authz): EF migration adding Authorization tables"
+```
+
+---
+
+### Task 8: AuthorizationRepository implementation
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/AuthorizationRepository.cs`
+
+- [ ] **Step 1: Create the repository (public, ADR-004 — binding added later in the module)**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public class AuthorizationRepository : IAuthorizationRepository
+{
+    private readonly ApplicationDbContext _db;
+
+    public AuthorizationRepository(ApplicationDbContext db) => _db = db;
+
+    public Task<AppUser?> GetUserByObjectIdAsync(string entraObjectId, CancellationToken ct = default) =>
+        _db.AppUsers.FirstOrDefaultAsync(u => u.EntraObjectId == entraObjectId, ct);
+
+    public async Task<AppUser> AddUserAsync(AppUser user, CancellationToken ct = default)
+    {
+        await _db.AppUsers.AddAsync(user, ct);
+        return user;
+    }
+
+    public Task<AppUser?> GetUserByIdAsync(Guid id, CancellationToken ct = default) =>
+        _db.AppUsers.Include(u => u.UserGroups).FirstOrDefaultAsync(u => u.Id == id, ct);
+
+    public async Task<List<AppUser>> GetAllUsersAsync(CancellationToken ct = default) =>
+        await _db.AppUsers.AsNoTracking().Include(u => u.UserGroups).ToListAsync(ct);
+
+    public async Task<List<PermissionGroup>> GetAllGroupsAsync(CancellationToken ct = default) =>
+        await _db.PermissionGroups.AsNoTracking()
+            .Include(g => g.Permissions).Include(g => g.Parents)
+            .ToListAsync(ct);
+
+    public Task<PermissionGroup?> GetGroupByIdAsync(Guid id, CancellationToken ct = default) =>
+        _db.PermissionGroups.Include(g => g.Permissions).Include(g => g.Parents)
+            .FirstOrDefaultAsync(g => g.Id == id, ct);
+
+    public Task<PermissionGroup?> GetGroupByNameAsync(string name, CancellationToken ct = default) =>
+        _db.PermissionGroups.Include(g => g.Permissions).Include(g => g.Parents)
+            .FirstOrDefaultAsync(g => g.Name == name, ct);
+
+    public async Task<PermissionGroup> AddGroupAsync(PermissionGroup group, CancellationToken ct = default)
+    {
+        await _db.PermissionGroups.AddAsync(group, ct);
+        return group;
+    }
+
+    public Task RemoveGroupAsync(PermissionGroup group, CancellationToken ct = default)
+    {
+        _db.PermissionGroups.Remove(group);
+        return Task.CompletedTask;
+    }
+
+    public async Task<List<UserGroup>> GetUserGroupsAsync(Guid userId, CancellationToken ct = default) =>
+        await _db.UserGroups.Where(ug => ug.UserId == userId).ToListAsync(ct);
+
+    public async Task<(List<GroupPermission> Permissions, List<GroupParent> Parents)> GetGroupGraphAsync(CancellationToken ct = default)
+    {
+        var perms = await _db.GroupPermissions.AsNoTracking().ToListAsync(ct);
+        var parents = await _db.GroupParents.AsNoTracking().ToListAsync(ct);
+        return (perms, parents);
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Authorization/AuthorizationRepository.cs
+git commit -m "feat(authz): add AuthorizationRepository"
+```
+
+---
+
+### Task 9: System-group seeder (TDD)
+
+The seeder upserts the 10 `AccessMatrix.Groups` as `IsSystem=true` rows and re-syncs their permissions on every startup, and prunes `GroupPermission` rows whose value left `AccessMatrix`.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/AuthorizationSeeder.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/AuthorizationSeederTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class AuthorizationSeederTests
+{
+    private static ApplicationDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"seed_{Guid.NewGuid()}").Options);
+
+    [Fact]
+    public async Task Seed_CreatesAllSystemGroupsFromAccessMatrix()
+    {
+        await using var db = NewDb();
+        await AuthorizationSeeder.SeedAsync(db, default);
+
+        var groups = await db.PermissionGroups.Include(g => g.Permissions).ToListAsync();
+        groups.Should().HaveCount(AccessMatrix.Groups.Count);
+        groups.Should().OnlyContain(g => g.IsSystem);
+
+        var spravce = groups.Single(g => g.Name == "Spravce");
+        spravce.Permissions.Select(p => p.PermissionValue)
+            .Should().BeEquivalentTo(AccessMatrix.AllRoleValues());
+    }
+
+    [Fact]
+    public async Task Seed_IsIdempotent_NoDuplicatesOnSecondRun()
+    {
+        await using var db = NewDb();
+        await AuthorizationSeeder.SeedAsync(db, default);
+        await AuthorizationSeeder.SeedAsync(db, default);
+
+        (await db.PermissionGroups.CountAsync()).Should().Be(AccessMatrix.Groups.Count);
+    }
+
+    [Fact]
+    public async Task Seed_PrunesPermissionValuesNotInAccessMatrix()
+    {
+        await using var db = NewDb();
+        await AuthorizationSeeder.SeedAsync(db, default);
+        var grp = await db.PermissionGroups.FirstAsync(g => g.Name == "Nakupci");
+        db.GroupPermissions.Add(new GroupPermission { GroupId = grp.Id, PermissionValue = "ghost.read" });
+        await db.SaveChangesAsync();
+
+        await AuthorizationSeeder.SeedAsync(db, default);
+
+        (await db.GroupPermissions.AnyAsync(p => p.PermissionValue == "ghost.read"))
+            .Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~AuthorizationSeederTests"`
+Expected: FAIL — `AuthorizationSeeder` does not exist.
+
+- [ ] **Step 3: Implement the seeder**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public static class AuthorizationSeeder
+{
+    public static async Task SeedAsync(ApplicationDbContext db, CancellationToken ct)
+    {
+        var validPermissions = AccessMatrix.AllRoleValues().ToHashSet();
+
+        var existing = await db.PermissionGroups
+            .Include(g => g.Permissions)
+            .ToListAsync(ct);
+
+        foreach (var matrixGroup in AccessMatrix.Groups)
+        {
+            var group = existing.FirstOrDefault(g => g.Name == matrixGroup.Name);
+            if (group is null)
+            {
+                group = new PermissionGroup
+                {
+                    Id = Guid.NewGuid(),
+                    Name = matrixGroup.Name,
+                    Description = "System group (managed in code)",
+                    IsSystem = true,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    CreatedBy = "system",
+                };
+                db.PermissionGroups.Add(group);
+            }
+            else
+            {
+                group.IsSystem = true;
+            }
+
+            // Re-sync permissions: code is authoritative for system groups.
+            var desired = matrixGroup.Roles.Where(validPermissions.Contains).ToHashSet();
+            var current = group.Permissions.Select(p => p.PermissionValue).ToHashSet();
+
+            foreach (var toAdd in desired.Except(current))
+                group.Permissions.Add(new GroupPermission { GroupId = group.Id, PermissionValue = toAdd });
+
+            foreach (var perm in group.Permissions.Where(p => !desired.Contains(p.PermissionValue)).ToList())
+                group.Permissions.Remove(perm);
+        }
+
+        // Global prune: drop any GroupPermission whose value left AccessMatrix entirely.
+        var orphans = await db.GroupPermissions
+            .Where(p => !validPermissions.Contains(p.PermissionValue))
+            .ToListAsync(ct);
+        db.GroupPermissions.RemoveRange(orphans);
+
+        await db.SaveChangesAsync(ct);
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~AuthorizationSeederTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Authorization/AuthorizationSeeder.cs \
+        backend/test/Anela.Heblo.Tests/Authorization/AuthorizationSeederTests.cs
+git commit -m "feat(authz): system-group seeder with re-sync and prune"
+```
+
+---
+
+## Phase 3 — Resolver: group closure + caching + materialization
+
+### Task 10: Pure group-closure helper (TDD)
+
+Isolates the cycle-safe transitive closure so it can be unit-tested without a DB.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/GroupClosure.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/GroupClosureTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class GroupClosureTests
+{
+    private static readonly Guid A = Guid.NewGuid();
+    private static readonly Guid B = Guid.NewGuid();
+    private static readonly Guid C = Guid.NewGuid();
+
+    private static GroupPermission Perm(Guid g, string v) => new() { GroupId = g, PermissionValue = v };
+    private static GroupParent Parent(Guid child, Guid parent) => new() { GroupId = child, ParentGroupId = parent };
+
+    [Fact]
+    public void Resolve_UnionsDirectGroupPermissions()
+    {
+        var perms = new[] { Perm(A, "catalog.read"), Perm(B, "journal.read") };
+        var result = GroupClosure.Resolve(new[] { A }, perms, Array.Empty<GroupParent>());
+        result.Should().BeEquivalentTo(new[] { "catalog.read" });
+    }
+
+    [Fact]
+    public void Resolve_IncludesParentPermissions()
+    {
+        var perms = new[] { Perm(A, "catalog.read"), Perm(B, "journal.read") };
+        var parents = new[] { Parent(A, B) }; // A inherits B
+        var result = GroupClosure.Resolve(new[] { A }, perms, parents);
+        result.Should().BeEquivalentTo(new[] { "catalog.read", "journal.read" });
+    }
+
+    [Fact]
+    public void Resolve_DeepChain_AccumulatesAllAncestors()
+    {
+        var perms = new[] { Perm(A, "a.read"), Perm(B, "b.read"), Perm(C, "c.read") };
+        var parents = new[] { Parent(A, B), Parent(B, C) }; // A -> B -> C
+        var result = GroupClosure.Resolve(new[] { A }, perms, parents);
+        result.Should().BeEquivalentTo(new[] { "a.read", "b.read", "c.read" });
+    }
+
+    [Fact]
+    public void Resolve_DiamondParent_CountsOnce_NoError()
+    {
+        var perms = new[] { Perm(A, "a.read"), Perm(B, "b.read"), Perm(C, "c.read") };
+        // Diamond: A -> B, A -> C, B -> C
+        var parents = new[] { Parent(A, B), Parent(A, C), Parent(B, C) };
+        var result = GroupClosure.Resolve(new[] { A }, perms, parents);
+        result.Should().BeEquivalentTo(new[] { "a.read", "b.read", "c.read" });
+    }
+
+    [Fact]
+    public void Resolve_Cycle_Terminates_WithBoundedSet()
+    {
+        var perms = new[] { Perm(A, "a.read"), Perm(B, "b.read") };
+        var parents = new[] { Parent(A, B), Parent(B, A) }; // cycle
+        var result = GroupClosure.Resolve(new[] { A }, perms, parents);
+        result.Should().BeEquivalentTo(new[] { "a.read", "b.read" });
+    }
+
+    [Fact]
+    public void Resolve_NoGroups_ReturnsEmpty()
+    {
+        var result = GroupClosure.Resolve(Array.Empty<Guid>(), Array.Empty<GroupPermission>(), Array.Empty<GroupParent>());
+        result.Should().BeEmpty();
+    }
+}
+```
+
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~GroupClosureTests"`
+Expected: FAIL — `GroupClosure` does not exist.
+
+- [ ] **Step 3: Implement `GroupClosure`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+/// <summary>Cycle-safe transitive closure of group nesting → union of permissions.</summary>
+public static class GroupClosure
+{
+    public static IReadOnlyCollection<string> Resolve(
+        IEnumerable<Guid> directGroupIds,
+        IReadOnlyCollection<GroupPermission> allPermissions,
+        IReadOnlyCollection<GroupParent> allParents)
+    {
+        var permsByGroup = allPermissions
+            .GroupBy(p => p.GroupId)
+            .ToDictionary(g => g.Key, g => g.Select(p => p.PermissionValue).ToArray());
+        var parentsByGroup = allParents
+            .GroupBy(p => p.GroupId)
+            .ToDictionary(g => g.Key, g => g.Select(p => p.ParentGroupId).ToArray());
+
+        var visited = new HashSet<Guid>();
+        var queue = new Queue<Guid>(directGroupIds);
+        var result = new HashSet<string>(StringComparer.Ordinal);
+
+        while (queue.Count > 0)
+        {
+            var groupId = queue.Dequeue();
+            if (!visited.Add(groupId)) continue; // already processed → cycle/diamond safe
+
+            if (permsByGroup.TryGetValue(groupId, out var perms))
+                foreach (var p in perms) result.Add(p);
+
+            if (parentsByGroup.TryGetValue(groupId, out var parents))
+                foreach (var parent in parents) queue.Enqueue(parent);
+        }
+
+        return result;
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~GroupClosureTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Authorization/GroupClosure.cs \
+        backend/test/Anela.Heblo.Tests/Authorization/GroupClosureTests.cs
+git commit -m "feat(authz): cycle-safe group closure helper"
+```
+
+---
+
+### Task 11: PermissionResolver with materialization + cache (TDD)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Authorization/PermissionResolver.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/PermissionResolverTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class PermissionResolverTests
+{
+    private static ApplicationDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"resolver_{Guid.NewGuid()}").Options);
+
+    private static PermissionResolver NewResolver(ApplicationDbContext db) =>
+        new(new AuthorizationRepository(db), new MemoryCache(new MemoryCacheOptions()));
+
+    [Fact]
+    public async Task Resolve_UnknownUser_MaterializesAppUser_WithHebloUserOnly()
+    {
+        await using var db = NewDb();
+        var resolver = NewResolver(db);
+
+        var result = await resolver.ResolveAsync("oid-1", "a@b.cz", "Alice");
+
+        result.IsSuperUser.Should().BeFalse();
+        result.Permissions.Should().BeEquivalentTo(new[] { "heblo_user" });
+        (await db.AppUsers.AnyAsync(u => u.EntraObjectId == "oid-1")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Resolve_ActiveUserInGroup_ReturnsGroupPermissionsPlusBase()
+    {
+        await using var db = NewDb();
+        var group = new PermissionGroup { Id = Guid.NewGuid(), Name = "G", CreatedAt = DateTimeOffset.UtcNow };
+        group.Permissions.Add(new GroupPermission { GroupId = group.Id, PermissionValue = "catalog.read" });
+        db.PermissionGroups.Add(group);
+        var user = new AppUser { Id = Guid.NewGuid(), EntraObjectId = "oid-2", Email = "x", DisplayName = "X", IsActive = true, CreatedAt = DateTimeOffset.UtcNow };
+        user.UserGroups.Add(new UserGroup { UserId = user.Id, GroupId = group.Id });
+        db.AppUsers.Add(user);
+        await db.SaveChangesAsync();
+
+        var result = await NewResolver(db).ResolveAsync("oid-2", "x", "X");
+
+        result.Permissions.Should().BeEquivalentTo(new[] { "heblo_user", "catalog.read" });
+        result.Groups.Should().BeEquivalentTo(new[] { "G" });
+    }
+
+    [Fact]
+    public async Task Resolve_InactiveUser_ReturnsEmpty()
+    {
+        await using var db = NewDb();
+        db.AppUsers.Add(new AppUser { Id = Guid.NewGuid(), EntraObjectId = "oid-3", Email = "x", DisplayName = "X", IsActive = false, CreatedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await NewResolver(db).ResolveAsync("oid-3", "x", "X");
+
+        result.Permissions.Should().BeEmpty();
+        result.IsSuperUser.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~PermissionResolverTests"`
+Expected: FAIL — `PermissionResolver` does not exist.
+
+- [ ] **Step 3: Implement `PermissionResolver`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Anela.Heblo.Persistence.Features.Authorization;
+
+public class PermissionResolver : IPermissionResolver
+{
+    private readonly IAuthorizationRepository _repo;
+    private readonly IMemoryCache _cache;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    public PermissionResolver(IAuthorizationRepository repo, IMemoryCache cache)
+    {
+        _repo = repo;
+        _cache = cache;
+    }
+
+    private static string CacheKey(string objectId) => $"perms:{objectId}";
+
+    public async Task<EffectivePermissions> ResolveAsync(
+        string entraObjectId, string? email, string? displayName, CancellationToken ct = default)
+    {
+        if (_cache.TryGetValue(CacheKey(entraObjectId), out EffectivePermissions? cached) && cached is not null)
+            return cached;
+
+        var user = await _repo.GetUserByObjectIdAsync(entraObjectId, ct);
+        if (user is null)
+        {
+            user = new AppUser
+            {
+                Id = Guid.NewGuid(),
+                EntraObjectId = entraObjectId,
+                Email = email ?? entraObjectId,
+                DisplayName = displayName ?? email ?? entraObjectId,
+                IsActive = true,
+                CreatedAt = DateTimeOffset.UtcNow,
+                LastLoginAt = DateTimeOffset.UtcNow,
+            };
+            await _repo.AddUserAsync(user, ct);
+            await _repo.SaveChangesAsync(ct);
+        }
+
+        EffectivePermissions result;
+        if (!user.IsActive)
+        {
+            result = EffectivePermissions.Empty;
+        }
+        else
+        {
+            var userGroups = await _repo.GetUserGroupsAsync(user.Id, ct);
+            var groupIds = userGroups.Select(ug => ug.GroupId).ToList();
+            var (perms, parents) = await _repo.GetGroupGraphAsync(ct);
+
+            var resolved = GroupClosure.Resolve(groupIds, perms, parents);
+            var permissions = new HashSet<string>(resolved, StringComparer.Ordinal) { AccessRoles.Base };
+
+            var allGroups = await _repo.GetAllGroupsAsync(ct);
+            var groupNames = allGroups.Where(g => groupIds.Contains(g.Id)).Select(g => g.Name).ToArray();
+
+            result = new EffectivePermissions(false, permissions.ToArray(), groupNames);
+        }
+
+        _cache.Set(CacheKey(entraObjectId), result, CacheTtl);
+        return result;
+    }
+
+    public void InvalidateCache(string entraObjectId) => _cache.Remove(CacheKey(entraObjectId));
+}
+```
+
+> Add `using Anela.Heblo.Domain.Features.Authorization;` is already present; `AccessRoles` lives there.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~PermissionResolverTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Authorization/PermissionResolver.cs \
+        backend/test/Anela.Heblo.Tests/Authorization/PermissionResolverTests.cs
+git commit -m "feat(authz): permission resolver with materialization and cache"
+```
+
+---
+## Phase 4 — Enforcement: claims transformation + wiring
+
+### Task 12: PermissionClaimsTransformation (TDD)
+
+Injects effective permissions as `Role` claims. `super_user` (from the token) short-circuits to all `AccessMatrix` permissions; otherwise it calls the resolver.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Security.Claims;
+using Anela.Heblo.API.Infrastructure.Authentication;
+using Anela.Heblo.Domain.Features.Authorization;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class PermissionClaimsTransformationTests
+{
+    private static ClaimsPrincipal Principal(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "Test"));
+
+    [Fact]
+    public async Task Transform_SuperUserRoleInToken_AddsAllPermissions_NoResolverCall()
+    {
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(
+            new Claim(ClaimTypes.NameIdentifier, "oid-super"),
+            new Claim(ClaimTypes.Role, AccessRoles.SuperUser));
+
+        var result = await sut.TransformAsync(principal);
+
+        foreach (var perm in AccessMatrix.AllRoleValues())
+            result.IsInRole(perm).Should().BeTrue($"super_user must grant {perm}");
+        result.IsInRole(AccessRoles.Base).Should().BeTrue();
+        resolver.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Transform_RegularUser_AddsResolvedPermissionsAsRoles()
+    {
+        var resolver = new Mock<IPermissionResolver>();
+        resolver
+            .Setup(r => r.ResolveAsync("oid-1", It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "heblo_user", "catalog.read" }, new[] { "G" }));
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, "oid-1"));
+
+        var result = await sut.TransformAsync(principal);
+
+        result.IsInRole("catalog.read").Should().BeTrue();
+        result.IsInRole("heblo_user").Should().BeTrue();
+        result.IsInRole("journal.read").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Transform_Idempotent_DoesNotDuplicateClaims()
+    {
+        var resolver = new Mock<IPermissionResolver>();
+        resolver
+            .Setup(r => r.ResolveAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, Array.Empty<string>()));
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, "oid-1"));
+
+        var once = await sut.TransformAsync(principal);
+        var twice = await sut.TransformAsync(once);
+
+        twice.Claims.Count(c => c.Type == ClaimTypes.Role && c.Value == "catalog.read").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Transform_Unauthenticated_ReturnsUnchanged()
+    {
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var anon = new ClaimsPrincipal(new ClaimsIdentity()); // not authenticated
+
+        var result = await sut.TransformAsync(anon);
+
+        result.Claims.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~PermissionClaimsTransformationTests"`
+Expected: FAIL — type does not exist.
+
+- [ ] **Step 3: Implement the transformation**
+
+```csharp
+using System.Security.Claims;
+using Anela.Heblo.Domain.Features.Authorization;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Anela.Heblo.API.Infrastructure.Authentication;
+
+/// <summary>Injects a user's effective permissions as Role claims after authentication.
+/// super_user (from the token) is a wildcard granting all AccessMatrix permissions.</summary>
+public class PermissionClaimsTransformation : IClaimsTransformation
+{
+    private readonly IPermissionResolver _resolver;
+
+    public PermissionClaimsTransformation(IPermissionResolver resolver) => _resolver = resolver;
+
+    public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+    {
+        var identity = principal.Identity as ClaimsIdentity;
+        if (identity is null || !identity.IsAuthenticated)
+            return principal;
+
+        // Guard against re-running (IClaimsTransformation can be invoked multiple times per request).
+        if (identity.HasClaim("authz_applied", "1"))
+            return principal;
+
+        var objectId = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                       ?? principal.FindFirst("oid")?.Value
+                       ?? principal.FindFirst("sub")?.Value;
+
+        IReadOnlyCollection<string> permissions;
+        if (principal.IsInRole(AccessRoles.SuperUser))
+        {
+            permissions = AccessMatrix.AllRoleValues().Append(AccessRoles.Base).ToArray();
+        }
+        else if (objectId is not null)
+        {
+            var email = principal.FindFirst(ClaimTypes.Email)?.Value
+                        ?? principal.FindFirst("preferred_username")?.Value;
+            var name = principal.FindFirst(ClaimTypes.Name)?.Value
+                       ?? principal.FindFirst("name")?.Value;
+            var resolved = await _resolver.ResolveAsync(objectId, email, name);
+            permissions = resolved.Permissions;
+        }
+        else
+        {
+            permissions = Array.Empty<string>();
+        }
+
+        // CRITICAL: add role claims using the identity's RoleClaimType, NOT a hardcoded
+        // ClaimTypes.Role. Microsoft.Identity.Web configures Entra to use the "roles" claim
+        // type; [Authorize(Roles=…)] / IsInRole check that configured type. Using the wrong
+        // type would silently make every role check fail.
+        var roleClaimType = identity.RoleClaimType; // e.g. "roles" for Entra, ClaimTypes.Role for mock
+        foreach (var perm in permissions)
+            if (!identity.HasClaim(roleClaimType, perm))
+                identity.AddClaim(new Claim(roleClaimType, perm));
+
+        identity.AddClaim(new Claim("authz_applied", "1"));
+        return principal;
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~PermissionClaimsTransformationTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs \
+        backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+git commit -m "feat(authz): permission claims transformation (super_user wildcard + resolver)"
+```
+
+---
+
+### Task 13: AuthorizationModule (DI wiring per ADR-004)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/AuthorizationModule.cs`
+- Modify: `backend/src/Anela.Heblo.Application/ApplicationModule.cs` (register the module)
+
+> The repository + resolver implementations live in `Anela.Heblo.Persistence` (single DbContext, ADR-001) but the DI binding lives in the feature module (ADR-004). The Application project already references Persistence (other modules bind Persistence repos the same way).
+
+- [ ] **Step 1: Create `AuthorizationModule.cs`**
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Persistence.Features.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Authorization;
+
+public static class AuthorizationModule
+{
+    public static IServiceCollection AddAuthorizationModule(this IServiceCollection services)
+    {
+        services.AddMemoryCache();
+        services.AddScoped<IAuthorizationRepository, AuthorizationRepository>();
+        services.AddScoped<IPermissionResolver, PermissionResolver>();
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Register in `ApplicationModule.cs`**
+
+Add the using at the top with the other `Anela.Heblo.Application.Features.*` usings:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization;
+```
+
+And add this line in the "Register all feature modules" block (e.g. right after `services.AddFeatureFlagsModule(configuration);`):
+
+```csharp
+        services.AddAuthorizationModule();
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/AuthorizationModule.cs \
+        backend/src/Anela.Heblo.Application/ApplicationModule.cs
+git commit -m "feat(authz): AuthorizationModule DI wiring"
+```
+
+---
+
+### Task 14: Register the claims transformation + run the seeder at startup
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs` (register `IClaimsTransformation` in `ConfigureAuthorizationPolicies`)
+- Modify: `backend/src/Anela.Heblo.API/Program.cs` (run `AuthorizationSeeder` after the app is built, near other startup DB work)
+
+- [ ] **Step 1: Register the transformation**
+
+In `AuthenticationExtensions.cs`, add the using:
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Authentication;
+```
+
+(Already present — confirm.) Then inside `ConfigureAuthorizationPolicies(IServiceCollection services)`, before/after `services.AddAuthorization(...)`, add:
+
+```csharp
+        services.AddScoped<Microsoft.AspNetCore.Authentication.IClaimsTransformation, PermissionClaimsTransformation>();
+```
+
+This runs for BOTH mock and real auth (both call `ConfigureAuthorizationPolicies`).
+
+- [ ] **Step 2: Run the seeder at startup**
+
+In `Program.cs`, after `var app = builder.Build();` and wherever migrations/DB warm-up happen (search for `app.Services.CreateScope()` or an existing startup DB block), add a seeding block. If no such block exists, add right before `app.Run();`:
+
+```csharp
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<Anela.Heblo.Persistence.ApplicationDbContext>();
+            // InMemory provider (tests) has no relational migrations; guard accordingly.
+            if (db.Database.IsRelational())
+            {
+                await db.Database.MigrateAsync();
+            }
+            await Anela.Heblo.Persistence.Features.Authorization.AuthorizationSeeder.SeedAsync(db, default);
+        }
+```
+
+> If the project already calls `MigrateAsync()` at startup, do NOT duplicate it — only add the `AuthorizationSeeder.SeedAsync` call inside the existing scope. Check first.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.API`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs \
+        backend/src/Anela.Heblo.API/Program.cs
+git commit -m "feat(authz): register claims transformation and run system-group seeder at startup"
+```
+
+---
+
+### Task 15: Make mock auth a super_user (route dev/test through the wildcard path)
+
+Today `MockAuthenticationHandler` emits all 52 roles directly. Replace that with the single `super_user` role so mock dev exercises the real enforcement path while keeping full access.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs:30-34`
+
+- [ ] **Step 1: Replace the role claims**
+
+Replace:
+
+```csharp
+        var roleClaims = new[] { AccessMatrix.BaseRole }
+            .Concat(AccessMatrix.AllRoleValues())
+            .Select(r => new Claim(ClaimTypes.Role, r));
+```
+
+with:
+
+```csharp
+        // Mock users are super_users: full access via the same wildcard path as production break-glass.
+        var roleClaims = new[]
+        {
+            new Claim(ClaimTypes.Role, AccessMatrix.BaseRole),
+            new Claim(ClaimTypes.Role, AccessRoles.SuperUser),
+        };
+```
+
+Ensure `using Anela.Heblo.Domain.Features.Authorization;` is present (it is — `AccessMatrix` is already used).
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.API`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Run the existing auth/mock tests to check for regressions**
+
+Run: `dotnet test --filter "FullyQualifiedName~Authentication|FullyQualifiedName~Mock"`
+Expected: PASS. If a test asserted the mock principal carries all 52 explicit role claims, update it to assert `super_user` instead (the net access is identical because the claims transformation expands it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs
+git commit -m "feat(authz): mock auth emits super_user (exercises wildcard path)"
+```
+
+---
+## Phase 5 — Application use cases (MediatR)
+
+> All requests/handlers/responses live under
+> `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/<UseCase>/`.
+> Responses inherit `BaseResponse`. Handlers resolve identity via injected
+> `ICurrentUserService` (ADR-005) where they need the acting user.
+
+### Task 16: GetPermissionCatalogue query
+
+Returns the `AccessMatrix` features/levels/groups so the admin UI renders permission
+checkboxes from the source of truth.
+
+**Files:**
+- Create: `.../UseCases/GetPermissionCatalogue/GetPermissionCatalogueRequest.cs`
+- Create: `.../UseCases/GetPermissionCatalogue/GetPermissionCatalogueResponse.cs`
+- Create: `.../UseCases/GetPermissionCatalogue/GetPermissionCatalogueHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/GetPermissionCatalogueHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetPermissionCatalogue;
+using Anela.Heblo.Domain.Features.Authorization;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class GetPermissionCatalogueHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsAllPermissionsAndSystemGroups()
+    {
+        var handler = new GetPermissionCatalogueHandler();
+        var result = await handler.Handle(new GetPermissionCatalogueRequest(), default);
+
+        result.Success.Should().BeTrue();
+        result.Permissions.Should().BeEquivalentTo(AccessMatrix.AllRoleValues());
+        result.SystemGroups.Select(g => g.Name).Should().BeEquivalentTo(AccessMatrix.Groups.Select(g => g.Name));
+        result.Features.Should().Contain(f => f.Key == "catalog" && f.HasWrite);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetPermissionCatalogueHandlerTests"`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Implement request/response/handler**
+
+`GetPermissionCatalogueRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetPermissionCatalogue;
+
+public class GetPermissionCatalogueRequest : IRequest<GetPermissionCatalogueResponse> { }
+```
+
+`GetPermissionCatalogueResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetPermissionCatalogue;
+
+public class GetPermissionCatalogueResponse : BaseResponse
+{
+    public List<string> Permissions { get; set; } = new();
+    public List<CatalogueFeatureDto> Features { get; set; } = new();
+    public List<CatalogueGroupDto> SystemGroups { get; set; } = new();
+}
+
+public class CatalogueFeatureDto
+{
+    public string Key { get; set; } = null!;
+    public string Label { get; set; } = null!;
+    public string Section { get; set; } = null!;
+    public bool HasWrite { get; set; }
+    public bool HasAdmin { get; set; }
+}
+
+public class CatalogueGroupDto
+{
+    public string Name { get; set; } = null!;
+    public List<string> Permissions { get; set; } = new();
+}
+```
+
+`GetPermissionCatalogueHandler.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetPermissionCatalogue;
+
+public class GetPermissionCatalogueHandler
+    : IRequestHandler<GetPermissionCatalogueRequest, GetPermissionCatalogueResponse>
+{
+    public Task<GetPermissionCatalogueResponse> Handle(GetPermissionCatalogueRequest request, CancellationToken ct)
+    {
+        var response = new GetPermissionCatalogueResponse
+        {
+            Permissions = AccessMatrix.AllRoleValues().ToList(),
+            Features = AccessMatrix.Features.Select(f => new CatalogueFeatureDto
+            {
+                Key = f.Key,
+                Label = f.Label,
+                Section = f.Section,
+                HasWrite = f.HasWrite,
+                HasAdmin = f.HasAdmin,
+            }).ToList(),
+            SystemGroups = AccessMatrix.Groups.Select(g => new CatalogueGroupDto
+            {
+                Name = g.Name,
+                Permissions = g.Roles.ToList(),
+            }).ToList(),
+        };
+        return Task.FromResult(response);
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetPermissionCatalogueHandlerTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetPermissionCatalogue/ \
+        backend/test/Anela.Heblo.Tests/Authorization/GetPermissionCatalogueHandlerTests.cs
+git commit -m "feat(authz): GetPermissionCatalogue query"
+```
+
+---
+
+### Task 17: GetMe query (feeds /api/auth/me)
+
+Resolves the current user's effective permissions for the frontend.
+
+**Files:**
+- Create: `.../UseCases/GetMe/GetMeRequest.cs`
+- Create: `.../UseCases/GetMe/GetMeResponse.cs`
+- Create: `.../UseCases/GetMe/GetMeHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/GetMeHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetMe;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class GetMeHandlerTests
+{
+    [Fact]
+    public async Task Handle_SuperUser_ReturnsAllPermissionsAndIsSuperUser()
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.Setup(c => c.GetCurrentUser()).Returns(new CurrentUser("oid-s", "Sue", "s@x.cz", true));
+        currentUser.Setup(c => c.IsInRole(AccessRoles.SuperUser)).Returns(true);
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+
+        var handler = new GetMeHandler(currentUser.Object, resolver.Object);
+        var result = await handler.Handle(new GetMeRequest(), default);
+
+        result.IsSuperUser.Should().BeTrue();
+        result.Permissions.Should().BeEquivalentTo(AccessMatrix.AllRoleValues().Append(AccessRoles.Base));
+    }
+
+    [Fact]
+    public async Task Handle_RegularUser_ReturnsResolvedPermissionsAndGroups()
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.Setup(c => c.GetCurrentUser()).Returns(new CurrentUser("oid-1", "Al", "a@x.cz", true));
+        currentUser.Setup(c => c.IsInRole(AccessRoles.SuperUser)).Returns(false);
+        var resolver = new Mock<IPermissionResolver>();
+        resolver.Setup(r => r.ResolveAsync("oid-1", "a@x.cz", "Al", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "heblo_user", "catalog.read" }, new[] { "Marketer" }));
+
+        var handler = new GetMeHandler(currentUser.Object, resolver.Object);
+        var result = await handler.Handle(new GetMeRequest(), default);
+
+        result.IsSuperUser.Should().BeFalse();
+        result.Permissions.Should().BeEquivalentTo(new[] { "heblo_user", "catalog.read" });
+        result.Groups.Should().BeEquivalentTo(new[] { "Marketer" });
+        result.Email.Should().Be("a@x.cz");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetMeHandlerTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement request/response/handler**
+
+`GetMeRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetMe;
+
+public class GetMeRequest : IRequest<GetMeResponse> { }
+```
+
+`GetMeResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetMe;
+
+public class GetMeResponse : BaseResponse
+{
+    public string? Email { get; set; }
+    public string? DisplayName { get; set; }
+    public bool IsSuperUser { get; set; }
+    public List<string> Permissions { get; set; } = new();
+    public List<string> Groups { get; set; } = new();
+}
+```
+
+`GetMeHandler.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetMe;
+
+public class GetMeHandler : IRequestHandler<GetMeRequest, GetMeResponse>
+{
+    private readonly ICurrentUserService _currentUser;
+    private readonly IPermissionResolver _resolver;
+
+    public GetMeHandler(ICurrentUserService currentUser, IPermissionResolver resolver)
+    {
+        _currentUser = currentUser;
+        _resolver = resolver;
+    }
+
+    public async Task<GetMeResponse> Handle(GetMeRequest request, CancellationToken ct)
+    {
+        var user = _currentUser.GetCurrentUser();
+
+        if (_currentUser.IsInRole(AccessRoles.SuperUser))
+        {
+            return new GetMeResponse
+            {
+                Email = user.Email,
+                DisplayName = user.Name,
+                IsSuperUser = true,
+                Permissions = AccessMatrix.AllRoleValues().Append(AccessRoles.Base).ToList(),
+                Groups = new List<string>(),
+            };
+        }
+
+        var resolved = await _resolver.ResolveAsync(user.Id ?? string.Empty, user.Email, user.Name, ct);
+        return new GetMeResponse
+        {
+            Email = user.Email,
+            DisplayName = user.Name,
+            IsSuperUser = false,
+            Permissions = resolved.Permissions.ToList(),
+            Groups = resolved.Groups.ToList(),
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetMeHandlerTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetMe/ \
+        backend/test/Anela.Heblo.Tests/Authorization/GetMeHandlerTests.cs
+git commit -m "feat(authz): GetMe query for /api/auth/me"
+```
+
+---
+
+### Task 18: Cycle-detection helper for group parents (TDD)
+
+Used by Create/Update group handlers to reject a parent edge that would create a cycle.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/GroupCycleCheck.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/GroupCycleCheckTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class GroupCycleCheckTests
+{
+    private static readonly Guid A = Guid.NewGuid();
+    private static readonly Guid B = Guid.NewGuid();
+    private static readonly Guid C = Guid.NewGuid();
+
+    [Fact]
+    public void WouldCreateCycle_DirectSelfParent_True()
+    {
+        GroupCycleCheck.WouldCreateCycle(A, new[] { A }, new Dictionary<Guid, List<Guid>>())
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void WouldCreateCycle_BackEdge_True()
+    {
+        // Existing: B -> A (B has parent A). Adding A -> B closes a cycle.
+        var existing = new Dictionary<Guid, List<Guid>> { [B] = new() { A } };
+        GroupCycleCheck.WouldCreateCycle(A, new[] { B }, existing).Should().BeTrue();
+    }
+
+    [Fact]
+    public void WouldCreateCycle_TransitiveBackEdge_True()
+    {
+        // Existing: B -> C, C -> A. Adding A -> B closes A->B->C->A.
+        var existing = new Dictionary<Guid, List<Guid>> { [B] = new() { C }, [C] = new() { A } };
+        GroupCycleCheck.WouldCreateCycle(A, new[] { B }, existing).Should().BeTrue();
+    }
+
+    [Fact]
+    public void WouldCreateCycle_AcyclicParent_False()
+    {
+        var existing = new Dictionary<Guid, List<Guid>> { [B] = new() { C } };
+        GroupCycleCheck.WouldCreateCycle(A, new[] { B }, existing).Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~GroupCycleCheckTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `GroupCycleCheck`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Authorization;
+
+/// <summary>Detects whether assigning parents to a group would create a cycle in the nesting DAG.</summary>
+public static class GroupCycleCheck
+{
+    /// <param name="groupId">The group being edited.</param>
+    /// <param name="proposedParentIds">Parent group ids we want to assign to groupId.</param>
+    /// <param name="existingParents">Map of groupId → its current parent ids (excluding the edited group's edges).</param>
+    public static bool WouldCreateCycle(
+        Guid groupId,
+        IEnumerable<Guid> proposedParentIds,
+        IReadOnlyDictionary<Guid, List<Guid>> existingParents)
+    {
+        foreach (var parent in proposedParentIds)
+        {
+            if (parent == groupId) return true; // self-parent
+
+            // Walk up from `parent`; if we reach `groupId`, the new edge closes a cycle.
+            var visited = new HashSet<Guid>();
+            var stack = new Stack<Guid>();
+            stack.Push(parent);
+            while (stack.Count > 0)
+            {
+                var current = stack.Pop();
+                if (current == groupId) return true;
+                if (!visited.Add(current)) continue;
+                if (existingParents.TryGetValue(current, out var grandparents))
+                    foreach (var gp in grandparents) stack.Push(gp);
+            }
+        }
+        return false;
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~GroupCycleCheckTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/GroupCycleCheck.cs \
+        backend/test/Anela.Heblo.Tests/Authorization/GroupCycleCheckTests.cs
+git commit -m "feat(authz): group nesting cycle-detection helper"
+```
+
+---
+### Task 19: Group DTOs + read queries (GetGroups, GetGroupDetail)
+
+**Files:**
+- Create: `.../UseCases/GroupDtos.cs`
+- Create: `.../UseCases/GetGroups/GetGroupsRequest.cs`, `GetGroupsResponse.cs`, `GetGroupsHandler.cs`
+- Create: `.../UseCases/GetGroupDetail/GetGroupDetailRequest.cs`, `GetGroupDetailResponse.cs`, `GetGroupDetailHandler.cs`
+
+- [ ] **Step 1: Create shared `GroupDtos.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Authorization.UseCases;
+
+public class GroupSummaryDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public bool IsSystem { get; set; }
+    public int PermissionCount { get; set; }
+    public int ParentCount { get; set; }
+    public int MemberCount { get; set; }
+}
+
+public class GroupDetailDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public bool IsSystem { get; set; }
+    public List<string> Permissions { get; set; } = new();
+    public List<Guid> ParentGroupIds { get; set; } = new();
+}
+```
+
+- [ ] **Step 2: GetGroups (request/response/handler)**
+
+`GetGroupsRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetGroups;
+
+public class GetGroupsRequest : IRequest<GetGroupsResponse> { }
+```
+
+`GetGroupsResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetGroups;
+
+public class GetGroupsResponse : BaseResponse
+{
+    public List<GroupSummaryDto> Groups { get; set; } = new();
+}
+```
+
+`GetGroupsHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetGroups;
+
+public class GetGroupsHandler : IRequestHandler<GetGroupsRequest, GetGroupsResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public GetGroupsHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<GetGroupsResponse> Handle(GetGroupsRequest request, CancellationToken ct)
+    {
+        var groups = await _repo.GetAllGroupsAsync(ct);
+        return new GetGroupsResponse
+        {
+            Groups = groups.Select(g => new GroupSummaryDto
+            {
+                Id = g.Id,
+                Name = g.Name,
+                Description = g.Description,
+                IsSystem = g.IsSystem,
+                PermissionCount = g.Permissions.Count,
+                ParentCount = g.Parents.Count,
+                MemberCount = g.UserGroups.Count,
+            }).OrderBy(g => g.Name).ToList(),
+        };
+    }
+}
+```
+
+> `GetAllGroupsAsync` already `Include`s Permissions and Parents. To populate `MemberCount`, extend it to also `.Include(g => g.UserGroups)` — update `AuthorizationRepository.GetAllGroupsAsync` to add `.Include(g => g.UserGroups)`.
+
+- [ ] **Step 3: GetGroupDetail (request/response/handler)**
+
+`GetGroupDetailRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetGroupDetail;
+
+public class GetGroupDetailRequest : IRequest<GetGroupDetailResponse>
+{
+    public Guid Id { get; set; }
+}
+```
+
+`GetGroupDetailResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetGroupDetail;
+
+public class GetGroupDetailResponse : BaseResponse
+{
+    public GroupDetailDto? Group { get; set; }
+    public GetGroupDetailResponse() { }
+    public GetGroupDetailResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+`GetGroupDetailHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetGroupDetail;
+
+public class GetGroupDetailHandler : IRequestHandler<GetGroupDetailRequest, GetGroupDetailResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public GetGroupDetailHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<GetGroupDetailResponse> Handle(GetGroupDetailRequest request, CancellationToken ct)
+    {
+        var group = await _repo.GetGroupByIdAsync(request.Id, ct);
+        if (group is null)
+            return new GetGroupDetailResponse(ErrorCodes.AuthorizationGroupNotFound);
+
+        return new GetGroupDetailResponse
+        {
+            Group = new GroupDetailDto
+            {
+                Id = group.Id,
+                Name = group.Name,
+                Description = group.Description,
+                IsSystem = group.IsSystem,
+                Permissions = group.Permissions.Select(p => p.PermissionValue).OrderBy(v => v).ToList(),
+                ParentGroupIds = group.Parents.Select(p => p.ParentGroupId).ToList(),
+            },
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application`
+Expected: Build succeeded.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GroupDtos.cs \
+        backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetGroups/ \
+        backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetGroupDetail/ \
+        backend/src/Anela.Heblo.Persistence/Features/Authorization/AuthorizationRepository.cs
+git commit -m "feat(authz): group read queries (GetGroups, GetGroupDetail)"
+```
+
+---
+
+### Task 20: CreateGroup command (TDD — validation, cycle, duplicate, system)
+
+**Files:**
+- Create: `.../UseCases/CreateGroup/CreateGroupRequest.cs`, `CreateGroupResponse.cs`, `CreateGroupHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/CreateGroupHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.CreateGroup;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class CreateGroupHandlerTests
+{
+    private static ApplicationDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"creategroup_{Guid.NewGuid()}").Options);
+
+    private static CreateGroupHandler NewHandler(ApplicationDbContext db)
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.Setup(c => c.GetCurrentUser()).Returns(new CurrentUser("oid", "Admin", "admin@x.cz", true));
+        return new CreateGroupHandler(new AuthorizationRepository(db), currentUser.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidGroup_PersistsWithPermissions()
+    {
+        await using var db = NewDb();
+        var result = await NewHandler(db).Handle(new CreateGroupRequest
+        {
+            Name = "Custom",
+            Description = "desc",
+            Permissions = new() { "catalog.read", "journal.read" },
+        }, default);
+
+        result.Success.Should().BeTrue();
+        var saved = await db.PermissionGroups.Include(g => g.Permissions).SingleAsync();
+        saved.IsSystem.Should().BeFalse();
+        saved.Permissions.Select(p => p.PermissionValue).Should().BeEquivalentTo(new[] { "catalog.read", "journal.read" });
+    }
+
+    [Fact]
+    public async Task Handle_UnknownPermission_ReturnsInvalidPermission()
+    {
+        await using var db = NewDb();
+        var result = await NewHandler(db).Handle(new CreateGroupRequest
+        {
+            Name = "Bad",
+            Permissions = new() { "ghost.read" },
+        }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.AuthorizationInvalidPermission);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateName_ReturnsDuplicate()
+    {
+        await using var db = NewDb();
+        db.PermissionGroups.Add(new PermissionGroup { Id = Guid.NewGuid(), Name = "Dup", CreatedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await NewHandler(db).Handle(new CreateGroupRequest { Name = "Dup", Permissions = new() }, default);
+
+        result.ErrorCode.Should().Be(ErrorCodes.AuthorizationDuplicateGroupName);
+    }
+
+    [Fact]
+    public async Task Handle_ParentCreatingCycle_ReturnsCycleError()
+    {
+        await using var db = NewDb();
+        // existing: P (will be the new group's parent). Then make P's parent the new group -> not possible at create.
+        // Instead: self-cycle is impossible at create (no id yet), so test parent that points back via existing chain.
+        var p = new PermissionGroup { Id = Guid.NewGuid(), Name = "P", CreatedAt = DateTimeOffset.UtcNow };
+        db.PermissionGroups.Add(p);
+        await db.SaveChangesAsync();
+        // No back-edge exists yet, so adding P as parent is fine — assert success to lock in behavior.
+        var result = await NewHandler(db).Handle(new CreateGroupRequest
+        {
+            Name = "Child", Permissions = new(), ParentGroupIds = new() { p.Id },
+        }, default);
+
+        result.Success.Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~CreateGroupHandlerTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement request/response/handler**
+
+`CreateGroupRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.CreateGroup;
+
+public class CreateGroupRequest : IRequest<CreateGroupResponse>
+{
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public List<string> Permissions { get; set; } = new();
+    public List<Guid> ParentGroupIds { get; set; } = new();
+}
+```
+
+`CreateGroupResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.CreateGroup;
+
+public class CreateGroupResponse : BaseResponse
+{
+    public Guid Id { get; set; }
+    public CreateGroupResponse() { }
+    public CreateGroupResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+`CreateGroupHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.CreateGroup;
+
+public class CreateGroupHandler : IRequestHandler<CreateGroupRequest, CreateGroupResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    private readonly ICurrentUserService _currentUser;
+
+    public CreateGroupHandler(IAuthorizationRepository repo, ICurrentUserService currentUser)
+    {
+        _repo = repo;
+        _currentUser = currentUser;
+    }
+
+    public async Task<CreateGroupResponse> Handle(CreateGroupRequest request, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return new CreateGroupResponse(ErrorCodes.ValidationError);
+
+        var valid = AccessMatrix.AllRoleValues().ToHashSet();
+        if (request.Permissions.Any(p => !valid.Contains(p)))
+            return new CreateGroupResponse(ErrorCodes.AuthorizationInvalidPermission);
+
+        if (await _repo.GetGroupByNameAsync(request.Name, ct) is not null)
+            return new CreateGroupResponse(ErrorCodes.AuthorizationDuplicateGroupName);
+
+        var id = Guid.NewGuid();
+        if (request.ParentGroupIds.Count > 0)
+        {
+            var (_, parents) = await _repo.GetGroupGraphAsync(ct);
+            var existing = parents.GroupBy(p => p.GroupId)
+                .ToDictionary(g => g.Key, g => g.Select(p => p.ParentGroupId).ToList());
+            if (GroupCycleCheck.WouldCreateCycle(id, request.ParentGroupIds, existing))
+                return new CreateGroupResponse(ErrorCodes.AuthorizationGroupCycleDetected);
+        }
+
+        var group = new PermissionGroup
+        {
+            Id = id,
+            Name = request.Name.Trim(),
+            Description = request.Description,
+            IsSystem = false,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = _currentUser.GetCurrentUser().Email,
+        };
+        foreach (var p in request.Permissions.Distinct())
+            group.Permissions.Add(new GroupPermission { GroupId = id, PermissionValue = p });
+        foreach (var parentId in request.ParentGroupIds.Distinct())
+            group.Parents.Add(new GroupParent { GroupId = id, ParentGroupId = parentId });
+
+        await _repo.AddGroupAsync(group, ct);
+        await _repo.SaveChangesAsync(ct);
+
+        return new CreateGroupResponse { Id = id };
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~CreateGroupHandlerTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/CreateGroup/ \
+        backend/test/Anela.Heblo.Tests/Authorization/CreateGroupHandlerTests.cs
+git commit -m "feat(authz): CreateGroup command with validation and cycle guard"
+```
+
+---
+### Task 21: UpdateGroup + DeleteGroup (TDD — system groups immutable)
+
+**Files:**
+- Create: `.../UseCases/UpdateGroup/UpdateGroupRequest.cs`, `UpdateGroupResponse.cs`, `UpdateGroupHandler.cs`
+- Create: `.../UseCases/DeleteGroup/DeleteGroupRequest.cs`, `DeleteGroupResponse.cs`, `DeleteGroupHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/UpdateDeleteGroupHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.DeleteGroup;
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateGroup;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class UpdateDeleteGroupHandlerTests
+{
+    private static ApplicationDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"upd_{Guid.NewGuid()}").Options);
+
+    private static async Task<PermissionGroup> SeedGroup(ApplicationDbContext db, bool isSystem)
+    {
+        var g = new PermissionGroup { Id = Guid.NewGuid(), Name = "G", IsSystem = isSystem, CreatedAt = DateTimeOffset.UtcNow };
+        g.Permissions.Add(new GroupPermission { GroupId = g.Id, PermissionValue = "catalog.read" });
+        db.PermissionGroups.Add(g);
+        await db.SaveChangesAsync();
+        return g;
+    }
+
+    [Fact]
+    public async Task Update_NonSystem_ReplacesPermissions()
+    {
+        await using var db = NewDb();
+        var g = await SeedGroup(db, isSystem: false);
+        var handler = new UpdateGroupHandler(new AuthorizationRepository(db));
+
+        var result = await handler.Handle(new UpdateGroupRequest
+        {
+            Id = g.Id, Name = "G2", Permissions = new() { "journal.read" }, ParentGroupIds = new()
+        }, default);
+
+        result.Success.Should().BeTrue();
+        var reloaded = await db.PermissionGroups.Include(x => x.Permissions).SingleAsync();
+        reloaded.Name.Should().Be("G2");
+        reloaded.Permissions.Select(p => p.PermissionValue).Should().BeEquivalentTo(new[] { "journal.read" });
+    }
+
+    [Fact]
+    public async Task Update_SystemGroup_ReturnsImmutable()
+    {
+        await using var db = NewDb();
+        var g = await SeedGroup(db, isSystem: true);
+        var handler = new UpdateGroupHandler(new AuthorizationRepository(db));
+
+        var result = await handler.Handle(new UpdateGroupRequest
+        {
+            Id = g.Id, Name = "X", Permissions = new(), ParentGroupIds = new()
+        }, default);
+
+        result.ErrorCode.Should().Be(ErrorCodes.AuthorizationSystemGroupImmutable);
+    }
+
+    [Fact]
+    public async Task Delete_SystemGroup_ReturnsImmutable()
+    {
+        await using var db = NewDb();
+        var g = await SeedGroup(db, isSystem: true);
+        var handler = new DeleteGroupHandler(new AuthorizationRepository(db));
+
+        var result = await handler.Handle(new DeleteGroupRequest { Id = g.Id }, default);
+
+        result.ErrorCode.Should().Be(ErrorCodes.AuthorizationSystemGroupImmutable);
+        (await db.PermissionGroups.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Delete_NonSystem_Removes()
+    {
+        await using var db = NewDb();
+        var g = await SeedGroup(db, isSystem: false);
+        var handler = new DeleteGroupHandler(new AuthorizationRepository(db));
+
+        var result = await handler.Handle(new DeleteGroupRequest { Id = g.Id }, default);
+
+        result.Success.Should().BeTrue();
+        (await db.PermissionGroups.CountAsync()).Should().Be(0);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~UpdateDeleteGroupHandlerTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement UpdateGroup**
+
+`UpdateGroupRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateGroup;
+
+public class UpdateGroupRequest : IRequest<UpdateGroupResponse>
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public List<string> Permissions { get; set; } = new();
+    public List<Guid> ParentGroupIds { get; set; } = new();
+}
+```
+
+`UpdateGroupResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateGroup;
+
+public class UpdateGroupResponse : BaseResponse
+{
+    public UpdateGroupResponse() { }
+    public UpdateGroupResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+`UpdateGroupHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateGroup;
+
+public class UpdateGroupHandler : IRequestHandler<UpdateGroupRequest, UpdateGroupResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public UpdateGroupHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<UpdateGroupResponse> Handle(UpdateGroupRequest request, CancellationToken ct)
+    {
+        var group = await _repo.GetGroupByIdAsync(request.Id, ct);
+        if (group is null)
+            return new UpdateGroupResponse(ErrorCodes.AuthorizationGroupNotFound);
+        if (group.IsSystem)
+            return new UpdateGroupResponse(ErrorCodes.AuthorizationSystemGroupImmutable);
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return new UpdateGroupResponse(ErrorCodes.ValidationError);
+
+        var valid = AccessMatrix.AllRoleValues().ToHashSet();
+        if (request.Permissions.Any(p => !valid.Contains(p)))
+            return new UpdateGroupResponse(ErrorCodes.AuthorizationInvalidPermission);
+
+        // Cycle check using all parents EXCEPT this group's own outgoing edges (being replaced).
+        var (_, allParents) = await _repo.GetGroupGraphAsync(ct);
+        var existing = allParents.Where(p => p.GroupId != group.Id)
+            .GroupBy(p => p.GroupId)
+            .ToDictionary(g => g.Key, g => g.Select(p => p.ParentGroupId).ToList());
+        if (GroupCycleCheck.WouldCreateCycle(group.Id, request.ParentGroupIds, existing))
+            return new UpdateGroupResponse(ErrorCodes.AuthorizationGroupCycleDetected);
+
+        group.Name = request.Name.Trim();
+        group.Description = request.Description;
+
+        group.Permissions.Clear();
+        foreach (var p in request.Permissions.Distinct())
+            group.Permissions.Add(new GroupPermission { GroupId = group.Id, PermissionValue = p });
+
+        group.Parents.Clear();
+        foreach (var parentId in request.ParentGroupIds.Distinct())
+            group.Parents.Add(new GroupParent { GroupId = group.Id, ParentGroupId = parentId });
+
+        await _repo.SaveChangesAsync(ct);
+        return new UpdateGroupResponse();
+    }
+}
+```
+
+- [ ] **Step 4: Implement DeleteGroup**
+
+`DeleteGroupRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.DeleteGroup;
+
+public class DeleteGroupRequest : IRequest<DeleteGroupResponse>
+{
+    public Guid Id { get; set; }
+}
+```
+
+`DeleteGroupResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.DeleteGroup;
+
+public class DeleteGroupResponse : BaseResponse
+{
+    public DeleteGroupResponse() { }
+    public DeleteGroupResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+`DeleteGroupHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.DeleteGroup;
+
+public class DeleteGroupHandler : IRequestHandler<DeleteGroupRequest, DeleteGroupResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public DeleteGroupHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<DeleteGroupResponse> Handle(DeleteGroupRequest request, CancellationToken ct)
+    {
+        var group = await _repo.GetGroupByIdAsync(request.Id, ct);
+        if (group is null)
+            return new DeleteGroupResponse(ErrorCodes.AuthorizationGroupNotFound);
+        if (group.IsSystem)
+            return new DeleteGroupResponse(ErrorCodes.AuthorizationSystemGroupImmutable);
+
+        await _repo.RemoveGroupAsync(group, ct);
+        await _repo.SaveChangesAsync(ct);
+        return new DeleteGroupResponse();
+    }
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~UpdateDeleteGroupHandlerTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateGroup/ \
+        backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/DeleteGroup/ \
+        backend/test/Anela.Heblo.Tests/Authorization/UpdateDeleteGroupHandlerTests.cs
+git commit -m "feat(authz): UpdateGroup and DeleteGroup (system groups immutable)"
+```
+
+---
+### Task 22: User read queries (GetUsers, GetUserEffectivePermissions)
+
+**Files:**
+- Create: `.../UseCases/UserDtos.cs`
+- Create: `.../UseCases/GetUsers/GetUsersRequest.cs`, `GetUsersResponse.cs`, `GetUsersHandler.cs`
+- Create: `.../UseCases/GetUserEffectivePermissions/GetUserEffectivePermissionsRequest.cs`, `...Response.cs`, `...Handler.cs`
+
+- [ ] **Step 1: Create `UserDtos.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Authorization.UseCases;
+
+public class AppUserDto
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = null!;
+    public string DisplayName { get; set; } = null!;
+    public bool IsActive { get; set; }
+    public DateTimeOffset? LastLoginAt { get; set; }
+    public List<Guid> GroupIds { get; set; } = new();
+}
+```
+
+- [ ] **Step 2: GetUsers**
+
+`GetUsersRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetUsers;
+
+public class GetUsersRequest : IRequest<GetUsersResponse> { }
+```
+
+`GetUsersResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetUsers;
+
+public class GetUsersResponse : BaseResponse
+{
+    public List<AppUserDto> Users { get; set; } = new();
+}
+```
+
+`GetUsersHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetUsers;
+
+public class GetUsersHandler : IRequestHandler<GetUsersRequest, GetUsersResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public GetUsersHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<GetUsersResponse> Handle(GetUsersRequest request, CancellationToken ct)
+    {
+        var users = await _repo.GetAllUsersAsync(ct);
+        return new GetUsersResponse
+        {
+            Users = users.Select(u => new AppUserDto
+            {
+                Id = u.Id,
+                Email = u.Email,
+                DisplayName = u.DisplayName,
+                IsActive = u.IsActive,
+                LastLoginAt = u.LastLoginAt,
+                GroupIds = u.UserGroups.Select(ug => ug.GroupId).ToList(),
+            }).OrderBy(u => u.DisplayName).ToList(),
+        };
+    }
+}
+```
+
+- [ ] **Step 3: GetUserEffectivePermissions**
+
+`GetUserEffectivePermissionsRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetUserEffectivePermissions;
+
+public class GetUserEffectivePermissionsRequest : IRequest<GetUserEffectivePermissionsResponse>
+{
+    public Guid UserId { get; set; }
+}
+```
+
+`GetUserEffectivePermissionsResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetUserEffectivePermissions;
+
+public class GetUserEffectivePermissionsResponse : BaseResponse
+{
+    public List<string> Permissions { get; set; } = new();
+    public GetUserEffectivePermissionsResponse() { }
+    public GetUserEffectivePermissionsResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+`GetUserEffectivePermissionsHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Persistence.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetUserEffectivePermissions;
+
+public class GetUserEffectivePermissionsHandler
+    : IRequestHandler<GetUserEffectivePermissionsRequest, GetUserEffectivePermissionsResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public GetUserEffectivePermissionsHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<GetUserEffectivePermissionsResponse> Handle(
+        GetUserEffectivePermissionsRequest request, CancellationToken ct)
+    {
+        var user = await _repo.GetUserByIdAsync(request.UserId, ct);
+        if (user is null)
+            return new GetUserEffectivePermissionsResponse(ErrorCodes.AuthorizationUserNotFound);
+
+        if (!user.IsActive)
+            return new GetUserEffectivePermissionsResponse { Permissions = new() };
+
+        var (perms, parents) = await _repo.GetGroupGraphAsync(ct);
+        var groupIds = user.UserGroups.Select(ug => ug.GroupId);
+        var resolved = GroupClosure.Resolve(groupIds, perms, parents);
+        var all = new HashSet<string>(resolved) { AccessRoles.Base };
+
+        return new GetUserEffectivePermissionsResponse { Permissions = all.OrderBy(p => p).ToList() };
+    }
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application`
+Expected: Build succeeded.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UserDtos.cs \
+        backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetUsers/ \
+        backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetUserEffectivePermissions/
+git commit -m "feat(authz): user read queries"
+```
+
+---
+
+### Task 23: AssignUserGroups + SetUserActive (TDD)
+
+**Files:**
+- Add to `IAuthorizationRepository` + `AuthorizationRepository`: `RemoveUserGroupsAsync`, `AddUserGroupAsync`.
+- Create: `.../UseCases/AssignUserGroups/AssignUserGroupsRequest.cs`, `...Response.cs`, `...Handler.cs`
+- Create: `.../UseCases/SetUserActive/SetUserActiveRequest.cs`, `...Response.cs`, `...Handler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/AssignUserGroupsHandlerTests.cs`
+
+- [ ] **Step 1: Extend the repository contract**
+
+Add to `IAuthorizationRepository`:
+
+```csharp
+    Task SetUserGroupsAsync(Guid userId, IEnumerable<Guid> groupIds, CancellationToken ct = default);
+```
+
+Implement in `AuthorizationRepository`:
+
+```csharp
+    public async Task SetUserGroupsAsync(Guid userId, IEnumerable<Guid> groupIds, CancellationToken ct = default)
+    {
+        var existing = await _db.UserGroups.Where(ug => ug.UserId == userId).ToListAsync(ct);
+        _db.UserGroups.RemoveRange(existing);
+        foreach (var gid in groupIds.Distinct())
+            _db.UserGroups.Add(new UserGroup { UserId = userId, GroupId = gid });
+    }
+```
+
+(Add `using Anela.Heblo.Domain.Features.Authorization.Entities;` if not present — it is.)
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.AssignUserGroups;
+using Anela.Heblo.Application.Features.Authorization.UseCases.SetUserActive;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class AssignUserGroupsHandlerTests
+{
+    private static ApplicationDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"assign_{Guid.NewGuid()}").Options);
+
+    private static async Task<(AppUser user, PermissionGroup g1, PermissionGroup g2)> Seed(ApplicationDbContext db)
+    {
+        var g1 = new PermissionGroup { Id = Guid.NewGuid(), Name = "G1", CreatedAt = DateTimeOffset.UtcNow };
+        var g2 = new PermissionGroup { Id = Guid.NewGuid(), Name = "G2", CreatedAt = DateTimeOffset.UtcNow };
+        var user = new AppUser { Id = Guid.NewGuid(), EntraObjectId = "oid", Email = "u@x.cz", DisplayName = "U", IsActive = true, CreatedAt = DateTimeOffset.UtcNow };
+        user.UserGroups.Add(new UserGroup { UserId = user.Id, GroupId = g1.Id });
+        db.AddRange(g1, g2, user);
+        await db.SaveChangesAsync();
+        return (user, g1, g2);
+    }
+
+    [Fact]
+    public async Task Assign_ReplacesUserGroups()
+    {
+        await using var db = NewDb();
+        var (user, _, g2) = await Seed(db);
+        var handler = new AssignUserGroupsHandler(new AuthorizationRepository(db));
+
+        var result = await handler.Handle(new AssignUserGroupsRequest
+        {
+            UserId = user.Id, GroupIds = new() { g2.Id }
+        }, default);
+
+        result.Success.Should().BeTrue();
+        var groups = await db.UserGroups.Where(ug => ug.UserId == user.Id).Select(ug => ug.GroupId).ToListAsync();
+        groups.Should().BeEquivalentTo(new[] { g2.Id });
+    }
+
+    [Fact]
+    public async Task Assign_UnknownUser_ReturnsNotFound()
+    {
+        await using var db = NewDb();
+        var handler = new AssignUserGroupsHandler(new AuthorizationRepository(db));
+        var result = await handler.Handle(new AssignUserGroupsRequest { UserId = Guid.NewGuid(), GroupIds = new() }, default);
+        result.ErrorCode.Should().Be(ErrorCodes.AuthorizationUserNotFound);
+    }
+
+    [Fact]
+    public async Task SetActive_TogglesFlag()
+    {
+        await using var db = NewDb();
+        var (user, _, _) = await Seed(db);
+        var handler = new SetUserActiveHandler(new AuthorizationRepository(db));
+
+        var result = await handler.Handle(new SetUserActiveRequest { UserId = user.Id, IsActive = false }, default);
+
+        result.Success.Should().BeTrue();
+        (await db.AppUsers.SingleAsync(u => u.Id == user.Id)).IsActive.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~AssignUserGroupsHandlerTests"`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement AssignUserGroups**
+
+`AssignUserGroupsRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.AssignUserGroups;
+
+public class AssignUserGroupsRequest : IRequest<AssignUserGroupsResponse>
+{
+    public Guid UserId { get; set; }
+    public List<Guid> GroupIds { get; set; } = new();
+}
+```
+
+`AssignUserGroupsResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.AssignUserGroups;
+
+public class AssignUserGroupsResponse : BaseResponse
+{
+    public AssignUserGroupsResponse() { }
+    public AssignUserGroupsResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+`AssignUserGroupsHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.AssignUserGroups;
+
+public class AssignUserGroupsHandler : IRequestHandler<AssignUserGroupsRequest, AssignUserGroupsResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public AssignUserGroupsHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<AssignUserGroupsResponse> Handle(AssignUserGroupsRequest request, CancellationToken ct)
+    {
+        var user = await _repo.GetUserByIdAsync(request.UserId, ct);
+        if (user is null)
+            return new AssignUserGroupsResponse(ErrorCodes.AuthorizationUserNotFound);
+
+        await _repo.SetUserGroupsAsync(request.UserId, request.GroupIds, ct);
+        await _repo.SaveChangesAsync(ct);
+        return new AssignUserGroupsResponse();
+    }
+}
+```
+
+- [ ] **Step 5: Implement SetUserActive**
+
+`SetUserActiveRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.SetUserActive;
+
+public class SetUserActiveRequest : IRequest<SetUserActiveResponse>
+{
+    public Guid UserId { get; set; }
+    public bool IsActive { get; set; }
+}
+```
+
+`SetUserActiveResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.SetUserActive;
+
+public class SetUserActiveResponse : BaseResponse
+{
+    public SetUserActiveResponse() { }
+    public SetUserActiveResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+`SetUserActiveHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.SetUserActive;
+
+public class SetUserActiveHandler : IRequestHandler<SetUserActiveRequest, SetUserActiveResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    public SetUserActiveHandler(IAuthorizationRepository repo) => _repo = repo;
+
+    public async Task<SetUserActiveResponse> Handle(SetUserActiveRequest request, CancellationToken ct)
+    {
+        var user = await _repo.GetUserByIdAsync(request.UserId, ct);
+        if (user is null)
+            return new SetUserActiveResponse(ErrorCodes.AuthorizationUserNotFound);
+
+        user.IsActive = request.IsActive;
+        await _repo.SaveChangesAsync(ct);
+        return new SetUserActiveResponse();
+    }
+}
+```
+
+> Note: per spec decision #6 (short-TTL cache, no active invalidation), these admin writes do
+> NOT call `IPermissionResolver.InvalidateCache`. Changes take effect within the cache TTL
+> (~5 min). Disabling a user therefore also lands within one TTL window — documented behavior.
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~AssignUserGroupsHandlerTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/AssignUserGroups/ \
+        backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/SetUserActive/ \
+        backend/src/Anela.Heblo.Domain/Features/Authorization/IAuthorizationRepository.cs \
+        backend/src/Anela.Heblo.Persistence/Features/Authorization/AuthorizationRepository.cs \
+        backend/test/Anela.Heblo.Tests/Authorization/AssignUserGroupsHandlerTests.cs
+git commit -m "feat(authz): assign user groups and set-active commands"
+```
+
+---
+## Phase 6 — API controllers
+
+### Task 24: Add an "authenticated-only" policy for /api/auth/me
+
+The default policy requires the `heblo_user` role, but `/api/auth/me` must be reachable by
+users with no access yet (and disabled users) so the frontend can show the right state.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs` (in `ConfigureAuthorizationPolicies`)
+
+- [ ] **Step 1: Add the named policy**
+
+Inside the `services.AddAuthorization(options => { ... })` lambda, after setting `DefaultPolicy`, add:
+
+```csharp
+            options.AddPolicy("AuthenticatedUser", p => p.RequireAuthenticatedUser());
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.API`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs
+git commit -m "feat(authz): add AuthenticatedUser policy for /api/auth/me"
+```
+
+---
+
+### Task 25: AuthController (/api/auth/me)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Controllers/AuthController.cs`
+
+- [ ] **Step 1: Create the controller**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetMe;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : BaseApiController
+{
+    private readonly IMediator _mediator;
+    public AuthController(IMediator mediator) => _mediator = mediator;
+
+    /// <summary>Returns the current user's effective permissions for the frontend.
+    /// Reachable by any authenticated user (incl. no-access/disabled) via the AuthenticatedUser policy.</summary>
+    [HttpGet("me")]
+    [Authorize(Policy = "AuthenticatedUser")]
+    public async Task<ActionResult<GetMeResponse>> Me(CancellationToken ct)
+    {
+        var response = await _mediator.Send(new GetMeRequest(), ct);
+        return HandleResponse(response);
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.API`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/AuthController.cs
+git commit -m "feat(authz): /api/auth/me endpoint"
+```
+
+---
+
+### Task 26: Admin AuthorizationController
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Controllers/AuthorizationController.cs`
+
+- [ ] **Step 1: Create the controller**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.AssignUserGroups;
+using Anela.Heblo.Application.Features.Authorization.UseCases.CreateGroup;
+using Anela.Heblo.Application.Features.Authorization.UseCases.DeleteGroup;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetGroupDetail;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetGroups;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetPermissionCatalogue;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetUserEffectivePermissions;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetUsers;
+using Anela.Heblo.Application.Features.Authorization.UseCases.SetUserActive;
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateGroup;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+
+[Authorize(Roles = AccessRoles.AdministrationRead)]
+[ApiController]
+[Route("api/admin/authorization")]
+public class AuthorizationController : BaseApiController
+{
+    private readonly IMediator _mediator;
+    public AuthorizationController(IMediator mediator) => _mediator = mediator;
+
+    [HttpGet("catalogue")]
+    public async Task<ActionResult<GetPermissionCatalogueResponse>> Catalogue(CancellationToken ct)
+        => HandleResponse(await _mediator.Send(new GetPermissionCatalogueRequest(), ct));
+
+    [HttpGet("groups")]
+    public async Task<ActionResult<GetGroupsResponse>> GetGroups(CancellationToken ct)
+        => HandleResponse(await _mediator.Send(new GetGroupsRequest(), ct));
+
+    [HttpGet("groups/{id:guid}")]
+    public async Task<ActionResult<GetGroupDetailResponse>> GetGroup([FromRoute] Guid id, CancellationToken ct)
+        => HandleResponse(await _mediator.Send(new GetGroupDetailRequest { Id = id }, ct));
+
+    [HttpPost("groups")]
+    [Authorize(Roles = AccessRoles.AdministrationWrite)]
+    public async Task<ActionResult<CreateGroupResponse>> CreateGroup([FromBody] CreateGroupRequest request, CancellationToken ct)
+        => HandleResponse(await _mediator.Send(request, ct));
+
+    [HttpPut("groups/{id:guid}")]
+    [Authorize(Roles = AccessRoles.AdministrationWrite)]
+    public async Task<ActionResult<UpdateGroupResponse>> UpdateGroup([FromRoute] Guid id, [FromBody] UpdateGroupRequest request, CancellationToken ct)
+    {
+        request.Id = id;
+        return HandleResponse(await _mediator.Send(request, ct));
+    }
+
+    [HttpDelete("groups/{id:guid}")]
+    [Authorize(Roles = AccessRoles.AdministrationWrite)]
+    public async Task<ActionResult<DeleteGroupResponse>> DeleteGroup([FromRoute] Guid id, CancellationToken ct)
+        => HandleResponse(await _mediator.Send(new DeleteGroupRequest { Id = id }, ct));
+
+    [HttpGet("users")]
+    public async Task<ActionResult<GetUsersResponse>> GetUsers(CancellationToken ct)
+        => HandleResponse(await _mediator.Send(new GetUsersRequest(), ct));
+
+    [HttpGet("users/{id:guid}/permissions")]
+    public async Task<ActionResult<GetUserEffectivePermissionsResponse>> GetUserPermissions([FromRoute] Guid id, CancellationToken ct)
+        => HandleResponse(await _mediator.Send(new GetUserEffectivePermissionsRequest { UserId = id }, ct));
+
+    [HttpPut("users/{id:guid}/groups")]
+    [Authorize(Roles = AccessRoles.AdministrationWrite)]
+    public async Task<ActionResult<AssignUserGroupsResponse>> AssignGroups([FromRoute] Guid id, [FromBody] AssignUserGroupsRequest request, CancellationToken ct)
+    {
+        request.UserId = id;
+        return HandleResponse(await _mediator.Send(request, ct));
+    }
+
+    [HttpPut("users/{id:guid}/active")]
+    [Authorize(Roles = AccessRoles.AdministrationWrite)]
+    public async Task<ActionResult<SetUserActiveResponse>> SetActive([FromRoute] Guid id, [FromBody] SetUserActiveRequest request, CancellationToken ct)
+    {
+        request.UserId = id;
+        return HandleResponse(await _mediator.Send(request, ct));
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/src/Anela.Heblo.API`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Regenerate the TypeScript API client**
+
+The OpenAPI TS client is generated on build. Run a full build so the new endpoints appear in `frontend/src/api/generated/`:
+
+Run: `dotnet build`
+Expected: Build succeeded; `git status` shows changes under `frontend/src/api/generated/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/AuthorizationController.cs frontend/src/api/generated/
+git commit -m "feat(authz): admin AuthorizationController + regenerated API client"
+```
+
+---
+## Phase 7 — Frontend
+
+> The OpenAPI TS client is regenerated on `dotnet build` (Task 26). Before writing the hooks,
+> confirm the generated method name for `GET /api/auth/me`. NSwag names it
+> `{controller}_{operationId}` → most likely **`auth_Me`** on the generated `ApiClient`.
+> Grep: `grep -r "auth_" frontend/src/api/generated/` and use the actual name.
+
+### Task 27: usePermissions hook + PermissionsProvider, and switch RequireAccess
+
+**Files:**
+- Create: `frontend/src/api/hooks/usePermissions.ts`
+- Create: `frontend/src/auth/PermissionsContext.tsx`
+- Modify: `frontend/src/components/auth/RequireAccess.tsx`
+- Modify: `frontend/src/App.tsx` (or wherever providers are composed) to wrap with `PermissionsProvider`
+- Test: `frontend/src/components/auth/__tests__/RequireAccess.test.tsx`
+
+- [ ] **Step 1: Create `usePermissions.ts`**
+
+```typescript
+import { useQuery } from "@tanstack/react-query";
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+
+export interface MePermissions {
+  email?: string;
+  displayName?: string;
+  isSuperUser: boolean;
+  permissions: string[];
+  groups: string[];
+}
+
+export const permissionsQueryKey = ["auth", "me"] as const;
+
+export const usePermissions = (enabled: boolean) => {
+  return useQuery({
+    queryKey: permissionsQueryKey,
+    enabled,
+    staleTime: 5 * 60 * 1000, // align with backend ~5 min TTL
+    queryFn: async (): Promise<MePermissions> => {
+      const client = getAuthenticatedApiClient();
+      // Confirm the generated method name (see Phase 7 note). Likely `auth_Me`.
+      const res = await client.auth_Me();
+      return {
+        email: res?.email ?? undefined,
+        displayName: res?.displayName ?? undefined,
+        isSuperUser: res?.isSuperUser ?? false,
+        permissions: res?.permissions ?? [],
+        groups: res?.groups ?? [],
+      };
+    },
+  });
+};
+```
+
+> If `QUERY_KEYS` has no slot for this, just use the local `permissionsQueryKey`; do not force a change to `QUERY_KEYS`.
+
+- [ ] **Step 2: Create `PermissionsContext.tsx`**
+
+```typescript
+import React, { createContext, useContext, ReactNode } from "react";
+import { usePermissions, MePermissions } from "../api/hooks/usePermissions";
+
+interface PermissionsContextValue {
+  permissions: string[];
+  isSuperUser: boolean;
+  groups: string[];
+  isLoading: boolean;
+  hasPermission: (perm: string) => boolean;
+}
+
+const PermissionsContext = createContext<PermissionsContextValue | undefined>(undefined);
+
+interface ProviderProps {
+  isAuthenticated: boolean;
+  children: ReactNode;
+}
+
+export const PermissionsProvider: React.FC<ProviderProps> = ({ isAuthenticated, children }) => {
+  const { data, isLoading } = usePermissions(isAuthenticated);
+
+  const value: PermissionsContextValue = {
+    permissions: data?.permissions ?? [],
+    isSuperUser: data?.isSuperUser ?? false,
+    groups: data?.groups ?? [],
+    isLoading: isAuthenticated && isLoading,
+    hasPermission: (perm: string) =>
+      (data?.isSuperUser ?? false) || (data?.permissions ?? []).includes(perm),
+  };
+
+  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>;
+};
+
+export const usePermissionsContext = (): PermissionsContextValue => {
+  const ctx = useContext(PermissionsContext);
+  if (!ctx) throw new Error("usePermissionsContext must be used within PermissionsProvider");
+  return ctx;
+};
+```
+
+- [ ] **Step 3: Wire the provider**
+
+In `frontend/src/App.tsx`, find where auth is established (the `AuthGuard` / msal provider region) and wrap the authenticated app subtree:
+
+```tsx
+// import at top
+import { PermissionsProvider } from "./auth/PermissionsContext";
+import { useAuth } from "./auth/useAuth";
+```
+
+Wrap the routed content (inside the authenticated region) with:
+
+```tsx
+<PermissionsProvider isAuthenticated={isAuthenticated}>
+  {/* existing routed content */}
+</PermissionsProvider>
+```
+
+> Use whatever `isAuthenticated` source the surrounding component already uses (real `useAuth` or `useMockAuth`). If `App.tsx` doesn't expose it directly, place the provider just inside `AuthGuard`'s authenticated branch where `isAuthenticated === true`.
+
+- [ ] **Step 4: Write the failing RequireAccess test**
+
+```tsx
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { RequireAccess } from "../RequireAccess";
+
+const mockCtx = { permissions: ["catalog.read"], isSuperUser: false, groups: [], isLoading: false,
+  hasPermission: (p: string) => ["catalog.read"].includes(p) };
+
+jest.mock("../../../auth/PermissionsContext", () => ({
+  usePermissionsContext: () => mockCtx,
+}));
+
+const renderAt = (required: string) =>
+  render(
+    <MemoryRouter initialEntries={["/secret"]}>
+      <Routes>
+        <Route path="/" element={<div>home</div>} />
+        <Route path="/secret" element={<RequireAccess requiredRole={required}><div>secret</div></RequireAccess>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe("RequireAccess", () => {
+  it("renders children when permission present", () => {
+    renderAt("catalog.read");
+    expect(screen.getByText("secret")).toBeInTheDocument();
+  });
+
+  it("redirects home when permission missing", () => {
+    renderAt("journal.read");
+    expect(screen.getByText("home")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run (from `frontend/`): `npm test -- --watchAll=false RequireAccess`
+Expected: FAIL — `RequireAccess` still reads from `useAuth`.
+
+- [ ] **Step 6: Update `RequireAccess.tsx`**
+
+```tsx
+import { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { usePermissionsContext } from "../../auth/PermissionsContext";
+
+interface RequireAccessProps {
+  requiredRole?: string;
+  children: ReactNode;
+}
+
+export function RequireAccess({ requiredRole, children }: RequireAccessProps) {
+  const { hasPermission, isLoading } = usePermissionsContext();
+
+  if (isLoading) {
+    return null; // wait for /api/auth/me before deciding
+  }
+
+  if (requiredRole && !hasPermission(requiredRole)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 7: Run to verify pass**
+
+Run (from `frontend/`): `npm test -- --watchAll=false RequireAccess`
+Expected: PASS.
+
+- [ ] **Step 8: Build + lint**
+
+Run (from `frontend/`): `npm run build && npm run lint`
+Expected: Both succeed. Fix any unused-import lint errors introduced.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/api/hooks/usePermissions.ts frontend/src/auth/PermissionsContext.tsx \
+        frontend/src/components/auth/RequireAccess.tsx frontend/src/App.tsx \
+        frontend/src/components/auth/__tests__/RequireAccess.test.tsx
+git commit -m "feat(authz): source permissions from /api/auth/me; gate RequireAccess on it"
+```
+
+---
+### Task 28: Admin access-management hooks
+
+**Files:**
+- Create: `frontend/src/api/hooks/useAccessManagement.ts`
+
+> Confirm generated method names with `grep -r "authorization_" frontend/src/api/generated/`.
+> Expected: `authorization_Catalogue`, `authorization_GetGroups`, `authorization_GetGroup`,
+> `authorization_CreateGroup`, `authorization_UpdateGroup`, `authorization_DeleteGroup`,
+> `authorization_GetUsers`, `authorization_GetUserPermissions`, `authorization_AssignGroups`,
+> `authorization_SetActive`. Adjust if the generator differs.
+
+- [ ] **Step 1: Create the hooks**
+
+```typescript
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getAuthenticatedApiClient } from "../client";
+
+const keys = {
+  catalogue: ["authz", "catalogue"] as const,
+  groups: ["authz", "groups"] as const,
+  group: (id: string) => ["authz", "group", id] as const,
+  users: ["authz", "users"] as const,
+};
+
+export const useCatalogue = () =>
+  useQuery({
+    queryKey: keys.catalogue,
+    queryFn: async () => (await getAuthenticatedApiClient().authorization_Catalogue()),
+  });
+
+export const useGroups = () =>
+  useQuery({
+    queryKey: keys.groups,
+    queryFn: async () => (await getAuthenticatedApiClient().authorization_GetGroups())?.groups ?? [],
+  });
+
+export const useGroup = (id: string | null) =>
+  useQuery({
+    queryKey: keys.group(id ?? ""),
+    enabled: !!id,
+    queryFn: async () => (await getAuthenticatedApiClient().authorization_GetGroup(id!))?.group,
+  });
+
+export const useUsers = () =>
+  useQuery({
+    queryKey: keys.users,
+    queryFn: async () => (await getAuthenticatedApiClient().authorization_GetUsers())?.users ?? [],
+  });
+
+export const useCreateGroup = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: { name: string; description?: string; permissions: string[]; parentGroupIds: string[] }) => {
+      const client = getAuthenticatedApiClient();
+      // The generated client typically takes a request DTO instance; adapt construction to the generated type.
+      await client.authorization_CreateGroup(body as any);
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.groups }),
+  });
+};
+
+export const useUpdateGroup = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: { name: string; description?: string; permissions: string[]; parentGroupIds: string[] } }) => {
+      await getAuthenticatedApiClient().authorization_UpdateGroup(id, body as any);
+    },
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: keys.groups });
+      qc.invalidateQueries({ queryKey: keys.group(vars.id) });
+    },
+  });
+};
+
+export const useDeleteGroup = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => { await getAuthenticatedApiClient().authorization_DeleteGroup(id); },
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.groups }),
+  });
+};
+
+export const useAssignUserGroups = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ userId, groupIds }: { userId: string; groupIds: string[] }) => {
+      await getAuthenticatedApiClient().authorization_AssignGroups(userId, { groupIds } as any);
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.users }),
+  });
+};
+
+export const useSetUserActive = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ userId, isActive }: { userId: string; isActive: boolean }) => {
+      await getAuthenticatedApiClient().authorization_SetActive(userId, { isActive } as any);
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: keys.users }),
+  });
+};
+```
+
+> The `as any` casts bridge to whatever request DTO classes the generator emits (e.g.
+> `new CreateGroupRequest({...})`). When wiring, replace `as any` with the generated DTO
+> constructors imported from `../generated/api-client` for type safety.
+
+- [ ] **Step 2: Lint**
+
+Run (from `frontend/`): `npm run lint`
+Expected: passes (resolve unused/any warnings per the repo's eslint config; if `any` is disallowed, switch to the generated DTO constructors now).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/hooks/useAccessManagement.ts
+git commit -m "feat(authz): admin access-management API hooks"
+```
+
+---
+
+### Task 29: Access-management admin page + route + nav
+
+**Files:**
+- Create: `frontend/src/pages/AccessManagementPage.tsx`
+- Modify: the router (where `ACCESS_ROUTES`/admin routes are registered) to add `/admin/access`
+- Modify: the sidebar/nav config to add an "Access management" entry under Administration
+- Test: `frontend/src/pages/__tests__/AccessManagementPage.test.tsx`
+
+> The `administration` feature already exists in `AccessMatrix` (no nav path today). Gate the
+> route with `<RequireAccess requiredRole="administration.read">`.
+
+- [ ] **Step 1: Create the page (Groups + Users tabs)**
+
+```tsx
+import React, { useState } from "react";
+import {
+  useGroups, useUsers, useCatalogue, useDeleteGroup, useSetUserActive,
+} from "../api/hooks/useAccessManagement";
+
+const AccessManagementPage: React.FC = () => {
+  const [tab, setTab] = useState<"groups" | "users">("groups");
+  const groups = useGroups();
+  const users = useUsers();
+  const catalogue = useCatalogue();
+  const deleteGroup = useDeleteGroup();
+  const setActive = useSetUserActive();
+
+  return (
+    <div className="p-8 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-semibold text-gray-900 mb-4">Access management</h1>
+
+      <div className="flex gap-2 mb-6">
+        <button
+          onClick={() => setTab("groups")}
+          className={`px-4 py-2 rounded ${tab === "groups" ? "bg-indigo-600 text-white" : "bg-gray-100"}`}
+        >Groups</button>
+        <button
+          onClick={() => setTab("users")}
+          className={`px-4 py-2 rounded ${tab === "users" ? "bg-indigo-600 text-white" : "bg-gray-100"}`}
+        >Users</button>
+      </div>
+
+      {tab === "groups" && (
+        <div className="space-y-3">
+          {groups.isLoading && <div className="text-gray-500">Loading groups…</div>}
+          {groups.data?.map((g) => (
+            <div key={g.id} className="flex items-center justify-between bg-white border border-gray-200 rounded-lg p-4">
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-gray-900">{g.name}</span>
+                  {g.isSystem && <span className="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded">system</span>}
+                </div>
+                <p className="text-sm text-gray-500">{g.permissionCount} permissions · {g.memberCount} members</p>
+              </div>
+              {!g.isSystem && (
+                <button
+                  onClick={() => g.id && deleteGroup.mutate(g.id)}
+                  disabled={deleteGroup.isPending}
+                  className="text-sm text-red-600 hover:underline"
+                  aria-label={`Delete ${g.name}`}
+                >Delete</button>
+              )}
+            </div>
+          ))}
+          <p className="text-xs text-gray-400">
+            {catalogue.data?.permissions?.length ?? 0} permissions available. Create/edit forms use the catalogue.
+          </p>
+        </div>
+      )}
+
+      {tab === "users" && (
+        <div className="space-y-3">
+          {users.isLoading && <div className="text-gray-500">Loading users…</div>}
+          {users.data?.map((u) => (
+            <div key={u.id} className="flex items-center justify-between bg-white border border-gray-200 rounded-lg p-4">
+              <div>
+                <div className="font-medium text-gray-900">{u.displayName}</div>
+                <p className="text-sm text-gray-500">{u.email} · {u.groupIds?.length ?? 0} groups</p>
+              </div>
+              <button
+                onClick={() => u.id && setActive.mutate({ userId: u.id, isActive: !u.isActive })}
+                disabled={setActive.isPending}
+                className={`text-sm ${u.isActive ? "text-red-600" : "text-green-600"} hover:underline`}
+                aria-label={`Toggle active ${u.email}`}
+              >{u.isActive ? "Disable" : "Enable"}</button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AccessManagementPage;
+```
+
+> This page ships the list/delete/enable-disable surface. The create/edit group dialog
+> (permission checkbox matrix + parent multi-select using `useCatalogue`, `useCreateGroup`,
+> `useUpdateGroup`) and the per-user group-assignment dialog (`useAssignUserGroups`) are
+> wired the same way; add them as a follow-up step within this task if time allows, or as a
+> fast-follow. The backend already supports all of it.
+
+- [ ] **Step 2: Register the route**
+
+Where routes are declared (search for an existing admin route such as `/admin/feature-flags`), add:
+
+```tsx
+<Route
+  path="/admin/access"
+  element={
+    <RequireAccess requiredRole="administration.read">
+      <AccessManagementPage />
+    </RequireAccess>
+  }
+/>
+```
+
+Add the import: `import AccessManagementPage from "../pages/AccessManagementPage";` (adjust relative path to the router file).
+
+- [ ] **Step 3: Add the nav entry**
+
+In the sidebar/nav config, add an "Access management" item under the Administration section pointing to `/admin/access` (mirror how `/admin/feature-flags` is registered).
+
+- [ ] **Step 4: Write a smoke test**
+
+```tsx
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AccessManagementPage from "../AccessManagementPage";
+
+jest.mock("../../api/hooks/useAccessManagement", () => ({
+  useGroups: () => ({ data: [{ id: "1", name: "Spravce", isSystem: true, permissionCount: 52, memberCount: 1 }], isLoading: false }),
+  useUsers: () => ({ data: [], isLoading: false }),
+  useCatalogue: () => ({ data: { permissions: ["catalog.read"] } }),
+  useDeleteGroup: () => ({ mutate: jest.fn(), isPending: false }),
+  useSetUserActive: () => ({ mutate: jest.fn(), isPending: false }),
+}));
+
+describe("AccessManagementPage", () => {
+  it("renders groups tab with a system group badge", () => {
+    render(<AccessManagementPage />);
+    expect(screen.getByText("Spravce")).toBeInTheDocument();
+    expect(screen.getByText("system")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5: Run test + build + lint**
+
+Run (from `frontend/`): `npm test -- --watchAll=false AccessManagementPage && npm run build && npm run lint`
+Expected: PASS / succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/AccessManagementPage.tsx \
+        frontend/src/pages/__tests__/AccessManagementPage.test.tsx
+# plus the router + nav files you modified:
+git add -A
+git commit -m "feat(authz): access-management admin page, route, and nav entry"
+```
+
+---
+## Phase 8 — Integration, architecture, cutover, validation
+
+### Task 30: End-to-end integration test (claims transformation + seeder + admin authz)
+
+Exercises the full wiring under the real pipeline (Test env → mock auth → super_user wildcard).
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Authorization/AuthorizationIntegrationTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetGroups;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetMe;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Tests.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class AuthorizationIntegrationTests : IClassFixture<HebloWebApplicationFactory>
+{
+    private readonly HebloWebApplicationFactory _factory;
+    public AuthorizationIntegrationTests(HebloWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Me_UnderMockAuth_IsSuperUser_WithAllPermissions()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/auth/me");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var me = await response.Content.ReadFromJsonAsync<GetMeResponse>();
+        me!.IsSuperUser.Should().BeTrue();
+        me.Permissions.Should().Contain("catalog.read");
+        me.Permissions.Should().Contain(AccessRoles.Base);
+    }
+
+    [Fact]
+    public async Task SuperUser_CanCall_RoleGatedEndpoint()
+    {
+        var client = _factory.CreateClient();
+        // catalog list requires AccessRoles.CatalogRead — super_user must pass via the wildcard.
+        var response = await client.GetAsync("/api/catalog");
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task AdminGroups_ReturnsSeededSystemGroups()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/admin/authorization/groups");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<GetGroupsResponse>();
+        body!.Groups.Select(g => g.Name).Should().Contain("Spravce");
+        body.Groups.Should().OnlyContain(g => g.IsSystem);
+    }
+}
+```
+
+> The exact catalog route in `SuperUser_CanCall_RoleGatedEndpoint` may differ; if `/api/catalog`
+> needs required query params, pick any GET action decorated with `[Authorize(Roles = AccessRoles.CatalogRead)]`
+> and assert it is not 401/403. The point is that the wildcard grants the role.
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `dotnet test --filter "FullyQualifiedName~AuthorizationIntegrationTests"`
+Expected: PASS (3 tests). If the seeder didn't run for the InMemory provider, confirm Task 14's startup block calls `AuthorizationSeeder.SeedAsync` unconditionally (it must run even when `IsRelational()` is false — only the `MigrateAsync` call is guarded).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/AuthorizationIntegrationTests.cs
+git commit -m "test(authz): end-to-end claims transformation, seeder, and admin authz"
+```
+
+---
+
+### Task 31: Module-wiring architecture test
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Authorization/AuthorizationModuleTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class AuthorizationModuleTests
+{
+    [Fact]
+    public void AddAuthorizationModule_RegistersResolverAndRepository()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(o => o.UseInMemoryDatabase("authz_module"));
+        services.AddAuthorizationModule();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        scope.ServiceProvider.GetService<IPermissionResolver>().Should().NotBeNull();
+        scope.ServiceProvider.GetService<IAuthorizationRepository>().Should().NotBeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `dotnet test --filter "FullyQualifiedName~AuthorizationModuleTests"`
+Expected: PASS.
+
+- [ ] **Step 3: Confirm ADR-004 guard still passes (no repo binding leaked into PersistenceModule)**
+
+Run: `dotnet test --filter "FullyQualifiedName~PersistenceModuleTests"`
+Expected: PASS — the `AuthorizationRepository` binding lives in `AuthorizationModule`, not `PersistenceModule`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/AuthorizationModuleTests.cs
+git commit -m "test(authz): module wiring asserts resolver/repository registration"
+```
+
+---
+
+### Task 32: Cutover runbook + Entra `super_user` app role
+
+Document the operational cutover (no shadow mode — decision #7) and the one Entra change.
+
+**Files:**
+- Create: `docs/features/rbac-inapp-permissions-cutover.md`
+
+- [ ] **Step 1: Write the runbook**
+
+```markdown
+# In-app permissions — cutover runbook
+
+## One-time Entra change
+Add a `super_user` **app role** (value `super_user`) to the API app registration and assign
+it to the operator account(s). This is the break-glass/admin bootstrap. Per-feature app roles
+remain in the manifest but become unused (optional cleanup later).
+
+## Deploy
+1. Apply the DB migration `AddAuthorizationTables` (migrations are manual — see CLAUDE.md).
+   Startup also runs `AuthorizationSeeder` to create/sync the 10 system groups.
+2. Deploy the build. Enforcement now flows through the claims transformation.
+
+## Immediately after deploy (the access-gap mitigation)
+Non-super users have **no access until assigned** (decision #4). To minimize the window:
+1. Pre-write the assignment list: each staff email → the in-app group matching their old
+   Entra role (names align 1:1: Marketer, Skladnik, Ucetni, …).
+2. A `super_user` logs in → `/admin/access` → Users tab → assign each user their group(s).
+   Users appear in the list after their first login (AppUser is materialized on login); for
+   users who haven't logged in yet, assignment can be done as soon as they do.
+3. Verify with the per-user "effective permissions" view.
+
+## Rollback
+Remove the deploy; the additive tables are harmless if unused. (No feature flag by decision #7.)
+
+## Notes
+- Disabling a user (Users tab) takes effect within ~5 min (cache TTL).
+- System groups are read-only and re-synced from `AccessMatrix` on every startup.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/features/rbac-inapp-permissions-cutover.md
+git commit -m "docs(authz): cutover runbook"
+```
+
+---
+
+### Task 33: Full validation sweep
+
+- [ ] **Step 1: Backend build + format**
+
+Run: `dotnet build`
+Expected: Build succeeded, 0 errors.
+
+Run: `dotnet format --verify-no-changes`
+Expected: No formatting changes needed. If it reports diffs, run `dotnet format` and commit:
+
+```bash
+dotnet format
+git add -A && git commit -m "style(authz): dotnet format"
+```
+
+- [ ] **Step 2: Full backend test run for the slice**
+
+Run: `dotnet test --filter "FullyQualifiedName~Authorization"`
+Expected: All Authorization tests PASS.
+
+- [ ] **Step 3: Full backend test suite (regression — existing auth/mock tests)**
+
+Run: `dotnet test`
+Expected: PASS. Pay attention to any pre-existing test that asserted the mock principal's
+explicit role set (Task 15) — it must now assert `super_user`.
+
+- [ ] **Step 4: Frontend build + lint + test**
+
+Run (from `frontend/`): `npm run build && npm run lint && npm test -- --watchAll=false`
+Expected: All succeed.
+
+- [ ] **Step 5: Final commit (if anything pending) and push**
+
+```bash
+git push -u origin claude/rbac-inapp-permissions-spike-wHmHw
+```
+
+---
+
+## Appendix: Spec coverage map
+
+| Spec section | Implemented by |
+| --- | --- |
+| §2 Architecture/enforcement (claims transformation, super_user) | Tasks 1, 12, 14, 15 |
+| §3 Data model (5 tables, code-defined perms) | Tasks 2, 5, 6, 7 |
+| §3 System groups read-only + re-synced | Task 9 (+ Task 21 immutability) |
+| §4 Resolution (closure, cache, materialize) | Tasks 10, 11 |
+| §5 Admin surface (groups/users/catalogue) | Tasks 16, 19, 20, 21, 22, 23, 26 |
+| §6 /api/auth/me frontend delivery | Tasks 17, 24, 25, 27 |
+| §7 Seed & direct cutover | Tasks 9, 14, 32 |
+| §8 Testing strategy | Tasks 9–12, 16–23, 30, 31 |
+| §11 Decisions (system read-only, /me groups, cutover) | Tasks 9/21, 17/25, 32 |

--- a/docs/superpowers/specs/2026-06-05-rbac-inapp-permissions-option-a-design.md
+++ b/docs/superpowers/specs/2026-06-05-rbac-inapp-permissions-option-a-design.md
@@ -1,0 +1,292 @@
+# Design Spec: In-app Permission System — Option A (claims transformation)
+
+**Date:** 2026-06-05
+**Branch:** `claude/rbac-inapp-permissions-spike-wHmHw`
+**Status:** Design approved (brainstorming) — pending written-spec review → implementation plan
+**Related:** `docs/features/rbac-inapp-permissions-spike.md` (the originating spike)
+
+---
+
+## 1. Summary
+
+Move **authorization data** (groups, group nesting, user assignments) out of Entra ID and
+into the application database, while keeping **Entra ID for authentication**. Enforcement
+happens via an ASP.NET Core **`IClaimsTransformation`** that injects a user's effective
+permissions as `Role` claims, so **every existing `[Authorize(Roles = "feature.level")]`
+attribute and `ICurrentUserService.IsInRole` keeps working unchanged**.
+
+This is "Option A" from the spike. It is deliberately the lowest-blast-radius path: the
+change is data + one transformation step, not a rewrite of the enforcement surface.
+
+### Decisions locked during brainstorming
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Build approach | **Roll-your-own** `Authorization` vertical slice (no AuthP/Casbin) |
+| 2 | Permission source | **Code-defined** — `AccessMatrix` stays the source of truth; only groups & assignments are data |
+| 3 | Group relationships | **Full group→group nesting** (cycle-guarded DAG) |
+| 4 | New user default | **No access until assigned** (least privilege) |
+| 5 | super_user bootstrap | **Entra app role `super_user`** = wildcard, honored directly from the token |
+| 6 | Permission freshness | **Short-TTL in-memory cache** (~5 min), no active invalidation |
+| 7 | Rollout | **Direct cutover** (single release, no shadow/feature-flag parallel run) |
+
+---
+
+## 2. Architecture & enforcement flow
+
+Authentication is **unchanged**: Microsoft Identity Web (web-app + web-API flows), mock
+auth (`UseMockAuth`), and E2E cookie auth all stay as-is. Entra now issues only identity
+plus (optionally) the `super_user` app role. All per-feature roles leave the token.
+
+One new cross-cutting slice, `Authorization`:
+- `IPermissionResolver` interface in `Domain/Features/Authorization/`.
+- EF entities + resolution implementation in `Anela.Heblo.Persistence`.
+- DI binding in a new `AuthorizationModule.cs` (ADR-004 — binding lives in the owning
+  module, not `PersistenceModule`).
+
+### Request flow
+
+```
+Request
+  → Entra JWT validated (identity + maybe "super_user" app role)
+  → PermissionClaimsTransformation : IClaimsTransformation
+        if token has "super_user":
+            inject ALL AccessMatrix.AllRoleValues() + "heblo_user" as Role claims
+            short-circuit (no DB lookup, no closure)
+        else:
+            resolve AppUser by Entra objectId  → effective permissions (cached)
+            inject each "feature.level" + "heblo_user" as Role claims
+  → [Authorize(Roles = "catalog.read")]  // reads Role claims — UNCHANGED
+  → MediatR handler, ICurrentUserService.IsInRole(...) — UNCHANGED
+```
+
+Because effective permissions become **`Role` claims**, the ~50 existing
+`[Authorize(Roles = …)]` attributes, the default policy (`RequireRole("heblo_user")`),
+and `CurrentUserService` need **no code change**.
+
+### `super_user` (break-glass)
+
+`super_user` is an **Entra app role**, read **directly from the token claims, before and
+independent of any DB lookup**. It grants **all** `AccessMatrix` permissions and
+short-circuits resolution. It works even when the user has **no `AppUser` row, no group
+assignments, or `IsActive=false`** — nothing in the DB can lock out a super_user. The
+`AppUser` row is still upserted for audit/`LastLoginAt`, but super_user permissions never
+depend on it. Any permission later added to `AccessMatrix` is automatically granted to
+super users with zero config.
+
+This is also how the **first admin** reaches the admin UI before any assignments exist:
+Entra (controlled by IT) is the bootstrap and permanent break-glass path.
+
+---
+
+## 3. Data model
+
+Permissions remain **code constants** in `AccessMatrix` (capabilities tied to `[Authorize]`
+attributes — a DB row must never grant something the code doesn't enforce). Only groups,
+nesting, and assignments are data. Five new tables in the existing single
+`ApplicationDbContext` (ADR-001), added by one EF migration.
+
+```
+AppUser
+  Id              (PK, Guid)
+  EntraObjectId   (string, unique)     -- from NameIdentifier; the join key
+  Email, DisplayName
+  IsActive        (bool)               -- soft disable without deleting
+  CreatedAt, LastLoginAt
+  -- materialized on first successful login
+
+PermissionGroup                        -- a "group" / role bundle
+  Id              (PK, Guid)
+  Name            (string, unique)
+  Description
+  IsSystem        (bool)               -- seeded from AccessMatrix.Groups; not deletable
+  CreatedAt, CreatedBy
+
+GroupPermission                        -- group → permission (perm = code constant)
+  GroupId         (FK → PermissionGroup)
+  PermissionValue (string)             -- validated ∈ AccessMatrix.AllRoleValues()
+  PK (GroupId, PermissionValue)
+
+GroupParent                            -- group → group nesting (DAG)
+  GroupId         (FK → PermissionGroup)
+  ParentGroupId   (FK → PermissionGroup)
+  PK (GroupId, ParentGroupId)
+  -- write-time cycle guard rejects edges that would close a loop
+
+UserGroup                              -- user → group
+  UserId          (FK → AppUser)
+  GroupId         (FK → PermissionGroup)
+  PK (UserId, GroupId)
+```
+
+**Notes**
+- Permissions are **not** a table — `GroupPermission.PermissionValue` is validated against
+  `AccessMatrix.AllRoleValues()` on write; a seed-sync prunes rows whose permission was
+  removed from `AccessMatrix` (DB ⊆ code).
+- The 10 existing `AccessMatrix.Groups` seed `PermissionGroup` rows with `IsSystem=true`
+  and their `GroupPermission` edges → day-one behavior equals today's tiers.
+- `super_user` is **not** a DB row — it is the Entra wildcard.
+
+---
+
+## 4. Effective-permission resolution & caching
+
+`IPermissionResolver.GetEffectivePermissions(entraObjectId)`:
+
+1. Load `AppUser` by `EntraObjectId`; materialize on first login. If `IsActive == false`
+   → return empty set (passes Entra login, no app access).
+2. Collect directly-assigned groups (`UserGroup`).
+3. **Transitive closure** over `GroupParent`: BFS over parents with a **visited-set**, so
+   shared/diamond parents are counted once and any cycle terminates with a bounded result.
+4. Union `GroupPermission.PermissionValue` across all reached groups.
+5. Always add `heblo_user` for an active user.
+
+**Caching:** `IMemoryCache`, key `perms:{entraObjectId}`, value = permission set, TTL ~5 min
+(configurable). Populated by the claims transformation on a miss. No active invalidation —
+admin edits land within the TTL window. Disabling a user (`IsActive=false`) takes effect
+within one TTL window; if an instant kill-switch is ever needed, add per-user invalidation
+later (YAGNI for now).
+
+**Scale note:** the group graph is tiny (dozens of nodes); the uncached path is a couple of
+cheap queries. In-memory cache suits the current single-instance deployment; a scale-out
+would move to a distributed cache or accept per-instance TTL.
+
+---
+
+## 5. Admin surface
+
+New admin area under the existing `administration` feature (gated by `administration.read`
+/`administration.write`). Backend = MediatR vertical slices in
+`Application/Features/Authorization`; thin controllers (ADR-003/005).
+
+**Use-cases (MediatR)**
+- *Groups:* `GetGroups`, `GetGroupDetail`, `CreateGroup`, `UpdateGroup`
+  (name/description/permissions/parents), `DeleteGroup`.
+  - Validation: permissions ∈ `AccessMatrix`; parent edges **cycle-checked**; **system
+    groups are not deletable** (permission/description edits allowed — exact lock level to
+    confirm at review).
+- *Users:* `GetUsers`, `GetUserEffectivePermissions` (read-only closure preview),
+  `AssignUserGroups`, `RemoveUserGroups`, `SetUserActive`.
+- *Catalogue:* `GetPermissionCatalogue` — returns `AccessMatrix` features/levels/groups so
+  the UI renders checkboxes from the source of truth (no hardcoded React list).
+
+**API:** `/api/admin/authorization/{groups,users,catalogue}`; writes `administration.write`,
+reads `administration.read`. OpenAPI → TS client auto-generated.
+
+**Frontend:** Administration → Access management screen, reusing the existing design system
+(`docs/design/`), gated by `RequireAccess` on `administration.*`:
+- **Groups** tab — list; create/edit with a permission checkbox matrix grouped by
+  feature/section and a parent-group multi-select; delete (non-system only).
+- **Users** tab — list; toggle active; assign groups; "view effective permissions" drawer.
+
+---
+
+## 6. Frontend permission delivery
+
+Feature roles are no longer in the token, so the SPA fetches its own permissions:
+
+- **`GET /api/auth/me`** → `{ email, displayName, isSuperUser, permissions: ["catalog.read", …] }`,
+  computed server-side via the same `IPermissionResolver` (single source of truth).
+- `useAuth.ts`: replace `idTokenClaims?.roles` with `permissions` from `/api/auth/me`.
+  Downstream (`RequireAccess.tsx`, `accessMatrix.generated.ts` route→permission map) is
+  unchanged — it just consumes a differently-sourced string array.
+- `accessMatrix.generated.ts` stays (route→required-permission map, still generated from
+  `AccessMatrix`); only the source of the *user's own* list changes.
+- Mock auth (`mockAuth.ts`) and E2E: `/api/auth/me` honors the mock/E2E identity and returns
+  the appropriate set (mock = all, matching today).
+- Refresh: refetch on app load / token refresh; admin changes land on next session/refetch
+  (consistent with the backend short-TTL cache). No live push (YAGNI).
+
+---
+
+## 7. Seed & direct cutover
+
+**Seeding (idempotent; startup or migration):**
+1. Upsert the 10 `AccessMatrix.Groups` as `IsSystem=true` `PermissionGroup` rows + their
+   `GroupPermission` edges (`Spravce` = all roles, `Vedeni` = all `.read`, …).
+2. Prune `GroupPermission` rows whose `PermissionValue` left `AccessMatrix`.
+3. No user assignments seeded (decision #4). Until assigned, `super_user` (Entra) is the
+   way in.
+
+**Direct cutover (single release — decision #7):**
+1. Ship migration + `Authorization` slice + claims transformation + `/api/auth/me` + admin
+   UI together.
+2. Switch enforcement to the in-app claims transformation (no feature flag, no parallel run).
+3. Entra: keep the `super_user` app role; per-feature app roles become unused (can be
+   removed from the manifest later — not required for cutover).
+4. **Operational runbook (replaces shadow mode):** immediately post-deploy, a super_user
+   logs in → admin UI → assigns each staff member to the in-app group matching their old
+   Entra role (names already align 1:1: `Marketer`, `Skladnik`, …). System groups mirror
+   the old matrix exactly, so this is mechanical.
+
+**Risk (explicit):** between deploy and finishing assignments, non-super_users have **no
+access**. Mitigations: low-traffic window; pre-written assignment list; super_user always
+available. Rejected fallback (auto-assign from current Entra groups on first login) needs
+Graph group data and contradicts decision #4 — left out unless reconsidered at review.
+
+**Dev/test:** mock auth keeps granting everything; nothing changes locally.
+
+---
+
+## 8. Testing strategy
+
+**Unit — resolution (risk concentrates here):**
+- Closure: union across groups; diamond/shared parent counted once; deep chains; empty groups.
+- Cycle safety: a `GroupParent` cycle still terminates with a bounded set (visited-set).
+- Cycle rejection: an `UpdateGroup`/add-parent that would close a loop is rejected.
+- `super_user`: returns all permissions with **no AppUser row**, **no groups**, and when
+  **`IsActive=false`**.
+- Inactive non-super user → empty; active user always has `heblo_user`.
+- Validation: writing a `PermissionValue` ∉ `AccessMatrix` is rejected; seed-prune removes
+  orphans.
+
+**Integration (use-case / WebApplicationFactory):**
+- First login materializes `AppUser`; repeat login updates `LastLoginAt`, no duplicate.
+- Claims transformation injects correct `Role` claims → a representative
+  `[Authorize(Roles="catalog.read")]` endpoint: 200 with group, 403 without.
+- `/api/auth/me` parity with enforcement (same set the transformation computes).
+- Admin endpoints gated by `administration.write`; non-admin → 403.
+- Cache: change a group → effect within TTL.
+
+**Architecture tests** (extend existing suites):
+- `AuthorizationModule` owns its repo DI binding (ADR-004); `PersistenceModule` registers
+  no new repo.
+
+**Frontend (Jest):** `useAuth` consumes `/api/auth/me`; `RequireAccess` allow/redirect;
+mock path returns all.
+
+**E2E (nightly, staging):** existing role-gated journeys still pass under in-app
+enforcement; one new smoke test for the Access-management screen (create group → assign
+user → verify access), using `navigateToApp()` + fixtures.
+
+---
+
+## 9. Out of scope / deferred (YAGNI)
+
+- Per-object / relationship-based authorization (OpenFGA/Permify/Zanzibar).
+- Active cache invalidation / instant kill-switch (revisit if needed).
+- Multi-instance distributed cache (single instance today).
+- Removing per-feature Entra app roles from the manifest (optional cleanup, post-cutover).
+- Auto-assigning users from Entra groups on first login (rejected; contradicts decision #4).
+
+---
+
+## 10. Impact on existing ADRs
+
+- **ADR-001** (single DbContext): new tables added to `ApplicationDbContext`.
+- **ADR-003** (MediatR + controllers): admin use-cases follow it; thin controllers.
+- **ADR-004** (repo DI in feature module): `AuthorizationModule.cs` owns its binding.
+- **ADR-005** (identity resolution): unchanged; `ICurrentUserService` still resolves the
+  current user inside handlers; permission checks remain claim-based via `IsInRole`.
+
+---
+
+## 11. Open questions for spec review
+
+1. **System-group lock level:** are `IsSystem` groups fully read-only, or
+   editable-but-not-deletable? (Spec currently assumes the latter.)
+2. **`/api/auth/me` shape:** is `isSuperUser` + flat `permissions[]` enough, or do you also
+   want the user's assigned group names for display?
+3. **Cutover window:** comfortable with the brief "no access until assigned" gap, or do you
+   want the rejected Entra-group auto-map fallback reconsidered?
+</content>

--- a/docs/superpowers/specs/2026-06-05-rbac-inapp-permissions-option-a-design.md
+++ b/docs/superpowers/specs/2026-06-05-rbac-inapp-permissions-option-a-design.md
@@ -125,6 +125,10 @@ UserGroup                              -- user → group
   removed from `AccessMatrix` (DB ⊆ code).
 - The 10 existing `AccessMatrix.Groups` seed `PermissionGroup` rows with `IsSystem=true`
   and their `GroupPermission` edges → day-one behavior equals today's tiers.
+- **System groups (`IsSystem=true`) are read-only and re-synced from `AccessMatrix` on
+  every startup** (name + permissions). They are the canonical tiers; code stays their
+  source of truth. Admins compose custom access via **non-system groups, which may nest a
+  system group as a parent** — building on top of the canonical tiers without mutating them.
 - `super_user` is **not** a DB row — it is the Entra wildcard.
 
 ---
@@ -163,8 +167,9 @@ New admin area under the existing `administration` feature (gated by `administra
 - *Groups:* `GetGroups`, `GetGroupDetail`, `CreateGroup`, `UpdateGroup`
   (name/description/permissions/parents), `DeleteGroup`.
   - Validation: permissions ∈ `AccessMatrix`; parent edges **cycle-checked**; **system
-    groups are not deletable** (permission/description edits allowed — exact lock level to
-    confirm at review).
+    groups (`IsSystem=true`) are fully read-only** — not editable, not deletable; they are
+    re-synced from `AccessMatrix` on startup. Non-system groups support full CRUD and may
+    nest a system group as a parent.
 - *Users:* `GetUsers`, `GetUserEffectivePermissions` (read-only closure preview),
   `AssignUserGroups`, `RemoveUserGroups`, `SetUserActive`.
 - *Catalogue:* `GetPermissionCatalogue` — returns `AccessMatrix` features/levels/groups so
@@ -185,8 +190,10 @@ reads `administration.read`. OpenAPI → TS client auto-generated.
 
 Feature roles are no longer in the token, so the SPA fetches its own permissions:
 
-- **`GET /api/auth/me`** → `{ email, displayName, isSuperUser, permissions: ["catalog.read", …] }`,
-  computed server-side via the same `IPermissionResolver` (single source of truth).
+- **`GET /api/auth/me`** →
+  `{ email, displayName, isSuperUser, permissions: ["catalog.read", …], groups: ["Marketer", …] }`,
+  computed server-side via the same `IPermissionResolver` (single source of truth). `groups`
+  is the user's directly-assigned group names, for display ("You're in: Marketer, Skladnik").
 - `useAuth.ts`: replace `idTokenClaims?.roles` with `permissions` from `/api/auth/me`.
   Downstream (`RequireAccess.tsx`, `accessMatrix.generated.ts` route→permission map) is
   unchanged — it just consumes a differently-sourced string array.
@@ -203,7 +210,8 @@ Feature roles are no longer in the token, so the SPA fetches its own permissions
 
 **Seeding (idempotent; startup or migration):**
 1. Upsert the 10 `AccessMatrix.Groups` as `IsSystem=true` `PermissionGroup` rows + their
-   `GroupPermission` edges (`Spravce` = all roles, `Vedeni` = all `.read`, …).
+   `GroupPermission` edges (`Spravce` = all roles, `Vedeni` = all `.read`, …). System groups
+   are **re-synced** here on every startup (name + permissions authoritative from code).
 2. Prune `GroupPermission` rows whose `PermissionValue` left `AccessMatrix`.
 3. No user assignments seeded (decision #4). Until assigned, `super_user` (Entra) is the
    way in.
@@ -281,12 +289,18 @@ user → verify access), using `navigateToApp()` + fixtures.
 
 ---
 
-## 11. Open questions for spec review
+## 11. Resolved review decisions
 
-1. **System-group lock level:** are `IsSystem` groups fully read-only, or
-   editable-but-not-deletable? (Spec currently assumes the latter.)
-2. **`/api/auth/me` shape:** is `isSuperUser` + flat `permissions[]` enough, or do you also
-   want the user's assigned group names for display?
-3. **Cutover window:** comfortable with the brief "no access until assigned" gap, or do you
-   want the rejected Entra-group auto-map fallback reconsidered?
+These three points were left open during brainstorming and resolved before planning:
+
+1. **System-group lock level → fully read-only.** `IsSystem` groups are not editable and not
+   deletable; they are re-synced from `AccessMatrix` on every startup (avoids the
+   seed-overwrites-admin-edit conflict). Admins build custom access via non-system groups,
+   which may nest a system group as a parent. (See §3, §5, §7.)
+2. **`/api/auth/me` shape → include group names.** Returns `isSuperUser`, flat
+   `permissions[]`, and the user's directly-assigned `groups[]` for display. (See §6.)
+3. **Cutover → unchanged.** Keep direct cutover (#7) and no-access-until-assigned (#4); the
+   Graph-based Entra-group auto-map stays rejected (contradicts #4, adds complexity). The
+   runbook (low-traffic window, pre-written assignment list, super_user break-glass) is the
+   mitigation for the brief access gap. (See §7.)
 </content>


### PR DESCRIPTION
Investigate moving authorization from EntraID app-role driven RBAC to an
in-app permission system (permissions, groups, user-to-group, group-to-group).
Covers current-state analysis, enforcement options (claims transformation vs
policy provider), NuGet/OSS evaluation (AuthPermissions.AspNetCore, Casbin.NET,
OpenFGA, Permify, roll-your-own), proposed data model, phased migration plan,
ADR impact, risks, and a recommendation.