### PR TITLE
feat(baleni): packing dashboard on Balení home page

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
@@ -38,6 +38,12 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
         _orderSettings = orderSettings.Value;
     }
 
+    public async Task<int> GetOrdersBeingPackedCountAsync(CancellationToken ct = default)
+    {
+        var response = await _orderClient.GetOrdersByStatusAsync(_orderSettings.PackingStateId, page: 1, ct);
+        return response.Data.Paginator.TotalCount;
+    }
+
     public async Task<PackingOrder?> GetPackingOrderAsync(string code, CancellationToken ct = default)
     {
         ExpeditionOrderDetail detail;

--- a/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Features.Authorization.UseCases.GetPackingUsers;
 using Anela.Heblo.Application.Features.Packaging.UseCases.DeletePackage;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackageLabelPdf;
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackages;
 using Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment;
 using Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
@@ -84,6 +85,13 @@ public class PackagingController : BaseApiController
 
         Response.Headers.CacheControl = "no-store";
         return File(response.Content, response.ContentType, response.FileName);
+    }
+
+    [HttpGet("dashboard")]
+    public async Task<ActionResult<GetPackingDashboardResponse>> GetDashboard(CancellationToken ct)
+    {
+        var response = await _mediator.Send(new GetPackingDashboardRequest(), ct);
+        return HandleResponse(response);
     }
 
     [HttpGet("packages")]

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
@@ -1,0 +1,61 @@
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Domain.Features.Packaging;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard;
+
+public class GetPackingDashboardHandler : IRequestHandler<GetPackingDashboardRequest, GetPackingDashboardResponse>
+{
+    private readonly IPackageRepository _repo;
+    private readonly IPackingOrderClient _packingOrderClient;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<GetPackingDashboardHandler> _logger;
+
+    public GetPackingDashboardHandler(
+        IPackageRepository repo,
+        IPackingOrderClient packingOrderClient,
+        TimeProvider timeProvider,
+        ILogger<GetPackingDashboardHandler> logger)
+    {
+        _repo = repo;
+        _packingOrderClient = packingOrderClient;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<GetPackingDashboardResponse> Handle(
+        GetPackingDashboardRequest request,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetLocalNow();
+        var start = new DateTimeOffset(now.Date, now.Offset);
+        var end = start.AddDays(1);
+
+        var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(start, end, cancellationToken);
+
+        int? ordersBeingPackedCount = null;
+        try
+        {
+            ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to retrieve orders-being-packed count from Shoptet; dashboard will show null");
+        }
+
+        return new GetPackingDashboardResponse
+        {
+            OrdersBeingPackedCount = ordersBeingPackedCount,
+            TotalOrdersPackedToday = total,
+            PackedByPacker = byPacker
+                .Select(p => new PackerStatsDto
+                {
+                    PackerId = p.PackedByUserId,
+                    PackerName = p.PackedBy ?? "Neznámý",
+                    OrderCount = p.DistinctOrderCount,
+                })
+                .ToList(),
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardRequest.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard;
+
+public class GetPackingDashboardRequest : IRequest<GetPackingDashboardResponse>
+{
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardResponse.cs
@@ -1,0 +1,20 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard;
+
+public class GetPackingDashboardResponse : BaseResponse
+{
+    public int? OrdersBeingPackedCount { get; set; }
+    public int TotalOrdersPackedToday { get; set; }
+    public List<PackerStatsDto> PackedByPacker { get; set; } = new();
+
+    public GetPackingDashboardResponse() { }
+    public GetPackingDashboardResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+
+public class PackerStatsDto
+{
+    public Guid? PackerId { get; set; }
+    public string PackerName { get; set; } = string.Empty;
+    public int OrderCount { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
@@ -12,6 +12,11 @@ public interface IPackingOrderClient
     /// Returns the packing view of the order, or null if no order exists for the code.
     /// </summary>
     Task<PackingOrder?> GetPackingOrderAsync(string code, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the total count of orders currently in the configured packing state ("Balí se").
+    /// </summary>
+    Task<int> GetOrdersBeingPackedCountAsync(CancellationToken ct = default);
 }
 
 /// <summary>Packing view of an eshop order. Internal contract — not an API DTO.</summary>

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
@@ -18,4 +18,7 @@ public interface IPackageRepository
     Task<Package?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
     Task AddAsync(Package package, CancellationToken cancellationToken = default);
     Task DeleteAsync(Package package, CancellationToken cancellationToken = default);
+
+    Task<(int TotalDistinctOrders, IReadOnlyList<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)> ByPacker)>
+        GetPackedTodayByPackerAsync(DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
@@ -19,6 +19,6 @@ public interface IPackageRepository
     Task AddAsync(Package package, CancellationToken cancellationToken = default);
     Task DeleteAsync(Package package, CancellationToken cancellationToken = default);
 
-    Task<(int TotalDistinctOrders, IReadOnlyList<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)> ByPacker)>
+    Task<(int TotalDistinctOrders, IReadOnlyList<PackerPackingSummary> ByPacker)>
         GetPackedTodayByPackerAsync(DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/PackerPackingSummary.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/PackerPackingSummary.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Domain.Features.Packaging;
+
+public sealed record PackerPackingSummary(
+    Guid? PackedByUserId,
+    string? PackedBy,
+    int DistinctOrderCount);

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -72,28 +72,28 @@ public class PackageRepository : IPackageRepository
         await _db.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task<(int TotalDistinctOrders, IReadOnlyList<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)> ByPacker)>
+    public async Task<(int TotalDistinctOrders, IReadOnlyList<PackerPackingSummary> ByPacker)>
         GetPackedTodayByPackerAsync(DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken ct = default)
     {
-        // Npgsql requires UTC offset (0) when writing to timestamptz columns.
+        // Npgsql requires UTC-zero DateTimeOffset values for timestamptz comparisons.
         var from = fromUtc.ToUniversalTime();
         var to = toUtc.ToUniversalTime();
 
-        var rows = await _db.Packages
+        // SELECT DISTINCT (packer, orderCode) triples — far fewer rows than loading all packages.
+        var pairs = await _db.Packages
             .AsNoTracking()
             .Where(p => p.PackedAt >= from && p.PackedAt < to)
+            .Select(p => new { p.PackedByUserId, p.PackedBy, p.OrderCode })
+            .Distinct()
             .ToListAsync(ct);
 
-        var byPacker = rows
+        var byPacker = pairs
             .GroupBy(p => new { p.PackedByUserId, p.PackedBy })
-            .Select(g => (
-                PackedByUserId: g.Key.PackedByUserId,
-                PackedBy: g.Key.PackedBy,
-                DistinctOrderCount: g.Select(p => p.OrderCode).Distinct().Count()))
+            .Select(g => new PackerPackingSummary(g.Key.PackedByUserId, g.Key.PackedBy, g.Count()))
             .OrderByDescending(x => x.DistinctOrderCount)
             .ToList();
 
-        var total = rows.Select(p => p.OrderCode).Distinct().Count();
+        var total = pairs.Select(p => p.OrderCode).Distinct().Count();
 
         return (total, byPacker);
     }

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -72,6 +72,32 @@ public class PackageRepository : IPackageRepository
         await _db.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task<(int TotalDistinctOrders, IReadOnlyList<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)> ByPacker)>
+        GetPackedTodayByPackerAsync(DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken ct = default)
+    {
+        // Npgsql requires UTC offset (0) when writing to timestamptz columns.
+        var from = fromUtc.ToUniversalTime();
+        var to = toUtc.ToUniversalTime();
+
+        var rows = await _db.Packages
+            .AsNoTracking()
+            .Where(p => p.PackedAt >= from && p.PackedAt < to)
+            .ToListAsync(ct);
+
+        var byPacker = rows
+            .GroupBy(p => new { p.PackedByUserId, p.PackedBy })
+            .Select(g => (
+                PackedByUserId: g.Key.PackedByUserId,
+                PackedBy: g.Key.PackedBy,
+                DistinctOrderCount: g.Select(p => p.OrderCode).Distinct().Count()))
+            .OrderByDescending(x => x.DistinctOrderCount)
+            .ToList();
+
+        var total = rows.Select(p => p.OrderCode).Distinct().Count();
+
+        return (total, byPacker);
+    }
+
     private static string EscapeLike(string value) =>
         value.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingDashboardHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingDashboardHandlerTests.cs
@@ -34,7 +34,7 @@ public class GetPackingDashboardHandlerTests
     private static GetPackingDashboardHandler MakeSut(
         out Mock<IPackageRepository> repo,
         out Mock<IPackingOrderClient> packingClient,
-        (int TotalDistinctOrders, IReadOnlyList<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)> ByPacker) repoResult,
+        (int TotalDistinctOrders, IReadOnlyList<PackerPackingSummary> ByPacker) repoResult,
         int shoptetCount = 5)
     {
         repo = new Mock<IPackageRepository>();
@@ -58,10 +58,10 @@ public class GetPackingDashboardHandlerTests
     {
         // Arrange
         var packerId = Guid.NewGuid();
-        var byPacker = new List<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)>
+        var byPacker = new List<PackerPackingSummary>
         {
-            (packerId, "Alice", 4),
-            (null, "Bob", 2),
+            new(packerId, "Alice", 4),
+            new(null, "Bob", 2),
         };
         var sut = MakeSut(out _, out _, (6, byPacker), shoptetCount: 3);
 
@@ -84,7 +84,7 @@ public class GetPackingDashboardHandlerTests
     public async Task Handle_PassesTodayWindowToRepository_InPragueTime()
     {
         // Arrange — today in Prague is 2026-06-10, offset +02:00
-        var sut = MakeSut(out var repo, out _, (0, Array.Empty<(Guid?, string?, int)>()), shoptetCount: 0);
+        var sut = MakeSut(out var repo, out _, (0, Array.Empty<PackerPackingSummary>()), shoptetCount: 0);
         var expectedStart = new DateTimeOffset(2026, 6, 10, 0, 0, 0, TimeSpan.FromHours(2));
         var expectedEnd = new DateTimeOffset(2026, 6, 11, 0, 0, 0, TimeSpan.FromHours(2));
 
@@ -99,7 +99,7 @@ public class GetPackingDashboardHandlerTests
     public async Task Handle_SetsOrdersBeingPackedCountToNull_WhenShoptetThrows()
     {
         // Arrange
-        var sut = MakeSut(out _, out var packingClient, (2, Array.Empty<(Guid?, string?, int)>()));
+        var sut = MakeSut(out _, out var packingClient, (2, Array.Empty<PackerPackingSummary>()));
         packingClient.Setup(c => c.GetOrdersBeingPackedCountAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Shoptet unreachable"));
 
@@ -116,10 +116,7 @@ public class GetPackingDashboardHandlerTests
     public async Task Handle_ShowsUnknownPackerName_WhenPackedByIsNull()
     {
         // Arrange
-        var byPacker = new List<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)>
-        {
-            (null, null, 1),
-        };
+        var byPacker = new List<PackerPackingSummary> { new(null, null, 1) };
         var sut = MakeSut(out _, out _, (1, byPacker));
 
         // Act

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingDashboardHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingDashboardHandlerTests.cs
@@ -1,0 +1,131 @@
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard;
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Domain.Features.Packaging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Packaging;
+
+public class GetPackingDashboardHandlerTests
+{
+    private static readonly DateTimeOffset PragueNow =
+        new(2026, 6, 10, 14, 30, 0, TimeSpan.FromHours(2));
+
+    // TimeProvider.GetLocalNow() is not virtual, so we subclass instead of using Moq.
+    // Overriding GetUtcNow() + LocalTimeZone makes GetLocalNow() return PragueNow correctly.
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _localNow;
+        private readonly TimeZoneInfo _zone;
+
+        public FakeTimeProvider(DateTimeOffset localNow)
+        {
+            _localNow = localNow;
+            _zone = TimeZoneInfo.CreateCustomTimeZone(
+                "FakeZone", localNow.Offset, "FakeZone", "FakeZone");
+        }
+
+        public override DateTimeOffset GetUtcNow() => _localNow.ToUniversalTime();
+        public override TimeZoneInfo LocalTimeZone => _zone;
+    }
+
+    private static GetPackingDashboardHandler MakeSut(
+        out Mock<IPackageRepository> repo,
+        out Mock<IPackingOrderClient> packingClient,
+        (int TotalDistinctOrders, IReadOnlyList<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)> ByPacker) repoResult,
+        int shoptetCount = 5)
+    {
+        repo = new Mock<IPackageRepository>();
+        repo.Setup(r => r.GetPackedTodayByPackerAsync(
+                It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(repoResult);
+
+        packingClient = new Mock<IPackingOrderClient>();
+        packingClient.Setup(c => c.GetOrdersBeingPackedCountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(shoptetCount);
+
+        return new GetPackingDashboardHandler(
+            repo.Object,
+            packingClient.Object,
+            new FakeTimeProvider(PragueNow),
+            NullLogger<GetPackingDashboardHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCorrectTotalAndPackerBreakdown()
+    {
+        // Arrange
+        var packerId = Guid.NewGuid();
+        var byPacker = new List<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)>
+        {
+            (packerId, "Alice", 4),
+            (null, "Bob", 2),
+        };
+        var sut = MakeSut(out _, out _, (6, byPacker), shoptetCount: 3);
+
+        // Act
+        var result = await sut.Handle(new GetPackingDashboardRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.TotalOrdersPackedToday.Should().Be(6);
+        result.OrdersBeingPackedCount.Should().Be(3);
+        result.PackedByPacker.Should().HaveCount(2);
+        result.PackedByPacker[0].PackerId.Should().Be(packerId);
+        result.PackedByPacker[0].PackerName.Should().Be("Alice");
+        result.PackedByPacker[0].OrderCount.Should().Be(4);
+        result.PackedByPacker[1].PackerName.Should().Be("Bob");
+        result.PackedByPacker[1].OrderCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_PassesTodayWindowToRepository_InPragueTime()
+    {
+        // Arrange — today in Prague is 2026-06-10, offset +02:00
+        var sut = MakeSut(out var repo, out _, (0, Array.Empty<(Guid?, string?, int)>()), shoptetCount: 0);
+        var expectedStart = new DateTimeOffset(2026, 6, 10, 0, 0, 0, TimeSpan.FromHours(2));
+        var expectedEnd = new DateTimeOffset(2026, 6, 11, 0, 0, 0, TimeSpan.FromHours(2));
+
+        // Act
+        await sut.Handle(new GetPackingDashboardRequest(), CancellationToken.None);
+
+        // Assert
+        repo.Verify(r => r.GetPackedTodayByPackerAsync(expectedStart, expectedEnd, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SetsOrdersBeingPackedCountToNull_WhenShoptetThrows()
+    {
+        // Arrange
+        var sut = MakeSut(out _, out var packingClient, (2, Array.Empty<(Guid?, string?, int)>()));
+        packingClient.Setup(c => c.GetOrdersBeingPackedCountAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shoptet unreachable"));
+
+        // Act
+        var result = await sut.Handle(new GetPackingDashboardRequest(), CancellationToken.None);
+
+        // Assert — dashboard still succeeds, count is null
+        result.Success.Should().BeTrue();
+        result.OrdersBeingPackedCount.Should().BeNull();
+        result.TotalOrdersPackedToday.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_ShowsUnknownPackerName_WhenPackedByIsNull()
+    {
+        // Arrange
+        var byPacker = new List<(Guid? PackedByUserId, string? PackedBy, int DistinctOrderCount)>
+        {
+            (null, null, 1),
+        };
+        var sut = MakeSut(out _, out _, (1, byPacker));
+
+        // Act
+        var result = await sut.Handle(new GetPackingDashboardRequest(), CancellationToken.None);
+
+        // Assert
+        result.PackedByPacker[0].PackerName.Should().Be("Neznámý");
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/PackageRepositoryPackedTodayTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/PackageRepositoryPackedTodayTests.cs
@@ -1,0 +1,127 @@
+using Anela.Heblo.Domain.Features.Packaging;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Repositories.Packaging;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Packaging;
+
+public class PackageRepositoryPackedTodayTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly PackageRepository _repo;
+
+    // All times in Prague offset (+02:00) for clarity
+    private static readonly TimeSpan Prague = TimeSpan.FromHours(2);
+    private static readonly DateTimeOffset Today = new(2026, 6, 10, 0, 0, 0, Prague);
+    private static readonly DateTimeOffset Tomorrow = Today.AddDays(1);
+
+    public PackageRepositoryPackedTodayTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"PackedToday_{Guid.NewGuid()}")
+            .Options;
+        _db = new ApplicationDbContext(options);
+        _repo = new PackageRepository(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static Package MakePackage(string orderCode, string? packedBy, Guid? packedByUserId, DateTimeOffset packedAt)
+        => new()
+        {
+            OrderCode = orderCode,
+            CustomerName = "Test",
+            PackageNumber = $"PKG-{Guid.NewGuid():N}",
+            ShippingProviderCode = "6",
+            ShipmentGuid = Guid.NewGuid(),
+            PackedAt = packedAt,
+            CreatedAt = packedAt,
+            PackedBy = packedBy,
+            PackedByUserId = packedByUserId,
+        };
+
+    [Fact]
+    public async Task GetPackedTodayByPackerAsync_CountsDistinctOrdersPerPacker()
+    {
+        // Arrange — Alice packed ORD-1 twice (two packages), ORD-2 once → 2 distinct orders
+        //           Bob packed ORD-3 once → 1 distinct order
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var withinWindow = Today.AddHours(10);
+
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-1", "Alice", aliceId, withinWindow),
+            MakePackage("ORD-1", "Alice", aliceId, withinWindow),
+            MakePackage("ORD-2", "Alice", aliceId, withinWindow),
+            MakePackage("ORD-3", "Bob", bobId, withinWindow));
+        await _db.SaveChangesAsync();
+
+        // Act
+        var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(Today, Tomorrow);
+
+        // Assert — distinct orders: ORD-1, ORD-2, ORD-3 → 3
+        total.Should().Be(3);
+        byPacker.Should().HaveCount(2);
+
+        var alice = byPacker.First(p => p.PackedBy == "Alice");
+        alice.DistinctOrderCount.Should().Be(2);
+        alice.PackedByUserId.Should().Be(aliceId);
+
+        var bob = byPacker.First(p => p.PackedBy == "Bob");
+        bob.DistinctOrderCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetPackedTodayByPackerAsync_ExcludesPackagesOutsideWindow()
+    {
+        // Arrange — one package before today, one package today
+        var userId = Guid.NewGuid();
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-YESTERDAY", "Alice", userId, Today.AddSeconds(-1)),
+            MakePackage("ORD-TODAY", "Alice", userId, Today.AddHours(1)));
+        await _db.SaveChangesAsync();
+
+        // Act
+        var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(Today, Tomorrow);
+
+        // Assert
+        total.Should().Be(1);
+        byPacker.Should().ContainSingle(p => p.PackedBy == "Alice" && p.DistinctOrderCount == 1);
+    }
+
+    [Fact]
+    public async Task GetPackedTodayByPackerAsync_ReturnsZeroTotal_WhenNoPackagesInWindow()
+    {
+        // Arrange — no packages at all
+        // Act
+        var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(Today, Tomorrow);
+
+        // Assert
+        total.Should().Be(0);
+        byPacker.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPackedTodayByPackerAsync_OrdersByCountDescending()
+    {
+        // Arrange — Bob has more orders than Alice
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var t = Today.AddHours(5);
+
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-A1", "Alice", aliceId, t),
+            MakePackage("ORD-B1", "Bob", bobId, t),
+            MakePackage("ORD-B2", "Bob", bobId, t));
+        await _db.SaveChangesAsync();
+
+        // Act
+        var (_, byPacker) = await _repo.GetPackedTodayByPackerAsync(Today, Tomorrow);
+
+        // Assert — Bob first (2 orders), Alice second (1 order)
+        byPacker[0].PackedBy.Should().Be("Bob");
+        byPacker[1].PackedBy.Should().Be("Alice");
+    }
+}

--- a/frontend/src/api/hooks/usePackingDashboard.ts
+++ b/frontend/src/api/hooks/usePackingDashboard.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getAuthenticatedApiClient } from "../client";
+import { getApiBaseUrl, getAuthenticatedFetch } from "../client";
 
 export type PackerStatsDto = {
   packerId?: string;
@@ -21,14 +21,10 @@ export const usePackingDashboard = () =>
   useQuery({
     queryKey: packingDashboardKeys.all,
     queryFn: async (): Promise<GetPackingDashboardResponse> => {
-      const apiClient = getAuthenticatedApiClient() as any;
-      const fullUrl = `${apiClient.baseUrl}/api/packaging/dashboard`;
-
-      const response = await apiClient.http.fetch(fullUrl, {
+      const url = `${getApiBaseUrl()}/api/packaging/dashboard`;
+      const response = await getAuthenticatedFetch()(url, {
         method: "GET",
-        headers: {
-          Accept: "application/json",
-        },
+        headers: { Accept: "application/json" },
       });
 
       if (!response.ok) {

--- a/frontend/src/api/hooks/usePackingDashboard.ts
+++ b/frontend/src/api/hooks/usePackingDashboard.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAuthenticatedApiClient } from "../client";
+
+export type PackerStatsDto = {
+  packerId?: string;
+  packerName: string;
+  orderCount: number;
+};
+
+export type GetPackingDashboardResponse = {
+  ordersBeingPackedCount: number | null;
+  totalOrdersPackedToday: number;
+  packedByPacker: PackerStatsDto[];
+};
+
+export const packingDashboardKeys = {
+  all: ["packingDashboard"] as const,
+};
+
+export const usePackingDashboard = () =>
+  useQuery({
+    queryKey: packingDashboardKeys.all,
+    queryFn: async (): Promise<GetPackingDashboardResponse> => {
+      const apiClient = getAuthenticatedApiClient() as any;
+      const fullUrl = `${apiClient.baseUrl}/api/packaging/dashboard`;
+
+      const response = await apiClient.http.fetch(fullUrl, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return response.json() as Promise<GetPackingDashboardResponse>;
+    },
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: true,
+  });

--- a/frontend/src/components/baleni/BaleniHome.tsx
+++ b/frontend/src/components/baleni/BaleniHome.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Package, Truck, BarChart3 } from 'lucide-react';
 import { useScreenView } from '../../telemetry/useScreenView';
+import { usePackingDashboard } from '../../api/hooks/usePackingDashboard';
 
 interface BaleniTile {
   id: string;
@@ -35,29 +36,89 @@ const TILES: BaleniTile[] = [
   },
 ];
 
+const StatCard: React.FC<{ label: string; value: React.ReactNode; loading: boolean }> = ({
+  label,
+  value,
+  loading,
+}) => (
+  <div className="bg-white border border-border-light rounded-xl p-6 shadow-soft">
+    <p className="text-sm text-neutral-gray mb-2">{label}</p>
+    {loading ? (
+      <div className="h-10 w-24 bg-secondary-blue-pale rounded animate-pulse" />
+    ) : (
+      <p className="text-4xl font-bold text-primary-blue">{value}</p>
+    )}
+  </div>
+);
+
 const BaleniHome: React.FC = () => {
   useScreenView('Baleni', 'BaleniHome');
+  const { data, isLoading } = usePackingDashboard();
+
   return (
-    <div className="pt-4">
-      <h1 className="text-2xl font-bold text-neutral-slate mb-6">Vyberte operaci</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        {TILES.map(({ id, title, description, href, icon: Icon }) => (
-          <Link
-            key={id}
-            to={href}
-            data-testid={`baleni-tile-${id}`}
-            className="flex flex-col items-center justify-center gap-4 bg-white border border-border-light rounded-xl p-6 shadow-soft hover:border-primary-blue hover:shadow-hover transition-all min-h-[160px]"
-          >
-            <div className="w-16 h-16 bg-secondary-blue-pale rounded-xl flex items-center justify-center">
-              <Icon className="h-8 w-8 text-primary-blue" />
+    <div className="pt-4 space-y-8">
+      <section>
+        <h2 className="text-lg font-semibold text-neutral-slate mb-4">Přehled</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          <StatCard
+            label="Balí se (Shoptet)"
+            value={data?.ordersBeingPackedCount ?? '—'}
+            loading={isLoading}
+          />
+          <StatCard
+            label="Zabaleno dnes"
+            value={data?.totalOrdersPackedToday ?? '—'}
+            loading={isLoading}
+          />
+        </div>
+
+        <div className="bg-white border border-border-light rounded-xl p-6 shadow-soft">
+          <p className="text-sm text-neutral-gray mb-4">Zabaleno dnes podle baličů</p>
+          {isLoading ? (
+            <div className="space-y-3">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="h-8 bg-secondary-blue-pale rounded animate-pulse" />
+              ))}
             </div>
-            <div className="text-center">
-              <p className="text-lg font-semibold text-neutral-slate">{title}</p>
-              <p className="text-sm text-neutral-gray mt-1">{description}</p>
-            </div>
-          </Link>
-        ))}
-      </div>
+          ) : data && data.packedByPacker.length > 0 ? (
+            <ul className="space-y-2">
+              {data.packedByPacker.map((p) => (
+                <li
+                  key={p.packerId ?? p.packerName}
+                  className="flex items-center justify-between py-2 px-3 bg-secondary-blue-pale rounded-lg"
+                >
+                  <span className="text-sm font-medium text-neutral-slate">{p.packerName}</span>
+                  <span className="text-sm font-bold text-primary-blue">{p.orderCount}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-neutral-gray italic">Dnes zatím nikdo nezabalil žádnou objednávku.</p>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-neutral-slate mb-4">Navigace</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {TILES.map(({ id, title, description, href, icon: Icon }) => (
+            <Link
+              key={id}
+              to={href}
+              data-testid={`baleni-tile-${id}`}
+              className="flex flex-col items-center justify-center gap-4 bg-white border border-border-light rounded-xl p-6 shadow-soft hover:border-primary-blue hover:shadow-hover transition-all min-h-[160px]"
+            >
+              <div className="w-16 h-16 bg-secondary-blue-pale rounded-xl flex items-center justify-center">
+                <Icon className="h-8 w-8 text-primary-blue" />
+              </div>
+              <div className="text-center">
+                <p className="text-lg font-semibold text-neutral-slate">{title}</p>
+                <p className="text-sm text-neutral-gray mt-1">{description}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Adds a live operational dashboard to `/baleni`: orders currently in "Balí se" (Shoptet, null-safe on failure) + distinct orders packed today per packer with 60s background auto-refresh
- Backend: `GetPackingDashboard` vertical slice (`IPackageRepository.GetPackedTodayByPackerAsync`, `IPackingOrderClient.GetOrdersBeingPackedCountAsync`, handler, `GET /api/packaging/dashboard`)
- Frontend: `usePackingDashboard` React Query hook + redesigned `BaleniHome.tsx` with stat cards, per-packer list, loading skeletons; nav tiles moved to bottom
- 8 new tests (4 handler unit tests, 4 repository tests with in-memory DB)

## Test plan

- [ ] Open `/baleni` on staging — confirm "Balí se" count matches Shoptet admin
- [ ] Pack an order — verify packer row and daily total increment after ≤60s refresh (or hard reload)
- [ ] Disconnect Shoptet (or break the URL) — confirm dashboard still renders packer stats with "—" for the count
- [ ] Confirm all three nav buttons (Balení, Zásilky, Statistiky) still route correctly from the bottom of the page
- [ ] `dotnet test` — all new tests pass