### PR TITLE
feat(packaging): FillTrackingNumbers Hangfire job + Zásilky table tracking number display

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"0f4f6343-41bc-439e-b636-1ea593af0d26","pid":44516,"procStart":"Wed May 27 05:37:32 2026","acquiredAt":1779861131192}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Shipments/ShoptetShipmentClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Shipments/ShoptetShipmentClient.cs
@@ -31,6 +31,43 @@ public class ShoptetShipmentClient : IShipmentClient
         string orderCode,
         CancellationToken ct = default)
     {
+        var items = await FetchShipmentsAsync(orderCode, ct);
+
+        return items
+            .Where(IsActive)
+            .SelectMany(shipment => (shipment.Packages ?? [])
+                .Select(pkg => new ShipmentLabel
+                {
+                    ShipmentGuid = shipment.Guid,
+                    OrderCode = orderCode,
+                    PackageName = pkg.Name ?? string.Empty,
+                    LabelUrl = pkg.LabelUrl,
+                    LabelZpl = pkg.LabelZpl,
+                    TrackingNumber = pkg.TrackingNumber,
+                    TrackingUrl = pkg.TrackingUrl,
+                }))
+            .ToList();
+    }
+
+    public async Task<string?> GetLatestActiveTrackingNumberAsync(
+        string orderCode,
+        CancellationToken ct = default)
+    {
+        var items = await FetchShipmentsAsync(orderCode, ct);
+
+        // Shoptet returns shipments oldest-first (guids are UUIDv7, time-ordered), so the last
+        // non-cancelled shipment is the latest active one. Package names are unreliable as a match
+        // key (non-unique within an order, and renamed once the label is generated), so the tracking
+        // number is taken from the shipment itself rather than matched by package name.
+        var latestActive = items.Where(IsActive).LastOrDefault();
+
+        return latestActive?.Packages?
+            .Select(pkg => pkg.TrackingNumber)
+            .FirstOrDefault(trackingNumber => !string.IsNullOrEmpty(trackingNumber));
+    }
+
+    private async Task<List<ShoptetShipmentDto>> FetchShipmentsAsync(string orderCode, CancellationToken ct)
+    {
         var encodedOrderCode = Uri.EscapeDataString(orderCode);
         var response = await _http.GetAsync($"/api/shipments?orderCode={encodedOrderCode}", ct);
 
@@ -49,23 +86,11 @@ public class ShoptetShipmentClient : IShipmentClient
             throw new HttpRequestException($"Shoptet Delivery API error for order {orderCode}: {errorMsg}");
         }
 
-        var items = data?.Data?.Items ?? [];
-
-        return items
-            .Where(s => s.Status is null || !DeadStatuses.Contains(s.Status))
-            .SelectMany(shipment => (shipment.Packages ?? [])
-                .Select(pkg => new ShipmentLabel
-                {
-                    ShipmentGuid = shipment.Guid,
-                    OrderCode = orderCode,
-                    PackageName = pkg.Name ?? string.Empty,
-                    LabelUrl = pkg.LabelUrl,
-                    LabelZpl = pkg.LabelZpl,
-                    TrackingNumber = pkg.TrackingNumber,
-                    TrackingUrl = pkg.TrackingUrl,
-                }))
-            .ToList();
+        return data?.Data?.Items ?? [];
     }
+
+    private static bool IsActive(ShoptetShipmentDto shipment) =>
+        shipment.Status is null || !DeadStatuses.Contains(shipment.Status);
 
     public async Task<IReadOnlyList<ShippingOption>> GetShippingOptionsAsync(
         string orderCode,

--- a/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.Authorization.UseCases.GetPackingUsers;
 using Anela.Heblo.Application.Features.Packaging.UseCases.DeletePackage;
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackageLabelPdf;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackages;
@@ -85,6 +86,23 @@ public class PackagingController : BaseApiController
 
         Response.Headers.CacheControl = "no-store";
         return File(response.Content, response.ContentType, response.FileName);
+    }
+
+    /// <summary>
+    /// Returns the tracking number of the latest active (non-cancelled) shipment for the order,
+    /// backfilling it onto the order's package rows. Used by the kiosk confirmation screen once
+    /// the label has printed (tracking is guaranteed assigned by then). Returns trackingNumber: null
+    /// when no active shipment has one yet — callers fall back to the package name.
+    /// </summary>
+    [HttpGet("orders/{orderCode}/tracking-number")]
+    public async Task<ActionResult<GetOrderTrackingNumberResponse>> GetOrderTrackingNumber(
+        [FromRoute] string orderCode,
+        CancellationToken cancellationToken)
+    {
+        var response = await _mediator.Send(
+            new GetOrderTrackingNumberRequest { OrderCode = orderCode },
+            cancellationToken);
+        return HandleResponse(response);
     }
 
     [HttpGet("dashboard")]

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/Infrastructure/Jobs/FillTrackingNumbersJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/Infrastructure/Jobs/FillTrackingNumbersJob.cs
@@ -57,29 +57,26 @@ public sealed class FillTrackingNumbersJob : IRecurringJob
         foreach (var group in byOrder)
         {
             var orderCode = group.Key;
-            IReadOnlyList<ShipmentLabel> labels;
+            string? trackingNumber;
 
             try
             {
-                labels = await _client.GetLabelsByOrderCodeAsync(orderCode, cancellationToken);
+                trackingNumber = await _client.GetLatestActiveTrackingNumberAsync(orderCode, cancellationToken);
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex,
-                    "FillTrackingNumbers: failed to fetch labels for order {OrderCode}. Will retry next run.",
+                    "FillTrackingNumbers: failed to fetch shipments for order {OrderCode}. Will retry next run.",
                     orderCode);
                 continue;
             }
 
-            var labelByPackageName = labels
-                .Where(l => l.TrackingNumber is not null)
-                .ToDictionary(l => l.PackageName, l => l.TrackingNumber!);
+            // No active shipment has a tracking number yet — leave the rows alone and retry next run.
+            if (string.IsNullOrEmpty(trackingNumber))
+                continue;
 
             foreach (var package in group)
             {
-                if (!labelByPackageName.TryGetValue(package.PackageNumber, out var trackingNumber))
-                    continue;
-
                 await _repo.SetTrackingNumberAsync(package.Id, trackingNumber, cancellationToken);
                 updated++;
 

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/Infrastructure/Jobs/FillTrackingNumbersJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/Infrastructure/Jobs/FillTrackingNumbersJob.cs
@@ -1,0 +1,94 @@
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.Packaging;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Packaging.Infrastructure.Jobs;
+
+public sealed class FillTrackingNumbersJob : IRecurringJob
+{
+    private const int DaysBack = 3;
+
+    private readonly IPackageRepository _repo;
+    private readonly IShipmentClient _client;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILogger<FillTrackingNumbersJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "fill-tracking-numbers",
+        DisplayName = "Fill Tracking Numbers",
+        Description = "Backfills TrackingNumber for recently-packed shipments where Shoptet had not yet generated the carrier label at scan time.",
+        CronExpression = "*/10 * * * *",
+        DefaultIsEnabled = true,
+    };
+
+    public FillTrackingNumbersJob(
+        IPackageRepository repo,
+        IShipmentClient client,
+        IRecurringJobStatusChecker statusChecker,
+        ILogger<FillTrackingNumbersJob> logger)
+    {
+        _repo = repo;
+        _client = client;
+        _statusChecker = statusChecker;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+            return;
+        }
+
+        var packages = await _repo.GetWithNullTrackingNumberAsync(DaysBack, cancellationToken);
+        if (packages.Count == 0)
+            return;
+
+        _logger.LogInformation(
+            "FillTrackingNumbers: found {Count} package(s) with null TrackingNumber in the last {Days} days.",
+            packages.Count, DaysBack);
+
+        var byOrder = packages.GroupBy(p => p.OrderCode);
+        var updated = 0;
+
+        foreach (var group in byOrder)
+        {
+            var orderCode = group.Key;
+            IReadOnlyList<ShipmentLabel> labels;
+
+            try
+            {
+                labels = await _client.GetLabelsByOrderCodeAsync(orderCode, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "FillTrackingNumbers: failed to fetch labels for order {OrderCode}. Will retry next run.",
+                    orderCode);
+                continue;
+            }
+
+            var labelByPackageName = labels
+                .Where(l => l.TrackingNumber is not null)
+                .ToDictionary(l => l.PackageName, l => l.TrackingNumber!);
+
+            foreach (var package in group)
+            {
+                if (!labelByPackageName.TryGetValue(package.PackageNumber, out var trackingNumber))
+                    continue;
+
+                await _repo.SetTrackingNumberAsync(package.Id, trackingNumber, cancellationToken);
+                updated++;
+
+                _logger.LogInformation(
+                    "FillTrackingNumbers: set TrackingNumber={TrackingNumber} on Package {Id} (order {OrderCode}).",
+                    trackingNumber, package.Id, orderCode);
+            }
+        }
+
+        _logger.LogInformation("FillTrackingNumbers: updated {Updated}/{Total} package(s).", updated, packages.Count);
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/PackagingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/PackagingModule.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.Behaviors;
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackages;
 using Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
 using Anela.Heblo.Application.Features.Packaging.Validators;
@@ -26,6 +27,11 @@ public static class PackagingModule
         services.AddScoped<
             IPipelineBehavior<GetPackagesRequest, GetPackagesResponse>,
             ValidationBehavior<GetPackagesRequest, GetPackagesResponse>>();
+
+        services.AddScoped<IValidator<GetOrderTrackingNumberRequest>, GetOrderTrackingNumberRequestValidator>();
+        services.AddScoped<
+            IPipelineBehavior<GetOrderTrackingNumberRequest, GetOrderTrackingNumberResponse>,
+            ValidationBehavior<GetOrderTrackingNumberRequest, GetOrderTrackingNumberResponse>>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberHandler.cs
@@ -41,7 +41,15 @@ public class GetOrderTrackingNumberHandler
 
         if (!string.IsNullOrEmpty(trackingNumber))
         {
-            await _packageRepository.SetTrackingNumberByOrderCodeAsync(request.OrderCode, trackingNumber, cancellationToken);
+            try
+            {
+                await _packageRepository.SetTrackingNumberByOrderCodeAsync(request.OrderCode, trackingNumber, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "GetOrderTrackingNumber: failed to backfill tracking number for order {OrderCode}.", request.OrderCode);
+            }
         }
 
         return new GetOrderTrackingNumberResponse { TrackingNumber = trackingNumber };

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberHandler.cs
@@ -1,0 +1,49 @@
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.Packaging;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+
+public class GetOrderTrackingNumberHandler
+    : IRequestHandler<GetOrderTrackingNumberRequest, GetOrderTrackingNumberResponse>
+{
+    private readonly IShipmentClient _shipmentClient;
+    private readonly IPackageRepository _packageRepository;
+    private readonly ILogger<GetOrderTrackingNumberHandler> _logger;
+
+    public GetOrderTrackingNumberHandler(
+        IShipmentClient shipmentClient,
+        IPackageRepository packageRepository,
+        ILogger<GetOrderTrackingNumberHandler> logger)
+    {
+        _shipmentClient = shipmentClient;
+        _packageRepository = packageRepository;
+        _logger = logger;
+    }
+
+    public async Task<GetOrderTrackingNumberResponse> Handle(
+        GetOrderTrackingNumberRequest request,
+        CancellationToken cancellationToken)
+    {
+        string? trackingNumber;
+        try
+        {
+            trackingNumber = await _shipmentClient.GetLatestActiveTrackingNumberAsync(request.OrderCode, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: the confirmation screen falls back to the package name. Never surface an error here.
+            _logger.LogWarning(ex,
+                "GetOrderTrackingNumber: failed to fetch tracking for order {OrderCode}.", request.OrderCode);
+            return new GetOrderTrackingNumberResponse { TrackingNumber = null };
+        }
+
+        if (!string.IsNullOrEmpty(trackingNumber))
+        {
+            await _packageRepository.SetTrackingNumberByOrderCodeAsync(request.OrderCode, trackingNumber, cancellationToken);
+        }
+
+        return new GetOrderTrackingNumberResponse { TrackingNumber = trackingNumber };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequest.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+
+public class GetOrderTrackingNumberRequest : IRequest<GetOrderTrackingNumberResponse>
+{
+    public string OrderCode { get; set; } = null!;
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequest.cs
@@ -4,5 +4,5 @@ namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNu
 
 public class GetOrderTrackingNumberRequest : IRequest<GetOrderTrackingNumberResponse>
 {
-    public string OrderCode { get; set; } = null!;
+    public required string OrderCode { get; init; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequestValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+
+public class GetOrderTrackingNumberRequestValidator : AbstractValidator<GetOrderTrackingNumberRequest>
+{
+    public GetOrderTrackingNumberRequestValidator()
+    {
+        RuleFor(x => x.OrderCode).NotEmpty();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberResponse.cs
@@ -1,0 +1,8 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+
+public class GetOrderTrackingNumberResponse : BaseResponse
+{
+    public string? TrackingNumber { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
@@ -104,6 +104,8 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
 
         if (existingShipment is not null)
         {
+            await BackfillExistingShipmentPackagesAsync(
+                request.OrderCode, orderData.CustomerName, existingLabels, request.PackingUserId, ct);
             await TryMarkAsPackedAsync(request.OrderCode, ct);
             return new ScanPackingOrderResponse(orderData, existingShipment);
         }
@@ -218,6 +220,55 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
                 return (user.Id, user.DisplayName);
         }
         return (null, _currentUserService.GetCurrentUser().Email);
+    }
+
+    /// <summary>
+    /// Backfills Package rows for an order whose Shoptet shipment already exists (reprint path).
+    /// Idempotent and best-effort: never throws, so a reprint always returns the existing shipment.
+    /// </summary>
+    private async Task BackfillExistingShipmentPackagesAsync(
+        string orderCode,
+        string customerName,
+        IReadOnlyList<ShipmentLabel> existingLabels,
+        Guid? packingUserId,
+        CancellationToken cancellationToken)
+    {
+        if (existingLabels.Count == 0)
+            return;
+
+        try
+        {
+            var options = await _shipmentClient.GetShippingOptionsAsync(orderCode, cancellationToken);
+            var carrierCode = options.Count > 0 ? options[0].CarrierCode : string.Empty;
+            var carrierName = options.Count > 0 ? options[0].Name : null;
+
+            var now = DateTimeOffset.UtcNow;
+            var (packedByUserId, packedBy) = await ResolvePackerAsync(packingUserId, cancellationToken);
+
+            var packages = existingLabels
+                .Select(label => new Package
+                {
+                    OrderCode = orderCode,
+                    CustomerName = customerName,
+                    PackageNumber = label.PackageName,
+                    TrackingNumber = label.TrackingNumber,
+                    ShippingProviderCode = carrierCode,
+                    ShippingProviderName = carrierName,
+                    ShipmentGuid = label.ShipmentGuid,
+                    PackedAt = now,
+                    PackedBy = packedBy,
+                    PackedByUserId = packedByUserId,
+                    CreatedAt = now,
+                })
+                .ToList();
+
+            await _packageRepository.AddMissingAsync(packages, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to backfill Package rows for existing shipment of order {OrderCode}", orderCode);
+        }
     }
 
     private async Task PersistPackagesAsync(

--- a/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/IShipmentClient.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/IShipmentClient.cs
@@ -4,6 +4,14 @@ public interface IShipmentClient
 {
     Task<IReadOnlyList<ShipmentLabel>> GetLabelsByOrderCodeAsync(string orderCode, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns the tracking number of the latest active (non-cancelled) shipment for the order,
+    /// or null if no active shipment has a tracking number yet. Used to backfill tracking numbers
+    /// that Shoptet had not generated at scan time — matching by shipment, not by package name
+    /// (package names are non-unique within an order and change once the carrier label is generated).
+    /// </summary>
+    Task<string?> GetLatestActiveTrackingNumberAsync(string orderCode, CancellationToken ct = default);
+
     Task<IReadOnlyList<ShippingOption>> GetShippingOptionsAsync(string orderCode, CancellationToken ct = default);
 
     Task<CreatedShipment> CreateShipmentAsync(CreateShipmentCommand command, CancellationToken ct = default);

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
@@ -17,6 +17,13 @@ public interface IPackageRepository
 
     Task<Package?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
     Task AddAsync(Package package, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts the given packages, skipping any whose (OrderCode, PackageNumber) already exists.
+    /// Idempotent: safe to call on a reprint that already has rows.
+    /// </summary>
+    Task AddMissingAsync(IReadOnlyList<Package> packages, CancellationToken cancellationToken = default);
+
     Task DeleteAsync(Package package, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
@@ -18,4 +18,16 @@ public interface IPackageRepository
     Task<Package?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
     Task AddAsync(Package package, CancellationToken cancellationToken = default);
     Task DeleteAsync(Package package, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns packages created within the last <paramref name="daysBack"/> days
+    /// whose <see cref="Package.TrackingNumber"/> is null.
+    /// </summary>
+    Task<List<Package>> GetWithNullTrackingNumberAsync(int daysBack, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists a tracking number onto an existing package row.
+    /// No-ops silently if the row no longer exists.
+    /// </summary>
+    Task SetTrackingNumberAsync(int id, string trackingNumber, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
@@ -31,6 +31,12 @@ public interface IPackageRepository
     /// </summary>
     Task SetTrackingNumberAsync(int id, string trackingNumber, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sets <paramref name="trackingNumber"/> on every package row for the given order
+    /// whose <see cref="Package.TrackingNumber"/> is currently null. No-ops if there are none.
+    /// </summary>
+    Task SetTrackingNumberByOrderCodeAsync(string orderCode, string trackingNumber, CancellationToken cancellationToken = default);
+
     Task<(int TotalDistinctOrders, IReadOnlyList<PackerPackingSummary> ByPacker)>
         GetPackedTodayByPackerAsync(DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -101,7 +101,7 @@ public class PackageRepository : IPackageRepository
         CancellationToken cancellationToken = default)
     {
         var packages = await _db.Packages
-            .Where(p => p.OrderCode == orderCode && p.TrackingNumber == null)
+            .Where(p => p.OrderCode == orderCode)
             .ToListAsync(cancellationToken);
 
         if (packages.Count == 0)

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -128,7 +128,7 @@ public class PackageRepository : IPackageRepository
         CancellationToken cancellationToken = default)
     {
         var packages = await _db.Packages
-            .Where(p => p.OrderCode == orderCode)
+            .Where(p => p.OrderCode == orderCode && p.TrackingNumber == null)
             .ToListAsync(cancellationToken);
 
         if (packages.Count == 0)

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -95,6 +95,24 @@ public class PackageRepository : IPackageRepository
         await _db.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task SetTrackingNumberByOrderCodeAsync(
+        string orderCode,
+        string trackingNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var packages = await _db.Packages
+            .Where(p => p.OrderCode == orderCode && p.TrackingNumber == null)
+            .ToListAsync(cancellationToken);
+
+        if (packages.Count == 0)
+            return;
+
+        foreach (var package in packages)
+            package.TrackingNumber = trackingNumber;
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task<(int TotalDistinctOrders, IReadOnlyList<PackerPackingSummary> ByPacker)>
         GetPackedTodayByPackerAsync(DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken ct = default)
     {

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -66,6 +66,33 @@ public class PackageRepository : IPackageRepository
         await _db.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task AddMissingAsync(IReadOnlyList<Package> packages, CancellationToken cancellationToken = default)
+    {
+        if (packages.Count == 0)
+            return;
+
+        var orderCodes = packages.Select(p => p.OrderCode).Distinct().ToList();
+        var existing = await _db.Packages
+            .AsNoTracking()
+            .Where(p => orderCodes.Contains(p.OrderCode))
+            .Select(p => new { p.OrderCode, p.PackageNumber })
+            .ToListAsync(cancellationToken);
+
+        var existingKeys = existing
+            .Select(p => (p.OrderCode, p.PackageNumber))
+            .ToHashSet();
+
+        var toAdd = packages
+            .Where(p => existingKeys.Add((p.OrderCode, p.PackageNumber)))
+            .ToList();
+
+        if (toAdd.Count == 0)
+            return;
+
+        await _db.Packages.AddRangeAsync(toAdd, cancellationToken);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task DeleteAsync(Package package, CancellationToken cancellationToken = default)
     {
         _db.Packages.Remove(package);

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -72,6 +72,29 @@ public class PackageRepository : IPackageRepository
         await _db.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task<List<Package>> GetWithNullTrackingNumberAsync(
+        int daysBack,
+        CancellationToken cancellationToken = default)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-daysBack);
+        return await _db.Packages
+            .AsNoTracking()
+            .Where(p => p.TrackingNumber == null && p.CreatedAt >= cutoff)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task SetTrackingNumberAsync(
+        int id,
+        string trackingNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var package = await _db.Packages.FindAsync([id], cancellationToken);
+        if (package is null)
+            return;
+        package.TrackingNumber = trackingNumber;
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
     private static string EscapeLike(string value) =>
         value.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
 }

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetShipmentClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetShipmentClientTests.cs
@@ -262,6 +262,204 @@ public class ShoptetShipmentClientTests
     }
 
     [Fact]
+    public async Task GetLatestActiveTrackingNumberAsync_ReturnsTrackingFromLatestActiveShipment_ExcludingDeadStatuses()
+    {
+        // Arrange — mirrors order 126000035: older cancelled shipments carry tracking,
+        // the latest 'created' shipment is the one whose tracking should be backfilled.
+        // All packages share the name "Vlastní balení" (non-unique), proving the match
+        // is by shipment, not by package name.
+        var client = BuildClient(_ => Json(new
+        {
+            data = new
+            {
+                items = new[]
+                {
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "126000035",
+                        status = "deleted",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)null } },
+                    },
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "126000035",
+                        status = "canceled",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)"70603624111" } },
+                    },
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "126000035",
+                        status = "created",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)"70603624124" } },
+                    },
+                },
+            },
+            errors = Array.Empty<object>(),
+        }));
+
+        // Act
+        var result = await client.GetLatestActiveTrackingNumberAsync("126000035");
+
+        // Assert
+        result.Should().Be("70603624124");
+    }
+
+    [Fact]
+    public async Task GetLatestActiveTrackingNumberAsync_ReturnsLastActiveShipment_WhenMultipleActive()
+    {
+        // Arrange — two active shipments; the latest (last in Shoptet's oldest-first order) wins.
+        var client = BuildClient(_ => Json(new
+        {
+            data = new
+            {
+                items = new[]
+                {
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "0001234",
+                        status = "created",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)"TRK-OLDER" } },
+                    },
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "0001234",
+                        status = "created",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)"TRK-LATEST" } },
+                    },
+                },
+            },
+            errors = Array.Empty<object>(),
+        }));
+
+        // Act
+        var result = await client.GetLatestActiveTrackingNumberAsync("0001234");
+
+        // Assert
+        result.Should().Be("TRK-LATEST");
+    }
+
+    [Fact]
+    public async Task GetLatestActiveTrackingNumberAsync_ReturnsNull_WhenLatestActiveShipmentHasNoTrackingYet()
+    {
+        // Arrange — latest active shipment is still 'requested' with no tracking; an older
+        // cancelled shipment has tracking but must NOT be used (it's a dead label).
+        var client = BuildClient(_ => Json(new
+        {
+            data = new
+            {
+                items = new[]
+                {
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "0001234",
+                        status = "canceled",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)"TRK-DEAD" } },
+                    },
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "0001234",
+                        status = "requested",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)null } },
+                    },
+                },
+            },
+            errors = Array.Empty<object>(),
+        }));
+
+        // Act
+        var result = await client.GetLatestActiveTrackingNumberAsync("0001234");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetLatestActiveTrackingNumberAsync_ReturnsFirstNonEmptyTracking_WhenLatestActiveHasMultiplePackages()
+    {
+        // Arrange — latest active shipment has several packages; the first carries no tracking yet.
+        var client = BuildClient(_ => Json(new
+        {
+            data = new
+            {
+                items = new[]
+                {
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "0001234",
+                        status = "created",
+                        packages = new[]
+                        {
+                            new { name = "Vlastní balení", trackingNumber = (string?)null },
+                            new { name = "Vlastní balení", trackingNumber = (string?)"TRK-SECOND" },
+                        },
+                    },
+                },
+            },
+            errors = Array.Empty<object>(),
+        }));
+
+        // Act
+        var result = await client.GetLatestActiveTrackingNumberAsync("0001234");
+
+        // Assert
+        result.Should().Be("TRK-SECOND");
+    }
+
+    [Fact]
+    public async Task GetLatestActiveTrackingNumberAsync_ReturnsNull_WhenNoShipments()
+    {
+        // Arrange
+        var client = BuildClient(_ => Json(new
+        {
+            data = new { items = Array.Empty<object>() },
+            errors = Array.Empty<object>(),
+        }));
+
+        // Act
+        var result = await client.GetLatestActiveTrackingNumberAsync("0001234");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetLatestActiveTrackingNumberAsync_ReturnsNull_WhenAllShipmentsAreDead()
+    {
+        // Arrange
+        var client = BuildClient(_ => Json(new
+        {
+            data = new
+            {
+                items = new[]
+                {
+                    new
+                    {
+                        guid = Guid.NewGuid(),
+                        orderCode = "0001234",
+                        status = "canceled",
+                        packages = new[] { new { name = "Vlastní balení", trackingNumber = (string?)"TRK-DEAD" } },
+                    },
+                },
+            },
+            errors = Array.Empty<object>(),
+        }));
+
+        // Act
+        var result = await client.GetLatestActiveTrackingNumberAsync("0001234");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetShippingOptionsAsync_WithOptions_ReturnsMappedList()
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/GetOrderTrackingNumberHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/GetOrderTrackingNumberHandlerTests.cs
@@ -1,0 +1,64 @@
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.Packaging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Application.Packaging;
+
+public class GetOrderTrackingNumberHandlerTests
+{
+    private static (GetOrderTrackingNumberHandler Sut, Mock<IShipmentClient> Client, Mock<IPackageRepository> Repo)
+        MakeSut()
+    {
+        var client = new Mock<IShipmentClient>();
+        var repo = new Mock<IPackageRepository>();
+        var sut = new GetOrderTrackingNumberHandler(
+            client.Object, repo.Object, NullLogger<GetOrderTrackingNumberHandler>.Instance);
+        return (sut, client, repo);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsAndPersistsTracking_WhenLatestActiveShipmentHasIt()
+    {
+        var (sut, client, repo) = MakeSut();
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync("126000034", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("2421907688");
+
+        var response = await sut.Handle(new GetOrderTrackingNumberRequest { OrderCode = "126000034" }, default);
+
+        response.Success.Should().BeTrue();
+        response.TrackingNumber.Should().Be("2421907688");
+        repo.Verify(r => r.SetTrackingNumberByOrderCodeAsync("126000034", "2421907688", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNullAndDoesNotPersist_WhenNoActiveTrackingYet()
+    {
+        var (sut, client, repo) = MakeSut();
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var response = await sut.Handle(new GetOrderTrackingNumberRequest { OrderCode = "ORD-1" }, default);
+
+        response.Success.Should().BeTrue();
+        response.TrackingNumber.Should().BeNull();
+        repo.Verify(r => r.SetTrackingNumberByOrderCodeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNullAndDoesNotThrow_WhenShoptetThrows()
+    {
+        var (sut, client, repo) = MakeSut();
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shoptet 500"));
+
+        var response = await sut.Handle(new GetOrderTrackingNumberRequest { OrderCode = "ORD-1" }, default);
+
+        response.Success.Should().BeTrue();
+        response.TrackingNumber.Should().BeNull();
+        repo.Verify(r => r.SetTrackingNumberByOrderCodeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.Packaging.Infrastructure.Jobs;
 using Anela.Heblo.Application.Features.ShipmentLabels;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.Packaging;
-using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -51,7 +50,7 @@ public class FillTrackingNumbersJobTests
         await sut.ExecuteAsync();
 
         repo.Verify(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
-        client.Verify(c => c.GetLabelsByOrderCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        client.Verify(c => c.GetLatestActiveTrackingNumberAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -63,29 +62,21 @@ public class FillTrackingNumbersJobTests
 
         await sut.ExecuteAsync();
 
-        client.Verify(c => c.GetLabelsByOrderCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        client.Verify(c => c.GetLatestActiveTrackingNumberAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         repo.Verify(r => r.SetTrackingNumberAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task ExecuteAsync_UpdatesTrackingNumber_WhenShoptetReturnsIt()
+    public async Task ExecuteAsync_UpdatesTrackingNumber_WhenLatestActiveShipmentHasTracking()
     {
         var (sut, repo, client, _) = MakeSut();
-        var package = SamplePackage(id: 5, orderCode: "ORD-42", packageNumber: "PKG-1");
+        var package = SamplePackage(id: 5, orderCode: "ORD-42");
 
         repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([package]);
 
-        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-42", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new ShipmentLabel
-                {
-                    OrderCode = "ORD-42",
-                    PackageName = "PKG-1",
-                    ShipmentGuid = package.ShipmentGuid,
-                    TrackingNumber = "70603624124",
-                }
-            ]);
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync("ORD-42", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("70603624124");
 
         await sut.ExecuteAsync();
 
@@ -93,18 +84,16 @@ public class FillTrackingNumbersJobTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_SkipsPackage_WhenShoptetStillReturnsNullTracking()
+    public async Task ExecuteAsync_SkipsPackage_WhenNoActiveShipmentHasTrackingYet()
     {
         var (sut, repo, client, _) = MakeSut();
-        var package = SamplePackage(id: 3, orderCode: "ORD-5", packageNumber: "PKG-A");
+        var package = SamplePackage(id: 3, orderCode: "ORD-5");
 
         repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([package]);
 
-        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-5", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new ShipmentLabel { OrderCode = "ORD-5", PackageName = "PKG-A", TrackingNumber = null }
-            ]);
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync("ORD-5", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
 
         await sut.ExecuteAsync();
 
@@ -112,45 +101,40 @@ public class FillTrackingNumbersJobTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_MakesOneShoptetCallPerOrder_WhenOrderHasMultipleNullPackages()
+    public async Task ExecuteAsync_AppliesTrackingToAllOrderPackages_AndCallsShoptetOncePerOrder()
     {
         var (sut, repo, client, _) = MakeSut();
-        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-10", packageNumber: "PKG-A");
-        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-10", packageNumber: "PKG-B");
+        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-10", packageNumber: "Vlastní balení");
+        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-10", packageNumber: "Vlastní balení");
 
         repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([pkg1, pkg2]);
 
-        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-10", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new ShipmentLabel { OrderCode = "ORD-10", PackageName = "PKG-A", TrackingNumber = "TRK-A" },
-                new ShipmentLabel { OrderCode = "ORD-10", PackageName = "PKG-B", TrackingNumber = "TRK-B" },
-            ]);
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync("ORD-10", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("TRK-LATEST");
 
         await sut.ExecuteAsync();
 
-        client.Verify(c => c.GetLabelsByOrderCodeAsync("ORD-10", It.IsAny<CancellationToken>()), Times.Once);
-        repo.Verify(r => r.SetTrackingNumberAsync(1, "TRK-A", It.IsAny<CancellationToken>()), Times.Once);
-        repo.Verify(r => r.SetTrackingNumberAsync(2, "TRK-B", It.IsAny<CancellationToken>()), Times.Once);
+        client.Verify(c => c.GetLatestActiveTrackingNumberAsync("ORD-10", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetTrackingNumberAsync(1, "TRK-LATEST", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetTrackingNumberAsync(2, "TRK-LATEST", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task ExecuteAsync_ContinuesProcessing_WhenShoptetThrowsForOneOrder()
     {
         var (sut, repo, client, _) = MakeSut();
-        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-FAIL", packageNumber: "PKG-1");
-        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-OK", packageNumber: "PKG-2");
+        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-FAIL");
+        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-OK");
 
         repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([pkg1, pkg2]);
 
-        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-FAIL", It.IsAny<CancellationToken>()))
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync("ORD-FAIL", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Shoptet 500"));
 
-        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-OK", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([
-                new ShipmentLabel { OrderCode = "ORD-OK", PackageName = "PKG-2", TrackingNumber = "TRK-OK" }
-            ]);
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync("ORD-OK", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("TRK-OK");
 
         await sut.ExecuteAsync();
 

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs
@@ -1,0 +1,162 @@
+using Anela.Heblo.Application.Features.Packaging.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.Packaging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Packaging;
+
+public class FillTrackingNumbersJobTests
+{
+    private static (
+        FillTrackingNumbersJob Sut,
+        Mock<IPackageRepository> Repo,
+        Mock<IShipmentClient> Client,
+        Mock<IRecurringJobStatusChecker> StatusChecker)
+        MakeSut(bool jobEnabled = true)
+    {
+        var repo = new Mock<IPackageRepository>();
+        var client = new Mock<IShipmentClient>();
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jobEnabled);
+        var logger = NullLogger<FillTrackingNumbersJob>.Instance;
+        var sut = new FillTrackingNumbersJob(repo.Object, client.Object, statusChecker.Object, logger);
+        return (sut, repo, client, statusChecker);
+    }
+
+    private static Package SamplePackage(int id = 1, string orderCode = "ORD-1", string packageNumber = "PKG-1") =>
+        new()
+        {
+            Id = id,
+            OrderCode = orderCode,
+            CustomerName = "Alice",
+            PackageNumber = packageNumber,
+            TrackingNumber = null,
+            ShippingProviderCode = "PPL",
+            ShipmentGuid = Guid.NewGuid(),
+            PackedAt = DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsWork_WhenJobDisabled()
+    {
+        var (sut, repo, client, _) = MakeSut(jobEnabled: false);
+
+        await sut.ExecuteAsync();
+
+        repo.Verify(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        client.Verify(c => c.GetLabelsByOrderCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNothing_WhenNoPackagesWithNullTracking()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await sut.ExecuteAsync();
+
+        client.Verify(c => c.GetLabelsByOrderCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.SetTrackingNumberAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpdatesTrackingNumber_WhenShoptetReturnsIt()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var package = SamplePackage(id: 5, orderCode: "ORD-42", packageNumber: "PKG-1");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([package]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-42", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel
+                {
+                    OrderCode = "ORD-42",
+                    PackageName = "PKG-1",
+                    ShipmentGuid = package.ShipmentGuid,
+                    TrackingNumber = "70603624124",
+                }
+            ]);
+
+        await sut.ExecuteAsync();
+
+        repo.Verify(r => r.SetTrackingNumberAsync(5, "70603624124", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsPackage_WhenShoptetStillReturnsNullTracking()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var package = SamplePackage(id: 3, orderCode: "ORD-5", packageNumber: "PKG-A");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([package]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-5", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel { OrderCode = "ORD-5", PackageName = "PKG-A", TrackingNumber = null }
+            ]);
+
+        await sut.ExecuteAsync();
+
+        repo.Verify(r => r.SetTrackingNumberAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MakesOneShoptetCallPerOrder_WhenOrderHasMultipleNullPackages()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-10", packageNumber: "PKG-A");
+        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-10", packageNumber: "PKG-B");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([pkg1, pkg2]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-10", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel { OrderCode = "ORD-10", PackageName = "PKG-A", TrackingNumber = "TRK-A" },
+                new ShipmentLabel { OrderCode = "ORD-10", PackageName = "PKG-B", TrackingNumber = "TRK-B" },
+            ]);
+
+        await sut.ExecuteAsync();
+
+        client.Verify(c => c.GetLabelsByOrderCodeAsync("ORD-10", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetTrackingNumberAsync(1, "TRK-A", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetTrackingNumberAsync(2, "TRK-B", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContinuesProcessing_WhenShoptetThrowsForOneOrder()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-FAIL", packageNumber: "PKG-1");
+        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-OK", packageNumber: "PKG-2");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([pkg1, pkg2]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-FAIL", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shoptet 500"));
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-OK", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel { OrderCode = "ORD-OK", PackageName = "PKG-2", TrackingNumber = "TRK-OK" }
+            ]);
+
+        await sut.ExecuteAsync();
+
+        // ORD-OK still processed despite ORD-FAIL throwing
+        repo.Verify(r => r.SetTrackingNumberAsync(2, "TRK-OK", It.IsAny<CancellationToken>()), Times.Once);
+        // ORD-FAIL package not updated
+        repo.Verify(r => r.SetTrackingNumberAsync(1, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/PackageRepositoryAddMissingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/PackageRepositoryAddMissingTests.cs
@@ -1,0 +1,103 @@
+using Anela.Heblo.Domain.Features.Packaging;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Repositories.Packaging;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Packaging;
+
+public class PackageRepositoryAddMissingTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly PackageRepository _repo;
+
+    public PackageRepositoryAddMissingTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"AddMissing_{Guid.NewGuid()}")
+            .Options;
+        _db = new ApplicationDbContext(options);
+        _repo = new PackageRepository(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static Package MakePackage(string orderCode, string packageNumber, string? trackingNumber = null)
+        => new()
+        {
+            OrderCode = orderCode,
+            CustomerName = "Test",
+            PackageNumber = packageNumber,
+            TrackingNumber = trackingNumber,
+            ShippingProviderCode = "PPL",
+            ShipmentGuid = Guid.NewGuid(),
+            PackedAt = DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+    [Fact]
+    public async Task AddMissingAsync_InsertsRows_WhenNoneExist()
+    {
+        // Arrange
+        var packages = new[]
+        {
+            MakePackage("ORD-1", "PKG-1", "TRK1"),
+            MakePackage("ORD-1", "PKG-2", "TRK2"),
+        };
+
+        // Act
+        await _repo.AddMissingAsync(packages);
+
+        // Assert
+        var stored = await _db.Packages.AsNoTracking().ToListAsync();
+        stored.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task AddMissingAsync_SkipsRows_WithExistingOrderCodeAndPackageNumber()
+    {
+        // Arrange — ORD-1/PKG-1 already persisted
+        await _db.Packages.AddAsync(MakePackage("ORD-1", "PKG-1", "OLD"));
+        await _db.SaveChangesAsync();
+
+        // Act — re-submit PKG-1 (duplicate) plus a new PKG-2
+        await _repo.AddMissingAsync(new[]
+        {
+            MakePackage("ORD-1", "PKG-1", "NEW"),
+            MakePackage("ORD-1", "PKG-2", "TRK2"),
+        });
+
+        // Assert — PKG-1 not duplicated and not overwritten; PKG-2 added
+        var stored = await _db.Packages.AsNoTracking().OrderBy(p => p.PackageNumber).ToListAsync();
+        stored.Should().HaveCount(2);
+        stored.Single(p => p.PackageNumber == "PKG-1").TrackingNumber.Should().Be("OLD");
+        stored.Should().ContainSingle(p => p.PackageNumber == "PKG-2");
+    }
+
+    [Fact]
+    public async Task AddMissingAsync_DeduplicatesWithinBatch()
+    {
+        // Arrange — same (OrderCode, PackageNumber) appears twice in one batch
+        // Act
+        await _repo.AddMissingAsync(new[]
+        {
+            MakePackage("ORD-1", "PKG-1", "TRK1"),
+            MakePackage("ORD-1", "PKG-1", "TRK1"),
+        });
+
+        // Assert
+        var stored = await _db.Packages.AsNoTracking().ToListAsync();
+        stored.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task AddMissingAsync_NoOps_WhenBatchEmpty()
+    {
+        // Act
+        await _repo.AddMissingAsync(Array.Empty<Package>());
+
+        // Assert
+        (await _db.Packages.CountAsync()).Should().Be(0);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/ScanPackingOrderHandlerPackagePersistenceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/ScanPackingOrderHandlerPackagePersistenceTests.cs
@@ -107,14 +107,44 @@ public class ScanPackingOrderHandlerPackagePersistenceTests
     }
 
     [Fact]
-    public async Task Handle_DoesNotPersist_WhenShipmentAlreadyExisted()
+    public async Task Handle_BackfillsPackages_WhenEligibleShipmentAlreadyExisted()
     {
-        // Arrange
+        // Arrange — eligible order re-scanned (reprint); shipment already exists in Shoptet
+        var shipmentGuid = Guid.NewGuid();
+        var existingLabels = new List<ShipmentLabel>
+        {
+            new() { PackageName = "PKG-1", ShipmentGuid = shipmentGuid, TrackingNumber = "TRK1" },
+        };
+        var sut = MakeSut(out var repo, order: MakeOrder(), existingLabels: existingLabels);
+
+        // Act
+        var response = await sut.Handle(new ScanPackingOrderRequest { OrderCode = "ORD-1" }, CancellationToken.None);
+
+        // Assert — reprint returns the existing shipment AND backfills the missing row idempotently
+        response.Success.Should().BeTrue();
+        response.Shipment!.AlreadyExisted.Should().BeTrue();
+        repo.Verify(r => r.AddMissingAsync(
+            It.Is<IReadOnlyList<Package>>(list =>
+                list.Count == 1 &&
+                list[0].OrderCode == "ORD-1" &&
+                list[0].PackageNumber == "PKG-1" &&
+                list[0].TrackingNumber == "TRK1" &&
+                list[0].ShipmentGuid == shipmentGuid &&
+                list[0].ShippingProviderCode == "PPL"),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        repo.Verify(r => r.AddAsync(It.IsAny<Package>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotBackfill_WhenOrderNotEligible()
+    {
+        // Arrange — already-packed order rescanned for review (review path is intentionally untouched)
         var existingLabels = new List<ShipmentLabel>
         {
             new() { PackageName = "PKG-1", ShipmentGuid = Guid.NewGuid(), TrackingNumber = "TRK1" },
         };
-        var sut = MakeSut(out var repo, order: MakeOrder(), existingLabels: existingLabels);
+        var sut = MakeSut(out var repo, order: MakeOrder(isEligible: false), existingLabels: existingLabels);
 
         // Act
         var response = await sut.Handle(new ScanPackingOrderRequest { OrderCode = "ORD-1" }, CancellationToken.None);
@@ -122,7 +152,27 @@ public class ScanPackingOrderHandlerPackagePersistenceTests
         // Assert
         response.Success.Should().BeTrue();
         response.Shipment!.AlreadyExisted.Should().BeTrue();
+        repo.Verify(r => r.AddMissingAsync(It.IsAny<IReadOnlyList<Package>>(), It.IsAny<CancellationToken>()), Times.Never);
         repo.Verify(r => r.AddAsync(It.IsAny<Package>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotFailScan_WhenBackfillThrows()
+    {
+        // Arrange
+        var existingLabels = new List<ShipmentLabel>
+        {
+            new() { PackageName = "PKG-1", ShipmentGuid = Guid.NewGuid(), TrackingNumber = "TRK1" },
+        };
+        var sut = MakeSut(out var repo, order: MakeOrder(), existingLabels: existingLabels);
+        repo.Setup(r => r.AddMissingAsync(It.IsAny<IReadOnlyList<Package>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        // Act
+        var response = await sut.Handle(new ScanPackingOrderRequest { OrderCode = "ORD-1" }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
     }
 
     [Fact]

--- a/docs/integrations/shoptet-api.md
+++ b/docs/integrations/shoptet-api.md
@@ -982,6 +982,18 @@ When Shoptet returns an error (non-2xx or populated `errors[]`):
 - An order may have multiple shipments, each with multiple packages. All are returned; the kiosk prints each.
 - If both `labelUrl` and `labelZpl` are `null` for all packages, labels have not been generated yet.
 
+### 11.5.1 Package `name` is NOT a stable match key — and shipments accumulate per order
+
+> **Verified 2026-06-10 against the live test store (780175), order `126000035`.** A GET returned **12 shipments** for the single order.
+
+Hard-won findings from the FillTrackingNumbers backfill job — read before matching packages to DB rows:
+
+- **`packages[].name` is non-unique within an order.** Every package across all 12 shipments was named `"Vlastní balení"` ("custom packaging" — the packaging type, not an identifier). Building a `Dictionary` keyed by `name` will throw a duplicate-key exception the moment two non-dead packages share a name.
+- **`packages[].name` is NOT stable across label generation.** Immediately after `POST /api/shipments` (status `requested`, label not yet ready) the package name is a placeholder sequence (`"1"`, `"2"`, …). Once the carrier label generates, Shoptet **renames** the package to the packaging type (`"Vlastní balení"`). So a name persisted at scan time will not match the name read back later. **Never match a persisted package to a live label by name.**
+- **Shipments accumulate; `ResetOrderShipmentHandler` orphans the DB `ShipmentGuid`.** Each pack/reset cancels the old shipment (status → `canceled`/`deleted`) and creates a brand-new one. The Heblo `Package` row is **not** updated on reset, so its `ShipmentGuid` points at a now-cancelled shipment that still carries an (invalid) tracking number. The live, deliverable tracking number lives on a different, newer shipment.
+- **Latest active shipment = the last non-dead shipment in the response.** Shoptet returns shipments **oldest-first** (the `guid` is UUIDv7, time-ordered). "Active" = status not in `{canceled, cancel_requested, deleted, request_failed}`. To resolve the current tracking number for an order, take the **last** active shipment and read its package tracking number — ignore the persisted `ShipmentGuid` and all package names. Implemented as `IShipmentClient.GetLatestActiveTrackingNumberAsync` and used by `FillTrackingNumbersJob`.
+- Each Heblo-created shipment has **exactly one package** (`ScanPackingOrderHandler`/`ResetOrderShipmentHandler` always send a single `packages[]` entry), so an order's single tracking number maps to its single `Package` row.
+
 ### 11.6 Authentication
 
 Same host (`https://api.myshoptet.com`) and `Shoptet-Private-API-Token` header as all other Shoptet endpoints. `ShoptetApiSettings.BaseUrl` and `ShoptetApiSettings.ApiToken` are reused — no new configuration keys.

--- a/docs/superpowers/plans/2026-06-10-confirmation-screen-tracking-number.md
+++ b/docs/superpowers/plans/2026-06-10-confirmation-screen-tracking-number.md
@@ -1,0 +1,760 @@
+# Confirmation-Screen Tracking Number Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The packing kiosk confirmation screen ("Zakázka byla vyexpedována") shows the real carrier tracking number instead of the `"Vlastní balení"` package-name placeholder, by fetching the latest active shipment's tracking number once the label PDF has printed.
+
+**Architecture:** A new read endpoint `GET /api/packaging/orders/{orderCode}/tracking-number` returns the tracking number of the latest active (non-cancelled) shipment via the existing `IShipmentClient.GetLatestActiveTrackingNumberAsync`. As a side effect it backfills the order's null-tracking `Package` rows so the Zásilky page updates immediately (no 10-minute job lag). On the frontend, `PackingLabelPrinter` calls this endpoint once printing completes (`isDone`) and passes the resolved number into `PackingShipmentDoneView`.
+
+**Why this timing works:** The `/label.pdf` endpoint (`GetPackageLabelPdfHandler`) already polls Shoptet until the carrier label is ready. Shoptet assigns the `labelUrl` and the `trackingNumber` together, so by the time the label has printed and `isDone` is true, the tracking number is guaranteed present in Shoptet.
+
+**Tech Stack:** .NET 8, EF Core 8, MediatR, MVC controllers, xUnit, Moq, FluentAssertions · React, TypeScript, @tanstack/react-query, Jest, @testing-library/react
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs` | Add `SetTrackingNumberByOrderCodeAsync` |
+| Modify | `backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs` | Implement `SetTrackingNumberByOrderCodeAsync` |
+| Create | `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequest.cs` | MediatR request |
+| Create | `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberResponse.cs` | MediatR response (extends `BaseResponse`) |
+| Create | `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberHandler.cs` | Fetch latest active tracking, persist, return it |
+| Create | `backend/test/Anela.Heblo.Tests/Application/Packaging/GetOrderTrackingNumberHandlerTests.cs` | Handler unit tests |
+| Modify | `backend/src/Anela.Heblo.API/Controllers/PackagingController.cs` | Add `GET orders/{orderCode}/tracking-number` |
+| Create | `frontend/src/api/hooks/useOrderTrackingNumber.ts` | React-query hook for the endpoint |
+| Create | `frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts` | Hook unit tests |
+| Modify | `frontend/src/components/baleni/PackingShipmentDoneView.tsx` | Add `resolvedTrackingNumber` prop |
+| Modify | `frontend/src/components/baleni/__tests__/PackingShipmentDoneView.test.tsx` | Tests for the new prop |
+| Modify | `frontend/src/components/baleni/PackingLabelPrinter.tsx` | Fetch tracking on `isDone`, pass to done view |
+| Modify | `frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx` | Keep green + assert wiring |
+
+**Note on `IShipmentClient.GetLatestActiveTrackingNumberAsync`:** already exists (added in the FillTrackingNumbers fix on this branch). Do not re-create it.
+
+**Note on the OpenAPI TS client:** the baleni module uses hand-written fetch hooks with absolute URLs (`${apiClient.baseUrl}${relativeUrl}`) — see `useScanPackingOrder.ts` / `useResetOrderShipment.ts`. Follow that pattern; do NOT use the generated client for this endpoint. The generated client will still pick up the new endpoint on `npm run build`, which is harmless.
+
+---
+
+## Task 1: Add `SetTrackingNumberByOrderCodeAsync` to the package repository
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs`
+- Modify: `backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs`
+
+- [ ] **Step 1: Add the interface method**
+
+In `IPackageRepository.cs`, add this method signature after the existing `SetTrackingNumberAsync` declaration (keep all existing members unchanged):
+
+```csharp
+    /// <summary>
+    /// Sets <paramref name="trackingNumber"/> on every package row for the given order
+    /// whose <see cref="Package.TrackingNumber"/> is currently null. No-ops if there are none.
+    /// </summary>
+    Task SetTrackingNumberByOrderCodeAsync(string orderCode, string trackingNumber, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 2: Implement it in `PackageRepository`**
+
+In `PackageRepository.cs`, add this method directly after the existing `SetTrackingNumberAsync` method (before the `private static string EscapeLike` helper):
+
+```csharp
+    public async Task SetTrackingNumberByOrderCodeAsync(
+        string orderCode,
+        string trackingNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var packages = await _db.Packages
+            .Where(p => p.OrderCode == orderCode && p.TrackingNumber == null)
+            .ToListAsync(cancellationToken);
+
+        if (packages.Count == 0)
+            return;
+
+        foreach (var package in packages)
+            package.TrackingNumber = trackingNumber;
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build Anela.Heblo.sln`
+Expected: `Build succeeded.` with 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs \
+        backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+git commit -m "feat(packaging): add SetTrackingNumberByOrderCodeAsync to IPackageRepository"
+```
+
+---
+
+## Task 2: Create the `GetOrderTrackingNumber` use case (TDD)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/GetOrderTrackingNumberHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Application/Packaging/GetOrderTrackingNumberHandlerTests.cs`
+
+**Behavior contract:**
+- Calls `IShipmentClient.GetLatestActiveTrackingNumberAsync(orderCode)`.
+- If it returns a non-empty tracking number → persists it via `IPackageRepository.SetTrackingNumberByOrderCodeAsync(orderCode, tracking)` and returns it in the response.
+- If it returns null/empty → does NOT persist; returns a success response with `TrackingNumber = null`.
+- If Shoptet throws → logs a warning and returns a success response with `TrackingNumber = null` (kiosk falls back to the package name; the screen must never error here).
+
+- [ ] **Step 1: Create the request type**
+
+`GetOrderTrackingNumberRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+
+public class GetOrderTrackingNumberRequest : IRequest<GetOrderTrackingNumberResponse>
+{
+    public string OrderCode { get; set; } = null!;
+}
+```
+
+- [ ] **Step 2: Create the response type (MUST extend `BaseResponse`)**
+
+`GetOrderTrackingNumberResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+
+public class GetOrderTrackingNumberResponse : BaseResponse
+{
+    public string? TrackingNumber { get; set; }
+}
+```
+
+> A reflection contract test in CI fails for any Application `*Response` that does not extend `BaseResponse`. This one does — keep it that way.
+
+- [ ] **Step 3: Write the failing handler tests**
+
+`GetOrderTrackingNumberHandlerTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.Packaging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Application.Packaging;
+
+public class GetOrderTrackingNumberHandlerTests
+{
+    private static (GetOrderTrackingNumberHandler Sut, Mock<IShipmentClient> Client, Mock<IPackageRepository> Repo)
+        MakeSut()
+    {
+        var client = new Mock<IShipmentClient>();
+        var repo = new Mock<IPackageRepository>();
+        var sut = new GetOrderTrackingNumberHandler(
+            client.Object, repo.Object, NullLogger<GetOrderTrackingNumberHandler>.Instance);
+        return (sut, client, repo);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsAndPersistsTracking_WhenLatestActiveShipmentHasIt()
+    {
+        var (sut, client, repo) = MakeSut();
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync("126000034", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("2421907688");
+
+        var response = await sut.Handle(new GetOrderTrackingNumberRequest { OrderCode = "126000034" }, default);
+
+        response.Success.Should().BeTrue();
+        response.TrackingNumber.Should().Be("2421907688");
+        repo.Verify(r => r.SetTrackingNumberByOrderCodeAsync("126000034", "2421907688", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNullAndDoesNotPersist_WhenNoActiveTrackingYet()
+    {
+        var (sut, client, repo) = MakeSut();
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var response = await sut.Handle(new GetOrderTrackingNumberRequest { OrderCode = "ORD-1" }, default);
+
+        response.Success.Should().BeTrue();
+        response.TrackingNumber.Should().BeNull();
+        repo.Verify(r => r.SetTrackingNumberByOrderCodeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNullAndDoesNotThrow_WhenShoptetThrows()
+    {
+        var (sut, client, repo) = MakeSut();
+        client.Setup(c => c.GetLatestActiveTrackingNumberAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shoptet 500"));
+
+        var response = await sut.Handle(new GetOrderTrackingNumberRequest { OrderCode = "ORD-1" }, default);
+
+        response.Success.Should().BeTrue();
+        response.TrackingNumber.Should().BeNull();
+        repo.Verify(r => r.SetTrackingNumberByOrderCodeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they fail to compile (RED)**
+
+Run: `cd backend/test/Anela.Heblo.Tests && dotnet build`
+Expected: build FAILS with `The type or namespace name 'GetOrderTrackingNumberHandler' could not be found`.
+
+- [ ] **Step 5: Implement the handler (GREEN)**
+
+`GetOrderTrackingNumberHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.Packaging;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+
+public class GetOrderTrackingNumberHandler
+    : IRequestHandler<GetOrderTrackingNumberRequest, GetOrderTrackingNumberResponse>
+{
+    private readonly IShipmentClient _shipmentClient;
+    private readonly IPackageRepository _packageRepository;
+    private readonly ILogger<GetOrderTrackingNumberHandler> _logger;
+
+    public GetOrderTrackingNumberHandler(
+        IShipmentClient shipmentClient,
+        IPackageRepository packageRepository,
+        ILogger<GetOrderTrackingNumberHandler> logger)
+    {
+        _shipmentClient = shipmentClient;
+        _packageRepository = packageRepository;
+        _logger = logger;
+    }
+
+    public async Task<GetOrderTrackingNumberResponse> Handle(
+        GetOrderTrackingNumberRequest request,
+        CancellationToken cancellationToken)
+    {
+        string? trackingNumber;
+        try
+        {
+            trackingNumber = await _shipmentClient.GetLatestActiveTrackingNumberAsync(request.OrderCode, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: the confirmation screen falls back to the package name. Never surface an error here.
+            _logger.LogWarning(ex,
+                "GetOrderTrackingNumber: failed to fetch tracking for order {OrderCode}.", request.OrderCode);
+            return new GetOrderTrackingNumberResponse { TrackingNumber = null };
+        }
+
+        if (!string.IsNullOrEmpty(trackingNumber))
+        {
+            await _packageRepository.SetTrackingNumberByOrderCodeAsync(request.OrderCode, trackingNumber, cancellationToken);
+        }
+
+        return new GetOrderTrackingNumberResponse { TrackingNumber = trackingNumber };
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests (GREEN)**
+
+Run: `cd backend/test/Anela.Heblo.Tests && dotnet test --filter "GetOrderTrackingNumberHandlerTests"`
+Expected: 3 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetOrderTrackingNumber/ \
+        backend/test/Anela.Heblo.Tests/Application/Packaging/GetOrderTrackingNumberHandlerTests.cs
+git commit -m "feat(packaging): GetOrderTrackingNumber use case returns latest active shipment tracking"
+```
+
+---
+
+## Task 3: Expose the endpoint on `PackagingController`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackagingController.cs`
+
+- [ ] **Step 1: Add the using directive**
+
+At the top of `PackagingController.cs`, add this `using` alongside the existing `Anela.Heblo.Application.Features.Packaging.UseCases.*` imports (keep alphabetical grouping):
+
+```csharp
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
+```
+
+- [ ] **Step 2: Add the endpoint action**
+
+Add this method to `PackagingController` (place it right after the `GetPackageLabelPdf` action, before `GetDashboard`):
+
+```csharp
+    /// <summary>
+    /// Returns the tracking number of the latest active (non-cancelled) shipment for the order,
+    /// backfilling it onto the order's package rows. Used by the kiosk confirmation screen once
+    /// the label has printed (tracking is guaranteed assigned by then). Returns trackingNumber: null
+    /// when no active shipment has one yet — callers fall back to the package name.
+    /// </summary>
+    [HttpGet("orders/{orderCode}/tracking-number")]
+    public async Task<ActionResult<GetOrderTrackingNumberResponse>> GetOrderTrackingNumber(
+        [FromRoute] string orderCode,
+        CancellationToken cancellationToken)
+    {
+        var response = await _mediator.Send(
+            new GetOrderTrackingNumberRequest { OrderCode = orderCode },
+            cancellationToken);
+        return HandleResponse(response);
+    }
+```
+
+- [ ] **Step 3: Build and run the full backend test suite for the feature**
+
+Run: `dotnet build Anela.Heblo.sln && cd backend/test/Anela.Heblo.Tests && dotnet test --filter "FullyQualifiedName~Packaging"`
+Expected: `Build succeeded.`; all Packaging tests pass (includes the new handler tests).
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+dotnet format Anela.Heblo.sln --include backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
+git add backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
+git commit -m "feat(packaging): expose GET orders/{orderCode}/tracking-number endpoint"
+```
+
+---
+
+## Task 4: Create the `useOrderTrackingNumber` frontend hook (TDD)
+
+**Files:**
+- Create: `frontend/src/api/hooks/useOrderTrackingNumber.ts`
+- Test: `frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts`
+
+All frontend commands run from `frontend/`.
+
+- [ ] **Step 1: Write the failing hook test**
+
+`frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts`:
+
+```typescript
+import { renderHook, waitFor } from '@testing-library/react';
+import { useOrderTrackingNumber } from '../useOrderTrackingNumber';
+import { createMockApiClient, mockAuthenticatedApiClient, createQueryClientWrapper } from '../../testUtils';
+
+jest.mock('../../client');
+
+describe('useOrderTrackingNumber', () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    const mock = createMockApiClient();
+    mockFetch = mock.mockFetch;
+    mockAuthenticatedApiClient(mock.mockClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the tracking number from a successful response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, trackingNumber: '2421907688' }),
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('126000034', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe('2421907688');
+  });
+
+  it('returns null when the response has no tracking number', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, trackingNumber: null }),
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('ORD-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('returns null when the response is not successful', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: false, errorCode: 'Exception' }),
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('ORD-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('does not fetch when disabled', () => {
+    const { wrapper } = createQueryClientWrapper();
+    renderHook(() => useOrderTrackingNumber('ORD-1', false), { wrapper });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails (RED)**
+
+Run: `CI=true npm test -- --testPathPattern="useOrderTrackingNumber"`
+Expected: FAIL — `Cannot find module '../useOrderTrackingNumber'`.
+
+- [ ] **Step 3: Implement the hook (GREEN)**
+
+`frontend/src/api/hooks/useOrderTrackingNumber.ts`:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import { getAuthenticatedApiClient } from '../client';
+
+interface ApiClientWithInternals {
+  baseUrl: string;
+  http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+}
+
+const fetchOrderTrackingNumber = async (orderCode: string): Promise<string | null> => {
+  const apiClient = getAuthenticatedApiClient(false) as unknown as ApiClientWithInternals;
+  const response = await apiClient.http.fetch(
+    `${apiClient.baseUrl}/api/packaging/orders/${encodeURIComponent(orderCode)}/tracking-number`,
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data = (await response.json()) as any;
+  if (!data.success) return null;
+  return (data.trackingNumber as string | null) ?? null;
+};
+
+export const useOrderTrackingNumber = (orderCode: string, enabled: boolean) =>
+  useQuery<string | null>({
+    queryKey: ['order-tracking-number', orderCode],
+    queryFn: () => fetchOrderTrackingNumber(orderCode),
+    enabled,
+    staleTime: 0,
+  });
+```
+
+- [ ] **Step 4: Run the test (GREEN)**
+
+Run: `CI=true npm test -- --testPathPattern="useOrderTrackingNumber"`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/hooks/useOrderTrackingNumber.ts \
+        frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts
+git commit -m "feat(baleni): useOrderTrackingNumber hook for the confirmation screen"
+```
+
+---
+
+## Task 5: Add `resolvedTrackingNumber` prop to `PackingShipmentDoneView` (TDD)
+
+**Files:**
+- Modify: `frontend/src/components/baleni/PackingShipmentDoneView.tsx`
+- Test: `frontend/src/components/baleni/__tests__/PackingShipmentDoneView.test.tsx`
+
+**Behavior:** when `resolvedTrackingNumber` is a non-empty string, render it as the "Číslo zásilky" value. Otherwise fall back to the existing `shipment.packages.map((p) => p.trackingNumber ?? p.name).join(', ')`.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append these two tests inside the `describe('PackingShipmentDoneView', ...)` block in `PackingShipmentDoneView.test.tsx` (before its closing `});`):
+
+```typescript
+  it('shows resolvedTrackingNumber when provided, overriding the package summary', () => {
+    render(
+      <PackingShipmentDoneView
+        order={makeOrder()}
+        shipment={makeShipment()}
+        resolvedTrackingNumber="2421907688"
+        onReprint={() => {}}
+      />
+    );
+    expect(screen.getByText('2421907688')).toBeInTheDocument();
+    expect(screen.queryByText('TR-1, TR-2')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the package summary when resolvedTrackingNumber is null or empty', () => {
+    render(
+      <PackingShipmentDoneView
+        order={makeOrder()}
+        shipment={makeShipment()}
+        resolvedTrackingNumber={null}
+        onReprint={() => {}}
+      />
+    );
+    expect(screen.getByText('TR-1, TR-2')).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the tests to confirm the first fails (RED)**
+
+Run: `CI=true npm test -- --testPathPattern="PackingShipmentDoneView"`
+Expected: the `shows resolvedTrackingNumber...` test FAILS (component ignores the prop, still renders `TR-1, TR-2`).
+
+- [ ] **Step 3: Implement the prop**
+
+In `PackingShipmentDoneView.tsx`, update the props interface and the `trackingSummary` computation. Replace the interface:
+
+```typescript
+interface PackingShipmentDoneViewProps {
+  order: PackingOrder;
+  shipment: ScanShipment;
+  onReprint: () => void;
+}
+```
+
+with:
+
+```typescript
+interface PackingShipmentDoneViewProps {
+  order: PackingOrder;
+  shipment: ScanShipment;
+  resolvedTrackingNumber?: string | null;
+  onReprint: () => void;
+}
+```
+
+Then replace the function signature line:
+
+```typescript
+function PackingShipmentDoneView({ order, shipment, onReprint }: PackingShipmentDoneViewProps) {
+  const addressLines = buildAddressLines(order);
+  const trackingSummary = shipment.packages.map((p) => p.trackingNumber ?? p.name).join(', ');
+```
+
+with:
+
+```typescript
+function PackingShipmentDoneView({
+  order,
+  shipment,
+  resolvedTrackingNumber,
+  onReprint,
+}: PackingShipmentDoneViewProps) {
+  const addressLines = buildAddressLines(order);
+  const trackingSummary =
+    resolvedTrackingNumber && resolvedTrackingNumber.length > 0
+      ? resolvedTrackingNumber
+      : shipment.packages.map((p) => p.trackingNumber ?? p.name).join(', ');
+```
+
+(The `{trackingSummary}` usage in the JSX is unchanged.)
+
+- [ ] **Step 4: Run the tests (GREEN)**
+
+Run: `CI=true npm test -- --testPathPattern="PackingShipmentDoneView"`
+Expected: all PackingShipmentDoneView tests pass (the original ones still pass because the prop is optional).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/baleni/PackingShipmentDoneView.tsx \
+        frontend/src/components/baleni/__tests__/PackingShipmentDoneView.test.tsx
+git commit -m "feat(baleni): PackingShipmentDoneView accepts resolvedTrackingNumber override"
+```
+
+---
+
+## Task 6: Wire the fetch into `PackingLabelPrinter`
+
+**Files:**
+- Modify: `frontend/src/components/baleni/PackingLabelPrinter.tsx`
+- Modify: `frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx`
+
+`PackingLabelPrinter` already computes `isDone`. Call `useOrderTrackingNumber(order.code, isDone)` and pass `data` into the done view. The hook only fetches once `isDone` is true (printing finished → tracking ready).
+
+- [ ] **Step 1: Update the existing test file so it does not break, and assert the wiring**
+
+The current test mocks `PackingShipmentDoneView` and does NOT provide a `QueryClientProvider`. Adding a `useQuery` call to the component would throw "No QueryClient set". So mock the new hook, and make the done-view mock surface the prop.
+
+In `PackingLabelPrinter.test.tsx`, add this mock next to the existing `jest.mock('../printLabelPdf', ...)` mock (top of file):
+
+```typescript
+jest.mock('../../../api/hooks/useOrderTrackingNumber', () => ({
+  useOrderTrackingNumber: jest.fn(() => ({ data: null })),
+}));
+```
+
+Replace the existing `jest.mock('../PackingShipmentDoneView', ...)` block with one that renders the resolved tracking number so wiring can be asserted:
+
+```typescript
+jest.mock('../PackingShipmentDoneView', () => ({
+  __esModule: true,
+  default: ({
+    resolvedTrackingNumber,
+    onReprint,
+  }: {
+    resolvedTrackingNumber?: string | null;
+    onReprint: () => void;
+  }) => (
+    <div data-testid="done-view">
+      <span data-testid="done-tracking">{resolvedTrackingNumber ?? ''}</span>
+      <button data-testid="reprint" onClick={onReprint}>R</button>
+    </div>
+  ),
+}));
+```
+
+Add this import near the top (after the other imports):
+
+```typescript
+import { useOrderTrackingNumber } from '../../../api/hooks/useOrderTrackingNumber';
+```
+
+Add a typed handle to the mock (after `const mockPrintLabelPdf = ...`):
+
+```typescript
+const mockUseOrderTrackingNumber = useOrderTrackingNumber as jest.MockedFunction<typeof useOrderTrackingNumber>;
+```
+
+Add this test inside the `describe('PackingLabelPrinter', ...)` block (before its closing `});`):
+
+```typescript
+  it('passes the resolved tracking number into the done view once printing is finished', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseOrderTrackingNumber.mockReturnValue({ data: '2421907688' } as any);
+
+    render(
+      <PackingLabelPrinter order={makeOrder('250001')} shipment={makeShipment([pkg1])} />
+    );
+    fireAck(0);
+
+    expect(screen.getByTestId('done-view')).toBeInTheDocument();
+    expect(screen.getByTestId('done-tracking')).toHaveTextContent('2421907688');
+  });
+```
+
+- [ ] **Step 2: Run the test to confirm the new one fails (RED)**
+
+Run: `CI=true npm test -- --testPathPattern="PackingLabelPrinter"`
+Expected: the new `passes the resolved tracking number...` test FAILS (component does not yet pass `resolvedTrackingNumber`). Existing tests still pass (the hook is mocked, returning `{ data: null }`).
+
+- [ ] **Step 3: Wire the hook into the component**
+
+In `PackingLabelPrinter.tsx`, add the import after the existing imports:
+
+```typescript
+import { useOrderTrackingNumber } from '../../api/hooks/useOrderTrackingNumber';
+```
+
+Inside the component, after the line `const isDone = labels.length > 0 && acknowledgedCount >= labels.length;`, add:
+
+```typescript
+  const trackingQuery = useOrderTrackingNumber(order.code, isDone);
+```
+
+Then update the done-view render block:
+
+```typescript
+  if (isDone) {
+    return (
+      <PackingShipmentDoneView
+        order={order}
+        shipment={shipment}
+        onReprint={handleReprint}
+      />
+    );
+  }
+```
+
+to pass the resolved value:
+
+```typescript
+  if (isDone) {
+    return (
+      <PackingShipmentDoneView
+        order={order}
+        shipment={shipment}
+        resolvedTrackingNumber={trackingQuery.data ?? null}
+        onReprint={handleReprint}
+      />
+    );
+  }
+```
+
+- [ ] **Step 4: Run the test (GREEN)**
+
+Run: `CI=true npm test -- --testPathPattern="PackingLabelPrinter"`
+Expected: all PackingLabelPrinter tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/baleni/PackingLabelPrinter.tsx \
+        frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
+git commit -m "feat(baleni): show latest active tracking number on the confirmation screen"
+```
+
+---
+
+## Task 7: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend build + targeted tests**
+
+Run: `dotnet build Anela.Heblo.sln && cd backend/test/Anela.Heblo.Tests && dotnet test --filter "FullyQualifiedName~Packaging|FullyQualifiedName~ShoptetShipment"`
+Expected: `Build succeeded.`; all pass.
+
+- [ ] **Step 2: Backend format check**
+
+Run: `dotnet format Anela.Heblo.sln --verify-no-changes` (if it reports changes, run `dotnet format Anela.Heblo.sln` and re-commit the touched files).
+
+- [ ] **Step 3: Frontend build + lint + targeted tests**
+
+Run (from `frontend/`):
+```bash
+npm run build
+CI=true npm test -- --testPathPattern="useOrderTrackingNumber|PackingShipmentDoneView|PackingLabelPrinter"
+```
+Expected: build succeeds; all listed tests pass. (`npm run lint` over the whole repo has pre-existing failures unrelated to these files — confirm no NEW lint errors are introduced in the files you touched.)
+
+- [ ] **Step 4: Manual staging verification (after deploy)**
+
+1. On the Balení kiosk, scan an already-packed order whose latest active shipment has a label (e.g. `126000034`).
+2. Let the label print; on "Zakázka byla vyexpedována", confirm "Číslo zásilky" shows the carrier tracking number (e.g. `2421907688`), not `Vlastní balení`.
+3. Open the Zásilky page and confirm the same order now shows the tracking number in "Sledovací č." immediately (the endpoint backfilled the DB row — no wait for the 10-minute job).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Confirmation screen shows real tracking number → Tasks 4-6 (hook + prop + wiring).
+- Tracking sourced from latest active shipment → Task 2 (reuses `GetLatestActiveTrackingNumberAsync`).
+- Captured at the moment it's ready (post-print `isDone`) → Task 6 (`enabled: isDone`).
+- Immediate Zásilky update (no 10-min lag) → Tasks 1-2 (`SetTrackingNumberByOrderCodeAsync` persisted in the handler).
+- Graceful fallback when tracking not ready / Shoptet error → handler returns `null` (Task 2), done view falls back to package name (Task 5).
+
+**Placeholder scan:** none — every code/test step contains full content and exact commands.
+
+**Type consistency:**
+- `SetTrackingNumberByOrderCodeAsync(string, string, CancellationToken)` — defined Task 1, mocked Task 2, called Task 2 handler. ✔
+- `GetLatestActiveTrackingNumberAsync` — pre-existing on `IShipmentClient`. ✔
+- `GetOrderTrackingNumberResponse.TrackingNumber` (`string?`) — defined Task 2, read by controller (Task 3) and hook JSON (`data.trackingNumber`, Task 4). ✔
+- `useOrderTrackingNumber(orderCode: string, enabled: boolean)` → `useQuery<string | null>` — defined Task 4, called Task 6 with `(order.code, isDone)`. ✔
+- `resolvedTrackingNumber?: string | null` on `PackingShipmentDoneView` — defined Task 5, passed Task 6. ✔
+
+**Scope note:** `PackingShipmentCreator` also renders `PackingShipmentDoneView` directly for the non-eligible rescan review path (without `resolvedTrackingNumber`); that path keeps its current behavior, which already shows tracking when the scan response carries it (rescans return the latest active shipment's labels). Out of scope here; revisit only if that screen also shows the placeholder.

--- a/docs/superpowers/plans/2026-06-10-fill-tracking-numbers-job.md
+++ b/docs/superpowers/plans/2026-06-10-fill-tracking-numbers-job.md
@@ -1,0 +1,491 @@
+# Fill Tracking Numbers Background Job Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A Hangfire recurring job that finds Package rows with a null `TrackingNumber` (created within the last 3 days), fetches current label data from Shoptet, and fills in any tracking numbers that are now available.
+
+**Architecture:** The job queries the package repository for recently-created rows with null `TrackingNumber`, groups them by `OrderCode` to make one Shoptet API call per order, matches labels by `PackageName == PackageNumber`, and updates only rows where a tracking number is now available. Rows where Shoptet still returns null are left alone and retried on the next run (every 10 minutes).
+
+**Tech Stack:** .NET 8, EF Core 8, Hangfire, xUnit, Moq, FluentAssertions
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs` | Add 2 new methods |
+| Modify | `backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs` | Implement 2 new methods |
+| Create | `backend/src/Anela.Heblo.Application/Features/Packaging/Infrastructure/Jobs/FillTrackingNumbersJob.cs` | The recurring job |
+| Create | `backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs` | Unit tests for the job |
+
+---
+
+## Task 1: Extend IPackageRepository with two new methods
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs`
+
+- [ ] **Step 1: Add the two method signatures**
+
+Replace the file content with:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Packaging;
+
+public interface IPackageRepository
+{
+    Task<(List<Package> Items, int TotalCount)> GetPaginatedAsync(
+        string? orderCode,
+        string? customerName,
+        string? packageNumber,
+        IReadOnlyList<string>? shippingProviderCodes,
+        DateTime? fromDate,
+        DateTime? toDate,
+        int pageNumber,
+        int pageSize,
+        string sortBy,
+        bool sortDescending,
+        CancellationToken cancellationToken = default);
+
+    Task<Package?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task AddAsync(Package package, CancellationToken cancellationToken = default);
+    Task DeleteAsync(Package package, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns packages created within the last <paramref name="daysBack"/> days
+    /// whose <see cref="Package.TrackingNumber"/> is null.
+    /// </summary>
+    Task<List<Package>> GetWithNullTrackingNumberAsync(int daysBack, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists a tracking number onto an existing package row.
+    /// No-ops silently if the row no longer exists.
+    /// </summary>
+    Task SetTrackingNumberAsync(int id, string trackingNumber, CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Verify the project still builds**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: Build succeeded, 0 errors.
+
+---
+
+## Task 2: Implement the two new methods in PackageRepository
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs`
+
+- [ ] **Step 1: Add GetWithNullTrackingNumberAsync and SetTrackingNumberAsync**
+
+Append these two methods before the closing `}` of the class (after `EscapeLike`):
+
+```csharp
+    public async Task<List<Package>> GetWithNullTrackingNumberAsync(
+        int daysBack,
+        CancellationToken cancellationToken = default)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-daysBack);
+        return await _db.Packages
+            .AsNoTracking()
+            .Where(p => p.TrackingNumber == null && p.CreatedAt >= cutoff)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task SetTrackingNumberAsync(
+        int id,
+        string trackingNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var package = await _db.Packages.FindAsync([id], cancellationToken);
+        if (package is null)
+            return;
+        package.TrackingNumber = trackingNumber;
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+```
+
+- [ ] **Step 2: Verify the project still builds**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs \
+        backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+git commit -m "feat(packaging): add GetWithNullTrackingNumber and SetTrackingNumber to IPackageRepository"
+```
+
+---
+
+## Task 3: Write unit tests for FillTrackingNumbersJob (RED phase)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs`
+
+The job class does not exist yet — the tests will fail to compile until Task 4. Write them first.
+
+- [ ] **Step 1: Create the test file**
+
+```csharp
+using Anela.Heblo.Application.Features.Packaging.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.Packaging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Packaging;
+
+public class FillTrackingNumbersJobTests
+{
+    private static (
+        FillTrackingNumbersJob Sut,
+        Mock<IPackageRepository> Repo,
+        Mock<IShipmentClient> Client,
+        Mock<IRecurringJobStatusChecker> StatusChecker)
+        MakeSut(bool jobEnabled = true)
+    {
+        var repo = new Mock<IPackageRepository>();
+        var client = new Mock<IShipmentClient>();
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jobEnabled);
+        var logger = NullLogger<FillTrackingNumbersJob>.Instance;
+        var sut = new FillTrackingNumbersJob(repo.Object, client.Object, statusChecker.Object, logger);
+        return (sut, repo, client, statusChecker);
+    }
+
+    private static Package SamplePackage(int id = 1, string orderCode = "ORD-1", string packageNumber = "PKG-1") =>
+        new()
+        {
+            Id = id,
+            OrderCode = orderCode,
+            CustomerName = "Alice",
+            PackageNumber = packageNumber,
+            TrackingNumber = null,
+            ShippingProviderCode = "PPL",
+            ShipmentGuid = Guid.NewGuid(),
+            PackedAt = DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsWork_WhenJobDisabled()
+    {
+        var (sut, repo, client, _) = MakeSut(jobEnabled: false);
+
+        await sut.ExecuteAsync();
+
+        repo.Verify(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        client.Verify(c => c.GetLabelsByOrderCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNothing_WhenNoPackagesWithNullTracking()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await sut.ExecuteAsync();
+
+        client.Verify(c => c.GetLabelsByOrderCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.SetTrackingNumberAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpdatesTrackingNumber_WhenShoptetReturnsIt()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var package = SamplePackage(id: 5, orderCode: "ORD-42", packageNumber: "PKG-1");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([package]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-42", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel
+                {
+                    OrderCode = "ORD-42",
+                    PackageName = "PKG-1",
+                    ShipmentGuid = package.ShipmentGuid,
+                    TrackingNumber = "70603624124",
+                }
+            ]);
+
+        await sut.ExecuteAsync();
+
+        repo.Verify(r => r.SetTrackingNumberAsync(5, "70603624124", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsPackage_WhenShoptetStillReturnsNullTracking()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var package = SamplePackage(id: 3, orderCode: "ORD-5", packageNumber: "PKG-A");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([package]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-5", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel { OrderCode = "ORD-5", PackageName = "PKG-A", TrackingNumber = null }
+            ]);
+
+        await sut.ExecuteAsync();
+
+        repo.Verify(r => r.SetTrackingNumberAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MakesOneShoptetCallPerOrder_WhenOrderHasMultipleNullPackages()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-10", packageNumber: "PKG-A");
+        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-10", packageNumber: "PKG-B");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([pkg1, pkg2]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-10", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel { OrderCode = "ORD-10", PackageName = "PKG-A", TrackingNumber = "TRK-A" },
+                new ShipmentLabel { OrderCode = "ORD-10", PackageName = "PKG-B", TrackingNumber = "TRK-B" },
+            ]);
+
+        await sut.ExecuteAsync();
+
+        client.Verify(c => c.GetLabelsByOrderCodeAsync("ORD-10", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetTrackingNumberAsync(1, "TRK-A", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetTrackingNumberAsync(2, "TRK-B", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContinuesProcessing_WhenShoptetThrowsForOneOrder()
+    {
+        var (sut, repo, client, _) = MakeSut();
+        var pkg1 = SamplePackage(id: 1, orderCode: "ORD-FAIL", packageNumber: "PKG-1");
+        var pkg2 = SamplePackage(id: 2, orderCode: "ORD-OK", packageNumber: "PKG-2");
+
+        repo.Setup(r => r.GetWithNullTrackingNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([pkg1, pkg2]);
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-FAIL", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Shoptet 500"));
+
+        client.Setup(c => c.GetLabelsByOrderCodeAsync("ORD-OK", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new ShipmentLabel { OrderCode = "ORD-OK", PackageName = "PKG-2", TrackingNumber = "TRK-OK" }
+            ]);
+
+        await sut.ExecuteAsync();
+
+        // ORD-OK still processed despite ORD-FAIL throwing
+        repo.Verify(r => r.SetTrackingNumberAsync(2, "TRK-OK", It.IsAny<CancellationToken>()), Times.Once);
+        // ORD-FAIL package not updated
+        repo.Verify(r => r.SetTrackingNumberAsync(1, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}
+```
+
+- [ ] **Step 2: Confirm the tests don't compile yet (RED)**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: Build **fails** with errors like `The type or namespace name 'FillTrackingNumbersJob' could not be found`.
+
+---
+
+## Task 4: Implement FillTrackingNumbersJob (GREEN phase)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Packaging/Infrastructure/Jobs/FillTrackingNumbersJob.cs`
+
+- [ ] **Step 1: Create the job class**
+
+```csharp
+using Anela.Heblo.Application.Features.ShipmentLabels;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.Packaging;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Packaging.Infrastructure.Jobs;
+
+public sealed class FillTrackingNumbersJob : IRecurringJob
+{
+    private const int DaysBack = 3;
+
+    private readonly IPackageRepository _repo;
+    private readonly IShipmentClient _client;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILogger<FillTrackingNumbersJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "fill-tracking-numbers",
+        DisplayName = "Fill Tracking Numbers",
+        Description = "Backfills TrackingNumber for recently-packed shipments where Shoptet had not yet generated the carrier label at scan time.",
+        CronExpression = "*/10 * * * *",
+        DefaultIsEnabled = true,
+    };
+
+    public FillTrackingNumbersJob(
+        IPackageRepository repo,
+        IShipmentClient client,
+        IRecurringJobStatusChecker statusChecker,
+        ILogger<FillTrackingNumbersJob> logger)
+    {
+        _repo = repo;
+        _client = client;
+        _statusChecker = statusChecker;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+            return;
+        }
+
+        var packages = await _repo.GetWithNullTrackingNumberAsync(DaysBack, cancellationToken);
+        if (packages.Count == 0)
+            return;
+
+        _logger.LogInformation(
+            "FillTrackingNumbers: found {Count} package(s) with null TrackingNumber in the last {Days} days.",
+            packages.Count, DaysBack);
+
+        var byOrder = packages.GroupBy(p => p.OrderCode);
+        var updated = 0;
+
+        foreach (var group in byOrder)
+        {
+            var orderCode = group.Key;
+            IReadOnlyList<ShipmentLabel> labels;
+
+            try
+            {
+                labels = await _client.GetLabelsByOrderCodeAsync(orderCode, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "FillTrackingNumbers: failed to fetch labels for order {OrderCode}. Will retry next run.",
+                    orderCode);
+                continue;
+            }
+
+            var labelByPackageName = labels
+                .Where(l => l.TrackingNumber is not null)
+                .ToDictionary(l => l.PackageName, l => l.TrackingNumber!);
+
+            foreach (var package in group)
+            {
+                if (!labelByPackageName.TryGetValue(package.PackageNumber, out var trackingNumber))
+                    continue;
+
+                await _repo.SetTrackingNumberAsync(package.Id, trackingNumber, cancellationToken);
+                updated++;
+
+                _logger.LogInformation(
+                    "FillTrackingNumbers: set TrackingNumber={TrackingNumber} on Package {Id} (order {OrderCode}).",
+                    trackingNumber, package.Id, orderCode);
+            }
+        }
+
+        _logger.LogInformation("FillTrackingNumbers: updated {Updated}/{Total} package(s).", updated, packages.Count);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests (GREEN)**
+
+```bash
+cd backend && dotnet test --filter "FillTrackingNumbersJobTests" --no-build
+```
+
+Wait — build first:
+
+```bash
+cd backend && dotnet build && dotnet test --filter "FillTrackingNumbersJobTests"
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+cd backend && dotnet test
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Packaging/Infrastructure/Jobs/FillTrackingNumbersJob.cs \
+        backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs
+git commit -m "feat(packaging): FillTrackingNumbers recurring job backfills null TrackingNumbers from Shoptet"
+```
+
+---
+
+## Task 5: Seed the job configuration (database)
+
+The `RecurringJobDiscoveryService` auto-discovers and registers the job with Hangfire via reflection — no code registration needed. However, the job schedule is stored in the `RecurringJobConfigurations` table. This table is seeded by the `RecurringJobDiscoveryService` on startup for any jobs not yet present.
+
+**No code changes are needed** for registration. The job will be active the next time the application starts.
+
+- [ ] **Step 1: Verify auto-discovery picks up the new job**
+
+Check `RecurringJobDiscoveryService` to confirm it scans the Application assembly. If so, no action needed.
+
+```bash
+grep -r "AddRecurringJobs\|RecurringJobDiscovery" backend/src --include="*.cs" -l
+```
+
+Expected: at least one file found.
+
+- [ ] **Step 2: Run dotnet build and dotnet test one final time**
+
+```bash
+cd backend && dotnet build && dotnet test
+```
+
+Expected: Build succeeded, all tests pass.
+
+- [ ] **Step 3: Final commit (if any files changed)**
+
+```bash
+git add -p
+git commit -m "chore(packaging): verify FillTrackingNumbers job auto-discovery"
+```
+
+---
+
+## Verification
+
+After deploying to staging:
+
+1. Check the Background Jobs UI (Hangfire dashboard) — the `fill-tracking-numbers` job should appear under recurring jobs.
+2. Trigger it manually from the UI.
+3. Check that order `126000035` now shows `70603624124` in the Sledovací č. column on the Zásilky page.
+4. Monitor logs: look for `FillTrackingNumbers: updated` entries.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -503,6 +503,7 @@ export const QUERY_KEYS = {
   manufacturedProductInventory: ["manufactured-product-inventory"] as const,
   meetingTasks: ["meetingTasks"] as const,
   packingOrder: ["packingOrder"] as const,
+  orderTrackingNumber: ["order-tracking-number"] as const,
   shipmentLabels: ["shipmentLabels"] as const,
   featureFlags: ["feature-flags"] as const,
   catalogDocuments: ["catalog-documents"] as const,

--- a/frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts
+++ b/frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useOrderTrackingNumber } from '../useOrderTrackingNumber';
+import { createMockApiClient, mockAuthenticatedApiClient, createQueryClientWrapper } from '../../testUtils';
+
+jest.mock('../../client');
+
+describe('useOrderTrackingNumber', () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    const mock = createMockApiClient();
+    mockFetch = mock.mockFetch;
+    mockAuthenticatedApiClient(mock.mockClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the tracking number from a successful response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, trackingNumber: '2421907688' }),
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('126000034', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe('2421907688');
+  });
+
+  it('returns null when the response has no tracking number', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, trackingNumber: null }),
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('ORD-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('returns null when the response is not successful', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: false, errorCode: 'Exception' }),
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('ORD-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('does not fetch when disabled', () => {
+    const { wrapper } = createQueryClientWrapper();
+    renderHook(() => useOrderTrackingNumber('ORD-1', false), { wrapper });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts
+++ b/frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts
@@ -69,6 +69,16 @@ describe('useOrderTrackingNumber', () => {
     expect(result.current.data).toBeNull();
   });
 
+  it('returns null when a network error occurs', async () => {
+    mockFetch.mockRejectedValue(new Error('Network failure'));
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('ORD-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
   it('does not fetch when disabled', () => {
     const { wrapper } = createQueryClientWrapper();
     renderHook(() => useOrderTrackingNumber('ORD-1', false), { wrapper });

--- a/frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts
+++ b/frontend/src/api/hooks/__tests__/useOrderTrackingNumber.test.ts
@@ -56,6 +56,19 @@ describe('useOrderTrackingNumber', () => {
     expect(result.current.data).toBeNull();
   });
 
+  it('returns null when the HTTP response is not ok', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const { wrapper } = createQueryClientWrapper();
+    const { result } = renderHook(() => useOrderTrackingNumber('ORD-1', true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
   it('does not fetch when disabled', () => {
     const { wrapper } = createQueryClientWrapper();
     renderHook(() => useOrderTrackingNumber('ORD-1', false), { wrapper });

--- a/frontend/src/api/hooks/useOrderTrackingNumber.ts
+++ b/frontend/src/api/hooks/useOrderTrackingNumber.ts
@@ -11,6 +11,7 @@ const fetchOrderTrackingNumber = async (orderCode: string): Promise<string | nul
   const response = await apiClient.http.fetch(
     `${apiClient.baseUrl}/api/packaging/orders/${encodeURIComponent(orderCode)}/tracking-number`,
   );
+  if (!response.ok) return null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data = (await response.json()) as any;
   if (!data.success) return null;

--- a/frontend/src/api/hooks/useOrderTrackingNumber.ts
+++ b/frontend/src/api/hooks/useOrderTrackingNumber.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAuthenticatedApiClient } from '../client';
+
+interface ApiClientWithInternals {
+  baseUrl: string;
+  http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+}
+
+const fetchOrderTrackingNumber = async (orderCode: string): Promise<string | null> => {
+  const apiClient = (await getAuthenticatedApiClient(false)) as unknown as ApiClientWithInternals;
+  const response = await apiClient.http.fetch(
+    `${apiClient.baseUrl}/api/packaging/orders/${encodeURIComponent(orderCode)}/tracking-number`,
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data = (await response.json()) as any;
+  if (!data.success) return null;
+  return (data.trackingNumber as string | null) ?? null;
+};
+
+export const useOrderTrackingNumber = (orderCode: string, enabled: boolean) =>
+  useQuery<string | null>({
+    queryKey: ['order-tracking-number', orderCode],
+    queryFn: () => fetchOrderTrackingNumber(orderCode),
+    enabled,
+    staleTime: 0,
+  });

--- a/frontend/src/api/hooks/useOrderTrackingNumber.ts
+++ b/frontend/src/api/hooks/useOrderTrackingNumber.ts
@@ -7,7 +7,7 @@ interface ApiClientWithInternals {
 }
 
 const fetchOrderTrackingNumber = async (orderCode: string): Promise<string | null> => {
-  const apiClient = (await getAuthenticatedApiClient(false)) as unknown as ApiClientWithInternals;
+  const apiClient = getAuthenticatedApiClient(false) as unknown as ApiClientWithInternals;
   const response = await apiClient.http.fetch(
     `${apiClient.baseUrl}/api/packaging/orders/${encodeURIComponent(orderCode)}/tracking-number`,
   );

--- a/frontend/src/api/hooks/useOrderTrackingNumber.ts
+++ b/frontend/src/api/hooks/useOrderTrackingNumber.ts
@@ -7,15 +7,19 @@ interface ApiClientWithInternals {
 }
 
 const fetchOrderTrackingNumber = async (orderCode: string): Promise<string | null> => {
-  const apiClient = getAuthenticatedApiClient(false) as unknown as ApiClientWithInternals;
-  const response = await apiClient.http.fetch(
-    `${apiClient.baseUrl}/api/packaging/orders/${encodeURIComponent(orderCode)}/tracking-number`,
-  );
-  if (!response.ok) return null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const data = (await response.json()) as any;
-  if (!data.success) return null;
-  return (data.trackingNumber as string | null) ?? null;
+  try {
+    const apiClient = getAuthenticatedApiClient(false) as unknown as ApiClientWithInternals;
+    const response = await apiClient.http.fetch(
+      `${apiClient.baseUrl}/api/packaging/orders/${encodeURIComponent(orderCode)}/tracking-number`,
+    );
+    if (!response.ok) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = (await response.json()) as any;
+    if (!data.success) return null;
+    return (data.trackingNumber as string | null) ?? null;
+  } catch {
+    return null;
+  }
 };
 
 export const useOrderTrackingNumber = (orderCode: string, enabled: boolean) =>
@@ -24,4 +28,5 @@ export const useOrderTrackingNumber = (orderCode: string, enabled: boolean) =>
     queryFn: () => fetchOrderTrackingNumber(orderCode),
     enabled,
     staleTime: 0,
+    retry: false,
   });

--- a/frontend/src/api/hooks/useOrderTrackingNumber.ts
+++ b/frontend/src/api/hooks/useOrderTrackingNumber.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getAuthenticatedApiClient } from '../client';
+import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
 
 interface ApiClientWithInternals {
   baseUrl: string;
@@ -24,7 +24,7 @@ const fetchOrderTrackingNumber = async (orderCode: string): Promise<string | nul
 
 export const useOrderTrackingNumber = (orderCode: string, enabled: boolean) =>
   useQuery<string | null>({
-    queryKey: ['order-tracking-number', orderCode],
+    queryKey: [...QUERY_KEYS.orderTrackingNumber, orderCode],
     queryFn: () => fetchOrderTrackingNumber(orderCode),
     enabled,
     staleTime: 0,

--- a/frontend/src/api/testUtils.ts
+++ b/frontend/src/api/testUtils.ts
@@ -21,8 +21,10 @@ export const createMockApiClient = (baseUrl = 'http://localhost:5000') => {
  */
 export const mockAuthenticatedApiClient = (mockClient: any) => {
     const { getAuthenticatedApiClient } = require('./client');
-    // Mock as function that returns a Promise (works with await)
-    (getAuthenticatedApiClient as jest.Mock).mockReturnValue(Promise.resolve(mockClient));
+    // Mock as function that returns the client directly (synchronous, matches actual signature).
+    // Callers that still use `await getAuthenticatedApiClient()` are unaffected — awaiting a
+    // non-Promise value is a no-op in JavaScript.
+    (getAuthenticatedApiClient as jest.Mock).mockReturnValue(mockClient);
 };
 
 /**

--- a/frontend/src/components/baleni/PackingLabelPrinter.tsx
+++ b/frontend/src/components/baleni/PackingLabelPrinter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { printLabelPdf } from './printLabelPdf';
 import type { PackingOrder, ScanShipment } from '../../api/hooks/useScanPackingOrder';
 import type { ShipmentLabelDto } from '../../api/generated/api-client';
@@ -26,6 +26,14 @@ function toLabels(shipment: ScanShipment): ShipmentLabelDto[] {
 function PackingLabelPrinter({ order, shipment, onDoneStateChange }: PackingLabelPrinterProps) {
   const [printedCount, setPrintedCount] = useState(0);
   const [acknowledgedCount, setAcknowledgedCount] = useState(0);
+  const [reprintGeneration, setReprintGeneration] = useState(0);
+
+  // Tracks which "print context" we've already auto-printed for. A state guard
+  // (printedCount === 0) can't prevent the double-print because React StrictMode
+  // double-invokes effects synchronously in development, before the state update
+  // commits — so both invocations see the stale value. A ref is written
+  // synchronously and survives that double-invoke, firing the print exactly once.
+  const autoPrintedContextRef = useRef<string | null>(null);
 
   const labels = useMemo(() => toLabels(shipment), [shipment]);
   const isDone = labels.length > 0 && acknowledgedCount >= labels.length;
@@ -33,26 +41,29 @@ function PackingLabelPrinter({ order, shipment, onDoneStateChange }: PackingLabe
   const trackingQuery = useOrderTrackingNumber(order.code, isDone);
 
   useEffect(() => {
-    setPrintedCount(0);
-    setAcknowledgedCount(0);
-  }, [order.code]);
-
-  useEffect(() => {
     onDoneStateChange?.(isDone);
   }, [isDone, onDoneStateChange]);
 
   useEffect(() => {
-    if (labels.length > 0 && printedCount === 0) {
-      printLabelPdf(order.code, labels[0], () =>
-        setAcknowledgedCount((c) => c + 1)
-      );
-      setPrintedCount(1);
-    }
-  }, [labels, order.code, printedCount]);
+    if (labels.length === 0) return;
+
+    // A new order or a reprint click starts a fresh print context. Re-runs within
+    // the same context (StrictMode double-invoke, unrelated re-renders) are ignored.
+    const printContext = `${order.code}|${reprintGeneration}`;
+    if (autoPrintedContextRef.current === printContext) return;
+    autoPrintedContextRef.current = printContext;
+
+    setPrintedCount(1);
+    setAcknowledgedCount(0);
+    printLabelPdf(order.code, labels[0], () =>
+      setAcknowledgedCount((c) => c + 1)
+    );
+  }, [labels, order.code, reprintGeneration]);
 
   function handleReprint() {
     setPrintedCount(0);
     setAcknowledgedCount(0);
+    setReprintGeneration((g) => g + 1);
   }
 
   if (labels.length === 0) {

--- a/frontend/src/components/baleni/PackingLabelPrinter.tsx
+++ b/frontend/src/components/baleni/PackingLabelPrinter.tsx
@@ -3,6 +3,7 @@ import { printLabelPdf } from './printLabelPdf';
 import type { PackingOrder, ScanShipment } from '../../api/hooks/useScanPackingOrder';
 import type { ShipmentLabelDto } from '../../api/generated/api-client';
 import PackingShipmentDoneView from './PackingShipmentDoneView';
+import { useOrderTrackingNumber } from '../../api/hooks/useOrderTrackingNumber';
 
 interface PackingLabelPrinterProps {
   order: PackingOrder;
@@ -28,6 +29,8 @@ function PackingLabelPrinter({ order, shipment, onDoneStateChange }: PackingLabe
 
   const labels = useMemo(() => toLabels(shipment), [shipment]);
   const isDone = labels.length > 0 && acknowledgedCount >= labels.length;
+
+  const trackingQuery = useOrderTrackingNumber(order.code, isDone);
 
   useEffect(() => {
     setPrintedCount(0);
@@ -61,6 +64,7 @@ function PackingLabelPrinter({ order, shipment, onDoneStateChange }: PackingLabe
       <PackingShipmentDoneView
         order={order}
         shipment={shipment}
+        resolvedTrackingNumber={trackingQuery.data ?? null}
         onReprint={handleReprint}
       />
     );

--- a/frontend/src/components/baleni/PackingShipmentDoneView.tsx
+++ b/frontend/src/components/baleni/PackingShipmentDoneView.tsx
@@ -4,6 +4,7 @@ import type { PackingOrder, ScanShipment } from '../../api/hooks/useScanPackingO
 interface PackingShipmentDoneViewProps {
   order: PackingOrder;
   shipment: ScanShipment;
+  resolvedTrackingNumber?: string | null;
   onReprint: () => void;
 }
 
@@ -21,9 +22,17 @@ function buildAddressLines(order: PackingOrder): AddressLines | null {
   return { street, cityZip };
 }
 
-function PackingShipmentDoneView({ order, shipment, onReprint }: PackingShipmentDoneViewProps) {
+function PackingShipmentDoneView({
+  order,
+  shipment,
+  resolvedTrackingNumber,
+  onReprint,
+}: PackingShipmentDoneViewProps) {
   const addressLines = buildAddressLines(order);
-  const trackingSummary = shipment.packages.map((p) => p.trackingNumber ?? p.name).join(', ');
+  const trackingSummary =
+    resolvedTrackingNumber && resolvedTrackingNumber.length > 0
+      ? resolvedTrackingNumber
+      : shipment.packages.map((p) => p.trackingNumber ?? p.name).join(', ');
 
   return (
     <div

--- a/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
+++ b/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
@@ -238,6 +238,7 @@ describe('PackingLabelPrinter', () => {
     );
     fireAck(0);
 
+    expect(mockUseOrderTrackingNumber).toHaveBeenCalledWith('250001', true);
     expect(screen.getByTestId('done-view')).toBeInTheDocument();
     expect(screen.getByTestId('done-tracking')).toHaveTextContent('2421907688');
   });

--- a/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
+++ b/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
@@ -2,22 +2,35 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import PackingLabelPrinter from '../PackingLabelPrinter';
 import { printLabelPdf } from '../printLabelPdf';
+import { useOrderTrackingNumber } from '../../../api/hooks/useOrderTrackingNumber';
 import type { PackingOrder, ScanShipment } from '../../../api/hooks/useScanPackingOrder';
 
 jest.mock('../printLabelPdf', () => ({
   printLabelPdf: jest.fn(),
 }));
 
+jest.mock('../../../api/hooks/useOrderTrackingNumber', () => ({
+  useOrderTrackingNumber: jest.fn(() => ({ data: null })),
+}));
+
 jest.mock('../PackingShipmentDoneView', () => ({
   __esModule: true,
-  default: ({ onReprint }: { onReprint: () => void }) => (
+  default: ({
+    resolvedTrackingNumber,
+    onReprint,
+  }: {
+    resolvedTrackingNumber?: string | null;
+    onReprint: () => void;
+  }) => (
     <div data-testid="done-view">
+      <span data-testid="done-tracking">{resolvedTrackingNumber ?? ''}</span>
       <button data-testid="reprint" onClick={onReprint}>R</button>
     </div>
   ),
 }));
 
 const mockPrintLabelPdf = printLabelPdf as jest.MockedFunction<typeof printLabelPdf>;
+const mockUseOrderTrackingNumber = useOrderTrackingNumber as jest.MockedFunction<typeof useOrderTrackingNumber>;
 
 const makeOrder = (code: string): PackingOrder => ({
   code,
@@ -59,6 +72,8 @@ function fireAck(callIndex: number): void {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockUseOrderTrackingNumber.mockReturnValue({ data: null } as any);
 });
 
 describe('PackingLabelPrinter', () => {
@@ -212,5 +227,18 @@ describe('PackingLabelPrinter', () => {
       expect.any(Function)
     );
     expect(screen.queryByTestId('done-view')).not.toBeInTheDocument();
+  });
+
+  it('passes the resolved tracking number into the done view once printing is finished', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseOrderTrackingNumber.mockReturnValue({ data: '2421907688' } as any);
+
+    render(
+      <PackingLabelPrinter order={makeOrder('250001')} shipment={makeShipment([pkg1])} />
+    );
+    fireAck(0);
+
+    expect(screen.getByTestId('done-view')).toBeInTheDocument();
+    expect(screen.getByTestId('done-tracking')).toHaveTextContent('2421907688');
   });
 });

--- a/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
+++ b/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
@@ -85,6 +85,21 @@ describe('PackingLabelPrinter', () => {
     expect(mockPrintLabelPdf).not.toHaveBeenCalled();
   });
 
+  it('auto-prints exactly once under React.StrictMode (no double print)', () => {
+    render(
+      <React.StrictMode>
+        <PackingLabelPrinter order={makeOrder('250001')} shipment={makeShipment([pkg1])} />
+      </React.StrictMode>
+    );
+
+    expect(mockPrintLabelPdf).toHaveBeenCalledTimes(1);
+    expect(mockPrintLabelPdf).toHaveBeenCalledWith(
+      '250001',
+      expectedLabel('guid-1', 'PKG-1', 'https://x.com/1.pdf'),
+      expect.any(Function)
+    );
+  });
+
   it('auto-prints first label on mount with an onAfterPrint callback', () => {
     render(
       <PackingLabelPrinter order={makeOrder('250001')} shipment={makeShipment([pkg1])} />

--- a/frontend/src/components/baleni/__tests__/PackingShipmentDoneView.test.tsx
+++ b/frontend/src/components/baleni/__tests__/PackingShipmentDoneView.test.tsx
@@ -129,11 +129,22 @@ describe('PackingShipmentDoneView', () => {
   });
 
   it('falls back to the package summary when resolvedTrackingNumber is null or empty', () => {
-    render(
+    const { unmount } = render(
       <PackingShipmentDoneView
         order={makeOrder()}
         shipment={makeShipment()}
         resolvedTrackingNumber={null}
+        onReprint={() => {}}
+      />
+    );
+    expect(screen.getByText('TR-1, TR-2')).toBeInTheDocument();
+    unmount();
+
+    render(
+      <PackingShipmentDoneView
+        order={makeOrder()}
+        shipment={makeShipment()}
+        resolvedTrackingNumber=""
         onReprint={() => {}}
       />
     );

--- a/frontend/src/components/baleni/__tests__/PackingShipmentDoneView.test.tsx
+++ b/frontend/src/components/baleni/__tests__/PackingShipmentDoneView.test.tsx
@@ -114,4 +114,29 @@ describe('PackingShipmentDoneView', () => {
     );
     expect(screen.getByText('PKG-A, TR-B')).toBeInTheDocument();
   });
+
+  it('shows resolvedTrackingNumber when provided, overriding the package summary', () => {
+    render(
+      <PackingShipmentDoneView
+        order={makeOrder()}
+        shipment={makeShipment()}
+        resolvedTrackingNumber="2421907688"
+        onReprint={() => {}}
+      />
+    );
+    expect(screen.getByText('2421907688')).toBeInTheDocument();
+    expect(screen.queryByText('TR-1, TR-2')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the package summary when resolvedTrackingNumber is null or empty', () => {
+    render(
+      <PackingShipmentDoneView
+        order={makeOrder()}
+        shipment={makeShipment()}
+        resolvedTrackingNumber={null}
+        onReprint={() => {}}
+      />
+    );
+    expect(screen.getByText('TR-1, TR-2')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/baleni/zasilky/ZasilkyTable.tsx
+++ b/frontend/src/components/baleni/zasilky/ZasilkyTable.tsx
@@ -57,7 +57,7 @@ export function ZasilkyTable({
           <tr key={p.id} className="border-t hover:bg-slate-50">
             <td className="px-4 py-3 font-mono">{p.orderCode}</td>
             <td className="px-4 py-3">{p.customerName}</td>
-            <td className="px-4 py-3">{p.packageNumber}</td>
+            <td className="px-4 py-3">{p.trackingNumber ?? p.packageNumber}</td>
             <td className="px-4 py-3 font-mono text-sm">{p.trackingNumber ?? "—"}</td>
             <td className="px-4 py-3">{p.shippingProviderName ?? p.shippingProviderCode}</td>
             <td className="px-4 py-3">{new Date(p.packedAt).toLocaleString("cs-CZ")}</td>

--- a/frontend/src/components/baleni/zasilky/__tests__/ZasilkyPage.test.tsx
+++ b/frontend/src/components/baleni/zasilky/__tests__/ZasilkyPage.test.tsx
@@ -82,9 +82,25 @@ describe("ZasilkyPage", () => {
     render(<ZasilkyPage />);
     expect(screen.getByText("ORD-1")).toBeInTheDocument();
     expect(screen.getByText("Alice")).toBeInTheDocument();
-    expect(screen.getByText("PKG-1")).toBeInTheDocument();
+    expect(screen.getAllByText("TRK-1").length).toBeGreaterThanOrEqual(1);
     const table = screen.getByRole("table");
     expect(table).toHaveTextContent("PPL");
+  });
+
+  it("falls back to packageNumber in Balík column when trackingNumber is absent", () => {
+    const packageWithoutTracking: PackageDto = {
+      ...samplePackage,
+      trackingNumber: undefined,
+      packageNumber: "Vlastní balení",
+    };
+    mockUsePackagesQuery.mockReturnValue({
+      data: { items: [packageWithoutTracking], totalCount: 1, pageNumber: 1, pageSize: 20 },
+      isLoading: false,
+      isError: false,
+    });
+    render(<ZasilkyPage />);
+    const cells = screen.getAllByText("Vlastní balení");
+    expect(cells.length).toBeGreaterThanOrEqual(1);
   });
 
   it("calls printLabelPdf when reprint button is clicked", () => {


### PR DESCRIPTION
## Summary

- Adds `FillTrackingNumbersJob` — a Hangfire recurring job (every 10 min) that finds packages with a null `TrackingNumber` created in the last 3 days, fetches labels from Shoptet grouped by order code, and backfills any tracking numbers that are now available; per-order errors are logged and skipped so one failure doesn't abort the rest.
- Extends `IPackageRepository` with `GetWithNullTrackingNumberAsync` and `SetTrackingNumberAsync`; the job is auto-discovered via the existing `RecurringJobDiscoveryService` reflection scan — no manual registration needed.
- Fixes `ZasilkyTable` to display the tracking number in the Balík column, falling back to `packageNumber` when tracking is not yet available.
- 6 unit tests (xUnit/Moq) covering the job's enabled/disabled gate, empty result, update path, null-tracking skip, one-call-per-order deduplication, and resilience when Shoptet throws.

## Test plan

- [ ] Run `dotnet test --filter "FillTrackingNumbersJobTests"` — 6/6 pass
- [ ] Run frontend tests for `ZasilkyPage` — 11/11 pass
- [ ] Deploy to staging, check Hangfire dashboard for `fill-tracking-numbers` recurring job
- [ ] Trigger job manually from dashboard; verify order `126000035` shows `70603624124` in the Sledovací č. column