### PR TITLE
fix(tests): fix flaky CatalogCacheOptimization timing test

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogRepositoryCacheOptimizationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogRepositoryCacheOptimizationTests.cs
@@ -348,10 +348,11 @@ public class CatalogRepositoryCacheOptimizationTests
         staleCache.Should().NotBeNull();
         staleCache!.First().ProductCode.Should().Be("OLD001");
 
-        // Update time should be recent
+        // Update time should match the mocked TimeProvider's value
         var updateTime = _cache.Get<DateTime?>("CatalogData_LastUpdate");
         updateTime.Should().NotBeNull();
-        updateTime!.Value.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        var expectedUpdateTime = _timeProviderMock.Object.GetUtcNow().UtcDateTime;
+        updateTime!.Value.Should().Be(expectedUpdateTime);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- One BE test was failing intermittently in CI: `CatalogRepositoryCacheOptimizationTests.ExecuteBackgroundMergeAsync_ShouldReplaceCurrentCacheAtomically`
- The assertion compared the cache's last-update timestamp (set via the mocked `TimeProvider` at constructor time) against `DateTime.UtcNow` at assertion time with a 1-second tolerance
- On slow CI runners the test took ~1.19s, just barely exceeding the tolerance

## Root cause

`ReplaceCacheAtomicallyAsync` stores `_timeProvider.GetUtcNow().DateTime` in cache. The mock is configured with `Returns(DateTimeOffset.UtcNow)` — a **fixed value captured at setup time**. The assertion then compared this fixed mock value against the *real* wall clock at assertion time, failing whenever the test took longer than 1 second.

## Fix

Changed the assertion to compare against `_timeProviderMock.Object.GetUtcNow().UtcDateTime` — the exact value the mock always returns — making the assertion fully deterministic and independent of execution time.

## Test plan

- [x] `ExecuteBackgroundMergeAsync_ShouldReplaceCurrentCacheAtomically` passes locally
- [x] All 11 `CatalogRepositoryCacheOptimizationTests` tests pass locally
- [ ] CI Backend Tests pass