### PR TITLE
feat(authz): edit display name, email, and can-pack on user detail page

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"0f4f6343-41bc-439e-b636-1ea593af0d26","pid":44516,"procStart":"Wed May 27 05:37:32 2026","acquiredAt":1779861131192}

--- a/backend/src/Anela.Heblo.API/Controllers/AuthorizationController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/AuthorizationController.cs
@@ -12,6 +12,7 @@ using Anela.Heblo.Application.Features.Authorization.UseCases.CreateLocalUser;
 using Anela.Heblo.Application.Features.Authorization.UseCases.SetUserActive;
 using Anela.Heblo.Application.Features.Authorization.UseCases.SetUserCanPack;
 using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateGroup;
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
 using Anela.Heblo.Domain.Features.Authorization;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -87,6 +88,14 @@ public class AuthorizationController : BaseApiController
     [HttpPut("users/{id:guid}/active")]
     [FeatureAuthorize(Feature.Admin_Administration, AccessLevel.Write)]
     public async Task<ActionResult<SetUserActiveResponse>> SetActive([FromRoute] Guid id, [FromBody] SetUserActiveRequest request, CancellationToken ct)
+    {
+        request.UserId = id;
+        return HandleResponse(await _mediator.Send(request, ct));
+    }
+
+    [HttpPut("users/{id:guid}")]
+    [FeatureAuthorize(Feature.Admin_Administration, AccessLevel.Write)]
+    public async Task<ActionResult<UpdateUserResponse>> UpdateUser([FromRoute] Guid id, [FromBody] UpdateUserRequest request, CancellationToken ct)
     {
         request.UserId = id;
         return HandleResponse(await _mediator.Send(request, ct));

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/AuthorizationModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/AuthorizationModule.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Common.Behaviors;
 using Anela.Heblo.Application.Features.Authorization.UseCases.AddGroupMember;
 using Anela.Heblo.Application.Features.Authorization.UseCases.CreateLocalUser;
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
 using Anela.Heblo.Domain.Features.Authorization;
 using Anela.Heblo.Persistence.Features.Authorization;
 using FluentValidation;
@@ -22,6 +23,9 @@ public static class AuthorizationModule
         services.AddScoped<IValidator<CreateLocalUserRequest>, CreateLocalUserValidator>();
         services.AddTransient<IPipelineBehavior<CreateLocalUserRequest, CreateLocalUserResponse>,
             ValidationBehavior<CreateLocalUserRequest, CreateLocalUserResponse>>();
+        services.AddScoped<IValidator<UpdateUserRequest>, UpdateUserValidator>();
+        services.AddTransient<IPipelineBehavior<UpdateUserRequest, UpdateUserResponse>,
+            ValidationBehavior<UpdateUserRequest, UpdateUserResponse>>();
         return services;
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserHandler.cs
@@ -1,0 +1,34 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserHandler : IRequestHandler<UpdateUserRequest, UpdateUserResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    private readonly IPermissionResolver _resolver;
+
+    public UpdateUserHandler(IAuthorizationRepository repo, IPermissionResolver resolver)
+    {
+        _repo = repo;
+        _resolver = resolver;
+    }
+
+    public async Task<UpdateUserResponse> Handle(UpdateUserRequest request, CancellationToken ct)
+    {
+        var user = await _repo.GetUserByIdAsync(request.UserId, ct);
+        if (user is null)
+            return new UpdateUserResponse(ErrorCodes.AuthorizationUserNotFound);
+
+        user.DisplayName = request.DisplayName.Trim();
+        user.Email = request.Email?.Trim() ?? string.Empty;
+        user.CanPack = request.CanPack;
+        await _repo.SaveChangesAsync(ct);
+
+        if (user.EntraObjectId is not null)
+            _resolver.InvalidateCache(user.EntraObjectId);
+
+        return new UpdateUserResponse();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserRequest.cs
@@ -1,0 +1,11 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserRequest : IRequest<UpdateUserResponse>
+{
+    public Guid UserId { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public bool CanPack { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserResponse.cs
@@ -1,0 +1,9 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserResponse : BaseResponse
+{
+    public UpdateUserResponse() { }
+    public UpdateUserResponse(ErrorCodes errorCode) : base(errorCode) { }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserValidator : AbstractValidator<UpdateUserRequest>
+{
+    public UpdateUserValidator()
+    {
+        RuleFor(x => x.DisplayName)
+            .NotEmpty().WithMessage("Display name is required.")
+            .MaximumLength(255);
+
+        RuleFor(x => x.Email)
+            .MaximumLength(255)
+            .EmailAddress().WithMessage("Email is not valid.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Email));
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -289,6 +289,10 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment.ResetOrderShipmentHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IPackingOrderClient",
         "Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment.ResetOrderShipmentHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrder",
         "Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment.ResetOrderShipmentHandler -> Anela.Heblo.Application.Features.ShoptetOrders.PackingOrderItem",
+
+        // GetPackingDashboardHandler consumes IPackingOrderClient to read the orders-being-packed
+        // count for the dashboard (no ShoptetOrders DTOs cross the boundary — the call returns int?).
+        "Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard.GetPackingDashboardHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IPackingOrderClient",
     };
 
     public static TheoryData<ModuleBoundaryRule> Rules() => new()

--- a/backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs
@@ -1,0 +1,109 @@
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class UpdateUserHandlerTests
+{
+    private static ApplicationDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"updateuser_{Guid.NewGuid()}").Options);
+
+    private static IPermissionResolver NoOpResolver() => new Mock<IPermissionResolver>().Object;
+
+    private static async Task<AppUser> SeedUser(ApplicationDbContext db)
+    {
+        var user = new AppUser
+        {
+            Id = Guid.NewGuid(),
+            EntraObjectId = "oid",
+            Email = "old@x.cz",
+            DisplayName = "Old",
+            IsActive = true,
+            CanPack = false,
+            Source = AppUserSource.Entra,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+        db.AppUsers.Add(user);
+        await db.SaveChangesAsync();
+        return user;
+    }
+
+    [Fact]
+    public async Task Handle_UpdatesFields_WhenUserExists()
+    {
+        await using var db = NewDb();
+        var user = await SeedUser(db);
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), NoOpResolver());
+
+        var result = await handler.Handle(new UpdateUserRequest
+        {
+            UserId = user.Id,
+            DisplayName = "  New Name  ",
+            Email = "  new@x.cz  ",
+            CanPack = true,
+        }, default);
+
+        result.Success.Should().BeTrue();
+        var saved = await db.AppUsers.SingleAsync(u => u.Id == user.Id);
+        saved.DisplayName.Should().Be("New Name");   // trimmed
+        saved.Email.Should().Be("new@x.cz");          // trimmed
+        saved.CanPack.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_AllowsEmptyEmail()
+    {
+        await using var db = NewDb();
+        var user = await SeedUser(db);
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), NoOpResolver());
+
+        var result = await handler.Handle(new UpdateUserRequest
+        {
+            UserId = user.Id,
+            DisplayName = "Name",
+            Email = null,
+            CanPack = false,
+        }, default);
+
+        result.Success.Should().BeTrue();
+        (await db.AppUsers.SingleAsync(u => u.Id == user.Id)).Email.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenUserMissing()
+    {
+        await using var db = NewDb();
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), NoOpResolver());
+
+        var result = await handler.Handle(new UpdateUserRequest
+        {
+            UserId = Guid.NewGuid(),
+            DisplayName = "Name",
+        }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.AuthorizationUserNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidatesCache_WhenEntraUser()
+    {
+        await using var db = NewDb();
+        var user = await SeedUser(db);
+        var resolverMock = new Mock<IPermissionResolver>();
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), resolverMock.Object);
+
+        await handler.Handle(new UpdateUserRequest { UserId = user.Id, DisplayName = "Name", CanPack = true }, default);
+
+        resolverMock.Verify(r => r.InvalidateCache(user.EntraObjectId!), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs
@@ -106,4 +106,30 @@ public class UpdateUserHandlerTests
 
         resolverMock.Verify(r => r.InvalidateCache(user.EntraObjectId!), Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_DoesNotInvalidateCache_WhenLocalUser()
+    {
+        await using var db = NewDb();
+        var user = new AppUser
+        {
+            Id = Guid.NewGuid(),
+            EntraObjectId = null,          // Local operator
+            Email = "op@x.cz",
+            DisplayName = "Operator",
+            IsActive = true,
+            CanPack = false,
+            Source = AppUserSource.Local,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+        db.AppUsers.Add(user);
+        await db.SaveChangesAsync();
+
+        var resolverMock = new Mock<IPermissionResolver>();
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), resolverMock.Object);
+
+        await handler.Handle(new UpdateUserRequest { UserId = user.Id, DisplayName = "Op" }, default);
+
+        resolverMock.Verify(r => r.InvalidateCache(It.IsAny<string>()), Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Authorization/UpdateUserValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/UpdateUserValidatorTests.cs
@@ -1,0 +1,34 @@
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class UpdateUserValidatorTests
+{
+    private readonly UpdateUserValidator _validator = new();
+
+    [Fact]
+    public void Rejects_BlankDisplayName()
+    {
+        var result = _validator.Validate(new UpdateUserRequest { DisplayName = "", Email = "a@b.cz" });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Rejects_InvalidEmail()
+    {
+        var result = _validator.Validate(new UpdateUserRequest { DisplayName = "Name", Email = "not-an-email" });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Accepts_EmptyEmail(string? email)
+    {
+        var result = _validator.Validate(new UpdateUserRequest { DisplayName = "Name", Email = email });
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/docs/superpowers/plans/2026-06-10-user-detail-editable-fields.md
+++ b/docs/superpowers/plans/2026-06-10-user-detail-editable-fields.md
@@ -1,0 +1,656 @@
+# User Detail Editable Fields Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an admin edit a user's Display name, Email, and Can-pack flag on the Access management → User detail page, committed alongside group changes via the existing Save button.
+
+**Architecture:** Add one new MediatR use case `UpdateUser` (PUT `users/{id}`) handling scalar profile fields, following the existing `SetUserActive` pattern exactly. Group assignment stays on its own dedicated endpoint; the page's **Save** fires both mutations in parallel. Applies to both Entra (SSO) and Local users — auth is keyed on `EntraObjectId`, so editing DB display name/email is a safe independent override.
+
+**Tech Stack:** .NET 8, MediatR, FluentValidation, EF Core (in-memory for tests), xUnit + FluentAssertions + Moq; React + TanStack Query, NSwag-generated TypeScript client.
+
+---
+
+## File Structure
+
+**Backend (new — `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/`):**
+- `UpdateUserRequest.cs` — MediatR request, OpenAPI contract (plain class, **not a record**)
+- `UpdateUserResponse.cs` — `: BaseResponse` (MUST inherit BaseResponse or the CI reflection contract test fails)
+- `UpdateUserHandler.cs` — load user, set fields, save, invalidate cache
+- `UpdateUserValidator.cs` — DisplayName required; Email optional but valid when present
+
+**Backend (modify):**
+- `backend/src/Anela.Heblo.Application/Features/Authorization/AuthorizationModule.cs` — register validator + ValidationBehavior (manual, per project rule)
+- `backend/src/Anela.Heblo.API/Controllers/AuthorizationController.cs` — new `PUT users/{id}` endpoint
+
+**Backend tests (new):**
+- `backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Authorization/UpdateUserValidatorTests.cs`
+
+**Frontend (modify):**
+- `frontend/src/api/generated/api-client.ts` — regenerated (do not hand-edit)
+- `frontend/src/api/hooks/useAccessManagement.ts` — add `useUpdateUser`
+- `frontend/src/pages/UserDetailPage.tsx` — editable form + combined save
+
+---
+
+## Task 1: Backend UpdateUser request, response, and handler
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing handler test**
+
+Create `backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Authorization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class UpdateUserHandlerTests
+{
+    private static ApplicationDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"updateuser_{Guid.NewGuid()}").Options);
+
+    private static IPermissionResolver NoOpResolver() => new Mock<IPermissionResolver>().Object;
+
+    private static async Task<AppUser> SeedUser(ApplicationDbContext db)
+    {
+        var user = new AppUser
+        {
+            Id = Guid.NewGuid(),
+            EntraObjectId = "oid",
+            Email = "old@x.cz",
+            DisplayName = "Old",
+            IsActive = true,
+            CanPack = false,
+            Source = AppUserSource.Entra,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+        db.AppUsers.Add(user);
+        await db.SaveChangesAsync();
+        return user;
+    }
+
+    [Fact]
+    public async Task Handle_UpdatesFields_WhenUserExists()
+    {
+        await using var db = NewDb();
+        var user = await SeedUser(db);
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), NoOpResolver());
+
+        var result = await handler.Handle(new UpdateUserRequest
+        {
+            UserId = user.Id,
+            DisplayName = "  New Name  ",
+            Email = "  new@x.cz  ",
+            CanPack = true,
+        }, default);
+
+        result.Success.Should().BeTrue();
+        var saved = await db.AppUsers.SingleAsync(u => u.Id == user.Id);
+        saved.DisplayName.Should().Be("New Name");   // trimmed
+        saved.Email.Should().Be("new@x.cz");          // trimmed
+        saved.CanPack.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_AllowsEmptyEmail()
+    {
+        await using var db = NewDb();
+        var user = await SeedUser(db);
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), NoOpResolver());
+
+        var result = await handler.Handle(new UpdateUserRequest
+        {
+            UserId = user.Id,
+            DisplayName = "Name",
+            Email = null,
+            CanPack = false,
+        }, default);
+
+        result.Success.Should().BeTrue();
+        (await db.AppUsers.SingleAsync(u => u.Id == user.Id)).Email.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenUserMissing()
+    {
+        await using var db = NewDb();
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), NoOpResolver());
+
+        var result = await handler.Handle(new UpdateUserRequest
+        {
+            UserId = Guid.NewGuid(),
+            DisplayName = "Name",
+        }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.AuthorizationUserNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidatesCache_WhenEntraUser()
+    {
+        await using var db = NewDb();
+        var user = await SeedUser(db);
+        var resolverMock = new Mock<IPermissionResolver>();
+        var handler = new UpdateUserHandler(new AuthorizationRepository(db), resolverMock.Object);
+
+        await handler.Handle(new UpdateUserRequest { UserId = user.Id, DisplayName = "Name", CanPack = true }, default);
+
+        resolverMock.Verify(r => r.InvalidateCache(user.EntraObjectId!), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (does not compile)**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests`
+Expected: FAIL — `UpdateUserRequest`, `UpdateUserResponse`, `UpdateUserHandler` do not exist.
+
+- [ ] **Step 3: Create `UpdateUserRequest.cs`**
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserRequest : IRequest<UpdateUserResponse>
+{
+    public Guid UserId { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public bool CanPack { get; set; }
+}
+```
+
+- [ ] **Step 4: Create `UpdateUserResponse.cs`**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserResponse : BaseResponse
+{
+    public UpdateUserResponse() { }
+    public UpdateUserResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 5: Create `UpdateUserHandler.cs`**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserHandler : IRequestHandler<UpdateUserRequest, UpdateUserResponse>
+{
+    private readonly IAuthorizationRepository _repo;
+    private readonly IPermissionResolver _resolver;
+
+    public UpdateUserHandler(IAuthorizationRepository repo, IPermissionResolver resolver)
+    {
+        _repo = repo;
+        _resolver = resolver;
+    }
+
+    public async Task<UpdateUserResponse> Handle(UpdateUserRequest request, CancellationToken ct)
+    {
+        var user = await _repo.GetUserByIdAsync(request.UserId, ct);
+        if (user is null)
+            return new UpdateUserResponse(ErrorCodes.AuthorizationUserNotFound);
+
+        user.DisplayName = request.DisplayName.Trim();
+        user.Email = request.Email?.Trim() ?? string.Empty;
+        user.CanPack = request.CanPack;
+        await _repo.SaveChangesAsync(ct);
+
+        if (user.EntraObjectId is not null)
+            _resolver.InvalidateCache(user.EntraObjectId);
+
+        return new UpdateUserResponse();
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~UpdateUserHandlerTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser backend/test/Anela.Heblo.Tests/Authorization/UpdateUserHandlerTests.cs
+git commit -m "feat(authz): add UpdateUser handler for editable user profile fields"
+```
+
+---
+
+## Task 2: Backend UpdateUser validator
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserValidator.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/UpdateUserValidatorTests.cs`
+
+- [ ] **Step 1: Write the failing validator test**
+
+Create `backend/test/Anela.Heblo.Tests/Authorization/UpdateUserValidatorTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class UpdateUserValidatorTests
+{
+    private readonly UpdateUserValidator _validator = new();
+
+    [Fact]
+    public void Rejects_BlankDisplayName()
+    {
+        var result = _validator.Validate(new UpdateUserRequest { DisplayName = "", Email = "a@b.cz" });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Rejects_InvalidEmail()
+    {
+        var result = _validator.Validate(new UpdateUserRequest { DisplayName = "Name", Email = "not-an-email" });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Accepts_EmptyEmail(string? email)
+    {
+        var result = _validator.Validate(new UpdateUserRequest { DisplayName = "Name", Email = email });
+        result.IsValid.Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (does not compile)**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests`
+Expected: FAIL — `UpdateUserValidator` does not exist.
+
+- [ ] **Step 3: Create `UpdateUserValidator.cs`**
+
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+
+public class UpdateUserValidator : AbstractValidator<UpdateUserRequest>
+{
+    public UpdateUserValidator()
+    {
+        RuleFor(x => x.DisplayName)
+            .NotEmpty().WithMessage("Display name is required.")
+            .MaximumLength(255);
+
+        RuleFor(x => x.Email)
+            .MaximumLength(255)
+            .EmailAddress().WithMessage("Email is not valid.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Email));
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~UpdateUserValidatorTests"`
+Expected: PASS (5 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/UpdateUser/UpdateUserValidator.cs backend/test/Anela.Heblo.Tests/Authorization/UpdateUserValidatorTests.cs
+git commit -m "feat(authz): add UpdateUser validator"
+```
+
+---
+
+## Task 3: Register DI + expose controller endpoint
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Authorization/AuthorizationModule.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/AuthorizationController.cs`
+
+- [ ] **Step 1: Register the validator and ValidationBehavior**
+
+In `AuthorizationModule.cs`, add the `using` at the top (alongside the existing UseCases usings):
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+```
+
+Then add these two lines inside `AddAuthorizationModule`, right before `return services;`:
+
+```csharp
+        services.AddScoped<IValidator<UpdateUserRequest>, UpdateUserValidator>();
+        services.AddTransient<IPipelineBehavior<UpdateUserRequest, UpdateUserResponse>,
+            ValidationBehavior<UpdateUserRequest, UpdateUserResponse>>();
+```
+
+(MediatR auto-registers the handler via assembly scan — no handler registration needed.)
+
+- [ ] **Step 2: Add the controller endpoint**
+
+In `AuthorizationController.cs`, add the `using` at the top (alphabetically with the other UseCases usings):
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.UpdateUser;
+```
+
+Then add this action after the `SetActive` method (line ~93), before `CreateLocalUser`:
+
+```csharp
+    [HttpPut("users/{id:guid}")]
+    [FeatureAuthorize(Feature.Admin_Administration, AccessLevel.Write)]
+    public async Task<ActionResult<UpdateUserResponse>> UpdateUser([FromRoute] Guid id, [FromBody] UpdateUserRequest request, CancellationToken ct)
+    {
+        request.UserId = id;
+        return HandleResponse(await _mediator.Send(request, ct));
+    }
+```
+
+- [ ] **Step 3: Build the backend and run the full Authorization test suite**
+
+Run: `dotnet build backend/src/Anela.Heblo.API && dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~Authorization"`
+Expected: PASS — including the `*Response : BaseResponse` reflection contract test and `AuthorizationModuleTests`.
+
+- [ ] **Step 4: Format**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: no remaining diagnostics.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Authorization/AuthorizationModule.cs backend/src/Anela.Heblo.API/Controllers/AuthorizationController.cs
+git commit -m "feat(authz): expose PUT users/{id} UpdateUser endpoint"
+```
+
+---
+
+## Task 4: Regenerate TS client + add `useUpdateUser` hook
+
+**Files:**
+- Modify (generated): `frontend/src/api/generated/api-client.ts`
+- Modify: `frontend/src/api/hooks/useAccessManagement.ts`
+
+- [ ] **Step 1: Regenerate the TypeScript client**
+
+Run: `cd frontend && npm run generate-client`
+Expected: `frontend/src/api/generated/api-client.ts` now contains `UpdateUserRequest`, `UpdateUserResponse`, and an `authorization_UpdateUser(id, request)` method.
+
+- [ ] **Step 2: Verify the generated symbols exist**
+
+Run: `grep -n "authorization_UpdateUser\|class UpdateUserRequest\|class UpdateUserResponse" frontend/src/api/generated/api-client.ts`
+Expected: at least 3 matches.
+
+- [ ] **Step 3: Add the hook**
+
+In `frontend/src/api/hooks/useAccessManagement.ts`:
+
+Add `UpdateUserResponse` to the `import type { ... }` block (the type-only import list ending at line ~18):
+
+```typescript
+  UpdateUserResponse,
+```
+
+Add `UpdateUserRequest` to the value `import { ... }` block (lines ~19–27):
+
+```typescript
+  UpdateUserRequest,
+```
+
+Add this hook after `useSetUserActive` (after line ~177):
+
+```typescript
+export const useUpdateUser = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      request,
+    }: {
+      id: string;
+      request: UpdateUserRequest;
+    }): Promise<UpdateUserResponse> => {
+      const client = getAuthenticatedApiClient();
+      return client.authorization_UpdateUser(id, request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: keys.users });
+      queryClient.invalidateQueries({ queryKey: keys.userPermissionsPrefix, exact: false });
+    },
+  });
+};
+```
+
+Add `UpdateUserRequest` to the re-export `export type { ... }` line at the bottom (line ~236):
+
+```typescript
+export type { CreateGroupRequest, UpdateGroupRequest, AssignUserGroupsRequest, SetUserActiveRequest, AddGroupMemberRequest, CreateLocalUserRequest, SetUserCanPackRequest, UpdateUserRequest };
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/generated/api-client.ts frontend/src/api/hooks/useAccessManagement.ts
+git commit -m "feat(authz): regenerate client and add useUpdateUser hook"
+```
+
+---
+
+## Task 5: Editable form + combined save on UserDetailPage
+
+**Files:**
+- Modify: `frontend/src/pages/UserDetailPage.tsx`
+
+- [ ] **Step 1: Update imports**
+
+Change the hooks import (lines 3–8) to add `useUpdateUser`:
+
+```typescript
+import {
+  useUsers,
+  useAssignUserGroups,
+  useSetUserActive,
+  useUserPermissions,
+  useUpdateUser,
+} from "../api/hooks/useAccessManagement";
+```
+
+Change the api-client import (line 9) to add `UpdateUserRequest`:
+
+```typescript
+import { AssignUserGroupsRequest, SetUserActiveRequest, UpdateUserRequest } from "../api/generated/api-client";
+```
+
+- [ ] **Step 2: Extend the draft shape and seed all fields**
+
+Replace the `UserDraft` interface (lines 13–15):
+
+```typescript
+interface UserDraft {
+  displayName: string;
+  email: string;
+  canPack: boolean;
+  groupIds: string[];
+}
+```
+
+Add the hook with the other mutation hooks (after line 25):
+
+```typescript
+  const updateUser = useUpdateUser();
+```
+
+Replace the draft initialization inside the init `useEffect` (line 36):
+
+```typescript
+    const d: UserDraft = {
+      displayName: user.displayName ?? "",
+      email: user.email ?? "",
+      canPack: user.canPack ?? false,
+      groupIds: user.groupIds ?? [],
+    };
+```
+
+- [ ] **Step 3: Replace `onSave` with the combined, validated save**
+
+Replace the `onSave` function (lines 44–55):
+
+```typescript
+  const onSave = async () => {
+    if (!draft) return;
+    if (!draft.displayName.trim()) {
+      toast.showError("Save failed", "Display name is required");
+      return;
+    }
+    try {
+      await Promise.all([
+        updateUser.mutateAsync({
+          id,
+          request: new UpdateUserRequest({
+            userId: id,
+            displayName: draft.displayName.trim(),
+            email: draft.email.trim(),
+            canPack: draft.canPack,
+          }),
+        }),
+        assignUserGroups.mutateAsync({
+          id,
+          request: new AssignUserGroupsRequest({ userId: id, groupIds: draft.groupIds }),
+        }),
+      ]);
+      toast.showSuccess("Saved", "User updated successfully");
+    } catch {
+      toast.showError("Save failed", "An error occurred while saving changes");
+    }
+  };
+```
+
+- [ ] **Step 4: Include the new mutation in the saving state**
+
+Replace the `isSaving` line (line 74):
+
+```typescript
+  const isSaving = assignUserGroups.isPending || updateUser.isPending;
+```
+
+- [ ] **Step 5: Replace the read-only header card with editable inputs**
+
+Replace the card block (lines 107–121, the `<div className="bg-white border ... justify-between">` … `</div>` showing email, last login, and the Disable/Enable button) with:
+
+```tsx
+      <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">Last login: {lastLoginText}</p>
+          <button
+            type="button"
+            onClick={onToggleActive}
+            disabled={setActive.isPending}
+            className={`text-sm ${user.isActive ? "text-red-600" : "text-green-600"} hover:underline disabled:opacity-50`}
+            aria-label={user.isActive ? "Disable user" : "Enable user"}
+          >
+            {user.isActive ? "Disable" : "Enable"}
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <label className="block">
+            <span className="block text-sm font-medium text-gray-700 mb-1">Display name</span>
+            <input
+              type="text"
+              value={draft.displayName}
+              onChange={(e) => updateDraft({ displayName: e.target.value })}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm font-medium text-gray-700 mb-1">Email</span>
+            <input
+              type="email"
+              value={draft.email}
+              onChange={(e) => updateDraft({ email: e.target.value })}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={draft.canPack}
+            onChange={(e) => updateDraft({ canPack: e.target.checked })}
+            className="rounded border-gray-300"
+          />
+          <span className="text-sm text-gray-700">Can pack</span>
+        </label>
+      </div>
+```
+
+(The `<h1>{user.displayName}</h1>` page title at line 104 stays bound to the saved value — it refreshes after Save via the `users` query invalidation.)
+
+- [ ] **Step 6: Build the frontend (strict) and lint**
+
+Run: `cd frontend && npm run build && npm run lint`
+Expected: build succeeds (catches stricter type errors than `tsc`), lint clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/UserDetailPage.tsx
+git commit -m "feat(authz): edit display name, email, and can-pack on user detail page"
+```
+
+---
+
+## Manual Verification
+
+1. **Backend:** `dotnet build backend/Anela.Heblo.sln` + `dotnet format backend/Anela.Heblo.sln` + `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~Authorization"` — all green.
+2. **Frontend:** `cd frontend && npm run build && npm run lint` — clean.
+3. **End-to-end (run the app):**
+   - Open **Access management → Users**, click a user to open the detail page.
+   - Edit **Display name**, change **Email**, toggle **Can pack**, click **Save** → success toast.
+   - Navigate back to the list and confirm the new display name/email persist; reopen detail to confirm Can-pack persisted.
+   - Repeat for **one Entra (SSO) user and one Local operator** to confirm both sources are editable.
+   - Clear Email and Save → succeeds (empty email allowed). Enter an invalid email (e.g. `abc`) and Save → backend rejects via validation (save fails toast). Clear Display name and Save → client blocks with "Display name is required".
+
+## Self-Review Notes
+
+- **Spec coverage:** Display name (Task 5 input + Task 1 handler), Email (same), Can pack (same), both user sources (no source gating anywhere — Task 1 handler treats all users uniformly; cache invalidation guarded only by `EntraObjectId != null`). ✔
+- **Type consistency:** `UpdateUserRequest { userId, displayName, email, canPack }` is identical across Task 1 (C# request), Task 4 (hook generic), and Task 5 (constructor call). Hook method `authorization_UpdateUser(id, request)` matches the controller route `PUT users/{id}`. ✔
+- **No placeholders:** every code/step is complete and runnable. ✔

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -1180,6 +1180,47 @@ export class ApiClient {
         return Promise.resolve<SetUserActiveResponse>(null as any);
     }
 
+    authorization_UpdateUser(id: string, request: UpdateUserRequest): Promise<UpdateUserResponse> {
+        let url_ = this.baseUrl + "/api/admin/authorization/users/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processAuthorization_UpdateUser(_response);
+        });
+    }
+
+    protected processAuthorization_UpdateUser(response: Response): Promise<UpdateUserResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = UpdateUserResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<UpdateUserResponse>(null as any);
+    }
+
     authorization_CreateLocalUser(request: CreateLocalUserRequest): Promise<CreateLocalUserResponse> {
         let url_ = this.baseUrl + "/api/admin/authorization/users/local";
         url_ = url_.replace(/[?&]$/, "");
@@ -8553,7 +8594,41 @@ export class ApiClient {
         return Promise.resolve<FileResponse>(null as any);
     }
 
-    packaging_GetPackages(orderCode: string | null | undefined, customerName: string | null | undefined, packageNumber: string | null | undefined, shippingProviderCode: string | null | undefined, fromDate: Date | null | undefined, toDate: Date | null | undefined, pageNumber: number | undefined, pageSize: number | undefined, sortBy: string | undefined, sortDescending: boolean | undefined): Promise<GetPackagesResponse> {
+    packaging_GetDashboard(): Promise<GetPackingDashboardResponse> {
+        let url_ = this.baseUrl + "/api/packaging/dashboard";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackaging_GetDashboard(_response);
+        });
+    }
+
+    protected processPackaging_GetDashboard(response: Response): Promise<GetPackingDashboardResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetPackingDashboardResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetPackingDashboardResponse>(null as any);
+    }
+
+    packaging_GetPackages(orderCode: string | null | undefined, customerName: string | null | undefined, packageNumber: string | null | undefined, carrier: Carriers | null | undefined, fromDate: Date | null | undefined, toDate: Date | null | undefined, pageNumber: number | undefined, pageSize: number | undefined, sortBy: string | undefined, sortDescending: boolean | undefined): Promise<GetPackagesResponse> {
         let url_ = this.baseUrl + "/api/packaging/packages?";
         if (orderCode !== undefined && orderCode !== null)
             url_ += "OrderCode=" + encodeURIComponent("" + orderCode) + "&";
@@ -8561,8 +8636,8 @@ export class ApiClient {
             url_ += "CustomerName=" + encodeURIComponent("" + customerName) + "&";
         if (packageNumber !== undefined && packageNumber !== null)
             url_ += "PackageNumber=" + encodeURIComponent("" + packageNumber) + "&";
-        if (shippingProviderCode !== undefined && shippingProviderCode !== null)
-            url_ += "ShippingProviderCode=" + encodeURIComponent("" + shippingProviderCode) + "&";
+        if (carrier !== undefined && carrier !== null)
+            url_ += "Carrier=" + encodeURIComponent("" + carrier) + "&";
         if (fromDate !== undefined && fromDate !== null)
             url_ += "FromDate=" + encodeURIComponent(fromDate ? "" + fromDate.toISOString() : "") + "&";
         if (toDate !== undefined && toDate !== null)
@@ -12994,6 +13069,7 @@ export enum ErrorCodes {
     PackageLabelNotFound = "PackageLabelNotFound",
     PackageLabelDownloadFailed = "PackageLabelDownloadFailed",
     PackageNotFound = "PackageNotFound",
+    PackingUserNotEligible = "PackingUserNotEligible",
     CatalogDocumentInvalidTypeCode = "CatalogDocumentInvalidTypeCode",
     CatalogDocumentLotRequired = "CatalogDocumentLotRequired",
     CatalogDocumentFolderNotFound = "CatalogDocumentFolderNotFound",
@@ -15608,6 +15684,81 @@ export class SetUserActiveRequest implements ISetUserActiveRequest {
 export interface ISetUserActiveRequest {
     userId?: string;
     isActive?: boolean;
+}
+
+export class UpdateUserResponse extends BaseResponse implements IUpdateUserResponse {
+
+    constructor(data?: IUpdateUserResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): UpdateUserResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateUserResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUpdateUserResponse extends IBaseResponse {
+}
+
+export class UpdateUserRequest implements IUpdateUserRequest {
+    userId?: string;
+    displayName?: string;
+    email?: string | undefined;
+    canPack?: boolean;
+
+    constructor(data?: IUpdateUserRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.userId = _data["userId"];
+            this.displayName = _data["displayName"];
+            this.email = _data["email"];
+            this.canPack = _data["canPack"];
+        }
+    }
+
+    static fromJS(data: any): UpdateUserRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateUserRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["userId"] = this.userId;
+        data["displayName"] = this.displayName;
+        data["email"] = this.email;
+        data["canPack"] = this.canPack;
+        return data;
+    }
+}
+
+export interface IUpdateUserRequest {
+    userId?: string;
+    displayName?: string;
+    email?: string | undefined;
+    canPack?: boolean;
 }
 
 export class CreateLocalUserResponse extends BaseResponse implements ICreateLocalUserResponse {
@@ -32310,6 +32461,99 @@ export interface IResetShipmentPackage {
     name?: string;
     labelUrl?: string | undefined;
     labelZpl?: string | undefined;
+}
+
+export class GetPackingDashboardResponse extends BaseResponse implements IGetPackingDashboardResponse {
+    ordersBeingPackedCount?: number | undefined;
+    totalOrdersPackedToday?: number;
+    packedByPacker?: PackerStatsDto[];
+
+    constructor(data?: IGetPackingDashboardResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.ordersBeingPackedCount = _data["ordersBeingPackedCount"];
+            this.totalOrdersPackedToday = _data["totalOrdersPackedToday"];
+            if (Array.isArray(_data["packedByPacker"])) {
+                this.packedByPacker = [] as any;
+                for (let item of _data["packedByPacker"])
+                    this.packedByPacker!.push(PackerStatsDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetPackingDashboardResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetPackingDashboardResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["ordersBeingPackedCount"] = this.ordersBeingPackedCount;
+        data["totalOrdersPackedToday"] = this.totalOrdersPackedToday;
+        if (Array.isArray(this.packedByPacker)) {
+            data["packedByPacker"] = [];
+            for (let item of this.packedByPacker)
+                data["packedByPacker"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetPackingDashboardResponse extends IBaseResponse {
+    ordersBeingPackedCount?: number | undefined;
+    totalOrdersPackedToday?: number;
+    packedByPacker?: PackerStatsDto[];
+}
+
+export class PackerStatsDto implements IPackerStatsDto {
+    packerId?: string | undefined;
+    packerName?: string;
+    orderCount?: number;
+
+    constructor(data?: IPackerStatsDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.packerId = _data["packerId"];
+            this.packerName = _data["packerName"];
+            this.orderCount = _data["orderCount"];
+        }
+    }
+
+    static fromJS(data: any): PackerStatsDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackerStatsDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["packerId"] = this.packerId;
+        data["packerName"] = this.packerName;
+        data["orderCount"] = this.orderCount;
+        return data;
+    }
+}
+
+export interface IPackerStatsDto {
+    packerId?: string | undefined;
+    packerName?: string;
+    orderCount?: number;
 }
 
 export class GetPackagesResponse extends BaseResponse implements IGetPackagesResponse {

--- a/frontend/src/api/hooks/useAccessManagement.ts
+++ b/frontend/src/api/hooks/useAccessManagement.ts
@@ -191,9 +191,10 @@ export const useUpdateUser = () => {
       const client = getAuthenticatedApiClient();
       return client.authorization_UpdateUser(id, request);
     },
+    // Profile fields (display name, email, can-pack) don't affect effective
+    // permissions, so only the users list needs refreshing.
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: keys.users });
-      queryClient.invalidateQueries({ queryKey: keys.userPermissionsPrefix, exact: false });
     },
   });
 };

--- a/frontend/src/api/hooks/useAccessManagement.ts
+++ b/frontend/src/api/hooks/useAccessManagement.ts
@@ -15,6 +15,7 @@ import type {
   GetUserEffectivePermissionsResponse,
   CreateLocalUserResponse,
   SetUserCanPackResponse,
+  UpdateUserResponse,
 } from "../generated/api-client";
 import {
   CreateGroupRequest,
@@ -24,6 +25,7 @@ import {
   AddGroupMemberRequest,
   CreateLocalUserRequest,
   SetUserCanPackRequest,
+  UpdateUserRequest,
 } from "../generated/api-client";
 
 const keys = {
@@ -176,6 +178,26 @@ export const useSetUserActive = () => {
   });
 };
 
+export const useUpdateUser = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      request,
+    }: {
+      id: string;
+      request: UpdateUserRequest;
+    }): Promise<UpdateUserResponse> => {
+      const client = getAuthenticatedApiClient();
+      return client.authorization_UpdateUser(id, request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: keys.users });
+      queryClient.invalidateQueries({ queryKey: keys.userPermissionsPrefix, exact: false });
+    },
+  });
+};
+
 export const useEntraAccessUsers = () => {
   return useQuery({
     queryKey: keys.entraUsers,
@@ -233,4 +255,4 @@ export const useCreateLocalUser = () => {
   });
 };
 
-export type { CreateGroupRequest, UpdateGroupRequest, AssignUserGroupsRequest, SetUserActiveRequest, AddGroupMemberRequest, CreateLocalUserRequest, SetUserCanPackRequest };
+export type { CreateGroupRequest, UpdateGroupRequest, AssignUserGroupsRequest, SetUserActiveRequest, AddGroupMemberRequest, CreateLocalUserRequest, SetUserCanPackRequest, UpdateUserRequest };

--- a/frontend/src/components/baleni/__tests__/BaleniHome.test.tsx
+++ b/frontend/src/components/baleni/__tests__/BaleniHome.test.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import BaleniHome from '../BaleniHome';
 
-const renderHome = () =>
-  render(
-    <MemoryRouter>
-      <BaleniHome />
-    </MemoryRouter>,
+const renderHome = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <BaleniHome />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
+};
 
 describe('BaleniHome', () => {
   it('renders heading', () => {
     renderHome();
-    expect(screen.getByText('Vyberte operaci')).toBeInTheDocument();
+    expect(screen.getByText('Navigace')).toBeInTheDocument();
   });
 
   it('renders Balení tile with correct href', () => {

--- a/frontend/src/pages/UserDetailPage.tsx
+++ b/frontend/src/pages/UserDetailPage.tsx
@@ -5,12 +5,16 @@ import {
   useAssignUserGroups,
   useSetUserActive,
   useUserPermissions,
+  useUpdateUser,
 } from "../api/hooks/useAccessManagement";
-import { AssignUserGroupsRequest, SetUserActiveRequest } from "../api/generated/api-client";
+import { AssignUserGroupsRequest, SetUserActiveRequest, UpdateUserRequest } from "../api/generated/api-client";
 import { useToast } from "../contexts/ToastContext";
 import GroupsPicker from "../components/access-management/GroupsPicker";
 
 interface UserDraft {
+  displayName: string;
+  email: string;
+  canPack: boolean;
   groupIds: string[];
 }
 
@@ -23,6 +27,7 @@ export default function UserDetailPage() {
   const permissionsQuery = useUserPermissions(id || null);
   const assignUserGroups = useAssignUserGroups();
   const setActive = useSetUserActive();
+  const updateUser = useUpdateUser();
 
   const [draft, setDraft] = useState<UserDraft | null>(null);
   const initialized = useRef(false);
@@ -33,7 +38,12 @@ export default function UserDetailPage() {
     if (initialized.current) return;
     if (!user) return;
 
-    const d: UserDraft = { groupIds: user.groupIds ?? [] };
+    const d: UserDraft = {
+      displayName: user.displayName ?? "",
+      email: user.email ?? "",
+      canPack: user.canPack ?? false,
+      groupIds: user.groupIds ?? [],
+    };
     setDraft(d);
     initialized.current = true;
   }, [user]);
@@ -43,12 +53,27 @@ export default function UserDetailPage() {
 
   const onSave = async () => {
     if (!draft) return;
+    if (!draft.displayName.trim()) {
+      toast.showError("Save failed", "Display name is required");
+      return;
+    }
     try {
-      await assignUserGroups.mutateAsync({
-        id,
-        request: new AssignUserGroupsRequest({ userId: id, groupIds: draft.groupIds }),
-      });
-      toast.showSuccess("Saved", "User groups updated successfully");
+      await Promise.all([
+        updateUser.mutateAsync({
+          id,
+          request: new UpdateUserRequest({
+            userId: id,
+            displayName: draft.displayName.trim(),
+            email: draft.email.trim(),
+            canPack: draft.canPack,
+          }),
+        }),
+        assignUserGroups.mutateAsync({
+          id,
+          request: new AssignUserGroupsRequest({ userId: id, groupIds: draft.groupIds }),
+        }),
+      ]);
+      toast.showSuccess("Saved", "User updated successfully");
     } catch {
       toast.showError("Save failed", "An error occurred while saving changes");
     }
@@ -71,7 +96,7 @@ export default function UserDetailPage() {
   };
 
   const isLoading = usersQuery.isLoading;
-  const isSaving = assignUserGroups.isPending;
+  const isSaving = assignUserGroups.isPending || updateUser.isPending;
 
   if (isLoading) {
     return (
@@ -104,20 +129,50 @@ export default function UserDetailPage() {
         <h1 className="text-2xl font-semibold text-gray-900">{user.displayName}</h1>
       </div>
 
-      <div className="bg-white border border-gray-200 rounded-lg p-4 flex items-center justify-between">
-        <div className="space-y-1">
-          <p className="text-sm text-gray-700">{user.email}</p>
+      <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+        <div className="flex items-center justify-between">
           <p className="text-sm text-gray-500">Last login: {lastLoginText}</p>
+          <button
+            type="button"
+            onClick={onToggleActive}
+            disabled={setActive.isPending}
+            className={`text-sm ${user.isActive ? "text-red-600" : "text-green-600"} hover:underline disabled:opacity-50`}
+            aria-label={user.isActive ? "Disable user" : "Enable user"}
+          >
+            {user.isActive ? "Disable" : "Enable"}
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={onToggleActive}
-          disabled={setActive.isPending}
-          className={`text-sm ${user.isActive ? "text-red-600" : "text-green-600"} hover:underline disabled:opacity-50`}
-          aria-label={user.isActive ? "Disable user" : "Enable user"}
-        >
-          {user.isActive ? "Disable" : "Enable"}
-        </button>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <label className="block">
+            <span className="block text-sm font-medium text-gray-700 mb-1">Display name</span>
+            <input
+              type="text"
+              value={draft.displayName}
+              onChange={(e) => updateDraft({ displayName: e.target.value })}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm font-medium text-gray-700 mb-1">Email</span>
+            <input
+              type="email"
+              value={draft.email}
+              onChange={(e) => updateDraft({ email: e.target.value })}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={draft.canPack}
+            onChange={(e) => updateDraft({ canPack: e.target.checked })}
+            className="rounded border-gray-300"
+          />
+          <span className="text-sm text-gray-700">Can pack</span>
+        </label>
       </div>
 
       <section>

--- a/frontend/src/pages/UserDetailPage.tsx
+++ b/frontend/src/pages/UserDetailPage.tsx
@@ -57,26 +57,31 @@ export default function UserDetailPage() {
       toast.showError("Save failed", "Display name is required");
       return;
     }
-    try {
-      await Promise.all([
-        updateUser.mutateAsync({
-          id,
-          request: new UpdateUserRequest({
-            userId: id,
-            displayName: draft.displayName.trim(),
-            email: draft.email.trim(),
-            canPack: draft.canPack,
-          }),
+    const [profileResult, groupResult] = await Promise.allSettled([
+      updateUser.mutateAsync({
+        id,
+        request: new UpdateUserRequest({
+          userId: id,
+          displayName: draft.displayName.trim(),
+          email: draft.email.trim(),
+          canPack: draft.canPack,
         }),
-        assignUserGroups.mutateAsync({
-          id,
-          request: new AssignUserGroupsRequest({ userId: id, groupIds: draft.groupIds }),
-        }),
-      ]);
-      toast.showSuccess("Saved", "User updated successfully");
-    } catch {
-      toast.showError("Save failed", "An error occurred while saving changes");
+      }),
+      assignUserGroups.mutateAsync({
+        id,
+        request: new AssignUserGroupsRequest({ userId: id, groupIds: draft.groupIds }),
+      }),
+    ]);
+
+    const profileFailed = profileResult.status === "rejected";
+    const groupFailed = groupResult.status === "rejected";
+    if (profileFailed || groupFailed) {
+      const part =
+        profileFailed && groupFailed ? "changes" : profileFailed ? "profile" : "group assignment";
+      toast.showError("Save failed", `Could not save ${part}. Please try again.`);
+      return;
     }
+    toast.showSuccess("Saved", "User updated successfully");
   };
 
   const onToggleActive = async () => {
@@ -150,7 +155,7 @@ export default function UserDetailPage() {
               type="text"
               value={draft.displayName}
               onChange={(e) => updateDraft({ displayName: e.target.value })}
-              className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </label>
           <label className="block">
@@ -159,7 +164,7 @@ export default function UserDetailPage() {
               type="email"
               value={draft.email}
               onChange={(e) => updateDraft({ email: e.target.value })}
-              className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </label>
         </div>
@@ -169,7 +174,7 @@ export default function UserDetailPage() {
             type="checkbox"
             checked={draft.canPack}
             onChange={(e) => updateDraft({ canPack: e.target.checked })}
-            className="rounded border-gray-300"
+            className="rounded border-gray-300 accent-indigo-600"
           />
           <span className="text-sm text-gray-700">Can pack</span>
         </label>

--- a/frontend/src/pages/__tests__/UserDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/UserDetailPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import UserDetailPage from "../UserDetailPage";
 
 const mockAssignUserGroups = jest.fn().mockResolvedValue({});
+const mockUpdateUser = jest.fn().mockResolvedValue({});
 const mockSetActive = jest.fn();
 const mockNavigate = jest.fn();
 
@@ -17,6 +18,7 @@ jest.mock("../../api/hooks/useAccessManagement", () => ({
           email: "alice@test.com",
           groupIds: ["g1"],
           isActive: true,
+          canPack: false,
           lastLoginAt: null,
         },
       ],
@@ -24,6 +26,7 @@ jest.mock("../../api/hooks/useAccessManagement", () => ({
     isLoading: false,
   }),
   useAssignUserGroups: () => ({ mutateAsync: mockAssignUserGroups, isPending: false }),
+  useUpdateUser: () => ({ mutateAsync: mockUpdateUser, isPending: false }),
   useSetUserActive: () => ({ mutateAsync: mockSetActive, isPending: false }),
   useUserPermissions: () => ({
     data: { permissions: ["catalog.read", "orders.write"] },
@@ -63,6 +66,7 @@ const renderWithRoute = (id: string) =>
 
 beforeEach(() => {
   mockAssignUserGroups.mockClear();
+  mockUpdateUser.mockClear();
   mockSetActive.mockClear();
   mockNavigate.mockClear();
 });
@@ -71,7 +75,7 @@ describe("UserDetailPage", () => {
   it("renders user displayName and email", async () => {
     renderWithRoute("user-1");
     expect(await screen.findByText("Alice")).toBeInTheDocument();
-    expect(screen.getByText("alice@test.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("alice@test.com")).toBeInTheDocument();
   });
 
   it("shows 'Never logged in' when lastLoginAt is null", async () => {
@@ -94,6 +98,45 @@ describe("UserDetailPage", () => {
         })
       )
     );
+  });
+
+  it("Save calls updateUser with edited displayName, email and canPack", async () => {
+    renderWithRoute("user-1");
+    await screen.findByText("Alice");
+
+    fireEvent.change(screen.getByDisplayValue("Alice"), {
+      target: { value: "Alice Updated" },
+    });
+    fireEvent.change(screen.getByDisplayValue("alice@test.com"), {
+      target: { value: "alice2@test.com" },
+    });
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(mockUpdateUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "user-1",
+          request: expect.objectContaining({
+            userId: "user-1",
+            displayName: "Alice Updated",
+            email: "alice2@test.com",
+            canPack: true,
+          }),
+        })
+      )
+    );
+  });
+
+  it("blocks Save and does not call updateUser when displayName is blank", async () => {
+    renderWithRoute("user-1");
+    await screen.findByText("Alice");
+
+    fireEvent.change(screen.getByDisplayValue("Alice"), { target: { value: "  " } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(mockUpdateUser).not.toHaveBeenCalled());
+    expect(mockAssignUserGroups).not.toHaveBeenCalled();
   });
 
   it("enable/disable button calls setActive with toggled isActive", async () => {


### PR DESCRIPTION
Adds a new `UpdateUser` MediatR use case exposed as `PUT /api/admin/authorization/users/{id}` (handler, validator, DI registration) so admins can edit a user's display name, email, and can-pack flag for both Entra and Local users. The user detail page now renders these as editable fields and commits them via `Promise.allSettled` alongside group assignment, with a client-side blank-name guard and a new `useUpdateUser` hook. The generated TypeScript client was regenerated to include the new endpoint. Covered by new backend handler/validator unit tests and updated `UserDetailPage` component tests; an implementation plan is included under `docs/superpowers/plans/`.