### PR TITLE
perf(tests): share single Postgres container across integration test classes

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Common/PostgresIntegrationCollection.cs
+++ b/backend/test/Anela.Heblo.Tests/Common/PostgresIntegrationCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Anela.Heblo.Tests.Common;
+
+[CollectionDefinition("PostgresIntegration")]
+public sealed class PostgresIntegrationCollection : ICollectionFixture<PostgresSharedContainerFixture>
+{
+}

--- a/backend/test/Anela.Heblo.Tests/Common/PostgresSharedContainerFixture.cs
+++ b/backend/test/Anela.Heblo.Tests/Common/PostgresSharedContainerFixture.cs
@@ -1,0 +1,47 @@
+using DotNet.Testcontainers.Configurations;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Anela.Heblo.Tests.Common;
+
+/// <summary>
+/// Starts a single postgres:16 container once for the entire "PostgresIntegration" collection.
+/// Each test class calls CreateDatabaseAsync to get its own isolated database, avoiding the
+/// cost of spinning up a new container per test method.
+/// </summary>
+public sealed class PostgresSharedContainerFixture : IAsyncLifetime
+{
+    static PostgresSharedContainerFixture()
+    {
+        // Required on macOS with Podman: the Ryuk ResourceReaper container
+        // cannot bind to the Docker socket and throws a NullReferenceException.
+        TestcontainersSettings.ResourceReaperEnabled = false;
+    }
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("postgres:16")
+        .Build();
+
+    public async Task InitializeAsync() => await _container.StartAsync();
+
+    public async Task DisposeAsync() => await _container.DisposeAsync();
+
+    /// <summary>
+    /// Creates a fresh database in the shared container and returns its connection string.
+    /// Each call produces a unique database, giving callers full isolation.
+    /// </summary>
+    public async Task<string> CreateDatabaseAsync(string nameHint)
+    {
+        var dbName = $"{nameHint}_{Guid.NewGuid():N}";
+        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE DATABASE \"{dbName}\"";
+        await cmd.ExecuteNonQueryAsync();
+
+        return new NpgsqlConnectionStringBuilder(_container.GetConnectionString())
+        {
+            Database = dbName
+        }.ConnectionString;
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportRepositoryIntegrationTests.cs
@@ -2,68 +2,62 @@ using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Shared;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Persistence.Features.Bank;
-using DotNet.Testcontainers.Configurations;
+using Anela.Heblo.Tests.Common;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Bank;
 
+[Collection("PostgresIntegration")]
 [Trait("Category", "Integration")]
 public class BankStatementImportRepositoryIntegrationTests : IAsyncLifetime
 {
-    static BankStatementImportRepositoryIntegrationTests()
-    {
-        // Required on macOS with Podman: the Ryuk ResourceReaper container
-        // cannot bind to the Docker socket and throws a NullReferenceException.
-        TestcontainersSettings.ResourceReaperEnabled = false;
-    }
-
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("postgres:16")
-        .Build();
-
+    private readonly PostgresSharedContainerFixture _fixture;
+    private string _connectionString = null!;
     private ApplicationDbContext _context = null!;
     private BankStatementImportRepository _repository = null!;
 
+    public BankStatementImportRepositoryIntegrationTests(PostgresSharedContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     public async Task InitializeAsync()
     {
-        await _container.StartAsync();
+        _connectionString = await _fixture.CreateDatabaseAsync("bank");
 
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseNpgsql(_container.GetConnectionString())
+            .UseNpgsql(_connectionString)
             .Options;
 
         _context = new ApplicationDbContext(options);
 
-        // Create only the BankStatements table manually
+        // Create only the BankStatements table manually.
         // Do NOT use EnsureCreatedAsync because it would try to install the "vector" extension
-        // which is not available in the plain postgres:16 image
-        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
-        {
-            await conn.OpenAsync();
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = """
-                CREATE SCHEMA IF NOT EXISTS public;
-                CREATE TABLE IF NOT EXISTS public."BankStatements" (
-                    "Id"            serial                       PRIMARY KEY,
-                    "TransferId"    character varying(100)       NOT NULL,
-                    "StatementDate" timestamp without time zone  NOT NULL,
-                    "ImportDate"    timestamp without time zone  NOT NULL,
-                    "Account"       text                         NOT NULL,
-                    "Currency"      integer                      NOT NULL,
-                    "ItemCount"     integer                      NOT NULL,
-                    "ImportResult"  text                         NOT NULL
-                );
-                CREATE UNIQUE INDEX IF NOT EXISTS "IX_BankStatements_TransferId"
-                    ON public."BankStatements" ("TransferId");
-                CREATE INDEX IF NOT EXISTS "IX_BankStatements_Account"
-                    ON public."BankStatements" ("Account");
-                """;
-            await cmd.ExecuteNonQueryAsync();
-        }
+        // which is not available in the plain postgres:16 image.
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE SCHEMA IF NOT EXISTS public;
+            CREATE TABLE IF NOT EXISTS public."BankStatements" (
+                "Id"            serial                       PRIMARY KEY,
+                "TransferId"    character varying(100)       NOT NULL,
+                "StatementDate" timestamp without time zone  NOT NULL,
+                "ImportDate"    timestamp without time zone  NOT NULL,
+                "Account"       text                         NOT NULL,
+                "Currency"      integer                      NOT NULL,
+                "ItemCount"     integer                      NOT NULL,
+                "ImportResult"  text                         NOT NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS "IX_BankStatements_TransferId"
+                ON public."BankStatements" ("TransferId");
+            CREATE INDEX IF NOT EXISTS "IX_BankStatements_Account"
+                ON public."BankStatements" ("Account");
+            """;
+        await cmd.ExecuteNonQueryAsync();
 
         _repository = new BankStatementImportRepository(_context);
     }
@@ -71,7 +65,6 @@ public class BankStatementImportRepositoryIntegrationTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await _context.DisposeAsync();
-        await _container.DisposeAsync();
     }
 
     private async Task<BankStatementImport> SeedAsync(

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/GetStockUpOperationsSummaryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/GetStockUpOperationsSummaryIntegrationTests.cs
@@ -4,82 +4,76 @@ using Anela.Heblo.Application.Features.Catalog.UseCases.GetStockUpOperationsSumm
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Persistence.Catalog.Stock;
-using DotNet.Testcontainers.Configurations;
+using Anela.Heblo.Tests.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Catalog;
 
+[Collection("PostgresIntegration")]
 [Trait("Category", "Integration")]
 public class GetStockUpOperationsSummaryIntegrationTests : IAsyncLifetime
 {
-    static GetStockUpOperationsSummaryIntegrationTests()
-    {
-        // Required on macOS with Podman: the Ryuk ResourceReaper container
-        // cannot bind to the Docker socket and throws a NullReferenceException.
-        TestcontainersSettings.ResourceReaperEnabled = false;
-    }
-
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("postgres:16")
-        .Build();
-
+    private readonly PostgresSharedContainerFixture _fixture;
+    private string _connectionString = null!;
     private ApplicationDbContext _context = null!;
     private StockUpOperationRepository _repository = null!;
     private GetStockUpOperationsSummaryHandler _handler = null!;
 
+    public GetStockUpOperationsSummaryIntegrationTests(PostgresSharedContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     public async Task InitializeAsync()
     {
-        await _container.StartAsync();
+        _connectionString = await _fixture.CreateDatabaseAsync("catalog");
 
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseNpgsql(_container.GetConnectionString())
+            .UseNpgsql(_connectionString)
             .Options;
 
         _context = new ApplicationDbContext(options);
 
         // Create only the StockUpOperations table + indexes we exercise.
         // Running full EF migrations brings in too many unrelated tables; this keeps the test fast.
-        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
-        {
-            await conn.OpenAsync();
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = """
-                CREATE TABLE IF NOT EXISTS public."StockUpOperations" (
-                    "Id"             serial NOT NULL PRIMARY KEY,
-                    "DocumentNumber" varchar(100) NOT NULL,
-                    "ProductCode"    varchar(50)  NOT NULL,
-                    "Amount"         integer NOT NULL,
-                    "SourceType"     integer NOT NULL,
-                    "SourceId"       integer NOT NULL,
-                    "State"          integer NOT NULL,
-                    "CreatedAt"      timestamp with time zone NOT NULL,
-                    "SubmittedAt"    timestamp with time zone NULL,
-                    "CompletedAt"    timestamp with time zone NULL,
-                    "ErrorMessage"   varchar(2000) NULL
-                );
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS public."StockUpOperations" (
+                "Id"             serial NOT NULL PRIMARY KEY,
+                "DocumentNumber" varchar(100) NOT NULL,
+                "ProductCode"    varchar(50)  NOT NULL,
+                "Amount"         integer NOT NULL,
+                "SourceType"     integer NOT NULL,
+                "SourceId"       integer NOT NULL,
+                "State"          integer NOT NULL,
+                "CreatedAt"      timestamp with time zone NOT NULL,
+                "SubmittedAt"    timestamp with time zone NULL,
+                "CompletedAt"    timestamp with time zone NULL,
+                "ErrorMessage"   varchar(2000) NULL
+            );
 
-                CREATE UNIQUE INDEX IF NOT EXISTS "IX_StockUpOperations_DocumentNumber_Unique"
-                    ON public."StockUpOperations" ("DocumentNumber");
+            CREATE UNIQUE INDEX IF NOT EXISTS "IX_StockUpOperations_DocumentNumber_Unique"
+                ON public."StockUpOperations" ("DocumentNumber");
 
-                CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_State"
-                    ON public."StockUpOperations" ("State");
+            CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_State"
+                ON public."StockUpOperations" ("State");
 
-                CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_Source"
-                    ON public."StockUpOperations" ("SourceType", "SourceId");
+            CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_Source"
+                ON public."StockUpOperations" ("SourceType", "SourceId");
 
-                CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_State_CreatedAt"
-                    ON public."StockUpOperations" ("State", "CreatedAt");
+            CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_State_CreatedAt"
+                ON public."StockUpOperations" ("State", "CreatedAt");
 
-                CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_State_Active"
-                    ON public."StockUpOperations" ("SourceType", "State")
-                    WHERE "State" IN (0, 1, 3);
-                """;
-            await cmd.ExecuteNonQueryAsync();
-        }
+            CREATE INDEX IF NOT EXISTS "IX_StockUpOperations_State_Active"
+                ON public."StockUpOperations" ("SourceType", "State")
+                WHERE "State" IN (0, 1, 3);
+            """;
+        await cmd.ExecuteNonQueryAsync();
 
         _repository = new StockUpOperationRepository(
             _context,
@@ -92,7 +86,6 @@ public class GetStockUpOperationsSummaryIntegrationTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await _context.DisposeAsync();
-        await _container.DisposeAsync();
     }
 
     private async Task SeedAsync(params (StockUpSourceType source, StockUpOperationState state)[] ops)
@@ -205,7 +198,7 @@ public class GetStockUpOperationsSummaryIntegrationTests : IAsyncLifetime
         }
         await _context.SaveChangesAsync();
 
-        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await using var conn = new NpgsqlConnection(_connectionString);
         await conn.OpenAsync();
 
         // ANALYZE so the planner has fresh statistics

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/MeetingTranscriptRepositorySearchIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/MeetingTranscriptRepositorySearchIntegrationTests.cs
@@ -1,38 +1,34 @@
 using Anela.Heblo.Domain.Features.MeetingTasks;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Persistence.MeetingTasks;
-using DotNet.Testcontainers.Configurations;
+using Anela.Heblo.Tests.Common;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.MeetingTasks;
 
+[Collection("PostgresIntegration")]
 [Trait("Category", "Integration")]
 public class MeetingTranscriptRepositorySearchIntegrationTests : IAsyncLifetime
 {
-    static MeetingTranscriptRepositorySearchIntegrationTests()
-    {
-        // Required on macOS with Podman: the Ryuk ResourceReaper container
-        // cannot bind to the Docker socket and throws a NullReferenceException.
-        TestcontainersSettings.ResourceReaperEnabled = false;
-    }
-
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("postgres:16")
-        .Build();
-
+    private readonly PostgresSharedContainerFixture _fixture;
+    private string _connectionString = null!;
     private ApplicationDbContext _context = null!;
     private MeetingTranscriptRepository _repository = null!;
 
+    public MeetingTranscriptRepositorySearchIntegrationTests(PostgresSharedContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     public async Task InitializeAsync()
     {
-        await _container.StartAsync();
+        _connectionString = await _fixture.CreateDatabaseAsync("meeting");
 
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseNpgsql(_container.GetConnectionString())
+            .UseNpgsql(_connectionString)
             .Options;
 
         _context = new ApplicationDbContext(options);
@@ -40,67 +36,65 @@ public class MeetingTranscriptRepositorySearchIntegrationTests : IAsyncLifetime
         // Create only the three MeetingTasks tables we exercise.
         // EnsureCreatedAsync would try to install the "vector" extension which is
         // not available in the plain postgres:16 image, causing the whole suite to fail.
-        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
-        {
-            await conn.OpenAsync();
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = """
-                CREATE TABLE IF NOT EXISTS public."MeetingTranscripts" (
-                    "Id"              uuid         NOT NULL PRIMARY KEY,
-                    "PlaudRecordingId" varchar(200) NOT NULL,
-                    "PlaudCreatedAt"  timestamp    NOT NULL,
-                    "Subject"         varchar(500) NOT NULL,
-                    "Summary"         text         NOT NULL,
-                    "RawTranscript"   text         NOT NULL,
-                    "Status"          varchar(50)  NOT NULL,
-                    "ReceivedAt"      timestamp    NOT NULL,
-                    "ReviewedAt"      timestamp    NULL,
-                    "ReviewedByUser"  varchar(200) NULL,
-                    "AccessLevel"     varchar(20)  NOT NULL DEFAULT 'Private'
-                );
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS public."MeetingTranscripts" (
+                "Id"              uuid         NOT NULL PRIMARY KEY,
+                "PlaudRecordingId" varchar(200) NOT NULL,
+                "PlaudCreatedAt"  timestamp    NOT NULL,
+                "Subject"         varchar(500) NOT NULL,
+                "Summary"         text         NOT NULL,
+                "RawTranscript"   text         NOT NULL,
+                "Status"          varchar(50)  NOT NULL,
+                "ReceivedAt"      timestamp    NOT NULL,
+                "ReviewedAt"      timestamp    NULL,
+                "ReviewedByUser"  varchar(200) NULL,
+                "AccessLevel"     varchar(20)  NOT NULL DEFAULT 'Private'
+            );
 
-                CREATE UNIQUE INDEX IF NOT EXISTS "UX_MeetingTranscripts_PlaudRecordingId"
-                    ON public."MeetingTranscripts" ("PlaudRecordingId");
+            CREATE UNIQUE INDEX IF NOT EXISTS "UX_MeetingTranscripts_PlaudRecordingId"
+                ON public."MeetingTranscripts" ("PlaudRecordingId");
 
-                CREATE INDEX IF NOT EXISTS "IX_MeetingTranscripts_Status"
-                    ON public."MeetingTranscripts" ("Status");
+            CREATE INDEX IF NOT EXISTS "IX_MeetingTranscripts_Status"
+                ON public."MeetingTranscripts" ("Status");
 
-                CREATE INDEX IF NOT EXISTS "IX_MeetingTranscripts_AccessLevel"
-                    ON public."MeetingTranscripts" ("AccessLevel");
+            CREATE INDEX IF NOT EXISTS "IX_MeetingTranscripts_AccessLevel"
+                ON public."MeetingTranscripts" ("AccessLevel");
 
-                CREATE INDEX IF NOT EXISTS "IX_MeetingTranscripts_ReceivedAt"
-                    ON public."MeetingTranscripts" ("ReceivedAt");
+            CREATE INDEX IF NOT EXISTS "IX_MeetingTranscripts_ReceivedAt"
+                ON public."MeetingTranscripts" ("ReceivedAt");
 
-                CREATE TABLE IF NOT EXISTS public."ProposedTasks" (
-                    "Id"                  uuid         NOT NULL PRIMARY KEY,
-                    "MeetingTranscriptId" uuid         NOT NULL REFERENCES public."MeetingTranscripts"("Id") ON DELETE CASCADE,
-                    "Title"               varchar(500) NOT NULL,
-                    "Description"         text         NOT NULL,
-                    "Assignee"            varchar(200) NOT NULL,
-                    "AssigneeEmail"       varchar(320) NULL,
-                    "DueDate"             timestamp    NULL,
-                    "Status"              varchar(50)  NOT NULL,
-                    "ExternalTaskId"      varchar(200) NULL,
-                    "IsManuallyAdded"     boolean      NOT NULL DEFAULT false
-                );
+            CREATE TABLE IF NOT EXISTS public."ProposedTasks" (
+                "Id"                  uuid         NOT NULL PRIMARY KEY,
+                "MeetingTranscriptId" uuid         NOT NULL REFERENCES public."MeetingTranscripts"("Id") ON DELETE CASCADE,
+                "Title"               varchar(500) NOT NULL,
+                "Description"         text         NOT NULL,
+                "Assignee"            varchar(200) NOT NULL,
+                "AssigneeEmail"       varchar(320) NULL,
+                "DueDate"             timestamp    NULL,
+                "Status"              varchar(50)  NOT NULL,
+                "ExternalTaskId"      varchar(200) NULL,
+                "IsManuallyAdded"     boolean      NOT NULL DEFAULT false
+            );
 
-                CREATE INDEX IF NOT EXISTS "IX_ProposedTasks_MeetingTranscriptId"
-                    ON public."ProposedTasks" ("MeetingTranscriptId");
+            CREATE INDEX IF NOT EXISTS "IX_ProposedTasks_MeetingTranscriptId"
+                ON public."ProposedTasks" ("MeetingTranscriptId");
 
-                CREATE TABLE IF NOT EXISTS public."MeetingAccessGrants" (
-                    "Id"                  uuid         NOT NULL PRIMARY KEY,
-                    "MeetingTranscriptId" uuid         NOT NULL REFERENCES public."MeetingTranscripts"("Id") ON DELETE CASCADE,
-                    "UserEmail"           varchar(320) NOT NULL,
-                    "UserDisplayName"     varchar(200) NULL,
-                    "GrantedAt"           timestamp    NOT NULL,
-                    "GrantedByUserEmail"  varchar(320) NOT NULL
-                );
+            CREATE TABLE IF NOT EXISTS public."MeetingAccessGrants" (
+                "Id"                  uuid         NOT NULL PRIMARY KEY,
+                "MeetingTranscriptId" uuid         NOT NULL REFERENCES public."MeetingTranscripts"("Id") ON DELETE CASCADE,
+                "UserEmail"           varchar(320) NOT NULL,
+                "UserDisplayName"     varchar(200) NULL,
+                "GrantedAt"           timestamp    NOT NULL,
+                "GrantedByUserEmail"  varchar(320) NOT NULL
+            );
 
-                CREATE UNIQUE INDEX IF NOT EXISTS "UX_MeetingAccessGrants_TranscriptId_UserEmail"
-                    ON public."MeetingAccessGrants" ("MeetingTranscriptId", "UserEmail");
-                """;
-            await cmd.ExecuteNonQueryAsync();
-        }
+            CREATE UNIQUE INDEX IF NOT EXISTS "UX_MeetingAccessGrants_TranscriptId_UserEmail"
+                ON public."MeetingAccessGrants" ("MeetingTranscriptId", "UserEmail");
+            """;
+        await cmd.ExecuteNonQueryAsync();
 
         _repository = new MeetingTranscriptRepository(_context);
     }
@@ -108,7 +102,6 @@ public class MeetingTranscriptRepositorySearchIntegrationTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await _context.DisposeAsync();
-        await _container.DisposeAsync();
     }
 
     private static MeetingTranscript BuildTranscript(

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetTagsSqlShapeTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetTagsSqlShapeTests.cs
@@ -7,70 +7,64 @@ using System.Threading.Tasks;
 using Anela.Heblo.Application.Features.Photobank;
 using Anela.Heblo.Domain.Features.Photobank;
 using Anela.Heblo.Persistence;
-using DotNet.Testcontainers.Configurations;
+using Anela.Heblo.Tests.Common;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Photobank;
 
+[Collection("PostgresIntegration")]
 [Trait("Category", "Integration")]
 public class PhotobankRepositoryGetTagsSqlShapeTests : IAsyncLifetime
 {
-    static PhotobankRepositoryGetTagsSqlShapeTests()
-    {
-        // Required on macOS with Podman: the Ryuk ResourceReaper container
-        // cannot bind to the Docker socket and throws a NullReferenceException.
-        TestcontainersSettings.ResourceReaperEnabled = false;
-    }
-
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("postgres:16")
-        .Build();
-
+    private readonly PostgresSharedContainerFixture _fixture;
+    private string _connectionString = null!;
     private readonly CapturingCommandInterceptor _interceptor = new();
     private ApplicationDbContext _context = null!;
     private PhotobankRepository _repository = null!;
 
+    public PhotobankRepositoryGetTagsSqlShapeTests(PostgresSharedContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     public async Task InitializeAsync()
     {
-        await _container.StartAsync();
+        _connectionString = await _fixture.CreateDatabaseAsync("photobank");
 
         // Minimal schema — only the two tables the query touches, no FKs to keep seeding simple.
-        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
-        {
-            await conn.OpenAsync();
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = """
-                CREATE TABLE public."PhotobankTags" (
-                    "Id"   serial NOT NULL PRIMARY KEY,
-                    "Name" varchar(100) NOT NULL
-                );
-                CREATE UNIQUE INDEX "IX_PhotobankTags_Name" ON public."PhotobankTags" ("Name");
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE public."PhotobankTags" (
+                "Id"   serial NOT NULL PRIMARY KEY,
+                "Name" varchar(100) NOT NULL
+            );
+            CREATE UNIQUE INDEX "IX_PhotobankTags_Name" ON public."PhotobankTags" ("Name");
 
-                CREATE TABLE public."PhotoTags" (
-                    "PhotoId"   integer NOT NULL,
-                    "TagId"     integer NOT NULL,
-                    "Source"    varchar(20) NOT NULL,
-                    "CreatedAt" timestamp NOT NULL,
-                    CONSTRAINT "PK_PhotoTags" PRIMARY KEY ("PhotoId", "TagId")
-                );
-                CREATE INDEX "IX_PhotoTags_TagId" ON public."PhotoTags" ("TagId");
+            CREATE TABLE public."PhotoTags" (
+                "PhotoId"   integer NOT NULL,
+                "TagId"     integer NOT NULL,
+                "Source"    varchar(20) NOT NULL,
+                "CreatedAt" timestamp NOT NULL,
+                CONSTRAINT "PK_PhotoTags" PRIMARY KEY ("PhotoId", "TagId")
+            );
+            CREATE INDEX "IX_PhotoTags_TagId" ON public."PhotoTags" ("TagId");
 
-                INSERT INTO public."PhotobankTags" ("Name") VALUES ('summer'), ('winter'), ('orphan');
-                INSERT INTO public."PhotoTags" ("PhotoId","TagId","Source","CreatedAt") VALUES
-                    (1, 1, 'Manual', now()),
-                    (2, 1, 'Manual', now()),
-                    (1, 2, 'Manual', now());
-                """;
-            await cmd.ExecuteNonQueryAsync();
-        }
+            INSERT INTO public."PhotobankTags" ("Name") VALUES ('summer'), ('winter'), ('orphan');
+            INSERT INTO public."PhotoTags" ("PhotoId","TagId","Source","CreatedAt") VALUES
+                (1, 1, 'Manual', now()),
+                (2, 1, 'Manual', now()),
+                (1, 2, 'Manual', now());
+            """;
+        await cmd.ExecuteNonQueryAsync();
 
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseNpgsql(_container.GetConnectionString())
+            .UseNpgsql(_connectionString)
             .AddInterceptors(_interceptor)
             .Options;
 
@@ -81,7 +75,6 @@ public class PhotobankRepositoryGetTagsSqlShapeTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await _context.DisposeAsync();
-        await _container.DisposeAsync();
     }
 
     [Fact]
@@ -115,7 +108,6 @@ public class PhotobankRepositoryGetTagsSqlShapeTests : IAsyncLifetime
         result[0].Count.Should().Be(2, "summer has 2 photo-tags and sorts first (count desc)");
         result[2].Count.Should().Be(0, "orphan has no photo-tags and sorts last");
     }
-
 
     private sealed class CapturingCommandInterceptor : DbCommandInterceptor
     {

--- a/backend/test/Anela.Heblo.Tests/Features/Purchase/PurchaseOrderRepositoryHistorySqlShapeTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Purchase/PurchaseOrderRepositoryHistorySqlShapeTests.cs
@@ -5,68 +5,62 @@ using System.Threading;
 using System.Threading.Tasks;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Persistence.Purchase.PurchaseOrders;
-using DotNet.Testcontainers.Configurations;
+using Anela.Heblo.Tests.Common;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Purchase;
 
+[Collection("PostgresIntegration")]
 [Trait("Category", "Integration")]
 public class PurchaseOrderRepositoryHistorySqlShapeTests : IAsyncLifetime
 {
-    static PurchaseOrderRepositoryHistorySqlShapeTests()
-    {
-        // Required on macOS with Podman: the Ryuk ResourceReaper container
-        // cannot bind to the Docker socket and throws a NullReferenceException.
-        TestcontainersSettings.ResourceReaperEnabled = false;
-    }
-
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("postgres:16")
-        .Build();
-
+    private readonly PostgresSharedContainerFixture _fixture;
+    private string _connectionString = null!;
     private readonly CapturingCommandInterceptor _interceptor = new();
     private ApplicationDbContext _context = null!;
     private PurchaseOrderRepository _repository = null!;
 
+    public PurchaseOrderRepositoryHistorySqlShapeTests(PostgresSharedContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     public async Task InitializeAsync()
     {
-        await _container.StartAsync();
+        _connectionString = await _fixture.CreateDatabaseAsync("purchase");
 
         // Minimal schema — only the PurchaseOrderHistory table the query touches.
         // No FKs / no PurchaseOrders / no PurchaseOrderLines, so any unintended JOIN would fail at execution time.
-        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
-        {
-            await conn.OpenAsync();
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = """
-                CREATE TABLE public."PurchaseOrderHistory" (
-                    "Id"              serial      NOT NULL PRIMARY KEY,
-                    "PurchaseOrderId" integer     NOT NULL,
-                    "Action"          varchar(50) NOT NULL,
-                    "OldValue"        varchar(2000),
-                    "NewValue"        varchar(2000),
-                    "ChangedBy"       varchar(200) NOT NULL,
-                    "ChangedAt"       timestamp   NOT NULL
-                );
-                CREATE INDEX "IX_PurchaseOrderHistory_PurchaseOrderId" ON public."PurchaseOrderHistory" ("PurchaseOrderId");
-                CREATE INDEX "IX_PurchaseOrderHistory_ChangedAt"      ON public."PurchaseOrderHistory" ("ChangedAt");
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE public."PurchaseOrderHistory" (
+                "Id"              serial      NOT NULL PRIMARY KEY,
+                "PurchaseOrderId" integer     NOT NULL,
+                "Action"          varchar(50) NOT NULL,
+                "OldValue"        varchar(2000),
+                "NewValue"        varchar(2000),
+                "ChangedBy"       varchar(200) NOT NULL,
+                "ChangedAt"       timestamp   NOT NULL
+            );
+            CREATE INDEX "IX_PurchaseOrderHistory_PurchaseOrderId" ON public."PurchaseOrderHistory" ("PurchaseOrderId");
+            CREATE INDEX "IX_PurchaseOrderHistory_ChangedAt"      ON public."PurchaseOrderHistory" ("ChangedAt");
 
-                INSERT INTO public."PurchaseOrderHistory"
-                    ("PurchaseOrderId","Action","OldValue","NewValue","ChangedBy","ChangedAt") VALUES
-                    (42, 'Created', NULL, 'Draft', 'user-1', now() - interval '2 minute'),
-                    (42, 'StatusChanged', 'Draft', 'InTransit', 'user-2', now() - interval '1 minute'),
-                    (43, 'Created', NULL, 'Draft', 'user-3', now());
-                """;
-            await cmd.ExecuteNonQueryAsync();
-        }
+            INSERT INTO public."PurchaseOrderHistory"
+                ("PurchaseOrderId","Action","OldValue","NewValue","ChangedBy","ChangedAt") VALUES
+                (42, 'Created', NULL, 'Draft', 'user-1', now() - interval '2 minute'),
+                (42, 'StatusChanged', 'Draft', 'InTransit', 'user-2', now() - interval '1 minute'),
+                (43, 'Created', NULL, 'Draft', 'user-3', now());
+            """;
+        await cmd.ExecuteNonQueryAsync();
 
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseNpgsql(_container.GetConnectionString())
+            .UseNpgsql(_connectionString)
             .AddInterceptors(_interceptor)
             .Options;
 
@@ -77,7 +71,6 @@ public class PurchaseOrderRepositoryHistorySqlShapeTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         await _context.DisposeAsync();
-        await _container.DisposeAsync();
     }
 
     [Fact]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10974,16 +10974,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -22254,7 +22244,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## Summary

- Introduces `PostgresSharedContainerFixture` (xUnit collection fixture) that starts a single `postgres:16` Testcontainers container for the entire `PostgresIntegration` collection, replacing per-test-method container startups.
- Adds `PostgresIntegrationCollection` binding 5 test classes (`BankStatementImport`, `GetStockUpOperationsSummary`, `MeetingTranscriptSearch`, `PhotobankGetTagsSqlShape`, `PurchaseOrderHistorySqlShape`) to the shared fixture.
- Each test still receives a fully isolated database via `CreateDatabaseAsync`, so data isolation behaviour is unchanged.
- `KnowledgeBaseRepositoryIntegrationTests` (requires `pgvector/pgvector:pg16`) and `LedgerSyncIntegrationTests` (separate project) keep their own containers.

## Test plan

- [ ] Start Docker/Podman locally
- [ ] Run `dotnet test --filter "Category=Integration"` and confirm all 5 refactored test classes pass
- [ ] Confirm only 1 Postgres container starts for the shared collection (visible in Docker Dashboard)
- [ ] Run full suite `dotnet test` — non-integration tests must remain green (4740 passing)