### PR TITLE
fix(authz): use Entra oid for user pairing + slide-up user profile panel

### DIFF
--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs
@@ -22,7 +22,7 @@ public class MockAuthenticationHandler : AuthenticationHandler<MockAuthenticatio
     {
         var identityClaims = new[]
         {
-            new Claim(ClaimTypes.NameIdentifier, "mock-user-id"),
+            new Claim(ClaimTypes.NameIdentifier, "00000000-0000-0000-0000-000000000000"),
             new Claim(ClaimTypes.Name, "Mock User"),
             new Claim(ClaimTypes.Email, "mock@anela-heblo.com"),
             new Claim("preferred_username", "mock@anela-heblo.com"),

--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Anela.Heblo.Domain.Features.Authorization;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Identity.Web;
 
 namespace Anela.Heblo.API.Infrastructure.Authentication;
 
@@ -22,9 +23,13 @@ public class PermissionClaimsTransformation : IClaimsTransformation
         if (identity.HasClaim("authz_applied", "1"))
             return principal;
 
-        var objectId = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                       ?? principal.FindFirst("oid")?.Value
-                       ?? principal.FindFirst("sub")?.Value;
+        // GetObjectId() reads both "oid" (raw) and "http://schemas.microsoft.com/identity/claims/objectidentifier"
+        // (the URI the JwtBearer handler renames "oid" to when MapInboundClaims is on).
+        // This is the tenant-wide Entra Object ID — same value Graph returns as /users/{id}.id,
+        // which is what EntraMemberSearch stores in AppUser.EntraObjectId.
+        // NameIdentifier fallback is for mock auth (and any other scheme without an oid claim).
+        var objectId = principal.GetObjectId()
+                       ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
         IReadOnlyCollection<string> permissions;
         if (principal.IsInRole(AccessRoles.SuperUser))

--- a/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
@@ -129,4 +129,28 @@ public class PermissionClaimsTransformationTests
             Times.Once);
         resolver.VerifyNoOtherCalls();
     }
+
+    [Fact]
+    public async Task Transform_NoOidClaim_FallsBackToNameIdentifier()
+    {
+        // Mock auth scheme (used in dev/test/E2E) doesn't emit "oid" — only NameIdentifier.
+        // The fallback must still hand a non-null identifier to the resolver.
+        const string mockIdentifier = "mock-only-identifier";
+
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        resolver
+            .Setup(r => r.ResolveAsync(mockIdentifier, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, Array.Empty<string>()));
+
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, mockIdentifier));
+
+        var result = await sut.TransformAsync(principal);
+
+        result.IsInRole("catalog.read").Should().BeTrue();
+        resolver.Verify(
+            r => r.ResolveAsync(mockIdentifier, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        resolver.VerifyNoOtherCalls();
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
@@ -102,4 +102,31 @@ public class PermissionClaimsTransformationTests
             Times.Once);
         resolver.VerifyNoOtherCalls();
     }
+
+    [Fact]
+    public async Task Transform_EntraToken_UsesObjectIdentifierUri_WhenMapInboundClaimsApplied()
+    {
+        // When MapInboundClaims is enabled in JwtBearerOptions, the JWT "oid" claim is rewritten
+        // to the URI "http://schemas.microsoft.com/identity/claims/objectidentifier".
+        // GetObjectId() reads either form; pin that behavior here.
+        const string realOid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        resolver
+            .Setup(r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, new[] { "G" }));
+
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(
+            new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", realOid),
+            new Claim(ClaimTypes.NameIdentifier, "sub-mapped-to-name-identifier"));
+
+        var result = await sut.TransformAsync(principal);
+
+        result.IsInRole("catalog.read").Should().BeTrue();
+        resolver.Verify(
+            r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        resolver.VerifyNoOtherCalls();
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
@@ -73,4 +73,33 @@ public class PermissionClaimsTransformationTests
 
         result.Claims.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task Transform_EntraToken_UsesOidClaim_NotNameIdentifier()
+    {
+        // Real Entra JWT: contains both "oid" (tenant-wide object ID, used by Graph)
+        // and a NameIdentifier mapped from "sub" (per-user-per-app pairwise pseudonymous ID).
+        // The resolver MUST be called with the oid, not the sub — otherwise the pre-created
+        // AppUser row (keyed by oid from EntraMemberSearch) is missed and a duplicate is JIT-created.
+        const string realOid = "11111111-2222-3333-4444-555555555555";
+        const string subValue = "sub-value-different-from-oid";
+
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        resolver
+            .Setup(r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, new[] { "G" }));
+
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(
+            new Claim("oid", realOid),
+            new Claim(ClaimTypes.NameIdentifier, subValue));
+
+        var result = await sut.TransformAsync(principal);
+
+        result.IsInRole("catalog.read").Should().BeTrue();
+        resolver.Verify(
+            r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        resolver.VerifyNoOtherCalls();
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
@@ -37,7 +37,7 @@ public class PermissionClaimsTransformationTests
             .Setup(r => r.ResolveAsync("oid-1", It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EffectivePermissions(false, new[] { "heblo_user", "catalog.read" }, new[] { "G" }));
         var sut = new PermissionClaimsTransformation(resolver.Object);
-        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, "oid-1"));
+        var principal = Principal(new Claim("oid", "oid-1"));
 
         var result = await sut.TransformAsync(principal);
 
@@ -54,7 +54,7 @@ public class PermissionClaimsTransformationTests
             .Setup(r => r.ResolveAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, Array.Empty<string>()));
         var sut = new PermissionClaimsTransformation(resolver.Object);
-        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, "oid-1"));
+        var principal = Principal(new Claim("oid", "oid-1"));
 
         var once = await sut.TransformAsync(principal);
         var twice = await sut.TransformAsync(once);

--- a/docs/superpowers/plans/2026-06-08-fix-rbac-user-pairing-on-first-login.md
+++ b/docs/superpowers/plans/2026-06-08-fix-rbac-user-pairing-on-first-login.md
@@ -1,0 +1,427 @@
+# Fix RBAC user pairing on first login Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the new RBAC system from creating a duplicate `AppUser` row on a user's first login. After this fix, the pre-created row from `EntraMemberSearch` is correctly matched at first login and gets its permissions, instead of being orphaned next to a permission-less duplicate.
+
+**Architecture:** The bug lives in one file: `PermissionClaimsTransformation` reads `ClaimTypes.NameIdentifier` from the JWT as the "Entra object ID". With `Microsoft.AspNetCore.Authentication.JwtBearer`'s default inbound claim mapping, that's the `sub` claim (per-user-per-app pairwise) — not the tenant-wide `oid` claim that Graph (and therefore the pre-created `AppUser.EntraObjectId`) uses. Fix: read `oid` via Microsoft.Identity.Web's `ClaimsPrincipal.GetObjectId()` helper, which checks both the raw `oid` claim and the mapped `objectidentifier` URI. Add tests that pin the realistic Entra token shape so this can't silently regress.
+
+**Tech Stack:** .NET 8, ASP.NET Core, Microsoft.Identity.Web 2.x, Microsoft.AspNetCore.Authentication.JwtBearer 8.0.8, xUnit, FluentAssertions, Moq.
+
+---
+
+## File Structure
+
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs` — modified. Replace the 3‑line claim fallback with `GetObjectId()` + `NameIdentifier` fallback. Add `using Microsoft.Identity.Web;`.
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs` — modified. Change `ClaimTypes.NameIdentifier` value at line 25 to match the existing `oid` value at line 33, so anywhere that still reads `NameIdentifier` sees the same ID as `GetObjectId()`.
+- `backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs` — modified. Add three new tests (realistic Entra `oid` claim, mapped `objectidentifier` URI, mock-only `NameIdentifier` fallback). Refit two existing tests to use the realistic claim shape.
+
+No new files. No frontend changes. No EF migrations (orphan rows from past reproduction get cleaned up by a one-off SQL snippet in the deployment appendix).
+
+---
+
+### Task 1: Pin the bug with a failing test
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+Open `backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs` and append this test inside the existing `PermissionClaimsTransformationTests` class (after the four existing `[Fact]` methods, before the closing brace):
+
+```csharp
+    [Fact]
+    public async Task Transform_EntraToken_UsesOidClaim_NotNameIdentifier()
+    {
+        // Real Entra JWT: contains both "oid" (tenant-wide object ID, used by Graph)
+        // and a NameIdentifier mapped from "sub" (per-user-per-app pairwise pseudonymous ID).
+        // The resolver MUST be called with the oid, not the sub — otherwise the pre-created
+        // AppUser row (keyed by oid from EntraMemberSearch) is missed and a duplicate is JIT-created.
+        const string realOid = "11111111-2222-3333-4444-555555555555";
+        const string subValue = "sub-value-different-from-oid";
+
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        resolver
+            .Setup(r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, new[] { "G" }));
+
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(
+            new Claim("oid", realOid),
+            new Claim(ClaimTypes.NameIdentifier, subValue));
+
+        var result = await sut.TransformAsync(principal);
+
+        result.IsInRole("catalog.read").Should().BeTrue();
+        resolver.Verify(
+            r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        resolver.VerifyNoOtherCalls();
+    }
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~PermissionClaimsTransformationTests.Transform_EntraToken_UsesOidClaim_NotNameIdentifier"
+```
+
+Expected: FAIL with a Moq strict-mode exception — the resolver is being called with `subValue` (read from `NameIdentifier`) instead of `realOid`. This confirms the bug: the current code reads `NameIdentifier` before `oid`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+git commit -m "test(authz): pin oid-vs-sub mismatch in PermissionClaimsTransformation"
+```
+
+---
+
+### Task 2: Make the test pass by reading `oid`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs`
+
+- [ ] **Step 1: Add the `Microsoft.Identity.Web` using**
+
+Open `backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs`. Add `using Microsoft.Identity.Web;` to the using block so the top of the file reads:
+
+```csharp
+using System.Security.Claims;
+using Anela.Heblo.Domain.Features.Authorization;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Identity.Web;
+```
+
+`Microsoft.Identity.Web` is already a transitive package of the API project (used in `AuthenticationExtensions.cs`), so no `.csproj` change is needed.
+
+- [ ] **Step 2: Replace the claim lookup**
+
+Find lines 25-27 (the current `var objectId = …` block) and replace them with the mapping-agnostic helper. The current code:
+
+```csharp
+        var objectId = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                       ?? principal.FindFirst("oid")?.Value
+                       ?? principal.FindFirst("sub")?.Value;
+```
+
+becomes:
+
+```csharp
+        // GetObjectId() reads both "oid" (raw) and "http://schemas.microsoft.com/identity/claims/objectidentifier"
+        // (the URI the JwtBearer handler renames "oid" to when MapInboundClaims is on).
+        // This is the tenant-wide Entra Object ID — same value Graph returns as /users/{id}.id,
+        // which is what EntraMemberSearch stores in AppUser.EntraObjectId.
+        // NameIdentifier fallback is for mock auth (and any other scheme without an oid claim).
+        var objectId = principal.GetObjectId()
+                       ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+```
+
+- [ ] **Step 3: Run the failing test — it should now pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~PermissionClaimsTransformationTests.Transform_EntraToken_UsesOidClaim_NotNameIdentifier"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the full PermissionClaimsTransformationTests class — make sure nothing else broke yet**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~PermissionClaimsTransformationTests"
+```
+
+Expected: the new test PASSES. The two existing tests that build a principal with `new Claim(ClaimTypes.NameIdentifier, "oid-1")` (`Transform_RegularUser_AddsResolvedPermissionsAsRoles` and `Transform_Idempotent_DoesNotDuplicateClaims`) still PASS, because `GetObjectId()` returns null when there's no `oid` claim and falls back to `NameIdentifier`. `Transform_SuperUserRoleInToken_AddsAllPermissions_NoResolverCall` and `Transform_Unauthenticated_ReturnsUnchanged` also pass — neither hits the claim lookup that changed.
+
+- [ ] **Step 5: Commit the fix**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionClaimsTransformation.cs
+git commit -m "fix(authz): read Entra oid via GetObjectId() so first login matches pre-created AppUser"
+```
+
+---
+
+### Task 3: Cover the mapped `objectidentifier` URI shape
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs`
+
+- [ ] **Step 1: Add the test**
+
+Append this test below the one added in Task 1, still inside the `PermissionClaimsTransformationTests` class:
+
+```csharp
+    [Fact]
+    public async Task Transform_EntraToken_UsesObjectIdentifierUri_WhenMapInboundClaimsApplied()
+    {
+        // When MapInboundClaims is enabled in JwtBearerOptions, the JWT "oid" claim is rewritten
+        // to the URI "http://schemas.microsoft.com/identity/claims/objectidentifier".
+        // GetObjectId() reads either form; pin that behavior here.
+        const string realOid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        resolver
+            .Setup(r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, new[] { "G" }));
+
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(
+            new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", realOid),
+            new Claim(ClaimTypes.NameIdentifier, "sub-mapped-to-name-identifier"));
+
+        var result = await sut.TransformAsync(principal);
+
+        result.IsInRole("catalog.read").Should().BeTrue();
+        resolver.Verify(
+            r => r.ResolveAsync(realOid, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        resolver.VerifyNoOtherCalls();
+    }
+```
+
+- [ ] **Step 2: Run the test — it should pass on the fix from Task 2**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~PermissionClaimsTransformationTests.Transform_EntraToken_UsesObjectIdentifierUri_WhenMapInboundClaimsApplied"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+git commit -m "test(authz): cover mapped objectidentifier URI claim shape"
+```
+
+---
+
+### Task 4: Cover the mock-auth fallback (NameIdentifier without `oid`)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs`
+
+- [ ] **Step 1: Add the test**
+
+Append below Task 3's test:
+
+```csharp
+    [Fact]
+    public async Task Transform_NoOidClaim_FallsBackToNameIdentifier()
+    {
+        // Mock auth scheme (used in dev/test/E2E) doesn't emit "oid" — only NameIdentifier.
+        // The fallback must still hand a non-null identifier to the resolver.
+        const string mockIdentifier = "mock-only-identifier";
+
+        var resolver = new Mock<IPermissionResolver>(MockBehavior.Strict);
+        resolver
+            .Setup(r => r.ResolveAsync(mockIdentifier, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EffectivePermissions(false, new[] { "catalog.read" }, Array.Empty<string>()));
+
+        var sut = new PermissionClaimsTransformation(resolver.Object);
+        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, mockIdentifier));
+
+        var result = await sut.TransformAsync(principal);
+
+        result.IsInRole("catalog.read").Should().BeTrue();
+        resolver.Verify(
+            r => r.ResolveAsync(mockIdentifier, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        resolver.VerifyNoOtherCalls();
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~PermissionClaimsTransformationTests.Transform_NoOidClaim_FallsBackToNameIdentifier"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+git commit -m "test(authz): cover mock-auth NameIdentifier fallback"
+```
+
+---
+
+### Task 5: Refit the two existing tests to a realistic claim shape
+
+The two existing tests (`Transform_RegularUser_AddsResolvedPermissionsAsRoles`, `Transform_Idempotent_DoesNotDuplicateClaims`) currently pass an "oid-1" value through `NameIdentifier` — that's not the shape real Entra tokens have, so they offered no protection against the bug we just fixed. Move them to the realistic shape. Task 4 already covers the legacy mock shape, so coverage isn't lost.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs`
+
+- [ ] **Step 1: Replace the principal in `Transform_RegularUser_AddsResolvedPermissionsAsRoles`**
+
+Find this line in the existing test:
+
+```csharp
+        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, "oid-1"));
+```
+
+Replace it with:
+
+```csharp
+        var principal = Principal(new Claim("oid", "oid-1"));
+```
+
+- [ ] **Step 2: Replace the principal in `Transform_Idempotent_DoesNotDuplicateClaims`**
+
+Find this line in the existing test:
+
+```csharp
+        var principal = Principal(new Claim(ClaimTypes.NameIdentifier, "oid-1"));
+```
+
+Replace it with:
+
+```csharp
+        var principal = Principal(new Claim("oid", "oid-1"));
+```
+
+- [ ] **Step 3: Run the full test class — everything passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~PermissionClaimsTransformationTests"
+```
+
+Expected: all 7 tests pass (4 original + 3 new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/PermissionClaimsTransformationTests.cs
+git commit -m "test(authz): refit existing tests to use realistic oid claim shape"
+```
+
+---
+
+### Task 6: Align `MockAuthenticationHandler` NameIdentifier with its `oid`
+
+`GetObjectId()` will now return `"00000000-0000-0000-0000-000000000000"` for mock auth (the value at `MockAuthenticationHandler.cs:33`), while `NameIdentifier` still emits `"mock-user-id"`. Anywhere else in the codebase that still reads `NameIdentifier` would see a different identifier than the resolver does. A quick grep (`mock-user-id`) shows only that one line in the whole backend uses the literal, so changing it is safe and keeps the mock principal internally consistent.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs`
+
+- [ ] **Step 1: Update the NameIdentifier value**
+
+Open `backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs`. Line 25 currently reads:
+
+```csharp
+            new Claim(ClaimTypes.NameIdentifier, "mock-user-id"),
+```
+
+Replace it with:
+
+```csharp
+            new Claim(ClaimTypes.NameIdentifier, "00000000-0000-0000-0000-000000000000"),
+```
+
+This is the same GUID already emitted as the `"oid"` claim on line 33.
+
+- [ ] **Step 2: Run the full backend test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests
+```
+
+Expected: every test passes. If any test fails on the literal `"mock-user-id"`, the grep missed something — update that test to the GUID and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Authentication/MockAuthenticationHandler.cs
+git commit -m "refactor(authz): align mock auth NameIdentifier with its oid claim"
+```
+
+---
+
+### Task 7: Final validation gates
+
+- [ ] **Step 1: Build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with no new warnings.
+
+- [ ] **Step 2: Format**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit 0 (no formatting drift). If it fails, run without `--verify-no-changes`, then `git add` + amend the last commit or add a follow-up `chore: dotnet format` commit.
+
+- [ ] **Step 3: Full backend test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run staging end-to-end check (manual)**
+
+Pick a tenant user with no `AppUser` row in the staging DB.
+
+```sql
+-- Confirm no pre-existing row (run against the staging Heblo_TST DB)
+SELECT * FROM public."AppUsers" WHERE "Email" = '<their-email>';
+```
+
+Through the admin UI, navigate to a group and add that user via the "Add Entra user" search box. Verify a new row was created with the user's Entra Object ID:
+
+```sql
+SELECT "Id", "EntraObjectId", "Email", "LastLoginAt"
+FROM public."AppUsers" WHERE "Email" = '<their-email>';
+```
+
+Cross-check `EntraObjectId` against Azure Portal → Users → that user → Object ID. They should be identical (a single GUID).
+
+Have the user sign in. Then re-run the same SELECT:
+
+- There must still be exactly **one** row for that email (no duplicate).
+- `LastLoginAt` is now populated.
+- The user's UI shows the permissions of the group they were added to.
+
+---
+
+## Deployment appendix: one-shot cleanup for prior duplicates
+
+You've reproduced the bug at least once, so the staging DB likely contains orphan rows where `EntraObjectId` is a `sub` value. After deploying the code fix, run this SQL against `Heblo_TST` (and, if ever applicable, `Heblo`).
+
+```sql
+-- 1. List duplicate-by-email rows; the "good" row has groups, the orphan has none.
+SELECT u."Id",
+       u."EntraObjectId",
+       u."Email",
+       u."LastLoginAt",
+       (SELECT COUNT(*) FROM public."UserGroups" g WHERE g."UserId" = u."Id") AS group_count
+FROM public."AppUsers" u
+WHERE u."Email" IN (
+    SELECT "Email" FROM public."AppUsers" GROUP BY "Email" HAVING COUNT(*) > 1
+)
+ORDER BY u."Email", group_count DESC;
+
+-- 2. For each email with two rows: delete the row with group_count = 0.
+-- Replace <orphan-id> with the Id from the query above.
+-- DELETE FROM public."AppUsers" WHERE "Id" = '<orphan-id>';
+```
+
+After deletion, the next time the affected user logs in, the code fix in Task 2 matches them to the surviving row (now keyed by their real `oid`) and updates `LastLoginAt`. No manual `EntraObjectId` patching is required because the surviving row already carries the correct `oid` (it was set by EntraMemberSearch).
+
+---
+
+## What this plan does **not** change
+
+- `PermissionResolver.cs` — its find-or-create logic was already correct given a correct lookup key. We're feeding it the right key now, that's all.
+- `AppUser` schema or any EF migration — the `EntraObjectId` unique index is the right constraint; we don't need an `Email` unique constraint to fix this bug, and adding one would conflict with the orphan rows that exist today.
+- Frontend / `EntraMemberSearch` / Graph code — all already correct. The bug was purely in claim selection at login.

--- a/docs/superpowers/plans/2026-06-08-sidebar-user-modal-show-permissions.md
+++ b/docs/superpowers/plans/2026-06-08-sidebar-user-modal-show-permissions.md
@@ -1,0 +1,393 @@
+# Show DB Roles + Permissions + Groups in User Modal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add visible **Permissions** and **Groups** sections (with a super-user shortcut) to the user info modal opened from the sidebar avatar, alongside the existing **Role** chips.
+
+**Architecture:** The user info modal in `UserProfile.tsx` currently renders only the user's id-token roles (from `useAuth().getUserInfo().roles`). With the DB-backed RBAC (commit `a6d281494`), the actual access truth lives in `/api/auth/me` and is exposed via `PermissionsContext`. This plan keeps the existing Role section untouched and adds two new sections fed by `usePermissionsContext()`. No backend changes. No new component file — the additions live inside `UserProfile.tsx`.
+
+**Tech Stack:** React 18, TypeScript, `react-scripts test` (Jest + @testing-library/react + @testing-library/user-event), Tailwind, `lucide-react` icons.
+
+---
+
+## File Structure
+
+- **Modify:** `frontend/src/components/auth/UserProfile.tsx` — add Permissions and Groups sections + super-user badge inside the existing modal.
+- **Create:** `frontend/src/components/auth/UserProfile.test.tsx` — new test file (none exists today). Follows the mocking pattern from `RequireAccess.test.tsx`.
+
+No other files are touched. The provider `PermissionsProvider` already wraps the sidebar's render tree (`App.tsx:407`), so `usePermissionsContext()` is safe to call from `UserProfile`.
+
+---
+
+## Task 1: Permissions section for a non-super-user
+
+**Files:**
+- Create: `frontend/src/components/auth/UserProfile.test.tsx`
+- Modify: `frontend/src/components/auth/UserProfile.tsx` (add section between lines 171 and 173)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/auth/UserProfile.test.tsx`:
+
+```tsx
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserProfile from "./UserProfile";
+
+const baseAuth = {
+  isAuthenticated: true,
+  login: jest.fn(),
+  logout: jest.fn(),
+  inProgress: "none",
+  getUserInfo: () => ({
+    name: "Test User",
+    email: "test@anela.cz",
+    initials: "TU",
+    roles: ["super_user"],
+  }),
+  getStoredUserInfo: () => null,
+};
+
+let mockCtx = {
+  permissions: [] as string[],
+  isSuperUser: false,
+  groups: [] as string[],
+  isLoading: false,
+  hasPermission: (_: string) => false,
+};
+
+jest.mock("../../auth/useAuth", () => ({ useAuth: () => baseAuth }));
+jest.mock("../../auth/mockAuth", () => ({
+  useMockAuth: () => baseAuth,
+  shouldUseMockAuth: () => false,
+}));
+jest.mock("../../auth/PermissionsContext", () => ({
+  usePermissionsContext: () => mockCtx,
+}));
+
+const openModal = async () => {
+  render(<UserProfile />);
+  await userEvent.click(screen.getByRole("button"));
+};
+
+describe("UserProfile permissions display", () => {
+  it("renders Permissions chips when user has DB permissions", async () => {
+    mockCtx = {
+      permissions: ["catalog.read", "journal.read"],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.getByText("Oprávnění")).toBeInTheDocument();
+    expect(screen.getByText("catalog.read")).toBeInTheDocument();
+    expect(screen.getByText("journal.read")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `cd frontend && npx jest src/components/auth/UserProfile.test.tsx --watchAll=false`
+
+Expected: FAIL — `Unable to find an element with the text: Oprávnění` (the Permissions section does not exist yet).
+
+- [ ] **Step 3: Add the Permissions section to UserProfile.tsx**
+
+In `frontend/src/components/auth/UserProfile.tsx`:
+
+a) Add the icon import on line 2 — replace:
+
+```tsx
+import { User, LogIn, LogOut, X, ShieldCheck } from "lucide-react";
+```
+
+with:
+
+```tsx
+import { User, LogIn, LogOut, X, ShieldCheck, KeyRound, Users } from "lucide-react";
+```
+
+b) Add the context import on line 4 — after the `useMockAuth` import:
+
+```tsx
+import { usePermissionsContext } from "../../auth/PermissionsContext";
+```
+
+c) Inside the component body, just after line 23 (`const storedUserInfo = getStoredUserInfo();`):
+
+```tsx
+  const { permissions, groups, isSuperUser, isLoading: permissionsLoading } =
+    usePermissionsContext();
+```
+
+d) Insert the new Permissions section between the existing Role block (closes on line 171) and the Footer block (opens on line 174). Place this immediately after `)}` on line 171:
+
+```tsx
+              {/* Permissions */}
+              {!permissionsLoading && !isSuperUser && permissions.length > 0 && (
+                <div className="px-5 py-4 border-b border-gray-100">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <KeyRound className="h-4 w-4 text-emerald-600" />
+                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      Oprávnění
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {permissions.map((perm) => (
+                      <span
+                        key={perm}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
+                      >
+                        {perm}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+Run: `cd frontend && npx jest src/components/auth/UserProfile.test.tsx --watchAll=false`
+
+Expected: PASS — 1 test passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/auth/UserProfile.tsx frontend/src/components/auth/UserProfile.test.tsx
+git commit -m "feat(authz): show DB permissions chips in user info modal"
+```
+
+---
+
+## Task 2: Super-user badge (skip permission list when wildcard)
+
+**Files:**
+- Modify: `frontend/src/components/auth/UserProfile.test.tsx`
+- Modify: `frontend/src/components/auth/UserProfile.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/components/auth/UserProfile.test.tsx` inside the existing `describe` block:
+
+```tsx
+  it("renders a single super-user badge when isSuperUser is true", async () => {
+    mockCtx = {
+      permissions: ["catalog.read", "journal.read", "finance.read"],
+      isSuperUser: true,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.getByText("Super User · vše povoleno")).toBeInTheDocument();
+    expect(screen.queryByText("catalog.read")).not.toBeInTheDocument();
+    expect(screen.queryByText("journal.read")).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+Run: `cd frontend && npx jest src/components/auth/UserProfile.test.tsx --watchAll=false`
+
+Expected: FAIL — `Unable to find an element with the text: Super User · vše povoleno`, AND the "should not be in document" assertions fail because the implementation still lists `catalog.read` etc. for super-users.
+
+- [ ] **Step 3: Update the Permissions section to handle the super-user case**
+
+In `frontend/src/components/auth/UserProfile.tsx`, replace the entire Permissions block added in Task 1 with:
+
+```tsx
+              {/* Permissions */}
+              {!permissionsLoading && (isSuperUser || permissions.length > 0) && (
+                <div className="px-5 py-4 border-b border-gray-100">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <KeyRound className="h-4 w-4 text-emerald-600" />
+                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      Oprávnění
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {isSuperUser ? (
+                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700">
+                        Super User · vše povoleno
+                      </span>
+                    ) : (
+                      permissions.map((perm) => (
+                        <span
+                          key={perm}
+                          className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
+                        >
+                          {perm}
+                        </span>
+                      ))
+                    )}
+                  </div>
+                </div>
+              )}
+```
+
+- [ ] **Step 4: Run all UserProfile tests and watch them pass**
+
+Run: `cd frontend && npx jest src/components/auth/UserProfile.test.tsx --watchAll=false`
+
+Expected: PASS — 2 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/auth/UserProfile.tsx frontend/src/components/auth/UserProfile.test.tsx
+git commit -m "feat(authz): show single super-user badge instead of full permission list"
+```
+
+---
+
+## Task 3: Groups section
+
+**Files:**
+- Modify: `frontend/src/components/auth/UserProfile.test.tsx`
+- Modify: `frontend/src/components/auth/UserProfile.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/components/auth/UserProfile.test.tsx` inside the existing `describe` block:
+
+```tsx
+  it("renders Groups chips when user belongs to DB groups", async () => {
+    mockCtx = {
+      permissions: ["catalog.read"],
+      isSuperUser: false,
+      groups: ["Finance", "Marketing"],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.getByText("Skupiny")).toBeInTheDocument();
+    expect(screen.getByText("Finance")).toBeInTheDocument();
+    expect(screen.getByText("Marketing")).toBeInTheDocument();
+  });
+
+  it("hides Groups section when user has no groups", async () => {
+    mockCtx = {
+      permissions: ["catalog.read"],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.queryByText("Skupiny")).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+Run: `cd frontend && npx jest src/components/auth/UserProfile.test.tsx --watchAll=false`
+
+Expected: FAIL — `Unable to find an element with the text: Skupiny` on the first new test. (The "hides" test happens to pass already, but it locks the behavior in once the section exists.)
+
+- [ ] **Step 3: Add the Groups section to UserProfile.tsx**
+
+In `frontend/src/components/auth/UserProfile.tsx`, insert immediately after the Permissions section closing `)}` and before the `{/* Footer */}` comment (around the original line 173):
+
+```tsx
+              {/* Groups */}
+              {!permissionsLoading && groups.length > 0 && (
+                <div className="px-5 py-4 border-b border-gray-100">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <Users className="h-4 w-4 text-primary-blue" />
+                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      Skupiny
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {groups.map((group) => (
+                      <span
+                        key={group}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
+                      >
+                        {group}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+```
+
+- [ ] **Step 4: Run all UserProfile tests and watch them pass**
+
+Run: `cd frontend && npx jest src/components/auth/UserProfile.test.tsx --watchAll=false`
+
+Expected: PASS — 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/auth/UserProfile.tsx frontend/src/components/auth/UserProfile.test.tsx
+git commit -m "feat(authz): show DB group memberships in user info modal"
+```
+
+---
+
+## Task 4: Build, lint, and full test suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the frontend production build**
+
+Run: `cd frontend && npm run build`
+
+Expected: build succeeds with no TypeScript errors. (Remember: `npm run build` is stricter than `npx tsc --noEmit`.)
+
+- [ ] **Step 2: Run lint**
+
+Run: `cd frontend && npm run lint`
+
+Expected: no new lint errors.
+
+- [ ] **Step 3: Run the existing auth test suite to confirm nothing else broke**
+
+Run: `cd frontend && npx jest src/components/auth src/auth --watchAll=false`
+
+Expected: all tests pass (existing `RequireAccess.test.tsx`, `AuthGuard.test.tsx`, `useAuth.test.ts`, plus the new `UserProfile.test.tsx`).
+
+- [ ] **Step 4: Manual smoke test in mock auth mode**
+
+Run: `cd frontend && REACT_APP_USE_MOCK_AUTH=true npm start`
+
+In the browser: log in with mock auth, click the avatar in the sidebar, and confirm the modal shows:
+- Existing **Role** chips (from id-token roles)
+- New **Oprávnění** section with either the "Super User · vše povoleno" badge or per-permission chips
+- New **Skupiny** section if the mock identity has any group memberships (hidden otherwise)
+
+- [ ] **Step 5: Commit any cleanup (if needed) and finish**
+
+If the build/lint steps revealed any tweaks, commit them:
+
+```bash
+git add frontend/src/components/auth/UserProfile.tsx
+git commit -m "chore(authz): cleanup after lint/build verification"
+```
+
+If no changes were needed, this step is a no-op.
+
+---
+
+## Self-review notes (already applied)
+
+- **Spec coverage:** "Render a list in the sidebar (display)" is implemented in Tasks 1–3 (Permissions chips, super-user badge, Groups chips). The existing Role section is preserved as the user requested both visible.
+- **Scope discipline:** No changes to `Sidebar.tsx`'s `canSee()` gating — that's a separate concern (the idToken vs DB-permissions inconsistency) and is intentionally out of scope.
+- **Type consistency:** All three new sections read from the same `usePermissionsContext()` shape declared in `PermissionsContext.tsx:4-10` (`permissions: string[]`, `groups: string[]`, `isSuperUser: boolean`, `isLoading: boolean`).
+- **Empty-state handling:** Each section is wrapped in a guard so empty arrays / `isLoading` simply hide it.
+- **i18n:** Labels use Czech ("Oprávnění", "Skupiny", "Super User · vše povoleno") to match the existing "Role" / "Uživatel" / "Poslední přihlášení" / "Odhlásit se" labels in the same modal.

--- a/docs/superpowers/plans/2026-06-08-user-profile-slide-up-panel.md
+++ b/docs/superpowers/plans/2026-06-08-user-profile-slide-up-panel.md
@@ -1,0 +1,440 @@
+# User Profile Slide-Up Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the centered full-screen modal overlay in `UserProfile.tsx` with a panel that slides up from the sidebar's bottom user row, overlaying nav content, closing on click-outside or toggle.
+
+**Architecture:** The Sidebar's bottom section wrappers gain `relative` so the panel can position absolutely against the full row width. `UserProfile.tsx` drops the `fixed inset-0` overlay in favour of a Headless UI `Transition`-animated absolute panel. Click-outside is handled via `useRef` + `useEffect`. The `compact` prop controls panel width (full-row for expanded, fixed 240px for the 64px collapsed sidebar).
+
+**Tech Stack:** React 18, TypeScript, `@headlessui/react ^2.2.7` (`Transition`), Tailwind CSS, `react-scripts test` (Jest + @testing-library/react + @testing-library/user-event).
+
+---
+
+## File Structure
+
+- **Modify:** `frontend/src/components/layout/Sidebar.tsx` — add `relative` to both bottom section wrappers (expanded row + compact column) so the panel's `absolute` positioning is scoped to the full row width, not just UserProfile's container.
+- **Modify:** `frontend/src/components/auth/UserProfile.tsx` — replace modal with slide-up panel.
+- **Modify:** `frontend/src/components/auth/UserProfile.test.tsx` — rename `openModal` → `openPanel`, add toggle test.
+
+**Positioning note:** `UserProfile`'s own wrapper div must NOT carry `relative` — it holds `ref={panelRef}` for click-outside detection but must not be the positioning context. That role belongs to Sidebar's `relative` bottom section, so `inset-x-0` on the panel spans the full row (including the collapse-toggle button area).
+
+---
+
+## Task 1: Add `relative` to Sidebar bottom section wrappers
+
+**Files:**
+- Modify: `frontend/src/components/layout/Sidebar.tsx` (lines 633 and 647)
+
+No test needed — this is a pure CSS positioning change with no behaviour change.
+
+- [ ] **Step 1: Add `relative` to the expanded bottom row**
+
+In `frontend/src/components/layout/Sidebar.tsx`, find line 633 and add `relative` to the class list:
+
+```tsx
+// BEFORE (line 633):
+<div className="flex items-center justify-between h-16 py-2 border-t border-gray-100">
+
+// AFTER:
+<div className="relative flex items-center justify-between h-16 py-2 border-t border-gray-100">
+```
+
+- [ ] **Step 2: Add `relative` to the compact bottom column**
+
+On line 647, add `relative`:
+
+```tsx
+// BEFORE (line 647):
+<div className="flex flex-col items-center py-2 space-y-2 border-t border-gray-100">
+
+// AFTER:
+<div className="relative flex flex-col items-center py-2 space-y-2 border-t border-gray-100">
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/layout/Sidebar.tsx
+git commit -m "refactor(ui): add relative positioning to sidebar user profile row containers"
+```
+
+---
+
+## Task 2: Slide-up panel in UserProfile
+
+**Files:**
+- Modify: `frontend/src/components/auth/UserProfile.test.tsx`
+- Modify: `frontend/src/components/auth/UserProfile.tsx`
+
+- [ ] **Step 1: Write the failing toggle test**
+
+Append this test inside the existing `describe` block in `frontend/src/components/auth/UserProfile.test.tsx`:
+
+```tsx
+  it("closes the panel when the trigger is clicked a second time", async () => {
+    mockCtx = {
+      permissions: ["catalog.read"],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    render(<UserProfile />);
+    const button = screen.getByRole("button");
+
+    await userEvent.click(button);
+    expect(screen.getByText("Oprávnění")).toBeInTheDocument();
+
+    await userEvent.click(button);
+    expect(screen.queryByText("Oprávnění")).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the test and confirm it FAILS**
+
+```bash
+cd frontend && npx react-scripts test src/components/auth/UserProfile.test.tsx --watchAll=false --forceExit 2>&1 | tail -20
+```
+
+Expected: 6 pass, 1 fail — the new test fails because `onClick={() => setShowModal(true)}` never closes the panel once open.
+
+- [ ] **Step 3: Rewrite UserProfile.tsx**
+
+Replace the entire contents of `frontend/src/components/auth/UserProfile.tsx` with:
+
+```tsx
+import React, { useState, useRef, useEffect } from "react";
+import { Transition } from "@headlessui/react";
+import { User, LogIn, LogOut, ShieldCheck, KeyRound, Users } from "lucide-react";
+import { useAuth } from "../../auth/useAuth";
+import { useMockAuth, shouldUseMockAuth } from "../../auth/mockAuth";
+import { usePermissionsContext } from "../../auth/PermissionsContext";
+
+interface UserProfileProps {
+  compact?: boolean;
+  menuPosition?: "above" | "below";
+}
+
+const UserProfile: React.FC<UserProfileProps> = ({
+  compact = false,
+  menuPosition = "above",
+}) => {
+  const realAuth = useAuth();
+  const mockAuth = useMockAuth();
+
+  const auth = shouldUseMockAuth() ? mockAuth : realAuth;
+  const { isAuthenticated, login, logout, getUserInfo, getStoredUserInfo, inProgress } = auth;
+
+  const [showPanel, setShowPanel] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const userInfo = getUserInfo();
+  const storedUserInfo = getStoredUserInfo();
+  const { permissions, groups, isSuperUser, isLoading: permissionsLoading } =
+    usePermissionsContext();
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setShowPanel(false);
+      }
+    };
+    if (showPanel) {
+      document.addEventListener("mousedown", handleMouseDown);
+    }
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [showPanel]);
+
+  const handleLogin = async () => {
+    try {
+      await login();
+    } catch (error) {
+      console.error("Login error:", error);
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      setShowPanel(false);
+    } catch (error) {
+      console.error("Logout error:", error);
+    }
+  };
+
+  if (inProgress === "login" || inProgress === "logout") {
+    return (
+      <div className={`flex items-center ${compact ? "justify-center" : "justify-center p-2"}`}>
+        <div className="w-8 h-8 bg-gray-300 rounded-full animate-pulse"></div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    if (compact) {
+      return (
+        <button
+          onClick={handleLogin}
+          className="w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center hover:bg-gray-500 transition-colors"
+          title="Sign in"
+        >
+          <User className="h-4 w-4 text-white" />
+        </button>
+      );
+    }
+
+    return (
+      <button
+        onClick={handleLogin}
+        className="flex items-center space-x-3 p-2 w-full text-left hover:bg-secondary-blue-pale/50 rounded-md transition-colors group"
+        title="Sign in"
+      >
+        <div className="w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center">
+          <User className="h-4 w-4 text-white" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-gray-700 group-hover:text-gray-900">Sign in</p>
+          <p className="text-xs text-gray-500">Click to authenticate</p>
+        </div>
+        <LogIn className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
+      </button>
+    );
+  }
+
+  const panelPositionClass = compact
+    ? "absolute bottom-full left-0 w-60"
+    : "absolute bottom-full inset-x-0";
+
+  return (
+    <div ref={panelRef}>
+      {/* Trigger */}
+      {compact ? (
+        <button
+          onClick={() => setShowPanel((prev) => !prev)}
+          className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center hover:bg-accent-blue-bright transition-colors"
+          title={`${userInfo?.name} (${userInfo?.email})`}
+        >
+          <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
+        </button>
+      ) : (
+        <button
+          onClick={() => setShowPanel((prev) => !prev)}
+          className="flex items-center space-x-3 p-2 w-full text-left hover:bg-secondary-blue-pale/50 rounded-md transition-colors group"
+        >
+          <div className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center">
+            <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-neutral-slate group-hover:text-neutral-slate truncate">
+              {userInfo?.name || "User"}
+            </p>
+            <p className="text-xs text-gray-500 truncate">{userInfo?.email || "user@example.com"}</p>
+          </div>
+        </button>
+      )}
+
+      {/* Slide-up panel */}
+      <Transition
+        show={showPanel}
+        enter="transition ease-out duration-200"
+        enterFrom="opacity-0 translate-y-2"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-2"
+      >
+        <div
+          className={`${panelPositionClass} z-10 rounded-t-xl shadow-lg bg-white border border-gray-100 overflow-hidden`}
+        >
+          <div className="max-h-[80vh] overflow-y-auto">
+            {/* User identity */}
+            <div className="px-5 py-5 flex items-center space-x-4 border-b border-gray-100">
+              <div className="w-12 h-12 bg-primary-blue rounded-full flex items-center justify-center shrink-0">
+                <span className="text-white text-lg font-semibold">
+                  {userInfo?.initials || "U"}
+                </span>
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-neutral-slate truncate">
+                  {userInfo?.name}
+                </p>
+                <p className="text-xs text-gray-500 truncate">{userInfo?.email}</p>
+                {storedUserInfo?.lastLogin && (
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    Poslední přihlášení:{" "}
+                    {new Date(storedUserInfo.lastLogin).toLocaleString("cs-CZ")}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* Roles */}
+            {userInfo?.roles && userInfo.roles.length > 0 && (
+              <div className="px-5 py-4 border-b border-gray-100">
+                <div className="flex items-center space-x-2 mb-3">
+                  <ShieldCheck className="h-4 w-4 text-primary-blue" />
+                  <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    Role
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {userInfo.roles.map((role) => (
+                    <span
+                      key={role}
+                      className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
+                    >
+                      {role}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Permissions */}
+            {!permissionsLoading && (isSuperUser || permissions.length > 0) && (
+              <div className="px-5 py-4 border-b border-gray-100">
+                <div className="flex items-center space-x-2 mb-3">
+                  <KeyRound className="h-4 w-4 text-emerald-600" />
+                  <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    Oprávnění
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {isSuperUser ? (
+                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700">
+                      Super User · vše povoleno
+                    </span>
+                  ) : (
+                    permissions.map((perm) => (
+                      <span
+                        key={perm}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
+                      >
+                        {perm}
+                      </span>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Groups */}
+            {!permissionsLoading && groups.length > 0 && (
+              <div className="px-5 py-4 border-b border-gray-100">
+                <div className="flex items-center space-x-2 mb-3">
+                  <Users className="h-4 w-4 text-primary-blue" />
+                  <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    Skupiny
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {groups.map((group) => (
+                    <span
+                      key={group}
+                      className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
+                    >
+                      {group}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Footer */}
+            <div className="px-5 py-4">
+              <button
+                onClick={handleLogout}
+                className="flex items-center justify-center space-x-2 w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                <LogOut className="h-4 w-4" />
+                <span>Odhlásit se</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </div>
+  );
+};
+
+export default UserProfile;
+```
+
+- [ ] **Step 4: Rename `openModal` → `openPanel` in the test helper**
+
+In `frontend/src/components/auth/UserProfile.test.tsx`, rename the helper and its call sites:
+
+```tsx
+// BEFORE (around line 45):
+const openModal = async () => {
+  render(<UserProfile />);
+  await userEvent.click(screen.getByRole("button"));
+};
+
+// AFTER:
+const openPanel = async () => {
+  render(<UserProfile />);
+  await userEvent.click(screen.getByRole("button"));
+};
+```
+
+Also update every call site: replace `await openModal()` with `await openPanel()` throughout the file (6 occurrences in the existing tests).
+
+- [ ] **Step 5: Run all UserProfile tests and confirm all 7 pass**
+
+```bash
+cd frontend && npx react-scripts test src/components/auth/UserProfile.test.tsx --watchAll=false --forceExit 2>&1 | tail -20
+```
+
+Expected: 7 tests passing.
+
+> **If the toggle test fails with the panel still in the DOM:** Headless UI's Transition may not fire `transitionend` in jsdom. Wrap the closing assertion with `waitFor`:
+> ```tsx
+> await userEvent.click(button);
+> await waitFor(() => {
+>   expect(screen.queryByText("Oprávnění")).not.toBeInTheDocument();
+> });
+> ```
+> Add `import { waitFor } from "@testing-library/react";` at the top of the test file.
+
+- [ ] **Step 6: Run the full frontend build to confirm no TypeScript errors**
+
+```bash
+cd frontend && CI=false npm run build 2>&1 | tail -20
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/auth/UserProfile.tsx frontend/src/components/auth/UserProfile.test.tsx
+git commit -m "feat(ui): replace user profile modal with slide-up panel"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Covered by |
+|---|---|
+| Remove `fixed inset-0` overlay | Task 2 Step 3 — new JSX has no fixed overlay |
+| `relative` on Sidebar bottom wrappers | Task 1 |
+| `Transition` slide-up animation | Task 2 Step 3 — enter/leave classes |
+| Close on toggle | Task 2 Step 3 — `setShowPanel((prev) => !prev)` |
+| Close on click-outside | Task 2 Step 3 — `useEffect` + `mousedown` |
+| `rounded-t-xl shadow-lg` panel shell | Task 2 Step 3 — panel div classes |
+| Compact mode `w-60` | Task 2 Step 3 — `panelPositionClass` |
+| Expanded mode `inset-x-0` | Task 2 Step 3 — `panelPositionClass` |
+| No X close button | Task 2 Step 3 — removed from JSX |
+| All existing content preserved | Task 2 Step 3 — sections unchanged |
+| Toggle test (TDD anchor) | Task 2 Steps 1–2 |
+| Test helper rename | Task 2 Step 4 |
+
+**Placeholder scan:** None found — all steps include full code.
+
+**Type consistency:** `showPanel` (boolean state), `panelRef` (RefObject<HTMLDivElement>), `panelPositionClass` (string) — consistent across all references in the implementation.

--- a/docs/superpowers/specs/2026-06-08-user-profile-slide-up-panel-design.md
+++ b/docs/superpowers/specs/2026-06-08-user-profile-slide-up-panel-design.md
@@ -1,0 +1,90 @@
+# User Profile Slide-Up Panel Design
+
+**Date:** 2026-06-08
+**Branch:** onpaj/auth-user-identity-linking
+
+## Goal
+
+Replace the centered full-screen modal overlay in `UserProfile.tsx` with a slide-up panel anchored to the sidebar's bottom user row. The panel overlays the sidebar nav content above it, closes on click-outside or toggle, and animates in/out with a slide-up + fade.
+
+## Files Changed
+
+- `frontend/src/components/auth/UserProfile.tsx` — main change: replace modal with slide-up panel
+- `frontend/src/components/layout/Sidebar.tsx` — minor: add `relative` to both bottom section wrappers
+
+## Panel Positioning
+
+Both bottom section wrapper divs in `Sidebar.tsx` receive `relative` positioning. This makes them the nearest positioned ancestor for the absolute panel.
+
+**Expanded sidebar** (w-64):
+```
+absolute bottom-full inset-x-0
+```
+Stretches left-to-right across the full bottom row width (including the collapse button). Covers nav items above it.
+
+**Compact sidebar** (w-16):
+```
+absolute bottom-full left-0 w-60
+```
+Pops rightward from the 64px sidebar into the content area. Fixed width `w-60` (240px).
+
+The sidebar has no `overflow-hidden` on its outer shell — only `<nav>` has `overflow-y-auto`. The absolutely positioned panel will correctly overlay the nav content without being clipped.
+
+## Animation
+
+Headless UI `Transition` v2 (already installed: `@headlessui/react ^2.2.7`):
+
+```
+enter:     "transition ease-out duration-200"
+enterFrom: "opacity-0 translate-y-2"
+enterTo:   "opacity-100 translate-y-0"
+leave:     "transition ease-in duration-150"
+leaveFrom: "opacity-100 translate-y-0"
+leaveTo:   "opacity-0 translate-y-2"
+```
+
+Slides up 8px and fades in on open; reverses on close.
+
+## Open / Close Behavior
+
+- **Open:** click the trigger button (avatar or full-width user row)
+- **Close (toggle):** click the trigger button again
+- **Close (outside):** `mousedown` event listener via `useRef` wrapping the entire component (trigger + panel); fires `setShowPanel(false)` when click lands outside
+
+No background overlay. No X button inside the panel.
+
+## Panel Shell
+
+```
+absolute bottom-full ... z-10
+rounded-t-xl shadow-lg bg-white border border-gray-100 overflow-hidden
+```
+
+- Rounded top corners only (`rounded-t-xl`) — the bottom visually connects to the trigger row
+- Elevated shadow to separate it from nav content
+- `overflow-hidden` on the panel itself to clip content to rounded corners
+- `max-h-[80vh] overflow-y-auto` on the inner content container to handle overflow gracefully on small screens
+
+## Panel Content
+
+Identical to the current modal content — no sections removed or reordered:
+
+1. Identity row (avatar, name, email, last login)
+2. Roles section (id-token roles, blue chips)
+3. Permissions section (DB permissions: amber super-user badge or emerald chips)
+4. Groups section (DB groups, blue chips)
+5. Logout button row
+
+## State Rename
+
+`showModal` → `showPanel` throughout `UserProfile.tsx` for semantic accuracy.
+
+## Tests
+
+No structural test changes required. The existing 6 tests in `UserProfile.test.tsx` click the trigger button and assert on panel content — both behaviors are identical. The `openModal` helper is renamed to `openPanel` for clarity.
+
+## Out of Scope
+
+- No changes to panel content or data sources
+- No mobile-specific layout changes (mobile sidebar already hides behind a menu toggle; behavior unchanged)
+- No animation on the sidebar collapse/expand itself

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -630,7 +630,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
             {/* User Profile and Toggle button */}
             {!isCollapsed ? (
-              <div className="flex items-center justify-between h-16 py-2 border-t border-gray-100">
+              <div className="relative flex items-center justify-between h-16 py-2 border-t border-gray-100">
                 <div className="flex-1 min-w-0">
                   <UserProfile />
                 </div>
@@ -644,7 +644,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 </button>
               </div>
             ) : (
-              <div className="flex flex-col items-center py-2 space-y-2 border-t border-gray-100">
+              <div className="relative flex flex-col items-center py-2 space-y-2 border-t border-gray-100">
                 <div className="w-full flex justify-center">
                   <UserProfile compact />
                 </div>

--- a/frontend/src/components/Layout/TopBar.tsx
+++ b/frontend/src/components/Layout/TopBar.tsx
@@ -38,7 +38,7 @@ const TopBar: React.FC<TopBarProps> = ({ onMenuClick }) => {
         </div>
 
         {/* Right side - User Profile Menu */}
-        <div className="flex items-center">
+        <div className="relative flex items-center">
           <UserProfile menuPosition="below" />
         </div>
       </div>

--- a/frontend/src/components/auth/UserProfile.test.tsx
+++ b/frontend/src/components/auth/UserProfile.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserProfile from "./UserProfile";
+
+const mockBaseAuth = {
+  isAuthenticated: true,
+  login: jest.fn(),
+  logout: jest.fn(),
+  inProgress: "none",
+  getUserInfo: () => ({
+    name: "Test User",
+    email: "test@anela.cz",
+    initials: "TU",
+    roles: ["super_user"],
+  }),
+  getStoredUserInfo: () => null,
+};
+
+interface MockPermissionsCtx {
+  permissions: string[];
+  isSuperUser: boolean;
+  groups: string[];
+  isLoading: boolean;
+  hasPermission: (p: string) => boolean;
+}
+
+let mockCtx: MockPermissionsCtx = {
+  permissions: [],
+  isSuperUser: false,
+  groups: [],
+  isLoading: false,
+  hasPermission: (_: string) => false,
+};
+
+jest.mock("../../auth/useAuth", () => ({ useAuth: () => mockBaseAuth }));
+jest.mock("../../auth/mockAuth", () => ({
+  useMockAuth: () => mockBaseAuth,
+  shouldUseMockAuth: () => false,
+}));
+jest.mock("../../auth/PermissionsContext", () => ({
+  usePermissionsContext: () => mockCtx,
+}));
+
+const openModal = async () => {
+  render(<UserProfile />);
+  await userEvent.click(screen.getByRole("button"));
+};
+
+describe("UserProfile permissions display", () => {
+  it("renders Permissions chips when user has DB permissions", async () => {
+    mockCtx = {
+      permissions: ["catalog.read", "journal.read"],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.getByText("Oprávnění")).toBeInTheDocument();
+    expect(screen.getByText("catalog.read")).toBeInTheDocument();
+    expect(screen.getByText("journal.read")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/auth/UserProfile.test.tsx
+++ b/frontend/src/components/auth/UserProfile.test.tsx
@@ -119,4 +119,33 @@ describe("UserProfile permissions display", () => {
 
     expect(screen.queryByText("Skupiny")).not.toBeInTheDocument();
   });
+
+  it("hides Permissions and Groups sections while loading", async () => {
+    mockCtx = {
+      permissions: ["catalog.read"],
+      isSuperUser: false,
+      groups: ["Finance"],
+      isLoading: true,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.queryByText("Oprávnění")).not.toBeInTheDocument();
+    expect(screen.queryByText("Skupiny")).not.toBeInTheDocument();
+  });
+
+  it("hides Permissions section when non-super-user has no permissions", async () => {
+    mockCtx = {
+      permissions: [],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => false,
+    };
+
+    await openModal();
+
+    expect(screen.queryByText("Oprávnění")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/auth/UserProfile.test.tsx
+++ b/frontend/src/components/auth/UserProfile.test.tsx
@@ -48,6 +48,16 @@ const openModal = async () => {
 };
 
 describe("UserProfile permissions display", () => {
+  beforeEach(() => {
+    mockCtx = {
+      permissions: [],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => false,
+    };
+  });
+
   it("renders Permissions chips when user has DB permissions", async () => {
     mockCtx = {
       permissions: ["catalog.read", "journal.read"],
@@ -62,5 +72,21 @@ describe("UserProfile permissions display", () => {
     expect(screen.getByText("Oprávnění")).toBeInTheDocument();
     expect(screen.getByText("catalog.read")).toBeInTheDocument();
     expect(screen.getByText("journal.read")).toBeInTheDocument();
+  });
+
+  it("renders a single super-user badge when isSuperUser is true", async () => {
+    mockCtx = {
+      permissions: ["catalog.read", "journal.read", "finance.read"],
+      isSuperUser: true,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.getByText("Super User · vše povoleno")).toBeInTheDocument();
+    expect(screen.queryByText("catalog.read")).not.toBeInTheDocument();
+    expect(screen.queryByText("journal.read")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/auth/UserProfile.test.tsx
+++ b/frontend/src/components/auth/UserProfile.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UserProfile from "./UserProfile";
 
@@ -42,7 +42,7 @@ jest.mock("../../auth/PermissionsContext", () => ({
   usePermissionsContext: () => mockCtx,
 }));
 
-const openModal = async () => {
+const openPanel = async () => {
   render(<UserProfile />);
   await userEvent.click(screen.getByRole("button"));
 };
@@ -67,7 +67,7 @@ describe("UserProfile permissions display", () => {
       hasPermission: () => true,
     };
 
-    await openModal();
+    await openPanel();
 
     expect(screen.getByText("Oprávnění")).toBeInTheDocument();
     expect(screen.getByText("catalog.read")).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe("UserProfile permissions display", () => {
       hasPermission: () => true,
     };
 
-    await openModal();
+    await openPanel();
 
     expect(screen.getByText("Super User · vše povoleno")).toBeInTheDocument();
     expect(screen.queryByText("catalog.read")).not.toBeInTheDocument();
@@ -99,7 +99,7 @@ describe("UserProfile permissions display", () => {
       hasPermission: () => true,
     };
 
-    await openModal();
+    await openPanel();
 
     expect(screen.getByText("Skupiny")).toBeInTheDocument();
     expect(screen.getByText("Finance")).toBeInTheDocument();
@@ -115,7 +115,7 @@ describe("UserProfile permissions display", () => {
       hasPermission: () => true,
     };
 
-    await openModal();
+    await openPanel();
 
     expect(screen.queryByText("Skupiny")).not.toBeInTheDocument();
   });
@@ -129,7 +129,7 @@ describe("UserProfile permissions display", () => {
       hasPermission: () => true,
     };
 
-    await openModal();
+    await openPanel();
 
     expect(screen.queryByText("Oprávnění")).not.toBeInTheDocument();
     expect(screen.queryByText("Skupiny")).not.toBeInTheDocument();
@@ -144,8 +144,29 @@ describe("UserProfile permissions display", () => {
       hasPermission: () => false,
     };
 
-    await openModal();
+    await openPanel();
 
     expect(screen.queryByText("Oprávnění")).not.toBeInTheDocument();
+  });
+
+  it("closes the panel when the trigger is clicked a second time", async () => {
+    mockCtx = {
+      permissions: ["catalog.read"],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    render(<UserProfile />);
+    const button = screen.getByRole("button");
+
+    await userEvent.click(button);
+    expect(screen.getByText("Oprávnění")).toBeInTheDocument();
+
+    await userEvent.click(button);
+    await waitFor(() => {
+      expect(screen.queryByText("Oprávnění")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/auth/UserProfile.test.tsx
+++ b/frontend/src/components/auth/UserProfile.test.tsx
@@ -89,4 +89,34 @@ describe("UserProfile permissions display", () => {
     expect(screen.queryByText("catalog.read")).not.toBeInTheDocument();
     expect(screen.queryByText("journal.read")).not.toBeInTheDocument();
   });
+
+  it("renders Groups chips when user belongs to DB groups", async () => {
+    mockCtx = {
+      permissions: ["catalog.read"],
+      isSuperUser: false,
+      groups: ["Finance", "Marketing"],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.getByText("Skupiny")).toBeInTheDocument();
+    expect(screen.getByText("Finance")).toBeInTheDocument();
+    expect(screen.getByText("Marketing")).toBeInTheDocument();
+  });
+
+  it("hides Groups section when user has no groups", async () => {
+    mockCtx = {
+      permissions: ["catalog.read"],
+      isSuperUser: false,
+      groups: [],
+      isLoading: false,
+      hasPermission: () => true,
+    };
+
+    await openModal();
+
+    expect(screen.queryByText("Skupiny")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/auth/UserProfile.tsx
+++ b/frontend/src/components/auth/UserProfile.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
-import { User, LogIn, LogOut, X, ShieldCheck, KeyRound, Users } from "lucide-react";
+import React, { useState, useRef, useEffect } from "react";
+import { Transition } from "@headlessui/react";
+import { User, LogIn, LogOut, ShieldCheck, KeyRound, Users } from "lucide-react";
 import { useAuth } from "../../auth/useAuth";
 import { useMockAuth, shouldUseMockAuth } from "../../auth/mockAuth";
 import { usePermissionsContext } from "../../auth/PermissionsContext";
@@ -19,11 +20,26 @@ const UserProfile: React.FC<UserProfileProps> = ({
   const auth = shouldUseMockAuth() ? mockAuth : realAuth;
   const { isAuthenticated, login, logout, getUserInfo, getStoredUserInfo, inProgress } = auth;
 
-  const [showModal, setShowModal] = useState(false);
+  const [showPanel, setShowPanel] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
   const userInfo = getUserInfo();
   const storedUserInfo = getStoredUserInfo();
   const { permissions, groups, isSuperUser, isLoading: permissionsLoading } =
     usePermissionsContext();
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setShowPanel(false);
+      }
+    };
+    if (showPanel) {
+      document.addEventListener("mousedown", handleMouseDown);
+    }
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [showPanel]);
 
   const handleLogin = async () => {
     try {
@@ -36,7 +52,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
   const handleLogout = async () => {
     try {
       await logout();
-      setShowModal(false);
+      setShowPanel(false);
     } catch (error) {
       console.error("Logout error:", error);
     }
@@ -81,163 +97,160 @@ const UserProfile: React.FC<UserProfileProps> = ({
     );
   }
 
-  const triggerButton = compact ? (
-    <button
-      onClick={() => setShowModal(true)}
-      className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center hover:bg-accent-blue-bright transition-colors"
-      title={`${userInfo?.name} (${userInfo?.email})`}
-    >
-      <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
-    </button>
-  ) : (
-    <button
-      onClick={() => setShowModal(true)}
-      className="flex items-center space-x-3 p-2 w-full text-left hover:bg-secondary-blue-pale/50 rounded-md transition-colors group"
-    >
-      <div className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center">
-        <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-neutral-slate group-hover:text-neutral-slate truncate">
-          {userInfo?.name || "User"}
-        </p>
-        <p className="text-xs text-gray-500 truncate">{userInfo?.email || "user@example.com"}</p>
-      </div>
-    </button>
-  );
+  const verticalClass = menuPosition === "below" ? "top-full" : "bottom-full";
+  const panelPositionClass = compact
+    ? `absolute ${verticalClass} left-0 w-60`
+    : `absolute ${verticalClass} inset-x-0`;
 
   return (
-    <>
-      {triggerButton}
+    <div ref={panelRef}>
+      {/* Trigger */}
+      {compact ? (
+        <button
+          onClick={() => setShowPanel((prev) => !prev)}
+          className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center hover:bg-accent-blue-bright transition-colors"
+          title={`${userInfo?.name} (${userInfo?.email})`}
+        >
+          <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
+        </button>
+      ) : (
+        <button
+          onClick={() => setShowPanel((prev) => !prev)}
+          className="flex items-center space-x-3 p-2 w-full text-left hover:bg-secondary-blue-pale/50 rounded-md transition-colors group"
+        >
+          <div className="w-8 h-8 bg-primary-blue rounded-full flex items-center justify-center">
+            <span className="text-white text-sm font-medium">{userInfo?.initials || "U"}</span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-neutral-slate group-hover:text-neutral-slate truncate">
+              {userInfo?.name || "User"}
+            </p>
+            <p className="text-xs text-gray-500 truncate">{userInfo?.email || "user@example.com"}</p>
+          </div>
+        </button>
+      )}
 
-      {showModal && (
-        <div className="fixed inset-0 z-50 overflow-y-auto">
-          <div
-            className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
-            onClick={() => setShowModal(false)}
-          />
-
-          <div className="flex min-h-full items-center justify-center p-4">
-            <div className="relative bg-primary-white rounded-xl shadow-xl max-w-sm w-full">
-              {/* Header */}
-              <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
-                <h3 className="text-base font-semibold text-neutral-slate">Uživatel</h3>
-                <button
-                  onClick={() => setShowModal(false)}
-                  className="text-gray-400 hover:text-gray-600 transition-colors"
-                >
-                  <X className="h-5 w-5" />
-                </button>
+      {/* Slide-up panel */}
+      <Transition
+        show={showPanel}
+        enter="transition ease-out duration-200"
+        enterFrom="opacity-0 translate-y-2"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-2"
+      >
+        <div
+          className={`${panelPositionClass} z-10 ${menuPosition === "below" ? "rounded-b-xl" : "rounded-t-xl"} shadow-lg bg-white border border-gray-100 overflow-hidden`}
+        >
+          <div className="max-h-[80vh] overflow-y-auto">
+            {/* User identity */}
+            <div className="px-5 py-5 flex items-center space-x-4 border-b border-gray-100">
+              <div className="w-12 h-12 bg-primary-blue rounded-full flex items-center justify-center shrink-0">
+                <span className="text-white text-lg font-semibold">
+                  {userInfo?.initials || "U"}
+                </span>
               </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-neutral-slate truncate">
+                  {userInfo?.name}
+                </p>
+                <p className="text-xs text-gray-500 truncate">{userInfo?.email}</p>
+                {storedUserInfo?.lastLogin && (
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    Poslední přihlášení:{" "}
+                    {new Date(storedUserInfo.lastLogin).toLocaleString("cs-CZ")}
+                  </p>
+                )}
+              </div>
+            </div>
 
-              {/* User identity */}
-              <div className="px-5 py-5 flex items-center space-x-4 border-b border-gray-100">
-                <div className="w-12 h-12 bg-primary-blue rounded-full flex items-center justify-center shrink-0">
-                  <span className="text-white text-lg font-semibold">
-                    {userInfo?.initials || "U"}
+            {/* Roles */}
+            {userInfo?.roles && userInfo.roles.length > 0 && (
+              <div className="px-5 py-4 border-b border-gray-100">
+                <div className="flex items-center space-x-2 mb-3">
+                  <ShieldCheck className="h-4 w-4 text-primary-blue" />
+                  <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    Role
                   </span>
                 </div>
-                <div className="min-w-0">
-                  <p className="text-sm font-semibold text-neutral-slate truncate">
-                    {userInfo?.name}
-                  </p>
-                  <p className="text-xs text-gray-500 truncate">{userInfo?.email}</p>
-                  {storedUserInfo?.lastLogin && (
-                    <p className="text-xs text-gray-400 mt-0.5">
-                      Poslední přihlášení:{" "}
-                      {new Date(storedUserInfo.lastLogin).toLocaleString("cs-CZ")}
-                    </p>
+                <div className="flex flex-wrap gap-2">
+                  {userInfo.roles.map((role) => (
+                    <span
+                      key={role}
+                      className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
+                    >
+                      {role}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Permissions */}
+            {!permissionsLoading && (isSuperUser || permissions.length > 0) && (
+              <div className="px-5 py-4 border-b border-gray-100">
+                <div className="flex items-center space-x-2 mb-3">
+                  <KeyRound className="h-4 w-4 text-emerald-600" />
+                  <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    Oprávnění
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {isSuperUser ? (
+                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700">
+                      Super User · vše povoleno
+                    </span>
+                  ) : (
+                    permissions.map((perm) => (
+                      <span
+                        key={perm}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
+                      >
+                        {perm}
+                      </span>
+                    ))
                   )}
                 </div>
               </div>
+            )}
 
-              {/* Roles */}
-              {userInfo?.roles && userInfo.roles.length > 0 && (
-                <div className="px-5 py-4 border-b border-gray-100">
-                  <div className="flex items-center space-x-2 mb-3">
-                    <ShieldCheck className="h-4 w-4 text-primary-blue" />
-                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                      Role
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {userInfo.roles.map((role) => (
-                      <span
-                        key={role}
-                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
-                      >
-                        {role}
-                      </span>
-                    ))}
-                  </div>
+            {/* Groups */}
+            {!permissionsLoading && groups.length > 0 && (
+              <div className="px-5 py-4 border-b border-gray-100">
+                <div className="flex items-center space-x-2 mb-3">
+                  <Users className="h-4 w-4 text-primary-blue" />
+                  <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    Skupiny
+                  </span>
                 </div>
-              )}
-
-              {/* Permissions */}
-              {!permissionsLoading && (isSuperUser || permissions.length > 0) && (
-                <div className="px-5 py-4 border-b border-gray-100">
-                  <div className="flex items-center space-x-2 mb-3">
-                    <KeyRound className="h-4 w-4 text-emerald-600" />
-                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                      Oprávnění
+                <div className="flex flex-wrap gap-2">
+                  {groups.map((group) => (
+                    <span
+                      key={group}
+                      className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
+                    >
+                      {group}
                     </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {isSuperUser ? (
-                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700">
-                        Super User · vše povoleno
-                      </span>
-                    ) : (
-                      permissions.map((perm) => (
-                        <span
-                          key={perm}
-                          className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
-                        >
-                          {perm}
-                        </span>
-                      ))
-                    )}
-                  </div>
+                  ))}
                 </div>
-              )}
-
-              {/* Groups */}
-              {!permissionsLoading && groups.length > 0 && (
-                <div className="px-5 py-4 border-b border-gray-100">
-                  <div className="flex items-center space-x-2 mb-3">
-                    <Users className="h-4 w-4 text-primary-blue" />
-                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                      Skupiny
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {groups.map((group) => (
-                      <span
-                        key={group}
-                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
-                      >
-                        {group}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Footer */}
-              <div className="px-5 py-4">
-                <button
-                  onClick={handleLogout}
-                  className="flex items-center justify-center space-x-2 w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-                >
-                  <LogOut className="h-4 w-4" />
-                  <span>Odhlásit se</span>
-                </button>
               </div>
+            )}
+
+            {/* Footer */}
+            <div className="px-5 py-4">
+              <button
+                onClick={handleLogout}
+                className="flex items-center justify-center space-x-2 w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                <LogOut className="h-4 w-4" />
+                <span>Odhlásit se</span>
+              </button>
             </div>
           </div>
         </div>
-      )}
-    </>
+      </Transition>
+    </div>
   );
 };
 

--- a/frontend/src/components/auth/UserProfile.tsx
+++ b/frontend/src/components/auth/UserProfile.tsx
@@ -174,7 +174,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
               )}
 
               {/* Permissions */}
-              {!permissionsLoading && !isSuperUser && permissions.length > 0 && (
+              {!permissionsLoading && (isSuperUser || permissions.length > 0) && (
                 <div className="px-5 py-4 border-b border-gray-100">
                   <div className="flex items-center space-x-2 mb-3">
                     <KeyRound className="h-4 w-4 text-emerald-600" />
@@ -183,14 +183,20 @@ const UserProfile: React.FC<UserProfileProps> = ({
                     </span>
                   </div>
                   <div className="flex flex-wrap gap-2">
-                    {permissions.map((perm) => (
-                      <span
-                        key={perm}
-                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
-                      >
-                        {perm}
+                    {isSuperUser ? (
+                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700">
+                        Super User · vše povoleno
                       </span>
-                    ))}
+                    ) : (
+                      permissions.map((perm) => (
+                        <span
+                          key={perm}
+                          className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
+                        >
+                          {perm}
+                        </span>
+                      ))
+                    )}
                   </div>
                 </div>
               )}

--- a/frontend/src/components/auth/UserProfile.tsx
+++ b/frontend/src/components/auth/UserProfile.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
-import { User, LogIn, LogOut, X, ShieldCheck } from "lucide-react";
+import { User, LogIn, LogOut, X, ShieldCheck, KeyRound, Users } from "lucide-react";
 import { useAuth } from "../../auth/useAuth";
 import { useMockAuth, shouldUseMockAuth } from "../../auth/mockAuth";
+import { usePermissionsContext } from "../../auth/PermissionsContext";
 
 interface UserProfileProps {
   compact?: boolean;
@@ -21,6 +22,8 @@ const UserProfile: React.FC<UserProfileProps> = ({
   const [showModal, setShowModal] = useState(false);
   const userInfo = getUserInfo();
   const storedUserInfo = getStoredUserInfo();
+  const { permissions, groups, isSuperUser, isLoading: permissionsLoading } =
+    usePermissionsContext();
 
   const handleLogin = async () => {
     try {
@@ -164,6 +167,28 @@ const UserProfile: React.FC<UserProfileProps> = ({
                         className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
                       >
                         {role}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Permissions */}
+              {!permissionsLoading && !isSuperUser && permissions.length > 0 && (
+                <div className="px-5 py-4 border-b border-gray-100">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <KeyRound className="h-4 w-4 text-emerald-600" />
+                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      Oprávnění
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {permissions.map((perm) => (
+                      <span
+                        key={perm}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700"
+                      >
+                        {perm}
                       </span>
                     ))}
                   </div>

--- a/frontend/src/components/auth/UserProfile.tsx
+++ b/frontend/src/components/auth/UserProfile.tsx
@@ -201,6 +201,28 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 </div>
               )}
 
+              {/* Groups */}
+              {!permissionsLoading && groups.length > 0 && (
+                <div className="px-5 py-4 border-b border-gray-100">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <Users className="h-4 w-4 text-primary-blue" />
+                    <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      Skupiny
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {groups.map((group) => (
+                      <span
+                        key={group}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-secondary-blue-pale text-primary-blue"
+                      >
+                        {group}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {/* Footer */}
               <div className="px-5 py-4">
                 <button

--- a/frontend/src/components/baleni/BaleniLayout.tsx
+++ b/frontend/src/components/baleni/BaleniLayout.tsx
@@ -20,7 +20,7 @@ const BaleniLayout: React.FC = () => {
 
   return (
     <div className="min-h-screen flex flex-col bg-background-gray">
-      <header className="h-14 sticky top-0 z-10 bg-white border-b border-border-light flex items-center px-4 gap-3">
+      <header className="relative h-14 sticky top-0 z-10 bg-white border-b border-border-light flex items-center px-4 gap-3">
         {!isHome && (
           <button
             onClick={() => navigate(BALENI_ROOT)}

--- a/frontend/src/components/terminal/TerminalLayout.tsx
+++ b/frontend/src/components/terminal/TerminalLayout.tsx
@@ -22,7 +22,7 @@ const TerminalLayout: React.FC = () => {
 
   return (
     <div className="min-h-screen flex flex-col bg-background-gray">
-      <header className="h-14 sticky top-0 z-10 bg-white border-b border-border-light flex items-center px-4 gap-3">
+      <header className="relative h-14 sticky top-0 z-10 bg-white border-b border-border-light flex items-center px-4 gap-3">
         {!isHome && (
           <button
             onClick={() => navigate(-1)}

--- a/frontend/src/components/test/TestApp.tsx
+++ b/frontend/src/components/test/TestApp.tsx
@@ -7,6 +7,7 @@ import Layout from "../Layout/Layout";
 import Dashboard from "../pages/Dashboard";
 import AuthGuard from "../auth/AuthGuard";
 import { ChangelogProvider } from "../../contexts/ChangelogContext";
+import { PermissionsProvider } from "../../auth/PermissionsContext";
 import "../../i18n";
 
 // Test version of App component with mocked configuration
@@ -55,9 +56,11 @@ function TestApp() {
           <MsalProvider instance={msalInstance}>
             <Router>
               <AuthGuard>
-                <Layout>
-                  <Dashboard />
-                </Layout>
+                <PermissionsProvider isAuthenticated={true}>
+                  <Layout>
+                    <Dashboard />
+                  </Layout>
+                </PermissionsProvider>
               </AuthGuard>
             </Router>
           </MsalProvider>


### PR DESCRIPTION
## Summary

- **Bug fix:** `PermissionClaimsTransformation` was reading `ClaimTypes.NameIdentifier` (mapped from `sub`, a per-app pairwise ID) instead of the tenant-wide Entra `oid`. This caused a duplicate `AppUser` row on first login, orphaning the pre-created row from `EntraMemberSearch`. Fixed by using `GetObjectId()` from `Microsoft.Identity.Web`, which handles both the raw `oid` claim and the mapped `objectidentifier` URI.
- **UI:** Replaced the full-screen modal overlay in `UserProfile` with a slide-up panel anchored to the sidebar bottom row. Adds DB permissions chips (or super-user badge) and group membership chips to the panel.
- **Tests:** New tests pin the `oid`-vs-`sub` mismatch, cover the mapped URI claim shape, and cover the mock-auth `NameIdentifier` fallback. New `UserProfile.test.tsx` covers permissions display, super-user badge, groups, loading state, and panel toggle.

## Changed files

- `PermissionClaimsTransformation.cs` — use `GetObjectId()` + `NameIdentifier` fallback
- `MockAuthenticationHandler.cs` — align `NameIdentifier` value with the `oid` GUID
- `PermissionClaimsTransformationTests.cs` — 3 new tests + refit 2 existing tests
- `UserProfile.tsx` — slide-up panel, permissions/groups sections
- `UserProfile.test.tsx` — new test file (7 tests)
- `Sidebar.tsx`, `TopBar.tsx`, `BaleniLayout.tsx`, `TerminalLayout.tsx` — `relative` positioning on wrappers for panel anchoring

## Test plan

- [ ] `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~PermissionClaimsTransformationTests` — all 7 tests pass
- [ ] `cd frontend && npx react-scripts test src/components/auth/UserProfile.test.tsx --watchAll=false --forceExit` — all 7 tests pass
- [ ] `dotnet build backend/Anela.Heblo.sln` — no errors
- [ ] `cd frontend && npm run build` — no TypeScript errors
- [ ] Manual: sign in as a user pre-created via EntraMemberSearch on staging — confirm no duplicate `AppUser` row, `LastLoginAt` populated, permissions visible