### PR TITLE
feat: Remove embedded SaveChangesAsync from `IMarketingActionRepository.DeleteSoftAsync`

### DIFF
--- a/artifacts/feat-arch-review-marketing-deletesoftasync-em/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketing-deletesoftasync-em/arch-review.r1.md
@@ -1,0 +1,154 @@
+I have enough context. The Journal module's `DeleteJournalEntryHandler` already implements exactly the proposed pattern — this is the precedent. Now I'll write the review.
+
+# Architecture Review: Remove embedded `SaveChangesAsync` from `IMarketingActionRepository.DeleteSoftAsync`
+
+## Skip Design: true
+
+Backend-only refactor. No new endpoints, no contract changes, no UI surface touched.
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with what the codebase already establishes:
+
+- **Caller-controlled persistence** is the dominant pattern in this solution. `CreateMarketingActionHandler` and `UpdateMarketingActionHandler` already use `UpdateAsync` + `SaveChangesAsync` from the handler.
+- **A direct precedent exists**: `DeleteJournalEntryHandler` (`backend/src/Anela.Heblo.Application/Features/Journal/UseCases/DeleteJournalEntry/DeleteJournalEntryHandler.cs:51-53`) implements the exact sequence proposed — `entry.SoftDelete(...) → UpdateAsync → SaveChangesAsync`. This refactor brings Marketing into parity with Journal and removes the outlier.
+- **Generic `IRepository<,>`** (`BaseRepository<TEntity,TKey>`) does not expose a `DeleteSoftAsync`. The current Marketing-specific addition is a leak of caller concerns into the repository abstraction. Removing it makes `IMarketingActionRepository` lean and conventional.
+- **No new abstraction** (no Unit-of-Work, no `IUnitOfWork`, no service wrapper) is needed — the handler already holds all required collaborators (`ICurrentUserService`, repository, `_outlookSync`, options, logger).
+
+Integration points are narrow: one repository interface, one repository implementation, one handler, two test files.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ DeleteMarketingActionHandler  (Application)                     │
+│                                                                 │
+│   1. GetByIdAsync(id)            ◄── single load (was 2 loads) │
+│   2. if (OutlookEventId) DeleteEventAsync(outlookSync)         │
+│   3. action.SoftDelete(userId, username)   (domain mutation)   │
+│   4. UpdateAsync(action)         (EF state marker)             │
+│   5. SaveChangesAsync()          (commit)                      │
+└──────────────────┬──────────────────────────────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ IMarketingActionRepository  (Domain)                            │
+│   - GetByIdAsync, UpdateAsync, SaveChangesAsync  (inherited)    │
+│   - GetPagedAsync, GetForCalendarAsync, ...                     │
+│   ─ DeleteSoftAsync   ❌ REMOVED                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Remove `DeleteSoftAsync` entirely (Option B), do not keep a thinned wrapper (Option A)
+
+**Options considered:**
+- **A.** Keep `DeleteSoftAsync` on the interface, drop only the embedded `SaveChangesAsync` and accept the entity instead of an id.
+- **B.** Delete `DeleteSoftAsync` from interface + implementation. Handler inlines the three lines.
+
+**Chosen approach:** **B** (matches the spec).
+
+**Rationale:** A one-line "wrapper" that just calls `entity.SoftDelete(...)` + `UpdateAsync(...)` adds an abstraction with zero behaviour. The Journal module's precedent inlines it. Keeping the wrapper would re-introduce a discoverability hazard (developers expect a save). Deletion is also the only way to eliminate the double DB load — keeping the method by id forces the second `GetByIdAsync`.
+
+#### Decision 2: Keep `MarketingAction.SoftDelete(string userId, string username)` as-is (2 args, internal `DateTime.UtcNow`)
+
+**Options considered:**
+- **A.** Leave signature unchanged (per spec FR-3).
+- **B.** Refactor to `SoftDelete(userId, username, utcNow)` for consistency with `UpdateDetails` and the ctor.
+
+**Chosen approach:** **A**, matching FR-3 strictly.
+
+**Rationale:** FR-3 is explicit that the domain method signature does not change. The 3-arg call shown in the spec's "API / Interface Design" example is a spec defect (see Specification Amendments). The Journal precedent also uses the 2-arg form. Refactoring `SoftDelete` to accept `utcNow` is a worthwhile consistency cleanup, but is out of scope for this task and should be filed separately if pursued.
+
+#### Decision 3: Wrap `UpdateAsync` + `SaveChangesAsync` in the existing `try/catch` that returns `ErrorCodes.DatabaseError`
+
+**Options considered:**
+- **A.** Wrap both calls.
+- **B.** Wrap only `SaveChangesAsync` (since `BaseRepository.UpdateAsync` returns `Task.CompletedTask` and never throws today).
+
+**Chosen approach:** **A** — wrap both.
+
+**Rationale:** Preserves the existing handler's behaviour and the existing "already deleted" log message verified by `Handle_ReturnsDatabaseError_WhenDbDeleteFails`. Keeps the change surgical and tolerant of future repository overrides that could make `UpdateAsync` non-trivial.
+
+#### Decision 4: Call `UpdateAsync` even though the entity is already EF-tracked
+
+**Rationale:** Both `UpdateMarketingActionHandler` (line 115) and `DeleteJournalEntryHandler` (line 52) call `UpdateAsync` on already-tracked entities. Skipping it would break the established pattern with no behavioural benefit. `BaseRepository.UpdateAsync` is `DbSet.Update(entity)` — harmless on a tracked entity.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Edits to:
+
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs` — remove line 11 (`DeleteSoftAsync` declaration).
+- `backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs` — remove lines 27–36 (`DeleteSoftAsync` implementation).
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs` — replace lines 75–86 with the inlined sequence (see below).
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` — update all `DeleteSoftAsync` setups/verifications.
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` — update lines 286, 305, 330 (see Spec Amendments).
+
+### Interfaces and Contracts
+
+**Removed from `IMarketingActionRepository`:**
+```csharp
+Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default);
+```
+
+**Handler delete block** — replace the existing try/catch around `DeleteSoftAsync`:
+```csharp
+action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User");
+
+try
+{
+    await _repository.UpdateAsync(action, cancellationToken);
+    await _repository.SaveChangesAsync(cancellationToken);
+}
+catch (Exception ex)
+{
+    _logger.LogError(ex,
+        "DB soft-delete failed after Outlook delete for MarketingAction {ActionId}; Outlook event {EventId} already deleted — DB row still present",
+        request.Id, action.OutlookEventId);
+    return new DeleteMarketingActionResponse(ErrorCodes.DatabaseError);
+}
+```
+
+Everything else in the handler (auth check, `GetByIdAsync`, not-found branch, Outlook block, success log, response shape) stays byte-for-byte unchanged.
+
+### Data Flow
+
+**Before** (per delete request): `GetById` → Outlook.Delete → `DeleteSoftAsync` { `GetById` → mutate → `Update` → `Save` } = **2 reads, 1 write**.
+
+**After**: `GetById` → Outlook.Delete → mutate (in memory) → `Update` → `Save` = **1 read, 1 write**.
+
+The entity is already EF-tracked from the first `GetByIdAsync`, so the in-memory `SoftDelete` mutation is captured by the change tracker; `UpdateAsync` is a no-op state marker; `SaveChangesAsync` produces a single `UPDATE`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Tests in `MarketingActionHandlerSyncTests.cs` still mock `DeleteSoftAsync` and will break compilation. | Medium | Spec FR-4 must cover this file too — see Spec Amendments. Update all three call sites (lines 286, 305, 330). |
+| Spec example uses 3-arg `SoftDelete(...)` but domain method is 2-arg → implementer may add a third parameter speculatively. | Medium | Treat the 3-arg form as a spec typo; do not modify `MarketingAction.SoftDelete`. Match FR-3 verbatim. |
+| Existing test `Handle_ReturnsDatabaseError_WhenDbDeleteFails` mocks `DeleteSoftAsync.ThrowsAsync`. | Low | Re-target the throw to `SaveChangesAsync` (Moq on `IMarketingActionRepository.SaveChangesAsync`). The verified log message ("already deleted") is preserved by the handler. |
+| Tests verify call ordering between Outlook and the DB step (`callOrder.Add("db")` via `DeleteSoftAsync` callback). | Low | Re-anchor the "db" callback on `SaveChangesAsync` (the commit) — that's the operation that "closes" the DB step from a caller perspective. |
+| Removing `DeleteSoftAsync` could leak callers outside the Marketing module. | Low | `grep -r "DeleteSoftAsync"` (already done) confirms no callers outside `MarketingActionRepository` itself, `IMarketingActionRepository`, the handler, and the two test files. Solution must compile cleanly. |
+| `BaseRepository.UpdateAsync` returns immediately without saving — easy to mistake for a no-op and remove it. | Low | Keep the call for pattern consistency with `UpdateMarketingActionHandler` and `DeleteJournalEntryHandler`. A code comment is not warranted. |
+
+## Specification Amendments
+
+The following corrections to `spec.r1.md` are required before implementation:
+
+1. **§ API / Interface Design — handler change snippet.** Change the example from `action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User", now);` to `action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User");` The current `MarketingAction.SoftDelete` is a 2-arg method that captures `DateTime.UtcNow` internally (`MarketingAction.cs:129`). FR-3 explicitly says signature stays unchanged — the example contradicts FR-3.
+
+2. **§ FR-2 acceptance criteria — `SoftDelete` call.** Same fix: drop the `now` argument from the prescribed call.
+
+3. **§ FR-2 — drop the "load `now`" requirement.** No need for the handler to capture `DateTime.UtcNow`. The domain method owns the timestamp.
+
+4. **§ FR-4 — broaden test scope.** Add `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` to the list of test files that must be updated. The `DeleteHandler_CallsDeleteEvent_WhenOutlookEventIdExists` and `DeleteHandler_ReturnsError_WhenOutlookThrowsNonNotFound` tests both mock/verify `DeleteSoftAsync` (lines 286, 305, 330).
+
+5. **§ NFR-1 wording.** The "50% fewer reads" is correct for the delete path's read count (2 → 1), but the path still issues 1 write. Suggest rewording to: "Each delete request issues one entity load instead of two; total DB round-trips reduce from 3 to 2 (one read + one commit, plus the Outlook call which is unrelated)."
+
+## Prerequisites
+
+None. All collaborators (`ICurrentUserService`, repository, `_outlookSync`, options, logger) are already injected into `DeleteMarketingActionHandler`. No migrations, no config, no infrastructure changes. The Journal module's `DeleteJournalEntryHandler` already proves the pattern compiles and runs in this codebase.

--- a/artifacts/feat-arch-review-marketing-deletesoftasync-em/brief.md
+++ b/artifacts/feat-arch-review-marketing-deletesoftasync-em/brief.md
@@ -1,0 +1,75 @@
+## Module
+Marketing
+
+## Finding
+
+`IMarketingActionRepository.DeleteSoftAsync` commits to the database internally, which is inconsistent with every other repository operation in this module (and the project). This also forces `DeleteMarketingActionHandler` to load the entity twice.
+
+**Repository implementation** (`backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs`, lines 27–35):
+
+```csharp
+public async Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default)
+{
+    var entity = await GetByIdAsync(id, cancellationToken);   // DB load #2 (see below)
+    if (entity != null)
+    {
+        entity.SoftDelete(userId, username);
+        await UpdateAsync(entity, cancellationToken);
+        await SaveChangesAsync(cancellationToken);             // ← save embedded here
+    }
+}
+```
+
+**Handler pattern for all other operations** — callers control the save:
+```csharp
+// CreateMarketingActionHandler (lines 83–86)
+await _repository.AddAsync(action, cancellationToken);
+await _repository.SaveChangesAsync(cancellationToken);
+
+// UpdateMarketingActionHandler (lines 115–116)
+await _repository.UpdateAsync(action, cancellationToken);
+await _repository.SaveChangesAsync(cancellationToken);
+```
+
+**Double DB load in `DeleteMarketingActionHandler`** (`backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs`):
+- Line 47: `await _repository.GetByIdAsync(request.Id, ...)` — loads entity to read `action.OutlookEventId`
+- Line 77: `await _repository.DeleteSoftAsync(request.Id, ...)` — calls `GetByIdAsync` again internally
+
+The entity is therefore fetched from the database twice per delete request.
+
+## Why it matters
+
+- **Hidden side effect**: the interface signature (`DeleteSoftAsync`) gives no indication it commits to the DB. A caller wrapping multiple operations in a logical unit of work cannot include a soft-delete without an unexpected mid-unit commit.
+- **Inconsistency**: three other handler patterns in the same module all follow caller-controlled `SaveChangesAsync`. The delete is the odd one out, which creates a maintenance trap.
+- **Wasted I/O**: the double load is unnecessary. The handler already has the entity in memory when it calls `DeleteSoftAsync`.
+
+## Suggested fix
+
+Remove `SaveChangesAsync` from `DeleteSoftAsync` (or remove `DeleteSoftAsync` entirely from the interface and let the handler own the full sequence):
+
+```csharp
+// Option A — keep DeleteSoftAsync but remove the embedded save
+public async Task DeleteSoftAsync(int id, string userId, string username, CancellationToken ct = default)
+{
+    var entity = await GetByIdAsync(id, ct);
+    if (entity == null) return;
+    entity.SoftDelete(userId, username, utcNow: DateTime.UtcNow);
+    await UpdateAsync(entity, ct);
+    // caller is responsible for SaveChangesAsync
+}
+```
+
+Or (preferred, avoids double load):
+
+```csharp
+// Option B — handler owns full lifecycle, no DeleteSoftAsync needed
+// In DeleteMarketingActionHandler, after Outlook delete:
+action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User", now);
+await _repository.UpdateAsync(action, cancellationToken);
+await _repository.SaveChangesAsync(cancellationToken);
+```
+
+Option B also eliminates `IMarketingActionRepository.DeleteSoftAsync` from the domain interface, keeping the repository interface lean.
+
+---
+_Filed by daily arch-review routine on 2026-06-07._

--- a/artifacts/feat-arch-review-marketing-deletesoftasync-em/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketing-deletesoftasync-em/impl/main.r1.md
@@ -1,0 +1,54 @@
+All 5 tasks complete. Here is the output summary:
+
+---
+
+# Implementation: Remove embedded SaveChangesAsync from IMarketingActionRepository.DeleteSoftAsync
+
+## What was implemented
+
+Refactored the Marketing module's soft-delete path so `DeleteMarketingActionHandler` owns the persistence sequence. Removed `DeleteSoftAsync` from `IMarketingActionRepository` and inlined `entity.SoftDelete() → UpdateAsync → SaveChangesAsync` directly in the handler, eliminating a hidden mid-handler commit and a redundant second DB load. The implementation matches the precedent set by `DeleteJournalEntryHandler`.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs` — `DeleteSoftAsync` declaration removed
+- `backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs` — `DeleteSoftAsync` implementation removed
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs` — `DeleteSoftAsync` call replaced with `action.SoftDelete(userId, username)` → `UpdateAsync` → `SaveChangesAsync` inside existing try/catch
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` — all `DeleteSoftAsync` mocks/verifications switched to `UpdateAsync` + `SaveChangesAsync`; new regression test `Handle_LoadsEntityExactlyOnce_PerDeleteRequest` added
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` — 3 `DeleteSoftAsync` references replaced with `UpdateAsync` + `SaveChangesAsync`
+
+## Tests
+
+- `DeleteMarketingActionHandlerTests` — 11 tests, all pass. Includes new `Handle_LoadsEntityExactlyOnce_PerDeleteRequest` regression guard
+- `MarketingActionHandlerSyncTests` — delete handler tests updated and passing
+- 157 Marketing tests total pass; 38 Docker-dependent integration test failures are pre-existing and unrelated
+
+## How to verify
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build --filter "FullyQualifiedName~Marketing"
+grep -rn "DeleteSoftAsync" backend/src backend/test  # expected: zero output
+```
+
+## Notes
+
+- `MarketingAction.SoftDelete` is 2-arg (captures `DateTime.UtcNow` internally) — the spec example showing a third `now` arg was a spec typo per arch-review §Spec Amendments; the 2-arg form was used throughout
+- `action.SoftDelete(...)` is placed **outside** the try block (in-memory operation); only `UpdateAsync` and `SaveChangesAsync` are inside the try/catch
+- `UpdateAsync` call is retained even though EF already tracks the entity — matches `UpdateMarketingActionHandler` and `DeleteJournalEntryHandler` pattern
+- 38 pre-existing test failures are Testcontainers integration tests requiring Docker; unrelated to this change
+
+## PR Summary
+
+Removed the hidden `SaveChangesAsync` from `IMarketingActionRepository.DeleteSoftAsync` and moved the entire soft-delete sequence into `DeleteMarketingActionHandler`, aligning the Marketing delete path with the caller-controlled persistence pattern already used by the Create, Update, and Journal delete handlers.
+
+The previous implementation had two problems: a hidden mid-handler commit (the repository called `SaveChangesAsync` internally, invisible to callers) and a redundant second DB load (the repository re-fetched the entity the handler had already loaded for the Outlook event lookup). The new sequence reuses the entity already in memory: `action.SoftDelete(userId, name) → UpdateAsync(action) → SaveChangesAsync()`, wrapped in the existing try/catch. DB round-trips for the delete path drop from 3 to 2 (one read + one commit).
+
+### Changes
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs` — removed `DeleteSoftAsync` declaration
+- `backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs` — removed `DeleteSoftAsync` implementation
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs` — inlined soft-delete sequence
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` — retargeted mocks/verifications; added entity-loaded-once regression test
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` — retargeted 3 `DeleteSoftAsync` references
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-marketing-deletesoftasync-em/spec.r1.md
+++ b/artifacts/feat-arch-review-marketing-deletesoftasync-em/spec.r1.md
@@ -1,0 +1,105 @@
+# Specification: Remove embedded SaveChangesAsync from `IMarketingActionRepository.DeleteSoftAsync`
+
+## Summary
+Refactor the soft-delete path for `MarketingAction` so the repository no longer commits internally and no longer re-loads an entity the handler already has in memory. Align the delete flow with the existing caller-controlled `SaveChangesAsync` pattern used by Create and Update handlers in the Marketing module.
+
+## Background
+The Marketing module's `IMarketingActionRepository.DeleteSoftAsync` violates the project's caller-controlled persistence convention by calling `SaveChangesAsync` inside the repository method. This creates two concrete problems:
+
+1. **Hidden side effect.** A unit-of-work-style caller cannot batch a soft-delete with other operations because the repository forces a mid-sequence commit. The method signature gives no hint of this behaviour.
+2. **Double database load.** `DeleteMarketingActionHandler` loads the entity at line 47 (to read `OutlookEventId`) and then calls `DeleteSoftAsync`, which loads it again at line 29 via `GetByIdAsync`. Every delete pays for two round trips.
+
+Three other handlers in the same module (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`, and the existing read pattern) follow the "handler owns the save" convention. The soft-delete is the only outlier, making it a maintenance trap and a discoverability hazard.
+
+## Functional Requirements
+
+### FR-1: Remove `DeleteSoftAsync` from `IMarketingActionRepository`
+Delete the `DeleteSoftAsync` method from both the interface (`IMarketingActionRepository`) and its implementation (`MarketingActionRepository`). The soft-delete lifecycle becomes the handler's responsibility, eliminating the second DB load and the embedded save.
+
+**Acceptance criteria:**
+- `IMarketingActionRepository.DeleteSoftAsync` no longer exists.
+- `MarketingActionRepository.DeleteSoftAsync` no longer exists.
+- The solution compiles after removal (no orphaned callers).
+- No new abstraction is introduced to replace it.
+
+### FR-2: `DeleteMarketingActionHandler` owns the soft-delete sequence
+The handler performs the soft-delete inline using the entity it already loaded for the Outlook event lookup. Order of operations is preserved: load entity → delete Outlook event (if any) → soft-delete entity → update → save.
+
+**Acceptance criteria:**
+- The handler loads the entity exactly **once** per delete request.
+- After the existing Outlook delete step, the handler calls `action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User", now)`.
+- The handler then calls `_repository.UpdateAsync(action, cancellationToken)` followed by `_repository.SaveChangesAsync(cancellationToken)`.
+- All existing pre-conditions, authorization checks, error handling, response shape, and logging in `DeleteMarketingActionHandler` are preserved unchanged.
+- If the entity is not found, the handler returns its existing "not found" response (no behavioural change).
+
+### FR-3: Preserve existing soft-delete semantics on the domain entity
+The `MarketingAction.SoftDelete(userId, username, utcNow)` domain method continues to set the audit fields and `IsDeleted` flag exactly as it does today. No domain-level behaviour is changed.
+
+**Acceptance criteria:**
+- `MarketingAction.SoftDelete` signature and behaviour are unchanged.
+- The handler passes the same `userId`, `username`, and `utcNow` values that the repository method currently passes.
+
+### FR-4: Test coverage parity
+All existing tests for the delete flow continue to pass. Tests that mocked or verified `DeleteSoftAsync` are updated to verify the new sequence (`UpdateAsync` + `SaveChangesAsync`) on the repository mock.
+
+**Acceptance criteria:**
+- Existing `DeleteMarketingActionHandler` unit tests are updated and pass.
+- A test asserts the entity is loaded exactly once per delete (regression guard against the double-load).
+- Repository-level tests for `DeleteSoftAsync` are removed (the method no longer exists).
+- `dotnet build` succeeds; `dotnet format` reports clean; `dotnet test` for the Marketing module passes.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Each delete request issues one entity load instead of two. No new queries are introduced. The change should produce a measurable reduction in DB round trips on the delete path (50% fewer reads for this operation).
+
+### NFR-2: Consistency
+The soft-delete path matches the established Marketing module pattern: handlers compose repository mutations and explicitly call `SaveChangesAsync`. This eliminates the discoverability problem and removes the maintenance trap.
+
+### NFR-3: Backwards compatibility
+- **API surface:** The HTTP/MediatR contract for `DeleteMarketingAction` is unchanged (same request, same response, same status codes).
+- **Database state:** Soft-deleted rows look identical to before (same fields populated with the same values).
+- **Repository interface:** `DeleteSoftAsync` is removed; no callers outside `DeleteMarketingActionHandler` exist (verify during implementation).
+
+### NFR-4: Security / Auditing
+The audit trail (`DeletedBy`, `DeletedByName`, `DeletedAt` or whatever fields `SoftDelete` populates) remains populated with the same values from `ICurrentUser` and the current UTC timestamp. No change to authorization checks in the handler.
+
+## Data Model
+No schema changes. `MarketingAction` retains its existing soft-delete fields and `SoftDelete` domain method.
+
+## API / Interface Design
+
+**Removed:**
+```csharp
+// IMarketingActionRepository
+Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default);
+```
+
+**Handler change (conceptual):**
+```csharp
+// DeleteMarketingActionHandler — after existing Outlook delete step
+action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User", now);
+await _repository.UpdateAsync(action, cancellationToken);
+await _repository.SaveChangesAsync(cancellationToken);
+```
+
+No new endpoints, no new MediatR requests, no UI changes.
+
+## Dependencies
+- `MarketingAction.SoftDelete` — existing domain method, unchanged.
+- `IMarketingActionRepository.GetByIdAsync` / `UpdateAsync` / `SaveChangesAsync` — already used elsewhere; no changes.
+- `ICurrentUser` (or equivalent) — already injected into the handler.
+- `DateTime` provider currently used by the handler — already in place.
+
+## Out of Scope
+- Refactoring Create/Update handlers (already follow the correct pattern).
+- Introducing a generic Unit-of-Work abstraction.
+- Hard-delete functionality.
+- Changes to other repositories or modules — this fix is scoped to `IMarketingActionRepository` and `DeleteMarketingActionHandler` only.
+- Changes to `MarketingAction.SoftDelete` domain logic.
+- Performance work beyond eliminating the redundant load.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketing-deletesoftasync-em/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketing-deletesoftasync-em/task-plan.r1.md
@@ -1,0 +1,13 @@
+Plan saved. Running a quick self-review pass against the spec and the actual code I read.
+
+Spec coverage — all FRs and NFRs have a task row in the coverage map at the bottom. ✅
+
+Placeholder scan — no `TBD`/`TODO`/"add error handling"/"similar to" stubs. Every code step shows the exact replacement. ✅
+
+Type consistency — verified against the real signatures I read:
+- `UpdateAsync` returns `Task` → mocks use `.Returns(Task.CompletedTask)` everywhere. ✅
+- `SaveChangesAsync` returns `Task<int>` → mocks use `.ReturnsAsync(1)` everywhere, and `.ThrowsAsync(...)` in Step 1.8 (works for both `Task` and `Task<int>`). ✅
+- `MarketingAction.SoftDelete(userId, username)` is 2-arg throughout — flagged the spec's 3-arg typo per arch-review Amendment 1. ✅
+- `MarketingAction` type already imported in both test files I edit. ✅
+
+Plan saved to `docs/superpowers/plans/2026-06-09-marketing-delete-soft-async-handler-owns-save.md`. Five tasks, TDD-ordered (RED tests in Tasks 1–2, GREEN handler in Task 3, dead-code removal in Task 4, validation gate in Task 5), each step is ≤5 minutes with exact paths, code blocks, and commit messages. The arch-review's spec amendments (drop the `, now` arg; cover `MarketingActionHandlerSyncTests.cs`; wrap both `UpdateAsync` + `SaveChangesAsync` in the existing try/catch; keep the `UpdateAsync` call) are all materialized as concrete steps.

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
@@ -72,10 +72,12 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.DeleteMarketingAct
                 }
             }
 
+            action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User");
+
             try
             {
-                await _repository.DeleteSoftAsync(
-                    request.Id, currentUser.Id, currentUser.Name ?? "Unknown User", cancellationToken);
+                await _repository.UpdateAsync(action, cancellationToken);
+                await _repository.SaveChangesAsync(cancellationToken);
             }
             catch (Exception ex)
             {

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs
@@ -8,8 +8,6 @@ namespace Anela.Heblo.Domain.Features.Marketing
 {
     public interface IMarketingActionRepository : IRepository<MarketingAction, int>
     {
-        Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default);
-
         Task<PagedResult<MarketingAction>> GetPagedAsync(
             MarketingActionQueryCriteria criteria,
             CancellationToken cancellationToken = default);

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs
@@ -24,17 +24,6 @@ namespace Anela.Heblo.Persistence.Marketing
                 .FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted, cancellationToken);
         }
 
-        public async Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default)
-        {
-            var entity = await GetByIdAsync(id, cancellationToken);
-            if (entity != null)
-            {
-                entity.SoftDelete(userId, username);
-                await UpdateAsync(entity, cancellationToken);
-                await SaveChangesAsync(cancellationToken);
-            }
-        }
-
         public async Task<PagedResult<MarketingAction>> GetPagedAsync(
             MarketingActionQueryCriteria criteria,
             CancellationToken cancellationToken = default)

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs
@@ -46,9 +46,10 @@ public class DeleteMarketingActionHandlerTests
         _currentUserService.Setup(x => x.GetCurrentUser()).Returns(AuthenticatedUser);
         _repository.Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(BuildExistingAction());
-        _repository.Setup(x => x.DeleteSoftAsync(
-                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _repository.Setup(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        _repository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
         _outlookSync.Setup(x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
@@ -73,10 +74,9 @@ public class DeleteMarketingActionHandlerTests
             .Returns(Task.CompletedTask);
 
         _repository
-            .Setup(x => x.DeleteSoftAsync(
-                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<int, string, string, CancellationToken>((_, _, _, _) => callOrder.Add("db"))
-            .Returns(Task.CompletedTask);
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Callback<CancellationToken>(_ => callOrder.Add("db"))
+            .ReturnsAsync(1);
 
         await BuildHandler().Handle(BuildRequest(), CancellationToken.None);
 
@@ -93,8 +93,8 @@ public class DeleteMarketingActionHandlerTests
         var result = await BuildHandler().Handle(BuildRequest(), CancellationToken.None);
 
         result.Success.Should().BeTrue();
-        _repository.Verify(x => x.DeleteSoftAsync(
-            7, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -108,9 +108,8 @@ public class DeleteMarketingActionHandlerTests
 
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.MarketingCalendarAccessDenied);
-        _repository.Verify(x => x.DeleteSoftAsync(
-            It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -124,9 +123,8 @@ public class DeleteMarketingActionHandlerTests
 
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.MarketingCalendarSyncFailed);
-        _repository.Verify(x => x.DeleteSoftAsync(
-            It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -142,8 +140,8 @@ public class DeleteMarketingActionHandlerTests
         _outlookSync.Verify(
             x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        _repository.Verify(x => x.DeleteSoftAsync(
-            7, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -155,8 +153,8 @@ public class DeleteMarketingActionHandlerTests
         _outlookSync.Verify(
             x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
-        _repository.Verify(x => x.DeleteSoftAsync(
-            7, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -176,8 +174,7 @@ public class DeleteMarketingActionHandlerTests
     public async Task Handle_ReturnsDatabaseError_WhenDbDeleteFails()
     {
         _repository
-            .Setup(x => x.DeleteSoftAsync(
-                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("DB unavailable"));
 
         var result = await BuildHandler().Handle(BuildRequest(), CancellationToken.None);
@@ -248,6 +245,16 @@ public class DeleteMarketingActionHandlerTests
 
         _outlookSync.Verify(
             x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_LoadsEntityExactlyOnce_PerDeleteRequest()
+    {
+        await BuildHandler().Handle(BuildRequest(), CancellationToken.None);
+
+        _repository.Verify(
+            x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
@@ -283,8 +283,11 @@ namespace Anela.Heblo.Tests.Features.Marketing
                 .ReturnsAsync(existingAction);
 
             _repositoryMock
-                .Setup(x => x.DeleteSoftAsync(42, AuthenticatedUser.Id!, AuthenticatedUser.Name!, It.IsAny<CancellationToken>()))
+                .Setup(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
+            _repositoryMock
+                .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
 
             _outlookSyncMock
                 .Setup(s => s.DeleteEventAsync("evt-to-delete", It.IsAny<CancellationToken>()))
@@ -302,7 +305,10 @@ namespace Anela.Heblo.Tests.Features.Marketing
                 Times.Once);
             _outlookSyncMock.VerifyNoOtherCalls();
             _repositoryMock.Verify(
-                x => x.DeleteSoftAsync(42, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            _repositoryMock.Verify(
+                x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -327,7 +333,10 @@ namespace Anela.Heblo.Tests.Features.Marketing
             // Assert — fail-fast: Outlook error blocks soft-delete (non-404 errors are not swallowed)
             result.Success.Should().BeFalse();
             _repositoryMock.Verify(
-                x => x.DeleteSoftAsync(42, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            _repositoryMock.Verify(
+                x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
                 Times.Never);
         }
     }

--- a/docs/superpowers/plans/2026-06-09-marketing-delete-soft-async-handler-owns-save.md
+++ b/docs/superpowers/plans/2026-06-09-marketing-delete-soft-async-handler-owns-save.md
@@ -1,0 +1,521 @@
+# Remove embedded SaveChangesAsync from IMarketingActionRepository.DeleteSoftAsync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `DeleteSoftAsync` from `IMarketingActionRepository` and inline the soft-delete sequence in `DeleteMarketingActionHandler`, eliminating a hidden mid-handler commit and a redundant second DB load.
+
+**Architecture:** Caller-controlled persistence. The handler — which already loaded the entity for the Outlook lookup — now also owns the mutation: `entity.SoftDelete(...) → repository.UpdateAsync(entity) → repository.SaveChangesAsync()`. This matches the precedent set by `DeleteJournalEntryHandler` (`backend/src/Anela.Heblo.Application/Features/Journal/UseCases/DeleteJournalEntry/DeleteJournalEntryHandler.cs:51-53`) and the existing `UpdateMarketingActionHandler` pattern. No new abstractions; the surface area shrinks.
+
+**Tech Stack:** .NET 8, C# 12, MediatR, EF Core, xUnit + Moq + FluentAssertions.
+
+---
+
+## Scope and constraints
+
+- **Single feature module:** Marketing only. Journal already implements the target pattern — do not touch it.
+- **No domain change:** `MarketingAction.SoftDelete(string userId, string username)` (file `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs:129`) stays 2-arg. Per arch-review §Spec Amendments, the spec example showing a 3rd `now` argument is a spec typo — do NOT add a third parameter.
+- **No new abstractions:** no Unit-of-Work, no service wrapper, no thinned `DeleteSoftAsync(entity)` overload. Inline the three lines.
+- **No public contract change:** MediatR request/response for `DeleteMarketingAction` is byte-for-byte unchanged.
+- **No schema or migration change.**
+
+## Files touched
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs` | Remove line 11 (`DeleteSoftAsync` declaration). |
+| `backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs` | Remove lines 27–36 (`DeleteSoftAsync` implementation). |
+| `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs` | Replace the try-block at lines 75–86 with the inlined sequence. |
+| `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` | Switch all `DeleteSoftAsync` setups/verifications to `UpdateAsync` + `SaveChangesAsync`; add a regression test asserting `GetByIdAsync` is called exactly once. |
+| `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` | Switch the 3 `DeleteSoftAsync` references (lines 286, 305, 330) to `UpdateAsync` + `SaveChangesAsync`. |
+
+## Reference signatures (read these before editing)
+
+- `IRepository<TEntity, TKey>.UpdateAsync` → `Task UpdateAsync(TEntity entity, CancellationToken ct = default)` (`backend/src/Anela.Heblo.Xcc/Persistance/IRepository.cs:16`).
+- `IRepository<TEntity, TKey>.SaveChangesAsync` → `Task<int> SaveChangesAsync(CancellationToken ct = default)` (`backend/src/Anela.Heblo.Xcc/Persistance/IRepository.cs:22`). **Note:** returns `Task<int>`, not `Task`. Mock setups use `.ReturnsAsync(1)` (or any int) — `.Returns(Task.CompletedTask)` will NOT compile.
+- `MarketingAction.SoftDelete(string userId, string username)` (`backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs:129`) — 2 args; reads `DateTime.UtcNow` internally.
+- `BaseRepository.UpdateAsync` is a no-op state marker (`DbSet.Update(entity); return Task.CompletedTask;`) at `backend/src/Anela.Heblo.Persistence/Repositories/BaseRepository.cs:70-74`. Keep the call anyway — matches `UpdateMarketingActionHandler` and `DeleteJournalEntryHandler`.
+
+---
+
+## Task 1: Update DeleteMarketingActionHandlerTests to expect the new persistence sequence
+
+**Goal:** Switch every mock setup and verification on `DeleteSoftAsync` to `UpdateAsync` + `SaveChangesAsync`. Add a regression test asserting the entity is loaded exactly once per delete (FR-4). After this task the tests will FAIL because the handler still calls `DeleteSoftAsync` — that's the intended RED state and proves the assertions are meaningful.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs`
+
+- [ ] **Step 1.1: Replace the default `DeleteSoftAsync` setup in the constructor (lines 49–51)**
+
+Find this block at the top of the class constructor:
+
+```csharp
+        _repository.Setup(x => x.DeleteSoftAsync(
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+```
+
+Replace with:
+
+```csharp
+        _repository.Setup(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+```
+
+- [ ] **Step 1.2: Rewrite `Handle_CallsOutlookDeleteBeforeSoftDelete_WhenPushEnabled` (lines 65–84) to assert ordering against `SaveChangesAsync`**
+
+The "db" callback was anchored on `DeleteSoftAsync` (the commit). After the refactor the commit step is `SaveChangesAsync`. Replace the entire test body with:
+
+```csharp
+    [Fact]
+    public async Task Handle_CallsOutlookDeleteBeforeSoftDelete_WhenPushEnabled()
+    {
+        var callOrder = new List<string>();
+
+        _outlookSync
+            .Setup(x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((_, _) => callOrder.Add("outlook"))
+            .Returns(Task.CompletedTask);
+
+        _repository
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Callback<CancellationToken>(_ => callOrder.Add("db"))
+            .ReturnsAsync(1);
+
+        await BuildHandler().Handle(BuildRequest(), CancellationToken.None);
+
+        callOrder.Should().ContainInOrder("outlook", "db");
+    }
+```
+
+- [ ] **Step 1.3: Update `Handle_TreatsOutlook404AsSuccess_AndProceedsWithSoftDelete` (lines 86–98)**
+
+Replace the verification block at lines 96–97 (the `_repository.Verify(x => x.DeleteSoftAsync(...))` call) with:
+
+```csharp
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+```
+
+- [ ] **Step 1.4: Update `Handle_ReturnsForbiddenError_WhenOutlookThrows403` (lines 100–114)**
+
+Replace lines 111–113 (the `_repository.Verify(x => x.DeleteSoftAsync(...), Times.Never)` block) with:
+
+```csharp
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+```
+
+- [ ] **Step 1.5: Update `Handle_ReturnsSyncError_WhenOutlookThrowsNon403Non404` (lines 116–130)**
+
+Replace lines 127–129 (the `_repository.Verify(x => x.DeleteSoftAsync(...), Times.Never)` block) with:
+
+```csharp
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+```
+
+- [ ] **Step 1.6: Update `Handle_SkipsOutlook_WhenActionHasNoEventId` (lines 132–147)**
+
+Replace lines 145–146 (the `_repository.Verify(x => x.DeleteSoftAsync(...), Times.Once)` block) with:
+
+```csharp
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+```
+
+- [ ] **Step 1.7: Update `Handle_SkipsOutlook_WhenPushDisabled` (lines 149–160)**
+
+Replace lines 158–159 (the `_repository.Verify(x => x.DeleteSoftAsync(...), Times.Once)` block) with:
+
+```csharp
+        _repository.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+```
+
+- [ ] **Step 1.8: Update `Handle_ReturnsDatabaseError_WhenDbDeleteFails` (lines 175–198)**
+
+The throw was anchored on `DeleteSoftAsync`. Re-anchor on `SaveChangesAsync` (the commit step that fails). Replace lines 178–181 (the `_repository.Setup(x => x.DeleteSoftAsync(...)).ThrowsAsync(...)` block) with:
+
+```csharp
+        _repository
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB unavailable"));
+```
+
+Leave the response-shape assertions (lines 184–186), the Outlook verify (lines 187–189), and the log-message verify (lines 190–197) unchanged — the "already deleted" log message is preserved by the handler's catch block.
+
+- [ ] **Step 1.9: Add a new regression test asserting `GetByIdAsync` is called exactly once per delete (FR-4)**
+
+Append this test immediately after `Handle_HonorsRuntimePushEnabledFlip_FalseToTrue` (after the closing brace of that test, before the closing brace of the class):
+
+```csharp
+    [Fact]
+    public async Task Handle_LoadsEntityExactlyOnce_PerDeleteRequest()
+    {
+        await BuildHandler().Handle(BuildRequest(), CancellationToken.None);
+
+        _repository.Verify(
+            x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 1.10: Build the test project to verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: `Build succeeded.` with 0 errors. (The interface still has `DeleteSoftAsync` at this point — Moq does not require all interface methods to be set up, so removing setups is safe.)
+
+- [ ] **Step 1.11: Run only this test file to confirm RED state**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build \
+  --filter "FullyQualifiedName~DeleteMarketingActionHandlerTests"
+```
+
+Expected: tests FAIL with messages like `Expected invocation on the mock once, but was 0 times` for `UpdateAsync` / `SaveChangesAsync`. This proves the new assertions actually check the new behaviour. Do not proceed to Task 2 until you see failures of this shape — passing tests at this stage indicate the assertions are not wired correctly.
+
+- [ ] **Step 1.12: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs
+git commit -m "test(marketing): retarget DeleteMarketingActionHandler tests to UpdateAsync + SaveChangesAsync"
+```
+
+---
+
+## Task 2: Update MarketingActionHandlerSyncTests to expect the new persistence sequence
+
+**Goal:** Fix the 3 `DeleteSoftAsync` references in the sync-tests file so they don't break compilation once we remove `DeleteSoftAsync` from the interface (arch-review §Spec Amendments item 4 — the spec missed this file). This task is a parallel RED step to Task 1.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`
+
+- [ ] **Step 2.1: Update the setup at line 285–287 in `DeleteHandler_CallsDeleteEvent_WhenOutlookEventIdExists`**
+
+Find this block:
+
+```csharp
+            _repositoryMock
+                .Setup(x => x.DeleteSoftAsync(42, AuthenticatedUser.Id!, AuthenticatedUser.Name!, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+```
+
+Replace with:
+
+```csharp
+            _repositoryMock
+                .Setup(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            _repositoryMock
+                .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+```
+
+- [ ] **Step 2.2: Update the verification at line 304–306 in the same test**
+
+Find this block:
+
+```csharp
+            _repositoryMock.Verify(
+                x => x.DeleteSoftAsync(42, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+```
+
+Replace with:
+
+```csharp
+            _repositoryMock.Verify(
+                x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            _repositoryMock.Verify(
+                x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+                Times.Once);
+```
+
+- [ ] **Step 2.3: Update the verification at line 329–331 in `DeleteHandler_ReturnsError_WhenOutlookThrowsNonNotFound`**
+
+Find this block:
+
+```csharp
+            _repositoryMock.Verify(
+                x => x.DeleteSoftAsync(42, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+```
+
+Replace with:
+
+```csharp
+            _repositoryMock.Verify(
+                x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            _repositoryMock.Verify(
+                x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+                Times.Never);
+```
+
+- [ ] **Step 2.4: Build the test project**
+
+Run:
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: `Build succeeded.` with 0 errors.
+
+- [ ] **Step 2.5: Run the sync tests to confirm RED state**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build \
+  --filter "FullyQualifiedName~MarketingActionHandlerSyncTests.DeleteHandler"
+```
+
+Expected: `DeleteHandler_CallsDeleteEvent_WhenOutlookEventIdExists` FAILS with `Expected invocation on the mock once, but was 0 times` for `UpdateAsync` / `SaveChangesAsync`. `DeleteHandler_ReturnsError_WhenOutlookThrowsNonNotFound` should still PASS (it verifies `Times.Never`, which is satisfied regardless of which DB-write method exists).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+git commit -m "test(marketing): retarget DeleteHandler sync tests to UpdateAsync + SaveChangesAsync"
+```
+
+---
+
+## Task 3: Inline the soft-delete sequence in DeleteMarketingActionHandler (GREEN)
+
+**Goal:** Replace the `_repository.DeleteSoftAsync(...)` call with the three-line sequence (`SoftDelete` → `UpdateAsync` → `SaveChangesAsync`). The existing try/catch around the DB step wraps both new calls (arch-review Decision 3). All other handler logic — auth check, `GetByIdAsync`, not-found branch, Outlook block, success log, response shape — stays byte-for-byte unchanged.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs`
+
+- [ ] **Step 3.1: Replace the try/catch block at lines 75–86**
+
+Find this exact block:
+
+```csharp
+            try
+            {
+                await _repository.DeleteSoftAsync(
+                    request.Id, currentUser.Id, currentUser.Name ?? "Unknown User", cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "DB soft-delete failed after Outlook delete for MarketingAction {ActionId}; Outlook event {EventId} already deleted — DB row still present",
+                    request.Id, action.OutlookEventId);
+                return new DeleteMarketingActionResponse(ErrorCodes.DatabaseError);
+            }
+```
+
+Replace with:
+
+```csharp
+            action.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User");
+
+            try
+            {
+                await _repository.UpdateAsync(action, cancellationToken);
+                await _repository.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "DB soft-delete failed after Outlook delete for MarketingAction {ActionId}; Outlook event {EventId} already deleted — DB row still present",
+                    request.Id, action.OutlookEventId);
+                return new DeleteMarketingActionResponse(ErrorCodes.DatabaseError);
+            }
+```
+
+Notes:
+- `MarketingAction.SoftDelete` is a 2-arg method that captures `DateTime.UtcNow` internally. Do NOT pass a third `now` argument — the spec example showing `, now` is a typo per arch-review §Spec Amendments item 1.
+- The mutation (`SoftDelete`) is intentionally OUTSIDE the try. A pure in-memory mutation cannot throw the kind of exception this `catch` is designed to handle, and keeping it outside makes the catch's log message ("DB soft-delete failed") truthful.
+- `UpdateAsync` on an already-tracked entity is a no-op state marker (`DbSet.Update`). Keep the call for pattern parity with `UpdateMarketingActionHandler` and `DeleteJournalEntryHandler`.
+
+- [ ] **Step 3.2: Build the solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with 0 errors. (`DeleteSoftAsync` still exists on the interface — no callers reference it now, but the interface declaration is harmless.)
+
+- [ ] **Step 3.3: Run the full Marketing test suite to confirm GREEN**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build \
+  --filter "FullyQualifiedName~Marketing"
+```
+
+Expected: all Marketing tests PASS, including the tests retargeted in Tasks 1 and 2 and the new `Handle_LoadsEntityExactlyOnce_PerDeleteRequest` regression test.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
+git commit -m "refactor(marketing): inline soft-delete sequence in DeleteMarketingActionHandler"
+```
+
+---
+
+## Task 4: Remove DeleteSoftAsync from the repository surface
+
+**Goal:** Delete the now-orphaned `DeleteSoftAsync` from the interface and the implementation. After this task, `grep -rn DeleteSoftAsync backend/` over the Marketing scope must return zero hits in production and test code.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs`
+- Modify: `backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs`
+
+- [ ] **Step 4.1: Remove the interface declaration**
+
+In `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs`, delete line 11 and the blank line that follows it. Before:
+
+```csharp
+    public interface IMarketingActionRepository : IRepository<MarketingAction, int>
+    {
+        Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default);
+
+        Task<PagedResult<MarketingAction>> GetPagedAsync(
+```
+
+After:
+
+```csharp
+    public interface IMarketingActionRepository : IRepository<MarketingAction, int>
+    {
+        Task<PagedResult<MarketingAction>> GetPagedAsync(
+```
+
+- [ ] **Step 4.2: Remove the implementation**
+
+In `backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs`, delete lines 27–36 (the entire `DeleteSoftAsync` method body) and the blank line that follows. Before (lines 26–37):
+
+```csharp
+
+        public async Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default)
+        {
+            var entity = await GetByIdAsync(id, cancellationToken);
+            if (entity != null)
+            {
+                entity.SoftDelete(userId, username);
+                await UpdateAsync(entity, cancellationToken);
+                await SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        public async Task<PagedResult<MarketingAction>> GetPagedAsync(
+```
+
+After:
+
+```csharp
+
+        public async Task<PagedResult<MarketingAction>> GetPagedAsync(
+```
+
+- [ ] **Step 4.3: Grep-verify no remaining references in the backend source/test tree**
+
+Run:
+```bash
+grep -rn "DeleteSoftAsync" backend/src backend/test
+```
+
+Expected: zero output. If anything matches, the refactor has missed a caller — stop and report rather than guess; the spec FR-1 and §Backwards compatibility both require zero remaining references.
+
+(Documentation hits under `docs/superpowers/plans/` are pre-existing historical plans and are acceptable — the grep is scoped to `backend/` to ignore them.)
+
+- [ ] **Step 4.4: Build the solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with 0 errors. The compiler is the final guarantee that no caller was missed; any external implementer of `IMarketingActionRepository` (e.g. a hand-rolled fake) would surface here.
+
+- [ ] **Step 4.5: Run the full Marketing test suite again**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build \
+  --filter "FullyQualifiedName~Marketing"
+```
+
+Expected: all Marketing tests PASS.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs \
+        backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs
+git commit -m "refactor(marketing): remove orphaned DeleteSoftAsync from IMarketingActionRepository"
+```
+
+---
+
+## Task 5: Final validation
+
+**Goal:** Run the full validation gate listed in `CLAUDE.md` to confirm the refactor is shippable.
+
+- [ ] **Step 5.1: Format**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code 0, no diagnostics. If diagnostics appear, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`) to apply fixes, then commit them with message `chore: dotnet format`.
+
+- [ ] **Step 5.2: Full build**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with 0 errors and 0 warnings (or no NEW warnings relative to the pre-task baseline).
+
+- [ ] **Step 5.3: Full backend test suite**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: all tests PASS. Pay particular attention to any handler or repository test under the `Marketing` namespace — if any other test referenced `DeleteSoftAsync` and Task 4's grep missed it, the build would already have failed; this run is the behavioural cross-check.
+
+- [ ] **Step 5.4: (Optional, only if Step 5.1 produced format fixes) Commit the format-only changes**
+
+```bash
+git add -A
+git commit -m "chore: dotnet format"
+```
+
+If Step 5.1 reported no changes, skip this step.
+
+---
+
+## Spec coverage map
+
+| Spec requirement | Task |
+|------------------|------|
+| FR-1 — Remove `DeleteSoftAsync` from `IMarketingActionRepository` and `MarketingActionRepository`; no orphaned callers | Task 4 (Steps 4.1, 4.2); verified by Step 4.3 grep + Step 4.4 build |
+| FR-2 — Handler loads entity once; performs `SoftDelete → UpdateAsync → SaveChangesAsync`; preserves auth, not-found, error handling, response shape, logging | Task 3 (Step 3.1); regression-guarded by Task 1 Step 1.9 (entity loaded exactly once) and Task 1 Step 1.2 (Outlook→SaveChangesAsync ordering) |
+| FR-3 — `MarketingAction.SoftDelete(userId, username)` signature and behaviour unchanged | No code change to `MarketingAction.cs`; explicit non-goal note in Task 3 Step 3.1 |
+| FR-4 — Tests updated; entity-loaded-once test added; repository-level `DeleteSoftAsync` tests removed (none exist — direct repository tests were never written for it); build clean; format clean; Marketing tests pass | Tasks 1, 2 (test updates + new regression test); Task 5 (validation gate) |
+| NFR-1 — One entity load per delete instead of two | Achieved by Task 3 Step 3.1 (handler reuses the already-loaded entity); regression-guarded by Task 1 Step 1.9 |
+| NFR-2 — Soft-delete path matches established Marketing pattern | Task 3 Step 3.1 produces identical shape to `UpdateMarketingActionHandler` and `DeleteJournalEntryHandler` |
+| NFR-3 — API surface unchanged; DB state unchanged; no callers outside `DeleteMarketingActionHandler` | Verified by Task 4 Step 4.3 grep + Step 4.4 build; MediatR request/response classes are not touched |
+| NFR-4 — Audit fields populated identically; authorization unchanged | `MarketingAction.SoftDelete` not modified; auth check at handler lines 40–45 not touched |
+| Arch-review §Spec Amendments item 1 (drop `now` arg from `SoftDelete` call) | Task 3 Step 3.1 notes call MUST stay 2-arg |
+| Arch-review §Spec Amendments item 4 (`MarketingActionHandlerSyncTests.cs` must be updated) | Task 2 covers all 3 references |
+| Arch-review Decision 3 (wrap both `UpdateAsync` + `SaveChangesAsync` in the existing `try/catch`) | Task 3 Step 3.1 wraps both |
+| Arch-review Decision 4 (keep `UpdateAsync` call even though entity is tracked) | Task 3 Step 3.1 keeps the call with explanatory note |


### PR DESCRIPTION

Removed the hidden `SaveChangesAsync` from `IMarketingActionRepository.DeleteSoftAsync` and moved the entire soft-delete sequence into `DeleteMarketingActionHandler`, aligning the Marketing delete path with the caller-controlled persistence pattern already used by the Create, Update, and Journal delete handlers.

The previous implementation had two problems: a hidden mid-handler commit (the repository called `SaveChangesAsync` internally, invisible to callers) and a redundant second DB load (the repository re-fetched the entity the handler had already loaded for the Outlook event lookup). The new sequence reuses the entity already in memory: `action.SoftDelete(userId, name) → UpdateAsync(action) → SaveChangesAsync()`, wrapped in the existing try/catch. DB round-trips for the delete path drop from 3 to 2 (one read + one commit).

### Changes
- `backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs` — removed `DeleteSoftAsync` declaration
- `backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs` — removed `DeleteSoftAsync` implementation
- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs` — inlined soft-delete sequence
- `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` — retargeted mocks/verifications; added entity-loaded-once regression test
- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` — retargeted 3 `DeleteSoftAsync` references

---

Closes #2696

### Tokens used
11653713
