### PR TITLE
feat: Encapsulate Article Feedback Submission in the Domain Entity

### DIFF
--- a/artifacts/feat-arch-review-article-feedback-state-set-v/arch-review.r1.md
+++ b/artifacts/feat-arch-review-article-feedback-state-set-v/arch-review.r1.md
@@ -1,0 +1,155 @@
+# Architecture Review: Encapsulate Article Feedback Submission in the Domain Entity
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The proposal aligns perfectly with the established patterns in this codebase. Verified against the actual sources:
+
+- **Entity convention** (`backend/src/Anela.Heblo.Domain/Features/Article/Article.cs`): `Article` already exposes lifecycle behavior via `MarkAsResearching`, `MarkAsWriting`, `MarkAsGenerated`, and `MarkAsFailed`. Feedback submission is the sole anemic outlier. The new method slots into the existing method group without altering the entity's shape, identity, or persistence mapping.
+- **Domain-model guideline** (`docs/architecture/development_guidelines.md` — "Common Pitfalls #6: Don't create anemic domain models — Put behavior in entities"): this refactor is the canonical example of compliance.
+- **Handler boundary** (ADR-005, `SubmitArticleFeedbackHandler.cs:34-55`): identity resolution, repository access, and typed error responses stay in the handler — the entity stays free of cross-cutting collaborators. Keeping guards in the handler is correct under the codebase's conventions.
+- **Vertical-slice layout**: no boundary, contract, DTO, or DI binding moves. The OpenAPI surface and generated TypeScript client are untouched.
+
+Integration points are minimal and local: one new method, one call-site swap, one new domain test file. No infrastructure, migrations, or cross-module ripple.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP POST /api/articles/{id}/feedback
+        │
+        ▼
+ArticlesController (unchanged)
+        │  MediatR send
+        ▼
+SubmitArticleFeedbackHandler
+  ├── ICurrentUserService.GetCurrentUser()      [identity]
+  ├── IArticleRepository.GetForUpdateAsync()    [load]
+  ├── guard: ArticleNotFound
+  ├── guard: Forbidden (RequestedBy match)
+  ├── guard: ArticleNotGenerated
+  ├── guard: ArticleFeedbackAlreadySubmitted
+  ├── article.SubmitFeedback(p, s, c)           [NEW — entity behavior]
+  └── IArticleRepository.SaveChangesAsync()     [persist via EF change tracker]
+        │
+        ▼
+SubmitArticleFeedbackResponse
+```
+
+The only structural change: a single mutation site moves from the handler into the entity.
+
+### Key Design Decisions
+
+#### Decision 1: Keep guards in the handler, not the entity
+**Options considered:**
+1. Mirror the existing `MarkAs*` style: pure setter aggregator on the entity, guards stay in the handler.
+2. Push guard logic into the entity by throwing typed domain exceptions, then catch and map in the handler.
+
+**Chosen approach:** Option 1.
+
+**Rationale:** The brief and spec both scope this as a pure refactor. The handler's guards depend on collaborators (`ICurrentUserService`, repository state) and need typed error responses (`ErrorCodes.*`) that the rest of the slice already shapes. Introducing a domain-exceptions-to-error-codes translation layer for one method would be a larger architectural change than the brief justifies. This matches how the other `MarkAs*` methods behave (no internal guards beyond `MarkAsFailed`'s truncation, which is normalization, not validation).
+
+#### Decision 2: Do not change setter visibility on the three feedback properties
+**Options considered:**
+1. Leave public setters in place (EF Core + existing tests rely on them).
+2. Tighten to `private set` and switch tests to a factory/builder.
+
+**Chosen approach:** Option 1.
+
+**Rationale:** The existing test factory (`CreateArticle(..., precisionScore: 4, ...)`) and the handler-guard-stage assignments in seven test scenarios depend on the public setters. Tightening visibility is a separate, larger refactor explicitly listed as Out of Scope in the spec. This decision keeps the change surgical.
+
+#### Decision 3: Place the new domain test under `Tests/Domain/Article/`, not `Tests/Article/Domain/`
+**Options considered:**
+1. Follow the spec literally: `backend/test/Anela.Heblo.Tests/Article/Domain/ArticleTests.cs`.
+2. Follow the established repo convention.
+
+**Chosen approach:** Option 2 — `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs`.
+
+**Rationale:** Verified against the existing test tree: every other domain-entity test lives under `Tests/Domain/{Feature}/{Entity}Tests.cs` (`Domain/Logistics/TransportBoxStateTransitionTests.cs`, `Domain/Purchase/PurchaseOrderTests.cs`, `Domain/Catalog/CatalogAggregateTests.cs`, `Domain/Marketing/MarketingActionConstructorTests.cs`). The spec's proposed path inverts the namespace hierarchy and would create the first inconsistent location. See **Specification Amendments** below.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/
+├── src/Anela.Heblo.Domain/Features/Article/
+│   └── Article.cs                              [EDIT — add SubmitFeedback]
+├── src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/
+│   └── SubmitArticleFeedbackHandler.cs         [EDIT — replace lines 57-59]
+└── test/Anela.Heblo.Tests/
+    ├── Domain/Article/
+    │   └── ArticleTests.cs                     [NEW — entity-level tests]
+    └── Article/UseCases/
+        └── SubmitArticleFeedbackHandlerTests.cs [UNCHANGED — must pass as-is]
+```
+
+### Interfaces and Contracts
+
+```csharp
+// Anela.Heblo.Domain.Features.Article.Article — NEW METHOD
+// Placement: alongside MarkAsFailed (last method in the file)
+public void SubmitFeedback(int precisionScore, int styleScore, string? comment)
+{
+    PrecisionScore = precisionScore;
+    StyleScore = styleScore;
+    FeedbackComment = comment;
+}
+```
+
+```csharp
+// SubmitArticleFeedbackHandler.Handle — CHANGED BODY (lines 57-59)
+// Before:
+article.PrecisionScore = request.PrecisionScore;
+article.StyleScore = request.StyleScore;
+article.FeedbackComment = request.Comment;
+// After:
+article.SubmitFeedback(request.PrecisionScore, request.StyleScore, request.Comment);
+```
+
+No new types, no signature changes, no contract surface changes, no DI changes, no module registration changes. Public setters on `PrecisionScore`, `StyleScore`, `FeedbackComment` remain — required by EF Core change tracking and by the existing handler-test factory.
+
+### Data Flow
+
+1. Controller forwards HTTP body → `SubmitArticleFeedbackRequest` (MediatR).
+2. Handler loads tracked entity via `GetForUpdateAsync`.
+3. Handler runs four guards → typed error responses on failure.
+4. Handler calls `article.SubmitFeedback(p, s, c)` — sets three properties on the tracked entity.
+5. Handler calls `SaveChangesAsync` — EF Core emits the same `UPDATE Articles SET PrecisionScore=…, StyleScore=…, FeedbackComment=… WHERE Id=…` as today.
+6. Handler reads the three values back off the entity into `SubmitArticleFeedbackResponse`.
+
+The persistence path is byte-identical to today's. The only difference is the call stack at step 4.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing handler test (`HappyPath_SubmitsFeedback`) asserts on entity properties after `Handle` returns — could regress if method body diverges from direct assignment | LOW | Method body is a 3-line setter aggregator; the existing 7 scenarios remain unmodified and must pass. Validation = `dotnet test` on `Anela.Heblo.Tests`. |
+| EF Core change tracking misses one of the three properties if a future contributor adds normalization that creates a new object instead of mutating | LOW | Stay with in-place property assignment inside `SubmitFeedback`. If a future change adds bounds enforcement, the established pattern (see `MarkAsFailed`'s truncation) is in-place mutation, not record-style cloning. |
+| Spec asks for the test file at a non-canonical path | LOW | Place new tests under `Tests/Domain/Article/ArticleTests.cs` per repo convention. See Amendments. |
+| Future contributor reintroduces direct property assignment in another handler | LOW | Out of scope. Could be addressed later by tightening setters to `private set`, but that is a separate refactor explicitly out of scope here. |
+
+## Specification Amendments
+
+1. **Test file location.** Replace the proposed path `backend/test/Anela.Heblo.Tests/Article/Domain/ArticleTests.cs` with **`backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs`** and namespace **`Anela.Heblo.Tests.Domain.Article`**. This mirrors every existing domain-entity test in the repo (`Domain/Logistics`, `Domain/Purchase`, `Domain/Catalog`, `Domain/Marketing`).
+
+2. **Method placement clarification.** Place `SubmitFeedback` **immediately after `MarkAsFailed`** at the end of `Article.cs`. The current method ordering is chronological by lifecycle (`Researching → Writing → Generated → Failed`); feedback is the post-`Generated` action, so appending it preserves the lifecycle reading order.
+
+3. **No need to verify "first entity test"**: an existing `ArticleTests.cs` under `Tests/Domain/Article/` does **not** currently exist (verified). The new file establishes that location for this entity.
+
+No other amendments. The spec is otherwise tight and accurate.
+
+## Prerequisites
+
+None.
+
+- No migrations.
+- No configuration / Key Vault changes.
+- No DI registrations.
+- No OpenAPI regeneration.
+- No frontend changes.
+- No infrastructure changes.
+
+Implementation can begin immediately against the current `main`/feature branch.

--- a/artifacts/feat-arch-review-article-feedback-state-set-v/brief.md
+++ b/artifacts/feat-arch-review-article-feedback-state-set-v/brief.md
@@ -1,0 +1,55 @@
+## Module
+Article
+
+## Finding
+
+The `Article` entity encapsulates all status transitions through explicit methods:
+
+```csharp
+// backend/src/Anela.Heblo.Domain/Features/Article/Article.cs
+public void MarkAsResearching() => Status = ArticleStatus.Researching;
+public void MarkAsWriting() => Status = ArticleStatus.Writing;
+public void MarkAsGenerated(string? title, string? htmlContent) { ... }
+public void MarkAsFailed(string errorMessage) { ... }  // includes truncation logic
+```
+
+However, `SubmitArticleFeedbackHandler` bypasses this pattern and mutates the entity's feedback properties directly from the handler:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs lines 57-59
+article.PrecisionScore = request.PrecisionScore;
+article.StyleScore = request.StyleScore;
+article.FeedbackComment = request.Comment;
+```
+
+The business rule "an article can receive feedback exactly once, from its requester, when in Generated state" is split across the handler (the guard checks) and direct property assignment — rather than being expressed through an entity method like `article.SubmitFeedback(precisionScore, styleScore, comment)`.
+
+## Why it matters
+
+- **Anemic domain model**: the development guidelines explicitly state "Don't create anemic domain models — Put behavior in entities." The entity already follows this for status transitions; feedback is the inconsistent exception.
+- **Scattered future logic**: `MarkAsFailed` already embeds truncation logic inside the entity. If feedback scores ever need normalization, bounds enforcement, or a `FeedbackSubmittedAt` timestamp, that logic would land in the handler rather than the entity — contradicting the established pattern.
+- **Discoverability**: a developer looking at `Article.cs` to understand what state transitions the entity supports will not find feedback submission there.
+
+## Suggested fix
+
+Add a `SubmitFeedback` method to the `Article` entity in `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs`:
+
+```csharp
+public void SubmitFeedback(int precisionScore, int styleScore, string? comment)
+{
+    PrecisionScore = precisionScore;
+    StyleScore = styleScore;
+    FeedbackComment = comment;
+}
+```
+
+Replace the three direct property assignments in `SubmitArticleFeedbackHandler` (lines 57–59) with:
+
+```csharp
+article.SubmitFeedback(request.PrecisionScore, request.StyleScore, request.Comment);
+```
+
+No change to the guard logic or response shape is needed.
+
+---
+_Filed by daily arch-review routine on 2026-06-07._

--- a/artifacts/feat-arch-review-article-feedback-state-set-v/impl/main.r1.md
+++ b/artifacts/feat-arch-review-article-feedback-state-set-v/impl/main.r1.md
@@ -1,0 +1,57 @@
+All four tasks complete. Writing the output artifact.
+
+---
+
+# Implementation: Encapsulate Article Feedback Submission in Domain Entity
+
+## What was implemented
+
+A pure refactor that moves the three direct property assignments (`PrecisionScore`, `StyleScore`, `FeedbackComment`) from `SubmitArticleFeedbackHandler` into a new `Article.SubmitFeedback(precisionScore, styleScore, comment)` method on the domain entity. The entity now fully owns its lifecycle, consistent with `MarkAsResearching`, `MarkAsWriting`, `MarkAsGenerated`, `MarkAsFailed`. All behavior, error codes, HTTP shape, and persistence path are unchanged.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs` — added `SubmitFeedback(int precisionScore, int styleScore, string? comment)` method after `MarkAsFailed` (+6 lines)
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs` — replaced three direct property assignments with one `article.SubmitFeedback(...)` call (−3 +1 lines)
+- `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs` — new entity-level test file (created, ~40 lines)
+- `docs/superpowers/plans/2026-06-08-encapsulate-article-feedback-submission.md` — implementation plan (committed)
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs`:
+  - `SubmitFeedback_AssignsAllThreeProperties` — verifies all three properties are set correctly
+  - `SubmitFeedback_NullComment_IsAllowed` — verifies null comment does not throw
+- `backend/test/Anela.Heblo.Tests/Article/UseCases/SubmitArticleFeedbackHandlerTests.cs` — all 8 existing scenarios pass unchanged
+
+## How to verify
+
+```bash
+# Entity tests (2 pass)
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Domain.Article.ArticleTests" --nologo
+
+# Handler tests (8 pass)
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~SubmitArticleFeedbackHandlerTests" --nologo
+
+# Full build
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+## Notes
+
+- The test file uses fully-qualified `Heblo.Domain.Features.Article.Article` (not just `Article`) because the test namespace `Anela.Heblo.Tests.Domain.Article` shadows the entity type — this is required, not a style issue.
+- 38 Docker/Testcontainers integration tests fail in the full suite because Docker is not running in this environment; these are pre-existing and unrelated to this change.
+- No DI changes, no migrations, no OpenAPI regeneration, no frontend changes.
+
+## PR Summary
+
+Encapsulates article feedback submission in the `Article` domain entity by introducing a `SubmitFeedback(precisionScore, styleScore, comment)` method, replacing the three direct property assignments that lived in `SubmitArticleFeedbackHandler`. This closes the last anemic-model gap in the entity, aligning feedback with the established `MarkAs*` lifecycle-method pattern. All existing handler tests pass unchanged; two new focused entity-level tests establish the canonical `Domain/Article/ArticleTests.cs` location.
+
+### Changes
+- `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs` — added `SubmitFeedback` method after `MarkAsFailed`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs` — single `article.SubmitFeedback(...)` call replaces three property assignments
+- `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs` — new: two xUnit facts verifying the entity method in isolation
+- `docs/superpowers/plans/2026-06-08-encapsulate-article-feedback-submission.md` — implementation plan
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-article-feedback-state-set-v/spec.r1.md
+++ b/artifacts/feat-arch-review-article-feedback-state-set-v/spec.r1.md
@@ -1,0 +1,106 @@
+I have enough context to write the spec. The brief is clear and surgical — moving three property assignments into an entity method.
+
+# Specification: Encapsulate Article Feedback Submission in the Domain Entity
+
+## Summary
+Move the direct mutation of `Article.PrecisionScore`, `Article.StyleScore`, and `Article.FeedbackComment` out of `SubmitArticleFeedbackHandler` and into a new `Article.SubmitFeedback(precisionScore, styleScore, comment)` method on the domain entity. This brings feedback submission in line with the entity's existing state-transition pattern (`MarkAsResearching`, `MarkAsWriting`, `MarkAsGenerated`, `MarkAsFailed`) and removes the last anemic-model gap in this entity.
+
+## Background
+`backend/src/Anela.Heblo.Domain/Features/Article/Article.cs` already encapsulates every other lifecycle change as a method on the entity. Only feedback submission (`SubmitArticleFeedbackHandler.cs:57-59`) reaches into the entity and sets three public setters directly. The development guidelines (`docs/architecture/development_guidelines.md`) explicitly call out "Don't create anemic domain models — put behavior in entities." Aligning this one call site is a small, low-risk refactor that pays compounding interest the next time feedback gains behavior (timestamps, bounds enforcement, normalization, an `IsFeedbackSubmitted` predicate, or domain events).
+
+This is a pure refactor: behavior, public API, response shape, error codes, and guard logic are unchanged.
+
+## Functional Requirements
+
+### FR-1: Add `SubmitFeedback` method to the `Article` entity
+A new public instance method `SubmitFeedback(int precisionScore, int styleScore, string? comment)` is added to `Anela.Heblo.Domain.Features.Article.Article`. The method assigns the three values to `PrecisionScore`, `StyleScore`, and `FeedbackComment` respectively. It performs no validation and raises no exceptions — guard logic remains in the handler in this revision (see Out of Scope for the rationale).
+
+**Acceptance criteria:**
+- A method with signature `public void SubmitFeedback(int precisionScore, int styleScore, string? comment)` exists on `Article`.
+- After calling `article.SubmitFeedback(p, s, c)`, `article.PrecisionScore == p`, `article.StyleScore == s`, and `article.FeedbackComment == c`.
+- The method is grouped with the other state-transition methods (`MarkAsResearching`, `MarkAsWriting`, `MarkAsGenerated`, `MarkAsFailed`) in `Article.cs`.
+- No other members of `Article` are modified; public setters on the three feedback properties remain in place (EF Core and existing tests rely on them).
+
+### FR-2: Replace direct property assignment in `SubmitArticleFeedbackHandler`
+The three lines at `SubmitArticleFeedbackHandler.cs:57-59` are replaced with a single call to the new entity method.
+
+**Acceptance criteria:**
+- `SubmitArticleFeedbackHandler.Handle` calls `article.SubmitFeedback(request.PrecisionScore, request.StyleScore, request.Comment)` exactly once, immediately after the four guard checks (article-found, requester-match, status-is-Generated, no-prior-feedback) and immediately before `await _repository.SaveChangesAsync(ct)`.
+- No `article.PrecisionScore = …`, `article.StyleScore = …`, or `article.FeedbackComment = …` assignments remain in the handler.
+- The guard block (lines 26–55), the call to `SaveChangesAsync`, and the response construction are unchanged.
+- The response continues to populate `PrecisionScore`, `StyleScore`, and `FeedbackComment` from `article` after the call.
+
+### FR-3: Preserve all existing behavior and error semantics
+This is a refactor, not a behavior change. Every observable contract — HTTP shape, error codes, status code paths, validation, and persistence — stays identical.
+
+**Acceptance criteria:**
+- The existing test suite in `backend/test/Anela.Heblo.Tests/Article/UseCases/SubmitArticleFeedbackHandlerTests.cs` passes unmodified.
+- The seven existing test scenarios continue to produce the same `ErrorCode` / `Success` / persisted-field values: article-missing, other-user, same-display-name-different-identifier, same-identifier-different-display-name, null-`RequestedBy`, not-generated, already-submitted, and happy path.
+- No changes to `SubmitArticleFeedbackRequest`, `SubmitArticleFeedbackResponse`, `IArticleRepository`, or any controller.
+
+### FR-4: Add a unit test for the new entity method
+A small focused test verifies `Article.SubmitFeedback` in isolation, mirroring the structure of any existing entity-method tests (or introducing the first one if none exist).
+
+**Acceptance criteria:**
+- Test file `backend/test/Anela.Heblo.Tests/Article/Domain/ArticleTests.cs` (or the existing equivalent if one is found during implementation) contains at least one xUnit `[Fact]` named `SubmitFeedback_AssignsAllThreeProperties` that:
+  - Arranges a new `Article` with `PrecisionScore`, `StyleScore`, and `FeedbackComment` all `null`.
+  - Acts: calls `article.SubmitFeedback(5, 4, "Great")`.
+  - Asserts (FluentAssertions): all three properties hold the supplied values.
+- A second `[Fact]` named `SubmitFeedback_NullComment_IsAllowed` confirms `article.SubmitFeedback(3, 3, null)` does not throw and leaves `FeedbackComment` null.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change. The method is a trivial property-setter aggregation called once per `SubmitArticleFeedback` HTTP request (already a low-volume endpoint).
+
+### NFR-2: Security
+No change. Authorization, ownership check, and status guard continue to run in the handler before the entity method is invoked. The entity method is unreachable from outside an authenticated, authorized handler.
+
+### NFR-3: Maintainability
+Behavior co-located with state — a developer reading `Article.cs` sees the full lifecycle (status transitions + feedback) without jumping to handlers. New feedback-related logic (timestamps, normalization, bounds enforcement, domain events) will have an obvious home.
+
+### NFR-4: Backward compatibility
+The public HTTP contract, the OpenAPI surface, and the generated TypeScript client are unchanged. No client regeneration is required.
+
+## Data Model
+No schema changes. The three columns on the `Articles` table (`PrecisionScore`, `StyleScore`, `FeedbackComment`) are written by the same EF Core change tracking on the same entity instance — only the C# call path that mutates the in-memory entity changes.
+
+## API / Interface Design
+
+**Domain (new):**
+```csharp
+// Anela.Heblo.Domain.Features.Article.Article
+public void SubmitFeedback(int precisionScore, int styleScore, string? comment)
+{
+    PrecisionScore = precisionScore;
+    StyleScore = styleScore;
+    FeedbackComment = comment;
+}
+```
+
+**Application (changed):**
+```csharp
+// SubmitArticleFeedbackHandler.Handle — replace lines 57-59
+article.SubmitFeedback(request.PrecisionScore, request.StyleScore, request.Comment);
+```
+
+**HTTP / OpenAPI:** unchanged. The `POST /api/articles/{id}/feedback` (or equivalent) endpoint, its request/response DTOs, and all error codes (`ArticleNotFound`, `Forbidden`, `ArticleNotGenerated`, `ArticleFeedbackAlreadySubmitted`) remain exactly as today.
+
+## Dependencies
+- `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs` — entity edit.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs` — handler edit.
+- `backend/test/Anela.Heblo.Tests/Article/UseCases/SubmitArticleFeedbackHandlerTests.cs` — existing tests, expected to pass unchanged.
+- No new NuGet packages. No infrastructure changes. No database migration.
+
+## Out of Scope
+- **Moving the guard checks into the entity.** The handler retains the four guards (not-found, forbidden, not-generated, already-submitted) because they require collaborators (`ICurrentUserService`, `IArticleRepository`) and need to return typed error responses. Pushing them into the entity would require introducing domain exceptions and a translation layer in the handler — a larger refactor that is explicitly *not* requested by the brief.
+- **Making feedback properties `private set` / `init`.** The brief does not request encapsulating the setters; EF Core mapping and the existing test factory (`CreateArticle(..., precisionScore: 4, ...)`) read/write them directly. Tightening setter visibility is a separate, larger change.
+- **Adding a `FeedbackSubmittedAt` timestamp.** Mentioned in the brief as a *future* possibility — not part of this change.
+- **Normalization or bounds enforcement inside `SubmitFeedback`.** Range validation (1–5) lives on the request DTO via `[Range(1, 5)]` and is enforced by ASP.NET model binding. Duplicating it in the entity is unnecessary right now.
+- **Converting `Article` to a domain-events-publishing aggregate.** Out of scope for this refactor.
+- **Frontend changes.** None — the HTTP contract is unchanged.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-article-feedback-state-set-v/task-plan.r1.md
+++ b/artifacts/feat-arch-review-article-feedback-state-set-v/task-plan.r1.md
@@ -1,0 +1,8 @@
+Plan saved to `docs/superpowers/plans/2026-06-08-encapsulate-article-feedback-submission.md`.
+
+**Self-review:**
+- **Spec coverage:** FR-1 → Task 2; FR-2 → Task 3; FR-3 → Task 3 Step 2 + Task 4 Step 3; FR-4 → Task 1 (both `_AssignsAllThreeProperties` and `_NullComment_IsAllowed`). Arch-review amendments applied: test path `Domain/Article/ArticleTests.cs` and method placement after `MarkAsFailed`.
+- **Placeholders:** none — every code block contains complete content, every command is exact.
+- **Type consistency:** `SubmitFeedback(int precisionScore, int styleScore, string? comment)` and property names match across Tasks 1–3.
+
+**Plan shape:** 4 tasks, TDD red→green→refactor, each step 2–5 minutes, three commits + optional format commit. Touches exactly two source files and one new test file — no DI, OpenAPI, migrations, or frontend.

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs
@@ -54,9 +54,7 @@ public sealed class SubmitArticleFeedbackHandler
                 new Dictionary<string, string> { { "id", request.ArticleId.ToString() } });
         }
 
-        article.PrecisionScore = request.PrecisionScore;
-        article.StyleScore = request.StyleScore;
-        article.FeedbackComment = request.Comment;
+        article.SubmitFeedback(request.PrecisionScore, request.StyleScore, request.Comment);
 
         await _repository.SaveChangesAsync(ct);
 

--- a/backend/src/Anela.Heblo.Domain/Features/Article/Article.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Article/Article.cs
@@ -46,4 +46,11 @@ public sealed class Article
         Status = ArticleStatus.Failed;
         ErrorMessage = errorMessage.Length > 500 ? errorMessage[..500] : errorMessage;
     }
+
+    public void SubmitFeedback(int precisionScore, int styleScore, string? comment)
+    {
+        PrecisionScore = precisionScore;
+        StyleScore = styleScore;
+        FeedbackComment = comment;
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs
@@ -2,45 +2,44 @@ using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
 using Xunit;
 
-namespace Anela.Heblo.Tests.Domain.Article
+namespace Anela.Heblo.Tests.Domain.Article;
+
+public class ArticleTests
 {
-    public class ArticleTests
+    [Fact]
+    public void SubmitFeedback_AssignsAllThreeProperties()
     {
-        [Fact]
-        public void SubmitFeedback_AssignsAllThreeProperties()
+        var article = new Heblo.Domain.Features.Article.Article
         {
-            var article = new Heblo.Domain.Features.Article.Article
-            {
-                Id = Guid.NewGuid(),
-                Topic = "topic",
-            };
+            Id = Guid.NewGuid(),
+            Topic = "topic",
+        };
 
-            article.PrecisionScore.Should().BeNull();
-            article.StyleScore.Should().BeNull();
-            article.FeedbackComment.Should().BeNull();
+        article.PrecisionScore.Should().BeNull();
+        article.StyleScore.Should().BeNull();
+        article.FeedbackComment.Should().BeNull();
 
-            article.SubmitFeedback(precisionScore: 5, styleScore: 4, comment: "Great");
+        article.SubmitFeedback(precisionScore: 5, styleScore: 4, comment: "Great");
 
-            article.PrecisionScore.Should().Be(5);
-            article.StyleScore.Should().Be(4);
-            article.FeedbackComment.Should().Be("Great");
-        }
+        article.PrecisionScore.Should().Be(5);
+        article.StyleScore.Should().Be(4);
+        article.FeedbackComment.Should().Be("Great");
+    }
 
-        [Fact]
-        public void SubmitFeedback_NullComment_IsAllowed()
+    [Fact]
+    public void SubmitFeedback_NullComment_IsAllowed()
+    {
+        var article = new Heblo.Domain.Features.Article.Article
         {
-            var article = new Heblo.Domain.Features.Article.Article
-            {
-                Id = Guid.NewGuid(),
-                Topic = "topic",
-            };
+            Id = Guid.NewGuid(),
+            Topic = "topic",
+        };
 
-            var act = () => article.SubmitFeedback(precisionScore: 3, styleScore: 3, comment: null);
+        var act = () => article.SubmitFeedback(precisionScore: 3, styleScore: 3, comment: null);
 
-            act.Should().NotThrow();
-            article.PrecisionScore.Should().Be(3);
-            article.StyleScore.Should().Be(3);
-            article.FeedbackComment.Should().BeNull();
-        }
+        act.Should().NotThrow();
+        article.PrecisionScore.Should().Be(3);
+        article.StyleScore.Should().Be(3);
+        article.FeedbackComment.Should().BeNull();
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs
@@ -1,0 +1,46 @@
+using Anela.Heblo.Domain.Features.Article;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Domain.Article
+{
+    public class ArticleTests
+    {
+        [Fact]
+        public void SubmitFeedback_AssignsAllThreeProperties()
+        {
+            var article = new Heblo.Domain.Features.Article.Article
+            {
+                Id = Guid.NewGuid(),
+                Topic = "topic",
+            };
+
+            article.PrecisionScore.Should().BeNull();
+            article.StyleScore.Should().BeNull();
+            article.FeedbackComment.Should().BeNull();
+
+            article.SubmitFeedback(precisionScore: 5, styleScore: 4, comment: "Great");
+
+            article.PrecisionScore.Should().Be(5);
+            article.StyleScore.Should().Be(4);
+            article.FeedbackComment.Should().Be("Great");
+        }
+
+        [Fact]
+        public void SubmitFeedback_NullComment_IsAllowed()
+        {
+            var article = new Heblo.Domain.Features.Article.Article
+            {
+                Id = Guid.NewGuid(),
+                Topic = "topic",
+            };
+
+            var act = () => article.SubmitFeedback(precisionScore: 3, styleScore: 3, comment: null);
+
+            act.Should().NotThrow();
+            article.PrecisionScore.Should().Be(3);
+            article.StyleScore.Should().Be(3);
+            article.FeedbackComment.Should().BeNull();
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-06-08-encapsulate-article-feedback-submission.md
+++ b/docs/superpowers/plans/2026-06-08-encapsulate-article-feedback-submission.md
@@ -1,0 +1,263 @@
+# Encapsulate Article Feedback Submission in the Domain Entity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the three direct property assignments in `SubmitArticleFeedbackHandler` (`PrecisionScore`, `StyleScore`, `FeedbackComment`) into a new `Article.SubmitFeedback(precisionScore, styleScore, comment)` method on the domain entity so the entity owns its full lifecycle (matching the existing `MarkAsResearching`, `MarkAsWriting`, `MarkAsGenerated`, `MarkAsFailed` pattern).
+
+**Architecture:** Pure refactor. Behavior, public API, response shape, error codes, persistence path, and guard logic are unchanged. The handler still runs the four guards (not-found, forbidden, not-generated, already-submitted) and still calls `SaveChangesAsync`; it just delegates the in-memory mutation to a new entity method. Public setters on the three feedback properties remain (EF Core change-tracking and the existing handler-test factory rely on them).
+
+**Tech Stack:** .NET 8, C#, MediatR, EF Core, xUnit, FluentAssertions.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs` | Modify | Add `SubmitFeedback` method after `MarkAsFailed`. |
+| `backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs` | Modify | Replace lines 57–59 (three property assignments) with one method call. |
+| `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs` | Create | New entity-level unit tests for `SubmitFeedback`. Establishes the canonical location for `Article` domain tests (none exist today). |
+| `backend/test/Anela.Heblo.Tests/Article/UseCases/SubmitArticleFeedbackHandlerTests.cs` | Unchanged | Must pass as-is; proves behavior preservation. |
+
+Test path follows the existing repo convention (`Domain/{Feature}/{Entity}Tests.cs`), per the architecture review amendment — every other domain-entity test lives there (`Domain/Logistics`, `Domain/Purchase`, `Domain/Catalog`, `Domain/Marketing`).
+
+---
+
+### Task 1: Add failing unit tests for `Article.SubmitFeedback`
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create the file with the following exact content:
+
+```csharp
+using Anela.Heblo.Domain.Features.Article;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Domain.Article
+{
+    public class ArticleTests
+    {
+        [Fact]
+        public void SubmitFeedback_AssignsAllThreeProperties()
+        {
+            var article = new Heblo.Domain.Features.Article.Article
+            {
+                Id = Guid.NewGuid(),
+                Topic = "topic",
+            };
+
+            article.PrecisionScore.Should().BeNull();
+            article.StyleScore.Should().BeNull();
+            article.FeedbackComment.Should().BeNull();
+
+            article.SubmitFeedback(precisionScore: 5, styleScore: 4, comment: "Great");
+
+            article.PrecisionScore.Should().Be(5);
+            article.StyleScore.Should().Be(4);
+            article.FeedbackComment.Should().Be("Great");
+        }
+
+        [Fact]
+        public void SubmitFeedback_NullComment_IsAllowed()
+        {
+            var article = new Heblo.Domain.Features.Article.Article
+            {
+                Id = Guid.NewGuid(),
+                Topic = "topic",
+            };
+
+            var act = () => article.SubmitFeedback(precisionScore: 3, styleScore: 3, comment: null);
+
+            act.Should().NotThrow();
+            article.PrecisionScore.Should().Be(3);
+            article.StyleScore.Should().Be(3);
+            article.FeedbackComment.Should().BeNull();
+        }
+    }
+}
+```
+
+Notes for the engineer:
+- The namespace `Anela.Heblo.Tests.Domain.Article` collides with the entity's type name (`Anela.Heblo.Domain.Features.Article.Article`). The fully-qualified `Heblo.Domain.Features.Article.Article` in the test resolves the ambiguity from inside this namespace — keep it as written. (This mirrors how other domain tests handle name collisions in this repo.)
+- `using Anela.Heblo.Domain.Features.Article;` keeps the `using` block sorted and matches the style of `Domain/Marketing/MarketingActionConstructorTests.cs`.
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run from the repo root:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Domain.Article.ArticleTests" \
+  --nologo
+```
+
+Expected result: **build failure** with an error similar to `CS1061: 'Article' does not contain a definition for 'SubmitFeedback'`. This is the RED step — we have a test that proves the method doesn't yet exist.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs
+git commit -m "test: add failing unit tests for Article.SubmitFeedback"
+```
+
+---
+
+### Task 2: Add `SubmitFeedback` to the `Article` entity (make tests pass)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs:48`
+
+- [ ] **Step 1: Add the `SubmitFeedback` method immediately after `MarkAsFailed`**
+
+In `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs`, locate `MarkAsFailed` (currently lines 44–48). Add a blank line after its closing brace and append the new method so the bottom of the file becomes:
+
+```csharp
+    public void MarkAsFailed(string errorMessage)
+    {
+        Status = ArticleStatus.Failed;
+        ErrorMessage = errorMessage.Length > 500 ? errorMessage[..500] : errorMessage;
+    }
+
+    public void SubmitFeedback(int precisionScore, int styleScore, string? comment)
+    {
+        PrecisionScore = precisionScore;
+        StyleScore = styleScore;
+        FeedbackComment = comment;
+    }
+}
+```
+
+Do not modify any other member. Public setters on `PrecisionScore`, `StyleScore`, and `FeedbackComment` (lines 24–26) must stay — EF Core change-tracking and the existing handler-test factory depend on them.
+
+- [ ] **Step 2: Run the new entity tests and verify they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Domain.Article.ArticleTests" \
+  --nologo
+```
+
+Expected: `Passed: 2, Failed: 0`. This is the GREEN step.
+
+- [ ] **Step 3: Commit the entity change**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Article/Article.cs
+git commit -m "feat(article): add SubmitFeedback method to entity"
+```
+
+---
+
+### Task 3: Replace direct property assignment in `SubmitArticleFeedbackHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs:57-59`
+
+- [ ] **Step 1: Replace the three assignments with a single method call**
+
+In `SubmitArticleFeedbackHandler.cs`, find this block (lines 57–59, immediately before `await _repository.SaveChangesAsync(ct);`):
+
+```csharp
+        article.PrecisionScore = request.PrecisionScore;
+        article.StyleScore = request.StyleScore;
+        article.FeedbackComment = request.Comment;
+```
+
+Replace it with exactly one line:
+
+```csharp
+        article.SubmitFeedback(request.PrecisionScore, request.StyleScore, request.Comment);
+```
+
+Do not touch the four guard blocks (lines 26–55), the `SaveChangesAsync` call, or the `SubmitArticleFeedbackResponse` construction. The response continues to read `PrecisionScore`, `StyleScore`, and `FeedbackComment` straight off `article`.
+
+- [ ] **Step 2: Run the handler test suite and verify it still passes unchanged**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~SubmitArticleFeedbackHandlerTests" \
+  --nologo
+```
+
+Expected: all seven existing scenarios pass (article-missing, other-user, same-display-name-different-identifier, same-identifier-different-display-name, null-`RequestedBy`, not-generated, already-submitted, plus happy path) with no test edits. If anything fails, the handler edit diverged from the spec — revert the change and re-read the diff.
+
+- [ ] **Step 3: Commit the handler change**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs
+git commit -m "refactor(article): delegate feedback mutation to entity"
+```
+
+---
+
+### Task 4: Final validation (build, format, full test pass)
+
+**Files:** none modified — this task is verification only.
+
+- [ ] **Step 1: Build the backend solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: `Build succeeded` with `0 Warning(s)` and `0 Error(s)` introduced by this change.
+
+- [ ] **Step 2: Format the codebase**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+Expected: completes with no errors. If formatting changes were applied to either edited file, stage and amend the latest commit:
+
+```bash
+git status
+# If only the two edited files changed:
+git add backend/src/Anela.Heblo.Domain/Features/Article/Article.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs \
+        backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs
+git commit -m "style: apply dotnet format"
+```
+
+If `git status` shows unrelated files changed by `dotnet format`, do not include them — they belong to a separate cleanup.
+
+- [ ] **Step 3: Run the full backend test project once**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --nologo
+```
+
+Expected: `Failed: 0`. The new two tests pass, the seven existing `SubmitArticleFeedbackHandlerTests` pass, and nothing else regressed.
+
+- [ ] **Step 4: Confirm scope — only the planned files changed**
+
+```bash
+git log --oneline origin/main..HEAD
+git diff --stat origin/main..HEAD
+```
+
+Expected: three (or four, including the optional format commit) commits touching exactly:
+- `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs` (+6 lines)
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs` (−3 +1 lines)
+- `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs` (new file, ~35 lines)
+- `docs/superpowers/plans/2026-06-08-encapsulate-article-feedback-submission.md` (this plan)
+
+No frontend files, no migrations, no DI changes, no OpenAPI regeneration, no controller edits. If anything else shows up, stop and investigate before pushing.
+
+---
+
+## Out of Scope (reminder)
+
+Do not, in this plan, attempt any of the following — they are explicitly excluded by the spec and arch review:
+
+- Tighten setter visibility on `PrecisionScore` / `StyleScore` / `FeedbackComment` to `private set` or `init`.
+- Add range validation, normalization, or guard logic inside `SubmitFeedback` (range `[1, 5]` is enforced via `[Range]` on the request DTO).
+- Move handler guards (`ArticleNotFound`, `Forbidden`, `ArticleNotGenerated`, `ArticleFeedbackAlreadySubmitted`) into the entity.
+- Add a `FeedbackSubmittedAt` timestamp.
+- Publish a domain event from `SubmitFeedback`.
+- Any frontend or OpenAPI/TypeScript-client changes — the HTTP surface is unchanged.
+
+If any of these feel tempting while implementing, stop and raise a separate spec — they each warrant their own plan.


### PR DESCRIPTION

Encapsulates article feedback submission in the `Article` domain entity by introducing a `SubmitFeedback(precisionScore, styleScore, comment)` method, replacing the three direct property assignments that lived in `SubmitArticleFeedbackHandler`. This closes the last anemic-model gap in the entity, aligning feedback with the established `MarkAs*` lifecycle-method pattern. All existing handler tests pass unchanged; two new focused entity-level tests establish the canonical `Domain/Article/ArticleTests.cs` location.

### Changes
- `backend/src/Anela.Heblo.Domain/Features/Article/Article.cs` — added `SubmitFeedback` method after `MarkAsFailed`
- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/SubmitFeedback/SubmitArticleFeedbackHandler.cs` — single `article.SubmitFeedback(...)` call replaces three property assignments
- `backend/test/Anela.Heblo.Tests/Domain/Article/ArticleTests.cs` — new: two xUnit facts verifying the entity method in isolation
- `docs/superpowers/plans/2026-06-08-encapsulate-article-feedback-submission.md` — implementation plan

---

Closes #2689

### Tokens used
9066297
