### PR TITLE
feat: Remove unused `OrderIds` field from `PrintPickingListResult`

### DIFF
--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/arch-review.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/arch-review.r1.md
@@ -1,0 +1,151 @@
+# Architecture Review: Remove unused `OrderIds` field from `PrintPickingListResult`
+
+## Skip Design: true
+
+Backend-only DTO cleanup. No UI, no visual components, no layout changes.
+
+## Architectural Fit Assessment
+
+This is a surgical dead-code removal that **reinforces** existing architecture rather than altering it. Verified against the codebase:
+
+- `PrintPickingListResult` lives in `Anela.Heblo.Application.Features.Logistics.Picking` (relocated from Domain per the 2026-06-02 plan to satisfy Clean Architecture's dependency rule).
+- The DTO is **internal to the application layer**: it is consumed only by `LogisticsExpeditionPickingAdapter`, which translates it to the cross-feature `ExpeditionPickingResult` contract owned by ExpeditionList. It is not on the OpenAPI surface (confirmed — no references in `frontend/src/api/`), not persisted, and not on any MediatR contract returned to a controller.
+- The `OrderIds` field has exactly one producer-side path (`ShoptetApiExpeditionListSource.CreatePickingList` at line 227) which never sets it, and one consumer-side path (`LogisticsExpeditionPickingAdapter.CreatePickingListAsync` lines 32–36) which never reads it. Removal is mechanical.
+- Aligns with the project's stated **YAGNI** and **surgical changes** principles in `CLAUDE.md`.
+
+Repository-wide grep confirms the spec's claim: only three occurrences of `OrderIds` tied to `PrintPickingListResult` exist (definition, test arrange, and historical planning docs which are immutable artifacts and out of scope).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ ExpeditionList Feature (Application)                                │
+│   IExpeditionPickingSource ────► ExpeditionPickingResult            │
+│              ▲                     { ExportedFiles, TotalCount }    │
+│              │ implemented by                                       │
+└──────────────┼──────────────────────────────────────────────────────┘
+               │
+┌──────────────┴──────────────────────────────────────────────────────┐
+│ Logistics.Infrastructure (Application) — bridge                     │
+│   LogisticsExpeditionPickingAdapter                                 │
+│     ├─ delegates to IPickingListSource                              │
+│     └─ maps PrintPickingListResult ──► ExpeditionPickingResult      │
+│          { ExportedFiles, TotalCount[, OrderIds ✂ DELETE] }         │
+└──────────────┬──────────────────────────────────────────────────────┘
+               │ implemented by
+┌──────────────┴──────────────────────────────────────────────────────┐
+│ Adapters.ShoptetApi                                                 │
+│   ShoptetApiExpeditionListSource.CreatePickingList                  │
+│     returns new PrintPickingListResult { ExportedFiles, TotalCount }│
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+The cross-layer contract (`ExpeditionPickingResult`) never carried `OrderIds`. The deletion only narrows the inner DTO to match what producers actually populate and what the adapter actually consumes.
+
+### Key Design Decisions
+
+#### Decision 1: Delete the field outright rather than wire it through
+**Options considered:**
+1. Delete `OrderIds` from `PrintPickingListResult` and the test arrange line.
+2. Populate `OrderIds` in `ShoptetApiExpeditionListSource` and add a matching field to `ExpeditionPickingResult`.
+3. Mark `[Obsolete]` and defer removal.
+
+**Chosen approach:** Option 1 — delete.
+
+**Rationale:** No production caller requests `OrderIds`. There is no feature, telemetry need, or downstream consumer pulling for it. Option 2 builds infrastructure on speculation (violates YAGNI). Option 3 adds noise with no path to actual removal because this is an internal type with one producer and one consumer — there is no external contract to deprecate gracefully. Delete is reversible: the field can be re-added when a real consumer arrives, with the producer wired at the same time.
+
+#### Decision 2: Do not touch `ExpeditionPickingResult`
+**Options considered:** Touch the outer contract for symmetry vs. leave it alone.
+
+**Chosen approach:** Leave `ExpeditionPickingResult` untouched.
+
+**Rationale:** It never had `OrderIds`. The brief and spec correctly scope the change to the inner DTO. Modifying the outer contract would expand blast radius across the ExpeditionList feature for zero benefit.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Modify exactly two existing files:
+
+| File | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` | Delete line 7 (the `OrderIds` property). |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` | Delete line 60 (the `OrderIds = new List<int> { 1, 2, 3 },` initializer in `CreatePickingListAsync_TranslatesResultFields`). |
+
+Do **not** modify:
+- `ShoptetApiExpeditionListSource.cs` — already does not reference `OrderIds`.
+- `LogisticsExpeditionPickingAdapter.cs` — already does not reference `OrderIds`.
+- `ExpeditionPickingResult` or any ExpeditionList contract.
+- Other tests in `LogisticsExpeditionPickingAdapterTests.cs` — three tests use `new PrintPickingListResult()` with object-initializer defaults; they remain compile-clean after the property is gone.
+
+### Interfaces and Contracts
+
+Post-change shape of `PrintPickingListResult`:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Picking;
+
+public class PrintPickingListResult
+{
+    public IList<string> ExportedFiles { get; set; } = new List<string>();
+    public int TotalCount { get; set; }
+}
+```
+
+`IPickingListSource.CreatePickingList` signature unchanged. `IExpeditionPickingSource.CreatePickingListAsync` unchanged. No OpenAPI client regeneration needed (the DTO is not on the API surface).
+
+### Data Flow
+
+Unchanged in behaviour, narrowed in shape:
+
+```
+ShoptetApiExpeditionListSource.CreatePickingList
+    ├─ exportedFiles  ──┐
+    └─ processedCodes.Count ──┐
+                         │   │
+                         ▼   ▼
+        PrintPickingListResult { ExportedFiles, TotalCount }
+                         │   │
+                         ▼   ▼
+LogisticsExpeditionPickingAdapter.CreatePickingListAsync
+    └─ maps to ExpeditionPickingResult { ExportedFiles, TotalCount }
+                         │
+                         ▼
+            ExpeditionList consumer
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A hidden consumer reads `OrderIds` somewhere not caught by grep (e.g. reflection, serialization). | LOW | Verified: no JSON/System.Text.Json/Newtonsoft attributes on the type; not exposed via controller, MediatR result, EF entity, or OpenAPI generation. Repository-wide grep confirms only the three known sites. `dotnet build` will fail-fast on any compile-time reference. |
+| Other tests construct `PrintPickingListResult` with `OrderIds` set. | LOW | Verified: the other three uses in `LogisticsExpeditionPickingAdapterTests.cs` (lines 29, 89, 115) all use parameterless `new PrintPickingListResult()` — no field initializers to update. |
+| A future developer reintroduces the field without a producer. | LOW | The deletion itself removes the temptation. No automated guard needed for a one-property hygiene change. |
+| Concurrent in-flight branches reference `OrderIds`. | LOW | Solo developer per `CLAUDE.md`. Standard PR merge conflict resolution covers this. |
+
+## Specification Amendments
+
+None. The spec is correct, complete, and scoped appropriately:
+
+- FR-1, FR-2, FR-3 acceptance criteria match the codebase reality verified above.
+- NFR-2 (surgical scope) is already enforced by the file list.
+- Out-of-scope list correctly excludes `ExpeditionPickingResult`, frontend, and broader dead-code sweeps.
+
+One minor verification refinement worth recording during execution (not a spec change): when running FR-3's grep, expect to see remaining `OrderIds` matches in `docs/superpowers/plans/` (historical planning artifacts) and `frontend/src/features/grid-layout/` (unrelated `newOrderIds` callback) and an EF migration name (`ChangePurchaseOrderIdsToInt`). These are not references to `PrintPickingListResult.OrderIds` and should be ignored.
+
+## Prerequisites
+
+None. The change requires:
+
+- No database migration (DTO is not persisted).
+- No configuration update (no feature flag, no Key Vault secret).
+- No OpenAPI client regeneration (DTO is not on the API surface; `frontend/src/api/` will be unchanged).
+- No infrastructure change.
+- No coordination with other in-flight work beyond standard branch hygiene.
+
+Validation before completion (per `CLAUDE.md`):
+- `dotnet build` succeeds.
+- `dotnet format` produces no diff on the two edited files.
+- The four tests in `LogisticsExpeditionPickingAdapterTests` all pass.

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/brief.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/brief.md
@@ -1,0 +1,19 @@
+## Module
+ExpeditionList (found via Logistics integration chain)
+
+## Finding
+`PrintPickingListResult.OrderIds` in `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` (line 7) is declared and initialized to an empty list, but is never written to or read in any production code path:
+
+- **Producer** — `ShoptetApiExpeditionListSource.CreatePickingList` (`backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs`, line 229) returns `new PrintPickingListResult { ExportedFiles = ..., TotalCount = ... }` and never sets `OrderIds`.
+- **Consumer** — `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` (`backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs`, lines 16–22) maps only `ExportedFiles` and `TotalCount` to `ExpeditionPickingResult`; `OrderIds` is silently discarded. `ExpeditionPickingResult` has no corresponding field.
+
+The only place `OrderIds` appears outside its definition is in the test arrange step (`backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs`, line 60), where it is set but not asserted — confirming it is not mapped through.
+
+## Why it matters
+YAGNI: the field signals to future developers that order IDs are available in this result object, when in practice they are always the empty list initialized at construction. Any code written to read `OrderIds` will silently see an empty collection, producing a silent logic error that is hard to diagnose.
+
+## Suggested fix
+Remove `OrderIds` from `PrintPickingListResult`. Update `LogisticsExpeditionPickingAdapterTests.CreatePickingListAsync_TranslatesResultFields` to remove the unused `OrderIds = new List<int> { 1, 2, 3 }` from the arrange step (it adds setup complexity without exercising any real behaviour).
+
+---
+_Filed by daily arch-review routine on 2026-06-07._

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/impl/main.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/impl/main.r1.md
@@ -1,0 +1,44 @@
+All tasks complete. Here is the output artifact:
+
+---
+
+# Implementation: Remove unused `OrderIds` field from `PrintPickingListResult`
+
+## What was implemented
+
+Removed the dead `OrderIds` property from the internal application-layer DTO `PrintPickingListResult` and removed its corresponding unused arrange step from the adapter test. The field was initialized empty, never written by any producer (`ShoptetApiExpeditionListSource.CreatePickingList`), and never read by any consumer (`LogisticsExpeditionPickingAdapter.CreatePickingListAsync`). Exactly two lines deleted across two files; no runtime behaviour change.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` — removed `public IList<int> OrderIds { get; set; } = new List<int>();` (line 7)
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — removed `OrderIds = new List<int> { 1, 2, 3 },` from the arrange block of `CreatePickingListAsync_TranslatesResultFields`
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — all 4 existing tests pass; `CreatePickingListAsync_TranslatesResultFields` retains its assertions on `ExportedFiles` and `TotalCount`
+
+## How to verify
+
+```bash
+cd backend
+dotnet build Anela.Heblo.sln --nologo            # Build succeeded, 0 errors
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~LogisticsExpeditionPickingAdapterTests" --nologo  # Failed: 0, Passed: 4
+grep -rn "OrderIds" src/Anela.Heblo.Application/Features/Logistics/ --include="*.cs"  # no output
+git log -1 --stat                                # 2 files changed, 2 deletions(-)
+```
+
+## Notes
+
+Baseline confirmed 70 warnings before the change; post-change build also shows 70 warnings (no regression). `dotnet format --verify-no-changes` confirmed no formatting drift. The `OrderIds` symbol still appears in the repo in unrelated places (`ChangePurchaseOrderIdsToInt` EF migration name, React `newOrderIds` callback) — none of these reference `PrintPickingListResult.OrderIds`.
+
+## PR Summary
+
+Removes `PrintPickingListResult.OrderIds`, a dead property that was initialized to an empty list by the constructor default but never populated by `ShoptetApiExpeditionListSource.CreatePickingList` and never consumed by `LogisticsExpeditionPickingAdapter.CreatePickingListAsync`. The field violated YAGNI and created a misleading API surface that could lead a future developer to rely on it and produce a silent logic error. The cross-feature contract `ExpeditionPickingResult` never had `OrderIds` and is untouched; the OpenAPI surface is unaffected.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` — deleted the `OrderIds` property declaration
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — deleted the dead `OrderIds` initializer from the `CreatePickingListAsync_TranslatesResultFields` arrange block
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/spec.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/spec.r1.md
@@ -1,0 +1,76 @@
+# Specification: Remove unused `OrderIds` field from `PrintPickingListResult`
+
+## Summary
+Remove the dead `OrderIds` property from `PrintPickingListResult` and clean up the corresponding unused test arrange step. The field is initialized but never written by producers nor read by consumers, creating a misleading API surface that risks silent logic errors if future code attempts to use it.
+
+## Background
+A daily architecture review on 2026-06-07 flagged `PrintPickingListResult.OrderIds` as dead code in the ExpeditionList feature's Logistics integration chain:
+
+- **Definition:** `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs:7` — declared as `List<int>` initialized to an empty list.
+- **Producer:** `ShoptetApiExpeditionListSource.CreatePickingList` (`backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs:229`) constructs the result with only `ExportedFiles` and `TotalCount`; never sets `OrderIds`.
+- **Consumer:** `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` (`backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs:16-22`) maps only `ExportedFiles` and `TotalCount` into `ExpeditionPickingResult`; `OrderIds` is silently discarded, and `ExpeditionPickingResult` has no equivalent field.
+- **Test:** `LogisticsExpeditionPickingAdapterTests.CreatePickingListAsync_TranslatesResultFields` (`backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs:60`) sets `OrderIds = new List<int> { 1, 2, 3 }` in arrange but never asserts on it.
+
+The field violates YAGNI: it advertises a capability that does not exist. A future developer reading the result type may write code that consumes `OrderIds`, observe an empty list, and produce a silent logic error that is difficult to diagnose because no exception is thrown and no compiler warning is raised.
+
+## Functional Requirements
+
+### FR-1: Remove `OrderIds` from `PrintPickingListResult`
+Delete the `OrderIds` property from `PrintPickingListResult.cs`. No other production code references this property, so no replacement or migration is required.
+
+**Acceptance criteria:**
+- `PrintPickingListResult.cs` no longer declares an `OrderIds` property.
+- `grep -r "OrderIds" backend/src/Anela.Heblo.Application/Features/Logistics/` returns no matches against `PrintPickingListResult`.
+- `dotnet build` succeeds across the solution.
+
+### FR-2: Clean up unused test arrange step
+Remove the `OrderIds = new List<int> { 1, 2, 3 }` initializer from the arrange section of `CreatePickingListAsync_TranslatesResultFields`. The test currently sets a field it never asserts; with FR-1 applied, the initializer would fail to compile.
+
+**Acceptance criteria:**
+- The `OrderIds` initializer is removed from `LogisticsExpeditionPickingAdapterTests.cs`.
+- The test `CreatePickingListAsync_TranslatesResultFields` continues to assert that `ExportedFiles` and `TotalCount` are correctly translated.
+- No other assertions or test cases are altered.
+
+### FR-3: Verify no hidden consumers
+Confirm via repository-wide search that no other production code, serialization contract, or external consumer reads `PrintPickingListResult.OrderIds` before deletion. Because `PrintPickingListResult` is an internal application-layer DTO (not part of the OpenAPI surface), no client regeneration is expected.
+
+**Acceptance criteria:**
+- Repository-wide search for `OrderIds` returns no remaining references tied to `PrintPickingListResult` after the change.
+- Generated OpenAPI client (`frontend/src/api/`) is unchanged, confirming the field was not exposed externally.
+
+## Non-Functional Requirements
+
+### NFR-1: Behaviour preservation
+No runtime behaviour change. Producers, consumers, and downstream `ExpeditionPickingResult` mapping are unaffected because `OrderIds` was never written or read in production.
+
+### NFR-2: Surgical scope
+Touch only the three identified files. Do not refactor adjacent code, rename symbols, reorder properties, or reformat unrelated lines.
+
+### NFR-3: Test coverage maintained
+Existing test coverage of `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` for `ExportedFiles` and `TotalCount` must remain intact. The arrange-step cleanup must not weaken any assertion.
+
+## Data Model
+`PrintPickingListResult` (application-layer DTO) currently contains:
+- `ExportedFiles` — collection of generated picking-list files (retained)
+- `TotalCount` — number of orders included (retained)
+- `OrderIds` — `List<int>`, initialized empty, never populated (**to be removed**)
+
+`ExpeditionPickingResult` (downstream domain result) is unchanged; it has no `OrderIds` field and never did.
+
+## API / Interface Design
+No public API or external interface changes. `PrintPickingListResult` is internal to the application layer and is not serialized to any HTTP response, OpenAPI contract, MediatR contract exposed to clients, or persistence schema.
+
+## Dependencies
+None. The change is confined to one DTO file in `Anela.Heblo.Application` and one test file in `Anela.Heblo.Tests`. No NuGet packages, configuration, migrations, or external services are involved.
+
+## Out of Scope
+- Renaming, restructuring, or otherwise modifying `ExpeditionPickingResult` or any other type in the Logistics or Picking namespaces.
+- Adding new fields, telemetry, or logging to the picking-list flow.
+- Refactoring `ShoptetApiExpeditionListSource.CreatePickingList` or `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` beyond what is necessary for the field removal (which is nothing — neither file references `OrderIds`).
+- Frontend changes; the field is not exposed via the OpenAPI client.
+- Broader dead-code sweeps in the Logistics module.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/task-plan.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/task-plan.r1.md
@@ -1,0 +1,13 @@
+Implementation plan saved to `docs/superpowers/plans/2026-06-10-remove-orderids-from-printpickinglistresult.md`.
+
+The plan decomposes the spec into 7 tasks with checkbox-tracked steps:
+
+1. **Baseline** — confirm the 4 adapter tests pass and solution builds clean before any edit.
+2. **Repository search** — verify only the two expected `OrderIds` callsites exist (FR-3 pre-check).
+3. **Delete the DTO property** — single-line removal from `PrintPickingListResult.cs`, then build to confirm the failure now points only at the test arrange line (intentional RED).
+4. **Delete the test arrange line** — remove `OrderIds = new List<int> { 1, 2, 3 },` from `CreatePickingListAsync_TranslatesResultFields`, rebuild GREEN, run all 4 tests.
+5. **Post-change grep** — confirm zero `OrderIds` references remain in the Logistics namespace, and `frontend/src/api/` is untouched.
+6. **Project gates** — `dotnet build`, `dotnet format --verify-no-changes`, full `dotnet test`.
+7. **Commit** — exact staged-diff verification (two hunks, two minus-lines) before commit.
+
+Every step has the concrete command, expected output, and a stop-condition for unexpected results. Coverage check against the spec: FR-1 (Task 3), FR-2 (Task 4), FR-3 (Tasks 2 + 5), NFR-1/NFR-3 (Tasks 4.3 + 6.3), NFR-2 (Task 7.2 staged-diff guard).

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs
@@ -4,5 +4,4 @@ public class PrintPickingListResult
 {
     public IList<string> ExportedFiles { get; set; } = new List<string>();
     public int TotalCount { get; set; }
-    public IList<int> OrderIds { get; set; } = new List<int>();
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs
@@ -57,7 +57,6 @@ public class LogisticsExpeditionPickingAdapterTests
         {
             ExportedFiles = new List<string> { "/tmp/a.pdf", "/tmp/b.pdf" },
             TotalCount = 12,
-            OrderIds = new List<int> { 1, 2, 3 },
         };
         _innerSource
             .Setup(x => x.CreatePickingList(

--- a/docs/superpowers/plans/2026-06-10-remove-orderids-from-printpickinglistresult.md
+++ b/docs/superpowers/plans/2026-06-10-remove-orderids-from-printpickinglistresult.md
@@ -1,0 +1,409 @@
+# Remove `OrderIds` from `PrintPickingListResult` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the unused `OrderIds` property from the application-layer DTO `PrintPickingListResult` and remove the corresponding dead arrange step in `LogisticsExpeditionPickingAdapterTests`, eliminating a misleading API surface that no producer writes and no consumer reads.
+
+**Architecture:** Surgical two-file deletion confined to `Anela.Heblo.Application.Features.Logistics.Picking` and its tests. No production runtime behaviour change: `OrderIds` was always initialized empty, never populated by `ShoptetApiExpeditionListSource.CreatePickingList`, and never read by `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` when mapping to the outer `ExpeditionPickingResult`. The cross-feature contract `ExpeditionPickingResult` is untouched (it never had `OrderIds`). No OpenAPI surface change (the DTO is internal, not on a controller, MediatR result, or persisted entity).
+
+**Tech Stack:** .NET 8, xUnit, FluentAssertions, Moq. Solution path: `backend/Anela.Heblo.sln`.
+
+---
+
+## Pre-flight Context (read once before Task 1)
+
+Files in scope for this entire plan:
+
+| Path | Role |
+|------|------|
+| `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` | DTO definition — delete `OrderIds` property. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` | Tests — delete `OrderIds = new List<int> { 1, 2, 3 }` arrange line in `CreatePickingListAsync_TranslatesResultFields`. |
+
+Files **NOT** to modify (verified by spec + arch review):
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs` — does not reference `OrderIds`.
+- `backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs` — does not reference `OrderIds`.
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingResult.cs` — never had `OrderIds`.
+- `frontend/src/api/` — generated OpenAPI client; the DTO is not on the API surface, no regeneration needed.
+
+Current state of `PrintPickingListResult.cs` (8 lines total):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Picking;
+
+public class PrintPickingListResult
+{
+    public IList<string> ExportedFiles { get; set; } = new List<string>();
+    public int TotalCount { get; set; }
+    public IList<int> OrderIds { get; set; } = new List<int>();
+}
+```
+
+Current state of the relevant test (`CreatePickingListAsync_TranslatesResultFields`, lines 52–76):
+
+```csharp
+[Fact]
+public async Task CreatePickingListAsync_TranslatesResultFields()
+{
+    // Arrange
+    var innerResult = new PrintPickingListResult
+    {
+        ExportedFiles = new List<string> { "/tmp/a.pdf", "/tmp/b.pdf" },
+        TotalCount = 12,
+        OrderIds = new List<int> { 1, 2, 3 },
+    };
+    _innerSource
+        .Setup(x => x.CreatePickingList(
+            It.IsAny<PrintPickingListRequest>(),
+            It.IsAny<Func<IList<string>, Task>?>(),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(innerResult);
+
+    // Act
+    var result = await CreateAdapter().CreatePickingListAsync(
+        new ExpeditionPickingRequest(), onBatchFilesReady: null);
+
+    // Assert
+    result.ExportedFiles.Should().BeEquivalentTo(new[] { "/tmp/a.pdf", "/tmp/b.pdf" });
+    result.TotalCount.Should().Be(12);
+}
+```
+
+The other three tests in the same file construct `new PrintPickingListResult()` with no property initializers — they remain compile-clean.
+
+---
+
+## Task 1: Establish baseline — confirm all touched tests pass before changing anything
+
+**Why this step exists:** The arch review states the four tests in `LogisticsExpeditionPickingAdapterTests` currently pass. Verify that baseline so a post-change failure can be attributed to this plan, not pre-existing breakage.
+
+**Files:** none modified (read-only verification).
+
+- [ ] **Step 1.1: Run the entire adapter test class against `main` state**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln \
+  --filter "FullyQualifiedName~LogisticsExpeditionPickingAdapterTests" \
+  --nologo
+```
+
+Expected output (substring): `Passed!  - Failed: 0, Passed: 4, Skipped: 0`
+
+If any test fails here, **stop**. The failure is pre-existing and out of scope; report it and do not proceed.
+
+- [ ] **Step 1.2: Verify the solution builds clean before edits**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. Warning count must be recorded — the post-change build must not introduce new warnings.
+
+---
+
+## Task 2: Repository-wide search — confirm only the three expected `OrderIds` callsites on `PrintPickingListResult` exist
+
+**Why this step exists:** FR-3 of the spec demands proof that no hidden consumer reads `OrderIds`. Arch review expects exactly two production-relevant matches (definition + test arrange) plus historical planning artifacts and unrelated symbols (the `newOrderIds` React callback, the `ChangePurchaseOrderIdsToInt` EF migration).
+
+**Files:** none modified.
+
+- [ ] **Step 2.1: Grep the entire repository for `OrderIds`**
+
+Run:
+
+```bash
+grep -rn "OrderIds" backend/src backend/test \
+  --include="*.cs" \
+  --exclude-dir=bin --exclude-dir=obj
+```
+
+Expected matches (exactly these two files for `PrintPickingListResult`):
+
+```
+backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs:7:    public IList<int> OrderIds { get; set; } = new List<int>();
+backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs:60:            OrderIds = new List<int> { 1, 2, 3 },
+```
+
+Other `OrderIds` hits inside `backend/` (if any) must come from unrelated symbols — most commonly a `ChangePurchaseOrderIdsToInt` EF migration or other domain types. They must **not** reference `PrintPickingListResult.OrderIds`.
+
+If any *new* production reference to `PrintPickingListResult.OrderIds` appears (e.g. a producer setting it, a consumer reading it), **stop**. The spec's premise no longer holds and this plan is invalid.
+
+- [ ] **Step 2.2: Confirm the frontend generated client does not reference `OrderIds` from this DTO**
+
+Run:
+
+```bash
+grep -rn "OrderIds" frontend/src/api/ 2>/dev/null || echo "no matches"
+```
+
+Expected: `no matches` (the DTO is internal — not on the OpenAPI surface).
+
+If matches appear, inspect them. They must not relate to `PrintPickingListResult`; if any do, stop and escalate — the spec's assumption that the DTO is internal-only would be wrong.
+
+---
+
+## Task 3: Delete `OrderIds` from `PrintPickingListResult`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs`
+
+- [ ] **Step 3.1: Remove the `OrderIds` property line**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs`.
+
+Replace the entire file contents with:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Picking;
+
+public class PrintPickingListResult
+{
+    public IList<string> ExportedFiles { get; set; } = new List<string>();
+    public int TotalCount { get; set; }
+}
+```
+
+The change is deleting line 7 (`public IList<int> OrderIds { get; set; } = new List<int>();`). No other line is altered. Namespace and class declaration are unchanged.
+
+- [ ] **Step 3.2: Verify the build now fails on the dead test arrange line (RED)**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: build fails with a `CS0117` (or equivalent) error pointing at `LogisticsExpeditionPickingAdapterTests.cs` line 60 — `'PrintPickingListResult' does not contain a definition for 'OrderIds'`.
+
+This is the intended RED state for the next task. If the build instead **succeeds**, that means the test arrange was not where this plan thinks it is — stop and re-read both files before proceeding.
+
+If the build fails with errors in any file other than `LogisticsExpeditionPickingAdapterTests.cs`, stop. A hidden consumer exists that the architecture review missed; revert Step 3.1 and escalate.
+
+---
+
+## Task 4: Remove the dead test arrange step
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs`
+
+- [ ] **Step 4.1: Delete the `OrderIds` initializer line in `CreatePickingListAsync_TranslatesResultFields`**
+
+Edit `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs`.
+
+Find the arrange block in `CreatePickingListAsync_TranslatesResultFields` (line 56–61) which currently reads:
+
+```csharp
+        var innerResult = new PrintPickingListResult
+        {
+            ExportedFiles = new List<string> { "/tmp/a.pdf", "/tmp/b.pdf" },
+            TotalCount = 12,
+            OrderIds = new List<int> { 1, 2, 3 },
+        };
+```
+
+Replace with:
+
+```csharp
+        var innerResult = new PrintPickingListResult
+        {
+            ExportedFiles = new List<string> { "/tmp/a.pdf", "/tmp/b.pdf" },
+            TotalCount = 12,
+        };
+```
+
+That is, drop the `OrderIds = new List<int> { 1, 2, 3 },` line. Do not touch any other line in the method, the file, the assertions, or the other three tests (`CreatePickingListAsync_TranslatesRequestFieldsOneToOne`, `CreatePickingListAsync_PassesCallbackThroughVerbatim`, `CreatePickingListAsync_PassesCancellationTokenThrough`).
+
+- [ ] **Step 4.2: Verify the solution builds clean (GREEN compile)**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. Warning count must equal the baseline recorded in Step 1.2 — no new warnings introduced.
+
+If the build still fails, the failure location reveals an unexpected consumer. Stop and escalate; do not paper over by editing additional files outside the plan's two-file scope.
+
+- [ ] **Step 4.3: Run the adapter test class — all four tests must still pass**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln \
+  --filter "FullyQualifiedName~LogisticsExpeditionPickingAdapterTests" \
+  --nologo
+```
+
+Expected output (substring): `Passed!  - Failed: 0, Passed: 4, Skipped: 0`
+
+The assertions in `CreatePickingListAsync_TranslatesResultFields` were never about `OrderIds`; removing the arrange line cannot change behaviour. If any test now fails, the change in Task 3 or Task 4 deviated from the plan — diff against the snippets above before doing anything else.
+
+---
+
+## Task 5: Final verification — repository-wide grep is clean
+
+**Why this step exists:** FR-1 and FR-3 both require post-change repository search to confirm no lingering `PrintPickingListResult.OrderIds` references.
+
+**Files:** none modified.
+
+- [ ] **Step 5.1: Confirm `OrderIds` no longer appears in the Logistics namespace**
+
+Run:
+
+```bash
+grep -rn "OrderIds" \
+  backend/src/Anela.Heblo.Application/Features/Logistics \
+  backend/test/Anela.Heblo.Tests/Features/Logistics \
+  --include="*.cs"
+```
+
+Expected: **no output**. Any remaining match means either Task 3 or Task 4 was applied incorrectly — re-read the file and re-apply.
+
+- [ ] **Step 5.2: Confirm no producer-side regression in the Shoptet adapter**
+
+Run:
+
+```bash
+grep -n "OrderIds" \
+  backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+```
+
+Expected: **no output**. (Arch review verified this file never referenced `OrderIds`. This grep is a defensive double-check.)
+
+- [ ] **Step 5.3: Confirm OpenAPI client is unchanged**
+
+Run:
+
+```bash
+git status frontend/src/api/
+```
+
+Expected: clean — no modifications. Confirms the DTO was not on the API surface.
+
+---
+
+## Task 6: Validate full project gates (per `CLAUDE.md`)
+
+**Files:** none modified.
+
+- [ ] **Step 6.1: Run `dotnet build` across the solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: `Build succeeded` with `0 Error(s)`.
+
+- [ ] **Step 6.2: Run `dotnet format` and confirm no diff on the two edited files**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs \
+            backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs \
+  --verify-no-changes
+```
+
+Expected: exits 0 with no reported formatting changes. If `dotnet format` reports changes, re-run **without** `--verify-no-changes` to let it fix the formatting, then re-run with the flag to confirm clean.
+
+- [ ] **Step 6.3: Run the full backend test suite**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --nologo
+```
+
+Expected: all tests pass. The plan touched only an internal DTO field that has no producers or consumers in production code, so no other test should be affected. If any unrelated test fails, that failure is pre-existing or environmental — do not absorb its fix into this PR.
+
+---
+
+## Task 7: Commit
+
+**Files:** none modified beyond Tasks 3 and 4.
+
+- [ ] **Step 7.1: Stage exactly the two edited files**
+
+Run:
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs \
+  backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs
+```
+
+- [ ] **Step 7.2: Confirm the staged diff is exactly what is expected**
+
+Run:
+
+```bash
+git diff --cached
+```
+
+Expected diff:
+
+```diff
+diff --git a/backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs b/backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs
+@@
+ public class PrintPickingListResult
+ {
+     public IList<string> ExportedFiles { get; set; } = new List<string>();
+     public int TotalCount { get; set; }
+-    public IList<int> OrderIds { get; set; } = new List<int>();
+ }
+diff --git a/backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs b/backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs
+@@
+         var innerResult = new PrintPickingListResult
+         {
+             ExportedFiles = new List<string> { "/tmp/a.pdf", "/tmp/b.pdf" },
+             TotalCount = 12,
+-            OrderIds = new List<int> { 1, 2, 3 },
+         };
+```
+
+Only those two hunks. If the diff contains anything else — whitespace, reordering, an unrelated file — `git restore --staged` the extras and re-stage only the two intended files.
+
+- [ ] **Step 7.3: Commit**
+
+Run:
+
+```bash
+git commit -m "refactor: remove unused OrderIds field from PrintPickingListResult
+
+Drop the OrderIds property from the internal application-layer DTO
+PrintPickingListResult and its dead arrange step in
+LogisticsExpeditionPickingAdapterTests. The field was initialized empty,
+never written by ShoptetApiExpeditionListSource.CreatePickingList, and
+never read by LogisticsExpeditionPickingAdapter.CreatePickingListAsync.
+No runtime behaviour change; ExpeditionPickingResult (the cross-feature
+contract) is untouched and the OpenAPI surface is unaffected."
+```
+
+- [ ] **Step 7.4: Verify the working tree is clean and the commit landed**
+
+Run:
+
+```bash
+git status
+git log -1 --stat
+```
+
+Expected: `nothing to commit, working tree clean`, and the log entry shows exactly two files changed — `PrintPickingListResult.cs` (-1 line) and `LogisticsExpeditionPickingAdapterTests.cs` (-1 line).
+
+---
+
+## Done criteria
+
+- `PrintPickingListResult` no longer declares `OrderIds`. (FR-1)
+- `CreatePickingListAsync_TranslatesResultFields` no longer initializes `OrderIds`; its assertions on `ExportedFiles` and `TotalCount` are intact. (FR-2, NFR-3)
+- Repository grep finds zero references to `OrderIds` inside `backend/src/Anela.Heblo.Application/Features/Logistics/` and `backend/test/Anela.Heblo.Tests/Features/Logistics/`. (FR-3)
+- `frontend/src/api/` is unchanged — DTO was not on the API surface. (FR-3)
+- `dotnet build` + `dotnet format --verify-no-changes` + `dotnet test` all pass. (CLAUDE.md validation gates)
+- Exactly one commit, two files changed, two lines removed. (NFR-2)


### PR DESCRIPTION

Removes `PrintPickingListResult.OrderIds`, a dead property that was initialized to an empty list by the constructor default but never populated by `ShoptetApiExpeditionListSource.CreatePickingList` and never consumed by `LogisticsExpeditionPickingAdapter.CreatePickingListAsync`. The field violated YAGNI and created a misleading API surface that could lead a future developer to rely on it and produce a silent logic error. The cross-feature contract `ExpeditionPickingResult` never had `OrderIds` and is untouched; the OpenAPI surface is unaffected.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` — deleted the `OrderIds` property declaration
- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — deleted the dead `OrderIds` initializer from the `CreatePickingListAsync_TranslatesResultFields` arrange block

---

Closes #2703

### Tokens used
5297837
