### PR TITLE
feat: Remove dead mutable static `PrintPickingListRequest.DefaultCarriers`

### DIFF
--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/arch-review.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/arch-review.r1.md
@@ -1,151 +1,159 @@
-# Architecture Review: Remove unused `OrderIds` field from `PrintPickingListResult`
+# Architecture Review: Remove dead mutable static `PrintPickingListRequest.DefaultCarriers`
 
 ## Skip Design: true
 
-Backend-only DTO cleanup. No UI, no visual components, no layout changes.
+This is a backend-only dead-code/hazard removal. No UI, no API surface change, no new visual components.
 
 ## Architectural Fit Assessment
 
-This is a surgical dead-code removal that **reinforces** existing architecture rather than altering it. Verified against the codebase:
+The change strengthens existing patterns rather than introducing new ones.
 
-- `PrintPickingListResult` lives in `Anela.Heblo.Application.Features.Logistics.Picking` (relocated from Domain per the 2026-06-02 plan to satisfy Clean Architecture's dependency rule).
-- The DTO is **internal to the application layer**: it is consumed only by `LogisticsExpeditionPickingAdapter`, which translates it to the cross-feature `ExpeditionPickingResult` contract owned by ExpeditionList. It is not on the OpenAPI surface (confirmed — no references in `frontend/src/api/`), not persisted, and not on any MediatR contract returned to a controller.
-- The `OrderIds` field has exactly one producer-side path (`ShoptetApiExpeditionListSource.CreatePickingList` at line 227) which never sets it, and one consumer-side path (`LogisticsExpeditionPickingAdapter.CreatePickingListAsync` lines 32–36) which never reads it. Removal is mechanical.
-- Aligns with the project's stated **YAGNI** and **surgical changes** principles in `CLAUDE.md`.
+- **Duplication is the root cause.** Two static `DefaultCarriers` lists exist with byte-identical contents: one read-only (`ExpeditionPickingRequest.DefaultCarriers` at `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs:16`) and one with a public setter (`PrintPickingListRequest.DefaultCarriers` at `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs:16`). The read-only variant is the one production uses; the mutable variant is the hazard.
+- **Production callers are already aligned.** Verified consumers of the carrier defaults are `RunExpeditionListPrintFixHandler.cs:27` and `PrintPickingListJob.cs:51` — both read from `ExpeditionPickingRequest.DefaultCarriers`. No production reference to the mutable property exists.
+- **The integration test is the only remaining consumer.** `PickingListIntegrationTests.cs:88` reads `PrintPickingListRequest.DefaultCarriers`. Switching it to `ExpeditionPickingRequest.DefaultCarriers` actually improves test fidelity — the test starts exercising the same constant the production path uses.
+- **Cross-assembly reference is already acceptable.** `Anela.Heblo.Adapters.Shoptet.Tests` already references `Anela.Heblo.Application.Features.ExpeditionList` (line 2 of the test). Pulling in `…ExpeditionList.Contracts` introduces no new project dependency.
+- **Naming asymmetry is preserved (intentionally).** The class `PrintPickingListRequest` is retained — only the static member is removed. The two request DTOs (`PrintPickingListRequest` and `ExpeditionPickingRequest`) remain as separate concerns and any consolidation is explicitly out of scope per the spec.
 
-Repository-wide grep confirms the spec's claim: only three occurrences of `OrderIds` tied to `PrintPickingListResult` exist (definition, test arrange, and historical planning docs which are immutable artifacts and out of scope).
+Verdict: Fit is clean. This is a deletion, not a redesign.
 
 ## Proposed Architecture
 
 ### Component Overview
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│ ExpeditionList Feature (Application)                                │
-│   IExpeditionPickingSource ────► ExpeditionPickingResult            │
-│              ▲                     { ExportedFiles, TotalCount }    │
-│              │ implemented by                                       │
-└──────────────┼──────────────────────────────────────────────────────┘
-               │
-┌──────────────┴──────────────────────────────────────────────────────┐
-│ Logistics.Infrastructure (Application) — bridge                     │
-│   LogisticsExpeditionPickingAdapter                                 │
-│     ├─ delegates to IPickingListSource                              │
-│     └─ maps PrintPickingListResult ──► ExpeditionPickingResult      │
-│          { ExportedFiles, TotalCount[, OrderIds ✂ DELETE] }         │
-└──────────────┬──────────────────────────────────────────────────────┘
-               │ implemented by
-┌──────────────┴──────────────────────────────────────────────────────┐
-│ Adapters.ShoptetApi                                                 │
-│   ShoptetApiExpeditionListSource.CreatePickingList                  │
-│     returns new PrintPickingListResult { ExportedFiles, TotalCount }│
-└─────────────────────────────────────────────────────────────────────┘
-```
+                   ┌─────────────────────────────────────────────┐
+                   │  Application.Features.ExpeditionList        │
+                   │  ┌─────────────────────────────────────┐    │
+                   │  │ ExpeditionPickingRequest            │    │
+                   │  │  + DefaultCarriers (get only) ◄─────┼────┼─ SINGLE SOURCE
+                   │  └──────────────▲──────────────────────┘    │   OF TRUTH
+                   │                 │                            │
+                   │  ┌──────────────┴──────────────┐             │
+                   │  │ PrintPickingListJob         │             │
+                   │  │ RunExpeditionListPrintFix   │             │
+                   │  │ (read DefaultCarriers)      │             │
+                   │  └─────────────────────────────┘             │
+                   └─────────────────────────────────────────────┘
+                                       ▲
+                                       │ reads
+                   ┌───────────────────┼─────────────────────────┐
+                   │ Adapters.Shoptet.Tests.Integration          │
+                   │  PickingListIntegrationTests (line 88)      │  ← updated
+                   └─────────────────────────────────────────────┘
 
-The cross-layer contract (`ExpeditionPickingResult`) never carried `OrderIds`. The deletion only narrows the inner DTO to match what producers actually populate and what the adapter actually consumes.
+                   ┌─────────────────────────────────────────────┐
+                   │  Application.Features.Logistics.Picking     │
+                   │  ┌─────────────────────────────────────┐    │
+                   │  │ PrintPickingListRequest             │    │
+                   │  │   - DefaultCarriers (REMOVED)       │    │
+                   │  │   ✓ DefaultSourceStateId (kept)     │    │
+                   │  │   ✓ DefaultDesiredStateId (kept)    │    │
+                   │  │   ✓ instance members (kept)         │    │
+                   │  └─────────────────────────────────────┘    │
+                   └─────────────────────────────────────────────┘
+```
 
 ### Key Design Decisions
 
-#### Decision 1: Delete the field outright rather than wire it through
+#### Decision 1: Remove the property entirely (not convert to read-only)
+
 **Options considered:**
-1. Delete `OrderIds` from `PrintPickingListResult` and the test arrange line.
-2. Populate `OrderIds` in `ShoptetApiExpeditionListSource` and add a matching field to `ExpeditionPickingResult`.
-3. Mark `[Obsolete]` and defer removal.
+- (A) Change `{ get; set; }` to `{ get; }` — fixes the mutation hazard but leaves a redundant, identical list duplicated across two contracts.
+- (B) Remove the property entirely and redirect the lone test consumer to `ExpeditionPickingRequest.DefaultCarriers`.
 
-**Chosen approach:** Option 1 — delete.
+**Chosen approach:** B (matches the spec).
 
-**Rationale:** No production caller requests `OrderIds`. There is no feature, telemetry need, or downstream consumer pulling for it. Option 2 builds infrastructure on speculation (violates YAGNI). Option 3 adds noise with no path to actual removal because this is an internal type with one producer and one consumer — there is no external contract to deprecate gracefully. Delete is reversible: the field can be re-added when a real consumer arrives, with the producer wired at the same time.
+**Rationale:** The mutation hazard is only half the problem; the other half is duplication. Option A eliminates the hazard but creates two read-only lists that must be kept in sync forever (when carriers are added/removed). Option B converges on the single canonical list that production already uses, removing both the hazard and the drift risk in one move. The test's intent — "run picking with the production default carriers" — is better expressed by reading the production constant directly.
 
-#### Decision 2: Do not touch `ExpeditionPickingResult`
-**Options considered:** Touch the outer contract for symmetry vs. leave it alone.
+#### Decision 2: Keep `PrintPickingListRequest` and its other static constants
 
-**Chosen approach:** Leave `ExpeditionPickingResult` untouched.
+**Options considered:**
+- (A) Delete only `DefaultCarriers` and leave `DefaultSourceStateId`, `DefaultDesiredStateId`, and all instance members untouched.
+- (B) Broader cleanup — consolidate `PrintPickingListRequest` and `ExpeditionPickingRequest` into one shared contract.
 
-**Rationale:** It never had `OrderIds`. The brief and spec correctly scope the change to the inner DTO. Modifying the outer contract would expand blast radius across the ExpeditionList feature for zero benefit.
+**Chosen approach:** A.
+
+**Rationale:** `DefaultSourceStateId` and `DefaultDesiredStateId` are `const int` (compile-time constants, no mutation hazard) and are actively referenced by the same integration test (`PickingListIntegrationTests.cs:22, 87`). They are not part of this finding. Consolidation of the two request DTOs is explicitly out of scope and would expand blast radius far beyond a dead-code removal. Surgical change wins.
 
 ## Implementation Guidance
 
 ### Directory / Module Structure
 
-No new files. Modify exactly two existing files:
+No new files. No renames. Two existing files are touched:
 
-| File | Change |
-|------|--------|
-| `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` | Delete line 7 (the `OrderIds` property). |
-| `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` | Delete line 60 (the `OrderIds = new List<int> { 1, 2, 3 },` initializer in `CreatePickingListAsync_TranslatesResultFields`). |
-
-Do **not** modify:
-- `ShoptetApiExpeditionListSource.cs` — already does not reference `OrderIds`.
-- `LogisticsExpeditionPickingAdapter.cs` — already does not reference `OrderIds`.
-- `ExpeditionPickingResult` or any ExpeditionList contract.
-- Other tests in `LogisticsExpeditionPickingAdapterTests.cs` — three tests use `new PrintPickingListResult()` with object-initializer defaults; they remain compile-clean after the property is gone.
+```
+backend/
+└── src/Anela.Heblo.Application/Features/Logistics/Picking/
+│       └── PrintPickingListRequest.cs                          (delete lines 16-22)
+└── test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/
+        └── PickingListIntegrationTests.cs                      (update line 88 + add using)
+```
 
 ### Interfaces and Contracts
 
-Post-change shape of `PrintPickingListResult`:
+**Removed:**
+- `PrintPickingListRequest.DefaultCarriers` (public static property with public setter) — gone.
 
-```csharp
-namespace Anela.Heblo.Application.Features.Logistics.Picking;
+**Unchanged (do not touch):**
+- `PrintPickingListRequest` class itself.
+- `PrintPickingListRequest.DefaultSourceStateId` (`const int = -2`).
+- `PrintPickingListRequest.DefaultDesiredStateId` (`const int = 26`).
+- `PrintPickingListRequest` instance members: `Carriers`, `SourceStateId`, `DesiredStateId`, `ChangeOrderState`, `SendToPrinter`.
+- `ExpeditionPickingRequest` in any way — it stays as the single source of truth.
 
-public class PrintPickingListResult
-{
-    public IList<string> ExportedFiles { get; set; } = new List<string>();
-    public int TotalCount { get; set; }
-}
-```
-
-`IPickingListSource.CreatePickingList` signature unchanged. `IExpeditionPickingSource.CreatePickingListAsync` unchanged. No OpenAPI client regeneration needed (the DTO is not on the API surface).
+**Test surface:**
+- `PickingListIntegrationTests.cs` adds `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` (the test currently has `using Anela.Heblo.Application.Features.ExpeditionList;` but not the `.Contracts` sub-namespace where `ExpeditionPickingRequest` lives).
+- Line 88 changes from `Carriers = PrintPickingListRequest.DefaultCarriers,` to `Carriers = ExpeditionPickingRequest.DefaultCarriers,`.
 
 ### Data Flow
 
-Unchanged in behaviour, narrowed in shape:
+Unchanged at runtime. Both before and after:
 
 ```
-ShoptetApiExpeditionListSource.CreatePickingList
-    ├─ exportedFiles  ──┐
-    └─ processedCodes.Count ──┐
-                         │   │
-                         ▼   ▼
-        PrintPickingListResult { ExportedFiles, TotalCount }
-                         │   │
-                         ▼   ▼
-LogisticsExpeditionPickingAdapter.CreatePickingListAsync
-    └─ maps to ExpeditionPickingResult { ExportedFiles, TotalCount }
-                         │
-                         ▼
-            ExpeditionList consumer
+Hangfire trigger
+    └─► PrintPickingListJob.cs:51    ── reads ExpeditionPickingRequest.DefaultCarriers
+            │
+            └─► new PrintPickingListRequest { Carriers = […] }
+                    └─► IPickingListSource.CreatePickingList(request, …)
+                            └─► ShoptetApiExpeditionListSource (filters orders by carrier)
+
+Manual fix flow
+    └─► RunExpeditionListPrintFixHandler.cs:27  ── reads ExpeditionPickingRequest.DefaultCarriers
+            └─► (same as above)
+
+Integration test (after change)
+    └─► PickingListIntegrationTests.cs:88  ── reads ExpeditionPickingRequest.DefaultCarriers
+            └─► (same as above)
 ```
+
+The carrier set `{ Zasilkovna, GLS, PPL, Osobak }` flows through unchanged.
 
 ## Risks and Mitigations
 
 | Risk | Severity | Mitigation |
 |------|----------|------------|
-| A hidden consumer reads `OrderIds` somewhere not caught by grep (e.g. reflection, serialization). | LOW | Verified: no JSON/System.Text.Json/Newtonsoft attributes on the type; not exposed via controller, MediatR result, EF entity, or OpenAPI generation. Repository-wide grep confirms only the three known sites. `dotnet build` will fail-fast on any compile-time reference. |
-| Other tests construct `PrintPickingListResult` with `OrderIds` set. | LOW | Verified: the other three uses in `LogisticsExpeditionPickingAdapterTests.cs` (lines 29, 89, 115) all use parameterless `new PrintPickingListResult()` — no field initializers to update. |
-| A future developer reintroduces the field without a producer. | LOW | The deletion itself removes the temptation. No automated guard needed for a one-property hygiene change. |
-| Concurrent in-flight branches reference `OrderIds`. | LOW | Solo developer per `CLAUDE.md`. Standard PR merge conflict resolution covers this. |
+| A hidden reflection-based or string-named consumer of `PrintPickingListRequest.DefaultCarriers` is missed. | Low | Repo-wide grep already confirmed zero non-test references (verified during this review). Reflection on a property named `DefaultCarriers` is implausible for this codebase. Acceptance criterion already requires a final search. |
+| Test file forgets the new `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` and breaks the build. | Low | `dotnet build` will flag this immediately. CI runs build on every PR. |
+| Someone re-adds a `DefaultCarriers` member later under the same drift pattern. | Low | Acceptance criterion explicitly forbids reintroducing a local mutable carrier list. Code review on follow-up PRs should catch this. |
+| Documentation (`docs/superpowers/plans/…`) shows the old mutable form as a code sample. | Negligible | Those plans are historical artifacts describing past work and are not API contracts. Do not edit. |
+| Test asserts behavior that depended (silently) on a mutation elsewhere. | Negligible | The test never mutates `DefaultCarriers` and no other code does either. The list contents are identical, so test outcomes are unchanged. |
 
 ## Specification Amendments
 
-None. The spec is correct, complete, and scoped appropriately:
+The spec is sufficient and matches the codebase. One small implementation detail to add explicitly:
 
-- FR-1, FR-2, FR-3 acceptance criteria match the codebase reality verified above.
-- NFR-2 (surgical scope) is already enforced by the file list.
-- Out-of-scope list correctly excludes `ExpeditionPickingResult`, frontend, and broader dead-code sweeps.
+- **The test must add `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;`** — the current `using Anela.Heblo.Application.Features.ExpeditionList;` does not cover the `.Contracts` sub-namespace where `ExpeditionPickingRequest` lives. Without this, the build fails with `CS0246`. The spec implies the change but does not call out the new `using`; recording it here avoids a stumble during implementation.
 
-One minor verification refinement worth recording during execution (not a spec change): when running FR-3's grep, expect to see remaining `OrderIds` matches in `docs/superpowers/plans/` (historical planning artifacts) and `frontend/src/features/grid-layout/` (unrelated `newOrderIds` callback) and an EF migration name (`ChangePurchaseOrderIdsToInt`). These are not references to `PrintPickingListResult.OrderIds` and should be ignored.
+No other amendments needed.
 
 ## Prerequisites
 
-None. The change requires:
+None.
 
-- No database migration (DTO is not persisted).
-- No configuration update (no feature flag, no Key Vault secret).
-- No OpenAPI client regeneration (DTO is not on the API surface; `frontend/src/api/` will be unchanged).
-- No infrastructure change.
-- No coordination with other in-flight work beyond standard branch hygiene.
+- No migrations.
+- No config or infrastructure changes.
+- No new packages or NuGet references.
+- No assembly reference changes — the test project already references the Application assembly that contains `ExpeditionPickingRequest`.
+- No coordination with frontend, OpenAPI clients, or generated TypeScript code.
 
-Validation before completion (per `CLAUDE.md`):
-- `dotnet build` succeeds.
-- `dotnet format` produces no diff on the two edited files.
-- The four tests in `LogisticsExpeditionPickingAdapterTests` all pass.
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/brief.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/brief.md
@@ -2,18 +2,30 @@
 ExpeditionList (found via Logistics integration chain)
 
 ## Finding
-`PrintPickingListResult.OrderIds` in `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` (line 7) is declared and initialized to an empty list, but is never written to or read in any production code path:
+`PrintPickingListRequest.DefaultCarriers` in `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs` (line 16) is declared with a public setter:
 
-- **Producer** — `ShoptetApiExpeditionListSource.CreatePickingList` (`backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs`, line 229) returns `new PrintPickingListResult { ExportedFiles = ..., TotalCount = ... }` and never sets `OrderIds`.
-- **Consumer** — `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` (`backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs`, lines 16–22) maps only `ExportedFiles` and `TotalCount` to `ExpeditionPickingResult`; `OrderIds` is silently discarded. `ExpeditionPickingResult` has no corresponding field.
+```csharp
+public static IList<Carriers> DefaultCarriers { get; set; } = new List<Carriers>()
+{
+    Carriers.Zasilkovna, Carriers.GLS, Carriers.PPL, Carriers.Osobak
+};
+```
 
-The only place `OrderIds` appears outside its definition is in the test arrange step (`backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs`, line 60), where it is set but not asserted — confirming it is not mapped through.
+Any code can silently replace the entire default-carrier list with `PrintPickingListRequest.DefaultCarriers = someOtherList`. The change persists for the entire process lifetime.
+
+Compare with `ExpeditionPickingRequest.DefaultCarriers` (the consumer-facing equivalent in `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs`, line 16), which is read-only:
+
+```csharp
+public static IList<Carriers> DefaultCarriers { get; } = new List<Carriers> { ... };
+```
+
+Additionally, `PrintPickingListRequest.DefaultCarriers` is referenced only in an integration test (`backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs`, line 88). All production code (`PrintPickingListJob`, `RunExpeditionListPrintFixHandler`) uses `ExpeditionPickingRequest.DefaultCarriers` instead, so this property is dead in the production path.
 
 ## Why it matters
-YAGNI: the field signals to future developers that order IDs are available in this result object, when in practice they are always the empty list initialized at construction. Any code written to read `OrderIds` will silently see an empty collection, producing a silent logic error that is hard to diagnose.
+A public setter on a static property that holds shared mutable state is a global-variable mutation hazard. If any caller (including a test that forgets to restore state) writes to it, subsequent expedition list runs silently use a different carrier set with no diagnostic signal.
 
 ## Suggested fix
-Remove `OrderIds` from `PrintPickingListResult`. Update `LogisticsExpeditionPickingAdapterTests.CreatePickingListAsync_TranslatesResultFields` to remove the unused `OrderIds = new List<int> { 1, 2, 3 }` from the arrange step (it adds setup complexity without exercising any real behaviour).
+Remove the setter — change to `{ get; }`. Since it is not used in production code, also verify whether the property should be removed entirely and the integration test updated to use `ExpeditionPickingRequest.DefaultCarriers` directly (which is what production code already uses).
 
 ---
 _Filed by daily arch-review routine on 2026-06-07._

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/impl/main.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/impl/main.r1.md
@@ -1,44 +1,50 @@
-All tasks complete. Here is the output artifact:
+All three tasks are complete. Here is the output summary:
 
 ---
 
-# Implementation: Remove unused `OrderIds` field from `PrintPickingListResult`
+# Implementation: Remove dead mutable static `PrintPickingListRequest.DefaultCarriers`
 
 ## What was implemented
 
-Removed the dead `OrderIds` property from the internal application-layer DTO `PrintPickingListResult` and removed its corresponding unused arrange step from the adapter test. The field was initialized empty, never written by any producer (`ShoptetApiExpeditionListSource.CreatePickingList`), and never read by any consumer (`LogisticsExpeditionPickingAdapter.CreatePickingListAsync`). Exactly two lines deleted across two files; no runtime behaviour change.
+Eliminated a global-mutation hazard by removing the public-setter static `DefaultCarriers` property from `PrintPickingListRequest`. The lone integration test consumer was retargeted to `ExpeditionPickingRequest.DefaultCarriers` — the canonical read-only constant that all production code already uses. No behavior change; carrier set `{ Zasilkovna, GLS, PPL, Osobak }` is identical.
 
 ## Files created/modified
 
-- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` — removed `public IList<int> OrderIds { get; set; } = new List<int>();` (line 7)
-- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — removed `OrderIds = new List<int> { 1, 2, 3 },` from the arrange block of `CreatePickingListAsync_TranslatesResultFields`
+- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs` — removed the `public static IList<Carriers> DefaultCarriers { get; set; }` property (lines 16–22); all other members preserved
+- `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs` — added `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;`; changed line 88 from `PrintPickingListRequest.DefaultCarriers` to `ExpeditionPickingRequest.DefaultCarriers`
 
 ## Tests
 
-- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — all 4 existing tests pass; `CreatePickingListAsync_TranslatesResultFields` retains its assertions on `ExportedFiles` and `TotalCount`
+- All 4,766 non-integration tests passed (`dotnet test --filter "Category!=Integration"`)
+- `PickingListIntegrationTests` excluded from CI (requires live Shoptet store); the test file compiles cleanly and will exercise the production carrier set on next manual run
 
 ## How to verify
 
 ```bash
-cd backend
-dotnet build Anela.Heblo.sln --nologo            # Build succeeded, 0 errors
-dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~LogisticsExpeditionPickingAdapterTests" --nologo  # Failed: 0, Passed: 4
-grep -rn "OrderIds" src/Anela.Heblo.Application/Features/Logistics/ --include="*.cs"  # no output
-git log -1 --stat                                # 2 files changed, 2 deletions(-)
+# Confirm zero references to the removed property
+grep -rn 'PrintPickingListRequest\.DefaultCarriers' --include='*.cs' backend/
+
+# Confirm canonical constant is intact
+grep -A 6 'public static IList<Carriers> DefaultCarriers' backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs
+
+# Run tests
+cd backend && dotnet test Anela.Heblo.sln --filter "Category!=Integration"
+
+# Inspect commit
+git show --stat HEAD
 ```
 
 ## Notes
 
-Baseline confirmed 70 warnings before the change; post-change build also shows 70 warnings (no regression). `dotnet format --verify-no-changes` confirmed no formatting drift. The `OrderIds` symbol still appears in the repo in unrelated places (`ChangePurchaseOrderIdsToInt` EF migration name, React `newOrderIds` callback) — none of these reference `PrintPickingListResult.OrderIds`.
+The code quality reviewer flagged a pre-existing using-directive ordering issue (`Domain` before `Application.Logistics.Picking`) in the test file. This ordering predates this change and is preserved unchanged per the surgical-changes policy in CLAUDE.md. `dotnet format` ran without reordering them, confirming the project has no enforced ordering rule for this.
 
 ## PR Summary
 
-Removes `PrintPickingListResult.OrderIds`, a dead property that was initialized to an empty list by the constructor default but never populated by `ShoptetApiExpeditionListSource.CreatePickingList` and never consumed by `LogisticsExpeditionPickingAdapter.CreatePickingListAsync`. The field violated YAGNI and created a misleading API surface that could lead a future developer to rely on it and produce a silent logic error. The cross-feature contract `ExpeditionPickingResult` never had `OrderIds` and is untouched; the OpenAPI surface is unaffected.
+Removed `PrintPickingListRequest.DefaultCarriers` — a public-setter static property that duplicated the already read-only `ExpeditionPickingRequest.DefaultCarriers` used by all production callers. The mutation hazard was eliminated and the lone integration test consumer was redirected to the canonical constant, so the test now exercises the same carrier set as production code.
 
 ### Changes
-- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs` — deleted the `OrderIds` property declaration
-- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — deleted the dead `OrderIds` initializer from the `CreatePickingListAsync_TranslatesResultFields` arrange block
+- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs` — deleted the static `DefaultCarriers` property; all other members untouched
+- `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs` — added `.Contracts` using directive; retargeted line 88 to `ExpeditionPickingRequest.DefaultCarriers`
 
 ## Status
-
 DONE

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/spec.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/spec.r1.md
@@ -1,74 +1,93 @@
-# Specification: Remove unused `OrderIds` field from `PrintPickingListResult`
+# Specification: Remove dead mutable static `PrintPickingListRequest.DefaultCarriers`
 
 ## Summary
-Remove the dead `OrderIds` property from `PrintPickingListResult` and clean up the corresponding unused test arrange step. The field is initialized but never written by producers nor read by consumers, creating a misleading API surface that risks silent logic errors if future code attempts to use it.
+Eliminate a global-mutation hazard in `PrintPickingListRequest.DefaultCarriers` (a public-setter static field that holds shared mutable state). The property is dead code in the production path — production callers use `ExpeditionPickingRequest.DefaultCarriers` — so the safest fix is to remove the property entirely and update the lone integration test reference.
 
 ## Background
-A daily architecture review on 2026-06-07 flagged `PrintPickingListResult.OrderIds` as dead code in the ExpeditionList feature's Logistics integration chain:
+A daily architecture review flagged `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs:16`:
 
-- **Definition:** `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListResult.cs:7` — declared as `List<int>` initialized to an empty list.
-- **Producer:** `ShoptetApiExpeditionListSource.CreatePickingList` (`backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs:229`) constructs the result with only `ExportedFiles` and `TotalCount`; never sets `OrderIds`.
-- **Consumer:** `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` (`backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs:16-22`) maps only `ExportedFiles` and `TotalCount` into `ExpeditionPickingResult`; `OrderIds` is silently discarded, and `ExpeditionPickingResult` has no equivalent field.
-- **Test:** `LogisticsExpeditionPickingAdapterTests.CreatePickingListAsync_TranslatesResultFields` (`backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs:60`) sets `OrderIds = new List<int> { 1, 2, 3 }` in arrange but never asserts on it.
+```csharp
+public static IList<Carriers> DefaultCarriers { get; set; } = new List<Carriers>()
+{
+    Carriers.Zasilkovna, Carriers.GLS, Carriers.PPL, Carriers.Osobak
+};
+```
 
-The field violates YAGNI: it advertises a capability that does not exist. A future developer reading the result type may write code that consumes `OrderIds`, observe an empty list, and produce a silent logic error that is difficult to diagnose because no exception is thrown and no compiler warning is raised.
+Two distinct problems:
+
+1. **Mutation hazard.** The public setter on a static, process-wide list lets any caller silently swap the default carrier set for the lifetime of the process. There is no diagnostic signal if a test (or other code) forgets to restore state, which can cause downstream expedition list runs to use an unexpected carrier set.
+
+2. **Dead code in production.** The property is referenced only from one integration test (`backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs:88`). All production code — `PrintPickingListJob`, `RunExpeditionListPrintFixHandler`, and other ExpeditionList handlers — uses `ExpeditionPickingRequest.DefaultCarriers` (already read-only at `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs:16`).
+
+Removing the property eliminates the hazard, reduces duplication, and aligns the test with the production code path it claims to cover.
 
 ## Functional Requirements
 
-### FR-1: Remove `OrderIds` from `PrintPickingListResult`
-Delete the `OrderIds` property from `PrintPickingListResult.cs`. No other production code references this property, so no replacement or migration is required.
+### FR-1: Remove `PrintPickingListRequest.DefaultCarriers` entirely
+Delete the static `DefaultCarriers` property from `PrintPickingListRequest`. Do not retain it as read-only — production code does not reference it, so leaving a read-only duplicate of `ExpeditionPickingRequest.DefaultCarriers` would only add maintenance drift.
 
 **Acceptance criteria:**
-- `PrintPickingListResult.cs` no longer declares an `OrderIds` property.
-- `grep -r "OrderIds" backend/src/Anela.Heblo.Application/Features/Logistics/` returns no matches against `PrintPickingListResult`.
-- `dotnet build` succeeds across the solution.
+- `PrintPickingListRequest.cs` no longer declares any `DefaultCarriers` member.
+- A repo-wide search for `PrintPickingListRequest.DefaultCarriers` returns zero results.
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs` is unchanged and remains the single source of truth for the default carrier set.
 
-### FR-2: Clean up unused test arrange step
-Remove the `OrderIds = new List<int> { 1, 2, 3 }` initializer from the arrange section of `CreatePickingListAsync_TranslatesResultFields`. The test currently sets a field it never asserts; with FR-1 applied, the initializer would fail to compile.
-
-**Acceptance criteria:**
-- The `OrderIds` initializer is removed from `LogisticsExpeditionPickingAdapterTests.cs`.
-- The test `CreatePickingListAsync_TranslatesResultFields` continues to assert that `ExportedFiles` and `TotalCount` are correctly translated.
-- No other assertions or test cases are altered.
-
-### FR-3: Verify no hidden consumers
-Confirm via repository-wide search that no other production code, serialization contract, or external consumer reads `PrintPickingListResult.OrderIds` before deletion. Because `PrintPickingListResult` is an internal application-layer DTO (not part of the OpenAPI surface), no client regeneration is expected.
+### FR-2: Update the integration test to use `ExpeditionPickingRequest.DefaultCarriers`
+The only consumer (`PickingListIntegrationTests.cs:88`) must be updated to reference `ExpeditionPickingRequest.DefaultCarriers` — the same list production code uses — so the test exercises the production default rather than a parallel one.
 
 **Acceptance criteria:**
-- Repository-wide search for `OrderIds` returns no remaining references tied to `PrintPickingListResult` after the change.
-- Generated OpenAPI client (`frontend/src/api/`) is unchanged, confirming the field was not exposed externally.
+- The test continues to assert the same behavior it asserted before (no change in test intent, only in which constant it reads).
+- `PickingListIntegrationTests` references `ExpeditionPickingRequest.DefaultCarriers` and does not reintroduce a local mutable carrier list.
+- The integration test passes when run against the normal test environment (Postgres container per the shared-container setup in commit `7542d689`).
+
+### FR-3: Verify no behavioral change in production
+Production handlers (`PrintPickingListJob`, `RunExpeditionListPrintFixHandler`, any other ExpeditionList consumer) must continue to receive the same default carrier set they do today.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds with no new warnings related to this change.
+- Existing unit and integration tests for `PrintPickingListJob`, `RunExpeditionListPrintFixHandler`, and ExpeditionList carrier defaults all pass without modification (other than the FR-2 test update).
+- Manual review confirms the carrier set used at runtime is `{ Zasilkovna, GLS, PPL, Osobak }` — identical to today.
 
 ## Non-Functional Requirements
 
-### NFR-1: Behaviour preservation
-No runtime behaviour change. Producers, consumers, and downstream `ExpeditionPickingResult` mapping are unaffected because `OrderIds` was never written or read in production.
+### NFR-1: Performance
+No runtime performance impact expected. This is a compile-time / source-level change. Static list initialization cost is unchanged (one initialization, in `ExpeditionPickingRequest`).
 
-### NFR-2: Surgical scope
-Touch only the three identified files. Do not refactor adjacent code, rename symbols, reorder properties, or reformat unrelated lines.
+### NFR-2: Security
+No direct security implications. Indirectly improves robustness by removing a vector for accidental shared-state corruption that could cause incorrect carrier selection during expedition processing.
 
-### NFR-3: Test coverage maintained
-Existing test coverage of `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` for `ExportedFiles` and `TotalCount` must remain intact. The arrange-step cleanup must not weaken any assertion.
+### NFR-3: Maintainability
+After this change there is exactly one canonical default carrier list (`ExpeditionPickingRequest.DefaultCarriers`), reducing the risk of the two lists diverging when carriers are added or removed in the future.
 
 ## Data Model
-`PrintPickingListResult` (application-layer DTO) currently contains:
-- `ExportedFiles` — collection of generated picking-list files (retained)
-- `TotalCount` — number of orders included (retained)
-- `OrderIds` — `List<int>`, initialized empty, never populated (**to be removed**)
-
-`ExpeditionPickingResult` (downstream domain result) is unchanged; it has no `OrderIds` field and never did.
+No data model changes. `Carriers` enum is untouched. No database migrations.
 
 ## API / Interface Design
-No public API or external interface changes. `PrintPickingListResult` is internal to the application layer and is not serialized to any HTTP response, OpenAPI contract, MediatR contract exposed to clients, or persistence schema.
+
+**Removed surface:**
+- `PrintPickingListRequest.DefaultCarriers` (static property) — gone.
+
+**Unchanged surface:**
+- `PrintPickingListRequest` class itself remains; only the static `DefaultCarriers` member is removed. Instance members and the request contract for MediatR/picking flows are not touched.
+- `ExpeditionPickingRequest.DefaultCarriers` remains as the sole read-only default-carrier source.
+
+**Test surface:**
+- `PickingListIntegrationTests.cs:88` switches its reference target. No test method signatures change.
+
+No HTTP endpoints, no MediatR contracts, no OpenAPI schema, and no generated TypeScript client are affected.
 
 ## Dependencies
-None. The change is confined to one DTO file in `Anela.Heblo.Application` and one test file in `Anela.Heblo.Tests`. No NuGet packages, configuration, migrations, or external services are involved.
+- None added or removed.
+- Touches only files under:
+  - `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs`
+  - `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs`
+- Before completion, run repo-wide search to confirm no other consumer exists outside these two files.
 
 ## Out of Scope
-- Renaming, restructuring, or otherwise modifying `ExpeditionPickingResult` or any other type in the Logistics or Picking namespaces.
-- Adding new fields, telemetry, or logging to the picking-list flow.
-- Refactoring `ShoptetApiExpeditionListSource.CreatePickingList` or `LogisticsExpeditionPickingAdapter.CreatePickingListAsync` beyond what is necessary for the field removal (which is nothing — neither file references `OrderIds`).
-- Frontend changes; the field is not exposed via the OpenAPI client.
-- Broader dead-code sweeps in the Logistics module.
+- Refactoring `PrintPickingListRequest` more broadly (other members, naming, location).
+- Refactoring or consolidating `ExpeditionPickingRequest` and `PrintPickingListRequest` into a shared contract.
+- Auditing other static-mutable-state hazards elsewhere in the codebase. (A separate sweep can be filed if desired.)
+- Changing the default carrier set itself (`{ Zasilkovna, GLS, PPL, Osobak }`) — values stay identical.
+- Any frontend changes — this is backend-only.
 
 ## Open Questions
 None.

--- a/artifacts/feat-arch-review-expeditionlist-logistics-pri/task-plan.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-logistics-pri/task-plan.r1.md
@@ -1,13 +1,9 @@
-Implementation plan saved to `docs/superpowers/plans/2026-06-10-remove-orderids-from-printpickinglistresult.md`.
+Plan saved to `docs/superpowers/plans/2026-06-11-remove-print-picking-list-default-carriers.md`.
 
-The plan decomposes the spec into 7 tasks with checkbox-tracked steps:
+**Summary:** Three bite-sized tasks executed in strict order to avoid a mid-edit build break:
 
-1. **Baseline** — confirm the 4 adapter tests pass and solution builds clean before any edit.
-2. **Repository search** — verify only the two expected `OrderIds` callsites exist (FR-3 pre-check).
-3. **Delete the DTO property** — single-line removal from `PrintPickingListResult.cs`, then build to confirm the failure now points only at the test arrange line (intentional RED).
-4. **Delete the test arrange line** — remove `OrderIds = new List<int> { 1, 2, 3 },` from `CreatePickingListAsync_TranslatesResultFields`, rebuild GREEN, run all 4 tests.
-5. **Post-change grep** — confirm zero `OrderIds` references remain in the Logistics namespace, and `frontend/src/api/` is untouched.
-6. **Project gates** — `dotnet build`, `dotnet format --verify-no-changes`, full `dotnet test`.
-7. **Commit** — exact staged-diff verification (two hunks, two minus-lines) before commit.
+1. **Task 1 — Retarget the integration test first.** Add `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` and change `PickingListIntegrationTests.cs:88` from `PrintPickingListRequest.DefaultCarriers` to `ExpeditionPickingRequest.DefaultCarriers`. Build to confirm both constants still coexist cleanly.
+2. **Task 2 — Delete the dead property.** Remove lines 16-22 (the public-setter static `DefaultCarriers`) from `PrintPickingListRequest.cs`. Keep the `using`, both `Default*StateId` consts, and every instance member. Build the full solution to confirm zero remaining consumers.
+3. **Task 3 — Verify and commit.** Repo-wide grep for zero remaining `PrintPickingListRequest.DefaultCarriers` references, `dotnet format` the touched files, run `dotnet test --filter "Category!=Integration"`, confirm the canonical `ExpeditionPickingRequest.DefaultCarriers` is untouched, then stage and commit exactly the two files with a conventional-commit message.
 
-Every step has the concrete command, expected output, and a stop-condition for unexpected results. Coverage check against the spec: FR-1 (Task 3), FR-2 (Task 4), FR-3 (Tasks 2 + 5), NFR-1/NFR-3 (Tasks 4.3 + 6.3), NFR-2 (Task 7.2 staged-diff guard).
+Self-review confirmed every FR/NFR from the spec maps to a concrete step, the arch review's `using` directive caveat is explicitly handled, no placeholders, and naming/types are consistent throughout.

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs
@@ -12,14 +12,5 @@ public class PrintPickingListRequest
     public int SourceStateId { get; set; } = DefaultSourceStateId;
     public int DesiredStateId { get; set; } = DefaultDesiredStateId;
     public bool ChangeOrderState { get; set; }
-
-    public static IList<Carriers> DefaultCarriers { get; set; } = new List<Carriers>()
-    {
-        Anela.Heblo.Domain.Features.Logistics.Carriers.Zasilkovna,
-        Anela.Heblo.Domain.Features.Logistics.Carriers.GLS,
-        Anela.Heblo.Domain.Features.Logistics.Carriers.PPL,
-        Anela.Heblo.Domain.Features.Logistics.Carriers.Osobak
-    };
-
     public bool SendToPrinter { get; set; }
 }

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Adapters.Shoptet.Tests.Integration.Infrastructure;
 using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
 using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Application.Shared.Printing;
@@ -85,7 +86,7 @@ public class PickingListIntegrationTests
             {
                 SourceStateId = SourceStateId,
                 DesiredStateId = PrintPickingListRequest.DefaultDesiredStateId,
-                Carriers = PrintPickingListRequest.DefaultCarriers,
+                Carriers = ExpeditionPickingRequest.DefaultCarriers,
                 ChangeOrderState = false,
                 SendToPrinter = false,
             };

--- a/docs/superpowers/plans/2026-06-11-remove-print-picking-list-default-carriers.md
+++ b/docs/superpowers/plans/2026-06-11-remove-print-picking-list-default-carriers.md
@@ -1,0 +1,314 @@
+# Remove Dead Mutable Static `PrintPickingListRequest.DefaultCarriers` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the public-setter static `DefaultCarriers` property on `PrintPickingListRequest` (a process-wide mutation hazard and dead code in production) by deleting it and pointing the lone integration-test consumer at the canonical `ExpeditionPickingRequest.DefaultCarriers` constant.
+
+**Architecture:** Two byte-identical static carrier lists currently exist: `ExpeditionPickingRequest.DefaultCarriers` (read-only, used by all production callers) and `PrintPickingListRequest.DefaultCarriers` (mutable, used only by one integration test). Remove the duplicate, retarget the test, leave the rest of `PrintPickingListRequest` untouched. Net effect: one source of truth, zero behavior change.
+
+**Tech Stack:** .NET 8, C# 12, xUnit, FluentAssertions, MediatR. Backend-only — no migrations, no API surface change, no OpenAPI regen, no frontend impact.
+
+---
+
+## File Structure
+
+This change touches exactly two existing files. No new files, no renames, no project reference changes.
+
+```
+backend/
+├── src/Anela.Heblo.Application/Features/Logistics/Picking/
+│   └── PrintPickingListRequest.cs            ← DELETE the static DefaultCarriers property (lines 16-22)
+└── test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/
+    └── PickingListIntegrationTests.cs        ← Add using directive + retarget line 88
+```
+
+**Unchanged (do not touch):**
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs` — remains the single source of truth for the default carrier set.
+- All other members of `PrintPickingListRequest` (the `DefaultSourceStateId`, `DefaultDesiredStateId` consts and instance properties).
+- `PrintPickingListJob.cs`, `RunExpeditionListPrintFixHandler.cs`, and other ExpeditionList handlers — they already read `ExpeditionPickingRequest.DefaultCarriers`.
+
+**Task ordering matters:** the test must be retargeted **before** the property is deleted, otherwise the build breaks between the two edits. Plan reflects this order.
+
+---
+
+### Task 1: Retarget the integration test to `ExpeditionPickingRequest.DefaultCarriers`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs:7` (add a `using` directive)
+- Modify: `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs:88` (retarget the constant)
+
+**Why first:** Removing `PrintPickingListRequest.DefaultCarriers` before this edit causes `CS0117 'PrintPickingListRequest' does not contain a definition for 'DefaultCarriers'` at build time. Retarget first, then delete.
+
+- [ ] **Step 1: Confirm the current consumer site**
+
+Open `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs` and verify:
+- Line 7 currently reads: `using Anela.Heblo.Application.Features.Logistics.Picking;`
+- Line 88 currently reads: `                Carriers = PrintPickingListRequest.DefaultCarriers,`
+
+This is the only file that needs updating (verified by repo-wide grep — see Task 3 Step 3).
+
+- [ ] **Step 2: Add the `using` directive for `ExpeditionPickingRequest`**
+
+`ExpeditionPickingRequest` lives in the `Anela.Heblo.Application.Features.ExpeditionList.Contracts` sub-namespace. The test file already has `using Anela.Heblo.Application.Features.ExpeditionList;` (line 2) and `using Anela.Heblo.Application.Features.ExpeditionList.Services;` (line 3), but **not** the `.Contracts` sub-namespace. Add it.
+
+Use the Edit tool to insert the new `using` after the existing `ExpeditionList` usings. The block at the top of the file changes from:
+
+```csharp
+using Anela.Heblo.Adapters.Shoptet.Tests.Integration.Infrastructure;
+using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Application.Shared.Printing;
+using Anela.Heblo.Domain.Features.Logistics;
+using Anela.Heblo.Application.Features.Logistics.Picking;
+```
+
+to:
+
+```csharp
+using Anela.Heblo.Adapters.Shoptet.Tests.Integration.Infrastructure;
+using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Application.Shared.Printing;
+using Anela.Heblo.Domain.Features.Logistics;
+using Anela.Heblo.Application.Features.Logistics.Picking;
+```
+
+Do **not** remove `using Anela.Heblo.Application.Features.Logistics.Picking;` — it is still required because the test continues to reference `PrintPickingListRequest` itself (lines 22, 84, 87) and `PrintPickingListOptions` (line 40).
+
+- [ ] **Step 3: Retarget the carrier-list reference**
+
+Change line 88 of the same file from:
+
+```csharp
+                Carriers = PrintPickingListRequest.DefaultCarriers,
+```
+
+to:
+
+```csharp
+                Carriers = ExpeditionPickingRequest.DefaultCarriers,
+```
+
+This is the only line that needs changing on the consumer side. Surrounding lines (`SourceStateId`, `DesiredStateId`, `ChangeOrderState`, `SendToPrinter`) stay exactly as they are.
+
+- [ ] **Step 4: Build to confirm the retarget compiles**
+
+Run:
+
+```bash
+cd backend && dotnet build Anela.Heblo.sln
+```
+
+Expected: build succeeds with no new errors or warnings. Both `PrintPickingListRequest.DefaultCarriers` and `ExpeditionPickingRequest.DefaultCarriers` still exist at this point (both compile), so the test file uses the new one and the old property is still defined but now has zero consumers. This is the intermediate green state before the deletion in Task 2.
+
+- [ ] **Step 5: Verify the test class still loads correctly**
+
+Run the integration-test project's build target specifically:
+
+```bash
+cd backend && dotnet build test/Anela.Heblo.Adapters.Shoptet.Tests/Anela.Heblo.Adapters.Shoptet.Tests.csproj
+```
+
+Expected: build succeeds. We do **not** run the integration test itself here — `PickingListIntegrationTests` requires `Shoptet:IsTestEnvironment=true` user secrets and hits a live test store (see the `ShoptetTestGuard.Assert` call at line 55). It is excluded from CI via `[Trait("Category", "Integration")]` and is run manually per the file's docstring. Build success is the meaningful signal at this step.
+
+---
+
+### Task 2: Delete `PrintPickingListRequest.DefaultCarriers`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs:16-22` (delete the static property)
+
+**Why this is safe now:** After Task 1, no source file references `PrintPickingListRequest.DefaultCarriers`. Deleting it cannot break the build.
+
+- [ ] **Step 1: Confirm zero remaining references before deletion**
+
+Run the repo-wide search:
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-expeditionlist-logistics-pri && grep -rn 'PrintPickingListRequest\.DefaultCarriers' --include='*.cs'
+```
+
+Expected output: empty (no matches). If anything other than the test file (which was retargeted in Task 1) appears, stop and investigate before deleting.
+
+- [ ] **Step 2: Delete the property**
+
+Open `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs`. The current full file is:
+
+```csharp
+using Anela.Heblo.Domain.Features.Logistics;
+
+namespace Anela.Heblo.Application.Features.Logistics.Picking;
+
+public class PrintPickingListRequest
+{
+    public const int DefaultSourceStateId = -2; // Vyrizuje se
+    //private const string DesiredStateId = "26"; // Bali se
+    public const int DefaultDesiredStateId = 26; // Bali se
+
+    public IList<Carriers> Carriers { get; set; } = new List<Carriers>();
+    public int SourceStateId { get; set; } = DefaultSourceStateId;
+    public int DesiredStateId { get; set; } = DefaultDesiredStateId;
+    public bool ChangeOrderState { get; set; }
+
+    public static IList<Carriers> DefaultCarriers { get; set; } = new List<Carriers>()
+    {
+        Anela.Heblo.Domain.Features.Logistics.Carriers.Zasilkovna,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.GLS,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.PPL,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.Osobak
+    };
+
+    public bool SendToPrinter { get; set; }
+}
+```
+
+Delete lines 16-22 inclusive — the `public static IList<Carriers> DefaultCarriers { get; set; } = new List<Carriers>() { ... };` block — **and** the blank line that separates it from `public bool SendToPrinter { get; set; }`. Use the Edit tool with the exact `old_string` (the seven-line property block plus its trailing blank line) and an empty `new_string`.
+
+Resulting file must be exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.Logistics;
+
+namespace Anela.Heblo.Application.Features.Logistics.Picking;
+
+public class PrintPickingListRequest
+{
+    public const int DefaultSourceStateId = -2; // Vyrizuje se
+    //private const string DesiredStateId = "26"; // Bali se
+    public const int DefaultDesiredStateId = 26; // Bali se
+
+    public IList<Carriers> Carriers { get; set; } = new List<Carriers>();
+    public int SourceStateId { get; set; } = DefaultSourceStateId;
+    public int DesiredStateId { get; set; } = DefaultDesiredStateId;
+    public bool ChangeOrderState { get; set; }
+    public bool SendToPrinter { get; set; }
+}
+```
+
+Do **not** delete or modify:
+- The `using Anela.Heblo.Domain.Features.Logistics;` directive (still needed by the `Carriers` property type).
+- The `DefaultSourceStateId` and `DefaultDesiredStateId` consts (used by the integration test at lines 22 and 87).
+- Any instance property.
+- The commented-out line 8 (`//private const string DesiredStateId = "26"; // Bali se`) — not in scope, surgical change only.
+
+- [ ] **Step 3: Build the full solution**
+
+Run:
+
+```bash
+cd backend && dotnet build Anela.Heblo.sln
+```
+
+Expected: build succeeds with no errors and no new warnings (the existing baseline warning count is unchanged). If you see `CS0117 'PrintPickingListRequest' does not contain a definition for 'DefaultCarriers'`, a consumer was missed in Task 1 — go back, find it with grep, and retarget it before re-attempting the delete.
+
+- [ ] **Step 4: Verify the canonical source is untouched**
+
+Run:
+
+```bash
+grep -n 'DefaultCarriers' backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs
+```
+
+Expected output:
+
+```
+16:    public static IList<Carriers> DefaultCarriers { get; } = new List<Carriers>
+```
+
+(Line 16, read-only — the canonical declaration unchanged.) This confirms the single source of truth is intact.
+
+---
+
+### Task 3: Full verification and commit
+
+**Files:** None modified — verification only, then a single commit covering Tasks 1 and 2.
+
+- [ ] **Step 1: Re-run repo-wide search to confirm zero `PrintPickingListRequest.DefaultCarriers` references**
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-expeditionlist-logistics-pri && grep -rn 'PrintPickingListRequest\.DefaultCarriers' --include='*.cs'
+```
+
+Expected output: empty (no matches). This is FR-1 acceptance criterion #2 from the spec.
+
+- [ ] **Step 2: Run `dotnet format` on the two modified files**
+
+```bash
+cd backend && dotnet format Anela.Heblo.sln --include src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs
+```
+
+Expected: completes silently or reports formatting changes applied. If it makes changes, those are part of the same commit.
+
+- [ ] **Step 3: Run the unit-test suites that exercise the touched code paths**
+
+The integration test itself cannot run in CI (it requires Shoptet user secrets), but the unit-test projects that touch `PrintPickingListJob`, `RunExpeditionListPrintFixHandler`, and ExpeditionList contracts must pass. Run:
+
+```bash
+cd backend && dotnet test Anela.Heblo.sln --no-build --filter "Category!=Integration"
+```
+
+Expected: all tests pass. The `Category!=Integration` filter skips `PickingListIntegrationTests` (it has `[Trait("Category", "Integration")]` and would fail without the live test store) while still running every unit test in the solution. If anything in the ExpeditionList or Picking namespaces fails, investigate — but per the architecture review there should be no behavior change.
+
+- [ ] **Step 4: Confirm `ExpeditionPickingRequest.DefaultCarriers` still contains the same four carriers**
+
+```bash
+grep -A 5 'public static IList<Carriers> DefaultCarriers' backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs
+```
+
+Expected output contains the four carrier enum values in this order: `Zasilkovna, GLS, PPL, Osobak`. This is FR-3 acceptance criterion #3 — manual review that runtime carrier set is unchanged.
+
+- [ ] **Step 5: Stage and commit**
+
+Stage only the two intended files (no `-A` / no `.`) to avoid accidentally committing unrelated changes:
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-expeditionlist-logistics-pri && git add backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs
+```
+
+Then commit with a conventional-commit message:
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(logistics): remove dead mutable PrintPickingListRequest.DefaultCarriers
+
+The static property had a public setter (process-wide mutation hazard) and
+duplicated the read-only ExpeditionPickingRequest.DefaultCarriers that all
+production callers (PrintPickingListJob, RunExpeditionListPrintFixHandler)
+already use. The lone consumer — PickingListIntegrationTests — now reads
+the canonical constant directly, so the test exercises the same default
+carrier set the production path uses.
+
+No behavior change. Carrier set { Zasilkovna, GLS, PPL, Osobak } unchanged.
+EOF
+)"
+```
+
+- [ ] **Step 6: Verify the commit shows exactly two files changed**
+
+```bash
+git show --stat HEAD
+```
+
+Expected: two files in the diffstat — `PrintPickingListRequest.cs` (lines removed) and `PickingListIntegrationTests.cs` (small +/- around the `using` block and line 88). Any other file appearing means staging picked up unintended changes — investigate before pushing.
+
+---
+
+## Self-Review
+
+Checked the plan against the spec and architecture review:
+
+- **FR-1 (remove the property)** — covered by Task 2 Step 2 (delete) and Task 3 Step 1 (repo-wide grep).
+- **FR-2 (retarget the integration test)** — covered by Task 1 Steps 2-3, including the explicit `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` directive the arch review called out.
+- **FR-3 (no behavioral change in production)** — covered by Task 2 Step 3 (full solution build), Task 3 Step 3 (unit test run), and Task 3 Step 4 (manual verification of the canonical carrier set).
+- **NFR-3 (single source of truth)** — guaranteed by the deletion plus Task 2 Step 4 confirming `ExpeditionPickingRequest.DefaultCarriers` is untouched.
+- **Out of scope items** (broader `PrintPickingListRequest` refactor, contract consolidation, default carrier value changes) — none introduced.
+- **Risk #2 from arch review** (forgotten `using` directive breaking the build) — addressed by Task 1 Step 4 building immediately after the retarget.
+- **Risk #3** (someone re-adds the property later) — outside this plan's scope; relies on PR review per the arch review's mitigation.
+- **Ordering trap** (deleting before retargeting breaks the build) — explicitly addressed by Task 1 → Task 2 order and called out in both task preambles.
+- **Placeholders** — none. Every code block is the actual code; every command is the exact command to run; every "expected" line is the concrete expected result.
+- **Type/name consistency** — `DefaultCarriers`, `ExpeditionPickingRequest`, `PrintPickingListRequest`, namespace strings, file paths, and the `Carriers` enum all match between tasks and match the actual files inspected.
+
+Plan is complete.


### PR DESCRIPTION

Removed `PrintPickingListRequest.DefaultCarriers` — a public-setter static property that duplicated the already read-only `ExpeditionPickingRequest.DefaultCarriers` used by all production callers. The mutation hazard was eliminated and the lone integration test consumer was redirected to the canonical constant, so the test now exercises the same carrier set as production code.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/PrintPickingListRequest.cs` — deleted the static `DefaultCarriers` property; all other members untouched
- `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs` — added `.Contracts` using directive; retargeted line 88 to `ExpeditionPickingRequest.DefaultCarriers`

---

Closes #2704

### Tokens used
4674074
