### PR TITLE
feat: Migrate `ManufactureGroupId` to Typed Options Pattern

### DIFF
--- a/artifacts/feat-arch-review-manufacture-getmanufacturese/arch-review.r1.md
+++ b/artifacts/feat-arch-review-manufacture-getmanufacturese/arch-review.r1.md
@@ -1,0 +1,135 @@
+# Architecture Review: Migrate `ManufactureGroupId` to Typed Options Pattern
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a tightly scoped consistency refactor inside the existing Vertical Slice for the Manufacture module. It does **not** introduce new architectural surface — it removes an inconsistency. The proposal aligns with three established conventions in this codebase:
+
+1. **Options pattern is already the standard.** `SubmitManufactureHandler` (`backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufacture/SubmitManufactureHandler.cs:27`) already injects `IOptions<ManufactureErpOptions>` and resolves `.Value` at construction. `ManufactureAnalysisMapper` does the same with `ManufactureAnalysisOptions`. `GetManufactureSettingsHandler` is the lone outlier.
+2. **`ManufactureModule.AddManufactureModule` already binds the `ManufactureErp` section** to `ManufactureErpOptions` — no DI changes needed.
+3. **The endpoint contract is already documented** in `docs/architecture/development_guidelines.md:15` as the canonical "module-specific bootstrap value via the module's anonymous endpoint" pattern. The HTTP contract is unaffected; only the internal binding mechanism changes.
+
+Integration points: one handler, one options class, one config-keys file (to be deleted), two appsettings files, two test classes, and one Azure App Service environment-variable rename. No domain, persistence, or contract impact.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+appsettings.json ──┐
+                   ├── "ManufactureErp" section ──► IOptions<ManufactureErpOptions>
+env: ManufactureErp__ManufactureGroupId ──┘                       │
+                                                                  ▼
+                                                  GetManufactureSettingsHandler
+                                                                  │
+                                                                  ▼
+   ManufactureSettingsController ── MediatR ◄── GetManufactureSettingsResponse
+   (GET /api/manufacture/settings, [AllowAnonymous])
+```
+
+`ManufactureErpOptions` becomes the single typed surface for both ERP timeouts and the Entra-group bootstrap value. `ManufactureConfigurationKeys` is removed; the type system replaces the string constant.
+
+### Key Design Decisions
+
+#### Decision 1: Extend `ManufactureErpOptions` vs. introduce a new options class
+**Options considered:**
+- **A.** Add `ManufactureGroupId` to the existing `ManufactureErpOptions` (binds to `"ManufactureErp"` section).
+- **B.** Introduce a dedicated `ManufactureSettingsOptions` (or similar) bound to a new section.
+
+**Chosen approach:** Option A.
+
+**Rationale:** Option A is what the brief explicitly proposed and what the spec ratified. It avoids touching `ManufactureModule.AddManufactureModule` (the existing `services.Configure<ManufactureErpOptions>` call already binds the new property). A new section would require a third options class for one nullable string, and would force any future setting onto the same fragmentation problem. The naming awkwardness ("ERP options now holds a non-ERP value") is real but small; renaming the class is explicitly out of scope.
+
+#### Decision 2: Resolve `options.Value` once at construction vs. per-call
+**Options considered:**
+- **A.** Store `options.Value` in a private field at construction (matches `SubmitManufactureHandler` precedent).
+- **B.** Hold `IOptions<ManufactureErpOptions>` and read `.Value` inside `Handle`.
+
+**Chosen approach:** Option A.
+
+**Rationale:** The setting is bound from environment variables at process startup and never reloaded; `IOptionsMonitor` is not in use anywhere in the Manufacture module. Per-call `.Value` resolution buys nothing and diverges from the in-module precedent. Store once, read in `Handle`.
+
+#### Decision 3: Delete `ManufactureConfigurationKeys.cs` immediately vs. leave deprecated
+**Chosen approach:** Delete immediately as part of the same PR (FR-3).
+
+**Rationale:** Single-member file with one caller; deletion in the same change keeps the diff atomic and prevents the constant being resurrected. No external consumers (verified via repo grep — only the handler and one test reference it). No deprecation period needed for an internal compile-time symbol.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new folders. File changes:
+
+| Action | Path |
+|---|---|
+| **Edit** | `backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs` — add `ManufactureGroupId` |
+| **Edit** | `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs` — swap `IConfiguration` → `IOptions<ManufactureErpOptions>` |
+| **Delete** | `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs` |
+| **Edit** | `backend/src/Anela.Heblo.API/appsettings.json` — remove top-level `ManufactureGroupId`, add `ManufactureErp:ManufactureGroupId` placeholder |
+| **Edit** | `backend/src/Anela.Heblo.API/appsettings.Production.json` — remove top-level `ManufactureGroupId` placeholder |
+| **Edit** | `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs` — use `Options.Create(new ManufactureErpOptions { ... })` |
+| **Verify (no edit needed)** | `GetManufactureSettingsEndpointTests` — does NOT seed config; no change required (see Spec Amendment 1) |
+| **Verify (no edit needed)** | `ManufactureModule.cs` — already binds `"ManufactureErp"` section; the new property binds automatically |
+
+### Interfaces and Contracts
+
+`ManufactureErpOptions` after the change:
+
+```csharp
+public class ManufactureErpOptions
+{
+    public int ErpTimeoutSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Entra ID group identifier consumed by GetManufactureSettings to gate
+    /// "responsible person" workflows on the frontend.
+    /// </summary>
+    public string? ManufactureGroupId { get; set; }
+}
+```
+
+Handler constructor signature after the change:
+
+```csharp
+public GetManufactureSettingsHandler(
+    IOptions<ManufactureErpOptions> options,
+    ILogger<GetManufactureSettingsHandler> logger)
+```
+
+Public HTTP contract (`GetManufactureSettingsResponse.ManufactureGroupId : string?`) and MediatR request shape are **unchanged**.
+
+### Data Flow
+
+1. **Startup:** `Program` loads `appsettings.json` → environment overlay → environment variables. `ManufactureErp__ManufactureGroupId` (env) wins over the placeholder in `appsettings.json`. `ManufactureModule.AddManufactureModule` binds the `"ManufactureErp"` section into `IOptions<ManufactureErpOptions>`.
+2. **Request:** `GET /api/manufacture/settings` (anonymous) → `ManufactureSettingsController.GetSettings` → `IMediator.Send(new GetManufactureSettingsRequest())` → `GetManufactureSettingsHandler.Handle`.
+3. **Handle:** Reads cached `_options.ManufactureGroupId`; collapses null/empty/whitespace to `null`; logs `hasValue`; returns response.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Production env-var rename not coordinated with deploy → endpoint returns `null` post-deploy, frontend silently degrades because the handler swallows missing config | **HIGH** | NFR-3 covers this. Enforce: PR description MUST list `ManufactureErp__ManufactureGroupId` (double underscore) as the new var and call out that legacy `ManufactureGroupId` env var must be set in Azure App Service **before** the new image is promoted. Hold the merge until the deployer confirms. |
+| Staging environment has its own App Service env var `ManufactureGroupId` that the spec doesn't mention | **MEDIUM** | Spec NFR-3 only names production. Verify with the deployer whether `kv-heblo-stg` / Staging Web App also sets this var; rename in lock-step. See Spec Amendment 2. |
+| `IConfiguration.GetValue<string>("ManufactureErp:ManufactureGroupId")` whitespace handling differs from `IOptions` binding (binder trims nothing; raw `IConfiguration` indexer returns string as-is — both behave the same here) | **LOW** | The handler's `string.IsNullOrEmpty` collapses `null` and `""` identically; the spec already mandates `IsNullOrWhiteSpace` semantics — adopt that and the behavior is at-or-better than today. |
+| Other code paths read the legacy top-level `"ManufactureGroupId"` key | **LOW** | Verified: repo-wide grep shows only the handler and tests reference the key/constant. No frontend, no other backend reader. |
+| Test loses fidelity (FR-5 endpoint test) because `GetManufactureSettingsEndpointTests` doesn't actually seed config today | **LOW** | See Spec Amendment 1 — the FR-5 bullet on endpoint tests is over-specified; nothing in that file needs changing. |
+
+## Specification Amendments
+
+1. **FR-5 second bullet is unnecessary.** `GetManufactureSettingsEndpointTests` does not seed the configuration at all — it only asserts the endpoint is reachable, returns `application/json`, exposes the `ManufactureGroupId` property, and is anonymously accessible. No `IConfigurationBuilder` or in-memory dictionary appears in that test. **Amendment:** Drop the requirement to change endpoint-test config seeding. Leave that file untouched. The behavioral coverage for set/empty/missing remains in the unit tests, which is the correct level.
+
+2. **NFR-3 should also cover Staging.** Production is named explicitly but `appsettings.Staging.json` exists and the project has a `kv-heblo-stg` Key Vault. If Staging also pulls `ManufactureGroupId` from an env var or KV secret, the rename must happen in both environments. **Amendment:** Expand NFR-3 to "Production **and any non-Production environment that overrides this value** (notably Staging)." The PR description must enumerate every affected environment, not just production.
+
+3. **Clarify handler null/empty/whitespace semantics.** The spec's FR-2 acceptance criterion says "`null` when configured value is null, empty, or whitespace". The current handler uses `string.IsNullOrEmpty` (not `IsNullOrWhiteSpace`). **Amendment:** Explicitly call for `string.IsNullOrWhiteSpace` in the new code, and add a unit-test case for `"   "` to lock the behavior in. This is a tiny behavioral tightening and is safer than carrying over `IsNullOrEmpty`.
+
+4. **Recommend relocating `ManufactureConfigurationKeys.cs` deletion to also remove the now-unused `using Anela.Heblo.Application.Features.Manufacture;` import in the handler.** Already covered indirectly by FR-3's third bullet; just ensure the developer doesn't leave an orphan `using`.
+
+## Prerequisites
+
+Before merge:
+
+1. **Azure App Service env-var added** in Production (and Staging if applicable): `ManufactureErp__ManufactureGroupId` set to the current value of `ManufactureGroupId`. **Both** vars should coexist briefly so a rollback to the previous image still works; remove the legacy var only after the new image is healthy.
+2. **Deployer sign-off captured in the PR description** confirming step 1 is done and naming the environments touched.
+3. **`dotnet build` + `dotnet format` + `dotnet test`** green locally before push (per `CLAUDE.md` validation gates).
+4. **No code prerequisites** — `IOptions<>` and `Microsoft.Extensions.Options` are already transitively available throughout `Anela.Heblo.Application`.

--- a/artifacts/feat-arch-review-manufacture-getmanufacturese/brief.md
+++ b/artifacts/feat-arch-review-manufacture-getmanufacturese/brief.md
@@ -1,0 +1,56 @@
+## Module
+Manufacture
+
+## Finding
+`GetManufactureSettingsHandler` injects `IConfiguration` and reads the Entra group ID via a raw string key constant, while every other configuration value in the module is consumed through typed options classes:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs
+// lines 12–13, 25–26
+private readonly IConfiguration _configuration;
+...
+var groupId = _configuration[ManufactureConfigurationKeys.GroupId];  // raw key "ManufactureGroupId"
+```
+
+`ManufactureConfigurationKeys.GroupId` is a bare string constant pointing at a flat top-level key. The module has two typed options classes already registered in `ManufactureModule.AddManufactureModule`:
+- `ManufactureAnalysisOptions` (bound to `"ManufactureAnalysis"` section)
+- `ManufactureErpOptions` (bound to `"ManufactureErp"` section)
+
+Neither of them carries `ManufactureGroupId`.
+
+## Why it matters
+- **Consistency**: the rest of the module uses `IOptions<T>` injection. A reader of the handler is surprised to see raw `IConfiguration` in Application-layer code.
+- **Testability**: unit tests for this handler must construct a full `IConfiguration` mock with a raw string key. With a typed options class they would just `new()` the options object — no config builder needed.
+- **Type safety**: the raw-key approach gives no compile-time guarantee that the key exists in the options model; a rename of the string constant silently breaks the binding.
+
+## Suggested fix
+Add `ManufactureGroupId` to an existing or new typed options class and bind it in `ManufactureModule.cs`:
+
+```csharp
+// Option A: extend ManufactureErpOptions (already covers ERP/settings concerns)
+public class ManufactureErpOptions
+{
+    public int ErpTimeoutSeconds { get; set; } = 60;
+    public string? ManufactureGroupId { get; set; }   // add this
+}
+
+// ManufactureModule.cs — no change needed (already binds "ManufactureErp" section)
+// appsettings: "ManufactureErp": { "ManufactureGroupId": "..." }
+
+// GetManufactureSettingsHandler — replace IConfiguration with IOptions<ManufactureErpOptions>
+public GetManufactureSettingsHandler(IOptions<ManufactureErpOptions> options, ILogger<...> logger)
+{
+    _options = options.Value;
+}
+
+public Task<...> Handle(...) =>
+    Task.FromResult(new GetManufactureSettingsResponse
+    {
+        ManufactureGroupId = string.IsNullOrEmpty(_options.ManufactureGroupId) ? null : _options.ManufactureGroupId
+    });
+```
+
+Delete `ManufactureConfigurationKeys.cs` if `GroupId` is its only member after the migration.
+
+---
+_Filed by daily arch-review routine on 2026-06-06._

--- a/artifacts/feat-arch-review-manufacture-getmanufacturese/impl/main.r1.md
+++ b/artifacts/feat-arch-review-manufacture-getmanufacturese/impl/main.r1.md
@@ -1,0 +1,78 @@
+All 5 commits are on the branch. Here is the final output summary:
+
+---
+
+# Implementation: Migrate `ManufactureGroupId` to Typed Options Pattern
+
+## What was implemented
+
+Replaced `IConfiguration`-based access to `ManufactureGroupId` in `GetManufactureSettingsHandler` with strongly-typed `IOptions<ManufactureErpOptions>`. Added the property to `ManufactureErpOptions`, rewrote handler tests with `Options.Create(...)` (including a new whitespace test case), refactored the handler to use `IsNullOrWhiteSpace`, deleted the now-unused `ManufactureConfigurationKeys` constants file, and moved the `appsettings.json` placeholder from root level into the nested `ManufactureErp` section.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs` — added `public string? ManufactureGroupId { get; set; }` with XML doc
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs` — replaced `IConfiguration` with `IOptions<ManufactureErpOptions>`, `IsNullOrWhiteSpace`, stored `options.Value` at construction
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs` — **deleted**
+- `backend/src/Anela.Heblo.API/appsettings.json` — removed top-level `ManufactureGroupId`, added `ManufactureGroupId` inside `ManufactureErp` section
+- `backend/src/Anela.Heblo.API/appsettings.Production.json` — removed top-level `ManufactureGroupId` documentation placeholder
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs` — rewrote with `Options.Create(...)`, added whitespace test, added two constructor-null tests
+
+## Tests
+
+`GetManufactureSettingsHandlerTests.cs` — 6 tests all passing:
+1. `Handle_WhenManufactureGroupIdConfigured_ReturnsValueInResponse`
+2. `Handle_WhenManufactureGroupIdMissing_ReturnsNull`
+3. `Handle_WhenManufactureGroupIdEmpty_ReturnsNull`
+4. `Handle_WhenManufactureGroupIdWhitespace_ReturnsNull` *(new — per Spec Amendment 3)*
+5. `Constructor_WhenOptionsNull_ThrowsArgumentNullException`
+6. `Constructor_WhenLoggerNull_ThrowsArgumentNullException`
+
+`GetManufactureSettingsEndpointTests.cs` — 3 tests pass, file **untouched** (per Spec Amendment 1).
+
+Full solution: `dotnet build` clean, `dotnet format --verify-no-changes` clean, 4595 tests pass (38 Docker-dependent integration failures are pre-existing and unrelated).
+
+## How to verify
+
+```bash
+cd backend
+dotnet build Anela.Heblo.sln
+dotnet format Anela.Heblo.sln --verify-no-changes
+dotnet test Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetManufactureSettings"
+grep -rn "ManufactureConfigurationKeys" .   # expect: no matches
+grep -rn '"ManufactureGroupId"' src/        # expect: exactly 1 match (inside ManufactureErp section)
+```
+
+## Notes
+
+**⚠️ Required deployment coordination before merge (NFR-3 + Spec Amendment 2):**
+
+The Azure App Service environment variable key has changed:
+
+| | Before | After |
+|---|---|---|
+| Env var | `ManufactureGroupId` | `ManufactureErp__ManufactureGroupId` |
+| Config path | `ManufactureGroupId` (root) | `ManufactureErp:ManufactureGroupId` (nested) |
+
+Required actions in Azure Portal **before** the new image is promoted:
+1. **Production Web App:** Add `ManufactureErp__ManufactureGroupId` with the current value of `ManufactureGroupId`. Keep both vars set until the new image is healthy (rollback safety), then remove the legacy var.
+2. **Staging Web App (if applicable):** Check whether it also sets the legacy `ManufactureGroupId` env var; if yes, apply the same rename.
+3. **Any other environment** that overrides this value: same treatment.
+
+Without step 1, the endpoint silently returns `null` post-deploy and frontend "responsible person" gating degrades.
+
+## PR Summary
+
+Migrates `ManufactureGroupId` consumption in `GetManufactureSettingsHandler` from raw `IConfiguration` to the typed `IOptions<ManufactureErpOptions>` pattern. Adds the property to `ManufactureErpOptions`, deletes the now-unused `ManufactureConfigurationKeys`, moves the `appsettings.json` placeholder into the nested `ManufactureErp` section, and updates unit tests with full whitespace-handling coverage. Behavioral change: null/empty/whitespace now all collapse to `null` (previously only null/empty). HTTP contract is unchanged.
+
+**⚠️ Required deployment coordination — DO NOT MERGE before this is done:** The production binding key changes from `ManufactureGroupId` (top-level) to `ManufactureErp__ManufactureGroupId` (nested, double-underscore). Before the new image is promoted, add `ManufactureErp__ManufactureGroupId` in the Production (and Staging, if applicable) Azure Web App settings with the current value, and keep the old var until the new image is healthy. Without this, the endpoint silently returns `null` and frontend gating degrades.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs` — added `ManufactureGroupId` nullable string property
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs` — replaced `IConfiguration` with `IOptions<ManufactureErpOptions>`, `IsNullOrWhiteSpace`
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs` — deleted (unused)
+- `backend/src/Anela.Heblo.API/appsettings.json` — moved `ManufactureGroupId` from root into `ManufactureErp` section
+- `backend/src/Anela.Heblo.API/appsettings.Production.json` — removed stale top-level placeholder
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs` — rewrote with typed options, added whitespace + constructor-null tests
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-manufacture-getmanufacturese/spec.r1.md
+++ b/artifacts/feat-arch-review-manufacture-getmanufacturese/spec.r1.md
@@ -1,0 +1,117 @@
+# Specification: Migrate `ManufactureGroupId` to Typed Options Pattern
+
+## Summary
+Replace `IConfiguration`-based access to the `ManufactureGroupId` setting in `GetManufactureSettingsHandler` with a strongly-typed `IOptions<ManufactureErpOptions>` injection. This eliminates the last raw-key configuration access in the Manufacture module, aligning the handler with the surrounding code style and improving testability and type safety.
+
+## Background
+`GetManufactureSettingsHandler` currently injects `IConfiguration` and reads the Entra ID group identifier through a raw string constant `ManufactureConfigurationKeys.GroupId = "ManufactureGroupId"`. Every other configuration value in the Manufacture module is consumed through typed options classes (`ManufactureAnalysisOptions`, `ManufactureErpOptions`) registered in `ManufactureModule.AddManufactureModule`. The inconsistency causes three concrete problems:
+
+- **Consistency** — an Application-layer handler reading raw `IConfiguration` is surprising next to handlers that take `IOptions<T>`.
+- **Testability** — unit tests must build a full `IConfiguration` mock with the literal string key instead of `new ManufactureErpOptions { ... }`.
+- **Type safety** — renaming the string constant silently breaks the binding; nothing in the type system catches it.
+
+The current setting lives as a flat top-level key in `appsettings.json` (line 7) and is overridden in production through an App Service environment variable (`appsettings.Production.json` line 37 notes "Injected via app service env variables"). Migrating into the `ManufactureErp` section changes the configuration key shape and therefore the production environment-variable name, which must be coordinated with the deployment.
+
+## Functional Requirements
+
+### FR-1: Add `ManufactureGroupId` to `ManufactureErpOptions`
+Extend the existing `ManufactureErpOptions` class with a nullable string property representing the Entra ID group identifier.
+
+**Acceptance criteria:**
+- `ManufactureErpOptions` declares `public string? ManufactureGroupId { get; set; }` (default `null`).
+- Existing `ErpTimeoutSeconds` property and its default are preserved unchanged.
+- XML doc comment describes the property as the Entra ID group identifier used by `GetManufactureSettings`.
+- No new options class is introduced; the existing registration in `ManufactureModule` (binding the `"ManufactureErp"` section) is reused without modification.
+
+### FR-2: Refactor `GetManufactureSettingsHandler` to use `IOptions<ManufactureErpOptions>`
+Replace the `IConfiguration` dependency with `IOptions<ManufactureErpOptions>`.
+
+**Acceptance criteria:**
+- Constructor accepts `IOptions<ManufactureErpOptions> options` and `ILogger<GetManufactureSettingsHandler> logger`.
+- Constructor stores `options.Value` (or the property is read each call) and throws `ArgumentNullException` for null arguments, matching the current guard-clause style.
+- `Handle` returns a `GetManufactureSettingsResponse` with `ManufactureGroupId = null` when the configured value is null, empty, or whitespace; otherwise the configured string.
+- The existing debug log line `"GetManufactureSettings resolved ManufactureGroupId hasValue={HasValue}"` is preserved.
+- The `using Microsoft.Extensions.Configuration;` directive is removed; `Microsoft.Extensions.Options` is added.
+- No other handler behavior (request/response shape, MediatR contract) changes.
+
+### FR-3: Remove `ManufactureConfigurationKeys.cs`
+After the migration, `ManufactureConfigurationKeys.GroupId` is unused.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs` is deleted.
+- A repo-wide search for `ManufactureConfigurationKeys` returns no matches.
+- No `using Anela.Heblo.Application.Features.Manufacture;` imports remain solely to reference this class.
+
+### FR-4: Relocate `ManufactureGroupId` into the `ManufactureErp` section in `appsettings.json`
+Move the configuration key from a top-level entry to a nested entry under the `ManufactureErp` section.
+
+**Acceptance criteria:**
+- In `backend/src/Anela.Heblo.API/appsettings.json`:
+  - The top-level `"ManufactureGroupId"` entry (line 7) is removed.
+  - The `"ManufactureErp"` section (line 268) gains `"ManufactureGroupId": "your-entra-id-group-id-here"`, preserving the placeholder text.
+- In `backend/src/Anela.Heblo.API/appsettings.Production.json`:
+  - The top-level `"ManufactureGroupId"` placeholder line is removed (the actual value is injected via env var; see NFR-3).
+- No other appsettings keys, ordering elsewhere, or sections are modified.
+
+### FR-5: Update existing tests to use the typed options class
+`GetManufactureSettingsHandlerTests` and `GetManufactureSettingsEndpointTests` currently rely on `IConfiguration` with the raw key.
+
+**Acceptance criteria:**
+- Unit tests construct the handler with `Options.Create(new ManufactureErpOptions { ManufactureGroupId = "..." })` instead of an `IConfigurationBuilder`/in-memory dictionary keyed on `"ManufactureGroupId"`.
+- Endpoint tests that seed configuration switch to seeding the `ManufactureErp:ManufactureGroupId` key (or directly registering `IOptions<ManufactureErpOptions>` in the test host) so the bound options class receives the value.
+- Test coverage for the three observable behaviors is preserved:
+  - configured non-empty value flows through to `GetManufactureSettingsResponse.ManufactureGroupId`,
+  - empty/whitespace value yields `null`,
+  - missing configuration yields `null`.
+- All affected tests pass under `dotnet test`.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavioral parity
+The HTTP response and serialized JSON shape of `GET` `…/manufacture/settings` (or whichever endpoint maps `GetManufactureSettingsRequest`) MUST be byte-identical before and after the change for the three input states (set, empty, missing). No new public API surface is introduced.
+
+### NFR-2: Build and format
+`dotnet build` and `dotnet format` MUST pass with no new warnings introduced by the refactor. Nullable annotations on `ManufactureGroupId` MUST be honored (`string?`).
+
+### NFR-3: Production configuration coordination
+Because production currently sets the value through an App Service environment variable named `ManufactureGroupId`, the deployment configuration MUST be updated **at the same time as the code change**:
+
+- Add a new env var `ManufactureErp__ManufactureGroupId` (double underscore is the .NET section delimiter) carrying the current value.
+- Remove or stop relying on the legacy `ManufactureGroupId` env var.
+- The PR description MUST call this out explicitly so the deployer updates Azure Web App settings before the new image is promoted.
+
+### NFR-4: No security regression
+No secret values are added to source-controlled `appsettings*.json` beyond the existing placeholder text. The production secret continues to flow from environment variables (or Key Vault, per project rule).
+
+## Data Model
+No new domain entities or persisted data. The only data-shape change is in configuration:
+
+| Item | Before | After |
+|---|---|---|
+| Config key path | `ManufactureGroupId` (root) | `ManufactureErp:ManufactureGroupId` |
+| Env var (ASP.NET binding) | `ManufactureGroupId` | `ManufactureErp__ManufactureGroupId` |
+| Options class | (none — raw `IConfiguration`) | `ManufactureErpOptions.ManufactureGroupId` (nullable string) |
+
+## API / Interface Design
+- **Public HTTP contract**: unchanged. `GetManufactureSettingsResponse.ManufactureGroupId` (`string?`) continues to be the only field returned.
+- **Internal handler contract**:
+  - Before: `GetManufactureSettingsHandler(IConfiguration, ILogger<…>)`
+  - After: `GetManufactureSettingsHandler(IOptions<ManufactureErpOptions>, ILogger<…>)`
+- **DI registration**: no change to `ManufactureModule.AddManufactureModule`. `services.Configure<ManufactureErpOptions>(... GetSection("ManufactureErp") ...)` already binds the new property automatically.
+
+## Dependencies
+- `Microsoft.Extensions.Options` — already transitively available throughout the Application project; no new package reference needed.
+- No changes to MediatR, EF Core, or any external integration.
+- Coordinated update of the Azure Web App configuration (env var rename, NFR-3) — owned by the deployment, but the code change is blocked from production rollout until that is sequenced.
+
+## Out of Scope
+- Migrating other modules' raw `IConfiguration` reads (if any exist) to typed options.
+- Moving `ManufactureGroupId` to Azure Key Vault (if it isn't already). The KV-vs-env-var policy is honored by whatever mechanism currently sets the value; this change only renames the binding key.
+- Renaming `ManufactureErpOptions` or its section to better reflect that it now carries non-ERP settings. The brief explicitly accepts Option A (extend the existing class) over introducing a new options class.
+- Changes to the request/response DTOs, the MediatR request name, or the HTTP route.
+- Frontend changes — the response shape is unchanged.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-manufacture-getmanufacturese/task-plan.r1.md
+++ b/artifacts/feat-arch-review-manufacture-getmanufacturese/task-plan.r1.md
@@ -1,0 +1,13 @@
+Plan saved to `docs/superpowers/plans/2026-06-07-manufacture-group-id-typed-options.md`.
+
+The plan decomposes the migration into 8 tasks:
+1. Add `ManufactureGroupId` to `ManufactureErpOptions` (FR-1)
+2. Rewrite handler tests using `Options.Create(...)` with whitespace + ctor-null cases (FR-5 + Spec Amendment 3)
+3. Refactor handler to `IOptions<ManufactureErpOptions>` with `IsNullOrWhiteSpace` (FR-2) — committed together with Task 2 so the build is never broken between commits
+4. Delete `ManufactureConfigurationKeys.cs` (FR-3)
+5. Move `appsettings.json` placeholder into the `ManufactureErp` section (FR-4)
+6. Drop the top-level `ManufactureGroupId` from `appsettings.Production.json` (FR-4)
+7. Full-solution build/format/test validation (NFR-1, NFR-2)
+8. Mandatory PR-description deployment-coordination text covering Production + Staging (NFR-3 + Spec Amendment 2)
+
+Spec Amendment 1 is honored: `GetManufactureSettingsEndpointTests` stays untouched (verified — that file doesn't seed config). The endpoint-test file is verified-unchanged in Task 7 Step 2.

--- a/backend/src/Anela.Heblo.API/appsettings.Production.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Production.json
@@ -34,7 +34,6 @@
       "http://localhost:3001"
     ]
   },
-  "ManufactureGroupId": "---- Injected via app service env variables ----",
   "ApplicationInsights": {
     "ConnectionString": "",
     "CloudRole": "Heblo-API-Production",

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -4,7 +4,6 @@
     "is-stock-taking-enabled": false,
     "is-background-refresh-enabled": true
   },
-  "ManufactureGroupId": "your-entra-id-group-id-here",
   "MarketingCalendar": {
     "GroupId": "GROUP-ID-FOR-MARKETING-CALENDAR-ACCESS",
     "PushEnabled": false,
@@ -266,7 +265,8 @@
     "MaxConcurrentTileLoads": 4
   },
   "ManufactureErp": {
-    "ErpTimeoutSeconds": 60
+    "ErpTimeoutSeconds": 60,
+    "ManufactureGroupId": "your-entra-id-group-id-here"
   },
   "ManufactureAnalysis": {
     "DefaultMonthsBack": 12,

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs
@@ -10,4 +10,11 @@ public class ManufactureErpOptions
     /// Defaults to 60 seconds. Set to 0 to disable the application-level timeout.
     /// </summary>
     public int ErpTimeoutSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Entra ID group identifier consumed by GetManufactureSettings to gate
+    /// "responsible person" workflows on the frontend. Bound from configuration
+    /// key "ManufactureErp:ManufactureGroupId" (env var "ManufactureErp__ManufactureGroupId").
+    /// </summary>
+    public string? ManufactureGroupId { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs
@@ -1,6 +1,0 @@
-namespace Anela.Heblo.Application.Features.Manufacture;
-
-public static class ManufactureConfigurationKeys
-{
-    public const string GroupId = "ManufactureGroupId";
-}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs
@@ -1,20 +1,22 @@
+using Anela.Heblo.Application.Features.Manufacture.Configuration;
 using MediatR;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureSettings;
 
 public class GetManufactureSettingsHandler
     : IRequestHandler<GetManufactureSettingsRequest, GetManufactureSettingsResponse>
 {
-    private readonly IConfiguration _configuration;
+    private readonly ManufactureErpOptions _options;
     private readonly ILogger<GetManufactureSettingsHandler> _logger;
 
     public GetManufactureSettingsHandler(
-        IConfiguration configuration,
+        IOptions<ManufactureErpOptions> options,
         ILogger<GetManufactureSettingsHandler> logger)
     {
-        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -22,11 +24,9 @@ public class GetManufactureSettingsHandler
         GetManufactureSettingsRequest request,
         CancellationToken cancellationToken)
     {
-        var groupId = _configuration[ManufactureConfigurationKeys.GroupId];
-        if (string.IsNullOrEmpty(groupId))
-        {
-            groupId = null;
-        }
+        var groupId = string.IsNullOrWhiteSpace(_options.ManufactureGroupId)
+            ? null
+            : _options.ManufactureGroupId;
 
         _logger.LogDebug("GetManufactureSettings resolved ManufactureGroupId hasValue={HasValue}", groupId is not null);
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs
@@ -1,8 +1,8 @@
-using Anela.Heblo.Application.Features.Manufacture;
+using Anela.Heblo.Application.Features.Manufacture.Configuration;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureSettings;
 using FluentAssertions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -12,17 +12,21 @@ public class GetManufactureSettingsHandlerTests
 {
     private readonly Mock<ILogger<GetManufactureSettingsHandler>> _loggerMock = new();
 
+    private GetManufactureSettingsHandler CreateHandler(string? manufactureGroupId)
+    {
+        var options = Options.Create(new ManufactureErpOptions
+        {
+            ManufactureGroupId = manufactureGroupId
+        });
+        return new GetManufactureSettingsHandler(options, _loggerMock.Object);
+    }
+
     [Fact]
     public async Task Handle_WhenManufactureGroupIdConfigured_ReturnsValueInResponse()
     {
         // Arrange
         var configuredGroupId = "11111111-2222-3333-4444-555555555555";
-        var configDict = new Dictionary<string, string?>
-        {
-            { ManufactureConfigurationKeys.GroupId, configuredGroupId }
-        };
-        var config = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
-        var handler = new GetManufactureSettingsHandler(config, _loggerMock.Object);
+        var handler = CreateHandler(configuredGroupId);
 
         // Act
         var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
@@ -36,8 +40,7 @@ public class GetManufactureSettingsHandlerTests
     public async Task Handle_WhenManufactureGroupIdMissing_ReturnsNull()
     {
         // Arrange
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
-        var handler = new GetManufactureSettingsHandler(config, _loggerMock.Object);
+        var handler = CreateHandler(manufactureGroupId: null);
 
         // Act
         var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
@@ -51,12 +54,7 @@ public class GetManufactureSettingsHandlerTests
     public async Task Handle_WhenManufactureGroupIdEmpty_ReturnsNull()
     {
         // Arrange
-        var configDict = new Dictionary<string, string?>
-        {
-            { ManufactureConfigurationKeys.GroupId, string.Empty }
-        };
-        var config = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
-        var handler = new GetManufactureSettingsHandler(config, _loggerMock.Object);
+        var handler = CreateHandler(manufactureGroupId: string.Empty);
 
         // Act
         var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
@@ -64,5 +62,40 @@ public class GetManufactureSettingsHandlerTests
         // Assert
         response.Success.Should().BeTrue();
         response.ManufactureGroupId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenManufactureGroupIdWhitespace_ReturnsNull()
+    {
+        // Arrange
+        var handler = CreateHandler(manufactureGroupId: "   ");
+
+        // Act
+        var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.ManufactureGroupId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_WhenOptionsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        Action act = () => new GetManufactureSettingsHandler(null!, _loggerMock.Object);
+
+        // Act / Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("options");
+    }
+
+    [Fact]
+    public void Constructor_WhenLoggerNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var options = Options.Create(new ManufactureErpOptions());
+        Action act = () => new GetManufactureSettingsHandler(options, null!);
+
+        // Act / Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
     }
 }

--- a/docs/superpowers/plans/2026-06-07-manufacture-group-id-typed-options.md
+++ b/docs/superpowers/plans/2026-06-07-manufacture-group-id-typed-options.md
@@ -1,0 +1,603 @@
+# Migrate `ManufactureGroupId` to Typed Options Pattern — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `IConfiguration`-based access to `ManufactureGroupId` in `GetManufactureSettingsHandler` with strongly-typed `IOptions<ManufactureErpOptions>`, eliminating the last raw-key configuration access in the Manufacture module.
+
+**Architecture:** Add a nullable `ManufactureGroupId` property to the existing `ManufactureErpOptions` class (already bound to the `"ManufactureErp"` section by `ManufactureModule.AddManufactureModule`). Rewire the handler to consume `IOptions<ManufactureErpOptions>`. Move the `appsettings.json` placeholder into the nested `ManufactureErp` section, delete the now-unused `ManufactureConfigurationKeys` constants file, update unit tests to use `Options.Create(...)`, and tighten the null/empty/whitespace collapse to `string.IsNullOrWhiteSpace`. Endpoint test file stays untouched (it does not seed config). Coordinate the Azure App Service env-var rename (`ManufactureGroupId` → `ManufactureErp__ManufactureGroupId`) in the PR description for Production and any other overriding environment.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq, MediatR, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Configuration`.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Edit | `backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs` | Add `ManufactureGroupId` nullable string property |
+| Edit | `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs` | Swap `IConfiguration` → `IOptions<ManufactureErpOptions>`, use `IsNullOrWhiteSpace` |
+| Delete | `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs` | Remove unused string-key constants |
+| Edit | `backend/src/Anela.Heblo.API/appsettings.json` | Move `ManufactureGroupId` placeholder into the `ManufactureErp` section |
+| Edit | `backend/src/Anela.Heblo.API/appsettings.Production.json` | Remove top-level `ManufactureGroupId` placeholder |
+| Edit | `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs` | Construct handler with `Options.Create(new ManufactureErpOptions { ... })`; add whitespace test case |
+| Verify (no edit) | `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsEndpointTests.cs` | Does not seed config — no change required |
+| Verify (no edit) | `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs` | Already binds `"ManufactureErp"` section — new property binds automatically |
+
+---
+
+## Task 1: Add `ManufactureGroupId` to `ManufactureErpOptions`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs`
+Expected (current content):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Manufacture.Configuration;
+
+/// <summary>
+/// Configuration options for Manufacture ERP integration (FlexiBee).
+/// </summary>
+public class ManufactureErpOptions
+{
+    /// <summary>
+    /// Maximum number of seconds to wait for a single Flexi ERP call before timing out.
+    /// Defaults to 60 seconds. Set to 0 to disable the application-level timeout.
+    /// </summary>
+    public int ErpTimeoutSeconds { get; set; } = 60;
+}
+```
+
+- [ ] **Step 2: Add the `ManufactureGroupId` property**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs` to read:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Manufacture.Configuration;
+
+/// <summary>
+/// Configuration options for Manufacture ERP integration (FlexiBee).
+/// </summary>
+public class ManufactureErpOptions
+{
+    /// <summary>
+    /// Maximum number of seconds to wait for a single Flexi ERP call before timing out.
+    /// Defaults to 60 seconds. Set to 0 to disable the application-level timeout.
+    /// </summary>
+    public int ErpTimeoutSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Entra ID group identifier consumed by GetManufactureSettings to gate
+    /// "responsible person" workflows on the frontend. Bound from configuration
+    /// key "ManufactureErp:ManufactureGroupId" (env var "ManufactureErp__ManufactureGroupId").
+    /// </summary>
+    public string? ManufactureGroupId { get; set; }
+}
+```
+
+- [ ] **Step 3: Verify the project compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded. 0 Warning(s). 0 Error(s).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs
+git commit -m "feat: add ManufactureGroupId to ManufactureErpOptions"
+```
+
+---
+
+## Task 2: Update `GetManufactureSettingsHandlerTests` to typed options (RED for the handler)
+
+We write the new tests first so the next task implements against them. After this task, the unit tests will fail to compile until Task 3 lands.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs`
+
+- [ ] **Step 1: Rewrite the test file to use `Options.Create(...)` and add a whitespace case**
+
+Replace the entire contents of `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.Configuration;
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureSettings;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.Settings;
+
+public class GetManufactureSettingsHandlerTests
+{
+    private readonly Mock<ILogger<GetManufactureSettingsHandler>> _loggerMock = new();
+
+    private GetManufactureSettingsHandler CreateHandler(string? manufactureGroupId)
+    {
+        var options = Options.Create(new ManufactureErpOptions
+        {
+            ManufactureGroupId = manufactureGroupId
+        });
+        return new GetManufactureSettingsHandler(options, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenManufactureGroupIdConfigured_ReturnsValueInResponse()
+    {
+        // Arrange
+        var configuredGroupId = "11111111-2222-3333-4444-555555555555";
+        var handler = CreateHandler(configuredGroupId);
+
+        // Act
+        var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.ManufactureGroupId.Should().Be(configuredGroupId);
+    }
+
+    [Fact]
+    public async Task Handle_WhenManufactureGroupIdMissing_ReturnsNull()
+    {
+        // Arrange
+        var handler = CreateHandler(manufactureGroupId: null);
+
+        // Act
+        var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.ManufactureGroupId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenManufactureGroupIdEmpty_ReturnsNull()
+    {
+        // Arrange
+        var handler = CreateHandler(manufactureGroupId: string.Empty);
+
+        // Act
+        var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.ManufactureGroupId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenManufactureGroupIdWhitespace_ReturnsNull()
+    {
+        // Arrange
+        var handler = CreateHandler(manufactureGroupId: "   ");
+
+        // Act
+        var response = await handler.Handle(new GetManufactureSettingsRequest(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.ManufactureGroupId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_WhenOptionsNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        Action act = () => new GetManufactureSettingsHandler(null!, _loggerMock.Object);
+
+        // Act / Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("options");
+    }
+
+    [Fact]
+    public void Constructor_WhenLoggerNull_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var options = Options.Create(new ManufactureErpOptions());
+        Action act = () => new GetManufactureSettingsHandler(options, null!);
+
+        // Act / Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+}
+```
+
+- [ ] **Step 2: Verify tests fail to compile**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: Build FAILED. Errors reference `GetManufactureSettingsHandler` constructor — `cannot convert from 'Microsoft.Extensions.Options.IOptions<...>' to 'Microsoft.Extensions.Configuration.IConfiguration'` (or similar). This confirms the tests are RED.
+
+- [ ] **Step 3: Do NOT commit yet**
+
+Leave staged for the combined commit in Task 3 — the handler change and these tests ship together so the repo never has a broken build on `main`.
+
+---
+
+## Task 3: Refactor `GetManufactureSettingsHandler` to use `IOptions<ManufactureErpOptions>` (GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs`
+
+- [ ] **Step 1: Read the current handler**
+
+Run: `cat backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs`
+Expected (current content):
+
+```csharp
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureSettings;
+
+public class GetManufactureSettingsHandler
+    : IRequestHandler<GetManufactureSettingsRequest, GetManufactureSettingsResponse>
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<GetManufactureSettingsHandler> _logger;
+
+    public GetManufactureSettingsHandler(
+        IConfiguration configuration,
+        ILogger<GetManufactureSettingsHandler> logger)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<GetManufactureSettingsResponse> Handle(
+        GetManufactureSettingsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var groupId = _configuration[ManufactureConfigurationKeys.GroupId];
+        if (string.IsNullOrEmpty(groupId))
+        {
+            groupId = null;
+        }
+
+        _logger.LogDebug("GetManufactureSettings resolved ManufactureGroupId hasValue={HasValue}", groupId is not null);
+
+        return Task.FromResult(new GetManufactureSettingsResponse
+        {
+            ManufactureGroupId = groupId
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Replace the handler implementation**
+
+Overwrite `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.Configuration;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureSettings;
+
+public class GetManufactureSettingsHandler
+    : IRequestHandler<GetManufactureSettingsRequest, GetManufactureSettingsResponse>
+{
+    private readonly ManufactureErpOptions _options;
+    private readonly ILogger<GetManufactureSettingsHandler> _logger;
+
+    public GetManufactureSettingsHandler(
+        IOptions<ManufactureErpOptions> options,
+        ILogger<GetManufactureSettingsHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<GetManufactureSettingsResponse> Handle(
+        GetManufactureSettingsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var groupId = string.IsNullOrWhiteSpace(_options.ManufactureGroupId)
+            ? null
+            : _options.ManufactureGroupId;
+
+        _logger.LogDebug("GetManufactureSettings resolved ManufactureGroupId hasValue={HasValue}", groupId is not null);
+
+        return Task.FromResult(new GetManufactureSettingsResponse
+        {
+            ManufactureGroupId = groupId
+        });
+    }
+}
+```
+
+Notes:
+- `ArgumentNullException.ThrowIfNull(options)` matches the project's nullable-aware guard style and produces a `paramName` of `"options"` for Task 2's constructor-null test.
+- `using Anela.Heblo.Application.Features.Manufacture;` is no longer needed (no reference to `ManufactureConfigurationKeys`). The old `using Microsoft.Extensions.Configuration;` is removed.
+
+- [ ] **Step 3: Verify Application project compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded. 0 Warning(s). 0 Error(s).
+
+- [ ] **Step 4: Run the unit tests (expect green)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetManufactureSettingsHandlerTests"`
+Expected: All 6 tests pass (4 `Handle_*` + 2 `Constructor_*`).
+
+- [ ] **Step 5: Run formatter**
+
+Run: `dotnet format backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Run: `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: No diff or only whitespace fixups.
+
+- [ ] **Step 6: Commit handler + tests together**
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs
+git commit -m "refactor: GetManufactureSettingsHandler reads ManufactureGroupId via IOptions<ManufactureErpOptions>"
+```
+
+---
+
+## Task 4: Delete `ManufactureConfigurationKeys.cs`
+
+**Files:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs`
+
+- [ ] **Step 1: Confirm there are no remaining references**
+
+Run: `grep -rn "ManufactureConfigurationKeys" backend/`
+Expected: No matches. (After Task 3, the handler no longer references it and the test file no longer imports it.)
+
+If any match remains, fix it before deleting the file.
+
+- [ ] **Step 2: Delete the file**
+
+Run: `git rm backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs`
+Expected: `rm 'backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs'`.
+
+- [ ] **Step 3: Verify Application project compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded. 0 Warning(s). 0 Error(s).
+
+- [ ] **Step 4: Verify tests project compiles and passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetManufactureSettings"`
+Expected: All `GetManufactureSettings*` tests pass (handler + endpoint).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "refactor: remove unused ManufactureConfigurationKeys"
+```
+
+---
+
+## Task 5: Relocate `ManufactureGroupId` placeholder in `appsettings.json`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/appsettings.json`
+
+- [ ] **Step 1: Remove the top-level entry**
+
+Edit `backend/src/Anela.Heblo.API/appsettings.json`, locate the block at line 7:
+
+```json
+  "ManufactureGroupId": "your-entra-id-group-id-here",
+```
+
+Remove that entire line (and only that line). The preceding `FeatureManagement` block keeps its trailing `},` and the following `MarketingCalendar` entry remains valid JSON.
+
+- [ ] **Step 2: Add the nested entry inside `"ManufactureErp"`**
+
+In the same file, locate the existing `ManufactureErp` section (around line 268):
+
+```json
+  "ManufactureErp": {
+    "ErpTimeoutSeconds": 60
+  },
+```
+
+Replace it with:
+
+```json
+  "ManufactureErp": {
+    "ErpTimeoutSeconds": 60,
+    "ManufactureGroupId": "your-entra-id-group-id-here"
+  },
+```
+
+- [ ] **Step 3: Validate JSON syntax**
+
+Run: `python3 -m json.tool backend/src/Anela.Heblo.API/appsettings.json > /dev/null`
+Expected: Command exits 0 with no output. (If it errors, fix the trailing comma / brace.)
+
+- [ ] **Step 4: Verify the API project still builds**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: Build succeeded. 0 Warning(s). 0 Error(s).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/appsettings.json
+git commit -m "chore: move ManufactureGroupId under ManufactureErp section in appsettings.json"
+```
+
+---
+
+## Task 6: Remove top-level `ManufactureGroupId` placeholder from `appsettings.Production.json`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/appsettings.Production.json`
+
+- [ ] **Step 1: Remove the top-level entry**
+
+Edit `backend/src/Anela.Heblo.API/appsettings.Production.json` and delete line 37:
+
+```json
+  "ManufactureGroupId": "---- Injected via app service env variables ----",
+```
+
+Remove that entire line. The surrounding `"Cors": { ... },` (line 36) and `"ApplicationInsights": { ... },` (line 38) entries remain.
+
+Do **not** add a `ManufactureErp` section to this file — the value is supplied via env var (`ManufactureErp__ManufactureGroupId`) and the existing top-level placeholder was documentation-only.
+
+- [ ] **Step 2: Validate JSON syntax**
+
+Run: `python3 -m json.tool backend/src/Anela.Heblo.API/appsettings.Production.json > /dev/null`
+Expected: Command exits 0 with no output.
+
+- [ ] **Step 3: Verify the API project still builds**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: Build succeeded. 0 Warning(s). 0 Error(s).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/appsettings.Production.json
+git commit -m "chore: drop legacy ManufactureGroupId placeholder from appsettings.Production.json"
+```
+
+---
+
+## Task 7: Final validation across solution
+
+This task does no code change; it runs the full validation gate documented in `CLAUDE.md`.
+
+- [ ] **Step 1: Confirm no stale references to the old key or constant**
+
+Run: `grep -rn "ManufactureConfigurationKeys" backend/`
+Expected: No matches.
+
+Run: `grep -rn "\"ManufactureGroupId\"" backend/src/`
+Expected: Exactly **one** match — the nested entry in `backend/src/Anela.Heblo.API/appsettings.json` under the `ManufactureErp` section. No top-level key, no other appsettings file references it.
+
+- [ ] **Step 2: Confirm the endpoint test file is unchanged**
+
+Run: `git diff --name-only HEAD~5..HEAD -- backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsEndpointTests.cs`
+Expected: No output (the file is intentionally untouched per arch-review Spec Amendment 1).
+
+- [ ] **Step 3: Full backend build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded. 0 Warning(s). 0 Error(s).
+
+- [ ] **Step 4: Full backend format check**
+
+Run: `dotnet format backend/Anela.Heblo.sln --verify-no-changes`
+Expected: Exit code 0, no formatting diff.
+
+If it reports a diff, run `dotnet format backend/Anela.Heblo.sln` and amend the most relevant prior commit (or commit as `chore: format`).
+
+- [ ] **Step 5: Full backend test run**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: All tests pass. Pay particular attention to:
+
+- `GetManufactureSettingsHandlerTests` — 6 tests pass (configured, missing, empty, whitespace, ctor-null-options, ctor-null-logger).
+- `GetManufactureSettingsEndpointTests` — 3 tests still pass (reachable, content-type, exposes field, anonymous).
+
+- [ ] **Step 6: No commit needed**
+
+Validation only; no files changed at this step.
+
+---
+
+## Task 8: Document the production env-var rename in the PR description
+
+This task is **mandatory before merge** because the production binding key changes (NFR-3 + Spec Amendment 2). The PR description must enumerate every environment whose configuration must be updated in lock-step with the code change.
+
+- [ ] **Step 1: Confirm the affected environments**
+
+Verified by repo grep at planning time:
+
+- `appsettings.Production.json` — has a top-level placeholder; production Web App sets the env var.
+- `appsettings.Staging.json` — does NOT mention `ManufactureGroupId`. Confirm with the deployer whether the Staging Web App nonetheless sets `ManufactureGroupId` (legacy) or `ManufactureErp__ManufactureGroupId` (new). If the Staging Web App sets the legacy name, it must be renamed at the same time.
+- No other `appsettings.*.json` references the key.
+
+- [ ] **Step 2: Write the PR description (paste this into the PR body)**
+
+```
+## Summary
+Migrates `ManufactureGroupId` consumption in `GetManufactureSettingsHandler` from raw
+`IConfiguration` to the typed `IOptions<ManufactureErpOptions>` pattern. Adds the
+property to `ManufactureErpOptions`, deletes the now-unused `ManufactureConfigurationKeys`,
+moves the `appsettings.json` placeholder into the nested `ManufactureErp` section, and
+updates unit tests. Behavioral change: null/empty/whitespace now all collapse to `null`
+(was: null/empty only). HTTP contract is unchanged.
+
+## ⚠️ Required deployment coordination — DO NOT MERGE before this is done
+
+The production binding key changes from `ManufactureGroupId` (top-level) to
+`ManufactureErp:ManufactureGroupId` (nested). For Azure App Service, the env var
+delimiter is `__`, so:
+
+- **Old env var:** `ManufactureGroupId`
+- **New env var:** `ManufactureErp__ManufactureGroupId`
+
+Required actions in the Azure portal **before** the new image is promoted:
+
+1. **Production Web App:** add `ManufactureErp__ManufactureGroupId` with the current value
+   of `ManufactureGroupId`. Keep `ManufactureGroupId` set in parallel until the new image
+   is healthy (rollback safety), then remove the legacy var.
+2. **Staging Web App (if applicable):** verify whether `ManufactureGroupId` is set there.
+   If yes, repeat step 1 against Staging.
+3. **Any other environment** that overrides this value: same treatment.
+
+Without step 1, the endpoint will silently return `null` post-deploy and the frontend
+"responsible person" gating will degrade.
+
+## Test plan
+- [ ] `dotnet build backend/Anela.Heblo.sln` clean
+- [ ] `dotnet format backend/Anela.Heblo.sln --verify-no-changes` clean
+- [ ] `dotnet test backend/Anela.Heblo.sln` — full suite green
+- [ ] `GetManufactureSettingsHandlerTests` — 6 tests pass (configured / missing /
+      empty / whitespace / ctor null options / ctor null logger)
+- [ ] `GetManufactureSettingsEndpointTests` — 3 tests pass (reachable, content-type,
+      exposes field, anonymous) — file intentionally untouched
+- [ ] Deployer confirms `ManufactureErp__ManufactureGroupId` is set in every overriding
+      environment (Production confirmed; Staging confirmed or N/A)
+```
+
+- [ ] **Step 3: No commit needed**
+
+The PR description is authored when opening the PR — not committed.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+- FR-1 (add `ManufactureGroupId` to `ManufactureErpOptions`) → **Task 1**.
+- FR-2 (refactor handler to `IOptions<ManufactureErpOptions>`) → **Task 3**. Includes the `IsNullOrWhiteSpace` tightening (Spec Amendment 3), preservation of the debug log line, removed `IConfiguration` using, added `IOptions` using, no contract change.
+- FR-3 (delete `ManufactureConfigurationKeys.cs`) → **Task 4**. Includes the orphan-using check (Spec Amendment 4 — handled inline in Task 3 Step 2 by writing a clean using list).
+- FR-4 (relocate `ManufactureGroupId` into `ManufactureErp` section in `appsettings.json`) → **Task 5**; `appsettings.Production.json` top-level placeholder removed in **Task 6**.
+- FR-5 (update tests to typed options) → **Task 2**. Per Spec Amendment 1, `GetManufactureSettingsEndpointTests` is left untouched (verified in Task 7 Step 2); only `GetManufactureSettingsHandlerTests` changes.
+- NFR-1 (behavioral parity of HTTP response shape) → covered by Task 7 Step 5 running `GetManufactureSettingsEndpointTests`.
+- NFR-2 (build + format) → Task 7 Steps 3–4.
+- NFR-3 (production coordination — extended to all overriding envs per Spec Amendment 2) → **Task 8**.
+- NFR-4 (no secret regression) → no secret values added to any committed file; only placeholder text is moved (Tasks 5–6).
+
+**2. Placeholder scan:** No TBDs, no "implement later", no "similar to Task N" cross-references. Every code-modifying step shows the actual code. Validation commands have explicit expected outputs.
+
+**3. Type / signature consistency:**
+
+- `ManufactureErpOptions.ManufactureGroupId` is `string?` everywhere (Task 1 declaration, Task 2 test construction, Task 3 handler read).
+- Handler constructor `IOptions<ManufactureErpOptions> options, ILogger<GetManufactureSettingsHandler> logger` matches between Task 2 test (constructor-null tests) and Task 3 implementation.
+- `Options.Create(new ManufactureErpOptions { ManufactureGroupId = ... })` factory in Task 2 matches the property added in Task 1.
+- `using Anela.Heblo.Application.Features.Manufacture.Configuration;` is added in Task 3 (handler) and Task 2 (test) where needed; the orphan `using Anela.Heblo.Application.Features.Manufacture;` is dropped from both (no `ManufactureConfigurationKeys` reference remains).
+- `ArgumentNullException.ThrowIfNull(options)` produces `paramName == "options"`, which the Task 2 test `WithParameterName("options")` asserts.
+
+**4. Commit hygiene:** Handler + tests ship as a single commit (Task 3 Step 6) so the repo is never on a broken build between commits. The constants-file deletion (Task 4) is its own commit because it touches a different file and is mechanically reversible. Appsettings changes (Tasks 5 and 6) are separate commits per file to keep diffs reviewable.
+
+Plan ready.


### PR DESCRIPTION

Migrates `ManufactureGroupId` consumption in `GetManufactureSettingsHandler` from raw `IConfiguration` to the typed `IOptions<ManufactureErpOptions>` pattern. Adds the property to `ManufactureErpOptions`, deletes the now-unused `ManufactureConfigurationKeys`, moves the `appsettings.json` placeholder into the nested `ManufactureErp` section, and updates unit tests with full whitespace-handling coverage. Behavioral change: null/empty/whitespace now all collapse to `null` (previously only null/empty). HTTP contract is unchanged.

**⚠️ Required deployment coordination — DO NOT MERGE before this is done:** The production binding key changes from `ManufactureGroupId` (top-level) to `ManufactureErp__ManufactureGroupId` (nested, double-underscore). Before the new image is promoted, add `ManufactureErp__ManufactureGroupId` in the Production (and Staging, if applicable) Azure Web App settings with the current value, and keep the old var until the new image is healthy. Without this, the endpoint silently returns `null` and frontend gating degrades.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs` — added `ManufactureGroupId` nullable string property
- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureSettings/GetManufactureSettingsHandler.cs` — replaced `IConfiguration` with `IOptions<ManufactureErpOptions>`, `IsNullOrWhiteSpace`
- `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureConfigurationKeys.cs` — deleted (unused)
- `backend/src/Anela.Heblo.API/appsettings.json` — moved `ManufactureGroupId` from root into `ManufactureErp` section
- `backend/src/Anela.Heblo.API/appsettings.Production.json` — removed stale top-level placeholder
- `backend/test/Anela.Heblo.Tests/Features/Manufacture/Settings/GetManufactureSettingsHandlerTests.cs` — rewrote with typed options, added whitespace + constructor-null tests

---

Closes #2681

### Tokens used
18401776
