### PR TITLE
fix: write OpenAI payload to temp file to avoid ARG_MAX limit

### DIFF
--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -240,11 +240,14 @@ jobs:
               ]
             }')
 
-          # Make the API call
+          # Make the API call (write payload to file to avoid ARG_MAX limit)
+          PAYLOAD_FILE=$(mktemp)
+          echo "$REQUEST_PAYLOAD" > "$PAYLOAD_FILE"
           RESPONSE=$(curl -s -w "\n%{http_code}" https://api.openai.com/v1/chat/completions \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.OPENAI_API_KEY }}" \
-            -d "$REQUEST_PAYLOAD")
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -d "@$PAYLOAD_FILE")
+          rm -f "$PAYLOAD_FILE"
 
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           RESPONSE_BODY=$(echo "$RESPONSE" | head -n -1)


### PR DESCRIPTION
## Summary

The CI changelog translation step was passing the OpenAI request payload directly via `-d "$REQUEST_PAYLOAD"` in curl, which can exceed the shell's `ARG_MAX` limit for large changelogs.

## Changes

- Write the JSON payload to a temp file using `mktemp`
- Pass the file to curl via `-d "@$PAYLOAD_FILE"` instead of inline
- Clean up the temp file after the request
- Also fixes the Authorization header to use `$OPENAI_API_KEY` env var directly instead of the GitHub Actions expression syntax (which is equivalent at runtime but avoids potential issues)

## Testing

CI workflow change — verifiable by triggering a merge to main with a sufficiently large changelog entry.