### PR TITLE
fix(smartsupp): fetch unknown contact via REST instead of dropping ContactId

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/SmartsuppController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/SmartsuppController.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.CloseConversation;
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.GenerateDraftReply;
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetInfo;
+using Anela.Heblo.Application.Features.Smartsupp.UseCases.RefreshOrphanContacts;
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.SendMessage;
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.GetConversation;
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.GetVisitorInfo;
@@ -124,6 +125,16 @@ public class SmartsuppController : BaseApiController
         var result = await _mediator.Send(
             new CloseConversationRequest { ConversationId = id },
             cancellationToken);
+        return HandleResponse(result);
+    }
+
+    [HttpPost("admin/refresh-orphan-contacts")]
+    [Authorize(Roles = AccessRoles.AdministrationWrite)]
+    [ProducesResponseType(typeof(RefreshOrphanContactsResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<RefreshOrphanContactsResponse>> RefreshOrphanContacts(
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new RefreshOrphanContactsRequest(), cancellationToken);
         return HandleResponse(result);
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/RefreshOrphanContacts/RefreshOrphanContactsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/RefreshOrphanContacts/RefreshOrphanContactsHandler.cs
@@ -1,0 +1,83 @@
+using Anela.Heblo.Domain.Features.Smartsupp;
+using Anela.Heblo.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Smartsupp.UseCases.RefreshOrphanContacts;
+
+public class RefreshOrphanContactsHandler
+    : IRequestHandler<RefreshOrphanContactsRequest, RefreshOrphanContactsResponse>
+{
+    private readonly ISmartsuppRepository _repository;
+    private readonly ISmartsuppApiClient _apiClient;
+    private readonly ApplicationDbContext _db;
+    private readonly ILogger<RefreshOrphanContactsHandler> _logger;
+
+    public RefreshOrphanContactsHandler(
+        ISmartsuppRepository repository,
+        ISmartsuppApiClient apiClient,
+        ApplicationDbContext db,
+        ILogger<RefreshOrphanContactsHandler> logger)
+    {
+        _repository = repository;
+        _apiClient = apiClient;
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<RefreshOrphanContactsResponse> Handle(
+        RefreshOrphanContactsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var response = new RefreshOrphanContactsResponse();
+        var ids = await _repository.ListOrphanContactConversationIdsAsync(cancellationToken);
+        response.Scanned = ids.Count;
+
+        foreach (var conversationId in ids)
+        {
+            try
+            {
+                var remote = await _apiClient.GetConversationAsync(conversationId, cancellationToken);
+                if (remote?.ContactId is null)
+                {
+                    response.SkippedNoContactId++;
+                    continue;
+                }
+
+                var local = await _db.SmartsuppConversations
+                    .FirstOrDefaultAsync(c => c.Id == conversationId, cancellationToken);
+                if (local is null)
+                {
+                    response.SkippedNoContactId++;
+                    continue;
+                }
+
+                // Re-attach the contact_id Smartsupp still knows about and let UpsertConversationAsync
+                // pull the contact via REST (same path as the runtime fix).
+                local.ContactId = remote.ContactId;
+                local.SyncedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
+
+                await _repository.UpsertConversationAsync(local, cancellationToken);
+                await _repository.SaveChangesAsync(cancellationToken);
+
+                response.Updated++;
+            }
+            catch (Exception ex)
+            {
+                response.Failed++;
+                response.FailedIds.Add(conversationId);
+                _logger.LogError(ex,
+                    "smartsupp: orphan-contacts backfill failed for conversation {ConversationId}",
+                    conversationId);
+                _repository.DiscardChanges();
+            }
+        }
+
+        _logger.LogInformation(
+            "smartsupp orphan-contacts backfill done: scanned={Scanned} updated={Updated} skipped={Skipped} failed={Failed}",
+            response.Scanned, response.Updated, response.SkippedNoContactId, response.Failed);
+
+        return response;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/RefreshOrphanContacts/RefreshOrphanContactsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/RefreshOrphanContacts/RefreshOrphanContactsRequest.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Smartsupp.UseCases.RefreshOrphanContacts;
+
+public class RefreshOrphanContactsRequest : IRequest<RefreshOrphanContactsResponse>
+{
+}

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/RefreshOrphanContacts/RefreshOrphanContactsResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/RefreshOrphanContacts/RefreshOrphanContactsResponse.cs
@@ -1,0 +1,15 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Smartsupp.UseCases.RefreshOrphanContacts;
+
+public class RefreshOrphanContactsResponse : BaseResponse
+{
+    public int Scanned { get; set; }
+    public int Updated { get; set; }
+    public int SkippedNoContactId { get; set; }
+    public int Failed { get; set; }
+    public List<string> FailedIds { get; set; } = new();
+
+    public RefreshOrphanContactsResponse() { }
+    public RefreshOrphanContactsResponse(ErrorCodes errorCode) : base(errorCode) { }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Smartsupp/ISmartsuppRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Smartsupp/ISmartsuppRepository.cs
@@ -22,6 +22,9 @@ public interface ISmartsuppRepository
         SmartsuppContact contact,
         CancellationToken cancellationToken);
 
+    Task<List<string>> ListOrphanContactConversationIdsAsync(
+        CancellationToken cancellationToken);
+
     Task UpsertConversationAsync(
         SmartsuppConversation conversation,
         CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Persistence/Smartsupp/SmartsuppRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Smartsupp/SmartsuppRepository.cs
@@ -1,5 +1,7 @@
 using Anela.Heblo.Domain.Features.Smartsupp;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Anela.Heblo.Persistence.Smartsupp;
 
@@ -8,10 +10,17 @@ public sealed class SmartsuppRepository : ISmartsuppRepository
     private const int MaxOtherConversations = 20;
 
     private readonly ApplicationDbContext _db;
+    private readonly ISmartsuppApiClient _apiClient;
+    private readonly ILogger<SmartsuppRepository> _logger;
 
-    public SmartsuppRepository(ApplicationDbContext db)
+    public SmartsuppRepository(
+        ApplicationDbContext db,
+        ISmartsuppApiClient apiClient,
+        ILogger<SmartsuppRepository> logger)
     {
         _db = db;
+        _apiClient = apiClient;
+        _logger = logger;
     }
 
     public async Task<(List<SmartsuppConversation> Items, int Total)> ListConversationsAsync(
@@ -87,7 +96,16 @@ public sealed class SmartsuppRepository : ISmartsuppRepository
                 .FirstOrDefaultAsync(c => c.Id == conversation.ContactId, cancellationToken);
 
             if (linkedContact is null)
-                conversation.ContactId = null;
+            {
+                // Smartsupp webhooks reference contacts by id without inlining the name/email
+                // and we cannot rely on a contact.* event arriving — pull the record via REST so
+                // the FK link survives and the conversation row carries the display name.
+                linkedContact = await TryFetchAndStageContactAsync(
+                    conversation.ContactId, conversation.SyncedAt, cancellationToken);
+
+                if (linkedContact is null)
+                    conversation.ContactId = null;
+            }
         }
 
         conversation.ContactName ??= linkedContact?.Name;
@@ -245,6 +263,60 @@ public sealed class SmartsuppRepository : ISmartsuppRepository
             conv.ContactEmail = contact.Email ?? conv.ContactEmail;
         }
     }
+
+    public async Task<List<string>> ListOrphanContactConversationIdsAsync(
+        CancellationToken cancellationToken) =>
+        await _db.SmartsuppConversations
+            .AsNoTracking()
+            .Where(c => c.ContactName == null && c.ContactEmail == null)
+            .Select(c => c.Id)
+            .ToListAsync(cancellationToken);
+
+    private async Task<SmartsuppContact?> TryFetchAndStageContactAsync(
+        string contactId,
+        DateTime syncedAt,
+        CancellationToken cancellationToken)
+    {
+        SmartsuppContactData? data;
+        try
+        {
+            data = await _apiClient.GetContactAsync(contactId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Fail open: webhook still saves the conversation without the contact link.
+            // The orphan backfill job can pick it up later when Smartsupp REST is healthy.
+            _logger.LogWarning(ex,
+                "smartsupp: failed to fetch contact {ContactId} while upserting conversation; continuing without link",
+                contactId);
+            return null;
+        }
+
+        if (data is null)
+            return null;
+
+        var contact = MapContactDataToEntity(data, syncedAt);
+        await UpsertContactAsync(contact, cancellationToken);
+        return contact;
+    }
+
+    private static SmartsuppContact MapContactDataToEntity(SmartsuppContactData data, DateTime syncedAt) =>
+        new()
+        {
+            Id = data.Id,
+            Email = data.Email,
+            Name = data.Name,
+            Phone = data.Phone,
+            Note = data.Note,
+            BannedAt = data.BannedAt,
+            BannedBy = data.BannedBy,
+            GdprApproved = data.GdprApproved,
+            TagsJson = data.TagsJson,
+            PropertiesJson = data.PropertiesJson,
+            CreatedAt = DateTime.SpecifyKind(data.CreatedAt, DateTimeKind.Unspecified),
+            UpdatedAt = DateTime.SpecifyKind(data.UpdatedAt, DateTimeKind.Unspecified),
+            SyncedAt = DateTime.SpecifyKind(syncedAt, DateTimeKind.Unspecified),
+        };
 
     public async Task UpdateVisitorCacheAsync(
         string conversationId,

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppRepositoryContactConversationsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppRepositoryContactConversationsTests.cs
@@ -17,6 +17,9 @@ public class SmartsuppRepositoryContactConversationsTests
         return new ApplicationDbContext(options);
     }
 
+    private static SmartsuppRepository NewRepo(ApplicationDbContext db) =>
+        SmartsuppRepositoryTestFactory.New(db);
+
     private static SmartsuppConversation MakeConversation(string id, string? contactId, DateTime lastMessageAt) =>
         new()
         {
@@ -40,7 +43,7 @@ public class SmartsuppRepositoryContactConversationsTests
         db.SmartsuppConversations.AddRange(older, newer, current);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = NewRepo(db);
 
         // Act
         var result = await repo.ListConversationsForContactAsync("contact-1", "c-current", CancellationToken.None);
@@ -61,7 +64,7 @@ public class SmartsuppRepositoryContactConversationsTests
         db.SmartsuppConversations.AddRange(sibling, current);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = NewRepo(db);
 
         // Act
         var result = await repo.ListConversationsForContactAsync("contact-1", "c-current", CancellationToken.None);
@@ -82,7 +85,7 @@ public class SmartsuppRepositoryContactConversationsTests
         db.SmartsuppConversations.AddRange(mine, theirs, current);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = NewRepo(db);
 
         // Act
         var result = await repo.ListConversationsForContactAsync("contact-1", "c-current", CancellationToken.None);
@@ -102,7 +105,7 @@ public class SmartsuppRepositoryContactConversationsTests
         db.SmartsuppConversations.AddRange(conversations);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = NewRepo(db);
 
         // Act — "c-none" doesn't exist, so nothing is excluded
         var result = await repo.ListConversationsForContactAsync("contact-1", "c-none", CancellationToken.None);

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppRepositoryUnknownContactFetchTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppRepositoryUnknownContactFetchTests.cs
@@ -1,0 +1,175 @@
+using Anela.Heblo.Domain.Features.Smartsupp;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Smartsupp;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Smartsupp;
+
+public class SmartsuppRepositoryUnknownContactFetchTests
+{
+    private static ApplicationDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static SmartsuppConversation MakeConversation(string id, string contactId, DateTime updatedAt) =>
+        new()
+        {
+            Id = id,
+            ContactId = contactId,
+            Status = SmartsuppConversationStatus.Open,
+            CreatedAt = DateTime.SpecifyKind(updatedAt.AddHours(-1), DateTimeKind.Unspecified),
+            UpdatedAt = DateTime.SpecifyKind(updatedAt, DateTimeKind.Unspecified),
+            SyncedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+        };
+
+    private static SmartsuppContactData MakeContactData(string id, string? name = null, string? email = null) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            Email = email,
+            CreatedAt = new DateTime(2026, 5, 20, 10, 0, 0, DateTimeKind.Utc),
+            UpdatedAt = new DateTime(2026, 5, 20, 10, 0, 0, DateTimeKind.Utc),
+        };
+
+    [Fact]
+    public async Task UpsertConversationAsync_FetchesContactViaRest_WhenLocalContactMissing()
+    {
+        // Arrange
+        await using var db = NewContext();
+        var apiClient = new Mock<ISmartsuppApiClient>();
+        apiClient
+            .Setup(c => c.GetContactAsync("ct-unknown", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakeContactData("ct-unknown", name: "Michaela", email: "michaela@example.com"));
+
+        var repo = new SmartsuppRepository(db, apiClient.Object, NullLogger<SmartsuppRepository>.Instance);
+        var incoming = MakeConversation("conv-1", "ct-unknown", new DateTime(2026, 6, 8, 10, 0, 0));
+
+        // Act
+        await repo.UpsertConversationAsync(incoming, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        // Assert — REST was called, the contact was staged, and the conversation kept its link
+        apiClient.Verify(c => c.GetContactAsync("ct-unknown", It.IsAny<CancellationToken>()), Times.Once);
+        var storedContact = await db.SmartsuppContacts.SingleAsync();
+        storedContact.Name.Should().Be("Michaela");
+        storedContact.Email.Should().Be("michaela@example.com");
+
+        var storedConv = await db.SmartsuppConversations.SingleAsync();
+        storedConv.ContactId.Should().Be("ct-unknown");
+        storedConv.ContactName.Should().Be("Michaela");
+        storedConv.ContactEmail.Should().Be("michaela@example.com");
+    }
+
+    [Fact]
+    public async Task UpsertConversationAsync_WipesContactId_WhenRestReturnsNull()
+    {
+        // Arrange
+        await using var db = NewContext();
+        var apiClient = new Mock<ISmartsuppApiClient>();
+        apiClient
+            .Setup(c => c.GetContactAsync("ct-gone", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SmartsuppContactData?)null);
+
+        var repo = new SmartsuppRepository(db, apiClient.Object, NullLogger<SmartsuppRepository>.Instance);
+        var incoming = MakeConversation("conv-1", "ct-gone", new DateTime(2026, 6, 8, 10, 0, 0));
+
+        // Act
+        await repo.UpsertConversationAsync(incoming, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        // Assert — REST attempted, fell back to previous behavior (wipe FK)
+        apiClient.Verify(c => c.GetContactAsync("ct-gone", It.IsAny<CancellationToken>()), Times.Once);
+        var storedConv = await db.SmartsuppConversations.SingleAsync();
+        storedConv.ContactId.Should().BeNull();
+        storedConv.ContactName.Should().BeNull();
+        storedConv.ContactEmail.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpsertConversationAsync_WipesContactIdAndLogsWarning_WhenRestThrows()
+    {
+        // Arrange — REST blows up (e.g., 500). Webhook must still persist the conversation.
+        await using var db = NewContext();
+        var apiClient = new Mock<ISmartsuppApiClient>();
+        apiClient
+            .Setup(c => c.GetContactAsync("ct-broken", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Smartsupp 500"));
+
+        var repo = new SmartsuppRepository(db, apiClient.Object, NullLogger<SmartsuppRepository>.Instance);
+        var incoming = MakeConversation("conv-1", "ct-broken", new DateTime(2026, 6, 8, 10, 0, 0));
+
+        // Act
+        await repo.UpsertConversationAsync(incoming, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        // Assert — conversation saved without link; ready for the backfill job to retry later.
+        var storedConv = await db.SmartsuppConversations.SingleAsync();
+        storedConv.ContactId.Should().BeNull();
+        storedConv.ContactName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpsertConversationAsync_DoesNotCallRest_WhenContactAlreadyInDb()
+    {
+        // Arrange — happy path: contact already synced via contact.acquired earlier.
+        await using var db = NewContext();
+        db.SmartsuppContacts.Add(new SmartsuppContact
+        {
+            Id = "ct-known",
+            Name = "Vendy",
+            Email = "vendy@example.com",
+            CreatedAt = DateTime.SpecifyKind(new DateTime(2026, 6, 1), DateTimeKind.Unspecified),
+            UpdatedAt = DateTime.SpecifyKind(new DateTime(2026, 6, 1), DateTimeKind.Unspecified),
+            SyncedAt = DateTime.SpecifyKind(new DateTime(2026, 6, 1), DateTimeKind.Unspecified),
+        });
+        await db.SaveChangesAsync();
+
+        var apiClient = new Mock<ISmartsuppApiClient>(MockBehavior.Strict);
+        var repo = new SmartsuppRepository(db, apiClient.Object, NullLogger<SmartsuppRepository>.Instance);
+        var incoming = MakeConversation("conv-1", "ct-known", new DateTime(2026, 6, 8, 10, 0, 0));
+
+        // Act
+        await repo.UpsertConversationAsync(incoming, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        // Assert — strict mock means any unexpected call fails the test; verifies REST was skipped.
+        var storedConv = await db.SmartsuppConversations.SingleAsync();
+        storedConv.ContactName.Should().Be("Vendy");
+        storedConv.ContactEmail.Should().Be("vendy@example.com");
+        storedConv.ContactId.Should().Be("ct-known");
+    }
+
+    [Fact]
+    public async Task ListOrphanContactConversationIdsAsync_ReturnsOnlyConversationsWithNoNameOrEmail()
+    {
+        // Arrange
+        await using var db = NewContext();
+        var orphan = MakeConversation("c-orphan", "ct-x", new DateTime(2026, 6, 8, 10, 0, 0));
+        orphan.ContactId = null;
+        orphan.ContactName = null;
+        orphan.ContactEmail = null;
+        var named = MakeConversation("c-named", "ct-y", new DateTime(2026, 6, 8, 10, 0, 0));
+        named.ContactName = "Jana";
+        var emailed = MakeConversation("c-emailed", "ct-z", new DateTime(2026, 6, 8, 10, 0, 0));
+        emailed.ContactEmail = "j@x.cz";
+        db.SmartsuppConversations.AddRange(orphan, named, emailed);
+        await db.SaveChangesAsync();
+
+        var repo = new SmartsuppRepository(db, Mock.Of<ISmartsuppApiClient>(), NullLogger<SmartsuppRepository>.Instance);
+
+        // Act
+        var ids = await repo.ListOrphanContactConversationIdsAsync(CancellationToken.None);
+
+        // Assert
+        ids.Should().BeEquivalentTo(new[] { "c-orphan" });
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppRepositoryUpdatedAtGuardTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppRepositoryUpdatedAtGuardTests.cs
@@ -3,9 +3,17 @@ using Anela.Heblo.Persistence;
 using Anela.Heblo.Persistence.Smartsupp;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Smartsupp;
+
+internal static class SmartsuppRepositoryTestFactory
+{
+    public static SmartsuppRepository New(ApplicationDbContext db, ISmartsuppApiClient? apiClient = null) =>
+        new(db, apiClient ?? Mock.Of<ISmartsuppApiClient>(), NullLogger<SmartsuppRepository>.Instance);
+}
 
 public class SmartsuppRepositoryUpdatedAtGuardTests
 {
@@ -37,7 +45,7 @@ public class SmartsuppRepositoryUpdatedAtGuardTests
         db.SmartsuppConversations.Add(existing);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var incoming = MakeConversation("c1", new DateTime(2026, 5, 13, 11, 0, 0, DateTimeKind.Unspecified), subject: "new");
 
         // Act
@@ -59,7 +67,7 @@ public class SmartsuppRepositoryUpdatedAtGuardTests
         db.SmartsuppConversations.Add(existing);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var staleIncoming = MakeConversation("c1", new DateTime(2026, 5, 13, 11, 0, 0, DateTimeKind.Unspecified), subject: "older");
 
         // Act — should be a no-op, must not throw
@@ -76,7 +84,7 @@ public class SmartsuppRepositoryUpdatedAtGuardTests
     {
         // Arrange
         await using var db = NewContext();
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var incoming = MakeConversation("c-new", new DateTime(2026, 5, 13, 10, 0, 0, DateTimeKind.Unspecified));
 
         // Act
@@ -117,7 +125,7 @@ public class SmartsuppRepositoryContactGuardTests
         db.SmartsuppContacts.Add(existing);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var incoming = MakeContact("ct1", new DateTime(2026, 5, 13, 11, 0, 0, DateTimeKind.Unspecified));
         incoming.Email = "updated@example.com";
 
@@ -138,7 +146,7 @@ public class SmartsuppRepositoryContactGuardTests
         db.SmartsuppContacts.Add(existing);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var stale = MakeContact("ct1", new DateTime(2026, 5, 13, 11, 0, 0, DateTimeKind.Unspecified));
         stale.Email = "stale@example.com";
 
@@ -153,7 +161,7 @@ public class SmartsuppRepositoryContactGuardTests
     public async Task UpsertContactAsync_InsertsNew_WhenIdNotPresent()
     {
         await using var db = NewContext();
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var incoming = MakeContact("ct-new", new DateTime(2026, 5, 13, 10, 0, 0, DateTimeKind.Unspecified));
 
         await repo.UpsertContactAsync(incoming, CancellationToken.None);
@@ -190,7 +198,7 @@ public class SmartsuppRepositoryMessageDeliveryTests
         db.SmartsuppMessages.Add(msg);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var deliveredAt = new DateTime(2026, 5, 13, 11, 0, 0, DateTimeKind.Unspecified);
         await repo.UpdateMessageDeliveryStatusAsync("m1", "delivered", deliveredAt, CancellationToken.None);
         await db.SaveChangesAsync();
@@ -204,7 +212,7 @@ public class SmartsuppRepositoryMessageDeliveryTests
     public async Task UpdateMessageDeliveryStatusAsync_DoesNotThrow_WhenMessageNotFound()
     {
         await using var db = NewContext();
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
 
         var act = async () => await repo.UpdateMessageDeliveryStatusAsync("nonexistent", "delivered", null, CancellationToken.None);
 
@@ -259,7 +267,7 @@ public class SmartsuppRepositoryDenormFieldTests
         db.SmartsuppConversations.Add(existing);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var incoming = MakeConversation("c1", contactName: null, contactEmail: null);
         incoming.UpdatedAt = new DateTime(2026, 5, 20, 12, 0, 0, DateTimeKind.Unspecified);
 
@@ -282,7 +290,7 @@ public class SmartsuppRepositoryDenormFieldTests
         db.SmartsuppContacts.Add(contact);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var incoming = MakeConversation("conv-1", contactName: null, contactEmail: null, contactId: "c-contact-1");
 
         // Act
@@ -305,7 +313,7 @@ public class SmartsuppRepositoryDenormFieldTests
         db.SmartsuppConversations.Add(conv);
         await db.SaveChangesAsync();
 
-        var repo = new SmartsuppRepository(db);
+        var repo = SmartsuppRepositoryTestFactory.New(db);
         var contact = MakeContact("c-backfill", name: "Marie Svobodová", email: "marie@x.cz");
 
         // Act


### PR DESCRIPTION
## Summary

- Chat list showed "Neznámý" for ~39 prod conversations (incl. Messenger and pre-existing visitors) because `SmartsuppRepository.UpsertConversationAsync` was wiping `ContactId` whenever the contact wasn't yet in our local DB — and Smartsupp doesn't reliably emit a `contact.*` event for those visitors, so the link never recovered.
- The fix calls `ISmartsuppApiClient.GetContactAsync` to stage the missing contact before the conversation save, preserving the FK link. On REST 404 or transport failure it falls back to the original wipe so webhook processing stays resilient.
- Added a `RefreshOrphanContacts` MediatR command + admin-gated endpoint (`POST /api/smartsupp/admin/refresh-orphan-contacts`, role=`administration.write`) to retroactively repair the stuck rows by re-fetching each conversation via REST and reusing the same upsert path.

## Diagnostics (run against prod)

- 39 of 130 conversations had `ContactName=NULL`, `ContactEmail=NULL` — every single one of them also had `ContactId=NULL` despite the original webhook payload (in `SmartsuppWebhookAuditEntries`) containing a populated `contact_id`.
- Spot checks: `co5isyY4tDnm9` → `ctSvf3ztfnRtD` → REST returns name "Michaela"; `co_54MYEFzM6L` → `ctDb0v0AYgTm` → REST returns name "Hanďa Schrammová" (matches the Smartsupp UI).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] All 181 Smartsupp tests pass (5 new in `SmartsuppRepositoryUnknownContactFetchTests`)
- [ ] After deploy: hit `POST /api/smartsupp/admin/refresh-orphan-contacts` on staging — expect `scanned=0`
- [ ] After deploy: hit the same endpoint on prod — expect `updated=39, failed=0` and the Heblo chat list shows real names for the previously-Neznámý conversations