### PR TITLE
feat: Encapsulate Collection Replacement in MarketingAction Domain Entity

### DIFF
--- a/artifacts/feat-arch-review-marketing-updatemarketingact/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketing-updatemarketingact/arch-review.r1.md
@@ -1,222 +1,222 @@
-# Architecture Review: Marketing Module — Consistent DB Save Error Handling for Update and Delete Handlers
+# Architecture Review: Encapsulate Collection Replacement in MarketingAction Domain Entity
 
 ## Skip Design: true
 
-Backend-only behavior fix in three MediatR handlers. No new UI, no screens, no visual decisions. The externally visible change is "API returns a structured error envelope instead of HTTP 500" — same envelope shape the rest of the module already produces, so no frontend work is implied.
+This change is a backend-only refactor inside the Domain and Application layers. No UI components, screens, layout, or visual design decisions are introduced. The `UpdateMarketingActionCommand` wire contract is unchanged (spec confirms no OpenAPI regeneration), so the FE is not affected.
 
 ## Architectural Fit Assessment
 
-This change is a defect repair against an already-established convention, not a new pattern. The Marketing module already has the canonical implementation:
+The proposal is a textbook DDD-encapsulation refinement that aligns cleanly with the existing layering already present in this repo:
 
-- `CreateMarketingActionHandler` (lines 87–112) wraps `SaveChangesAsync` in try/catch, logs the inconsistency with structured placeholders, attempts an Outlook compensation, and returns `CreateMarketingActionResponse(ErrorCodes.DatabaseError)`.
-- `BaseResponse` already exposes the `Success` / `ErrorCode` / `Params` envelope used module-wide; every Marketing response class already has the `(ErrorCodes, Dictionary<string,string>?)` constructor.
-- `ErrorCodes.DatabaseError = 0011` exists in `Anela.Heblo.Application.Shared.ErrorCodes` with `HttpStatusCode.InternalServerError` attribute — no new enum value needed.
-- The MediatR pipeline + controller layer already translates these envelopes to the correct HTTP status; existing tests in `CreateMarketingActionHandlerTests.Handle_CompensatesOutlookEvent_WhenDbSaveFails` prove the pattern works end-to-end.
+- The codebase follows Clean Architecture with a clear Domain → Application → Persistence stack. `MarketingAction` already lives in `Anela.Heblo.Domain.Features.Marketing` and exposes encapsulated mutators (`UpdateDetails`, `AssociateWithProduct`, `LinkToFolder`, `SoftDelete`, `MarkOutlookSynced`, `ClearOutlookLink`). Adding `ReplaceProductAssociations` / `ReplaceFolderLinks` extends an established pattern; no new abstractions, conventions, or layering shifts.
+- The time-handling convention is **caller-supplies-`utcNow`** for mutators that need a timestamp on entity-level fields. `MarketingAction` ctor and `UpdateDetails` already take `DateTime utcNow`; `MarkOutlookSynced` does too. The spec's signature aligns. There is **no `IDateTimeProvider` abstraction** anywhere in the project — `DateTime.UtcNow` is captured at the handler boundary (e.g. `UpdateMarketingActionHandler.cs:59`, `CreateMarketingActionHandler.cs:47`). The open question in the brief is therefore already resolved: pass `now` (already in scope at line 59) to the new methods.
+- EF Core integration is unaffected. `MarketingActionRepository.GetByIdAsync` eagerly includes both child collections (`MarketingActionRepository.cs:22-23`), so when `Clear()` runs against tracked navigation properties from inside the entity, the change-tracker still emits the same `DELETE` + `INSERT` SQL it does today. No persistence-layer changes required.
+- Main integration points: (1) `UpdateMarketingActionHandler.Handle` lines 95–110; (2) the domain entity itself; (3) the existing domain test folder `backend/test/Anela.Heblo.Tests/Domain/Marketing/`.
 
-The only deviations are in `UpdateMarketingActionHandler.cs:112-113` and `DeleteMarketingActionHandler.cs:75-76`, which let `SaveChangesAsync` / `DeleteSoftAsync` exceptions propagate to MediatR. Fixing them brings these handlers into line with the module's existing Vertical Slice + structured-response convention — there is no architectural debate, only an execution gap.
-
-Two integration points need verification but should be no-ops:
-
-1. **Repository contract** — `IMarketingActionRepository.DeleteSoftAsync` performs its own `SaveChangesAsync` internally (brief.md states this and the existing handler has no follow-up save call). The catch must therefore wrap the `DeleteSoftAsync` call itself, not a separate save.
-2. **MediatR pipeline behaviors** — There is no global exception-to-envelope behavior in this module (otherwise the current code would not produce 500s, and the existing Create handler's try/catch would be redundant). The fix must happen inside each handler.
+The proposal is well-scoped and does not introduce coupling, layering violations, or architectural drift.
 
 ## Proposed Architecture
 
 ### Component Overview
 
 ```
-Controller (existing, unchanged)
-    │
-    ▼
-MediatR pipeline (existing, unchanged)
-    │
-    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ MarketingAction handlers (per-use-case)                     │
-│                                                             │
-│  ┌──────────────────────┐ ┌──────────────────────┐ ┌──────┐ │
-│  │ CreateMarketingActi… │ │ UpdateMarketingActi… │ │ Dele…│ │
-│  │ (reference impl —    │ │ (add guarded save)   │ │ (add │ │
-│  │  unchanged)          │ │                      │ │ guar…│ │
-│  └─────────┬────────────┘ └─────────┬────────────┘ └──┬───┘ │
-│            │                        │                 │     │
-│            └────────────────────────┴─────────────────┘     │
-│                              │                              │
-│             try { repo save } catch (Exception)            │
-│             → log {ActionId},{EventId}, "out of sync"      │
-│             → return Response(ErrorCodes.DatabaseError)     │
-└─────────────────────────────────────────────────────────────┘
-    │                                            │
-    ▼                                            ▼
-IMarketingActionRepository                IOutlookCalendarSync
-(UpdateAsync, SaveChangesAsync,          (CreateEventAsync,
- DeleteSoftAsync)                         UpdateEventAsync,
-                                          DeleteEventAsync)
+┌─────────────────────────────────────────────────────────────────┐
+│ Application Layer                                               │
+│   UpdateMarketingActionHandler.Handle                           │
+│     ├─ var now = DateTime.UtcNow;                               │
+│     ├─ action.UpdateDetails(..., utcNow: now)        (existing) │
+│     ├─ action.ReplaceProductAssociations(            (NEW CALL) │
+│     │     request.AssociatedProducts, now)                      │
+│     ├─ action.ReplaceFolderLinks(                    (NEW CALL) │
+│     │     request.FolderLinks?.Select(...), now)                │
+│     └─ _repository.UpdateAsync + SaveChangesAsync               │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ delegates to
+┌─────────────────────────────────────────────────────────────────┐
+│ Domain Layer — MarketingAction (aggregate root)                 │
+│   existing: AssociateWithProduct, LinkToFolder, UpdateDetails…  │
+│   NEW:      ReplaceProductAssociations(codes, utcNow)           │
+│   NEW:      ReplaceFolderLinks(links, utcNow)                   │
+│                                                                 │
+│   Both new methods:                                             │
+│     1. Treat null input as empty sequence                       │
+│     2. Normalize each entry (Trim + ToUpperInvariant for codes; │
+│        Trim for folderKey)                                      │
+│     3. Deduplicate                                              │
+│     4. Clear existing collection                                │
+│     5. Add new child entities with CreatedAt = utcNow           │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ EF change-tracker (unchanged)
+┌─────────────────────────────────────────────────────────────────┐
+│ Persistence — MarketingActionProduct / MarketingActionFolderLink│
+│   DELETE old rows + INSERT new rows (identical SQL to today)    │
+└─────────────────────────────────────────────────────────────────┘
 ```
-
-The dashed boundary above is the only thing changing. No new components, interfaces, services, packages, configuration, DI registration, controller routes, or database objects.
 
 ### Key Design Decisions
 
-#### Decision 1: Inline try/catch in each handler vs. extracted helper
-
+#### Decision 1: Method signature — caller passes `utcNow`
 **Options considered:**
-- (A) Add three near-identical try/catch blocks inline (one in each handler).
-- (B) Extract a shared helper / base class / MediatR `IPipelineBehavior` that runs the DB save and produces a `DatabaseError` response.
+- A) `ReplaceProductAssociations(IEnumerable<string>? codes, DateTime utcNow)` — caller supplies time.
+- B) `ReplaceProductAssociations(IEnumerable<string>? codes)` — domain calls `DateTime.UtcNow` internally (matches existing `AssociateWithProduct` / `LinkToFolder`).
+- C) Inject `IDateTimeProvider` into the entity (would require a new abstraction).
 
-**Chosen approach:** (A) — inline in each handler.
+**Chosen approach:** **A** — caller passes `utcNow`.
 
-**Rationale:** The catch bodies are not identical: the Create handler also runs a compensating Outlook delete; the Update handler logs "may now be out of sync"; the Delete handler logs "Outlook event already deleted". The compensation logic, log phrasing, and response *type* all differ. Spec §Out of Scope explicitly says "three near-identical try/catch blocks are acceptable" and NFR-4 ("a future developer can copy any of them as a template") is satisfied by symmetry, not by abstraction. A pipeline behavior cannot inject the per-handler log message or response type without ambient state, and would also catch errors thrown by *non-Outlook* operations (e.g. `GetByIdAsync`) we do not want to remap to `DatabaseError`. YAGNI: keep the surface area small.
+**Rationale:** `MarketingAction`'s constructor, `UpdateDetails`, and `MarkOutlookSynced` already follow this convention. Choosing B would propagate the same testability/clock-control friction the rest of the entity has already solved. C is over-engineering — no time abstraction exists in this codebase, and adding one solely for this refactor exceeds the spec's scope ("Out of Scope: replacing EF Core change tracking…"). Within the same Update transaction, the new child rows' `CreatedAt` and the action's `ModifiedAt` will now share a single timestamp, which is preferable.
 
-#### Decision 2: What to catch — `Exception` vs. a narrower type
-
+#### Decision 2: Replace methods do NOT delegate to `AssociateWithProduct` / `LinkToFolder`
 **Options considered:**
-- (A) `catch (Exception)` — matches the existing Create handler precedent.
-- (B) `catch (DbUpdateException)` / `catch (DbException)` — narrower, only intercepts persistence-layer errors.
+- A) Inline the Clear + normalize + dedupe + add logic inside each Replace method.
+- B) Clear, then loop and call `AssociateWithProduct(code)` / `LinkToFolder(key, type)` per item.
 
-**Chosen approach:** (A) `catch (Exception)` — match the Create handler exactly.
+**Chosen approach:** **A** — inline the logic (matches the spec's illustrative code).
 
-**Rationale:** Consistency with the established reference implementation (FR-4) is explicitly required, and the spec's stated goal is to ensure *any* DB-save failure surfaces as `DatabaseError` rather than 500. Narrowing the catch would re-introduce inconsistency and risk missing wrapped exceptions (`DbUpdateConcurrencyException`, broker-level timeouts wrapped by EF, etc.). `OperationCanceledException` from a caller-cancelled token will be caught and mapped to `DatabaseError`; this is acceptable because a cancellation after a successful Outlook write still represents an out-of-sync state the operator needs to know about — and that is what the log message says.
+**Rationale:** The single-add methods capture `DateTime.UtcNow` internally (`MarketingAction.cs:108, 125`), so reusing them would (1) ignore the caller-supplied `utcNow` parameter, (2) produce per-row timestamp drift, and (3) perform redundant per-item dedupe scans after a `Clear`. The brief's suggested implementation is correct on this point.
 
-#### Decision 3: Where the catch goes in `DeleteMarketingActionHandler`
-
+#### Decision 3: Folder-link dedup uses composite key `(folderKey, folderType)`
 **Options considered:**
-- (A) Wrap only the `DeleteSoftAsync` call (which internally does `SaveChangesAsync`).
-- (B) Add an explicit `SaveChangesAsync` after `DeleteSoftAsync` and wrap both.
+- A) Dedup by `folderKey` alone (matches existing `LinkToFolder` line 117).
+- B) Dedup by `(folderKey, folderType)` composite (matches spec FR-2).
 
-**Chosen approach:** (A).
+**Chosen approach:** **B** — composite key, per spec.
 
-**Rationale:** `IMarketingActionRepository.DeleteSoftAsync` already commits internally — the current handler never calls `SaveChangesAsync` separately. Adding a second save would either be a no-op or change repository semantics. Wrap the single call.
+**Rationale:** The existing `LinkToFolder` deduplicates by `FolderKey` only and ignores `FolderType` — this is arguably a latent bug, but in practice the existing handler iterates a single request list with no duplicates of either kind, so the bug is not user-observable. The Replace method is a new surface and should be correct from day one. This is a deliberate, narrow improvement over the legacy add method (FR-2 acceptance criterion: "two pairs differing only in `folderType` keeps both"). Document this divergence in the method's XML doc-comment so future readers understand the asymmetry with `LinkToFolder`.
 
-#### Decision 4: Update handler — wrap save only, or wrap update+save together
-
+#### Decision 4: Invalid individual entries — silently skip vs throw
 **Options considered:**
-- (A) Wrap both `UpdateAsync` and `SaveChangesAsync` in one try/catch.
-- (B) Wrap only `SaveChangesAsync`.
+- A) Throw `ArgumentException` on null/whitespace entries (mirrors `AssociateWithProduct` / `LinkToFolder` per-item validation).
+- B) Silently filter out null/whitespace entries.
 
-**Chosen approach:** (A) — mirror the Create handler, which has `AddAsync` outside the try but only because `AddAsync` is purely in-memory tracking. In EF Core both `UpdateAsync` and `SaveChangesAsync` *can* throw (`UpdateAsync` may trigger change-tracker work; in some repository implementations it touches the context). The spec's `FR-1` says "wrap the `UpdateAsync` + `SaveChangesAsync` calls".
+**Chosen approach:** **A** — throw on per-entry whitespace, matching the existing single-add validation contract.
 
-**Rationale:** Defer to the spec. Cost of including `UpdateAsync` in the try block is zero on the happy path.
+**Rationale:** The brief's "Open Questions" item is closed in spec FR-2 ("Rejects entries where `folderKey` is null, empty, or whitespace by throwing the same exception type the existing `LinkToFolder` uses"). Extend the same rule to `ReplaceProductAssociations` for symmetry. The Application layer should never send invalid codes in practice (the request DTO has `[Required]` annotations on `MarketingFolderLinkRequest.FolderKey`); fail-loud at the domain boundary is consistent with this aggregate's other invariants. A `null` *sequence* is still treated as empty (per FR-1/FR-2) — only invalid *entries within* the sequence throw.
 
-#### Decision 5: Log severity and structured fields
+#### Decision 5: Keep navigation collection setters as-is
+**Options considered:**
+- A) Convert `ProductAssociations` / `FolderLinks` to `IReadOnlyCollection<>` exposure with private `ICollection<>` backing field for EF.
+- B) Leave the public `virtual ICollection<>` setters untouched.
 
-**Chosen approach:** `LogError` with structured placeholders `{ActionId}` and `{EventId}`, and the literal phrase from the spec:
-- Update: `"DB save failed after Outlook update for MarketingAction {ActionId}; Outlook event {EventId} may now be out of sync"`
-- Delete: `"DB soft-delete failed after Outlook delete for MarketingAction {ActionId}; Outlook event {EventId} already deleted — DB row still present"`
+**Chosen approach:** **B** — leave them.
 
-**Rationale:** FR-3 requires structured placeholders (NOT interpolation) and the greppable phrases "may now be out of sync" / "already deleted". NFR-2 forbids logging marketing-action payload (title/description); only IDs are logged. The exception object is the first argument to `LogError`, matching the Create handler.
+**Rationale:** Out of scope per the spec. The architectural goal here is *Application-layer hygiene*, not full aggregate hardening. Locking down the collections would require also reviewing every read-site (handlers, repository projections at `MarketingActionRepository.cs:92, 99`, mapping code) — an unbounded change set. Flag it under Risks as a future opportunity.
 
 ## Implementation Guidance
 
 ### Directory / Module Structure
 
-No new directories, no new files. Touch exactly three production files and update two test files:
+No new files, no new folders. Strictly modify-in-place:
 
-```
-backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/
-  UpdateMarketingAction/UpdateMarketingActionHandler.cs   ← modify lines 112–113
-  DeleteMarketingAction/DeleteMarketingActionHandler.cs   ← modify lines 75–76
-  CreateMarketingAction/CreateMarketingActionHandler.cs   ← unchanged (FR-4)
+| Action | Path |
+|---|---|
+| Modify | `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` — add two methods |
+| Modify | `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs` — replace lines 95–110 |
+| Add | `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs` |
+| Add | `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs` |
+| Optional | Augment `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs` with one delta scenario (see "Specification Amendments") |
 
-backend/test/Anela.Heblo.Tests/Application/Marketing/
-  UpdateMarketingActionHandlerTests.cs   ← add DB-failure test
-  DeleteMarketingActionHandlerTests.cs   ← add DB-failure test
-  CreateMarketingActionHandlerTests.cs   ← unchanged
-```
+Follow the existing domain-file conventions exactly: block-scoped namespace (`namespace Anela.Heblo.Domain.Features.Marketing { ... }`), `using` directives inside the namespace block, `private` methods placed below public ones.
 
 ### Interfaces and Contracts
 
-No interface changes. The following already exist and must be reused as-is:
+```csharp
+// In Anela.Heblo.Domain.Features.Marketing.MarketingAction:
 
-- `IMarketingActionRepository.UpdateAsync(MarketingAction, CancellationToken)` and `SaveChangesAsync(CancellationToken)` (verified in `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs` via inheritance from `IRepository<MarketingAction,int>`).
-- `IMarketingActionRepository.DeleteSoftAsync(int id, string userId, string username, CancellationToken)` — performs its own commit.
-- `UpdateMarketingActionResponse(ErrorCodes, Dictionary<string,string>?)` constructor (verified `UpdateMarketingActionRequest.cs:41`).
-- `DeleteMarketingActionResponse(ErrorCodes, Dictionary<string,string>?)` constructor (verified `DeleteMarketingActionRequest.cs:19`).
-- `ErrorCodes.DatabaseError` with `[HttpStatusCode(HttpStatusCode.InternalServerError)]` (verified `ErrorCodes.cs:35`).
+/// <summary>
+/// Replaces the full set of product associations atomically.
+/// Null input is treated as an empty sequence (clears all associations).
+/// Inputs are trimmed, upper-cased (invariant), and deduplicated.
+/// Throws ArgumentException on entries that are null/empty/whitespace.
+/// </summary>
+public void ReplaceProductAssociations(
+    IEnumerable<string>? productCodes,
+    DateTime utcNow);
 
-API behavior change (not a contract change): `PUT` and `DELETE` endpoints will return `500 InternalServerError` carrying `{ success: false, errorCode: "DatabaseError" }` instead of an unhandled 500 page. The HTTP status is unchanged because `DatabaseError` itself maps to 500 — only the body shape becomes structured.
+/// <summary>
+/// Replaces the full set of folder links atomically.
+/// Null input is treated as an empty sequence (clears all links).
+/// Deduplicates by the composite key (folderKey, folderType) — note this is
+/// stricter than LinkToFolder which dedupes by folderKey alone.
+/// Throws ArgumentException on entries with null/empty/whitespace folderKey.
+/// </summary>
+public void ReplaceFolderLinks(
+    IEnumerable<(string folderKey, MarketingFolderType folderType)>? links,
+    DateTime utcNow);
+```
+
+**Handler delegation (replaces `UpdateMarketingActionHandler.cs:95-111`):**
+
+```csharp
+action.ReplaceProductAssociations(request.AssociatedProducts, now);
+action.ReplaceFolderLinks(
+    request.FolderLinks?.Select(l => (l.FolderKey, l.FolderType)),
+    now);
+```
+
+Note: `request.AssociatedProducts` is `List<string>?` (per `UpdateMarketingActionRequest.cs:29`) and assigns directly to `IEnumerable<string>?` — no `?? Enumerable.Empty<…>()` shim needed at the call site since the domain method handles `null` internally. This keeps the handler maximally terse and pushes the null-handling contract into the domain (which is the entire point of the refactor).
 
 ### Data Flow
 
-#### Update — failure path after this fix
+**Update path (after refactor) — clearing all associations:**
 ```
-Client → PUT /api/marketing-actions/{id}
-  → UpdateMarketingActionHandler.Handle
-    → GetByIdAsync                              [unchanged]
-    → mutate action fields                       [unchanged]
-    → IOutlookCalendarSync.UpdateEventAsync      [succeeds — Outlook now updated]
-    → try {
-        UpdateAsync(action)
-        SaveChangesAsync()                       [throws e.g. DbUpdateException]
-      } catch (Exception ex) {
-        _logger.LogError(ex, "...{ActionId}...{EventId}...may now be out of sync", id, eventId)
-        return new UpdateMarketingActionResponse(ErrorCodes.DatabaseError)
-      }
-  → controller serializes envelope → HTTP 500 + structured body
+PUT /api/marketing/actions/42  { AssociatedProducts: null, FolderLinks: null, ... }
+   → UpdateMarketingActionHandler.Handle
+   → repo.GetByIdAsync(42) → loads MarketingAction + ProductAssociations + FolderLinks
+   → action.UpdateDetails(..., utcNow: now)
+   → action.ReplaceProductAssociations(null, now)
+        → null → empty; ProductAssociations.Clear(); no Adds
+   → action.ReplaceFolderLinks(null, now)
+        → null → empty; FolderLinks.Clear(); no Adds
+   → repo.UpdateAsync + SaveChangesAsync
+        → EF emits: UPDATE MarketingAction; DELETE MarketingActionProduct WHERE …;
+                    DELETE MarketingActionFolderLink WHERE …
 ```
 
-#### Delete — failure path after this fix
+**Update path — delta scenario (some kept, some added, some removed):**
 ```
-Client → DELETE /api/marketing-actions/{id}
-  → DeleteMarketingActionHandler.Handle
-    → GetByIdAsync                              [unchanged]
-    → IOutlookCalendarSync.DeleteEventAsync     [succeeds — Outlook event gone]
-    → try {
-        _repository.DeleteSoftAsync(id, ...)    [throws]
-      } catch (Exception ex) {
-        _logger.LogError(ex, "...{ActionId}...{EventId}...already deleted", id, eventId)
-        return new DeleteMarketingActionResponse(ErrorCodes.DatabaseError)
-      }
-  → controller serializes envelope → HTTP 500 + structured body
+… AssociatedProducts = ["ABC", " def ", "abc"], FolderLinks = [(key1, General), (key1, Project)]
+   → ReplaceProductAssociations: normalize → ["ABC", "DEF"]; Clear; Add 2 rows
+   → ReplaceFolderLinks: dedup by composite → keeps both; Clear; Add 2 rows
+   → EF emits: DELETE all 3 old product rows; INSERT 2 new; DELETE old folder rows; INSERT 2 new
 ```
 
-#### Happy paths
-Unchanged. No new branches in success paths.
-
-### Testing Approach
-
-The existing test fixtures (`xUnit` + `Moq` + `FluentAssertions`, `Mock<ILogger<T>>` already in test classes) cover everything needed. Each new test:
-
-1. Reuses the existing constructor's default mocks.
-2. Overrides `SaveChangesAsync` / `DeleteSoftAsync` to `ThrowsAsync(new Exception("DB unavailable"))`.
-3. Asserts `result.Success == false`, `result.ErrorCode == ErrorCodes.DatabaseError`.
-4. Verifies the logger's `LogError` was called via `_logger.Verify(...)` matching on the message-template fragment (`"may now be out of sync"` / `"already deleted"`) and that `ActionId` and `EventId` appear in the structured state. The Create test (`Handle_CompensatesOutlookEvent_WhenDbSaveFails`) does *not* assert the log content today, but spec FR-1/FR-2 explicitly require asserting an error-level log — see Specification Amendments below for the recommended `Mock<ILogger<T>>.Verify` pattern.
-5. For Update: verifies Outlook update was attempted but **not** reverted (out of scope per spec).
-6. For Delete: verifies Outlook delete was attempted but **not** recreated.
-
-API-level integration test for HTTP 500 body shape is **NOT** added in this change unless there is an existing integration-test harness for Marketing endpoints — the search did not find one. Spec FR-1/FR-2 say "API integration test… returns the structured error envelope". Treat that as aspirational unless an existing pattern exists; the unit tests are the hard gate. See Specification Amendments.
+The DML pattern is identical to today (Clear+Add already produces full DELETE+INSERT churn). No round-trip change.
 
 ## Risks and Mitigations
 
 | Risk | Severity | Mitigation |
 |------|----------|------------|
-| `Mock<ILogger<T>>.Verify` for structured log messages is fragile (matches on the message template, not the rendered string) | Low | Use the documented `It.Is<It.IsAnyType>((v,t) => v.ToString()!.Contains("may now be out of sync"))` pattern; this is already in use elsewhere in the test suite — check `backend/test/Anela.Heblo.Tests/` for prior examples before writing new boilerplate. |
-| Catching `Exception` swallows `OperationCanceledException` and converts caller cancellation into `DatabaseError` | Low | Acceptable: a cancellation after a successful Outlook write *is* a divergence the operator needs to learn about. Matches the existing Create handler. If team disagrees, add `catch (OperationCanceledException) { throw; }` ahead of the general catch — note this would deviate from the Create reference. |
-| Update handler logs `action.OutlookEventId` which may be **freshly set** by `MarkOutlookSynced` on this request (line 77/82). If the Outlook step created a new event (`else` branch at 81), the logged ID is the new one — correct. | None | This is the desired behavior; the new ID is what's now in Outlook. |
-| Spec asks for the "Outlook event ID" but Update handler may not have one (push disabled). | Low | When `_options.CurrentValue.PushEnabled == false`, no Outlook write happened, so there is no drift on DB failure — the log message can still be emitted (`{EventId}` will be `null`/empty), and an operator who sees a null `EventId` knows Outlook was not the issue. No code branch needed. |
-| Catching after Update sets `action.MarkOutlookSynced` — the in-memory mutation has already happened on the now-stale tracked entity. EF context state may be poisoned for the next request if the repository is scoped per-request. | None | MediatR handlers in this codebase are scoped per-request (standard ASP.NET Core DI). The `DbContext` is discarded at request end. No leak between requests. |
-| Compensation parity question: should Update handler also attempt Outlook revert (mirroring Create)? | None | Explicitly out of scope per spec §Out of Scope. Do not add. |
-| Tests written today fail tomorrow when team adopts a global MediatR exception-handling behavior. | Low | The structured envelope shape (`{ Success, ErrorCode, Params }`) is the contract; a future global behavior would have to produce the same envelope. Tests assert against the envelope, not the absence of a behavior. Acceptable. |
+| `LinkToFolder` (still in use by `CreateMarketingActionHandler.cs:65`) dedupes by `folderKey` alone, while `ReplaceFolderLinks` dedupes by composite key. Two methods on the same aggregate now have asymmetric invariants. | Medium | Document the asymmetry in the new method's XML doc comment. Flag as a follow-up to harmonize `LinkToFolder` (out of scope per spec "Out of Scope: Renaming or restructuring `AssociateWithProduct` / `LinkToFolder`"). |
+| `ProductAssociations` / `FolderLinks` setters remain publicly settable (`public ... { get; set; }`), so any future Application code could still bypass encapsulation. | Low | Add a code-review checklist item; consider follow-up PR to switch to `IReadOnlyCollection<>` projections with private backing fields. Out of scope here. |
+| Existing per-item `CreatedAt` values are silently regenerated to `utcNow` even for child rows whose logical content is unchanged. EF cannot tell "kept" from "replaced" because we Clear+Add. | Low | Matches current behavior — the existing Clear+`AssociateWithProduct` flow does the same. No regression. Note for future: if `CreatedAt` semantics ever become audit-grade, switch to a true diff implementation. |
+| Per-entry `ArgumentException` on whitespace product codes is a new throw site reachable from the Update handler (the existing handler also reached it via `AssociateWithProduct`, but only when the request DTO contained such values). | Low | DTO validation is already in place (`UpdateMarketingActionRequest` doesn't currently validate individual list entries). Add a defensive `if (string.IsNullOrWhiteSpace(code)) continue;` filter inside the Replace method **only if** the spec is explicitly clarified to silently skip. Default to throwing per Decision 4. |
+| Test fixture currently writes assertions like `a.ProductAssociations.Count == 2` (line 202 of `UpdateMarketingActionHandlerTests.cs`) — these continue to pass, but they do not assert the *Clear* semantics. | Low | Add one negative-path handler test: pre-existing action has product associations, request sets `AssociatedProducts = null`, assert `a.ProductAssociations.Count == 0`. |
 
 ## Specification Amendments
 
-1. **FR-1 / FR-2 — clarify log assertion mechanism.** The spec says "asserts that an error-level log entry is emitted containing the action ID and the Outlook event ID." With `Mock<ILogger<T>>` this is done by `_logger.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.Is<It.IsAnyType>((v,_) => v.ToString()!.Contains("...")), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType,Exception?,string>>()))`. Recommend the spec's acceptance criteria be read as "assertion against the rendered message template substring," not literal field-by-field structured-state introspection.
+1. **Resolve the "Open Questions" section explicitly in spec.** The spec already says "Status: COMPLETE" but the body of FR-3 mentions "if no `IDateTimeProvider` is currently injected, fall through to `DateTime.UtcNow` at the call site — see Open Questions." Update FR-3 to a definitive statement: *"Use `var now = DateTime.UtcNow;` already declared at `UpdateMarketingActionHandler.cs:59`. No new abstraction will be introduced; this matches the existing codebase convention."* Same for FR-2's per-entry validation — settle on **throw**, as decided above.
 
-2. **FR-1 / FR-2 — API integration test.** The spec lists this as a hard acceptance criterion. The codebase does not appear to have a `WebApplicationFactory`-based integration harness for Marketing endpoints (search did not surface one). Recommend amending acceptance criteria to "unit tests prove handler returns the structured envelope; an integration test is added *only if* an existing harness covers similar endpoints." If no harness exists, do not introduce one in this change — that is a separate, much larger effort.
+2. **Tighten the method signatures to nullable types.** Spec body shows `IEnumerable<string>` but the "API / Interface Design" section shows `IEnumerable<string>?`. The nullable form is correct (the entity treats `null` as empty). Align the FR-1 / FR-2 illustrative signatures to use `?`.
 
-3. **FR-3 — exact phrase for Delete handler.** The spec says "Outlook event already deleted" should be greppable. The Delete handler's Outlook step already logs `"Outlook event {EventId} already deleted (404)"` (line 62-64) for the *successful* 404 case. To avoid grep collisions, the DB-failure log should use a more specific phrase. Recommend: `"DB soft-delete failed after Outlook delete; Outlook event {EventId} already deleted — DB row {ActionId} still present"`. This keeps the "already deleted" greppable token while making the DB-failure case unambiguous.
+3. **Clarify "integration test" wording in FR-3.** The repo has no DB-backed handler integration test for `UpdateMarketingActionHandler` — existing tests at `UpdateMarketingActionHandlerTests.cs` mock `IMarketingActionRepository`. The new test for "actually clears them in the database" should be reworded to "verifies that after the handler runs, the in-memory `MarketingAction` passed to `UpdateAsync` has the expected final collection state" — assertable via `Mock.Verify(It.Is<MarketingAction>(a => …))` exactly like the existing test at line 200.
 
-4. **FR-4 — clarify "no functional change."** The spec says no functional change to `CreateMarketingActionHandler`. This explicitly forbids extracting a shared helper that the Create handler would also call. Accepted as-is — Decision 1 above reinforces this.
+4. **Document the dedup-key asymmetry between `LinkToFolder` and `ReplaceFolderLinks`** in FR-2's behaviour list (it is currently only implicit). Future maintainers should not "fix" the asymmetry by silently aligning one to the other.
+
+5. **Add a Non-Functional Requirement on documentation:** XML doc-comments on both new methods explicitly call out (a) `null` ⇒ empty, (b) normalization rules, (c) dedup key, (d) the dedup-key divergence from `LinkToFolder` for the folder-link method.
 
 ## Prerequisites
 
-None. All required infrastructure exists:
+None. This change requires:
 
-- ✅ `ErrorCodes.DatabaseError = 0011` exists with the correct HTTP status mapping.
-- ✅ `UpdateMarketingActionResponse` and `DeleteMarketingActionResponse` both have the `(ErrorCodes, Dictionary<string,string>?)` constructor.
-- ✅ `ILogger<UpdateMarketingActionHandler>` and `ILogger<DeleteMarketingActionHandler>` are already injected.
-- ✅ Repository methods (`UpdateAsync`, `SaveChangesAsync`, `DeleteSoftAsync`) exist on `IMarketingActionRepository`.
-- ✅ Test fixtures with `Mock<ILogger<T>>`, `Mock<IMarketingActionRepository>`, `TestOptionsMonitor<MarketingCalendarOptions>` already wired up for both handlers.
-- ✅ No new packages, no DI registration, no config keys, no DB migration, no Key Vault secret.
+- No database schema changes / migrations
+- No EF configuration changes (`MarketingActionConfiguration.cs`, `MarketingActionProductConfiguration.cs`, `MarketingActionFolderLinkConfiguration.cs` are unaffected)
+- No new NuGet packages
+- No new DI registrations
+- No new configuration / `appsettings` entries
+- No new secrets / Key Vault entries
+- No OpenAPI regeneration; no FE client regeneration
+- No feature flag
 
-Implementation can start immediately. Total expected diff: ~30 LOC of production code + ~50 LOC of tests.
+Implementation can start immediately against the current `main` branch. Validation gates per the project's `CLAUDE.md`: `dotnet build`, `dotnet format`, new + existing tests in `Anela.Heblo.Tests` pass.

--- a/artifacts/feat-arch-review-marketing-updatemarketingact/brief.md
+++ b/artifacts/feat-arch-review-marketing-updatemarketingact/brief.md
@@ -3,67 +3,63 @@ Marketing
 
 ## Finding
 
-`CreateMarketingActionHandler` wraps the DB save in a try/catch and compensates (deletes the Outlook event) if the save fails:
+`UpdateMarketingActionHandler` clears the entity's navigation collections directly (bypassing the domain entity's encapsulation) before re-adding items via the encapsulated domain methods.
+
+File: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`
 
 ```csharp
-// CreateMarketingActionHandler.cs:87–112
-try
-{
-    await _repository.AddAsync(action, cancellationToken);
-    await _repository.SaveChangesAsync(cancellationToken);
-}
-catch (Exception dbEx)
-{
-    _logger.LogError(dbEx, "DB save failed after Outlook create; compensating Outlook event {EventId}", outlookEventId);
-    if (outlookEventId != null)
-    {
-        try { await _outlookSync.DeleteEventAsync(outlookEventId, cancellationToken); }
-        catch (Exception compEx) { /* logs orphan */ }
-    }
-    return new CreateMarketingActionResponse(ErrorCodes.DatabaseError);
-}
+// Lines 95–110
+action.ProductAssociations.Clear();          // reaches into EF collection directly
+if (request.AssociatedProducts?.Any() == true)
+    foreach (var product in request.AssociatedProducts.Distinct())
+        action.AssociateWithProduct(product);   // adds via domain method
+
+action.FolderLinks.Clear();                 // reaches into EF collection directly
+if (request.FolderLinks?.Any() == true)
+    foreach (var link in request.FolderLinks)
+        action.LinkToFolder(link.FolderKey.Trim(), link.FolderType);  // adds via domain method
 ```
 
-`UpdateMarketingActionHandler` has **no such protection**:
-
-```csharp
-// UpdateMarketingActionHandler.cs:112–113
-await _repository.UpdateAsync(action, cancellationToken);
-await _repository.SaveChangesAsync(cancellationToken);  // ← unguarded; exception propagates
-```
-
-The Outlook push happens at lines 70–91 (before the DB save). If the DB save throws, the Outlook calendar already reflects the new data while the database still holds the old data. The exception surfaces to MediatR with no compensation attempt and no structured error response — the caller sees a 500 instead of the module's `ErrorCodes.DatabaseError`.
-
-The Delete handler (`DeleteMarketingActionHandler.cs:75–76`) has the same gap: it calls `_repository.DeleteSoftAsync` (which includes `SaveChangesAsync`) after a successful Outlook deletion, with no catch.
+The `MarketingAction` entity provides `AssociateWithProduct` and `LinkToFolder` as encapsulated add methods with deduplication guards, but has no `ReplaceProducts` / `ClearProducts` / `ReplaceLinks` domain methods. The handler compensates by calling `.Clear()` on the raw `ICollection<>` navigation properties before re-adding — leaking persistence concerns into the Application layer.
 
 ## Why it matters
 
-- **Data consistency**: on any transient DB error (deadlock, connection drop), Outlook and the database diverge silently. The marketing action appears updated in the team calendar but unchanged in the app.
-- **Error surfacing**: the unhandled exception bypasses the response-object pattern used by every other handler in this module, causing the API to return 500 rather than a structured `{ success: false, errorCode: "..." }` response.
-- **Inconsistency**: the Create handler clearly documents the intended compensating-transaction pattern. The Update and Delete handlers don't follow it, which will confuse the next developer extending this module.
+- **Broken encapsulation**: the entity controls *adding* associations but not *clearing* them. Any invariant the entity would want to enforce on removal (e.g. audit log, minimum-association guard) cannot be expressed.
+- **EF coupling in Application layer**: `.Clear()` on an EF `virtual ICollection<>` works only because EF tracks the change via its change tracker. The Application-layer handler is now implicitly relying on EF behaviour — it would silently fail with a different persistence implementation.
+- **SOLID — Single Responsibility**: mutation of collection state is a domain concern; the handler should not need to know how to replace the list.
 
 ## Suggested fix
 
-Wrap the DB save in `UpdateMarketingActionHandler` with the same compensation pattern used in `CreateMarketingActionHandler`. For an update, a full revert is harder (you'd need to re-issue a `PATCH` with the original values), so the minimal fix is: catch the DB exception, log the Outlook-vs-DB inconsistency explicitly, and return `ErrorCodes.DatabaseError` so the caller knows the operation failed:
+Add replace methods to `MarketingAction` in the domain entity:
 
 ```csharp
-// UpdateMarketingActionHandler.cs — replace lines 112-113
-try
+public void ReplaceProductAssociations(IEnumerable<string> productCodes, DateTime utcNow)
 {
-    await _repository.UpdateAsync(action, cancellationToken);
-    await _repository.SaveChangesAsync(cancellationToken);
+    ProductAssociations.Clear();
+    foreach (var code in productCodes.Select(c => c.Trim().ToUpperInvariant()).Distinct())
+        ProductAssociations.Add(new MarketingActionProduct
+        {
+            MarketingActionId = Id,
+            ProductCodePrefix = code,
+            CreatedAt = utcNow,
+        });
 }
-catch (Exception dbEx)
+
+public void ReplaceFolderLinks(IEnumerable<(string key, MarketingFolderType type)> links)
 {
-    _logger.LogError(dbEx,
-        "DB save failed after Outlook update for MarketingAction {ActionId}; " +
-        "Outlook event {EventId} may now be out of sync",
-        action.Id, action.OutlookEventId);
-    return new UpdateMarketingActionResponse(ErrorCodes.DatabaseError);
+    FolderLinks.Clear();
+    foreach (var (key, type) in links)
+        FolderLinks.Add(new MarketingActionFolderLink
+        {
+            MarketingActionId = Id,
+            FolderKey = key.Trim(),
+            FolderType = type,
+            CreatedAt = utcNow,
+        });
 }
 ```
 
-Apply the same pattern to `DeleteMarketingActionHandler` around its `DeleteSoftAsync` call.
+The handler then calls `action.ReplaceProductAssociations(...)` and `action.ReplaceFolderLinks(...)` — no direct collection mutation in Application layer.
 
 ---
-_Filed by daily arch-review routine on 2026-05-29._
+_Filed by daily arch-review routine on 2026-06-07._

--- a/artifacts/feat-arch-review-marketing-updatemarketingact/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketing-updatemarketingact/impl/main.r1.md
@@ -1,50 +1,54 @@
 ---
 
-# Implementation: Marketing Module — Consistent DB Save Error Handling for Update and Delete Handlers
+# Implementation: Encapsulate Collection Replacement in MarketingAction Domain Entity
 
 ## What was implemented
 
-Added a `try/catch (Exception)` guard around the DB save calls in `UpdateMarketingActionHandler` and `DeleteMarketingActionHandler`, mirroring the pattern already in `CreateMarketingActionHandler`. On DB failure after a successful Outlook write, each handler now logs a structured `LogError` and returns `ErrorCodes.DatabaseError` instead of letting the exception surface as HTTP 500.
+Added `ReplaceProductAssociations` and `ReplaceFolderLinks` to the `MarketingAction` aggregate root, then refactored `UpdateMarketingActionHandler` to delegate to them instead of directly mutating EF Core navigation collections.
 
 ## Files created/modified
 
-- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs` — wrapped `UpdateAsync` + `SaveChangesAsync` in try/catch; logs `{ActionId}`, `{EventId}`, greppable phrase "may now be out of sync"; returns `ErrorCodes.DatabaseError`
-- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs` — wrapped `DeleteSoftAsync` in try/catch; logs `{ActionId}`, `{EventId}`, greppable phrase "already deleted — DB row still present"; returns `ErrorCodes.DatabaseError`
-- `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs` — added `Handle_ReturnsDatabaseError_WhenDbSaveFails` test; asserts `Success == false`, `ErrorCode == DatabaseError`, Outlook update called once, no Outlook rollback, error log contains "may now be out of sync"
-- `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` — added `Handle_ReturnsDatabaseError_WhenDbDeleteFails` test; asserts `Success == false`, `ErrorCode == DatabaseError`, Outlook delete called once, error log contains "already deleted"
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` — two new domain methods: `ReplaceProductAssociations(IEnumerable<string>?, DateTime)` and `ReplaceFolderLinks(IEnumerable<(string, MarketingFolderType)>?, DateTime)`, each with XML docs covering null→empty, normalization, dedup key, and the folderLink/composite-key asymmetry
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs` — replaced lines 95–111 (17-line Clear+loop block) with two delegated calls
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs` — 9 unit tests: empty, null, normalize+dedup, throw-on-invalid (theory×3), delta, utcNow, MarketingActionId
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs` — 11 unit tests: empty, null, trim, composite-key dedup, same-key-diff-type, throw-on-invalid (theory×3), delta, utcNow, MarketingActionId
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs` — added `BuildExistingActionWithCollections()` helper + 2 new tests locking in clear-on-null and delta-replace contracts
 
 ## Tests
 
-All 27 Marketing handler tests pass (`dotnet test --filter "FullyQualifiedName~Application.Marketing"` — 0 failures, 0 skipped).
-
-- `UpdateMarketingActionHandlerTests` — 11 tests including new DB-failure test
-- `DeleteMarketingActionHandlerTests` — 9 tests including new DB-failure test
-- `CreateMarketingActionHandlerTests` — 7 tests, all unchanged and still passing
+- `MarketingActionReplaceProductAssociationsTests` — 9 tests, all pass
+- `MarketingActionReplaceFolderLinksTests` — 11 tests, all pass
+- `UpdateMarketingActionHandlerTests` — 13 tests total (11 existing + 2 new), all pass
+- 178 Marketing tests total, all green; full suite 4802 pass, 38 pre-existing Docker integration failures (unrelated)
 
 ## How to verify
 
 ```bash
-dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
-  --filter "FullyQualifiedName~Application.Marketing"
-# Expected: 27 passed, 0 failed
+cd backend
+dotnet build --no-restore
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Marketing" --no-restore
+# Verify no direct collection mutations remain in Application layer:
+grep -rn "ProductAssociations\.Clear\|FolderLinks\.Clear" src/Anela.Heblo.Application/ || echo "No direct mutations"
 ```
 
 ## Notes
 
-- The solution-wide build fails due to missing NuGet restore assets in the worktree (pre-existing, not caused by this change). The Application project and test project both build cleanly.
-- Integration tests were not added — no existing `WebApplicationFactory`-based harness covers Marketing endpoints, per the arch-review specification amendment.
-- `CreateMarketingActionHandler` is untouched (FR-4).
+- Dedup key for `ReplaceFolderLinks` is composite `(folderKey, folderType)`, intentionally stricter than `LinkToFolder` (which dedupes by `folderKey` alone) — documented in XML doc comment
+- Both new methods validate per-entry null/whitespace and throw `ArgumentException` (matching existing single-add methods)
+- `null` sequence is treated as empty, consistent with spec FR-1/FR-2
+- No new NuGet packages, no EF config changes, no migrations needed
+- All commits are on `feat-arch-review-marketing-updatemarketingact` branch
 
 ## PR Summary
 
-Added guarded DB save error handling to `UpdateMarketingActionHandler` and `DeleteMarketingActionHandler` to match the existing pattern in `CreateMarketingActionHandler`. Previously, a DB failure after a successful Outlook write in these two handlers would propagate as an unhandled HTTP 500 and leave Outlook and the database silently diverged. Now both handlers catch the exception, log a structured error (with `{ActionId}`, `{EventId}`, and a greppable phrase), and return a `DatabaseError` response envelope.
+Encapsulates collection replacement in the `MarketingAction` aggregate by adding `ReplaceProductAssociations` and `ReplaceFolderLinks` domain methods, and refactoring `UpdateMarketingActionHandler` to delegate to them instead of directly calling `.Clear()` on EF navigation properties. This removes a persistence-layer concern from the Application layer and gives the domain entity full control over its invariants (normalization, deduplication, validation) for both add and replace operations.
 
 ### Changes
-- `UpdateMarketingActionHandler.cs` — try/catch around `UpdateAsync` + `SaveChangesAsync`; `LogError` with "may now be out of sync"; returns `ErrorCodes.DatabaseError`
-- `DeleteMarketingActionHandler.cs` — try/catch around `DeleteSoftAsync`; `LogError` with "already deleted — DB row still present"; returns `ErrorCodes.DatabaseError`
-- `UpdateMarketingActionHandlerTests.cs` — `Handle_ReturnsDatabaseError_WhenDbSaveFails` covering response shape, no Outlook rollback, and log assertion
-- `DeleteMarketingActionHandlerTests.cs` — `Handle_ReturnsDatabaseError_WhenDbDeleteFails` covering response shape, Outlook delete called once, and log assertion
+- `MarketingAction.cs` — two new replace methods with full XML documentation
+- `UpdateMarketingActionHandler.cs` — 17-line Clear+loop block replaced with 3-line delegation
+- `MarketingActionReplaceProductAssociationsTests.cs` — new file, 9 domain unit tests
+- `MarketingActionReplaceFolderLinksTests.cs` — new file, 11 domain unit tests
+- `UpdateMarketingActionHandlerTests.cs` — 2 new handler tests locking in clear-on-null and delta-replace contracts
 
 ## Status
-
 DONE

--- a/artifacts/feat-arch-review-marketing-updatemarketingact/spec.r1.md
+++ b/artifacts/feat-arch-review-marketing-updatemarketingact/spec.r1.md
@@ -1,108 +1,160 @@
-# Specification: Marketing Module — Consistent DB Save Error Handling for Update and Delete Handlers
+# Specification: Encapsulate Collection Replacement in MarketingAction Domain Entity
 
 ## Summary
-The `UpdateMarketingActionHandler` and `DeleteMarketingActionHandler` lack the compensation/error-handling pattern that `CreateMarketingActionHandler` already implements around the DB save call. When Outlook is updated successfully but the subsequent DB save fails, the exception propagates unhandled — surfacing as HTTP 500 instead of the module's structured `ErrorCodes.DatabaseError` response — and Outlook silently diverges from the database. This spec defines a consistent guarded-save + structured-error pattern across all three handlers.
+Refactor `UpdateMarketingActionHandler` to stop directly mutating EF Core navigation collections on the `MarketingAction` aggregate. Introduce domain-owned `ReplaceProductAssociations` and `ReplaceFolderLinks` methods on `MarketingAction` so the Application layer is decoupled from EF change-tracker behaviour and the entity retains full control over its invariants.
 
 ## Background
-The Marketing module uses MediatR handlers that synchronize a marketing action between the local database and an Outlook calendar event. The Outlook write is performed first; the DB write is performed second. If the DB write fails after a successful Outlook write, the two systems diverge.
+The current `UpdateMarketingActionHandler` (lines 95–110 of `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`) leaks persistence concerns into the Application layer:
 
-`CreateMarketingActionHandler` (lines 87–112) already documents the intended pattern: a try/catch around the DB save that (a) logs the inconsistency, (b) attempts a compensating Outlook delete, and (c) returns `ErrorCodes.DatabaseError` so the caller receives a structured failure rather than an unhandled exception.
+- It calls `action.ProductAssociations.Clear()` and `action.FolderLinks.Clear()` directly on `virtual ICollection<>` navigation properties.
+- It then re-populates them via the encapsulated domain methods `AssociateWithProduct` and `LinkToFolder`.
 
-`UpdateMarketingActionHandler` (lines 112–113) and `DeleteMarketingActionHandler` (lines 75–76) skip this pattern entirely. The result:
+The `MarketingAction` aggregate exposes encapsulated *add* methods (with deduplication guards) but no equivalent *replace* or *clear* operations. The handler compensates by reaching into the raw collection, which:
 
-- **Inconsistent error surface**: every other handler in the module returns a typed response with an error code; these two leak raw 500s.
-- **Silent divergence**: on transient DB errors (deadlock, connection drop, timeout), Outlook reflects the new state while the database keeps the old. Users see the team calendar move but the app shows no change.
-- **Maintainer confusion**: the Create handler establishes the convention; the other two violate it without explanation.
+1. Breaks aggregate encapsulation — removal-side invariants cannot be enforced or evolved (e.g. future audit logging, minimum-association guards).
+2. Implicitly couples the Application layer to EF Core change-tracking. The same code would silently no-op against an in-memory or non-EF repository.
+3. Violates SRP — collection-state mutation is a domain concern, not a handler concern.
 
-A full transactional rollback of an Outlook update is not feasible (it would require recording the original Outlook field values and re-issuing a PATCH); the practical minimum is to **detect, log, and report** the inconsistency through the existing response-object pattern.
+This refactor was identified by the daily architecture-review routine on 2026-06-07.
 
 ## Functional Requirements
 
-### FR-1: Guard the DB save in `UpdateMarketingActionHandler`
-Wrap the `UpdateAsync` + `SaveChangesAsync` calls in `UpdateMarketingActionHandler` (around lines 112–113) in a try/catch that mirrors the pattern in `CreateMarketingActionHandler`. On exception:
-1. Log an error at `LogError` level that includes the exception, the `MarketingAction` ID, the `OutlookEventId`, and an explicit message stating that Outlook and the database may now be out of sync.
-2. Return `new UpdateMarketingActionResponse(ErrorCodes.DatabaseError)` so the caller receives a structured failure response rather than a 500.
-3. Do **not** attempt to revert the Outlook event (out of scope — see Out of Scope).
+### FR-1: Add `ReplaceProductAssociations` to `MarketingAction`
+The `MarketingAction` domain entity must expose a method that atomically replaces the full set of product associations with a new set.
+
+**Signature (illustrative):**
+```csharp
+public void ReplaceProductAssociations(IEnumerable<string> productCodes, DateTime utcNow)
+```
+
+**Behaviour:**
+- Accepts a sequence of raw product-code prefixes plus a `utcNow` timestamp supplied by the caller (no `DateTime.UtcNow` inside the domain).
+- Normalises each code with `Trim()` and `ToUpperInvariant()` (matching the existing `AssociateWithProduct` normalisation).
+- Deduplicates the normalised codes.
+- Clears the existing `ProductAssociations` collection and repopulates it with new `MarketingActionProduct` entries (`MarketingActionId`, `ProductCodePrefix`, `CreatedAt = utcNow`).
+- A `null` sequence is treated as an empty sequence (i.e. clears all associations).
+- An empty input set leaves the collection empty.
 
 **Acceptance criteria:**
-- A unit test that forces `SaveChangesAsync` to throw (e.g. via mocked repository) on update returns an `UpdateMarketingActionResponse` with `ErrorCode == ErrorCodes.DatabaseError` and does **not** throw.
-- The same test asserts that an error-level log entry is emitted containing the action ID and the Outlook event ID.
-- An existing happy-path unit test for `UpdateMarketingActionHandler` continues to pass without modification.
-- The exception is no longer propagated to MediatR; the API integration test for a failing update returns the structured error envelope, not HTTP 500.
+- Calling `ReplaceProductAssociations` with `["abc", "ABC", " abc "]` results in exactly one association with `ProductCodePrefix = "ABC"`.
+- Calling with `null` or `[]` empties the collection.
+- Existing associations not present in the new set are removed.
+- New associations carry the supplied `utcNow` value as `CreatedAt`.
+- Unit test covers: empty input, null input, duplicate input, mixed-case input, whitespace input, and a delta scenario (some kept, some added, some removed).
 
-### FR-2: Guard the DB save in `DeleteMarketingActionHandler`
-Wrap the `_repository.DeleteSoftAsync` call in `DeleteMarketingActionHandler` (around lines 75–76) — which internally performs `SaveChangesAsync` — in the same try/catch pattern. On exception:
-1. Log an error including the exception, the action ID, and the (now-deleted) Outlook event ID, with an explicit message stating the Outlook event has already been removed while the DB row remains.
-2. Return the delete handler's typed response with `ErrorCodes.DatabaseError` (use whichever response class the handler currently constructs for success; if none exists for the error case, follow the same shape as the other handlers in the module).
-3. Do **not** attempt to recreate the Outlook event (out of scope).
+### FR-2: Add `ReplaceFolderLinks` to `MarketingAction`
+The `MarketingAction` domain entity must expose a method that atomically replaces the full set of folder links.
 
-**Acceptance criteria:**
-- A unit test that forces `DeleteSoftAsync` to throw returns the typed response with `ErrorCode == ErrorCodes.DatabaseError` and does not throw.
-- The test asserts an error-level log entry referencing the action ID and the deleted Outlook event ID.
-- The existing happy-path delete unit test continues to pass.
-- API integration test for a failing delete returns the structured error envelope, not HTTP 500.
+**Signature (illustrative):**
+```csharp
+public void ReplaceFolderLinks(
+    IEnumerable<(string folderKey, MarketingFolderType folderType)> links,
+    DateTime utcNow)
+```
 
-### FR-3: Consistent log message format across handlers
-All three handlers (Create, Update, Delete) must emit the post-DB-failure log message with:
-- A clear statement of which operation failed (create/update/delete).
-- The `MarketingAction.Id` (where available — on create it may be the in-memory value).
-- The `OutlookEventId`.
-- An explicit "Outlook and DB may be out of sync" / "Outlook event already deleted" phrase so the message is greppable for ops.
-
-**Acceptance criteria:**
-- A grep for "out of sync" / "may now be out of sync" / "already deleted" returns at least one match per handler.
-- Log messages use structured logging placeholders (`{ActionId}`, `{EventId}`), not string interpolation.
-
-### FR-4: Preserve existing Create handler behavior
-No functional change to `CreateMarketingActionHandler`. Its compensating-Outlook-delete behavior is the reference implementation and must continue to work. If a minor refactor (e.g. extracting a shared helper) is proposed during implementation, it must keep the Create handler's compensation path intact.
+**Behaviour:**
+- Accepts a sequence of `(folderKey, folderType)` pairs plus a `utcNow` timestamp.
+- Normalises `folderKey` with `Trim()` (matching the existing `LinkToFolder` normalisation).
+- Deduplicates by the composite key `(folderKey, folderType)`.
+- Clears existing `FolderLinks` and repopulates with new `MarketingActionFolderLink` entries (`MarketingActionId`, `FolderKey`, `FolderType`, `CreatedAt = utcNow`).
+- A `null` sequence is treated as an empty sequence.
+- Rejects entries where `folderKey` is null, empty, or whitespace by throwing the same exception type the existing `LinkToFolder` uses for invalid input (or, if `LinkToFolder` silently accepts, match that behaviour — see Open Questions).
 
 **Acceptance criteria:**
-- Existing `CreateMarketingActionHandler` unit tests pass without modification.
+- Calling `ReplaceFolderLinks` with two pairs differing only in `folderType` keeps both.
+- Calling with `null` or `[]` empties the collection.
+- Whitespace in `folderKey` is trimmed before persistence.
+- Unit test covers: empty input, null input, duplicate input (same key+type), distinct-type-same-key input, whitespace input, and a delta scenario.
+
+### FR-3: Refactor `UpdateMarketingActionHandler` to Use New Methods
+The handler must stop touching `action.ProductAssociations` and `action.FolderLinks` directly and instead delegate to the new domain methods.
+
+**Behaviour:**
+- Replace lines 95–110 of `UpdateMarketingActionHandler.cs` so the handler:
+  - Calls `action.ReplaceProductAssociations(request.AssociatedProducts ?? Enumerable.Empty<string>(), utcNow)`.
+  - Calls `action.ReplaceFolderLinks(request.FolderLinks?.Select(l => (l.FolderKey, l.FolderType)) ?? Enumerable.Empty<(string, MarketingFolderType)>(), utcNow)`.
+- `utcNow` must be obtained from the existing `IDateTimeProvider` / time abstraction already used in this handler (or, if none is currently injected, fall through to `DateTime.UtcNow` at the call site — see Open Questions).
+- No `.Clear()` call on EF navigation properties remains anywhere in the Application layer for this aggregate.
+
+**Acceptance criteria:**
+- `UpdateMarketingActionHandler.cs` contains no direct collection mutation (`Clear`, `Add`, `Remove`) against `MarketingAction` navigation properties.
+- Existing integration test(s) for `UpdateMarketingAction` continue to pass without modification (the externally observable behaviour is identical).
+- A new integration test verifies that an update which removes all product associations actually clears them in the database.
+- A new integration test verifies that an update which changes folder-link composition (mix of added, removed, retained) results in the expected final state.
+
+### FR-4: Preserve Backwards-Compatible External Behaviour
+The end-to-end semantics of `UpdateMarketingActionCommand` must not change for any caller.
+
+**Acceptance criteria:**
+- A request with `AssociatedProducts = null` clears all product associations (matches current behaviour — the existing handler only re-adds when `request.AssociatedProducts?.Any() == true`, but `Clear()` always runs).
+- A request with `FolderLinks = null` clears all folder links (same reasoning).
+- A request with the same sets as currently persisted is a no-op from the caller's perspective (final state matches input).
+- All existing unit and integration tests for the Marketing module continue to pass with no test modifications other than additions.
 
 ## Non-Functional Requirements
 
 ### NFR-1: Performance
-No measurable performance impact expected. The change adds only a try/catch wrapper; the catch path executes only on failure (already a rare, slow path involving I/O).
+- No regression in handler throughput. The replacement is bounded by the input list size, identical to the prior implementation.
+- No additional database round trips: the replace methods operate on in-memory tracked collections; EF Core change tracking continues to emit the same `DELETE`/`INSERT` SQL as before.
 
 ### NFR-2: Security
-No new attack surface. Log messages must not include sensitive marketing-action payload fields (description, customer data); they must only include identifiers (`ActionId`, `OutlookEventId`).
+- No new attack surface. Input validation (trimming, case normalisation, dedup) remains where it was, but is now enforced uniformly inside the domain entity.
 
-### NFR-3: Observability
-The error logs must be sufficient for an on-call engineer to identify drift between Outlook and the DB without needing additional instrumentation. Specifically: given the log entry, an operator must be able to (a) locate the `MarketingAction` row by ID and (b) locate the Outlook event by `OutlookEventId`.
+### NFR-3: Maintainability
+- After the refactor, the Application layer must contain zero direct mutations of `MarketingAction`'s navigation collections.
+- The domain entity becomes the single source of truth for both *adding* and *replacing* product associations and folder links.
 
-### NFR-4: Consistency / Maintainability
-After this change, all three handlers in the Marketing module must follow the same guarded-save shape, so a future developer adding a fourth handler can copy any of them as a template.
+### NFR-4: Testability
+- The new domain methods must be unit-testable without EF Core, an in-memory database, or any infrastructure dependency. Pure POCO construction + method call + collection assertion.
 
 ## Data Model
-No schema changes. The change is purely behavioral in three handler classes.
+No schema changes. Affected types (existing):
 
-Entities involved (unchanged):
-- `MarketingAction` — local DB entity with `Id`, `OutlookEventId`, and other fields.
-- Outlook calendar event — external, referenced by `OutlookEventId`.
+- `MarketingAction` (aggregate root) — gains two methods, no new state.
+- `MarketingActionProduct` (child entity) — unchanged.
+- `MarketingActionFolderLink` (child entity) — unchanged.
+- `MarketingFolderType` (enum) — unchanged.
+
+Existing relationships:
+- `MarketingAction 1..* MarketingActionProduct` via `ProductAssociations` navigation collection.
+- `MarketingAction 1..* MarketingActionFolderLink` via `FolderLinks` navigation collection.
 
 ## API / Interface Design
-No public API contract changes. The affected MediatR responses are:
-- `UpdateMarketingActionResponse(ErrorCodes errorCode)` — already supports an error-code constructor (verified by Create handler precedent); the Update path will now use it on DB failure instead of leaking an exception.
-- Delete handler response — same pattern; uses whichever response shape the handler already defines.
 
-Externally observable change: API endpoints for update and delete will return a structured `{ success: false, errorCode: "DatabaseError" }` envelope on DB save failure instead of HTTP 500. This is a **behavior fix**, not a breaking change — callers that relied on 500 to detect failure should already be checking the response envelope per module convention.
+### Public command / endpoint
+`UpdateMarketingActionCommand` request DTO and endpoint contract are unchanged. No OpenAPI regeneration required for the FE.
+
+### Domain entity surface (new)
+```csharp
+public class MarketingAction
+{
+    // existing members unchanged
+
+    public void ReplaceProductAssociations(
+        IEnumerable<string>? productCodes,
+        DateTime utcNow);
+
+    public void ReplaceFolderLinks(
+        IEnumerable<(string folderKey, MarketingFolderType folderType)>? links,
+        DateTime utcNow);
+}
+```
+
+### Handler surface (refactored)
+`UpdateMarketingActionHandler.Handle` keeps its current signature, dependencies, and return type. Internal block at lines 95–110 collapses to two delegated calls.
 
 ## Dependencies
-- Existing `ErrorCodes` enum/constant in the Marketing module — must contain `DatabaseError` (already used by Create handler).
-- Existing repository interface (`UpdateAsync`, `SaveChangesAsync`, `DeleteSoftAsync`).
-- Existing `ILogger<T>` injected into each handler.
-- MediatR pipeline — no changes.
-
-No new packages, no new services, no infrastructure changes.
+- **Entity Framework Core** — continues to handle change tracking of the cleared/repopulated collections (no change to EF configuration).
+- **Time abstraction** — the handler must supply a `DateTime` to the domain methods. Use whatever abstraction the surrounding code already uses; if none is present in this handler, accept `DateTime.UtcNow` at the call site (see Open Questions).
+- No new NuGet packages, no new infrastructure.
 
 ## Out of Scope
-- **Reverting / compensating Outlook updates** on DB failure in the Update handler. A true compensation would require capturing the pre-update Outlook field values and re-issuing a PATCH; this adds substantial complexity and is not required by this fix. The minimum viable behavior is "log + report".
-- **Recreating Outlook events** on DB failure in the Delete handler. Same reasoning.
-- **Introducing a distributed transaction / outbox pattern** between Outlook and the database. A proper two-phase or outbox-based solution is the long-term answer to this class of bug but is a separate, much larger initiative.
-- **Reordering Outlook and DB writes** (e.g. DB first, Outlook second). This would shift the inconsistency window but not eliminate it, and it changes the user-visible behavior of all three handlers — out of scope here.
-- **Adding retry logic** for transient DB errors. Could be added later via EF Core's retry-on-failure execution strategy; not in this fix.
-- **Extracting a shared base class or helper** for the guarded-save pattern. Allowed if trivially clean, but not required; three near-identical try/catch blocks are acceptable given the small surface area.
-- Changes to `CreateMarketingActionHandler` beyond what is needed to keep tests passing.
+- Renaming or restructuring `AssociateWithProduct` / `LinkToFolder` — they remain as-is for callers that need to add a single item.
+- Introducing a generic "child collection replace" pattern across other aggregates (e.g. orders, manufacturing) — this spec covers only `MarketingAction`.
+- Adding audit logging, soft-delete, or domain events for association removal — flagged as future opportunities only.
+- Changes to the `UpdateMarketingActionCommand` request shape or the corresponding FE client.
+- Database schema changes or EF migrations.
+- Replacing EF Core change tracking with explicit repository-managed deletes.
 
 ## Open Questions
 None.

--- a/artifacts/feat-arch-review-marketing-updatemarketingact/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketing-updatemarketingact/task-plan.r1.md
@@ -1,11 +1,15 @@
-Plan saved to `docs/superpowers/plans/2026-06-02-marketing-update-delete-db-error-handling.md`.
+Plan saved to `docs/superpowers/plans/2026-06-09-marketing-action-replace-collections.md`.
 
-The plan covers all spec requirements (FR-1 through FR-4, NFR-1 through NFR-4) in 6 bite-sized tasks, follows strict TDD (failing test → impl → verify per change), incorporates the arch-review's specification amendments (log-assertion mechanism, integration-test scoping, disambiguated Delete-handler phrase), and matches the Create handler reference shape exactly.
+## Summary
 
-**Summary of the plan:**
-- **Task 1–2**: TDD pair for `UpdateMarketingActionHandler` — failing test + guarded `UpdateAsync`/`SaveChangesAsync` returning `ErrorCodes.DatabaseError`
-- **Task 3–4**: TDD pair for `DeleteMarketingActionHandler` — failing test + guarded `DeleteSoftAsync`
-- **Task 5**: Grep verification of FR-3 greppable phrases and no-interpolation rule across all three handlers
-- **Task 6**: Final Marketing suite + full backend build/format/test sweep
+The plan decomposes the refactor into 14 TDD tasks:
 
-Three production files modified (Update + Delete handlers, Create untouched), two test files modified (one new `[Fact]` each), no new files, no schema/DI/package changes. Spec coverage, placeholder, and type-consistency self-checks completed inline.
+- **Tasks 1–5:** Add `ReplaceProductAssociations` to `MarketingAction` (empty/null/dedup/throw/delta + utcNow + Id propagation).
+- **Tasks 6–10:** Add `ReplaceFolderLinks` (empty/null/trim/composite-key dedup/distinct-type/throw/delta + utcNow + Id propagation).
+- **Tasks 11–12:** Lock the handler's externally-observable contract (clear-on-null, delta composition) with new tests against the *current* implementation before refactoring.
+- **Task 13:** Replace the 17-line block in `UpdateMarketingActionHandler.cs` with two delegated calls, plus a grep gate proving no direct mutations remain in the Application layer.
+- **Task 14:** Full `dotnet format` + `dotnet build` + full test-suite validation.
+
+Each task is fully self-contained with exact code, exact filter commands, expected outputs, and frequent commits. All FRs and NFRs from spec + arch-review amendments are covered (see the self-review matrix in the plan).
+
+Per the pipeline note, skipping the execution handoff prompt — the plan file is the artifact.

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
@@ -92,23 +92,10 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAct
                 }
             }
 
-            action.ProductAssociations.Clear();
-            if (request.AssociatedProducts?.Any() == true)
-            {
-                foreach (var product in request.AssociatedProducts.Distinct())
-                {
-                    action.AssociateWithProduct(product);
-                }
-            }
-
-            action.FolderLinks.Clear();
-            if (request.FolderLinks?.Any() == true)
-            {
-                foreach (var link in request.FolderLinks)
-                {
-                    action.LinkToFolder(link.FolderKey.Trim(), link.FolderType);
-                }
-            }
+            action.ReplaceProductAssociations(request.AssociatedProducts, now);
+            action.ReplaceFolderLinks(
+                request.FolderLinks?.Select(l => (l.FolderKey, l.FolderType)),
+                now);
 
             try
             {

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -126,6 +126,40 @@ namespace Anela.Heblo.Domain.Features.Marketing
             });
         }
 
+        /// <summary>
+        /// Atomically replaces the full set of product associations.
+        /// A <c>null</c> sequence is treated as empty (clears all associations).
+        /// Each entry is trimmed and upper-cased (invariant) before dedup.
+        /// Throws <see cref="ArgumentException"/> if any entry is null, empty, or whitespace.
+        /// </summary>
+        public void ReplaceProductAssociations(IEnumerable<string>? productCodes, DateTime utcNow)
+        {
+            var normalized = new List<string>();
+            if (productCodes != null)
+            {
+                foreach (var raw in productCodes)
+                {
+                    if (string.IsNullOrWhiteSpace(raw))
+                        throw new ArgumentException("Product code cannot be empty", nameof(productCodes));
+
+                    var code = raw.Trim().ToUpperInvariant();
+                    if (!normalized.Contains(code))
+                        normalized.Add(code);
+                }
+            }
+
+            ProductAssociations.Clear();
+            foreach (var code in normalized)
+            {
+                ProductAssociations.Add(new MarketingActionProduct
+                {
+                    MarketingActionId = Id,
+                    ProductCodePrefix = code,
+                    CreatedAt = utcNow,
+                });
+            }
+        }
+
         public void SoftDelete(string userId, string username)
         {
             IsDeleted = true;

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -160,6 +160,48 @@ namespace Anela.Heblo.Domain.Features.Marketing
             }
         }
 
+        /// <summary>
+        /// Atomically replaces the full set of folder links.
+        /// A <c>null</c> sequence is treated as empty (clears all links).
+        /// <paramref name="links"/> folderKey is trimmed before dedup.
+        /// Deduplicates by the composite key (<c>folderKey</c>, <c>folderType</c>) —
+        /// this is stricter than <see cref="LinkToFolder"/>, which dedupes by
+        /// <c>folderKey</c> alone. The asymmetry is intentional; new code should
+        /// use this method when replacing the full set.
+        /// Throws <see cref="ArgumentException"/> if any entry's
+        /// folderKey is null, empty, or whitespace.
+        /// </summary>
+        public void ReplaceFolderLinks(
+            IEnumerable<(string folderKey, MarketingFolderType folderType)>? links,
+            DateTime utcNow)
+        {
+            var normalized = new List<(string folderKey, MarketingFolderType folderType)>();
+            if (links != null)
+            {
+                foreach (var (rawKey, type) in links)
+                {
+                    if (string.IsNullOrWhiteSpace(rawKey))
+                        throw new ArgumentException("Folder key cannot be empty", nameof(links));
+
+                    var key = rawKey.Trim();
+                    if (!normalized.Any(n => n.folderKey == key && n.folderType == type))
+                        normalized.Add((key, type));
+                }
+            }
+
+            FolderLinks.Clear();
+            foreach (var (key, type) in normalized)
+            {
+                FolderLinks.Add(new MarketingActionFolderLink
+                {
+                    MarketingActionId = Id,
+                    FolderKey = key,
+                    FolderType = type,
+                    CreatedAt = utcNow,
+                });
+            }
+        }
+
         public void SoftDelete(string userId, string username)
         {
             IsDeleted = true;

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
@@ -316,4 +316,33 @@ public class UpdateMarketingActionHandlerTests
                 a.FolderLinks.Count == 0),
             It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_ReplacesCollections_OnDeltaInput()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildExistingActionWithCollections());
+
+        var request = BuildRequest();
+        request.AssociatedProducts = new List<string> { "OLD-PROD", "NEW-PROD" };
+        request.FolderLinks = new List<MarketingFolderLinkRequest>
+        {
+            new() { FolderKey = "old-key", FolderType = MarketingFolderType.General },
+            new() { FolderKey = "new-key", FolderType = MarketingFolderType.Project },
+        };
+
+        var result = await BuildHandler().Handle(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _repository.Verify(x => x.UpdateAsync(
+            It.Is<MarketingAction>(a =>
+                a.ProductAssociations.Count == 2 &&
+                a.ProductAssociations.Any(p => p.ProductCodePrefix == "OLD-PROD") &&
+                a.ProductAssociations.Any(p => p.ProductCodePrefix == "NEW-PROD") &&
+                a.FolderLinks.Count == 2 &&
+                a.FolderLinks.Any(f => f.FolderKey == "old-key" && f.FolderType == MarketingFolderType.General) &&
+                a.FolderLinks.Any(f => f.FolderKey == "new-key" && f.FolderType == MarketingFolderType.Project)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
@@ -329,7 +329,7 @@ public class UpdateMarketingActionHandlerTests
         request.FolderLinks = new List<MarketingFolderLinkRequest>
         {
             new() { FolderKey = "old-key", FolderType = MarketingFolderType.General },
-            new() { FolderKey = "new-key", FolderType = MarketingFolderType.Project },
+            new() { FolderKey = "new-key", FolderType = MarketingFolderType.Seasonal },
         };
 
         var result = await BuildHandler().Handle(request, CancellationToken.None);
@@ -342,7 +342,7 @@ public class UpdateMarketingActionHandlerTests
                 a.ProductAssociations.Any(p => p.ProductCodePrefix == "NEW-PROD") &&
                 a.FolderLinks.Count == 2 &&
                 a.FolderLinks.Any(f => f.FolderKey == "old-key" && f.FolderType == MarketingFolderType.General) &&
-                a.FolderLinks.Any(f => f.FolderKey == "new-key" && f.FolderType == MarketingFolderType.Project)),
+                a.FolderLinks.Any(f => f.FolderKey == "new-key" && f.FolderType == MarketingFolderType.Seasonal)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
@@ -40,6 +40,14 @@ public class UpdateMarketingActionHandlerTests
         return action;
     }
 
+    private static MarketingAction BuildExistingActionWithCollections()
+    {
+        var action = BuildExistingAction();
+        action.AssociateWithProduct("OLD-PROD");
+        action.LinkToFolder("old-key", MarketingFolderType.General);
+        return action;
+    }
+
     private static UpdateMarketingActionRequest BuildRequest(int id = 42) => new()
     {
         Id = id,
@@ -286,5 +294,26 @@ public class UpdateMarketingActionHandlerTests
         _outlookSync.Verify(
             x => x.UpdateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ClearsCollections_WhenRequestListsAreNull()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildExistingActionWithCollections());
+
+        var request = BuildRequest();
+        request.AssociatedProducts = null;
+        request.FolderLinks = null;
+
+        var result = await BuildHandler().Handle(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _repository.Verify(x => x.UpdateAsync(
+            It.Is<MarketingAction>(a =>
+                a.ProductAssociations.Count == 0 &&
+                a.FolderLinks.Count == 0),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
@@ -111,5 +111,29 @@ namespace Anela.Heblo.Tests.Domain.Marketing
                     MarketingFolderType.Campaign,
                 });
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ReplaceFolderLinks_Throws_WhenAnyFolderKeyIsNullEmptyOrWhitespace(string? badKey)
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            Action act = () =>
+                action.ReplaceFolderLinks(
+                    new[]
+                    {
+                        ("good", MarketingFolderType.General),
+                        (badKey!, MarketingFolderType.General),
+                    },
+                    UtcNow);
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("links");
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
@@ -51,5 +51,65 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             // Assert
             action.FolderLinks.Should().BeEmpty();
         }
+
+        [Fact]
+        public void ReplaceFolderLinks_TrimsWhitespaceFromFolderKey()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[] { ("  key-1  ", MarketingFolderType.General) },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Single().FolderKey.Should().Be("key-1");
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_DeduplicatesByCompositeKey_WhenSameKeyAndType()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("key-1", MarketingFolderType.General),
+                    ("key-1", MarketingFolderType.General),
+                    (" key-1 ", MarketingFolderType.General),
+                },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_KeepsBothEntries_WhenSameKeyButDifferentType()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("key-1", MarketingFolderType.General),
+                    ("key-1", MarketingFolderType.Campaign),
+                },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().HaveCount(2);
+            action.FolderLinks.Select(f => f.FolderType)
+                .Should().BeEquivalentTo(new[]
+                {
+                    MarketingFolderType.General,
+                    MarketingFolderType.Campaign,
+                });
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
@@ -135,5 +135,68 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             act.Should().Throw<ArgumentException>()
                 .Which.ParamName.Should().Be("links");
         }
+
+        [Fact]
+        public void ReplaceFolderLinks_ReplacesEntireSet_OnDeltaInput()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.LinkToFolder("KEEP", MarketingFolderType.General);
+            action.LinkToFolder("REMOVE", MarketingFolderType.General);
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("KEEP", MarketingFolderType.General),
+                    ("ADD", MarketingFolderType.Campaign),
+                },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks
+                .Select(f => (f.FolderKey, f.FolderType))
+                .Should().BeEquivalentTo(new[]
+                {
+                    ("KEEP", MarketingFolderType.General),
+                    ("ADD", MarketingFolderType.Campaign),
+                });
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_UsesProvidedUtcNowOnAllNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            var moment = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc);
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("a", MarketingFolderType.General),
+                    ("b", MarketingFolderType.Campaign),
+                },
+                moment);
+
+            // Assert
+            action.FolderLinks.Should().OnlyContain(f => f.CreatedAt == moment);
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_SetsMarketingActionIdOnNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.Id = 99;
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[] { ("a", MarketingFolderType.General) },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Single().MarketingActionId.Should().Be(99);
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
@@ -37,5 +37,19 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             // Assert
             action.FolderLinks.Should().BeEmpty();
         }
+
+        [Fact]
+        public void ReplaceFolderLinks_ClearsExisting_WhenInputIsNull()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.LinkToFolder("key-1", MarketingFolderType.General);
+
+            // Act
+            action.ReplaceFolderLinks(null, UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().BeEmpty();
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionReplaceFolderLinksTests
+    {
+        private static readonly DateTime UtcNow = new(2026, 6, 9, 12, 0, 0, DateTimeKind.Utc);
+
+        private static MarketingAction CreateAction() =>
+            new MarketingActionTestBuilder()
+                .WithId(1)
+                .WithTitle("Test Action")
+                .WithStartDate(UtcNow)
+                .WithCreatedAt(UtcNow)
+                .WithModifiedAt(UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
+
+        [Fact]
+        public void ReplaceFolderLinks_ClearsExisting_WhenInputIsEmpty()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.LinkToFolder("key-1", MarketingFolderType.General);
+            action.FolderLinks.Should().HaveCount(1);
+
+            // Act
+            action.ReplaceFolderLinks(
+                Enumerable.Empty<(string folderKey, MarketingFolderType folderType)>(),
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().BeEmpty();
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
@@ -50,5 +50,19 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             // Assert
             action.ProductAssociations.Should().BeEmpty();
         }
+
+        [Fact]
+        public void ReplaceProductAssociations_NormalizesAndDeduplicates_AcrossCaseAndWhitespace()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceProductAssociations(new[] { "abc", "ABC", " abc " }, UtcNow);
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
@@ -36,5 +36,19 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             // Assert
             action.ProductAssociations.Should().BeEmpty();
         }
+
+        [Fact]
+        public void ReplaceProductAssociations_ClearsExisting_WhenInputIsNull()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+
+            // Act
+            action.ReplaceProductAssociations(null, UtcNow);
+
+            // Assert
+            action.ProductAssociations.Should().BeEmpty();
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
@@ -64,5 +64,23 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             action.ProductAssociations.Should().HaveCount(1);
             action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ReplaceProductAssociations_Throws_WhenSequenceContainsNullEmptyOrWhitespace(string? badEntry)
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            Action act = () =>
+                action.ReplaceProductAssociations(new[] { "GOOD", badEntry! }, UtcNow);
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("productCodes");
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
@@ -82,5 +82,50 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             act.Should().Throw<ArgumentException>()
                 .Which.ParamName.Should().Be("productCodes");
         }
+
+        [Fact]
+        public void ReplaceProductAssociations_ReplacesEntireSet_OnDeltaInput()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("KEEP");
+            action.AssociateWithProduct("REMOVE");
+
+            // Act — KEEP stays (re-supplied), REMOVE goes away, ADD is new
+            action.ReplaceProductAssociations(new[] { "KEEP", "ADD" }, UtcNow);
+
+            // Assert
+            action.ProductAssociations
+                .Select(p => p.ProductCodePrefix)
+                .Should().BeEquivalentTo(new[] { "KEEP", "ADD" });
+        }
+
+        [Fact]
+        public void ReplaceProductAssociations_UsesProvidedUtcNowOnAllNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            var moment = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc);
+
+            // Act
+            action.ReplaceProductAssociations(new[] { "A", "B" }, moment);
+
+            // Assert
+            action.ProductAssociations.Should().OnlyContain(p => p.CreatedAt == moment);
+        }
+
+        [Fact]
+        public void ReplaceProductAssociations_SetsMarketingActionIdOnNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.Id = 99;
+
+            // Act
+            action.ReplaceProductAssociations(new[] { "A" }, UtcNow);
+
+            // Assert
+            action.ProductAssociations.Single().MarketingActionId.Should().Be(99);
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionReplaceProductAssociationsTests
+    {
+        private static readonly DateTime UtcNow = new(2026, 6, 9, 12, 0, 0, DateTimeKind.Utc);
+
+        private static MarketingAction CreateAction() =>
+            new MarketingActionTestBuilder()
+                .WithId(1)
+                .WithTitle("Test Action")
+                .WithStartDate(UtcNow)
+                .WithCreatedAt(UtcNow)
+                .WithModifiedAt(UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
+
+        [Fact]
+        public void ReplaceProductAssociations_ClearsExisting_WhenInputIsEmpty()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+            action.AssociateWithProduct("XYZ");
+            action.ProductAssociations.Should().HaveCount(2);
+
+            // Act
+            action.ReplaceProductAssociations(Enumerable.Empty<string>(), UtcNow);
+
+            // Assert
+            action.ProductAssociations.Should().BeEmpty();
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-06-09-marketing-action-replace-collections.md
+++ b/docs/superpowers/plans/2026-06-09-marketing-action-replace-collections.md
@@ -1,0 +1,982 @@
+# MarketingAction Encapsulate Collection Replacement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop mutating `MarketingAction`'s EF Core navigation collections from the Application layer by adding domain-owned `ReplaceProductAssociations` and `ReplaceFolderLinks` methods on the aggregate root, then refactor `UpdateMarketingActionHandler` to delegate to them.
+
+**Architecture:** Two new pure-domain methods on `MarketingAction` accept a sequence and a `utcNow` timestamp, normalize/deduplicate inputs, clear the existing tracked collection, and repopulate with new child entities. EF Core change tracking continues to emit identical DELETE+INSERT SQL because the navigation properties remain `virtual ICollection<>`. The handler stops calling `.Clear()`/`AssociateWithProduct`/`LinkToFolder` and instead delegates to the new methods.
+
+**Tech Stack:** .NET 8, C#, Entity Framework Core, xUnit, FluentAssertions, Moq, MediatR.
+
+---
+
+## File Structure
+
+| Action | Path |
+|---|---|
+| Modify | `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` — add `ReplaceProductAssociations` and `ReplaceFolderLinks` methods |
+| Modify | `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs` — replace lines 95–111 with two delegated calls |
+| Create | `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs` — pure-domain unit tests |
+| Create | `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs` — pure-domain unit tests |
+| Modify | `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs` — add tests asserting clearing semantics through the handler |
+
+No new files outside test additions, no namespace changes, no new dependencies.
+
+---
+
+## Conventions Recap
+
+Read once before starting; they apply to every task below.
+
+- **Time abstraction:** None exists in this codebase. The Application handler captures `var now = DateTime.UtcNow;` (line 59 of `UpdateMarketingActionHandler.cs`) and the domain methods accept `DateTime utcNow` parameters — same pattern as `MarketingAction.UpdateDetails` and `MarkOutlookSynced`.
+- **Validation:** Per-entry whitespace/empty/null inside the input sequence throws `ArgumentException`, matching the existing `AssociateWithProduct` and `LinkToFolder` single-add methods. A `null` *sequence* is treated as an empty sequence (clears the collection).
+- **Dedup key for folder links:** Composite `(folderKey, folderType)` (this differs intentionally from `LinkToFolder`, which dedupes by `folderKey` alone — document this asymmetry in XML doc comments). Out of scope to harmonize the existing method.
+- **Dedup key for products:** Normalized (trim + invariant-upper) string.
+- **Normalization:** Product codes — `Trim()` then `ToUpperInvariant()`. Folder keys — `Trim()` only (no case folding, matching `LinkToFolder`).
+- **Encapsulation surface:** `ProductAssociations` / `FolderLinks` setters remain public (`get; set;`). Out of scope to lock them down.
+- **File style:** Block-scoped namespaces, usings inside namespace block, private methods below public ones — match the existing `MarketingAction.cs` layout.
+- **Test patterns:** xUnit + FluentAssertions. Use `MarketingActionTestBuilder` from `Anela.Heblo.Tests.Domain.Marketing` to construct entities. Use AAA (Arrange / Act / Assert) — see `MarketingActionAssociateWithProductTests.cs` as the canonical reference.
+
+---
+
+## Task 1: Add `ReplaceProductAssociations` failing test — empty input clears existing
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create the test file with a single failing test that proves the method exists and clears existing associations when given an empty input.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionReplaceProductAssociationsTests
+    {
+        private static readonly DateTime UtcNow = new(2026, 6, 9, 12, 0, 0, DateTimeKind.Utc);
+
+        private static MarketingAction CreateAction() =>
+            new MarketingActionTestBuilder()
+                .WithId(1)
+                .WithTitle("Test Action")
+                .WithStartDate(UtcNow)
+                .WithCreatedAt(UtcNow)
+                .WithModifiedAt(UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
+
+        [Fact]
+        public void ReplaceProductAssociations_ClearsExisting_WhenInputIsEmpty()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+            action.AssociateWithProduct("XYZ");
+            action.ProductAssociations.Should().HaveCount(2);
+
+            // Act
+            action.ReplaceProductAssociations(Enumerable.Empty<string>(), UtcNow);
+
+            // Assert
+            action.ProductAssociations.Should().BeEmpty();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingActionReplaceProductAssociationsTests" --no-restore`
+
+Expected: COMPILATION FAILURE — `MarketingAction` does not contain a definition for `ReplaceProductAssociations`.
+
+- [ ] **Step 3: Add the minimal `ReplaceProductAssociations` method to `MarketingAction`**
+
+File: `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs`
+
+Insert the following method immediately after `LinkToFolder` (after line 127, before `SoftDelete`):
+
+```csharp
+        /// <summary>
+        /// Atomically replaces the full set of product associations.
+        /// A <c>null</c> sequence is treated as empty (clears all associations).
+        /// Each entry is trimmed and upper-cased (invariant) before dedup.
+        /// Throws <see cref="ArgumentException"/> if any entry is null, empty, or whitespace.
+        /// </summary>
+        public void ReplaceProductAssociations(IEnumerable<string>? productCodes, DateTime utcNow)
+        {
+            var normalized = new List<string>();
+            if (productCodes != null)
+            {
+                foreach (var raw in productCodes)
+                {
+                    if (string.IsNullOrWhiteSpace(raw))
+                        throw new ArgumentException("Product code cannot be empty", nameof(productCodes));
+
+                    var code = raw.Trim().ToUpperInvariant();
+                    if (!normalized.Contains(code))
+                        normalized.Add(code);
+                }
+            }
+
+            ProductAssociations.Clear();
+            foreach (var code in normalized)
+            {
+                ProductAssociations.Add(new MarketingActionProduct
+                {
+                    MarketingActionId = Id,
+                    ProductCodePrefix = code,
+                    CreatedAt = utcNow,
+                });
+            }
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingActionReplaceProductAssociationsTests" --no-restore`
+
+Expected: PASS — 1 test passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs \
+        backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+git commit -m "feat(marketing): add ReplaceProductAssociations to MarketingAction"
+```
+
+---
+
+## Task 2: `ReplaceProductAssociations` — null input clears existing
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append inside the existing class:
+
+```csharp
+        [Fact]
+        public void ReplaceProductAssociations_ClearsExisting_WhenInputIsNull()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+
+            // Act
+            action.ReplaceProductAssociations(null, UtcNow);
+
+            // Assert
+            action.ProductAssociations.Should().BeEmpty();
+        }
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName=Anela.Heblo.Tests.Domain.Marketing.MarketingActionReplaceProductAssociationsTests.ReplaceProductAssociations_ClearsExisting_WhenInputIsNull" --no-restore`
+
+Expected: PASS (the implementation from Task 1 already handles `null`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+git commit -m "test(marketing): cover null input on ReplaceProductAssociations"
+```
+
+---
+
+## Task 3: `ReplaceProductAssociations` — normalization + dedup
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+```csharp
+        [Fact]
+        public void ReplaceProductAssociations_NormalizesAndDeduplicates_AcrossCaseAndWhitespace()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceProductAssociations(new[] { "abc", "ABC", " abc " }, UtcNow);
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName=Anela.Heblo.Tests.Domain.Marketing.MarketingActionReplaceProductAssociationsTests.ReplaceProductAssociations_NormalizesAndDeduplicates_AcrossCaseAndWhitespace" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+git commit -m "test(marketing): cover normalize+dedup on ReplaceProductAssociations"
+```
+
+---
+
+## Task 4: `ReplaceProductAssociations` — throws on per-entry null/empty/whitespace
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+```csharp
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ReplaceProductAssociations_Throws_WhenSequenceContainsNullEmptyOrWhitespace(string? badEntry)
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            Action act = () =>
+                action.ReplaceProductAssociations(new[] { "GOOD", badEntry! }, UtcNow);
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("productCodes");
+        }
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceProductAssociations_Throws_WhenSequenceContainsNullEmptyOrWhitespace" --no-restore`
+
+Expected: PASS (validation already implemented in Task 1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+git commit -m "test(marketing): assert ReplaceProductAssociations throws on invalid entries"
+```
+
+---
+
+## Task 5: `ReplaceProductAssociations` — delta scenario (kept + added + removed)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+```csharp
+        [Fact]
+        public void ReplaceProductAssociations_ReplacesEntireSet_OnDeltaInput()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("KEEP");
+            action.AssociateWithProduct("REMOVE");
+
+            // Act — KEEP stays (re-supplied), REMOVE goes away, ADD is new
+            action.ReplaceProductAssociations(new[] { "KEEP", "ADD" }, UtcNow);
+
+            // Assert
+            action.ProductAssociations
+                .Select(p => p.ProductCodePrefix)
+                .Should().BeEquivalentTo(new[] { "KEEP", "ADD" });
+        }
+
+        [Fact]
+        public void ReplaceProductAssociations_UsesProvidedUtcNowOnAllNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            var moment = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc);
+
+            // Act
+            action.ReplaceProductAssociations(new[] { "A", "B" }, moment);
+
+            // Assert
+            action.ProductAssociations.Should().OnlyContain(p => p.CreatedAt == moment);
+        }
+
+        [Fact]
+        public void ReplaceProductAssociations_SetsMarketingActionIdOnNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.Id = 99;
+
+            // Act
+            action.ReplaceProductAssociations(new[] { "A" }, UtcNow);
+
+            // Assert
+            action.ProductAssociations.Single().MarketingActionId.Should().Be(99);
+        }
+```
+
+- [ ] **Step 2: Run all `ReplaceProductAssociations` tests**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingActionReplaceProductAssociationsTests" --no-restore`
+
+Expected: PASS — all 7 tests (1 from Task 1 + 1 from Task 2 + 1 from Task 3 + 3 InlineData from Task 4 + 3 from Task 5 = 9 facts including theory rows).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs
+git commit -m "test(marketing): cover delta/utcNow/MarketingActionId on ReplaceProductAssociations"
+```
+
+---
+
+## Task 6: Add `ReplaceFolderLinks` failing test — empty input clears existing
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs`
+
+- [ ] **Step 1: Write the failing test file**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionReplaceFolderLinksTests
+    {
+        private static readonly DateTime UtcNow = new(2026, 6, 9, 12, 0, 0, DateTimeKind.Utc);
+
+        private static MarketingAction CreateAction() =>
+            new MarketingActionTestBuilder()
+                .WithId(1)
+                .WithTitle("Test Action")
+                .WithStartDate(UtcNow)
+                .WithCreatedAt(UtcNow)
+                .WithModifiedAt(UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
+
+        [Fact]
+        public void ReplaceFolderLinks_ClearsExisting_WhenInputIsEmpty()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.LinkToFolder("key-1", MarketingFolderType.General);
+            action.FolderLinks.Should().HaveCount(1);
+
+            // Act
+            action.ReplaceFolderLinks(
+                Enumerable.Empty<(string folderKey, MarketingFolderType folderType)>(),
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().BeEmpty();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingActionReplaceFolderLinksTests" --no-restore`
+
+Expected: COMPILATION FAILURE — `MarketingAction` has no `ReplaceFolderLinks`.
+
+- [ ] **Step 3: Add the minimal `ReplaceFolderLinks` method to `MarketingAction`**
+
+File: `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs`
+
+Insert immediately after `ReplaceProductAssociations`:
+
+```csharp
+        /// <summary>
+        /// Atomically replaces the full set of folder links.
+        /// A <c>null</c> sequence is treated as empty (clears all links).
+        /// <paramref name="folderKey"/> is trimmed before dedup.
+        /// Deduplicates by the composite key (<c>folderKey</c>, <c>folderType</c>) —
+        /// this is stricter than <see cref="LinkToFolder"/>, which dedupes by
+        /// <c>folderKey</c> alone. The asymmetry is intentional; new code should
+        /// use this method when replacing the full set.
+        /// Throws <see cref="ArgumentException"/> if any entry's
+        /// <paramref name="folderKey"/> is null, empty, or whitespace.
+        /// </summary>
+        public void ReplaceFolderLinks(
+            IEnumerable<(string folderKey, MarketingFolderType folderType)>? links,
+            DateTime utcNow)
+        {
+            var normalized = new List<(string folderKey, MarketingFolderType folderType)>();
+            if (links != null)
+            {
+                foreach (var (rawKey, type) in links)
+                {
+                    if (string.IsNullOrWhiteSpace(rawKey))
+                        throw new ArgumentException("Folder key cannot be empty", nameof(links));
+
+                    var key = rawKey.Trim();
+                    if (!normalized.Any(n => n.folderKey == key && n.folderType == type))
+                        normalized.Add((key, type));
+                }
+            }
+
+            FolderLinks.Clear();
+            foreach (var (key, type) in normalized)
+            {
+                FolderLinks.Add(new MarketingActionFolderLink
+                {
+                    MarketingActionId = Id,
+                    FolderKey = key,
+                    FolderType = type,
+                    CreatedAt = utcNow,
+                });
+            }
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingActionReplaceFolderLinksTests" --no-restore`
+
+Expected: PASS — 1 test passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs \
+        backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+git commit -m "feat(marketing): add ReplaceFolderLinks to MarketingAction"
+```
+
+---
+
+## Task 7: `ReplaceFolderLinks` — null input clears existing
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+```csharp
+        [Fact]
+        public void ReplaceFolderLinks_ClearsExisting_WhenInputIsNull()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.LinkToFolder("key-1", MarketingFolderType.General);
+
+            // Act
+            action.ReplaceFolderLinks(null, UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().BeEmpty();
+        }
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName=Anela.Heblo.Tests.Domain.Marketing.MarketingActionReplaceFolderLinksTests.ReplaceFolderLinks_ClearsExisting_WhenInputIsNull" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+git commit -m "test(marketing): cover null input on ReplaceFolderLinks"
+```
+
+---
+
+## Task 8: `ReplaceFolderLinks` — whitespace trim + composite-key dedup
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+```csharp
+        [Fact]
+        public void ReplaceFolderLinks_TrimsWhitespaceFromFolderKey()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[] { ("  key-1  ", MarketingFolderType.General) },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Single().FolderKey.Should().Be("key-1");
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_DeduplicatesByCompositeKey_WhenSameKeyAndType()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("key-1", MarketingFolderType.General),
+                    ("key-1", MarketingFolderType.General),
+                    (" key-1 ", MarketingFolderType.General),
+                },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_KeepsBothEntries_WhenSameKeyButDifferentType()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("key-1", MarketingFolderType.General),
+                    ("key-1", MarketingFolderType.Project),
+                },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Should().HaveCount(2);
+            action.FolderLinks.Select(f => f.FolderType)
+                .Should().BeEquivalentTo(new[]
+                {
+                    MarketingFolderType.General,
+                    MarketingFolderType.Project,
+                });
+        }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingActionReplaceFolderLinksTests" --no-restore`
+
+Expected: PASS — all current tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+git commit -m "test(marketing): cover trim+composite-key dedup on ReplaceFolderLinks"
+```
+
+---
+
+## Task 9: `ReplaceFolderLinks` — throws on per-entry whitespace `folderKey`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+```csharp
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ReplaceFolderLinks_Throws_WhenAnyFolderKeyIsNullEmptyOrWhitespace(string? badKey)
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            Action act = () =>
+                action.ReplaceFolderLinks(
+                    new[]
+                    {
+                        ("good", MarketingFolderType.General),
+                        (badKey!, MarketingFolderType.General),
+                    },
+                    UtcNow);
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("links");
+        }
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceFolderLinks_Throws_WhenAnyFolderKeyIsNullEmptyOrWhitespace" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+git commit -m "test(marketing): assert ReplaceFolderLinks throws on invalid folder keys"
+```
+
+---
+
+## Task 10: `ReplaceFolderLinks` — delta + utcNow + MarketingActionId propagation
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs`
+
+- [ ] **Step 1: Add the failing tests**
+
+```csharp
+        [Fact]
+        public void ReplaceFolderLinks_ReplacesEntireSet_OnDeltaInput()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.LinkToFolder("KEEP", MarketingFolderType.General);
+            action.LinkToFolder("REMOVE", MarketingFolderType.General);
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("KEEP", MarketingFolderType.General),
+                    ("ADD", MarketingFolderType.Project),
+                },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks
+                .Select(f => (f.FolderKey, f.FolderType))
+                .Should().BeEquivalentTo(new[]
+                {
+                    ("KEEP", MarketingFolderType.General),
+                    ("ADD", MarketingFolderType.Project),
+                });
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_UsesProvidedUtcNowOnAllNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            var moment = new DateTime(2026, 12, 31, 23, 59, 59, DateTimeKind.Utc);
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[]
+                {
+                    ("a", MarketingFolderType.General),
+                    ("b", MarketingFolderType.Project),
+                },
+                moment);
+
+            // Assert
+            action.FolderLinks.Should().OnlyContain(f => f.CreatedAt == moment);
+        }
+
+        [Fact]
+        public void ReplaceFolderLinks_SetsMarketingActionIdOnNewRows()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.Id = 99;
+
+            // Act
+            action.ReplaceFolderLinks(
+                new[] { ("a", MarketingFolderType.General) },
+                UtcNow);
+
+            // Assert
+            action.FolderLinks.Single().MarketingActionId.Should().Be(99);
+        }
+```
+
+- [ ] **Step 2: Run all `ReplaceFolderLinks` tests**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingActionReplaceFolderLinksTests" --no-restore`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs
+git commit -m "test(marketing): cover delta/utcNow/MarketingActionId on ReplaceFolderLinks"
+```
+
+---
+
+## Task 11: Handler — failing test asserts `Clear` semantics when request lists are null
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs`
+
+This test will pass with the current implementation too (the existing handler also clears on null), but we use it to *lock in* the contract before the refactor in Task 13.
+
+- [ ] **Step 1: Add a helper to the test class and the new test**
+
+Add the following method and test inside `UpdateMarketingActionHandlerTests`. Place the helper above the existing static helpers (right after the private fields at line 22), and the test below the existing `Handle_UpdatesProductsAndFolderLinks_WhenProvided` test (after line 205).
+
+Helper (place near other private helpers):
+
+```csharp
+    private static MarketingAction BuildExistingActionWithCollections()
+    {
+        var action = BuildExistingAction();
+        action.AssociateWithProduct("OLD-PROD");
+        action.LinkToFolder("old-key", MarketingFolderType.General);
+        return action;
+    }
+```
+
+New test:
+
+```csharp
+    [Fact]
+    public async Task Handle_ClearsCollections_WhenRequestListsAreNull()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildExistingActionWithCollections());
+
+        var request = BuildRequest();
+        request.AssociatedProducts = null;
+        request.FolderLinks = null;
+
+        var result = await BuildHandler().Handle(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _repository.Verify(x => x.UpdateAsync(
+            It.Is<MarketingAction>(a =>
+                a.ProductAssociations.Count == 0 &&
+                a.FolderLinks.Count == 0),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it currently passes**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName=Anela.Heblo.Tests.Application.Marketing.UpdateMarketingActionHandlerTests.Handle_ClearsCollections_WhenRequestListsAreNull" --no-restore`
+
+Expected: PASS (current handler already clears via direct `.Clear()` — this test locks in the contract before refactor).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
+git commit -m "test(marketing): lock UpdateMarketingAction clear-on-null contract"
+```
+
+---
+
+## Task 12: Handler — failing test asserts delta semantics (mixed kept/added/removed)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs`
+
+- [ ] **Step 1: Add the new test below the previous one**
+
+```csharp
+    [Fact]
+    public async Task Handle_ReplacesCollections_OnDeltaInput()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildExistingActionWithCollections());
+
+        var request = BuildRequest();
+        request.AssociatedProducts = new List<string> { "OLD-PROD", "NEW-PROD" };
+        request.FolderLinks = new List<MarketingFolderLinkRequest>
+        {
+            new() { FolderKey = "old-key", FolderType = MarketingFolderType.General },
+            new() { FolderKey = "new-key", FolderType = MarketingFolderType.Project },
+        };
+
+        var result = await BuildHandler().Handle(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _repository.Verify(x => x.UpdateAsync(
+            It.Is<MarketingAction>(a =>
+                a.ProductAssociations.Count == 2 &&
+                a.ProductAssociations.Any(p => p.ProductCodePrefix == "OLD-PROD") &&
+                a.ProductAssociations.Any(p => p.ProductCodePrefix == "NEW-PROD") &&
+                a.FolderLinks.Count == 2 &&
+                a.FolderLinks.Any(f => f.FolderKey == "old-key" && f.FolderType == MarketingFolderType.General) &&
+                a.FolderLinks.Any(f => f.FolderKey == "new-key" && f.FolderType == MarketingFolderType.Project)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it currently passes**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName=Anela.Heblo.Tests.Application.Marketing.UpdateMarketingActionHandlerTests.Handle_ReplacesCollections_OnDeltaInput" --no-restore`
+
+Expected: PASS (current handler produces the same final state).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
+git commit -m "test(marketing): lock UpdateMarketingAction delta-replace contract"
+```
+
+---
+
+## Task 13: Refactor `UpdateMarketingActionHandler` to delegate to new domain methods
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`
+
+- [ ] **Step 1: Replace lines 95–111 with two delegated calls**
+
+In `UpdateMarketingActionHandler.cs`, the current block at lines 95–111 is:
+
+```csharp
+            action.ProductAssociations.Clear();
+            if (request.AssociatedProducts?.Any() == true)
+            {
+                foreach (var product in request.AssociatedProducts.Distinct())
+                {
+                    action.AssociateWithProduct(product);
+                }
+            }
+
+            action.FolderLinks.Clear();
+            if (request.FolderLinks?.Any() == true)
+            {
+                foreach (var link in request.FolderLinks)
+                {
+                    action.LinkToFolder(link.FolderKey.Trim(), link.FolderType);
+                }
+            }
+```
+
+Replace it with:
+
+```csharp
+            action.ReplaceProductAssociations(request.AssociatedProducts, now);
+            action.ReplaceFolderLinks(
+                request.FolderLinks?.Select(l => (l.FolderKey, l.FolderType)),
+                now);
+```
+
+(The `using System.Linq;` directive at line 3 already covers `.Select`.)
+
+- [ ] **Step 2: Run the entire `UpdateMarketingActionHandlerTests` suite to verify no behavioral regression**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateMarketingActionHandlerTests" --no-restore`
+
+Expected: PASS — all existing tests + the two new lock-in tests pass.
+
+- [ ] **Step 3: Verify no remaining direct collection mutations against `MarketingAction` in the Application layer**
+
+Run: `cd backend && grep -rn "ProductAssociations\.Clear\|FolderLinks\.Clear\|ProductAssociations\.Add\|FolderLinks\.Add\|ProductAssociations\.Remove\|FolderLinks\.Remove" src/Anela.Heblo.Application/ || echo "No direct mutations remain"`
+
+Expected output: `No direct mutations remain` (the grep returns no matches and the `||` branch prints the success message).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
+git commit -m "refactor(marketing): delegate collection replacement to MarketingAction domain methods"
+```
+
+---
+
+## Task 14: Full validation gates
+
+**Files:** none modified
+
+This is the final hard gate per `CLAUDE.md` — `dotnet build`, `dotnet format`, and the full test suite.
+
+- [ ] **Step 1: Format the modified files**
+
+Run: `cd backend && dotnet format --include src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceProductAssociationsTests.cs test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionReplaceFolderLinksTests.cs test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs`
+
+Expected: completes without errors. If `dotnet format` made changes, inspect them with `git diff` — they should be whitespace only.
+
+- [ ] **Step 2: Build the solution**
+
+Run: `cd backend && dotnet build --no-restore`
+
+Expected: `Build succeeded.` with 0 errors and 0 warnings introduced by the changes (pre-existing warnings unaffected).
+
+- [ ] **Step 3: Run the full Marketing test surface**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Marketing" --no-restore`
+
+Expected: All Marketing tests pass — at minimum the existing `MarketingActionAssociateWithProductTests`, `MarketingActionConstructorTests`, `MarketingActionSyncTests`, `MarketingActionUpdateDetailsTests`, `UpdateMarketingActionHandlerTests`, and the two new `MarketingActionReplaceProductAssociationsTests` + `MarketingActionReplaceFolderLinksTests` suites.
+
+- [ ] **Step 4: Run the full backend test suite as a final gate**
+
+Run: `cd backend && dotnet test --no-restore`
+
+Expected: PASS — entire test suite green, no regressions outside Marketing.
+
+- [ ] **Step 5: Commit any formatting changes (if any)**
+
+```bash
+git status
+# If `dotnet format` produced uncommitted changes:
+git add -u
+git commit -m "chore(marketing): apply dotnet format"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Implemented in |
+|---|---|
+| FR-1 `ReplaceProductAssociations` exists with given signature | Task 1 (impl), Tasks 1–5 (tests) |
+| FR-1 normalize trim+upper, dedup | Task 3 |
+| FR-1 null sequence → empty | Task 2 |
+| FR-1 empty input leaves collection empty | Task 1 |
+| FR-1 `utcNow` propagates to `CreatedAt` | Task 5 |
+| FR-1 unit test coverage (empty, null, dup, mixed-case, whitespace, delta) | Tasks 1, 2, 3, 5 |
+| FR-2 `ReplaceFolderLinks` exists with given signature | Task 6 |
+| FR-2 normalize trim on `folderKey` | Task 8 |
+| FR-2 composite-key dedup | Task 8 |
+| FR-2 null sequence → empty | Task 7 |
+| FR-2 same-key-different-type keeps both | Task 8 |
+| FR-2 throws on null/empty/whitespace key | Task 9 |
+| FR-2 unit test coverage (empty, null, dup, distinct-type, whitespace, delta) | Tasks 6, 7, 8, 9, 10 |
+| FR-3 Handler stops touching collections directly | Task 13 |
+| FR-3 Handler delegates to new methods with `now` | Task 13 |
+| FR-3 Existing handler tests still pass | Task 13 step 2 |
+| FR-3 New handler test for clear-all | Task 11 |
+| FR-3 New handler test for delta composition | Task 12 |
+| FR-4 `AssociatedProducts = null` clears | Task 11 |
+| FR-4 `FolderLinks = null` clears | Task 11 |
+| FR-4 Existing tests unchanged | Task 13 step 2 (no test edits to existing) |
+| NFR-1 No new round trips | Architecture unchanged (Clear+Add on tracked collection) |
+| NFR-2 Validation enforced in domain | Tasks 1, 6 |
+| NFR-3 Zero direct mutation in Application | Task 13 step 3 (grep gate) |
+| NFR-4 Tests use POCO construction only | Tasks 1–10 all use `MarketingActionTestBuilder` |
+| Arch-review amendment 5: XML docs documenting null⇒empty, normalization, dedup, asymmetry | Tasks 1, 6 (doc comments included) |
+
+All spec requirements covered.
+
+**Placeholder scan:** No `TBD`, `TODO`, `implement later`, `appropriate error handling`, `similar to Task N`, or stub-style instructions remain. Each step contains exact code or exact commands.
+
+**Type consistency:** Method names `ReplaceProductAssociations` / `ReplaceFolderLinks`, signatures `(IEnumerable<string>?, DateTime)` / `(IEnumerable<(string folderKey, MarketingFolderType folderType)>?, DateTime)`, and `ParamName` strings (`"productCodes"`, `"links"`) match consistently across the implementation steps (Tasks 1, 6) and test steps (Tasks 4, 9). Property names `ProductAssociations`, `FolderLinks`, `ProductCodePrefix`, `FolderKey`, `FolderType`, `CreatedAt`, `MarketingActionId` match the actual entity definitions verified by reading the source files.


### PR DESCRIPTION

Encapsulates collection replacement in the `MarketingAction` aggregate by adding `ReplaceProductAssociations` and `ReplaceFolderLinks` domain methods, and refactoring `UpdateMarketingActionHandler` to delegate to them instead of directly calling `.Clear()` on EF navigation properties. This removes a persistence-layer concern from the Application layer and gives the domain entity full control over its invariants (normalization, deduplication, validation) for both add and replace operations.

### Changes
- `MarketingAction.cs` — two new replace methods with full XML documentation
- `UpdateMarketingActionHandler.cs` — 17-line Clear+loop block replaced with 3-line delegation
- `MarketingActionReplaceProductAssociationsTests.cs` — new file, 9 domain unit tests
- `MarketingActionReplaceFolderLinksTests.cs` — new file, 11 domain unit tests
- `UpdateMarketingActionHandlerTests.cs` — 2 new handler tests locking in clear-on-null and delta-replace contracts

---

Closes #2695

### Tokens used
16615489
