### PR TITLE
chore: add conductor setup script for worktree env sync and deps

### DIFF
--- a/scripts/setup_conductor.sh
+++ b/scripts/setup_conductor.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+MAIN=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+
+if [ -n "$MAIN" ] && [ "$MAIN" != "$(pwd)" ]; then
+  find "$MAIN" -maxdepth 1 -name '.env*' -exec cp -n {} . \; 2>/dev/null || true
+  find "$MAIN/frontend" -maxdepth 1 -name '.env*' -exec cp -n {} ./frontend/ \; 2>/dev/null || true
+fi
+
+dotnet restore
+npm --prefix frontend install --legacy-peer-deps


### PR DESCRIPTION
## Summary

- Adds `scripts/setup_conductor.sh` to automate environment setup when working in git worktrees
- Copies `.env*` files from the main worktree into the current worktree (root and `frontend/`) without overwriting existing files
- Runs `dotnet restore` and `npm install --legacy-peer-deps` to ensure dependencies are ready

## Usage

Run after creating a new worktree to sync env files and install dependencies in one step.