### PR TITLE
feat: Replace `IConfiguration` injection in `GetInvoiceImportStatisticsHandler` with typed options

### DIFF
--- a/artifacts/feat-arch-review-analytics-iconfiguration-inj/arch-review.r1.md
+++ b/artifacts/feat-arch-review-analytics-iconfiguration-inj/arch-review.r1.md
@@ -1,0 +1,210 @@
+# Architecture Review: Replace `IConfiguration` injection in `GetInvoiceImportStatisticsHandler` with typed options
+
+## Skip Design: true
+
+This is a backend-only refactor. There is no UI surface, no visual component, no API contract change. Nothing for a designer to weigh in on.
+
+## Architectural Fit Assessment
+
+The proposed change aligns cleanly with patterns already established across the Application project. A direct survey of the codebase confirms:
+
+- **The Options pattern is the convention.** At least 20 modules already define a `*Options` POCO and bind it via `services.Configure<TOptions>(configuration.GetSection(...))`. Examples: `PrintPickingListOptions`, `ArticleOptions`, `MeetingTasksOptions`, `BankAccountSettings`, `CatalogCacheOptions`, `PhotobankTagsCacheOptions`, `ExpeditionListArchiveOptions`. The Analytics module is the outlier, not the proposal.
+- **The "module that needs config takes `IConfiguration`" pattern is well-established.** Modules that bind options change their signature from `AddXModule(this IServiceCollection services)` to `AddXModule(this IServiceCollection services, IConfiguration configuration)`. `ApplicationModule.cs` lines 73–108 show both styles side by side (e.g., `services.AddArticleModule(configuration);` vs `services.AddAnalyticsModule();`).
+- **`Microsoft.Extensions.Configuration.Binder` is already referenced** by `Anela.Heblo.Application.csproj`. `services.Configure<T>(IConfiguration)` works out of the box — no new package reference required. The spec's caveat about `Microsoft.Extensions.Options.ConfigurationExtensions` is unnecessary in this codebase.
+- **Integration points are exactly two files** (`AnalyticsModule.cs`, `GetInvoiceImportStatisticsHandler.cs`) plus one call site (`ApplicationModule.cs:74`) plus the existing test file. No collateral surface.
+- **No co-consumer to worry about.** Verified: the only other touch-point that might have read the same section — `InvoiceImportStatisticsTile` — does not read `InvoiceImport:*` at all (it only calls the repository). The refactor is fully isolated.
+
+The change is a small, faithful application of an established convention.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ApplicationModule.AddApplicationServices(IServiceCollection, IConfiguration)
+        │
+        └─► AnalyticsModule.AddAnalyticsModule(IServiceCollection, IConfiguration)   ◄── signature change
+                │
+                ├─► services.Configure<InvoiceImportOptions>(                          ◄── new line
+                │       configuration.GetSection(InvoiceImportOptions.ConfigurationKey))
+                │
+                └─► [MediatR auto-scan registers handler]
+                        │
+                        └─► GetInvoiceImportStatisticsHandler(
+                                IAnalyticsRepository,
+                                IOptions<InvoiceImportOptions>)                        ◄── constructor change
+
+InvoiceImportOptions  (new POCO, Application/Features/Analytics/)
+        ├── ConfigurationKey = "InvoiceImport"  (const string)
+        ├── MinimumDailyThreshold = 10
+        └── DefaultDaysBack = 14
+```
+
+### Key Design Decisions
+
+#### Decision 1: Options class location and namespace
+**Options considered:**
+- (a) `Features/Analytics/InvoiceImportOptions.cs` (flat, alongside `AnalyticsModule.cs` and `AnalyticsConstants.cs`)
+- (b) `Features/Analytics/UseCases/GetInvoiceImportStatistics/InvoiceImportOptions.cs` (co-located with the handler)
+- (c) `Features/Analytics/Configuration/InvoiceImportOptions.cs` (mirroring `Photobank/Configuration/`)
+
+**Chosen approach:** (a) — `backend/src/Anela.Heblo.Application/Features/Analytics/InvoiceImportOptions.cs`, namespace `Anela.Heblo.Application.Features.Analytics`.
+
+**Rationale:** Matches the dominant pattern in this codebase: `PrintPickingListOptions`, `ArticleOptions`, `MeetingTasksOptions`, `LeafletOptions`, `KnowledgeBaseOptions`, `ExpeditionListArchiveOptions`, `OrgChartOptions`, `ProductExportOptions` all sit at the module root next to their `*Module.cs`. The `Configuration/` subfolder is used only when a module has multiple options classes (Photobank, Marketing, Manufacture). Analytics has one. Co-locating with the use case (option b) would orphan the options if a second handler ever needed the same section.
+
+#### Decision 2: Convention for the section-name constant
+**Options considered:**
+- (a) `public const string ConfigurationKey = "InvoiceImport";`
+- (b) `public const string SectionName = "InvoiceImport";`
+- (c) Magic string at the call site in `AnalyticsModule.cs`
+
+**Chosen approach:** (a) `ConfigurationKey`.
+
+**Rationale:** `ConfigurationKey` is used by more existing options (`PrintPickingListOptions`, `ExpeditionListArchiveOptions`, `BankAccountSettings`). `SectionName` is used by some Photobank options. The spec doesn't mandate either — but defining a constant on the type (rather than a magic string in `AnalyticsModule`) is the project default and removes one source of typos. Choose `ConfigurationKey` for majority consistency.
+
+#### Decision 3: `IOptions<T>` vs `IOptionsSnapshot<T>` vs `IOptionsMonitor<T>`
+**Options considered:** all three.
+**Chosen approach:** `IOptions<InvoiceImportOptions>`, store `.Value` in a field.
+**Rationale:** The spec already calls this correctly. The values are static operational thresholds — they don't change at runtime, no hot-reload is required, and the handler is request-scoped (registered by MediatR scan). `IOptionsSnapshot` would add scoped-DI overhead for zero functional benefit; `IOptionsMonitor` would add a change-token subscription for zero functional benefit. Storing `.Value` matches what most consumers do across this codebase.
+
+#### Decision 4: Update `AnalyticsModule` signature vs. inject `IConfiguration` into the handler/tile
+**Options considered:**
+- (a) Change `AddAnalyticsModule()` → `AddAnalyticsModule(IConfiguration)` and call `services.Configure<InvoiceImportOptions>(...)` there.
+- (b) Leave the module signature alone and register the options binding at a higher level (e.g., `ApplicationModule`).
+
+**Chosen approach:** (a).
+
+**Rationale:** Every module in this codebase that owns options binds them in its own module — this is the vertical-slice composition pattern. Hoisting the binding into `ApplicationModule` would leak Analytics-internal config keys upward and break the "each slice owns its DI" convention. The signature change cost is one extra parameter and one updated call site.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Analytics/
+├── AnalyticsModule.cs                    ← MODIFIED: accept IConfiguration; add services.Configure<…>
+├── AnalyticsConstants.cs
+├── InvoiceImportOptions.cs               ← NEW
+├── Contracts/
+├── DashboardTiles/
+│   └── InvoiceImportStatisticsTile.cs    ← UNCHANGED (does not read InvoiceImport:* — verified)
+├── Services/
+├── Validators/
+└── UseCases/
+    └── GetInvoiceImportStatistics/
+        ├── GetInvoiceImportStatisticsHandler.cs   ← MODIFIED: IOptions<InvoiceImportOptions>
+        ├── GetInvoiceImportStatisticsRequest.cs
+        └── GetInvoiceImportStatisticsResponse.cs
+
+backend/src/Anela.Heblo.Application/
+└── ApplicationModule.cs                  ← MODIFIED line 74: AddAnalyticsModule(configuration)
+
+backend/test/Anela.Heblo.Tests/Features/Analytics/
+└── GetInvoiceImportStatisticsHandlerTests.cs   ← MODIFIED: 4 tests; replace ConfigurationBuilder with Options.Create
+```
+
+### Interfaces and Contracts
+
+```csharp
+// InvoiceImportOptions.cs
+namespace Anela.Heblo.Application.Features.Analytics;
+
+public class InvoiceImportOptions
+{
+    public const string ConfigurationKey = "InvoiceImport";
+
+    public int MinimumDailyThreshold { get; set; } = 10;
+    public int DefaultDaysBack { get; set; } = 14;
+}
+```
+
+```csharp
+// AnalyticsModule.cs — new signature
+public static IServiceCollection AddAnalyticsModule(
+    this IServiceCollection services,
+    IConfiguration configuration)
+{
+    services.Configure<InvoiceImportOptions>(
+        configuration.GetSection(InvoiceImportOptions.ConfigurationKey));
+
+    // ... existing registrations unchanged
+}
+```
+
+```csharp
+// GetInvoiceImportStatisticsHandler.cs — new constructor
+public GetInvoiceImportStatisticsHandler(
+    IAnalyticsRepository analyticsRepository,
+    IOptions<InvoiceImportOptions> invoiceImportOptions)
+{
+    _analyticsRepository = analyticsRepository;
+    _options = invoiceImportOptions.Value;   // store .Value — singleton-effective
+}
+```
+
+Replace the two reads:
+```csharp
+var minimumThreshold = _options.MinimumDailyThreshold;
+var defaultDaysBack  = _options.DefaultDaysBack;
+```
+
+### Data Flow
+
+```
+appsettings.json / Azure Key Vault
+        │
+        │  Section "InvoiceImport" → { MinimumDailyThreshold, DefaultDaysBack }
+        ▼
+IConfiguration (built in composition root)
+        │
+        ▼
+AnalyticsModule.AddAnalyticsModule(services, configuration)
+        │
+        │  services.Configure<InvoiceImportOptions>(section)
+        ▼
+IOptions<InvoiceImportOptions> (DI container)
+        │
+        ▼
+GetInvoiceImportStatisticsHandler ctor → _options = options.Value
+        │
+        ▼
+Handle() reads _options.MinimumDailyThreshold / DefaultDaysBack
+```
+
+Behavior is identical for: (a) both keys present, (b) one key present, (c) section absent — the `InvoiceImportOptions` defaults (10, 14) take effect whenever the configuration provider supplies no value, matching the prior `GetValue<int>(key, default)` semantics.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `AddAnalyticsModule()` signature change breaks the existing call site at `ApplicationModule.cs:74`. | High (build break) | Update the call to `services.AddAnalyticsModule(configuration);` in the same PR. Verified `configuration` is in scope at that line (it's the parameter of `AddApplicationServices`). |
+| Other call sites of `AddAnalyticsModule()` (e.g., test fixtures, integration-test factories) fail to compile. | Medium | Run `grep -rn "AddAnalyticsModule" backend/` before merge and update all call sites. Initial scan shows only `ApplicationModule.cs:74` — but verify exhaustively. |
+| Configuration section absent in `appsettings*.json` triggers a different code path than before. | Low | Both old (`GetValue<int>(key, 10)`) and new (`InvoiceImportOptions { = 10 }`) yield `10` when the section is missing. Equivalent. Test FR-4 adds an explicit assertion for this case. |
+| `services.Configure<T>(IConfiguration)` requires a package the Application project doesn't have. | None | Verified: `Microsoft.Extensions.Configuration.Binder` is already in `Anela.Heblo.Application.csproj`. No new package reference needed. The spec's hedge about `Microsoft.Extensions.Options.ConfigurationExtensions` can be dropped. |
+| Existing tests (4 of them) construct `IConfigurationRoot` in `ConfigurationBuilder` — they all need updating in lockstep with the constructor change. | Low | All four tests are in one file (`GetInvoiceImportStatisticsHandlerTests.cs`). The change is mechanical: replace `ConfigurationBuilder().Add… .Build()` with `Options.Create(new InvoiceImportOptions { MinimumDailyThreshold = …, DefaultDaysBack = … })`. |
+| `InvoiceImportStatisticsTile` is silently affected. | None | Verified by reading the tile: it never reads `InvoiceImport:*` config. Refactor is isolated to the handler. |
+
+## Specification Amendments
+
+1. **FR-1 — confirm options class location.** The spec says "or the conventional location for module-level options in this codebase — match existing examples if any." Confirmed convention: **module root** (`Features/Analytics/InvoiceImportOptions.cs`), not under `UseCases/GetInvoiceImportStatistics/`. Update the spec to remove the ambiguity.
+
+2. **FR-1 — add `ConfigurationKey` constant.** Add a `public const string ConfigurationKey = "InvoiceImport";` to the options class to match `PrintPickingListOptions`, `ExpeditionListArchiveOptions`, `BankAccountSettings`. Use this constant in `AnalyticsModule` instead of the magic string `"InvoiceImport"`.
+
+3. **FR-2 — `AddAnalyticsModule` signature change is required.** The spec says "If the module registration method does not already accept `IConfiguration`, follow the established pattern." It does not currently accept it. Make it explicit: the method signature changes to `AddAnalyticsModule(this IServiceCollection services, IConfiguration configuration)`, and `ApplicationModule.cs:74` must change from `services.AddAnalyticsModule();` to `services.AddAnalyticsModule(configuration);`. List both edits in the acceptance criteria.
+
+4. **FR-4 — existing tests already exist.** The spec phrases this conditionally ("any existing unit tests"). Confirmed: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` exists with 4 tests, all of which mock `IConfiguration` via `ConfigurationBuilder`. All 4 must be ported. The "default values" test the spec asks for already exists in spirit (`Handle_ShouldUseDefaultThresholdWhenNotConfigured` at line 69) — adapt rather than add.
+
+5. **Dependencies — remove the hedge.** The spec says "If the Application project does not yet reference [`Microsoft.Extensions.Options.ConfigurationExtensions`] directly, add a `PackageReference`." Verified `Microsoft.Extensions.Configuration.Binder` is already referenced and `services.Configure<T>(IConfiguration)` is in active use across other modules without any new package reference. Drop the hedge — no package edit required.
+
+6. **NFR-4 — clarify scope.** The spec says the Application project "must not gain (and ideally should lose…) a direct dependency on `Microsoft.Extensions.Configuration.Abstractions` for this handler." Clarify: removing the dep from the **handler** is the goal; the **project** will continue to reference `Microsoft.Extensions.Configuration.Abstractions` because `AnalyticsModule` (and many other modules) still legitimately consume `IConfiguration` at the module's composition seam. That is correct per existing patterns and not a violation.
+
+## Prerequisites
+
+None blocking. Specifically:
+
+- **No new package references.** Verified `Microsoft.Extensions.Configuration.Binder` already in `Anela.Heblo.Application.csproj`.
+- **No configuration changes.** Section `"InvoiceImport"` and key names `MinimumDailyThreshold` / `DefaultDaysBack` remain identical. `appsettings*.json` and Azure Key Vault entries continue to bind without edit.
+- **No migration, no infrastructure work, no feature flag.**
+- **No deployment-time coupling.** Single PR contains all changes.
+
+Ready for implementation as-is.

--- a/artifacts/feat-arch-review-analytics-iconfiguration-inj/brief.md
+++ b/artifacts/feat-arch-review-analytics-iconfiguration-inj/brief.md
@@ -1,0 +1,39 @@
+## Module
+Analytics
+
+## Finding
+`GetInvoiceImportStatisticsHandler` (Application layer) directly injects `Microsoft.Extensions.Configuration.IConfiguration` and reads raw key paths from it:
+
+```csharp
+// GetInvoiceImportStatisticsHandler.cs, lines 12, 16, 28-29
+using Microsoft.Extensions.Configuration;
+...
+private readonly IConfiguration _configuration;
+...
+var minimumThreshold = _configuration.GetValue<int>("InvoiceImport:MinimumDailyThreshold", 10);
+var defaultDaysBack = _configuration.GetValue<int>("InvoiceImport:DefaultDaysBack", 14);
+```
+
+File: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`, lines 12–29.
+
+## Why it matters
+`IConfiguration` is a Microsoft infrastructure type — it belongs in the composition root, not in Application-layer handlers. Injecting it here violates the Dependency Inversion Principle: the handler depends on a concrete infrastructure abstraction rather than a domain-owned options type. In practice it also makes the handler harder to unit-test (callers must set up a full `IConfiguration` mock with exact key paths instead of just supplying a typed options object).
+
+## Suggested fix
+1. Add a typed options class in the module:
+   ```csharp
+   // Application/Features/Analytics/AnalyticsOptions.cs
+   public class InvoiceImportOptions
+   {
+       public int MinimumDailyThreshold { get; set; } = 10;
+       public int DefaultDaysBack { get; set; } = 14;
+   }
+   ```
+2. Register it in `AnalyticsModule.cs`:
+   ```csharp
+   services.Configure<InvoiceImportOptions>(configuration.GetSection("InvoiceImport"));
+   ```
+3. Replace `IConfiguration` with `IOptions<InvoiceImportOptions>` in the handler constructor.
+
+---
+_Filed by daily arch-review routine on 2026-06-07._

--- a/artifacts/feat-arch-review-analytics-iconfiguration-inj/impl/main.r1.md
+++ b/artifacts/feat-arch-review-analytics-iconfiguration-inj/impl/main.r1.md
@@ -1,0 +1,54 @@
+All four tasks are complete. Here is the output summary:
+
+---
+
+# Implementation: Replace `IConfiguration` with `IOptions<InvoiceImportOptions>` in `GetInvoiceImportStatisticsHandler`
+
+## What was implemented
+
+Refactored the Analytics module to replace direct `IConfiguration` injection in `GetInvoiceImportStatisticsHandler` with a typed `InvoiceImportOptions` class bound via the standard .NET Options pattern. This removes the infrastructure dependency from the Application layer and eliminates the need for `ConfigurationBuilder` boilerplate in unit tests.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Analytics/InvoiceImportOptions.cs` — new options POCO with `ConfigurationKey = "InvoiceImport"`, `MinimumDailyThreshold = 10`, `DefaultDaysBack = 14`
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` — added `IConfiguration configuration` parameter, added `services.Configure<InvoiceImportOptions>(...)` as first registration
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — updated `services.AddAnalyticsModule()` → `services.AddAnalyticsModule(configuration)` at line 74
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs` — replaced `IConfiguration` field/ctor param with `IOptions<InvoiceImportOptions>`, reads `_options.MinimumDailyThreshold` / `_options.DefaultDaysBack`
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` — replaced `ConfigurationBuilder` setup with `Options.Create(new InvoiceImportOptions {...})` in all 4 existing tests; added `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless` defaults-lock test
+
+## Tests
+
+`GetInvoiceImportStatisticsHandlerTests.cs` — 5 test methods (6 runs due to `[Theory]`), all green:
+- `Handle_ShouldReturnStatisticsWithMinimumThreshold`
+- `Handle_ShouldUseDefaultThresholdWhenNotConfigured`
+- `Handle_ShouldUseConfigurableDefaultDaysBack`
+- `Handle_ShouldPassCorrectDateTypeToRepository` (2 InlineData cases)
+- `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless` (new)
+
+## How to verify
+
+```bash
+dotnet build backend/Anela.Heblo.Backend.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetInvoiceImportStatisticsHandlerTests"
+```
+
+## Notes
+
+- No new package references were needed — `Microsoft.Extensions.Configuration.Binder` was already in the Application project
+- Minor test overlap exists between the defaults-lock test and `Handle_ShouldUseDefaultThresholdWhenNotConfigured` (both verify threshold=10 with empty options), noted as low-severity maintenance concern by code quality reviewer — not a correctness issue
+- `InvoiceImportStatisticsTile` confirmed unaffected (does not read `InvoiceImport:*` config)
+
+## PR Summary
+
+Refactored `GetInvoiceImportStatisticsHandler` to use `IOptions<InvoiceImportOptions>` instead of raw `IConfiguration`, restoring Clean Architecture boundaries in the Application layer. The handler no longer depends on `Microsoft.Extensions.Configuration` — it reads typed properties from a POCO that is bound once in `AnalyticsModule` at DI registration time. Unit tests now construct options with `Options.Create(new InvoiceImportOptions {...})` instead of building an `IConfigurationRoot`, and a new defaults-lock test protects the 10/14 fallback values explicitly.
+
+### Changes
+- `Features/Analytics/InvoiceImportOptions.cs` — new typed options class with `ConfigurationKey` constant and defaults
+- `Features/Analytics/AnalyticsModule.cs` — accepts `IConfiguration`, binds `InvoiceImportOptions` to `"InvoiceImport"` section
+- `ApplicationModule.cs` — passes `configuration` to `AddAnalyticsModule`
+- `UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs` — constructor and reads migrated to typed options
+- `Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` — all tests migrated to `Options.Create`, one new defaults-lock test added
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-analytics-iconfiguration-inj/spec.r1.md
+++ b/artifacts/feat-arch-review-analytics-iconfiguration-inj/spec.r1.md
@@ -1,0 +1,138 @@
+# Specification: Replace `IConfiguration` injection in `GetInvoiceImportStatisticsHandler` with typed options
+
+## Summary
+Refactor `GetInvoiceImportStatisticsHandler` in the Analytics module so it no longer depends on `Microsoft.Extensions.Configuration.IConfiguration`. Introduce a typed `InvoiceImportOptions` class, bind it to the existing `InvoiceImport` configuration section in `AnalyticsModule`, and inject `IOptions<InvoiceImportOptions>` into the handler. This restores Clean Architecture boundaries (no infrastructure types in the Application layer) and simplifies unit testing.
+
+## Background
+The daily architecture review routine flagged `GetInvoiceImportStatisticsHandler` (Application layer) for directly injecting `IConfiguration` and reading raw key paths (`InvoiceImport:MinimumDailyThreshold`, `InvoiceImport:DefaultDaysBack`).
+
+`IConfiguration` is an infrastructure abstraction owned by `Microsoft.Extensions.Configuration`. Application-layer handlers should depend on domain-owned, strongly-typed options instead, per the Dependency Inversion Principle and the project's Clean Architecture/Vertical Slice conventions (see `docs/architecture/development_guidelines.md`).
+
+Concretely, this causes two issues:
+1. **Architectural leak** — the Application project takes a transitive dependency on raw configuration semantics and string key paths.
+2. **Test friction** — unit tests must construct an `IConfigurationRoot` (or mock `IConfiguration.GetValue<T>` extension behavior, which is non-trivial) instead of passing a plain options object.
+
+The fix is small, isolated to the Analytics module, and follows the standard .NET Options pattern.
+
+## Functional Requirements
+
+### FR-1: Introduce `InvoiceImportOptions` typed options class
+Add a new options class in the Analytics module that mirrors the existing `InvoiceImport` configuration section.
+
+- Namespace: `Anela.Heblo.Application.Features.Analytics` (or the existing module-level namespace used by the Analytics slice — match neighbors).
+- File location: `backend/src/Anela.Heblo.Application/Features/Analytics/InvoiceImportOptions.cs` (or the conventional location for module-level options in this codebase — match existing examples if any).
+- Class shape:
+  ```csharp
+  public class InvoiceImportOptions
+  {
+      public int MinimumDailyThreshold { get; set; } = 10;
+      public int DefaultDaysBack { get; set; } = 14;
+  }
+  ```
+- Property defaults must match the current fallback values passed to `GetValue<int>` (`10` and `14`) so behavior is identical when the section is missing.
+
+**Acceptance criteria:**
+- Class exists with both properties and the documented defaults.
+- Class is `public` and accessible from the Analytics handler and from `AnalyticsModule`.
+- No dependencies on `Microsoft.Extensions.Configuration` are introduced in the class itself.
+
+### FR-2: Register `InvoiceImportOptions` in `AnalyticsModule`
+Bind the options class to the existing `InvoiceImport` configuration section in the Analytics module's service-registration entry point.
+
+- Locate `AnalyticsModule.cs` (the module's `AddAnalyticsModule` / equivalent registration method).
+- Add: `services.Configure<InvoiceImportOptions>(configuration.GetSection("InvoiceImport"));`
+- The configuration section name (`"InvoiceImport"`) must match the key prefix currently used by the handler. Do not rename the section — existing `appsettings.json` / Key Vault entries must continue to bind without changes.
+
+**Acceptance criteria:**
+- `AnalyticsModule` registers `InvoiceImportOptions` against the `"InvoiceImport"` section.
+- Existing configuration values in `appsettings*.json` and Azure Key Vault continue to bind to the new options without any deployment-side changes.
+- If the module registration method does not already accept `IConfiguration`, follow the established pattern used by other modules in this codebase (do not invent a new pattern).
+
+### FR-3: Replace `IConfiguration` with `IOptions<InvoiceImportOptions>` in the handler
+Update `GetInvoiceImportStatisticsHandler` to depend on `IOptions<InvoiceImportOptions>` instead of `IConfiguration`.
+
+- File: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`.
+- Remove `using Microsoft.Extensions.Configuration;`.
+- Remove the `IConfiguration _configuration` field and its constructor parameter.
+- Add a constructor parameter `IOptions<InvoiceImportOptions> invoiceImportOptions` and store its `.Value` (or the `IOptions<T>` itself — match the convention used elsewhere in this codebase; storing `.Value` is the simpler default since the options are not expected to change at runtime here).
+- Replace the two `GetValue<int>` reads with the corresponding options properties:
+  - `_configuration.GetValue<int>("InvoiceImport:MinimumDailyThreshold", 10)` → `_options.MinimumDailyThreshold`
+  - `_configuration.GetValue<int>("InvoiceImport:DefaultDaysBack", 14)` → `_options.DefaultDaysBack`
+
+**Acceptance criteria:**
+- The handler no longer references `IConfiguration` or `Microsoft.Extensions.Configuration`.
+- Handler behavior is identical for every combination of present/missing configuration values that the prior implementation supported (defaults `10` and `14` apply when the section is absent).
+- Constructor signature change does not break other call sites (the handler is constructed by DI; no manual callers should exist outside tests).
+
+### FR-4: Update unit tests to use the typed options
+Update any existing unit tests for `GetInvoiceImportStatisticsHandler` to pass `IOptions<InvoiceImportOptions>` instead of mocking `IConfiguration`.
+
+- Use `Microsoft.Extensions.Options.Options.Create(new InvoiceImportOptions { ... })` to construct test instances.
+- Remove any `IConfiguration` mocks specific to the `"InvoiceImport:*"` keys.
+- Add at least one test that asserts the defaults (`10`, `14`) are used when an empty `InvoiceImportOptions` instance is supplied — this protects the default values explicitly.
+
+**Acceptance criteria:**
+- All previously passing tests for this handler continue to pass.
+- No test for this handler references `IConfiguration` anymore.
+- A test exists that verifies default values when the options object is constructed with its parameterless constructor.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. `IOptions<T>` resolution is a singleton DI lookup; switching from `IConfiguration.GetValue<int>` (which parses on every call) to a typed property access is, if anything, a marginal improvement. No benchmarking required.
+
+### NFR-2: Security
+No security impact. The values in question are operational thresholds, not secrets. Configuration source (appsettings + Key Vault) is unchanged.
+
+### NFR-3: Backwards compatibility
+Zero deployment-side changes required. The configuration section name (`"InvoiceImport"`) and key names (`MinimumDailyThreshold`, `DefaultDaysBack`) are preserved exactly, so existing `appsettings*.json` files and Azure Key Vault secrets continue to bind without modification.
+
+### NFR-4: Architectural conformance
+The Application project must not gain (and ideally should lose, if this was its only usage) a direct dependency on `Microsoft.Extensions.Configuration.Abstractions` for this handler. The options class itself depends only on `Microsoft.Extensions.Options` (transitively, via the standard Options pattern).
+
+### NFR-5: Validation
+After the change, the following must succeed:
+- `dotnet build` — clean build with no new warnings.
+- `dotnet format` — no formatting violations.
+- The unit-test project containing `GetInvoiceImportStatisticsHandler` tests — all green.
+
+## Data Model
+No changes to persistent or domain data models. The only new type is an in-process options POCO:
+
+| Type | Properties | Defaults |
+|------|-----------|----------|
+| `InvoiceImportOptions` | `int MinimumDailyThreshold`, `int DefaultDaysBack` | `10`, `14` |
+
+Bound from configuration section `InvoiceImport`:
+```json
+{
+  "InvoiceImport": {
+    "MinimumDailyThreshold": 10,
+    "DefaultDaysBack": 14
+  }
+}
+```
+
+## API / Interface Design
+No public API, HTTP endpoint, MediatR contract, or UI surface changes. The change is fully internal to the Analytics module's composition.
+
+- **Constructor change (internal):** `GetInvoiceImportStatisticsHandler(...)` — replaces `IConfiguration` parameter with `IOptions<InvoiceImportOptions>`.
+- **DI registration (internal):** `AnalyticsModule` — adds one `services.Configure<InvoiceImportOptions>(...)` call.
+
+The MediatR request/response contract for `GetInvoiceImportStatistics` is unchanged.
+
+## Dependencies
+- **`Microsoft.Extensions.Options`** — already a transitive dependency of any ASP.NET Core/.NET 8 app; no new package reference expected. If the Application project does not yet reference it directly, add a `PackageReference` to `Microsoft.Extensions.Options.ConfigurationExtensions` (needed for `services.Configure<T>(IConfiguration)`); this package is also typically already present transitively via `Microsoft.Extensions.Hosting` in the composition root.
+- **`AnalyticsModule`** — must already receive `IConfiguration` in its registration method (standard pattern in this codebase). Verify before implementation.
+
+## Out of Scope
+- Refactoring any other handlers that may use `IConfiguration` directly. This spec covers **only** `GetInvoiceImportStatisticsHandler`. A broader sweep is a separate effort.
+- Changing the configuration source, key names, or default values.
+- Adding `IOptionsSnapshot` / `IOptionsMonitor` for runtime reload — `IOptions<T>` (singleton) is sufficient for these settings.
+- Adding `DataAnnotations` validation or `ValidateOnStart` for `InvoiceImportOptions` — the existing handler had no validation either, and the two int fields with sensible defaults do not warrant it.
+- Documentation/comments on the options class beyond standard XML doc tags (omit unless they describe non-obvious constraints).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-analytics-iconfiguration-inj/task-plan.r1.md
+++ b/artifacts/feat-arch-review-analytics-iconfiguration-inj/task-plan.r1.md
@@ -1,0 +1,15 @@
+Now the self-review pass against the spec.
+
+**Spec coverage check:**
+- FR-1 (`InvoiceImportOptions` class with defaults 10/14) → Task 1.
+- FR-2 (`services.Configure<>` in `AnalyticsModule` using existing section name) → Task 2, Step 1.
+- FR-3 (handler swaps to `IOptions<>`, removes `IConfiguration` usings) → Task 3, Step 3.
+- FR-4 (tests use `Options.Create`, explicit default-value test added) → Task 3, Step 1 (new `Handler_ShouldUseDefaultsWhenOptionsAreParameterless`).
+- NFR-5 (build + format + tests green) → Task 4, Steps 2 & 3.
+- Arch review amendments — `ConfigurationKey` constant (Task 1), module signature change explicit (Task 2), `ApplicationModule.cs:74` call-site edit explicit (Task 2 Step 2), no new package reference (header), Tile not touched (File Structure section).
+
+**Placeholder scan:** No TBD / "implement later" / handwave validation steps. Every code step has full code. Every command has expected output.
+
+**Type consistency:** `InvoiceImportOptions.ConfigurationKey`, `MinimumDailyThreshold`, `DefaultDaysBack` — used identically across all tasks. Constructor `IOptions<InvoiceImportOptions> invoiceImportOptions` matches between handler code (Task 3 Step 3) and test usage (Task 3 Step 1).
+
+Plan saved to `artifacts/feat-arch-review-analytics-iconfiguration-inj/plan.r1.md`. Four tasks, each ending in a green build and a commit: (1) add `InvoiceImportOptions` POCO, (2) bind it in `AnalyticsModule` + update the single call site in `ApplicationModule.cs:74`, (3) swap the handler to `IOptions<>` and migrate all 4 existing tests + add a defaults-lock test, (4) final `dotnet format` / `dotnet build` / regression slice.

--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -71,7 +71,7 @@ public static class ApplicationModule
 
         // Register all feature modules
         services.AddConfigurationModule();
-        services.AddAnalyticsModule();
+        services.AddAnalyticsModule(configuration);
         services.AddBackgroundJobsModule();
         services.AddBankModule(configuration);
         services.AddCatalogModule(configuration);

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
@@ -9,6 +9,7 @@ using Anela.Heblo.Persistence.Features.Analytics;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using FluentValidation;
 using MediatR;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Anela.Heblo.Application.Features.Analytics;
@@ -19,8 +20,10 @@ namespace Anela.Heblo.Application.Features.Analytics;
 /// </summary>
 public static class AnalyticsModule
 {
-    public static IServiceCollection AddAnalyticsModule(this IServiceCollection services)
+    public static IServiceCollection AddAnalyticsModule(this IServiceCollection services, IConfiguration configuration)
     {
+        services.Configure<InvoiceImportOptions>(configuration.GetSection(InvoiceImportOptions.ConfigurationKey));
+
         // MediatR handlers are automatically registered by AddMediatR scan
 
         // Repository (implementation lives in the Persistence layer)

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/InvoiceImportOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/InvoiceImportOptions.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.Analytics;
+
+public class InvoiceImportOptions
+{
+    public const string ConfigurationKey = "InvoiceImport";
+
+    public int MinimumDailyThreshold { get; set; } = 10;
+    public int DefaultDaysBack { get; set; } = 14;
+}

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs
@@ -1,6 +1,6 @@
 using Anela.Heblo.Domain.Features.Analytics;
 using MediatR;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
 
@@ -10,14 +10,14 @@ namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportSt
 public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImportStatisticsRequest, GetInvoiceImportStatisticsResponse>
 {
     private readonly IAnalyticsRepository _analyticsRepository;
-    private readonly IConfiguration _configuration;
+    private readonly InvoiceImportOptions _options;
 
     public GetInvoiceImportStatisticsHandler(
         IAnalyticsRepository analyticsRepository,
-        IConfiguration configuration)
+        IOptions<InvoiceImportOptions> invoiceImportOptions)
     {
         _analyticsRepository = analyticsRepository;
-        _configuration = configuration;
+        _options = invoiceImportOptions.Value;
     }
 
     public async Task<GetInvoiceImportStatisticsResponse> Handle(
@@ -25,8 +25,8 @@ public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImpor
         CancellationToken cancellationToken)
     {
         // Get configuration values
-        var minimumThreshold = _configuration.GetValue<int>("InvoiceImport:MinimumDailyThreshold", 10);
-        var defaultDaysBack = _configuration.GetValue<int>("InvoiceImport:DefaultDaysBack", 14);
+        var minimumThreshold = _options.MinimumDailyThreshold;
+        var defaultDaysBack = _options.DefaultDaysBack;
 
         // Use provided days back or default from configuration
         var daysBack = request.DaysBack ?? defaultDaysBack;

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
@@ -1,7 +1,7 @@
+using Anela.Heblo.Application.Features.Analytics;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
 using Anela.Heblo.Domain.Features.Analytics;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -15,15 +15,12 @@ public class GetInvoiceImportStatisticsHandlerTests
     public GetInvoiceImportStatisticsHandlerTests()
     {
         _mockRepository = new Mock<IAnalyticsRepository>();
-        // Create a simple configuration for testing
-        var configurationBuilder = new ConfigurationBuilder();
-        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        var options = Options.Create(new InvoiceImportOptions
         {
-            { "InvoiceImport:MinimumDailyThreshold", "10" },
-            { "InvoiceImport:DefaultDaysBack", "14" }
+            MinimumDailyThreshold = 10,
+            DefaultDaysBack = 14
         });
-        var configuration = configurationBuilder.Build();
-        _handler = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, configuration);
+        _handler = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, options);
     }
 
     [Fact]
@@ -69,10 +66,9 @@ public class GetInvoiceImportStatisticsHandlerTests
     public async Task Handle_ShouldUseDefaultThresholdWhenNotConfigured()
     {
         // Arrange - Create handler with empty configuration
-        var emptyConfigurationBuilder = new ConfigurationBuilder();
-        emptyConfigurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>());
-        var emptyConfiguration = emptyConfigurationBuilder.Build();
-        var handlerWithEmptyConfig = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, emptyConfiguration);
+        var handlerWithEmptyConfig = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions()));
 
         var request = new GetInvoiceImportStatisticsRequest();
         var expectedData = new List<DailyInvoiceCount>();
@@ -95,14 +91,9 @@ public class GetInvoiceImportStatisticsHandlerTests
     public async Task Handle_ShouldUseConfigurableDefaultDaysBack()
     {
         // Arrange - Create handler with custom default days back
-        var customConfigurationBuilder = new ConfigurationBuilder();
-        customConfigurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            { "InvoiceImport:MinimumDailyThreshold", "10" },
-            { "InvoiceImport:DefaultDaysBack", "30" } // Custom default
-        });
-        var customConfiguration = customConfigurationBuilder.Build();
-        var handlerWithCustomConfig = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, customConfiguration);
+        var handlerWithCustomConfig = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions { DefaultDaysBack = 30 }));
 
         var request = new GetInvoiceImportStatisticsRequest(); // DaysBack = null to use default
         var expectedData = new List<DailyInvoiceCount>();
@@ -152,6 +143,35 @@ public class GetInvoiceImportStatisticsHandlerTests
             It.IsAny<DateTime>(),
             It.IsAny<DateTime>(),
             dateType,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless()
+    {
+        // Arrange
+        var handlerWithDefaults = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions()));
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ImportDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DailyInvoiceCount>());
+
+        var request = new GetInvoiceImportStatisticsRequest();
+
+        // Act
+        var result = await handlerWithDefaults.Handle(request, CancellationToken.None);
+
+        // Assert - defaults are 10 and 14
+        Assert.Equal(10, result.MinimumThreshold);
+        _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
+            It.Is<DateTime>(d => d.Date == DateTime.UtcNow.Date.AddDays(-14)),
+            It.IsAny<DateTime>(),
+            It.IsAny<ImportDateType>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION

Refactored `GetInvoiceImportStatisticsHandler` to use `IOptions<InvoiceImportOptions>` instead of raw `IConfiguration`, restoring Clean Architecture boundaries in the Application layer. The handler no longer depends on `Microsoft.Extensions.Configuration` — it reads typed properties from a POCO that is bound once in `AnalyticsModule` at DI registration time. Unit tests now construct options with `Options.Create(new InvoiceImportOptions {...})` instead of building an `IConfigurationRoot`, and a new defaults-lock test protects the 10/14 fallback values explicitly.

### Changes
- `Features/Analytics/InvoiceImportOptions.cs` — new typed options class with `ConfigurationKey` constant and defaults
- `Features/Analytics/AnalyticsModule.cs` — accepts `IConfiguration`, binds `InvoiceImportOptions` to `"InvoiceImport"` section
- `ApplicationModule.cs` — passes `configuration` to `AddAnalyticsModule`
- `UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs` — constructor and reads migrated to typed options
- `Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` — all tests migrated to `Options.Create`, one new defaults-lock test added

---

Closes #2698

### Tokens used
8016862
