### PR TITLE
feat(packaging): increase customer name and address font size in expedition PDF

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
@@ -146,7 +146,7 @@ public class ExpeditionProtocolDocument : IDocument
             // Customer info — single right-aligned line
             orderCol.Item().AlignRight().Text(
                 $"{order.CustomerName}, {order.Address} {order.Phone}".Trim())
-                .FontSize(8);
+                .FontSize(11).Bold();
 
             // Items table
             BuildItemsTable(orderCol.Item(), order.Items);

--- a/frontend/src/components/baleni/PackingOrderMeta.tsx
+++ b/frontend/src/components/baleni/PackingOrderMeta.tsx
@@ -16,8 +16,8 @@ function PackingOrderMeta({ order }: PackingOrderMetaProps) {
   return (
     <div data-testid="packing-order-meta">
       <h2 className="text-lg font-bold text-neutral-slate">Objednávka {order.code}</h2>
-      <p className="text-sm text-neutral-gray">{order.customerName}</p>
-      {address && <p className="text-sm text-neutral-gray">{address}</p>}
+      <p className="text-xl text-neutral-gray">{order.customerName}</p>
+      {address && <p className="text-xl text-neutral-gray">{address}</p>}
       <p className="text-sm text-neutral-gray">
         Doprava: <span className="text-neutral-slate font-medium">{order.shippingMethodName}</span>
       </p>


### PR DESCRIPTION
Increases the customer name and address font size in the expedition protocol PDF from 8pt to 11pt bold, making it easier to read at a glance when picking and packing orders.