### PR TITLE
feat: Restore Type Safety in `useMarketingCalendar.ts` API Calls

### DIFF
--- a/artifacts/feat-arch-review-marketing-usemarketingcalend/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketing-usemarketingcalend/arch-review.r1.md
@@ -1,0 +1,188 @@
+I have what I need. The root cause is an integer-versus-string-enum mismatch that the spec touches but doesn't fully resolve — let me write the review.
+
+# Architecture Review: Restore Type Safety in `useMarketingCalendar.ts`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The feature is a localized refactor inside the standard frontend data-access layer (`frontend/src/api/hooks/`). It does not introduce a new component, module boundary, or cross-cutting concern. It removes a deviation (`as any`) from the project's established pattern: generated NSwag client + thin TanStack Query hook wrappers. As such it improves architectural fit, not redesigns it.
+
+The spec is *underspecified in one critical respect*: it treats the cast as a positional-arguments problem and assumes "preserve runtime behavior" + "use `MarketingActionType` directly" are independently satisfiable. They aren't, because:
+
+- Generated `MarketingActionType` is a **string enum** (`"SocialMedia" | "Blog" | ... | "Meeting"`), backed by `JsonStringEnumConverter` globally in `backend/src/Anela.Heblo.API/Program.cs:142`.
+- The current hook serializes `actionType` as an **integer** (0,1,2,3,4,99) because `MarketingActionModal.tsx:188` and `MarketingCalendarPage.tsx:217` build numeric payloads (via `ACTION_TYPE_TO_INT` and inline integer constants). The `(client as any)` cast is what lets a `number` flow into a parameter typed as the string enum.
+- The backend's `JsonStringEnumConverter` happens to accept both names and numeric values on input, so the current numeric-on-the-wire format works *by tolerance, not by contract*. Responses are always string-form.
+
+The same dynamic applies, on a smaller scale, to `folderLinks.folderType` (`MarketingFolderType` is a string enum; the modal builds integers 0..3,99 via `FOLDER_TYPE_OPTIONS`).
+
+Removing the cast forces the team to pick a wire format. This is an architectural choice that belongs in the review, not in the implementer's hands at coding time.
+
+## Proposed Architecture
+
+### Component Overview
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Components (MarketingActionModal, MarketingCalendarPage,    │
+│             MobileAgendaView, MarketingActionFilters)       │
+│                                                             │
+│  - Build payload using MarketingActionType (string enum)    │
+│  - Build folderLinks using MarketingFolderType (string enum)│
+└──────────────────────┬──────────────────────────────────────┘
+                       │ typed enum values
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│ useMarketingCalendar.ts (TanStack Query hook layer)         │
+│                                                             │
+│  - Local payload interfaces re-use generated I*Request      │
+│    field types (no looser `number` aliases)                 │
+│  - Hook body calls client.marketingCalendar_*(...) directly │
+│    against generated, typed signatures                      │
+└──────────────────────┬──────────────────────────────────────┘
+                       │ ICreateMarketingActionRequest /
+                       │ IUpdateMarketingActionRequest /
+                       │ IImportFromOutlookRequest (typed)
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Generated ApiClient (frontend/src/api/generated/api-client) │
+│  - HTTP POST /api/MarketingCalendar/...                     │
+│  - actionType serialized as STRING ("SocialMedia", etc.)    │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Backend (JsonStringEnumConverter, already accepts strings)  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Wire format for `actionType` and `folderType`
+**Options considered:**
+- **A.** Standardize on the string enum end-to-end. Update callers to pass `MarketingActionType` / `MarketingFolderType` values; delete `ACTION_TYPE_TO_INT` (no longer used); change `MarketingActionModal`'s form state from `number` to the string enum.
+- **B.** Keep callers passing integers; do `int → MarketingActionType` mapping inside the hook before invoking the generated method. Local payload types stay `number`; hook performs the translation.
+- **C.** Keep callers passing integers; expose an adapter helper (e.g. `actionTypeFromInt(n): MarketingActionType`) that callers invoke before calling the hook.
+
+**Chosen approach:** **A.** Standardize on string enums; update callers.
+
+**Rationale:**
+- The generated client, backend OpenAPI contract, list responses, and existing `MarketingActionFilters`/`marketingActionTypeLabels.ts` already use the string enum. Integer codes are a legacy island in `MarketingActionModal`.
+- Option B contradicts the spec's FR-2.1 ("use the generated enum type directly in local interfaces"). It also relocates a mapping table into the hook, which is the wrong layer — the hook should be a transport-thin wrapper.
+- Option C preserves the integer island, which is the very thing that made `as any` necessary. Future contributors will keep building integer payloads and the mismatch returns.
+- Option A is a one-time consolidation that aligns the codebase with the contract the backend already publishes, and (architecturally) eliminates the dual representation that caused the bug class.
+- The wire body changes from `{"actionType": 0}` to `{"actionType": "SocialMedia"}`. This is **semantically identical** to the backend (`JsonStringEnumConverter` accepts both), and it makes request/response symmetric (responses are already strings). This is a *normalization*, not a behavior change — but it is a wire change, so it must be tested explicitly (smoke test all five flows on staging).
+
+#### Decision 2: Plain object vs. generated class instance at the call site
+**Options considered:**
+- **A.** Pass a plain object literal that satisfies `ICreateMarketingActionRequest` / `IUpdateMarketingActionRequest` / `IImportFromOutlookRequest`.
+- **B.** Construct `new CreateMarketingActionRequest({...})` etc.
+
+**Chosen approach:** **A** if the generated method accepts the structural type; **B** only if TypeScript refuses A.
+
+**Rationale:** Looking at the generated signatures (`api-client.ts:7458`, `7554`, `7702`), the parameter is typed as the *class* (`CreateMarketingActionRequest`, etc.), not the `I*Request` interface. TypeScript structural typing will accept a literal whose shape matches the class's public fields, **as long as the literal does not include any class-only members** (none of these classes have extra public members beyond fields). The serialized body is built by the generated method via `body_ = JSON.stringify(request)`, which on a plain object produces exactly the same wire shape as on a class instance with the same fields. Prefer plain objects — they avoid the allocation, the `init`/`fromJS`/`toJSON` boilerplate, and the conceptual question of "why am I instantiating a class to throw it at JSON.stringify." Fall back to `new …Request(payload)` only if TypeScript rejects the literal.
+
+#### Decision 3: Caller update scope
+**Options considered:**
+- **A.** Update only the hook; let callers continue passing integers and patch with mapping in the hook.
+- **B.** Update the hook *and* the two consumer files that build integer payloads (`MarketingActionModal.tsx`, `MarketingCalendarPage.tsx` — specifically `handleSubmit` and `handleEventMove`).
+
+**Chosen approach:** **B.**
+
+**Rationale:** Per Decision 1 we standardize on string enums; the modal's form-state `actionType: number` field must become `MarketingActionType`, and `handleEventMove`'s `ACTION_TYPE_TO_INT[event.actionType] ?? 99` becomes `event.actionType as MarketingActionType` (or a typed pass-through). Spec FR-2 acceptance permits this as long as the consumer files are listed; this review amends the spec to list them (see Specification Amendments).
+
+The `(detailQuery.data as any)` / `(listQuery.data as any)` casts in the same consumer files are **out of scope** — they exist because consumers map response fields to a different shape (`description → detail`, `startDate → dateFrom`) and that mapping concern is unrelated to the request-side type-safety fix.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Edits confined to:
+- `frontend/src/api/hooks/useMarketingCalendar.ts` — primary change.
+- `frontend/src/components/marketing/detail/MarketingActionModal.tsx` — `actionType` and `folderLinks[].folderType` change from `number` to the respective string enum in form state and submission.
+- `frontend/src/components/marketing/pages/MarketingCalendarPage.tsx` — `handleEventMove` (line 217) drops the `ACTION_TYPE_TO_INT[...]` lookup; passes the enum value directly.
+- `frontend/src/api/hooks/__tests__/useImportFromOutlook.test.ts` — line 35–37 mock typing (`as any` on the mock client object is unavoidable for a partial mock and can stay; but if `MarketingActionType` flows into a new test case, use the enum).
+- **Possibly** `frontend/src/components/marketing/calendar/fullcalendarAdapters.ts` — if `ACTION_TYPE_TO_INT` becomes unreferenced, delete the constant. **Verify with `grep` before deleting.**
+
+### Interfaces and Contracts
+
+Replace the local payload interfaces in `useMarketingCalendar.ts` with:
+
+```ts
+import {
+  MarketingActionType,
+  MarketingFolderType,
+  ICreateMarketingActionRequest,
+  IUpdateMarketingActionRequest,
+  IImportFromOutlookRequest,
+  IMarketingFolderLinkRequest,
+} from "../generated/api-client";
+
+interface GetMarketingActionsParams {
+  pageNumber?: number;
+  pageSize?: number;
+  searchTerm?: string;
+  actionType?: MarketingActionType;
+  productCodePrefix?: string;
+  startDateFrom?: Date;
+  startDateTo?: Date;
+  endDateFrom?: Date;
+  endDateTo?: Date;
+  includeDeleted?: boolean;
+}
+
+type CreateMarketingActionPayload = ICreateMarketingActionRequest;
+type UpdateMarketingActionPayload = IUpdateMarketingActionRequest;
+type ImportFromOutlookPayload    = IImportFromOutlookRequest;
+```
+
+Re-export them from the hook file so consumer imports do not break:
+```ts
+export type {
+  CreateMarketingActionPayload,
+  UpdateMarketingActionPayload,
+  ImportFromOutlookPayload,
+};
+```
+
+The hook public signatures (per spec section *API / Interface Design*) remain identical; only the field *types* on the payload narrow.
+
+### Data Flow
+
+For the canonical create flow (others are analogous):
+
+1. `MarketingActionModal.handleSubmit` (line 181) builds `payload: ICreateMarketingActionRequest` — `actionType` is now a `MarketingActionType` value (e.g. `MarketingActionType.SocialMedia`), `folderLinks[].folderType` is now a `MarketingFolderType`.
+2. `useCreateMarketingAction().mutateAsync(payload)` accepts the typed payload (no `any`).
+3. Inside `mutationFn`, the hook calls `client.marketingCalendar_CreateMarketingAction(payload)` — TypeScript matches the structural shape against `CreateMarketingActionRequest`.
+4. The generated method's `JSON.stringify` emits `{"title": "...", "actionType": "SocialMedia", ...}` to `POST /api/MarketingCalendar`.
+5. Backend `JsonStringEnumConverter` parses the string into the C# enum and proceeds normally.
+
+For the calendar drag-and-resize flow (`handleEventMove`, line 209): `event.actionType` is already a string (`'SocialMedia'`, etc.) per `CalendarEvent` in `fullcalendarAdapters.ts:6`. Just pass `event.actionType as MarketingActionType` (or, better, change `CalendarEvent.actionType` to `MarketingActionType` so the cast disappears too). Drop the `ACTION_TYPE_TO_INT[...] ?? 99` lookup.
+
+For the modal's `FOLDER_TYPE_OPTIONS` (line 24–30): change `value: number` to `value: MarketingFolderType` so the form binds enum strings directly. The `<select>` element will serialize them as strings without any change to the JSX.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Wire format changes from integer to string for `actionType` / `folderType` and a backend deployment somewhere accepts only integers | Medium | Backend uses `JsonStringEnumConverter` globally (`Program.cs:142`), which accepts both forms. Verified by reading source. Run the spec's manual smoke test against staging before merging. |
+| `ACTION_TYPE_TO_INT` is referenced from a file not surfaced by grep, deletion breaks a build | Low | Search with `grep -rn "ACTION_TYPE_TO_INT" frontend/src` before removing. If any reference remains outside the marketing module, leave the constant in place (it costs nothing). |
+| `MarketingActionModal`'s `resolveOptionValue` helper (line 32) was tolerating mixed string/number inputs from legacy data | Low | After the change, `existingAction.actionType` is already a `MarketingActionType` string from the typed response; `resolveOptionValue` collapses to "find option by `backendName === raw`." Validate with the existing modal test (`MarketingActionModal.test.tsx`). |
+| Consumer files (`MarketingCalendarPage`, `MobileAgendaView`) still cast `query.data as any` for unrelated reasons | Low | Explicitly out of scope. The hook now *returns* `GetMarketingActionsResponse` etc., so the read-side typing is available to a future cleanup. |
+| TypeScript rejects a plain-object literal where the generated method demands a `…Request` class instance | Low | Fall back to `new CreateMarketingActionRequest(payload)` etc. The generated constructor accepts the `I*Request` shape via `for (var property in data) (<any>this)[property] = ...` (api-client.ts:29887–29893). |
+| The `useImportFromOutlook.test.ts` mock (`as any` on line 37) is an inevitable partial-mock workaround, not a violation of FR-1 | None | FR-1 scopes "no new `as any`" to `useMarketingCalendar.ts`, not its tests. Leave the test mock unchanged; only the production hook file is bound by FR-1. |
+
+## Specification Amendments
+
+1. **Add consumer files to scope (FR-2 acceptance bullet 3).** The spec leaves "OR the spec's 'Out of Scope' list explicitly notes the consumer files that must update" as a fork in the road. Architecturally the correct fork is to update callers (see Decision 1 rationale). Amend the spec to declare these files **in scope**:
+   - `frontend/src/components/marketing/detail/MarketingActionModal.tsx` — form state `actionType: number` → `MarketingActionType`; `FolderLinkInput.folderType: number` → `MarketingFolderType`; `FOLDER_TYPE_OPTIONS[i].value` → `MarketingFolderType`; `ACTION_TYPE_OPTIONS[i].value` → `MarketingActionType`; submit payload aligned accordingly.
+   - `frontend/src/components/marketing/pages/MarketingCalendarPage.tsx` — `handleEventMove` (line 209) passes `event.actionType` (typed as `MarketingActionType`) directly; remove the `ACTION_TYPE_TO_INT` lookup.
+   - `frontend/src/components/marketing/calendar/fullcalendarAdapters.ts` — narrow `CalendarEvent.actionType: string` to `MarketingActionType`; if `ACTION_TYPE_TO_INT` becomes unreferenced, delete it.
+
+2. **Acknowledge wire-format normalization under FR-3.** "Identical HTTP requests" is true for field names, method, URL, and query parameters, but `actionType` and `folderType` JSON values change from integer to string. Both forms are accepted by the backend's `JsonStringEnumConverter`, and response bodies are already strings. The amendment makes this normalization explicit and requires the spec's smoke test to run against staging before merge (it already does).
+
+3. **FR-5 wording: clarify the open question is resolved.** The original `as any` was driven by the int↔string enum mismatch in local payload types, not by an NSwag generator gotcha. No change to `docs/development/api-client-generation.md` is needed. The spec already says "no documentation changes required … unless"; this review confirms the "unless" branch does not apply.
+
+4. **Remove `ImportFromOutlookResult` reaffirmation.** Spec NFR-4 lists `ImportFromOutlookResult` among public exports. It is currently used as a local shape for consumer-side normalization, not as a hook return type. The hook's `useImportFromOutlook` returns `UseMutationResult<ImportFromOutlookResponse, ...>` (the generated type). Keep `ImportFromOutlookResult` exported unchanged — it is a consumer-side projection, orthogonal to this refactor.
+
+## Prerequisites
+
+None. No migrations, infrastructure, or configuration changes required. The generated client already exposes the correct types, the backend already accepts the canonical string form via `JsonStringEnumConverter`, and `frontend/src/api/client.ts` already returns a typed `ApiClient` from `getAuthenticatedApiClient()`. Implementation can begin immediately.

--- a/artifacts/feat-arch-review-marketing-usemarketingcalend/brief.md
+++ b/artifacts/feat-arch-review-marketing-usemarketingcalend/brief.md
@@ -1,0 +1,69 @@
+## Module
+Marketing
+
+## Finding
+
+Every API call in `frontend/src/api/hooks/useMarketingCalendar.ts` uses `(client as any).method()`, which discards all TypeScript type information for the generated API client.
+
+Examples from the file:
+```typescript
+// Line 54
+return await (client as any).marketingCalendar_GetMarketingActions(
+    params.pageNumber, params.pageSize, params.searchTerm, ...
+);
+
+// Line 75
+return await (client as any).marketingCalendar_GetMarketingAction(id);
+
+// Line 92
+return await (client as any).marketingCalendar_GetCalendar(params.startDate, params.endDate);
+
+// Line 106
+return await (client as any).marketingCalendar_CreateMarketingAction(request);
+
+// Line 133
+return await (client as any).marketingCalendar_UpdateMarketingAction(id, { ...request, id });
+
+// Line 158
+return await (client as any).marketingCalendar_DeleteMarketingAction(id);
+
+// Line 191
+return await (client as any).marketingCalendar_ImportFromOutlook(payload);
+```
+
+The file even includes an explanatory comment acknowledging the fragility:
+```typescript
+// Line 51-53
+// Positional args match the generated signature (last verified at commit 2f582c12):
+// ...
+// If the backend DTO changes, re-run `npm run build` to regenerate and verify argument positions.
+```
+
+The comment shows that correctness is manually verified at a point in time — TypeScript cannot catch regressions automatically.
+
+## Why it matters
+
+- **Type safety is lost**: the entire purpose of auto-generating a TypeScript client from the OpenAPI spec is to get compile-time checking. Casting to `any` defeats this completely.
+- **Silent breakage on API change**: if a backend DTO field is renamed or the method signature changes, TypeScript won't flag the hook. The bug surfaces at runtime (or in E2E tests, which run nightly).
+- **Positional argument risk**: `GetMarketingActions` takes 10 positional parameters. A future reordering of query parameters in the backend DTO silently reorders the arguments at the call site — TypeScript cannot warn about this with an `any` cast.
+
+## Suggested fix
+
+Use the generated typed method directly. The generated `ApiClient` class exports `marketingCalendar_GetMarketingActions` as a properly typed method. Remove the `as any` cast and let TypeScript resolve the call:
+
+```typescript
+// Before
+return await (client as any).marketingCalendar_GetMarketingActions(
+    params.pageNumber, params.pageSize, ...
+);
+
+// After
+return await client.marketingCalendar_GetMarketingActions(
+    params.pageNumber, params.pageSize, ...
+);
+```
+
+If the current generated types don't compile cleanly without the cast, identify the specific mismatch (likely a `Date` vs `string` issue in the generated query parameter types) and fix the NSwag template or add a targeted type assertion only at that point, not a blanket `any` cast.
+
+---
+_Filed by daily arch-review routine on 2026-06-07._

--- a/artifacts/feat-arch-review-marketing-usemarketingcalend/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketing-usemarketingcalend/impl/main.r1.md
@@ -1,0 +1,66 @@
+All tasks complete, final review APPROVED (no CRITICAL or HIGH issues; MEDIUM observations are all pre-existing, not introduced by this refactor).
+
+---
+
+# Implementation: Restore Type Safety in `useMarketingCalendar.ts`
+
+## What was implemented
+
+Removed all seven `(client as any).marketingCalendar_*` casts from the Marketing Calendar hook layer and restored full compile-time type checking. Normalized `actionType`/`folderType` wire values from integers to the string-enum form the backend already publishes (`"SocialMedia"`, `"Campaign"`, etc.), aligning the entire create/update flow with the NSwag-generated types end-to-end.
+
+## Files created/modified
+
+- `frontend/src/api/hooks/useMarketingCalendar.ts` — All 7 `as any` casts removed; local payload interfaces replaced with type aliases to `ICreateMarketingActionRequest`, `IUpdateMarketingActionRequest`, `IImportFromOutlookRequest`; typed ApiClient methods called directly; `new Create/Update/ImportFromOutlookRequest(...)` constructors used as TypeScript required class instances
+- `frontend/src/components/marketing/detail/MarketingActionModal.tsx` — Option arrays retyped with `MarketingActionType`/`MarketingFolderType` enums; `resolveOptionValue` replaced with `resolveActionType`/`resolveFolderType` helpers; `FormState.actionType` and `FolderLinkInput.folderType` narrowed to enum types; all select handlers updated
+- `frontend/src/components/marketing/pages/MarketingCalendarPage.tsx` — `ACTION_TYPE_TO_INT` import removed; `handleEventMove` passes `event.actionType` directly
+- `frontend/src/components/marketing/calendar/fullcalendarAdapters.ts` — `CalendarEvent.actionType: string` narrowed to `MarketingActionType`; `ACTION_TYPE_TO_INT` table deleted
+- `frontend/src/components/marketing/detail/__tests__/MarketingActionModal.test.tsx` — Numeric assertions (`actionType: 0/99`, `folderType: 3`, `select.value "99"/"2"`) updated to string-enum assertions
+- `frontend/src/components/marketing/calendar/__tests__/fullcalendarAdapters.test.ts` — `ACTION_TYPE_TO_INT` test block removed
+
+## Tests
+
+- **Modal tests** (39): All pass GREEN — previously failing 6 assertions now confirmed with `MarketingActionType.SocialMedia`, `MarketingActionType.Meeting`, `MarketingFolderType.Campaign`
+- **Adapter tests** (17): All pass — `toFcEvent`, `fromFcDates`, `formatDateStr`, `ACTION_TYPE_COLORS` suites unaffected
+- **Full suite** (2066): 2061 passed, 5 skipped — same baseline as pre-refactor, zero regressions
+
+## How to verify
+
+```bash
+# No as any casts in the hook
+grep -n "as any" frontend/src/api/hooks/useMarketingCalendar.ts  # → no output
+
+# TypeScript build
+cd frontend && npm run build  # → Compiled successfully
+
+# Lint
+cd frontend && npm run lint  # → clean
+
+# Tests
+CI=true npm test -- --watchAll=false  # → 2061 passed, 0 failed
+```
+
+Manual smoke test (per spec FR-3): exercise list, view, create, update, delete, and import-from-Outlook flows against staging; confirm `actionType` in request bodies is `"SocialMedia"` (string), not `0` (integer).
+
+## Notes
+
+The class-constructor fallback (`new CreateMarketingActionRequest(request)`) was needed — TypeScript requires class instances, not plain literals, for these generated method signatures. This is the documented fallback in the arch review.
+
+Three pre-existing MEDIUM observations surfaced during final review (not introduced by this change):
+1. `handleSubmit` omits `label` from folder-link payloads (not in `IMarketingFolderLinkRequest`)
+2. `handleEventMove` omits `folderLinks`/`description` from drag-drop update payloads
+3. `FOLDER_TYPE_OPTIONS` label/enum-name mapping looks like a placeholder (e.g., `General` → "Obrázky")
+
+## PR Summary
+
+Removes all seven `(client as any).marketingCalendar_*` casts that disabled compile-time type checking on the Marketing Calendar feature. The root cause was a mismatch between local payload interfaces (numeric `actionType`) and the generated NSwag client (string-enum `MarketingActionType`). The fix standardizes on string enums end-to-end: hook payload types are now aliases to the generated `I*Request` interfaces, consumer components build `MarketingActionType`/`MarketingFolderType` values directly, and the obsolete `ACTION_TYPE_TO_INT` translation table is deleted. The backend's `JsonStringEnumConverter` accepts both forms, so the wire-format change from `0` to `"SocialMedia"` is backward-compatible.
+
+### Changes
+- `frontend/src/api/hooks/useMarketingCalendar.ts` — 7 `as any` casts removed; payload types aliased to generated `I*Request` interfaces
+- `frontend/src/components/marketing/detail/MarketingActionModal.tsx` — form state and submission aligned to `MarketingActionType`/`MarketingFolderType` string enums
+- `frontend/src/components/marketing/pages/MarketingCalendarPage.tsx` — `handleEventMove` passes typed enum directly, drops numeric lookup
+- `frontend/src/components/marketing/calendar/fullcalendarAdapters.ts` — `CalendarEvent.actionType` narrowed; `ACTION_TYPE_TO_INT` table deleted
+- `frontend/src/components/marketing/detail/__tests__/MarketingActionModal.test.tsx` — numeric assertions updated to enum assertions
+- `frontend/src/components/marketing/calendar/__tests__/fullcalendarAdapters.test.ts` — `ACTION_TYPE_TO_INT` test block removed
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-marketing-usemarketingcalend/spec.r1.md
+++ b/artifacts/feat-arch-review-marketing-usemarketingcalend/spec.r1.md
@@ -1,0 +1,156 @@
+# Specification: Restore Type Safety in `useMarketingCalendar.ts` API Calls
+
+## Summary
+Eliminate the seven `(client as any).*` casts in `frontend/src/api/hooks/useMarketingCalendar.ts` so the generated NSwag TypeScript client's compile-time type checking once again protects the Marketing Calendar feature. The hook must continue to expose the same public API to its consumers, but every call into `ApiClient` will be fully typed, every payload will satisfy the generated request DTO interfaces, and the manual "verified at commit X" comment can be removed.
+
+## Background
+`frontend/src/api/hooks/useMarketingCalendar.ts` wraps seven generated `ApiClient` methods (`marketingCalendar_GetMarketingActions`, `_GetMarketingAction`, `_GetCalendar`, `_CreateMarketingAction`, `_UpdateMarketingAction`, `_DeleteMarketingAction`, `_ImportFromOutlook`) and casts the client to `any` on every call. The NSwag-generated `ApiClient` (in `frontend/src/api/generated/api-client.ts`) already exposes these methods with full type signatures — for example:
+
+```ts
+marketingCalendar_GetMarketingActions(
+  pageNumber: number | undefined,
+  pageSize: number | undefined,
+  searchTerm: string | null | undefined,
+  actionType: MarketingActionType | null | undefined,
+  productCodePrefix: string | null | undefined,
+  startDateFrom: Date | null | undefined,
+  startDateTo: Date | null | undefined,
+  endDateFrom: Date | null | undefined,
+  endDateTo: Date | null | undefined,
+  includeDeleted: boolean | undefined,
+): Promise<GetMarketingActionsResponse>
+```
+
+The casts therefore disable a protection that the toolchain already provides. The author left a comment noting that argument positions are "last verified at commit 2f582c12" — proof that the team is aware the compiler can no longer catch regressions. Comparing the hook's locally-declared interfaces to the generated `ICreateMarketingActionRequest`, `IUpdateMarketingActionRequest`, and `IImportFromOutlookRequest` reveals the most likely original motivation for the cast: the hook's payload interfaces use `number` for `actionType` (the generated type is the `MarketingActionType` enum) and an inline `{ folderKey: string; folderType: number }` shape for `folderLinks` (the generated type is `MarketingFolderLinkRequest`). Resolving those mismatches restores type safety without changing runtime behavior.
+
+This change is a refactor: no new feature, no behavioral change, no UI change. The motivation is correctness — preventing a class of silent runtime breakage when backend DTOs evolve.
+
+## Functional Requirements
+
+### FR-1: Remove all `as any` casts on the client in `useMarketingCalendar.ts`
+Every `(client as any).marketingCalendar_*(...)` call in `frontend/src/api/hooks/useMarketingCalendar.ts` must be replaced by a directly-typed call on the `ApiClient` instance returned from `getAuthenticatedApiClient()`. No new `any`, `unknown`, or `as any` casts may be introduced anywhere in the file as a workaround.
+
+**Acceptance criteria:**
+- `grep -n "as any" frontend/src/api/hooks/useMarketingCalendar.ts` returns no matches.
+- `npm run lint` and `tsc --noEmit` (i.e. the project's `npm run build`) succeed with zero errors and zero new warnings attributable to this file.
+- All seven hooks (`useMarketingActions`, `useMarketingAction`, `useMarketingCalendar`, `useCreateMarketingAction`, `useUpdateMarketingAction`, `useDeleteMarketingAction`, `useImportFromOutlook`) call the generated method directly on the typed `client`.
+
+### FR-2: Align local payload types with generated request DTOs
+The local `CreateMarketingActionPayload`, `UpdateMarketingActionPayload`, and `ImportFromOutlookPayload` interfaces declare fields whose types are looser than what the generated DTOs expect (e.g. `actionType: number` vs. `MarketingActionType`, inline `folderLinks` literal vs. `MarketingFolderLinkRequest[]`). These local interfaces must be reconciled so the call site can construct a value that satisfies the generated request type without `any`.
+
+The reconciliation must:
+1. Use the generated enum type (`MarketingActionType` for `actionType`, `MarketingFolderType` for `folderType`) directly in the local interfaces.
+2. Replace inline `folderLinks` shape with the generated interface (`IMarketingFolderLinkRequest` or `MarketingFolderLinkRequest[]`) — pick whichever lets the call compile without runtime construction overhead.
+3. Construct an actual `CreateMarketingActionRequest` / `UpdateMarketingActionRequest` / `ImportFromOutlookRequest` instance at the call site if the method signature demands a class instance and TypeScript refuses a plain object literal. Use the generated class constructor (`new CreateMarketingActionRequest(payload)`) — these constructors accept the `I*Request` shape directly.
+
+**Acceptance criteria:**
+- The hook payload interfaces import enum and DTO types from `../generated/api-client` rather than declaring loose `number` aliases.
+- Each mutation hook constructs the request object using the generated type (either via plain object satisfying the `I*Request` interface, or via the generated class constructor) — no structural casts.
+- Existing callers of these hooks (components in `frontend/src/components/marketing/` and any other consumer) continue to compile without changes to their call sites, OR the spec's "Out of Scope" list explicitly notes the consumer files that must update.
+
+### FR-3: Preserve runtime behavior of the seven hooks
+The change is type-only. Every hook must produce identical HTTP requests (URL, method, query parameters, body shape, headers) as the current implementation, and return the same response objects. Query invalidation behavior in mutation hooks must be unchanged.
+
+**Acceptance criteria:**
+- Existing unit/integration/E2E coverage that exercises Marketing Calendar continues to pass without modification (other than fixing any test that itself relied on `as any`).
+- Manual smoke test of the five user-visible flows passes against staging: list marketing actions, view single action, view calendar range, create action, update action, delete action, import from Outlook (`dryRun: true` and `dryRun: false`).
+
+### FR-4: Remove the obsolete "last verified at commit" comment
+Once the typed signatures enforce argument order, the comment at lines 51–53 of the current file becomes both inaccurate and unnecessary. It must be deleted as part of this change.
+
+**Acceptance criteria:**
+- The phrase "Positional args match the generated signature" no longer appears in the file.
+- The replacement, if any, is one short comment per CLAUDE.md's "default to no comments" rule — preferably none, since well-typed call sites are self-documenting.
+
+### FR-5: Verify and document the fix in the regenerate-client workflow
+The hook had to be cast to `any` because at least one local interface diverged from the generated DTO. The spec must ensure this divergence cannot silently return. If `npm run build` regenerates the client, the typed call must continue to compile; if a future backend DTO change breaks the call, the TypeScript compiler must flag it.
+
+**Acceptance criteria:**
+- After re-running `npm run build` (which regenerates `frontend/src/api/generated/api-client.ts`), the hook file still compiles without `as any`.
+- No documentation changes required in `docs/development/api-client-generation.md` unless the implementer discovers a generator-template issue that warranted the cast (see Open Questions).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. The change is type-system only; the emitted JavaScript should be equivalent (or differ only by the removal of unnecessary type-assertion expressions, which are erased at compile time anyway). No additional runtime allocations are acceptable beyond what the generated class constructors already perform.
+
+### NFR-2: Security
+No security impact. Request/response payloads, authentication flow, and authorization checks are unchanged. The change strengthens the team's ability to catch incorrect parameter binding (which could in principle send the wrong field to the wrong query parameter) at compile time rather than runtime — a small defensive-coding improvement.
+
+### NFR-3: Maintainability
+The diff must be limited to:
+- `frontend/src/api/hooks/useMarketingCalendar.ts` (primary change)
+- At most: any test file that itself uses `(client as any)` on these same methods
+- At most: caller components if FR-2's reconciliation requires them to pass the enum type instead of a numeric literal
+
+No unrelated cleanup, no formatting passes, no renaming. Per CLAUDE.md "surgical changes" rule.
+
+### NFR-4: Backwards compatibility
+The public exports of the hook file (`useMarketingActions`, `useMarketingAction`, `useMarketingCalendar`, `useCreateMarketingAction`, `useUpdateMarketingAction`, `useDeleteMarketingAction`, `useImportFromOutlook`, `ImportFromOutlookResult`) must remain exported with names and call signatures compatible with current consumers. Internal payload interfaces may evolve as long as consumer call sites still compile (or are updated within this change).
+
+## Data Model
+No data model changes. The hook continues to work against the existing entities:
+
+- **`MarketingAction`** — the calendar entry, exposed through `GetMarketingActionResponse` / `GetMarketingActionsResponse`.
+- **`MarketingCalendar`** — the range view, exposed through `GetMarketingCalendarResponse`.
+- **`CreateMarketingActionRequest` / `UpdateMarketingActionRequest`** — write-side DTOs; their fields (`title`, `description`, `actionType: MarketingActionType`, `startDate: Date`, `endDate?: Date`, `associatedProducts?: string[]`, `folderLinks?: MarketingFolderLinkRequest[]`) become the source of truth for the local hook payload types.
+- **`ImportFromOutlookRequest` / `ImportFromOutlookResponse`** — sync DTOs; the response's `unmappedCategories?` remains normalized to `string[]` by the existing `?? []` logic.
+- **Enums** — `MarketingActionType`, `MarketingFolderType` are the generated enums the hook payloads must reference.
+
+## API / Interface Design
+
+### Existing public hook signatures (preserved)
+```ts
+useMarketingActions(params?: GetMarketingActionsParams): UseQueryResult<GetMarketingActionsResponse>
+useMarketingAction(id: number): UseQueryResult<GetMarketingActionResponse>
+useMarketingCalendar(params: GetMarketingCalendarParams): UseQueryResult<GetMarketingCalendarResponse>
+useCreateMarketingAction(): UseMutationResult<CreateMarketingActionResponse, unknown, CreateMarketingActionPayload>
+useUpdateMarketingAction(): UseMutationResult<UpdateMarketingActionResponse, unknown, { id: number; request: Omit<UpdateMarketingActionPayload, "id"> }>
+useDeleteMarketingAction(): UseMutationResult<DeleteMarketingActionResponse, unknown, number>
+useImportFromOutlook(): UseMutationResult<ImportFromOutlookResponse, unknown, ImportFromOutlookPayload>
+```
+
+Response types now flow through from the generated client rather than being widened to `Promise<any>` by the cast.
+
+### Internal call pattern (new)
+```ts
+const client = await getAuthenticatedApiClient();
+return await client.marketingCalendar_GetMarketingActions(
+  params.pageNumber,
+  params.pageSize,
+  params.searchTerm,
+  params.actionType,
+  params.productCodePrefix,
+  params.startDateFrom,
+  params.startDateTo,
+  params.endDateFrom,
+  params.endDateTo,
+  params.includeDeleted,
+);
+```
+
+For mutations that take a request DTO, prefer (in priority order):
+1. A plain object satisfying the `I*Request` interface, passed directly if the generated method accepts it.
+2. If TypeScript rejects the structural match (because the method signature names the class, not the interface), construct the class explicitly: `new CreateMarketingActionRequest({ ... })`. The generated constructors accept the `I*Request` shape.
+
+### Out-of-scope interfaces
+The component-facing payload interfaces (`GetMarketingActionsParams`, `GetMarketingCalendarParams`, `CreateMarketingActionPayload`, `UpdateMarketingActionPayload`, `ImportFromOutlookPayload`) remain in the hook file. Their field types tighten (`actionType` becomes `MarketingActionType`, `folderLinks` references the generated `IMarketingFolderLinkRequest`/`MarketingFolderLinkRequest`), but the field names and overall shape are preserved.
+
+## Dependencies
+- **`frontend/src/api/generated/api-client.ts`** (NSwag-generated). Source of typed `ApiClient` and request/response DTOs. Regenerated by `npm run build`.
+- **`frontend/src/api/client.ts`** — exports `getAuthenticatedApiClient()` returning a typed `ApiClient`. No changes required.
+- **`@tanstack/react-query`** — `useQuery`/`useMutation`. No version change required.
+- **Consumer components** — anything importing the affected hooks (typically `frontend/src/components/marketing/`). They may need to pass the `MarketingActionType` enum instead of a numeric literal; the implementer must grep for usages and update them if necessary.
+
+## Out of Scope
+- Refactoring `frontend/src/api/hooks/useMarketingCalendar.ts` beyond the type-safety fix (e.g. splitting into multiple files, switching state libraries, renaming hooks).
+- Auditing or fixing `(client as any)` usage in other hook files. The arch-review finding is scoped to Marketing Calendar; other hooks are addressed by separate findings/PRs if they exist.
+- Changing the NSwag generator configuration or upgrading the generator version, **unless** Open Question #1 reveals a generator bug that forced the original cast.
+- Backend changes to `MarketingCalendar` controller DTOs.
+- Adding new tests for marketing calendar; the existing test coverage is presumed adequate to detect regressions in this refactor. New tests are written only if existing coverage is materially absent.
+- Updating `docs/development/api-client-generation.md` unless FR-5's investigation surfaces a generator gotcha.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketing-usemarketingcalend/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketing-usemarketingcalend/task-plan.r1.md
@@ -1,0 +1,15 @@
+Plan saved to `artifacts/feat-arch-review-marketing-usemarketingcalend/plan.r1.md`.
+
+**Summary**
+
+The plan decomposes the refactor into 7 sequential tasks, ordered to keep the codebase coherent at commit boundaries:
+
+1. Update `MarketingActionModal.test.tsx` to pin string-enum assertions (RED).
+2. Drop the `ACTION_TYPE_TO_INT` test block.
+3. Rewrite `useMarketingCalendar.ts` with generated `I*Request` types and remove all seven `as any` casts.
+4. Narrow `CalendarEvent.actionType` to `MarketingActionType` in `fullcalendarAdapters.ts`.
+5. Coordinated consumer update — `MarketingActionModal` (form state + options + handlers) and `MarketingCalendarPage.handleEventMove` — restoring a green build.
+6. Delete the now-unused `ACTION_TYPE_TO_INT` constant.
+7. Full validation gate (`npm run build`, `npm run lint`, `grep "as any"`, focused + full Jest, staging smoke test).
+
+Each task lists exact file paths, the full code to write or replace, the verification command, expected output, and a commit message. The plan calls out the intermediate compile-broken state between Tasks 3–5 explicitly so executors don't chase phantom errors, and documents the class-constructor fallback in case TS rejects the plain-object payload.

--- a/frontend/src/api/hooks/useMarketingCalendar.ts
+++ b/frontend/src/api/hooks/useMarketingCalendar.ts
@@ -1,6 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
-import { MarketingActionType } from "../generated/api-client";
+import {
+  MarketingActionType,
+  CreateMarketingActionRequest,
+  UpdateMarketingActionRequest,
+  ImportFromOutlookRequest,
+  type ICreateMarketingActionRequest,
+  type IImportFromOutlookRequest,
+  type IUpdateMarketingActionRequest,
+} from "../generated/api-client";
 
 interface GetMarketingActionsParams {
   pageNumber?: number;
@@ -20,26 +28,9 @@ interface GetMarketingCalendarParams {
   endDate: Date;
 }
 
-interface CreateMarketingActionPayload {
-  title: string;
-  description?: string;
-  actionType: number;
-  startDate: Date;
-  endDate?: Date;
-  associatedProducts?: string[];
-  folderLinks?: Array<{ folderKey: string; folderType: number }>;
-}
-
-interface UpdateMarketingActionPayload {
-  id: number;
-  title: string;
-  description?: string;
-  actionType: number;
-  startDate: Date;
-  endDate?: Date;
-  associatedProducts?: string[];
-  folderLinks?: Array<{ folderKey: string; folderType: number }>;
-}
+export type CreateMarketingActionPayload = ICreateMarketingActionRequest;
+export type UpdateMarketingActionPayload = IUpdateMarketingActionRequest;
+export type ImportFromOutlookPayload = IImportFromOutlookRequest;
 
 export const useMarketingActions = (
   params: GetMarketingActionsParams = {},
@@ -48,10 +39,7 @@ export const useMarketingActions = (
     queryKey: [...QUERY_KEYS.marketingCalendar, "actions", params],
     queryFn: async () => {
       const client = await getAuthenticatedApiClient();
-      // Positional args match the generated signature (last verified at commit 2f582c12):
-      // (pageNumber, pageSize, searchTerm, actionType, productCodePrefix, startDateFrom, startDateTo, endDateFrom, endDateTo, includeDeleted)
-      // If the backend DTO changes, re-run `npm run build` to regenerate and verify argument positions.
-      return await (client as any).marketingCalendar_GetMarketingActions(
+      return await client.marketingCalendar_GetMarketingActions(
         params.pageNumber,
         params.pageSize,
         params.searchTerm,
@@ -72,7 +60,7 @@ export const useMarketingAction = (id: number) => {
     queryKey: [...QUERY_KEYS.marketingCalendar, "action", id],
     queryFn: async () => {
       const client = await getAuthenticatedApiClient();
-      return await (client as any).marketingCalendar_GetMarketingAction(id);
+      return await client.marketingCalendar_GetMarketingAction(id);
     },
     enabled: id > 0,
   });
@@ -88,7 +76,7 @@ export const useMarketingCalendar = (params: GetMarketingCalendarParams) => {
     ],
     queryFn: async () => {
       const client = await getAuthenticatedApiClient();
-      return await (client as any).marketingCalendar_GetCalendar(
+      return await client.marketingCalendar_GetCalendar(
         params.startDate,
         params.endDate,
       );
@@ -103,8 +91,8 @@ export const useCreateMarketingAction = () => {
   return useMutation({
     mutationFn: async (request: CreateMarketingActionPayload) => {
       const client = await getAuthenticatedApiClient();
-      return await (client as any).marketingCalendar_CreateMarketingAction(
-        request,
+      return await client.marketingCalendar_CreateMarketingAction(
+        new CreateMarketingActionRequest(request),
       );
     },
     onSuccess: () => {
@@ -130,10 +118,13 @@ export const useUpdateMarketingAction = () => {
       request: Omit<UpdateMarketingActionPayload, "id">;
     }) => {
       const client = await getAuthenticatedApiClient();
-      return await (client as any).marketingCalendar_UpdateMarketingAction(id, {
-        ...request,
+      return await client.marketingCalendar_UpdateMarketingAction(
         id,
-      });
+        new UpdateMarketingActionRequest({
+          ...request,
+          id,
+        }),
+      );
     },
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({
@@ -155,7 +146,7 @@ export const useDeleteMarketingAction = () => {
   return useMutation({
     mutationFn: async (id: number) => {
       const client = await getAuthenticatedApiClient();
-      return await (client as any).marketingCalendar_DeleteMarketingAction(id);
+      return await client.marketingCalendar_DeleteMarketingAction(id);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -167,12 +158,6 @@ export const useDeleteMarketingAction = () => {
     },
   });
 };
-
-interface ImportFromOutlookPayload {
-  fromUtc: Date;
-  toUtc: Date;
-  dryRun?: boolean;
-}
 
 export interface ImportFromOutlookResult {
   created: number;
@@ -188,14 +173,16 @@ export const useImportFromOutlook = () => {
   return useMutation({
     mutationFn: async (payload: ImportFromOutlookPayload) => {
       const client = await getAuthenticatedApiClient();
-      return await (client as any).marketingCalendar_ImportFromOutlook(payload);
+      return await client.marketingCalendar_ImportFromOutlook(
+        new ImportFromOutlookRequest(payload),
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [...QUERY_KEYS.marketingCalendar, 'actions'],
+        queryKey: [...QUERY_KEYS.marketingCalendar, "actions"],
       });
       queryClient.invalidateQueries({
-        queryKey: [...QUERY_KEYS.marketingCalendar, 'calendar'],
+        queryKey: [...QUERY_KEYS.marketingCalendar, "calendar"],
       });
     },
   });

--- a/frontend/src/components/marketing/calendar/__tests__/fullcalendarAdapters.test.ts
+++ b/frontend/src/components/marketing/calendar/__tests__/fullcalendarAdapters.test.ts
@@ -2,7 +2,6 @@ import {
   toFcEvent,
   fromFcDates,
   formatDateStr,
-  ACTION_TYPE_TO_INT,
   ACTION_TYPE_COLORS,
 } from '../fullcalendarAdapters';
 import type { CalendarEvent } from '../fullcalendarAdapters';
@@ -101,32 +100,6 @@ describe('formatDateStr', () => {
 
   it('zero-pads month and day', () => {
     expect(formatDateStr(new Date(2026, 0, 1))).toBe('2026-01-01');
-  });
-});
-
-describe('ACTION_TYPE_TO_INT', () => {
-  it('maps SocialMedia to 0', () => {
-    expect(ACTION_TYPE_TO_INT['SocialMedia']).toBe(0);
-  });
-
-  it('maps Blog to 1', () => {
-    expect(ACTION_TYPE_TO_INT['Blog']).toBe(1);
-  });
-
-  it('maps Newsletter to 2', () => {
-    expect(ACTION_TYPE_TO_INT['Newsletter']).toBe(2);
-  });
-
-  it('maps PR to 3', () => {
-    expect(ACTION_TYPE_TO_INT['PR']).toBe(3);
-  });
-
-  it('maps Event to 4', () => {
-    expect(ACTION_TYPE_TO_INT['Event']).toBe(4);
-  });
-
-  it('maps Meeting to 99', () => {
-    expect(ACTION_TYPE_TO_INT['Meeting']).toBe(99);
   });
 });
 

--- a/frontend/src/components/marketing/calendar/fullcalendarAdapters.ts
+++ b/frontend/src/components/marketing/calendar/fullcalendarAdapters.ts
@@ -1,9 +1,10 @@
+import { MarketingActionType } from '../../../api/generated/api-client';
 import type { EventInput } from '@fullcalendar/core';
 
 export interface CalendarEvent {
   id: number;
   title: string;
-  actionType: string;
+  actionType: MarketingActionType;
   dateFrom: string; // YYYY-MM-DD
   dateTo: string;   // YYYY-MM-DD, inclusive
   associatedProducts: string[];

--- a/frontend/src/components/marketing/calendar/fullcalendarAdapters.ts
+++ b/frontend/src/components/marketing/calendar/fullcalendarAdapters.ts
@@ -20,15 +20,6 @@ export const ACTION_TYPE_COLORS: Record<string, { bg: string; text: string }> = 
   Meeting:     { bg: '#14b8a6', text: '#ffffff' }, // Teal Category
 };
 
-export const ACTION_TYPE_TO_INT: Record<string, number> = {
-  SocialMedia: 0,
-  Blog:        1,
-  Newsletter:  2,
-  PR:          3,
-  Event:       4,
-  Meeting:     99,
-};
-
 export function formatDateStr(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, '0');

--- a/frontend/src/components/marketing/detail/MarketingActionModal.tsx
+++ b/frontend/src/components/marketing/detail/MarketingActionModal.tsx
@@ -11,46 +11,53 @@ import {
   catalogItemToProductCode,
   PRODUCT_TYPE_FILTERS,
 } from "../../common/CatalogAutocompleteAdapters";
+import {
+  MarketingActionType,
+  MarketingFolderType,
+  MarketingFolderLinkRequest,
+} from "../../../api/generated/api-client";
 
-const ACTION_TYPE_OPTIONS = [
-  { value: 0,  label: "Sociální sítě", backendName: "SocialMedia" },
-  { value: 1,  label: "Blog",          backendName: "Blog" },
-  { value: 2,  label: "Newsletter",    backendName: "Newsletter" },
-  { value: 3,  label: "PR",            backendName: "PR" },
-  { value: 4,  label: "Akce",          backendName: "Event" },
-  { value: 99, label: "Porada",        backendName: "Meeting" },
+const ACTION_TYPE_OPTIONS: ReadonlyArray<{ value: MarketingActionType; label: string }> = [
+  { value: MarketingActionType.SocialMedia, label: "Sociální sítě" },
+  { value: MarketingActionType.Blog,        label: "Blog" },
+  { value: MarketingActionType.Newsletter,  label: "Newsletter" },
+  { value: MarketingActionType.PR,          label: "PR" },
+  { value: MarketingActionType.Event,       label: "Akce" },
+  { value: MarketingActionType.Meeting,     label: "Porada" },
 ];
 
-const FOLDER_TYPE_OPTIONS = [
-  { value: 0, label: "Obrázky", backendName: "General" },
-  { value: 1, label: "Texty", backendName: "Seasonal" },
-  { value: 2, label: "Videa", backendName: "ProductLine" },
-  { value: 3, label: "Grafika", backendName: "Campaign" },
-  { value: 99, label: "Ostatní", backendName: "Other" },
+const FOLDER_TYPE_OPTIONS: ReadonlyArray<{ value: MarketingFolderType; label: string }> = [
+  { value: MarketingFolderType.General,     label: "Obrázky" },
+  { value: MarketingFolderType.Seasonal,    label: "Texty" },
+  { value: MarketingFolderType.ProductLine, label: "Videa" },
+  { value: MarketingFolderType.Campaign,    label: "Grafika" },
+  { value: MarketingFolderType.Other,       label: "Ostatní" },
 ];
 
-const resolveOptionValue = (
-  options: Array<{ value: number; backendName: string }>,
-  raw: string | number | undefined,
-): number => {
-  if (raw == null) return options[0]?.value ?? 0;
-  const numeric = Number(raw);
-  const byValue = options.find((o) => !isNaN(numeric) && o.value === numeric);
-  if (byValue) return byValue.value;
-  const byName = options.find((o) => o.backendName === String(raw));
-  return byName?.value ?? options[0]?.value ?? 0;
+const resolveActionType = (raw: string | undefined): MarketingActionType => {
+  if (raw && (Object.values(MarketingActionType) as string[]).includes(raw)) {
+    return raw as MarketingActionType;
+  }
+  return MarketingActionType.SocialMedia;
+};
+
+const resolveFolderType = (raw: string | undefined): MarketingFolderType => {
+  if (raw && (Object.values(MarketingFolderType) as string[]).includes(raw)) {
+    return raw as MarketingFolderType;
+  }
+  return MarketingFolderType.General;
 };
 
 interface FolderLinkInput {
   path: string;
   label: string;
-  folderType: number;
+  folderType: MarketingFolderType;
 }
 
 interface FormState {
   title: string;
   detail: string;
-  actionType: number;
+  actionType: MarketingActionType;
   dateFrom: string;
   dateTo: string;
   associatedProducts: string[];
@@ -60,7 +67,7 @@ interface FormState {
 const EMPTY_FORM: FormState = {
   title: "",
   detail: "",
-  actionType: 0,
+  actionType: MarketingActionType.SocialMedia,
   dateFrom: "",
   dateTo: "",
   associatedProducts: [],
@@ -110,14 +117,14 @@ const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
       setForm({
         title: existingAction.title ?? "",
         detail: existingAction.detail ?? "",
-        actionType: resolveOptionValue(ACTION_TYPE_OPTIONS, existingAction.actionType),
+        actionType: resolveActionType(existingAction.actionType),
         dateFrom: toDateInputValue(existingAction.dateFrom),
         dateTo: toDateInputValue(existingAction.dateTo),
         associatedProducts: existingAction.associatedProducts ?? [],
         folderLinks: (existingAction.folderLinks ?? []).map((fl) => ({
           path: fl.path ?? "",
           label: fl.label ?? "",
-          folderType: resolveOptionValue(FOLDER_TYPE_OPTIONS, fl.folderType),
+          folderType: resolveFolderType(fl.folderType),
         })),
       });
     } else if (prefillDates) {
@@ -157,13 +164,13 @@ const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
   const addFolderLink = () =>
     set("folderLinks", [
       ...form.folderLinks,
-      { path: "", label: "", folderType: 0 },
+      { path: "", label: "", folderType: MarketingFolderType.General },
     ]);
 
   const updateFolderLink = (
     i: number,
     field: keyof FolderLinkInput,
-    value: string | number,
+    value: string | MarketingFolderType,
   ) =>
     set(
       "folderLinks",
@@ -191,7 +198,7 @@ const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
       associatedProducts: form.associatedProducts,
       folderLinks: form.folderLinks
         .filter((fl) => fl.path.trim())
-        .map((fl) => ({
+        .map((fl) => new MarketingFolderLinkRequest({
           folderKey: fl.path.trim(),
           folderType: fl.folderType,
         })),
@@ -273,7 +280,7 @@ const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
               </label>
               <select
                 value={form.actionType}
-                onChange={(e) => set("actionType", Number(e.target.value))}
+                onChange={(e) => set("actionType", e.target.value as MarketingActionType)}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
                 {ACTION_TYPE_OPTIONS.map((o) => (
@@ -437,7 +444,7 @@ const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
                   <select
                     value={fl.folderType}
                     onChange={(e) =>
-                      updateFolderLink(i, "folderType", Number(e.target.value))
+                      updateFolderLink(i, "folderType", e.target.value as MarketingFolderType)
                     }
                     className="w-28 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                   >

--- a/frontend/src/components/marketing/detail/__tests__/MarketingActionModal.test.tsx
+++ b/frontend/src/components/marketing/detail/__tests__/MarketingActionModal.test.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import MarketingActionModal from "../MarketingActionModal";
 import { MarketingActionDto } from "../../list/MarketingActionGrid";
+import {
+  MarketingActionType,
+  MarketingFolderType,
+} from "../../../../api/generated/api-client";
 
 const mockCreateMutateAsync = jest.fn();
 const mockUpdateMutateAsync = jest.fn();
@@ -66,28 +70,30 @@ beforeEach(() => {
 // ─── CREATE ────────────────────────────────────────────────────────────────────
 
 describe("MarketingActionModal — create", () => {
-  it("submits actionType as a number, not a label string", async () => {
+  it("submits actionType as the string enum value, not a label string", async () => {
     render(<MarketingActionModal {...defaultProps} />);
     fillRequiredFields();
     submitForm();
 
     await waitFor(() =>
       expect(mockCreateMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ actionType: 0 }),
+        expect.objectContaining({ actionType: MarketingActionType.SocialMedia }),
       ),
     );
-    expect(typeof mockCreateMutateAsync.mock.calls[0][0].actionType).toBe("number");
+    expect(typeof mockCreateMutateAsync.mock.calls[0][0].actionType).toBe("string");
   });
 
-  it('submits "Ostatní" actionType as 99, not 5', async () => {
+  it('submits "Ostatní" (Meeting) actionType as the Meeting enum value', async () => {
     render(<MarketingActionModal {...defaultProps} />);
     fillRequiredFields();
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "99" } });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: MarketingActionType.Meeting },
+    });
     submitForm();
 
     await waitFor(() =>
       expect(mockCreateMutateAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ actionType: 99 }),
+        expect.objectContaining({ actionType: MarketingActionType.Meeting }),
       ),
     );
   });
@@ -165,13 +171,13 @@ describe("MarketingActionModal — edit field population", () => {
     expect(dates[0]).toHaveValue("2026-04-15");
   });
 
-  it('restores actionType "Meeting" (backend name) to select value 99', () => {
+  it('restores actionType "Meeting" (backend name) to select value "Meeting"', () => {
     render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
     const actionTypeSelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    expect(actionTypeSelect.value).toBe("99");
+    expect(actionTypeSelect.value).toBe(MarketingActionType.Meeting);
   });
 
-  it("restores actionType by backend enum name (Newsletter → 2)", () => {
+  it("restores actionType by backend enum name (Newsletter → Newsletter)", () => {
     render(
       <MarketingActionModal
         {...defaultProps}
@@ -179,18 +185,7 @@ describe("MarketingActionModal — edit field population", () => {
       />,
     );
     const actionTypeSelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    expect(actionTypeSelect.value).toBe("2");
-  });
-
-  it("restores actionType by numeric string (e.g. '2')", () => {
-    render(
-      <MarketingActionModal
-        {...defaultProps}
-        existingAction={{ ...existingAction, actionType: "2" }}
-      />,
-    );
-    const actionTypeSelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
-    expect(actionTypeSelect.value).toBe("2");
+    expect(actionTypeSelect.value).toBe(MarketingActionType.Newsletter);
   });
 
   it("populates associatedProducts chips", () => {
@@ -214,7 +209,7 @@ describe("MarketingActionModal — edit submit", () => {
     folderLinks: [{ path: "folder/key", label: "Složka", folderType: "Campaign" }],
   };
 
-  it("submits actionType as number 99 when editing Meeting", async () => {
+  it("submits actionType as the Meeting enum value when editing Meeting", async () => {
     render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
     submitForm();
 
@@ -222,19 +217,19 @@ describe("MarketingActionModal — edit submit", () => {
       expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 1,
-          request: expect.objectContaining({ actionType: 99 }),
+          request: expect.objectContaining({ actionType: MarketingActionType.Meeting }),
         }),
       ),
     );
   });
 
-  it("submits folderType as number (Campaign → 3)", async () => {
+  it("submits folderType as the Campaign enum value", async () => {
     render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
     submitForm();
 
     await waitFor(() => {
       const { request } = mockUpdateMutateAsync.mock.calls[0][0];
-      expect(request.folderLinks[0].folderType).toBe(3);
+      expect(request.folderLinks[0].folderType).toBe(MarketingFolderType.Campaign);
     });
   });
 });

--- a/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
+++ b/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
@@ -17,7 +17,7 @@ import {
   useMarketingAction,
   useUpdateMarketingAction,
 } from '../../../api/hooks/useMarketingCalendar';
-import { ACTION_TYPE_TO_INT, formatDateStr } from '../calendar/fullcalendarAdapters';
+import { formatDateStr } from '../calendar/fullcalendarAdapters';
 import type { CalendarEvent } from '../calendar/fullcalendarAdapters';
 import { PAGE_CONTAINER_HEIGHT } from '../../../constants/layout';
 import { useAuth } from '../../../auth/useAuth';
@@ -214,7 +214,7 @@ const MarketingCalendarPage: React.FC = () => {
         id,
         request: {
           title: event.title,
-          actionType: ACTION_TYPE_TO_INT[event.actionType] ?? 99,
+          actionType: event.actionType,
           startDate: new Date(dateFrom),
           endDate: new Date(dateTo),
           associatedProducts: event.associatedProducts,


### PR DESCRIPTION

Removes all seven `(client as any).marketingCalendar_*` casts that disabled compile-time type checking on the Marketing Calendar feature. The root cause was a mismatch between local payload interfaces (numeric `actionType`) and the generated NSwag client (string-enum `MarketingActionType`). The fix standardizes on string enums end-to-end: hook payload types are now aliases to the generated `I*Request` interfaces, consumer components build `MarketingActionType`/`MarketingFolderType` values directly, and the obsolete `ACTION_TYPE_TO_INT` translation table is deleted. The backend's `JsonStringEnumConverter` accepts both forms, so the wire-format change from `0` to `"SocialMedia"` is backward-compatible.

### Changes
- `frontend/src/api/hooks/useMarketingCalendar.ts` — 7 `as any` casts removed; payload types aliased to generated `I*Request` interfaces
- `frontend/src/components/marketing/detail/MarketingActionModal.tsx` — form state and submission aligned to `MarketingActionType`/`MarketingFolderType` string enums
- `frontend/src/components/marketing/pages/MarketingCalendarPage.tsx` — `handleEventMove` passes typed enum directly, drops numeric lookup
- `frontend/src/components/marketing/calendar/fullcalendarAdapters.ts` — `CalendarEvent.actionType` narrowed; `ACTION_TYPE_TO_INT` table deleted
- `frontend/src/components/marketing/detail/__tests__/MarketingActionModal.test.tsx` — numeric assertions updated to enum assertions
- `frontend/src/components/marketing/calendar/__tests__/fullcalendarAdapters.test.ts` — `ACTION_TYPE_TO_INT` test block removed

---

Closes #2697

### Tokens used
26821666
