### PR TITLE
feat: Remove misleading instance-level lock in FinancialAnalysisService

### DIFF
--- a/artifacts/feat-arch-review-financialoverview-instance-l/arch-review.r1.md
+++ b/artifacts/feat-arch-review-financialoverview-instance-l/arch-review.r1.md
@@ -1,0 +1,173 @@
+# Architecture Review: Remove misleading instance-level lock in FinancialAnalysisService
+
+## Skip Design: true
+
+No UI/UX work — pure backend refactor that removes dead concurrency code in an internal service. No new components, screens, or visual design.
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with existing patterns. `FinancialAnalysisService` already follows the project's conventions: Scoped lifetime per `docs/architecture/development_guidelines.md`, MediatR-driven handler usage, vertical-slice placement under `Features/FinancialOverview/Services/`, and shared state externalized to `IMemoryCache`. The instance-level `_refreshLock` is the one piece that contradicts those conventions — it implies cross-request coordination that a Scoped service cannot deliver. Removing it brings the implementation back in line with the rest of the module.
+
+Integration points unaffected:
+- `IBackgroundRefreshTaskRegistry` / `BackgroundRefreshSchedulerService` (confirmed at `BackgroundRefreshSchedulerService.cs:86` — creates a fresh DI scope per tick, so it always sees a *different* `_refreshLock` than user-request flows).
+- `IFinancialAnalysisService` public contract — unchanged.
+- DI graph — `IStockValueService` stays Scoped (`FinancialOverviewModule.cs:19`); `ILedgerService` stays Singleton (`FlexiAdapterServiceCollectionExtensions.cs:75`). No lifetime renegotiation required.
+
+The grep `_refreshLock` returned three hits: the file under change, a different lock with the same name in `ManufactureBasedMaterialCostProvider.cs` (unrelated, do not touch), and a planning doc under `docs/plans/`. Only the service file should be modified.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+[ HTTP request ]                         [ BackgroundRefreshSchedulerService ]
+       |                                              |
+       v                                              v (per-tick: CreateScope())
+[ DI scope #1 ]                                [ DI scope #2 ]
+       |                                              |
+       v                                              v
+[ FinancialAnalysisService instance A ]      [ FinancialAnalysisService instance B ]
+       |                                              |
+       +---------------+      +-----------------------+
+                       v      v
+                  [ IMemoryCache (Singleton, thread-safe) ]
+                       - financial_monthly_data_{year}_{month}
+                       - financial_stock_data_{year}_{month}
+                       - financial_last_refresh   <-- the actual cross-request gate
+```
+
+Before: each instance also holds a `_refreshLock` that only ever serializes the single request thread that owns it — i.e. no contention is possible, so the lock is decorative.
+
+After: the only synchronization primitive is `IMemoryCache`, which is genuinely shared and thread-safe for the operations used here (`Get<T>` / `Set` with a TTL). The 10-minute throttle remains a best-effort rate-limit, not a correctness invariant.
+
+### Key Design Decisions
+
+#### Decision 1: Remove the lock; keep the service Scoped
+**Options considered:**
+- A. Remove the lock; leave lifetime as Scoped (spec choice).
+- B. Promote service to Singleton so the lock would actually serialize refreshes.
+- C. Replace the lock with a static `SemaphoreSlim` or `Interlocked.CompareExchange` gate to provide a real at-most-one-refresh-in-flight guarantee without changing lifetime.
+
+**Chosen approach:** A.
+
+**Rationale:** Option B is rejected because `IStockValueService` is Scoped (`FinancialOverviewModule.cs:19`); injecting it into a Singleton creates a captive-dependency bug. Option C is over-engineering for a finding whose stated goal is to remove misleading code, not to introduce a stronger guarantee. The refresh is idempotent (writes the same keys with the same TTLs); the downstream services are concurrent-safe; the 10-minute window is a coarse rate-limit. Spec is correct to stop there.
+
+#### Decision 2: Do not add a "this is best-effort" comment
+**Options considered:**
+- Add a comment above the throttle check explaining the race window between read and write.
+- Leave the code uncommented.
+
+**Chosen approach:** Leave it uncommented.
+
+**Rationale:** Per the project's "Surgical changes" rule and the global "default to no comments" guidance, the removal itself eliminates the misleading signal. Adding prose about a race window the lock never prevented would replace one piece of decorative code with another. If a future requirement demands a real guarantee, that work introduces its own context and its own documentation.
+
+#### Decision 3: Regression test seeds `financial_last_refresh` directly
+**Options considered:**
+- A. Drive the throttle by calling `RefreshFinancialDataAsync` twice and asserting the second is a no-op.
+- B. Pre-seed `LAST_REFRESH_CACHE_KEY` in the shared `IMemoryCache` and assert one call is a no-op.
+
+**Chosen approach:** B.
+
+**Rationale:** Option A couples the test to the full refresh pipeline (24-month loop, ledger/stock fan-out) and runs many more mocked calls than necessary. Option B isolates the throttle behavior — exactly what the spec asks to verify in FR-4 — and matches the seeding pattern already used in `FinancialAnalysisServiceTests.cs:174` (`SeedCacheForMonth`).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. All changes touch:
+
+```
+backend/
+├── src/Anela.Heblo.Application/Features/FinancialOverview/Services/
+│   └── FinancialAnalysisService.cs        # delete line 22, replace lock block at 109-117
+└── test/Anela.Heblo.Tests/Application/FinancialOverview/
+    └── FinancialAnalysisServiceTests.cs   # add one regression test
+```
+
+`FinancialOverviewModule.cs` — unchanged. Public surface of `IFinancialAnalysisService` — unchanged.
+
+### Interfaces and Contracts
+
+No interface changes. `IFinancialAnalysisService.RefreshFinancialDataAsync(DateTime?, DateTime?, CancellationToken)` keeps its signature, observable side effects, and idempotency.
+
+Cache key contract unchanged:
+- `financial_monthly_data_{year}_{month}` — 24h TTL
+- `financial_stock_data_{year}_{month}` — 24h TTL
+- `financial_last_refresh` — 24h TTL, value is `DateTime` (UTC)
+
+### Data Flow
+
+```
+RefreshFinancialDataAsync(start, end, ct)
+  │
+  ├─► read LAST_REFRESH_CACHE_KEY from IMemoryCache
+  │     └─► if (now - last) < 10min → LogDebug + return (no-op)
+  │
+  ├─► default start/end if null
+  │
+  ├─► for each month, newest → oldest:
+  │     RefreshMonthlyDataAsync(monthStart, monthEnd, ct)
+  │       ├─► await Task.WhenAll(
+  │       │       ledger.GetLedgerItems(debit),
+  │       │       ledger.GetLedgerItems(credit),
+  │       │       stockValue.GetStockValueChangesAsync())
+  │       └─► IMemoryCache.Set(monthly + stock keys, 24h TTL)
+  │
+  └─► IMemoryCache.Set(LAST_REFRESH_CACHE_KEY, UtcNow, 24h)
+```
+
+The only structural change: the first step drops its `lock (_refreshLock) { ... }` wrapper. Everything downstream is byte-identical.
+
+### Test Plan
+
+Add one xUnit test to `FinancialAnalysisServiceTests.cs`. Suggested shape (use FluentAssertions; reuse the existing `_service` and `_memoryCache` fields):
+
+```csharp
+[Fact]
+public async Task RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices()
+{
+    // Arrange: seed last-refresh timestamp inside the 10-minute window
+    _memoryCache.Set("financial_last_refresh", DateTime.UtcNow.AddMinutes(-1), TimeSpan.FromHours(24));
+
+    // Act
+    await _service.RefreshFinancialDataAsync(startDate: null, endDate: null);
+
+    // Assert: throttle short-circuits before any downstream call
+    _ledgerServiceMock.Verify(
+        x => x.GetLedgerItems(
+            It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<IEnumerable<string>?>(), It.IsAny<IEnumerable<string>?>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+    _stockValueServiceMock.Verify(
+        x => x.GetStockValueChangesAsync(
+            It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+```
+
+No existing tests in `FinancialAnalysisServiceTests.cs` reference the lock; nothing else needs editing. `FinancialOverviewModuleTests.cs` is untouched.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Reader assumes the throttle is a hard at-most-one-in-flight guarantee | Low | Spec explicitly documents (NFR-2) the throttle is best-effort. Refresh is idempotent — concurrent overlapping refreshes converge on the same cache state. |
+| Background scheduler and a user-triggered cache miss perform a duplicate refresh in the narrow window after a 10-minute throttle expires | Low | This is the *current* observable behavior — the lock never prevented it. Downstream services (`ILedgerService`, `IStockValueService`) are safe under concurrent invocation. If a future change must eliminate this, introduce a `static SemaphoreSlim` or an Interlocked gate then. |
+| Tests inadvertently rely on lock ordering | Very low | Verified `FinancialAnalysisServiceTests.cs` — no test references `_refreshLock` or lock semantics. |
+| Unrelated `_refreshLock` symbol in `ManufactureBasedMaterialCostProvider.cs` gets edited by mistake | Low | Surgical-changes rule. Reviewer should confirm the diff is limited to `FinancialAnalysisService.cs` + the new test. |
+| `docs/plans/2025-12-21-margin-cache-architecture.md` references `_refreshLock` and becomes stale | Negligible | Out of scope; planning docs reflect historical context. Spec is explicit (Out of Scope: "Touching any other module"). |
+
+## Specification Amendments
+
+None. The spec is internally consistent and accurately describes the code as it exists (verified against `FinancialAnalysisService.cs:22` and `:109-117`, `FinancialOverviewModule.cs:19,28`, `BackgroundRefreshSchedulerService.cs:86`).
+
+One optional clarification for the implementer, not a spec change: the regression test in FR-4 should pre-seed `financial_last_refresh` directly in `IMemoryCache` rather than relying on two back-to-back calls. This isolates the throttle behavior under test and matches the `SeedCacheForMonth` pattern already established in the test file.
+
+## Prerequisites
+
+None. No migrations, no configuration changes, no infrastructure work, no new packages. The change is a pure code edit + one new test inside an existing test class. Validation gate is the standard project gate from `CLAUDE.md`:
+
+- `dotnet build` clean
+- `dotnet format` clean
+- `dotnet test` green for `Anela.Heblo.Tests` (touched test project)

--- a/artifacts/feat-arch-review-financialoverview-instance-l/brief.md
+++ b/artifacts/feat-arch-review-financialoverview-instance-l/brief.md
@@ -1,0 +1,47 @@
+## Module
+FinancialOverview
+
+## Finding
+`FinancialAnalysisService` declares an instance-level lock object:
+
+```csharp
+// FinancialAnalysisService.cs:22
+private readonly object _refreshLock = new();
+```
+
+And uses it in `RefreshFinancialDataAsync` (lines 109-117) to guard a 10-minute refresh throttle check:
+
+```csharp
+lock (_refreshLock)
+{
+    var lastRefresh = _memoryCache.Get<DateTime?>(LAST_REFRESH_CACHE_KEY) ?? DateTime.MinValue;
+    if (DateTime.UtcNow - lastRefresh < TimeSpan.FromMinutes(10))
+    {
+        _logger.LogDebug("Skipping refresh, last refresh was too recent");
+        return;
+    }
+}
+```
+
+However, `FinancialAnalysisService` is registered as **Scoped** (`FinancialOverviewModule.cs:28`):
+
+```csharp
+services.AddScoped<IFinancialAnalysisService, FinancialAnalysisService>();
+```
+
+A Scoped service gets a **new instance per HTTP request**. The instance-level lock guards concurrent access *within a single request instance only* — a scenario that cannot occur because a single handler instance is not called concurrently. The lock provides zero protection against two simultaneous HTTP requests both triggering a refresh.
+
+The actual throttle guard is the `IMemoryCache` timestamp check, which is shared across requests (correct). The `lock` around it is misleading: a reader would reasonably assume it prevents concurrent refreshes across requests, but it does not.
+
+## Why it matters
+The misleading lock creates false confidence that concurrent refreshes are blocked at the service level. If the background scheduler triggers a refresh concurrently with a user-initiated cache-miss refresh, both will pass the lock check and run in parallel.
+
+## Suggested fix
+**Option A (minimal):** Remove the instance lock and rely solely on the `IMemoryCache` timestamp check. `IMemoryCache` reads are thread-safe; the window between read and write is already narrow enough for the 10-minute throttle to be acceptable without a lock.
+
+**Option B (correct for refresh coordination):** Register `FinancialAnalysisService` as **Singleton** — it is a cache coordinator, not a request-scoped service. Verify first that `ILedgerService` and `IStockValueService` are Singleton-compatible (or resolve them from a child scope inside `RefreshFinancialDataAsync`). With Singleton lifetime, the instance lock becomes meaningful.
+
+Option A is the minimal safe fix; Option B is the architecturally correct one if the service is expected to guarantee at-most-one-refresh-in-flight.
+
+---
+_Filed by daily arch-review routine on 2026-06-06._

--- a/artifacts/feat-arch-review-financialoverview-instance-l/impl/main.r1.md
+++ b/artifacts/feat-arch-review-financialoverview-instance-l/impl/main.r1.md
@@ -1,0 +1,49 @@
+---
+
+# Implementation: Remove misleading instance-level lock in FinancialAnalysisService
+
+## What was implemented
+
+Removed the decorative `_refreshLock` instance field and `lock` statement from `FinancialAnalysisService.RefreshFinancialDataAsync`. The service is registered Scoped, so each HTTP request and each `IServiceProvider.CreateScope()` call (used by `BackgroundRefreshSchedulerService`) creates a fresh instance — the lock was never contended and provided no cross-request protection. The actual throttle gate is the `IMemoryCache` entry at `financial_last_refresh`, which is inherently thread-safe. A regression test was added before the lock removal to pin the throttle behavior in place.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs` — removed `_refreshLock` field (line 22) and unwrapped the `lock (_refreshLock) { ... }` block around the throttle check (lines 109-117); all other code unchanged
+- `backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs` — added `RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices` regression test
+
+## Tests
+
+- `FinancialAnalysisServiceTests.cs` — 5 tests total (4 existing + 1 new); all pass
+- New test seeds `"financial_last_refresh"` at `DateTime.UtcNow.AddMinutes(-1)` and asserts `Times.Never` on both `ILedgerService.GetLedgerItems` and `IStockValueService.GetStockValueChangesAsync`
+- Full solution test run: 4593 tests passed; 38 Docker/Testcontainers integration tests failed due to no PostgreSQL container available (pre-existing environment limitation, unrelated to this change)
+
+## How to verify
+
+```bash
+cd /path/to/worktree
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~FinancialAnalysisServiceTests"
+git diff --name-only main...HEAD
+```
+
+Expected: build clean, 5 tests green, diff shows exactly the two files above.
+
+## Notes
+
+- The 38 Testcontainer failures are pre-existing and require a running PostgreSQL container; they are not caused by this change.
+- `ManufactureBasedMaterialCostProvider.cs` also has a `_refreshLock` (a static `SemaphoreSlim`) — it was intentionally not touched.
+- `FinancialOverviewModule.cs` DI registration remains Scoped, as specified.
+- `dotnet format --verify-no-changes` confirmed "Formatted 0 of 3278 files" — code was already compliant after the edits.
+
+## PR Summary
+
+Removes the misleading `_refreshLock` instance lock from `FinancialAnalysisService.RefreshFinancialDataAsync`. Because the service is registered Scoped, every HTTP request and every `IServiceProvider.CreateScope()` call (used by `BackgroundRefreshSchedulerService`) receives a fresh service instance, so the lock was never contended and provided zero cross-request protection. The actual cross-request throttle gate is the `IMemoryCache` entry at `financial_last_refresh`, which `MemoryCache` makes thread-safe on its own. Removing the lock eliminates the false implication of cross-instance coordination without changing any observable behavior.
+
+A regression test was added before the removal to pin the throttle's short-circuit behavior: it seeds the cache key inside the 10-minute window and asserts that no downstream `ILedgerService` or `IStockValueService` calls are made.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs` — deleted `_refreshLock` field and unwrapped the `lock` block around the throttle check
+- `backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs` — added `RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices` regression test
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-financialoverview-instance-l/spec.r1.md
+++ b/artifacts/feat-arch-review-financialoverview-instance-l/spec.r1.md
@@ -1,0 +1,122 @@
+# Specification: Remove misleading instance-level lock in FinancialAnalysisService
+
+## Summary
+Eliminate the misleading `_refreshLock` instance lock inside `FinancialAnalysisService.RefreshFinancialDataAsync` and rely solely on the shared `IMemoryCache` timestamp throttle. The lock currently provides zero cross-request protection because the service is registered Scoped (a new instance per HTTP request / per DI scope), so the only readers it ever guards are the single thread holding the request. Removing it eliminates the false sense of concurrency safety without changing observable behavior.
+
+## Background
+`FinancialAnalysisService` is registered as **Scoped** in `FinancialOverviewModule.cs:28`:
+
+```csharp
+services.AddScoped<IFinancialAnalysisService, FinancialAnalysisService>();
+```
+
+It also declares an instance-level lock object at `FinancialAnalysisService.cs:22`:
+
+```csharp
+private readonly object _refreshLock = new();
+```
+
+The lock guards a 10-minute throttle check in `RefreshFinancialDataAsync` (`FinancialAnalysisService.cs:109-117`):
+
+```csharp
+lock (_refreshLock)
+{
+    var lastRefresh = _memoryCache.Get<DateTime?>(LAST_REFRESH_CACHE_KEY) ?? DateTime.MinValue;
+    if (DateTime.UtcNow - lastRefresh < TimeSpan.FromMinutes(10))
+    {
+        _logger.LogDebug("Skipping refresh, last refresh was too recent");
+        return;
+    }
+}
+```
+
+Because each HTTP request and each `IServiceProvider.CreateScope()` (e.g. `BackgroundRefreshSchedulerService.RunTaskLoop`, `BackgroundRefreshSchedulerService.cs:86-88`) gets a brand-new `FinancialAnalysisService` instance, the lock is created fresh and never contended. Two concurrent callers — for example the periodic background refresh scheduler and a user-triggered cache-miss path — each see their own `_refreshLock` and both pass through. The only actual cross-request guard is the `IMemoryCache` read of `LAST_REFRESH_CACHE_KEY`, which is thread-safe on its own.
+
+The fix is to remove the lock so the code accurately reflects its actual concurrency guarantees. Promoting the service to Singleton (Option B from the brief) is rejected because `IStockValueService` is registered Scoped (`FinancialOverviewModule.cs:19`) and cannot be injected into a Singleton without introducing a captive-dependency bug or refactoring scope handling — out of scope for this surgical fix.
+
+## Functional Requirements
+
+### FR-1: Remove the `_refreshLock` field
+Delete the `private readonly object _refreshLock = new();` declaration at `FinancialAnalysisService.cs:22`.
+
+**Acceptance criteria:**
+- The `_refreshLock` field no longer exists in `FinancialAnalysisService.cs`.
+- No other file references `_refreshLock` (verified by repo-wide search).
+- The project builds with `dotnet build` with zero warnings introduced by the change.
+
+### FR-2: Remove the `lock` statement and keep the throttle check
+Replace the `lock (_refreshLock) { ... }` block in `RefreshFinancialDataAsync` (`FinancialAnalysisService.cs:109-117`) with an unlocked equivalent that preserves the early-return behavior:
+
+```csharp
+var lastRefresh = _memoryCache.Get<DateTime?>(LAST_REFRESH_CACHE_KEY) ?? DateTime.MinValue;
+if (DateTime.UtcNow - lastRefresh < TimeSpan.FromMinutes(10))
+{
+    _logger.LogDebug("Skipping refresh, last refresh was too recent");
+    return;
+}
+```
+
+**Acceptance criteria:**
+- No `lock` keyword remains in `FinancialAnalysisService.cs`.
+- The throttle still skips refreshes when the last refresh was less than 10 minutes ago.
+- The early-return path still emits the same `LogDebug("Skipping refresh, last refresh was too recent")` message at the same log level.
+- The successful-refresh path still updates `LAST_REFRESH_CACHE_KEY` to `DateTime.UtcNow` with a 24-hour expiration (line 143 unchanged).
+
+### FR-3: Preserve existing behavior for all other code paths
+No changes to `GetFinancialOverviewAsync`, `RefreshMonthlyDataAsync`, `GetCacheStatus`, `GetCachedFinancialOverview`, `GetHybridWithCurrentMonthAsync`, `GetFinancialOverviewRealTimeAsync`, `CreateStockSummary`, or the DI registration (which remains Scoped).
+
+**Acceptance criteria:**
+- Diff is limited to (a) removing the `_refreshLock` field and (b) removing the `lock (_refreshLock) { ... }` braces around the throttle check.
+- `FinancialOverviewModule.cs` is unchanged.
+- The public surface of `IFinancialAnalysisService` is unchanged.
+
+### FR-4: Adjust or add unit tests
+Verify the throttle check still works without the lock. If existing tests assert lock-related behavior, update them to match the new structure. Add a regression test asserting that a second call to `RefreshFinancialDataAsync` within 10 minutes is a no-op (does not invoke `ILedgerService` again).
+
+**Acceptance criteria:**
+- `backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs` contains a test demonstrating that two back-to-back `RefreshFinancialDataAsync` calls result in only one set of underlying `ILedgerService` / `IStockValueService` invocations when the cache key `financial_last_refresh` is already populated within the 10-minute window.
+- All existing tests in `FinancialAnalysisServiceTests.cs` and `FinancialOverviewModuleTests.cs` pass.
+- `dotnet test` for the touched test project is green.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance change is expected. Removing a single uncontended `Monitor.Enter`/`Monitor.Exit` pair is negligible. The hot path (cached read in `GetFinancialOverviewAsync`) is untouched.
+
+### NFR-2: Concurrency semantics (documented honestly)
+The code must not imply guarantees it cannot deliver. The 10-minute throttle is best-effort: between the `IMemoryCache` read at line 111 and the `IMemoryCache.Set` at line 143, two concurrent refresh callers may both pass the gate and both perform a full refresh. This is the *current* behavior — the lock never prevented it — and is acceptable because:
+- The refresh is idempotent (it writes the same cache keys with the same TTLs).
+- The downstream `ILedgerService` / `IStockValueService` calls are themselves safe under concurrent invocation in the existing system.
+- The 10-minute throttle is a coarse rate-limit, not a correctness invariant.
+
+No code comment is required to document this; the removal alone removes the false impression. If a future requirement demands at-most-one-refresh-in-flight, see Open Questions.
+
+### NFR-3: Security
+No security impact. No auth, input validation, or secret handling is changed.
+
+### NFR-4: Backward compatibility
+Fully backward compatible — no API, contract, configuration, or schema change.
+
+## Data Model
+Unchanged. No entities, DTOs, or cache key formats are modified. The cache keys (`financial_monthly_data_*`, `financial_stock_data_*`, `financial_last_refresh`) remain identical.
+
+## API / Interface Design
+Unchanged. `IFinancialAnalysisService.RefreshFinancialDataAsync(DateTime?, DateTime?, CancellationToken)` keeps the same signature, observable side effects, and idempotency characteristics.
+
+## Dependencies
+- `Microsoft.Extensions.Caching.Memory.IMemoryCache` — already a constructor dependency; thread-safe for the operations used here.
+- `ILedgerService` — already registered Singleton in `FlexiAdapterServiceCollectionExtensions.cs:75`. No lifetime change.
+- `IStockValueService` — registered Scoped in `FinancialOverviewModule.cs:19`. No lifetime change.
+- No new packages or framework features.
+
+## Out of Scope
+- **Promoting `FinancialAnalysisService` to Singleton** (brief's Option B). Rejected because `IStockValueService` is Scoped and would become a captive dependency. Doing this properly requires refactoring scope handling inside `RefreshFinancialDataAsync` (e.g. resolving `IStockValueService` from a child scope per call), which is a larger architectural change and is not the goal of this finding.
+- **Adding a true at-most-one-refresh-in-flight guarantee** (e.g. a distributed lock, a `SemaphoreSlim` on a singleton coordinator, or an `Interlocked`-based gate). Not required by current product behavior; the throttle is best-effort and the refresh is idempotent.
+- **Changing the throttle duration** (10 minutes) or the `LAST_REFRESH_CACHE_KEY` TTL (24 hours).
+- **Refactoring the surrounding `RefreshFinancialDataAsync` method** (month loop, error handling, etc.) beyond removing the lock block.
+- **Touching any other module** of the application.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-financialoverview-instance-l/task-plan.r1.md
+++ b/artifacts/feat-arch-review-financialoverview-instance-l/task-plan.r1.md
@@ -1,0 +1,15 @@
+Plan saved to `docs/superpowers/plans/2026-06-08-remove-misleading-instance-lock-financial-analysis.md`.
+
+**Summary of the plan:**
+
+3 tasks, decomposed into bite-sized TDD steps with exact code and commands at every checkbox:
+
+1. **Task 1 — Pin behavior with a regression test** (4 steps). Added *before* touching the lock so it documents the throttle behavior under the current (lock-present) code, then proves the lock removal didn't regress it. Test seeds `financial_last_refresh` inside the 10-minute window and asserts `Times.Never` on both `ILedgerService.GetLedgerItems` and `IStockValueService.GetStockValueChangesAsync`. Matches the seeding pattern already used in `FinancialAnalysisServiceTests.cs:174`.
+
+2. **Task 2 — Remove the misleading lock** (9 steps). Deletes the `_refreshLock` field (line 22) and unwraps the `lock (_refreshLock) { ... }` block around the throttle check (lines 109-117). Each removal verified by a targeted grep. Build, format, test, and DI-module-unchanged checks all gated.
+
+3. **Task 3 — Final verification** (4 steps). Whole-solution build + full test suite + a diff-shape assertion that the only touched files are the two in scope — guards against accidentally editing the unrelated `_refreshLock` symbol in `ManufactureBasedMaterialCostProvider.cs` (different module, static `SemaphoreSlim`, must not be touched per the arch-review).
+
+The plan includes a spec-coverage table mapping every FR/NFR to its implementing step, the validation gate from `CLAUDE.md` (`dotnet build`, `dotnet format`, `dotnet test`), and the exact commit messages (one `test:` commit, one `refactor:` commit) so the diff history stays clean.
+
+Per the pipeline instructions, the execution-handoff prompt is intentionally skipped — the plan file is the deliverable.

--- a/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
@@ -19,8 +19,6 @@ public class FinancialAnalysisService : IFinancialAnalysisService
     private const string STOCK_DATA_CACHE_KEY_PREFIX = "financial_stock_data_";
     private const string LAST_REFRESH_CACHE_KEY = "financial_last_refresh";
 
-    private readonly object _refreshLock = new();
-
     public FinancialAnalysisService(
         ILedgerService ledgerService,
         IStockValueService stockValueService,
@@ -106,14 +104,11 @@ public class FinancialAnalysisService : IFinancialAnalysisService
         DateTime? endDate,
         CancellationToken cancellationToken = default)
     {
-        lock (_refreshLock)
+        var lastRefresh = _memoryCache.Get<DateTime?>(LAST_REFRESH_CACHE_KEY) ?? DateTime.MinValue;
+        if (DateTime.UtcNow - lastRefresh < TimeSpan.FromMinutes(10)) // Prevent too frequent refreshes
         {
-            var lastRefresh = _memoryCache.Get<DateTime?>(LAST_REFRESH_CACHE_KEY) ?? DateTime.MinValue;
-            if (DateTime.UtcNow - lastRefresh < TimeSpan.FromMinutes(10)) // Prevent too frequent refreshes
-            {
-                _logger.LogDebug("Skipping refresh, last refresh was too recent");
-                return;
-            }
+            _logger.LogDebug("Skipping refresh, last refresh was too recent");
+            return;
         }
 
         try

--- a/backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs
@@ -171,6 +171,38 @@ public class FinancialAnalysisServiceTests
             Times.AtLeast(1));
     }
 
+    [Fact]
+    public async Task RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices()
+    {
+        // Arrange: seed the last-refresh timestamp inside the 10-minute throttle window.
+        // The throttle check uses the cache key "financial_last_refresh" and skips the refresh
+        // when the timestamp is younger than 10 minutes.
+        _memoryCache.Set("financial_last_refresh", DateTime.UtcNow.AddMinutes(-1), TimeSpan.FromHours(24));
+
+        // Act
+        await _service.RefreshFinancialDataAsync(startDate: null, endDate: null);
+
+        // Assert: the throttle short-circuits before any downstream call.
+        _ledgerServiceMock.Verify(
+            x => x.GetLedgerItems(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "throttle should prevent any ledger query when last refresh was less than 10 minutes ago");
+
+        _stockValueServiceMock.Verify(
+            x => x.GetStockValueChangesAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "throttle should prevent any stock-value query when last refresh was less than 10 minutes ago");
+    }
+
     private void SeedCacheForMonth(int year, int month)
     {
         var key = $"financial_monthly_data_{year}_{month}";

--- a/docs/superpowers/plans/2026-06-08-remove-misleading-instance-lock-financial-analysis.md
+++ b/docs/superpowers/plans/2026-06-08-remove-misleading-instance-lock-financial-analysis.md
@@ -1,0 +1,366 @@
+# Remove misleading instance-level lock in FinancialAnalysisService — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the decorative `_refreshLock` instance lock from `FinancialAnalysisService` and rely solely on the shared `IMemoryCache` timestamp throttle, so the code accurately reflects its true concurrency guarantees.
+
+**Architecture:** `FinancialAnalysisService` is registered Scoped — every HTTP request and every `IServiceProvider.CreateScope()` (used by `BackgroundRefreshSchedulerService`) gets a fresh service instance with its own `_refreshLock`. The lock therefore guards only the single request thread that already owns the instance and provides zero cross-request protection. The only real cross-request gate is the `IMemoryCache` entry at key `financial_last_refresh`, which `IMemoryCache` makes thread-safe on its own. This plan removes the misleading lock and adds one regression test that pins the throttle behavior in place.
+
+**Tech Stack:** .NET 8, C#, `Microsoft.Extensions.Caching.Memory.IMemoryCache`, xUnit, Moq, FluentAssertions.
+
+---
+
+## File Structure
+
+Files modified by this plan (no new files):
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs` | Delete `_refreshLock` field (line 22) and the `lock (_refreshLock) { ... }` wrapper around the throttle check (lines 109-117). |
+| `backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs` | Add one regression test (`RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices`) that seeds `financial_last_refresh` inside the 10-minute window and asserts no downstream calls. |
+
+Out of scope and **must not be touched**:
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProvider.cs` — also defines a `_refreshLock`, but it is a different (static `SemaphoreSlim`) lock in an unrelated module.
+- `backend/src/Anela.Heblo.Application/Features/FinancialOverview/FinancialOverviewModule.cs` — DI registration stays Scoped.
+- `docs/plans/2025-12-21-margin-cache-architecture.md` — historical planning doc that references `_refreshLock`; leave as-is.
+- Every other method in `FinancialAnalysisService.cs` (`GetFinancialOverviewAsync`, `RefreshMonthlyDataAsync`, `GetCacheStatus`, `GetCachedFinancialOverview`, `GetHybridWithCurrentMonthAsync`, `GetFinancialOverviewRealTimeAsync`, `CreateStockSummary`) is untouched.
+
+---
+
+## Background context the implementer needs
+
+### Why this code exists in the first place
+`FinancialAnalysisService.RefreshFinancialDataAsync` is invoked from two places:
+1. **`BackgroundRefreshSchedulerService.RunTaskLoop`** — periodically calls registered refresh tasks. Per `BackgroundRefreshSchedulerService.cs:86`, every tick creates a fresh `IServiceProvider.CreateScope()` and resolves a brand-new `IFinancialAnalysisService` from it.
+2. **User-triggered cache-miss paths** — e.g. an HTTP request whose handler calls `RefreshFinancialDataAsync` to populate the cache. Each HTTP request also has its own DI scope.
+
+Because each invocation gets its own service instance, the `_refreshLock` field declared on the instance is created fresh per call and never contended. Removing it does not change observable behavior in any code path.
+
+### Why the throttle still works without the lock
+The throttle check on lines 111-116 reads `LAST_REFRESH_CACHE_KEY` from `IMemoryCache` and exits early if a refresh happened within the last 10 minutes. `IMemoryCache.Get<T>` and `IMemoryCache.Set` are thread-safe on `MemoryCache`, so the read and the write at line 143 do not need an extra `lock`. There is still a race window between read (line 111) and write (line 143) during which two callers could both pass the gate — but the lock never closed that window either (each caller holds its own lock), so removing it does not regress anything. The refresh is idempotent (writes the same keys with the same TTLs), so concurrent overlapping refreshes converge on the same cache state. See `spec.r1.md` NFR-2 for the documented honest semantics.
+
+### Why we are not promoting the service to Singleton
+`IStockValueService` is registered Scoped (`FinancialOverviewModule.cs:19`). Injecting a Scoped service into a Singleton creates a captive-dependency bug. Refactoring scope handling inside `RefreshFinancialDataAsync` to resolve `IStockValueService` per-call is a larger change explicitly out of scope per `spec.r1.md`.
+
+### Validation gate (from `CLAUDE.md`)
+Before declaring the task done:
+- `dotnet build` clean
+- `dotnet format` clean
+- `dotnet test` green for `backend/test/Anela.Heblo.Tests`
+
+No E2E, no migrations, no FE changes, no config changes.
+
+---
+
+### Task 1: Add the regression test that locks in the throttle behavior
+
+This test is added **before** the lock removal. It must pass against the current (lock-present) code so we can prove the throttle short-circuits downstream services without depending on the lock. After the lock removal in Task 2, it must continue to pass — that is the regression guarantee.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs` (add a new `[Fact]` at the end of the class, after the existing `GetFinancialOverviewAsync_WhenDepartmentsExcludedAndCurrentMonthRequested_UsesFullRealTime` test and before the private `SeedCacheForMonth` helper)
+
+#### Step 1.1: Add the regression test
+
+- [ ] **Add this `[Fact]` to `FinancialAnalysisServiceTests.cs`, immediately after the test method that ends at line 172 (the `GetFinancialOverviewAsync_WhenDepartmentsExcludedAndCurrentMonthRequested_UsesFullRealTime` test) and before the private `SeedCacheForMonth` helper declared at line 174:**
+
+```csharp
+[Fact]
+public async Task RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices()
+{
+    // Arrange: seed the last-refresh timestamp inside the 10-minute throttle window.
+    // The throttle check uses the cache key "financial_last_refresh" and skips the refresh
+    // when the timestamp is younger than 10 minutes.
+    _memoryCache.Set("financial_last_refresh", DateTime.UtcNow.AddMinutes(-1), TimeSpan.FromHours(24));
+
+    // Act
+    await _service.RefreshFinancialDataAsync(startDate: null, endDate: null);
+
+    // Assert: the throttle short-circuits before any downstream call.
+    _ledgerServiceMock.Verify(
+        x => x.GetLedgerItems(
+            It.IsAny<DateTime>(),
+            It.IsAny<DateTime>(),
+            It.IsAny<IEnumerable<string>?>(),
+            It.IsAny<IEnumerable<string>?>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()),
+        Times.Never,
+        "throttle should prevent any ledger query when last refresh was less than 10 minutes ago");
+
+    _stockValueServiceMock.Verify(
+        x => x.GetStockValueChangesAsync(
+            It.IsAny<DateTime>(),
+            It.IsAny<DateTime>(),
+            It.IsAny<CancellationToken>()),
+        Times.Never,
+        "throttle should prevent any stock-value query when last refresh was less than 10 minutes ago");
+}
+```
+
+Notes for the implementer:
+- The `_ledgerServiceMock`, `_stockValueServiceMock`, `_memoryCache`, and `_service` fields are already set up in the constructor at lines 20-53.
+- The 6-argument shape of `GetLedgerItems` (start, end, debit prefixes, credit prefixes, department, ct) matches the existing setup at lines 36-44, so do not modify or duplicate the constructor setup.
+- The cache key literal `"financial_last_refresh"` matches the `LAST_REFRESH_CACHE_KEY` constant defined in `FinancialAnalysisService.cs:20`. Keep the literal — do not try to import the private constant.
+- The 24-hour TTL on the `_memoryCache.Set` call mirrors how the production code writes this key at `FinancialAnalysisService.cs:143`.
+
+#### Step 1.2: Run the new test against current (unmodified) code
+
+- [ ] **Run the test and confirm it passes against the current code.**
+
+Run from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices"
+```
+
+Expected output: 1 passed, 0 failed. If it fails, **stop** — that means either (a) the test was not added correctly, or (b) the throttle is not behaving as `spec.r1.md` claims, both of which need investigation before continuing.
+
+#### Step 1.3: Run the whole touched test class to confirm no regression
+
+- [ ] **Run all tests in the file and confirm they all pass.**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~FinancialAnalysisServiceTests"
+```
+
+Expected: all green (4 existing tests + 1 new = 5 passed).
+
+#### Step 1.4: Commit the new test
+
+- [ ] **Commit the new test on its own.** Two commits keeps the lock-removal diff clean.
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs
+git commit -m "test: pin FinancialAnalysisService refresh throttle behavior"
+```
+
+---
+
+### Task 2: Remove the misleading `_refreshLock`
+
+Spec requirement: FR-1, FR-2, FR-3.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs`
+  - Delete line 22 (the `_refreshLock` field).
+  - Replace lines 109-117 (the `lock (_refreshLock) { ... }` block) with the bare throttle check.
+
+#### Step 2.1: Delete the `_refreshLock` field
+
+- [ ] **Remove line 22 from `FinancialAnalysisService.cs`.**
+
+Find and delete this exact line (preserve the blank line before line 24 so the spacing between the cache-key constants block and the constructor remains a single blank line):
+
+```csharp
+    private readonly object _refreshLock = new();
+```
+
+The block from lines 18-24 must look like this **after** the edit (no `_refreshLock` line):
+
+```csharp
+    private const string MONTHLY_DATA_CACHE_KEY_PREFIX = "financial_monthly_data_";
+    private const string STOCK_DATA_CACHE_KEY_PREFIX = "financial_stock_data_";
+    private const string LAST_REFRESH_CACHE_KEY = "financial_last_refresh";
+
+    public FinancialAnalysisService(
+```
+
+#### Step 2.2: Remove the lock wrapper around the throttle check
+
+- [ ] **Replace the entire block at lines 109-117 (the `lock (_refreshLock) { ... }` block) with the unwrapped throttle check.**
+
+Replace this:
+
+```csharp
+        lock (_refreshLock)
+        {
+            var lastRefresh = _memoryCache.Get<DateTime?>(LAST_REFRESH_CACHE_KEY) ?? DateTime.MinValue;
+            if (DateTime.UtcNow - lastRefresh < TimeSpan.FromMinutes(10)) // Prevent too frequent refreshes
+            {
+                _logger.LogDebug("Skipping refresh, last refresh was too recent");
+                return;
+            }
+        }
+```
+
+with this:
+
+```csharp
+        var lastRefresh = _memoryCache.Get<DateTime?>(LAST_REFRESH_CACHE_KEY) ?? DateTime.MinValue;
+        if (DateTime.UtcNow - lastRefresh < TimeSpan.FromMinutes(10)) // Prevent too frequent refreshes
+        {
+            _logger.LogDebug("Skipping refresh, last refresh was too recent");
+            return;
+        }
+```
+
+Notes for the implementer:
+- Indentation: the replacement body is one level shallower than the original. The opening of `RefreshFinancialDataAsync` is `public async Task RefreshFinancialDataAsync(...)`, so the body is indented with 8 spaces (two levels: class + method). Do **not** leave the body indented at 12 spaces (the depth it had inside `lock { ... }`).
+- Preserve the `// Prevent too frequent refreshes` inline comment exactly. It is an existing comment on the original line — the "surgical changes" rule in CLAUDE.md says to preserve unrelated content. (Per spec FR-2 the throttle behavior must be byte-identical apart from the lock removal.)
+- Preserve the `_logger.LogDebug("Skipping refresh, last refresh was too recent")` call verbatim — same message, same log level.
+- Do not touch anything inside the `try` block that follows. Lines from `try` (was line 119) onward stay byte-identical.
+
+#### Step 2.3: Verify no `_refreshLock` references remain in this file or the test file
+
+- [ ] **Grep the modified files to confirm `_refreshLock` is gone from both.**
+
+```bash
+grep -n "_refreshLock" \
+  backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs \
+  backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs
+```
+
+Expected output: nothing (no lines printed, exit code 1 from `grep`).
+
+If you see any match, the edit was incomplete — re-run the edit step.
+
+#### Step 2.4: Verify no `lock` keyword remains in `FinancialAnalysisService.cs`
+
+- [ ] **Per spec FR-2, no `lock` keyword should remain in the file.**
+
+```bash
+grep -nw "lock" \
+  backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
+```
+
+Expected output: nothing.
+
+#### Step 2.5: Build the backend solution
+
+- [ ] **Run `dotnet build` and confirm zero new warnings.**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with zero warnings introduced by this change. If the build introduces a new warning (e.g. an "unused field" hint that did not exist before), investigate before continuing — the spec FR-1 requires zero new warnings.
+
+#### Step 2.6: Apply formatter
+
+- [ ] **Run `dotnet format` so whitespace matches project conventions.**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+Expected: exit code 0. If formatting produces changes inside the modified file, that is expected — accept them. If it produces changes in unrelated files, **stop and review**: the project's "surgical changes" rule says we should not be reformatting files we did not touch. In that case revert the unrelated formatter changes with `git checkout -- <path>` and proceed.
+
+#### Step 2.7: Run the touched test project
+
+- [ ] **Run all tests in `Anela.Heblo.Tests` and confirm they all pass.**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all green. The new regression test from Task 1 must still pass — that is the whole point of adding it before the lock removal.
+
+If any other test fails, it most likely depends indirectly on the lock object's existence or timing; investigate before continuing. (Per arch-review, none of the existing tests reference `_refreshLock`, so a failure here is unexpected.)
+
+#### Step 2.8: Confirm DI registration is unchanged
+
+- [ ] **Spec FR-3 requires `FinancialOverviewModule.cs` to be untouched. Confirm with `git diff`.**
+
+```bash
+git diff backend/src/Anela.Heblo.Application/Features/FinancialOverview/FinancialOverviewModule.cs
+```
+
+Expected output: nothing (empty diff).
+
+#### Step 2.9: Commit the lock removal
+
+- [ ] **Commit the lock-removal diff.**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
+git commit -m "refactor: remove misleading instance-level lock in FinancialAnalysisService
+
+The _refreshLock field on FinancialAnalysisService was decorative.
+The service is registered Scoped, so each HTTP request and each
+IServiceProvider.CreateScope() (used by BackgroundRefreshSchedulerService)
+gets its own instance with its own _refreshLock — concurrent callers
+never contended on the same monitor.
+
+The real cross-request gate is the IMemoryCache entry at the
+'financial_last_refresh' key, which IMemoryCache makes thread-safe
+on its own. Removing the lock leaves observable behavior unchanged
+and removes the false implication of cross-instance coordination."
+```
+
+---
+
+### Task 3: Final verification
+
+#### Step 3.1: Whole-solution build
+
+- [ ] **Run a clean build of the full solution to confirm no regressions outside the modified module.**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with zero new warnings.
+
+#### Step 3.2: Run the full backend test suite
+
+- [ ] **Run all backend tests.**
+
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: all green. If a test outside `FinancialAnalysisServiceTests` fails, it almost certainly is unrelated (the diff only touches one private field and one synchronization wrapper) — investigate and report rather than papering over.
+
+#### Step 3.3: Confirm the final diff is exactly the two intended files
+
+- [ ] **Print the changed-file list since main and confirm it is exactly the two files in scope.**
+
+```bash
+git diff --name-only main...HEAD
+```
+
+Expected output (exactly these two paths, in some order):
+
+```
+backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
+backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs
+```
+
+If any other file appears (especially `ManufactureBasedMaterialCostProvider.cs`, `FinancialOverviewModule.cs`, or anything in `docs/plans/`), **stop** — that file should not have been touched. Inspect with `git diff` and `git checkout -- <path>` to revert anything unintended.
+
+#### Step 3.4: Confirm the FinancialAnalysisService diff is exactly the lock removal
+
+- [ ] **Inspect the `FinancialAnalysisService.cs` diff and confirm it touches only the two regions specified by FR-1 and FR-2.**
+
+```bash
+git diff main...HEAD -- backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
+```
+
+Expected shape:
+- One removed line: `    private readonly object _refreshLock = new();` (plus possibly a blank line)
+- The lock wrapper (`lock (_refreshLock)`, the opening `{`, and the closing `}`) removed; the throttle body re-indented by 4 spaces (one level shallower).
+- No other changes — no touched whitespace anywhere else, no touched method body anywhere else.
+
+If the diff is larger than that, undo the extra changes before proceeding to PR.
+
+---
+
+## Spec coverage map
+
+| Spec requirement | Implemented by |
+|------------------|----------------|
+| FR-1: remove `_refreshLock` field | Step 2.1, verified by Step 2.3 |
+| FR-2: remove the `lock` block but keep the throttle check (same log message, same early return, same successful-refresh path) | Step 2.2, verified by Step 2.4 |
+| FR-3: no other code path changes; `FinancialOverviewModule.cs` unchanged; `IFinancialAnalysisService` surface unchanged | Step 2.8 confirms DI module untouched; Steps 3.3 + 3.4 confirm diff is limited to the two intended files and regions |
+| FR-4: regression test for second call within 10-minute window being a no-op (no new ledger / stock-value invocations) | Task 1 (added before lock removal); verified again in Step 2.7 and Step 3.2 |
+| NFR-1: no measurable performance change | Inherent to the change; no benchmark required by spec |
+| NFR-2: honest concurrency semantics | Documented in this plan's "Background context"; spec NFR-2 explicitly accepts the residual best-effort throttle race |
+| NFR-3: no security impact | No auth / input / secrets touched; verified by Step 3.3's file-list assertion |
+| NFR-4: backward compatibility | No API / contract / config / schema change; verified by Step 2.8 |
+| Out of Scope: do not promote to Singleton, do not add new at-most-one-in-flight guarantee, do not change throttle duration, do not refactor surrounding method | The plan does none of these; Step 3.4's diff-shape check is the guardrail |
+
+## Pipeline note
+
+This plan was authored as part of an automated pipeline. Per the pipeline instructions, the execution-handoff prompt is intentionally omitted — the file content above is the deliverable artifact.


### PR DESCRIPTION

Removes the misleading `_refreshLock` instance lock from `FinancialAnalysisService.RefreshFinancialDataAsync`. Because the service is registered Scoped, every HTTP request and every `IServiceProvider.CreateScope()` call (used by `BackgroundRefreshSchedulerService`) receives a fresh service instance, so the lock was never contended and provided zero cross-request protection. The actual cross-request throttle gate is the `IMemoryCache` entry at `financial_last_refresh`, which `MemoryCache` makes thread-safe on its own. Removing the lock eliminates the false implication of cross-instance coordination without changing any observable behavior.

A regression test was added before the removal to pin the throttle's short-circuit behavior: it seeds the cache key inside the 10-minute window and asserts that no downstream `ILedgerService` or `IStockValueService` calls are made.

### Changes
- `backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs` — deleted `_refreshLock` field and unwrapped the `lock` block around the throttle check
- `backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs` — added `RefreshFinancialDataAsync_WhenLastRefreshWithinThrottleWindow_DoesNotInvokeDownstreamServices` regression test

---

Closes #2688

### Tokens used
10495430
