### PR TITLE
feat: Unit Test Coverage for InvoiceClassificationService.ClassifyInvoiceAsync

### DIFF
--- a/artifacts/feat-coverage-gap-invoiceclassification-invoi/arch-review.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-invoi/arch-review.r1.md
@@ -1,0 +1,231 @@
+I have enough context. Now writing the architecture review.
+
+```markdown
+# Architecture Review: Unit Test Coverage for InvoiceClassificationService.ClassifyInvoiceAsync
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a pure test-only addition — no production code is touched, no new types are introduced, no module boundaries are crossed. It fits cleanly into the existing test architecture:
+
+- A test class for `InvoiceClassificationService` belongs alongside the four sibling test classes in `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/` (the spec's nested `Services/` subfolder does NOT match existing layout — see Amendment 1).
+- The test project already references `xunit`, `Moq`, `FluentAssertions`, and `Microsoft.Extensions.Logging.Abstractions`, which is exactly the stack the spec demands. The pattern is established by `ClassifyInvoicesHandlerTests.cs`.
+- The system under test depends on six interfaces, all already abstracted behind clean repository/service boundaries — no test seams need to be added. The SUT can be constructed directly from six `Mock<T>.Object` instances and a `Mock<ILogger<InvoiceClassificationService>>`.
+
+Risk surface is essentially zero: no DB, no HTTP, no DI container. The only architectural concern is keeping the test fixtures faithful to the real types (see Amendments 1–4 — the spec contains several factual errors about the SUT's actual surface that would cause the tests to fail to compile if implemented literally).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+                   ┌──────────────────────────────────────────┐
+                   │ InvoiceClassificationServiceTests        │
+                   │  (xUnit, Moq, FluentAssertions)          │
+                   └────────────────┬─────────────────────────┘
+                                    │ constructs with 6 mocks
+                                    ▼
+         ┌──────────────────────────────────────────────┐
+         │       InvoiceClassificationService (SUT)     │
+         │       public ClassifyInvoiceAsync(invoice)   │
+         └──┬───────┬───────┬──────────┬───────┬─────┬──┘
+            │       │       │          │       │     │
+   Mock<IClassif    │  Mock<IInvoice  Mock<IRule    Mock<ICurrent
+   icationRule      │  Classifications Evaluation   UserService>
+   Repository>      │  Client>        Engine>       │     │
+                    │                               │     │
+   Mock<IClassif                                    │     Mock<ILogger<
+   icationHistory                                   │     InvoiceClassif
+   Repository>                                      │     icationService>>
+```
+
+### Key Design Decisions
+
+#### Decision 1: Single test class, four `[Fact]` methods (no `[Theory]`)
+**Options considered:**
+- (A) Four discrete `[Fact]` methods, one per outcome path.
+- (B) A single `[Theory]` parameterized over the four paths.
+- (C) Subclassed test fixtures per path.
+
+**Chosen approach:** (A) — four `[Fact]` methods named per FR-1..FR-4.
+
+**Rationale:** The four paths exercise different mock setups, different verifications, and different return-state assertions. A `[Theory]` would require either (i) hiding the setup divergence in a discriminator that obscures intent, or (ii) passing in `Action<Mocks>` delegates that fight xUnit's data-source design. Sibling test class `ClassifyInvoicesHandlerTests` uses one `[Fact]` per scenario — consistency wins.
+
+#### Decision 2: Shared fixture in constructor; no `IClassFixture<>`
+**Options considered:**
+- (A) Construct fresh mocks per test in the constructor (xUnit creates a new instance per test by design).
+- (B) Reuse expensive setup via `IClassFixture<>`.
+
+**Chosen approach:** (A).
+
+**Rationale:** Mocks are cheap; xUnit's per-test instantiation already gives isolation for free. `ClassifyInvoicesHandlerTests` follows this exact pattern (`ClassifyInvoicesHandlerTests.cs:11-31`). No reason to deviate.
+
+#### Decision 3: Capture `ClassificationHistory` argument with `Callback` + dedicated assertion
+**Options considered:**
+- (A) `Verify` with an inline `It.Is<ClassificationHistory>(h => h.Result == ... && h.ErrorMessage == ...)` predicate.
+- (B) `Setup(...).Callback<ClassificationHistory>(h => captured = h)` + post-act `FluentAssertions` on `captured`.
+
+**Chosen approach:** (B) for the history-recording assertions; (A) only for simple binary "was called once with this scalar arg" checks (e.g. `MarkInvoiceForManualReviewAsync`).
+
+**Rationale:** `ClassificationHistory` carries 11 constructor fields. An inline predicate makes test failure messages opaque ("expected at least one call matching predicate"). Capturing the object lets `FluentAssertions` print exact diffs — vital for the FR-5 requirement that "failure messages clearly identify which path's history recording broke."
+
+#### Decision 4: Test the actual public surface, not the brief's speculative surface
+**Options considered:**
+- (A) Implement the spec's acceptance criteria verbatim (e.g. mock `EvaluateAsync`, verify `GetByIdAsync` on ABRA-failure path).
+- (B) Test what the SUT actually does.
+
+**Chosen approach:** (B), with the spec amended.
+
+**Rationale:** The brief speculated about implementation details that turned out to be wrong. `IRuleEvaluationEngine` exposes `FindMatchingRule` (synchronous), not `EvaluateAsync`. The ABRA-failure path in the current code (`InvoiceClassificationService.cs:71-84`) does NOT call `GetByIdAsync` — it reuses the already-matched rule's `AccountingTemplateCode` and `Department`. Writing tests against the spec verbatim would either fail to compile or assert behavior that doesn't exist. Tests must reflect reality. See **Specification Amendments** for the corrections.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create exactly one file:
+
+```
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs
+```
+
+**Note:** The spec proposed `…/Features/InvoiceClassification/Services/InvoiceClassificationServiceTests.cs`. Reject the `Services/` nesting — the existing five test classes (`ClassifyInvoicesHandlerTests`, `ClassificationHistoryRepositoryTests`, `GetInvoiceDetailsHandlerTests`, `GetClassificationRuleTypesHandlerTests`, `InvoiceClassificationMappingProfileTests`) all live flat in the feature folder. Consistency with FR-6 outweighs the spec's path suggestion.
+
+No new test project, no new csproj entries, no new package references — everything is already wired.
+
+### Interfaces and Contracts
+
+The test class must construct the SUT exactly per `InvoiceClassificationService.cs:16-30`:
+
+```csharp
+new InvoiceClassificationService(
+    ruleRepositoryMock.Object,
+    historyRepositoryMock.Object,
+    classificationsClientMock.Object,
+    ruleEngineMock.Object,
+    currentUserServiceMock.Object,
+    loggerMock.Object);
+```
+
+Mock surfaces to set up per test (only the methods actually invoked on the path under test):
+
+| Mock | Methods invoked by SUT | Setup needed in which test |
+|------|------------------------|----------------------------|
+| `IClassificationRuleRepository` | `GetActiveRulesOrderedAsync()` | All four (returns `List<ClassificationRule>`; empty list OK for FR-1) |
+| `IRuleEvaluationEngine` | `FindMatchingRule(invoice, rules)` — **synchronous** | All four |
+| `IInvoiceClassificationsClient` | `MarkInvoiceForManualReviewAsync(id, reason, ct?)` | FR-1 |
+| `IInvoiceClassificationsClient` | `UpdateInvoiceClassificationAsync(id, code, dept, ct?)` | FR-2, FR-3 |
+| `IClassificationHistoryRepository` | `AddAsync(history)` | All four — **verified** |
+| `ICurrentUserService` | `GetCurrentUser()` → `CurrentUser(Id, Name, Email, IsAuthenticated)` | All four (must return non-null `CurrentUser` with non-null `Name`, since `ClassificationHistory` ctor throws on null `processedBy`) |
+| `ILogger<InvoiceClassificationService>` | `LogError(ex, message, args)` | Used only in FR-4; no verification required (logging is a side-channel, not behavior) |
+
+### Data Flow
+
+The SUT's four paths, exactly as implemented today (`InvoiceClassificationService.cs:32-100`):
+
+```
+ClassifyInvoiceAsync(invoice)
+  │
+  ├─ _currentUserService.GetCurrentUser()
+  ├─ try
+  │   ├─ rules = await _ruleRepository.GetActiveRulesOrderedAsync()
+  │   ├─ matchedRule = _ruleEngine.FindMatchingRule(invoice, rules)
+  │   │
+  │   ├─ [FR-1] matchedRule == null
+  │   │   ├─ RecordClassificationHistory(…, ManualReviewRequired, …, "No matching rule found", …)
+  │   │   ├─ MarkInvoiceForManualReviewAsync(invoice.InvoiceNumber, "No matching classification rule")
+  │   │   └─ return { Result = ManualReviewRequired }
+  │   │
+  │   ├─ success = await UpdateInvoiceClassificationAsync(…)
+  │   │
+  │   ├─ [FR-2] success == true
+  │   │   ├─ RecordClassificationHistory(…, Success, AccountingTemplateCode, Department, null, …)
+  │   │   └─ return { Success, RuleId, AccountingTemplateCode, Department }
+  │   │
+  │   └─ [FR-3] success == false
+  │       ├─ RecordClassificationHistory(…, Error, AccountingTemplateCode, Department,
+  │       │                              "Failed to update invoice classification in ABRA", …)
+  │       └─ return { Error, RuleId, Department, ErrorMessage }
+  │           // NOTE: AccountingTemplateCode is NOT set on the returned DTO in this branch
+  │
+  └─ [FR-4] catch (Exception ex)
+      ├─ RecordClassificationHistory(…, Error, null, null,
+      │                              $"Exception during classification: {ex.Message}", …)
+      ├─ _logger.LogError(ex, "Error classifying invoice {InvoiceId}", …)
+      └─ return { Error, ErrorMessage = "Exception during classification: {ex.Message}" }
+```
+
+### Test fixture sketch (illustrative, not prescriptive)
+
+```csharp
+public class InvoiceClassificationServiceTests
+{
+    private readonly Mock<IClassificationRuleRepository> _ruleRepo = new();
+    private readonly Mock<IClassificationHistoryRepository> _historyRepo = new();
+    private readonly Mock<IInvoiceClassificationsClient> _classificationsClient = new();
+    private readonly Mock<IRuleEvaluationEngine> _ruleEngine = new();
+    private readonly Mock<ICurrentUserService> _currentUser = new();
+    private readonly Mock<ILogger<InvoiceClassificationService>> _logger = new();
+    private readonly InvoiceClassificationService _sut;
+
+    public InvoiceClassificationServiceTests()
+    {
+        _currentUser.Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("u1", "test-user", "u@test", true));
+        _ruleRepo.Setup(x => x.GetActiveRulesOrderedAsync())
+            .ReturnsAsync(new List<ClassificationRule>());
+
+        _sut = new InvoiceClassificationService(
+            _ruleRepo.Object, _historyRepo.Object, _classificationsClient.Object,
+            _ruleEngine.Object, _currentUser.Object, _logger.Object);
+    }
+    // …four [Fact] methods
+}
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec contains factual errors about SUT surface (`EvaluateAsync`, `GetByIdAsync` on ABRA-fail path, `ClassificationHistoryStatus` enum name) | High | See Specification Amendments — implement against actual code, not spec text. |
+| Tests pass today but break the moment someone refactors the SUT (e.g. extracts a helper) | Low | Tests must assert on observable behavior (return DTO, mock invocations), not on internal call ordering. Avoid `MockSequence` / `Verifiable` chains. |
+| `CurrentUser.Name` is nullable (`string?`); a default mock returning `new CurrentUser(null, null, null, false)` will trigger `ArgumentNullException` in the `ClassificationHistory` constructor | Medium | Always stub `GetCurrentUser` with a non-null `Name` in the test fixture constructor (shown in sketch above). |
+| Constructing `ReceivedInvoice` test data risks omitting required fields (`InvoiceNumber`, `CompanyName`, `Description` are non-null) | Low | Use a small private helper `CreateInvoice(string? id = "INV-001")` that fills all non-null fields. Mirrors how `ClassifyInvoicesHandlerTests.cs:45` does it inline. |
+| Tests over-specify `CancellationToken` parameter on `IInvoiceClassificationsClient` calls (the interface accepts optional `CancellationToken?`, the SUT passes none) | Low | Use `It.IsAny<CancellationToken?>()` in `Verify`, or omit the parameter argument matcher entirely and verify just the required args. |
+| FR-3 expects "test verifies `GetByIdAsync` is called" but the current SUT does NOT call it on the ABRA-failure path | High | Remove that assertion from FR-3 (see Amendment 3). If the team wants this lookup, that's a SUT change — out of scope per the spec. |
+
+## Specification Amendments
+
+The following amendments are required because the spec was drafted from the brief without verifying SUT source. They are corrections, not scope changes.
+
+**Amendment 1 — File path correction (FR-6 / API/Interface Design section):**
+- **Spec says:** `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/InvoiceClassificationServiceTests.cs`
+- **Should be:** `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+- **Why:** All existing sibling test classes are flat under `Features/InvoiceClassification/`, not nested under `Services/`. The spec's own FR-6 demands matching existing conventions.
+
+**Amendment 2 — Method name correction (FR-1 acceptance criteria):**
+- **Spec says:** `Mocked IRuleEvaluationEngine.EvaluateAsync returns "no match"`
+- **Should be:** `Mocked IRuleEvaluationEngine.FindMatchingRule(invoice, rules) returns null`
+- **Why:** The actual interface (`IRuleEvaluationEngine.cs:7`) defines `ClassificationRule? FindMatchingRule(ReceivedInvoice invoice, List<ClassificationRule> rules)` — synchronous, not async. No `EvaluateAsync` method exists.
+
+**Amendment 3 — Remove `GetByIdAsync` assertion from FR-3:**
+- **Spec says:** `IClassificationRuleRepository.GetByIdAsync is verified called with the matched rule's ID.`
+- **Should be:** *Remove this acceptance criterion.*
+- **Why:** The current SUT (`InvoiceClassificationService.cs:71-84`) does not call `GetByIdAsync` on the ABRA-failure path. It reuses `matchedRule.AccountingTemplateCode` and `matchedRule.Department` from the already-matched rule. Implementing the assertion would fail. (The brief speculated about this; the spec carried the speculation forward without verifying.)
+
+**Amendment 4 — Enum name correction (Data Model section, FR-1..FR-4 acceptance criteria):**
+- **Spec says:** `ClassificationHistoryStatus.Success`, `…Error`, `…ManualReviewRequired`
+- **Should be:** `ClassificationResult.Success`, `…Error`, `…ManualReviewRequired`
+- **Why:** The actual enum (`ClassificationResult.cs:3`) is named `ClassificationResult`. No `ClassificationHistoryStatus` type exists. Both the SUT and `ClassificationHistory` use `ClassificationResult`.
+
+**Amendment 5 — Repository method correction (FR-1 acceptance criteria):**
+- **Spec implies:** `IClassificationHistoryRepository.AddAsync (or whichever method RecordClassificationHistory delegates to)`
+- **Confirmed:** `AddAsync(ClassificationHistory history)` — see `IClassificationHistoryRepository.cs:5`. Tests should assert on this exact method.
+
+**Amendment 6 — Returned DTO field expectations (FR-3 acceptance criteria, "rule's values"):**
+- **Note for implementer:** On the ABRA-failure path, the returned `InvoiceClassificationResult` sets `RuleId`, `Department`, and `ErrorMessage` — but **not** `AccountingTemplateCode`. FR-2 sets all four. Test assertions must reflect this asymmetry (`InvoiceClassificationService.cs:77-83`).
+
+## Prerequisites
+
+None. The test project, all required NuGet packages (`xunit`, `Moq`, `FluentAssertions`), the SUT, and all six dependency interfaces already exist. The implementer can create the file and start writing tests immediately. `dotnet build` and `dotnet test` from `backend/test/Anela.Heblo.Tests/` are the only commands needed.
+```

--- a/artifacts/feat-coverage-gap-invoiceclassification-invoi/brief.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-invoi/brief.md
@@ -1,0 +1,23 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`
+
+## Coverage
+No direct unit tests. `ClassifyInvoicesHandlerTests` mocks `IInvoiceClassificationService` entirely, so `ClassifyInvoiceAsync` has never been exercised by the test suite.
+
+## What's not tested
+Four distinct outcome paths in `ClassifyInvoiceAsync`:
+1. **No matching rule found** — marks invoice for manual review, records history with `ManualReviewRequired`, calls `MarkInvoiceForManualReviewAsync` on the client
+2. **Rule matched, ABRA update succeeds** — records history with `Success`, returns rule ID and accounting template
+3. **Rule matched, ABRA update fails** (`success == false`) — records history with `Error`, returns error result with the rule ID for display; the rule name lookup from `_ruleRepository.GetByIdAsync` is also untested
+4. **Exception during classification** — records history with `Error` and exception message, returns error result
+
+The history recording call (`RecordClassificationHistory`) fires on every path but is never asserted.
+
+## Why it matters
+`InvoiceClassificationService` drives automated invoice routing — it decides what accounting template and department every received invoice gets. A regression in the no-rule or ABRA-failure path could silently leave invoices unclassified or incorrectly recorded in history without any test catching it.
+
+## Suggested approach
+Unit-test `ClassifyInvoiceAsync` directly with mocked `IClassificationRuleRepository`, `IRuleEvaluationEngine`, `IInvoiceClassificationsClient`, `IClassificationHistoryRepository`, and `ICurrentUserService`. Four test methods covering each outcome. ~2–3 hours.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-08. Based on CI run #27104028537 (6568feba33640ae063b2cb6af3c81da31b3720e1)._

--- a/artifacts/feat-coverage-gap-invoiceclassification-invoi/impl/main.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-invoi/impl/main.r1.md
@@ -1,0 +1,53 @@
+All tasks complete. Here is the output summary:
+
+---
+
+# Implementation: Unit Test Coverage for InvoiceClassificationService.ClassifyInvoiceAsync
+
+## What was implemented
+
+Four xUnit `[Fact]` tests covering every outcome path of `ClassifyInvoiceAsync`:
+1. No rule matched → manual review + history recorded
+2. Rule matched, ABRA update succeeds → success result + history recorded
+3. Rule matched, ABRA update fails → error result with rule ID (AccountingTemplateCode null on DTO, present on history — matches SUT asymmetry) + history recorded
+4. Exception thrown → caught, error result with exception message + history recorded
+
+All tests use `Callback`-captured `ClassificationHistory` objects for diff-friendly failure messages on history assertions (FR-5), and follow the exact conventions of `ClassifyInvoicesHandlerTests`.
+
+## Files created/modified
+
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs` — 340-line test class with four `[Fact]` methods, six field-level Moq mocks, and SUT constructed in the xUnit constructor
+
+## Tests
+
+- `InvoiceClassificationServiceTests` — 4/4 passing, 65 ms total. Covers all four outcome paths of `ClassifyInvoiceAsync` including history recording verification on every path (FR-1 through FR-5).
+
+## How to verify
+
+```bash
+cd backend/test/Anela.Heblo.Tests
+dotnet test --filter "FullyQualifiedName~InvoiceClassificationServiceTests"
+# Expected: Passed: 4, Failed: 0
+```
+
+## Notes
+
+Two spec amendments were applied per the arch review:
+- `EvaluateAsync` → `FindMatchingRule` (synchronous, not async)
+- `ClassificationHistoryStatus` enum → `ClassificationResult` (actual enum name)
+- `GetByIdAsync` assertion removed from FR-3 (SUT does not call it on ABRA-failure path)
+- File placed flat under `Features/InvoiceClassification/` (no `Services/` subfolder) to match existing sibling test class layout
+
+The 38 pre-existing integration test failures in the full suite are Testcontainers PostgreSQL failures (Docker not available in this environment) — unrelated to this change.
+
+## PR Summary
+
+Added four unit tests for `InvoiceClassificationService.ClassifyInvoiceAsync` to close a critical coverage gap in the automated invoice routing pipeline. The service previously had zero unit test coverage despite being the core decision component that writes to the accounting history audit table on every processed invoice.
+
+Tests cover: no-rule-matched → manual review, rule matched + ABRA success, rule matched + ABRA failure (with the documented DTO/history asymmetry on `AccountingTemplateCode`), and exception catch. Every test asserts that `RecordClassificationHistory` was invoked with the correct `ClassificationResult` status, using Callback-captured history objects for clear assertion diffs.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs` — new file: 340-line xUnit test class, 4 Fact methods, Moq + FluentAssertions, matching conventions of sibling `ClassifyInvoicesHandlerTests`
+
+## Status
+DONE

--- a/artifacts/feat-coverage-gap-invoiceclassification-invoi/spec.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-invoi/spec.r1.md
@@ -1,0 +1,142 @@
+# Specification: Unit Test Coverage for InvoiceClassificationService.ClassifyInvoiceAsync
+
+## Summary
+Add direct unit tests for `InvoiceClassificationService.ClassifyInvoiceAsync` covering all four outcome paths (no rule matched, rule matched + ABRA success, rule matched + ABRA failure, exception during classification) and verifying that `RecordClassificationHistory` is invoked correctly on every path. This closes a critical coverage gap in the automated invoice routing pipeline where a regression could silently misclassify or fail to record received invoices.
+
+## Background
+`InvoiceClassificationService` is the core decision component for automated invoice routing at Anela Heblo. It evaluates classification rules against incoming invoices and pushes the resulting accounting template and department assignment to ABRA Flexi. The service is currently untested at the unit level — the only existing test class, `ClassifyInvoicesHandlerTests`, mocks `IInvoiceClassificationService` entirely, so `ClassifyInvoiceAsync` has never been exercised by the test suite.
+
+This gap was flagged by the weekly coverage-gap routine on 2026-06-08 (CI run #27104028537, commit `6568feba`). Given that the service decides the accounting template for every received invoice and writes to a history audit table, an untested regression could silently corrupt accounting data or leave invoices stuck in manual review without alerting.
+
+## Functional Requirements
+
+### FR-1: Test the "no matching rule" outcome path
+Verify that when `IRuleEvaluationEngine` returns no matching rule for an invoice, `ClassifyInvoiceAsync`:
+1. Calls `IInvoiceClassificationsClient.MarkInvoiceForManualReviewAsync` with the correct invoice identifier.
+2. Calls `RecordClassificationHistory` with status `ManualReviewRequired`.
+3. Returns a result indicating manual review is required (no rule ID, no accounting template).
+
+**Acceptance criteria:**
+- Test method `ClassifyInvoiceAsync_NoMatchingRule_MarksForManualReviewAndRecordsHistory` exists.
+- Mocked `IRuleEvaluationEngine.EvaluateAsync` returns "no match" (null or equivalent).
+- `IInvoiceClassificationsClient.MarkInvoiceForManualReviewAsync` is verified called exactly once with the invoice ID under test.
+- `IClassificationHistoryRepository.AddAsync` (or whichever method `RecordClassificationHistory` delegates to) is verified called with a history entry whose status equals `ManualReviewRequired`.
+- The returned result reflects manual-review state (assert on returned DTO fields).
+
+### FR-2: Test the "rule matched, ABRA update succeeds" outcome path
+Verify that when a rule matches and the ABRA client returns success, `ClassifyInvoiceAsync`:
+1. Calls `IInvoiceClassificationsClient` to update the invoice with the rule's accounting template and department.
+2. Records history with status `Success`.
+3. Returns a result containing the matched rule ID and accounting template.
+
+**Acceptance criteria:**
+- Test method `ClassifyInvoiceAsync_RuleMatchedAndAbraSucceeds_RecordsSuccessAndReturnsRuleResult` exists.
+- Mocked `IRuleEvaluationEngine` returns a matched rule with a known ID and template.
+- Mocked `IInvoiceClassificationsClient` update method returns `success == true`.
+- History repository is verified called with status `Success`.
+- The returned result's rule ID and accounting template equal the rule's values.
+
+### FR-3: Test the "rule matched, ABRA update fails" outcome path
+Verify that when a rule matches but the ABRA client returns failure, `ClassifyInvoiceAsync`:
+1. Looks up the rule name via `IClassificationRuleRepository.GetByIdAsync` for display purposes.
+2. Records history with status `Error`.
+3. Returns an error result containing the rule ID (so the UI can display which rule was attempted).
+
+**Acceptance criteria:**
+- Test method `ClassifyInvoiceAsync_RuleMatchedAndAbraFails_RecordsErrorAndReturnsRuleIdForDisplay` exists.
+- Mocked `IRuleEvaluationEngine` returns a matched rule.
+- Mocked `IInvoiceClassificationsClient` update method returns `success == false`.
+- `IClassificationRuleRepository.GetByIdAsync` is verified called with the matched rule's ID.
+- History repository is verified called with status `Error`.
+- The returned result indicates error state and contains the rule ID.
+
+### FR-4: Test the "exception during classification" outcome path
+Verify that when an exception is thrown during classification (e.g., by `IRuleEvaluationEngine` or `IInvoiceClassificationsClient`), `ClassifyInvoiceAsync`:
+1. Catches the exception (does not propagate to the caller).
+2. Records history with status `Error` and the exception message.
+3. Returns an error result.
+
+**Acceptance criteria:**
+- Test method `ClassifyInvoiceAsync_ExceptionThrown_RecordsErrorWithMessageAndReturnsErrorResult` exists.
+- A dependency mock is configured to throw a known exception with a known message.
+- History repository is verified called with status `Error` and a history entry whose error message equals (or contains) the thrown exception's message.
+- The returned result indicates error state.
+- The test asserts no exception is thrown out of `ClassifyInvoiceAsync`.
+
+### FR-5: Verify `RecordClassificationHistory` invocation on every path
+Each test (FR-1 through FR-4) must include an assertion that the history recording side effect occurred. This is currently never asserted anywhere in the suite.
+
+**Acceptance criteria:**
+- Every test in FR-1 through FR-4 calls `Verify` (or equivalent) on the history repository mock with the expected status and payload.
+- Test failure messages clearly identify which path's history recording broke if the assertion fails.
+
+### FR-6: Follow existing test conventions
+Tests must match the conventions of the surrounding suite (e.g., `ClassifyInvoicesHandlerTests`) so they are recognized as part of the standard backend test suite and run on every PR build.
+
+**Acceptance criteria:**
+- New test class lives in the matching test project under the same folder structure as `ClassifyInvoicesHandlerTests`.
+- Test class name is `InvoiceClassificationServiceTests`.
+- Uses the same mocking library, assertion library, and DI patterns as `ClassifyInvoicesHandlerTests`.
+- Tests follow Arrange-Act-Assert structure.
+- `dotnet build` and `dotnet test` pass cleanly with no new warnings.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- The new tests must run in under 500ms total wall-clock time. They are pure unit tests with all dependencies mocked — there should be no I/O, no database, no HTTP calls.
+- The new tests must not slow down the existing CI pipeline meaningfully (target: < 1 second added to total test suite runtime).
+
+### NFR-2: Security
+- No real credentials, connection strings, or external service URLs in test code.
+- Test data (invoice numbers, rule IDs, templates) must be synthetic — not copied from production.
+
+### NFR-3: Maintainability
+- Tests must be isolated: each test sets up its own mocks and does not depend on test execution order.
+- Test names must describe the scenario under test in `MethodName_StateUnderTest_ExpectedBehavior` form.
+- Mock setup should use shared helpers only when the helper genuinely reduces duplication across 2+ tests; avoid premature abstraction.
+
+### NFR-4: Coverage
+- After these tests are added, line and branch coverage of `InvoiceClassificationService.ClassifyInvoiceAsync` should reach ≥ 90% (target: 100% for the four outcome paths).
+- Coverage of `RecordClassificationHistory` invocations should be 100% (called from every path).
+
+## Data Model
+No data model changes. Tests interact with existing types:
+- `InvoiceClassificationService` (system under test)
+- `IClassificationRuleRepository` (mocked)
+- `IRuleEvaluationEngine` (mocked)
+- `IInvoiceClassificationsClient` (mocked)
+- `IClassificationHistoryRepository` (mocked)
+- `ICurrentUserService` (mocked)
+- The existing `ClassificationHistoryStatus` enum values: `Success`, `Error`, `ManualReviewRequired`
+- The existing invoice and rule DTOs/entities used by the service
+
+## API / Interface Design
+No production API or interface changes. The deliverable is a new test class:
+
+```
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/InvoiceClassificationServiceTests.cs
+```
+
+(Exact path must match the test project's existing layout — confirm against `ClassifyInvoicesHandlerTests` location.)
+
+The test class will contain at minimum the four test methods named in FR-1 through FR-4, plus any private helpers needed to construct mocked dependencies and the SUT.
+
+## Dependencies
+- Existing test project for the `InvoiceClassification` feature (where `ClassifyInvoicesHandlerTests` lives).
+- Existing mocking library used by the backend test suite (likely Moq, NSubstitute, or FakeItEasy — match what `ClassifyInvoicesHandlerTests` uses).
+- Existing assertion library (likely FluentAssertions or xUnit's built-in `Assert`).
+- `InvoiceClassificationService` source remains unchanged — this is a pure test addition.
+
+## Out of Scope
+- Refactoring `InvoiceClassificationService` itself. Tests are added against the current implementation as-is.
+- Integration tests, E2E tests, or tests against a real ABRA Flexi instance.
+- Adding new test coverage for `ClassifyInvoicesHandler` or other components in the classification feature.
+- Modifying `IRuleEvaluationEngine`, `IInvoiceClassificationsClient`, or any other dependency surface.
+- Changing the `ClassificationHistoryStatus` enum or history schema.
+- Performance, load, or stress tests.
+- Updating any documentation beyond what is implied by code changes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-coverage-gap-invoiceclassification-invoi/task-plan.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-invoi/task-plan.r1.md
@@ -1,0 +1,12 @@
+Plan saved to `artifacts/feat-coverage-gap-invoiceclassification-invoi/plan.r1.md`.
+
+Six tasks, each ending in a commit:
+
+1. **Task 1** — Scaffold the test class with fixture, mocks, and `CreateInvoice`/`CreateRule` helpers.
+2. **Task 2** — FR-1: no matching rule → manual review + history.
+3. **Task 3** — FR-2: rule matched, ABRA success → success + history.
+4. **Task 4** — FR-3: rule matched, ABRA failure → error + history (with the documented `AccountingTemplateCode` asymmetry between DTO and history).
+5. **Task 5** — FR-4: exception thrown → caught, error returned, history recorded.
+6. **Task 6** — Validation: run the class, run the feature folder, `dotnet format --verify-no-changes`, full `dotnet build`.
+
+The plan implements the architecture review's amendments (flat path under `Features/InvoiceClassification/`, sync `FindMatchingRule`, `ClassificationResult` enum, no `GetByIdAsync` on the ABRA-failure path, non-null `CurrentUser.Name`) and uses `Callback`-captured `ClassificationHistory` for diff-friendly failure messages on FR-5.

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs
@@ -1,0 +1,340 @@
+using Anela.Heblo.Application.Features.InvoiceClassification.Services;
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification;
+
+public class InvoiceClassificationServiceTests
+{
+    private readonly Mock<IClassificationRuleRepository> _ruleRepositoryMock = new();
+    private readonly Mock<IClassificationHistoryRepository> _historyRepositoryMock = new();
+    private readonly Mock<IInvoiceClassificationsClient> _classificationsClientMock = new();
+    private readonly Mock<IRuleEvaluationEngine> _ruleEngineMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+    private readonly Mock<ILogger<InvoiceClassificationService>> _loggerMock = new();
+    private readonly InvoiceClassificationService _sut;
+
+    public InvoiceClassificationServiceTests()
+    {
+        _sut = new InvoiceClassificationService(
+            _ruleRepositoryMock.Object,
+            _historyRepositoryMock.Object,
+            _classificationsClientMock.Object,
+            _ruleEngineMock.Object,
+            _currentUserServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task ClassifyInvoiceAsync_NoMatchingRule_MarksForManualReviewAndRecordsHistory()
+    {
+        // Arrange
+        var invoice = new ReceivedInvoice
+        {
+            InvoiceNumber = "INV-001",
+            InvoiceDate = DateTime.UtcNow,
+            CompanyName = "Test Company",
+            Description = "Test Invoice"
+        };
+
+        var currentUser = new CurrentUser("user-1", "test-user", "test@test.com", true);
+        ClassificationHistory? capturedHistory = null;
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(currentUser);
+
+        _ruleRepositoryMock
+            .Setup(x => x.GetActiveRulesOrderedAsync())
+            .ReturnsAsync(new List<ClassificationRule>());
+
+        _ruleEngineMock
+            .Setup(x => x.FindMatchingRule(invoice, It.IsAny<List<ClassificationRule>>()))
+            .Returns((ClassificationRule?)null);
+
+        _classificationsClientMock
+            .Setup(x => x.MarkInvoiceForManualReviewAsync(
+                invoice.InvoiceNumber,
+                "No matching classification rule",
+                It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(true);
+
+        _historyRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<ClassificationHistory>()))
+            .Callback<ClassificationHistory>(h => capturedHistory = h)
+            .ReturnsAsync((ClassificationHistory h) => h);
+
+        // Act
+        var result = await _sut.ClassifyInvoiceAsync(invoice);
+
+        // Assert
+        result.Result.Should().Be(ClassificationResult.ManualReviewRequired);
+        result.RuleId.Should().BeNull();
+        result.AccountingTemplateCode.Should().BeNull();
+        result.Department.Should().BeNull();
+        result.ErrorMessage.Should().BeNull();
+
+        capturedHistory.Should().NotBeNull();
+        capturedHistory.AbraInvoiceId.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceNumber.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceDate.Should().Be(invoice.InvoiceDate);
+        capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
+        capturedHistory.Description.Should().Be(invoice.Description);
+        capturedHistory.Result.Should().Be(ClassificationResult.ManualReviewRequired);
+        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ClassificationRuleId.Should().BeNull();
+        capturedHistory.AccountingTemplateCode.Should().BeNull();
+        capturedHistory.Department.Should().BeNull();
+        capturedHistory.ErrorMessage.Should().Be("No matching rule found");
+
+        _classificationsClientMock.Verify(
+            x => x.MarkInvoiceForManualReviewAsync(
+                invoice.InvoiceNumber,
+                "No matching classification rule",
+                It.IsAny<CancellationToken?>()),
+            Times.Once);
+
+        _historyRepositoryMock.Verify(
+            x => x.AddAsync(It.IsAny<ClassificationHistory>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ClassifyInvoiceAsync_RuleMatchedAndAbraSucceeds_RecordsSuccessAndReturnsRuleResult()
+    {
+        // Arrange
+        var invoice = new ReceivedInvoice
+        {
+            InvoiceNumber = "INV-002",
+            InvoiceDate = DateTime.UtcNow,
+            CompanyName = "Test Company",
+            Description = "Test Invoice with Rule"
+        };
+
+        var ruleWithId = new ClassificationRule(
+            "Test Rule",
+            "TYPE_A",
+            "pattern",
+            "TEMPLATE_001",
+            "Sales",
+            "admin-user");
+
+        var currentUser = new CurrentUser("user-1", "test-user", "test@test.com", true);
+        ClassificationHistory? capturedHistory = null;
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(currentUser);
+
+        _ruleRepositoryMock
+            .Setup(x => x.GetActiveRulesOrderedAsync())
+            .ReturnsAsync(new List<ClassificationRule> { ruleWithId });
+
+        _ruleEngineMock
+            .Setup(x => x.FindMatchingRule(invoice, It.IsAny<List<ClassificationRule>>()))
+            .Returns(ruleWithId);
+
+        _classificationsClientMock
+            .Setup(x => x.UpdateInvoiceClassificationAsync(
+                invoice.InvoiceNumber,
+                ruleWithId.AccountingTemplateCode,
+                ruleWithId.Department,
+                It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(true);
+
+        _historyRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<ClassificationHistory>()))
+            .Callback<ClassificationHistory>(h => capturedHistory = h)
+            .ReturnsAsync((ClassificationHistory h) => h);
+
+        // Act
+        var result = await _sut.ClassifyInvoiceAsync(invoice);
+
+        // Assert
+        result.Result.Should().Be(ClassificationResult.Success);
+        result.RuleId.Should().Be(ruleWithId.Id);
+        result.AccountingTemplateCode.Should().Be("TEMPLATE_001");
+        result.Department.Should().Be("Sales");
+        result.ErrorMessage.Should().BeNull();
+
+        capturedHistory.Should().NotBeNull();
+        capturedHistory.AbraInvoiceId.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceNumber.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceDate.Should().Be(invoice.InvoiceDate);
+        capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
+        capturedHistory.Description.Should().Be(invoice.Description);
+        capturedHistory.Result.Should().Be(ClassificationResult.Success);
+        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ClassificationRuleId.Should().Be(ruleWithId.Id);
+        capturedHistory.AccountingTemplateCode.Should().Be("TEMPLATE_001");
+        capturedHistory.Department.Should().Be("Sales");
+        capturedHistory.ErrorMessage.Should().BeNull();
+
+        _classificationsClientMock.Verify(
+            x => x.UpdateInvoiceClassificationAsync(
+                invoice.InvoiceNumber,
+                ruleWithId.AccountingTemplateCode,
+                ruleWithId.Department,
+                It.IsAny<CancellationToken?>()),
+            Times.Once);
+
+        _historyRepositoryMock.Verify(
+            x => x.AddAsync(It.IsAny<ClassificationHistory>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ClassifyInvoiceAsync_RuleMatchedAndAbraFails_RecordsErrorAndReturnsRuleIdForDisplay()
+    {
+        // Arrange
+        var invoice = new ReceivedInvoice
+        {
+            InvoiceNumber = "INV-003",
+            InvoiceDate = DateTime.UtcNow,
+            CompanyName = "Test Company",
+            Description = "Test Invoice with ABRA Failure"
+        };
+
+        var matchedRule = new ClassificationRule(
+            "Test Rule",
+            "TYPE_B",
+            "pattern",
+            "TEMPLATE_002",
+            "Purchases",
+            "admin-user");
+
+        var currentUser = new CurrentUser("user-2", "another-user", "another@test.com", true);
+        ClassificationHistory? capturedHistory = null;
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(currentUser);
+
+        _ruleRepositoryMock
+            .Setup(x => x.GetActiveRulesOrderedAsync())
+            .ReturnsAsync(new List<ClassificationRule> { matchedRule });
+
+        _ruleEngineMock
+            .Setup(x => x.FindMatchingRule(invoice, It.IsAny<List<ClassificationRule>>()))
+            .Returns(matchedRule);
+
+        _classificationsClientMock
+            .Setup(x => x.UpdateInvoiceClassificationAsync(
+                invoice.InvoiceNumber,
+                matchedRule.AccountingTemplateCode,
+                matchedRule.Department,
+                It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(false);
+
+        _historyRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<ClassificationHistory>()))
+            .Callback<ClassificationHistory>(h => capturedHistory = h)
+            .ReturnsAsync((ClassificationHistory h) => h);
+
+        // Act
+        var result = await _sut.ClassifyInvoiceAsync(invoice);
+
+        // Assert
+        result.Result.Should().Be(ClassificationResult.Error);
+        result.RuleId.Should().Be(matchedRule.Id);
+        result.Department.Should().Be("Purchases");
+        result.AccountingTemplateCode.Should().BeNull();
+        result.ErrorMessage.Should().Be("Failed to update invoice classification in ABRA");
+
+        capturedHistory.Should().NotBeNull();
+        capturedHistory.AbraInvoiceId.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceNumber.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceDate.Should().Be(invoice.InvoiceDate);
+        capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
+        capturedHistory.Description.Should().Be(invoice.Description);
+        capturedHistory.Result.Should().Be(ClassificationResult.Error);
+        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ClassificationRuleId.Should().Be(matchedRule.Id);
+        capturedHistory.AccountingTemplateCode.Should().Be("TEMPLATE_002");
+        capturedHistory.Department.Should().Be("Purchases");
+        capturedHistory.ErrorMessage.Should().Be("Failed to update invoice classification in ABRA");
+
+        _classificationsClientMock.Verify(
+            x => x.UpdateInvoiceClassificationAsync(
+                invoice.InvoiceNumber,
+                matchedRule.AccountingTemplateCode,
+                matchedRule.Department,
+                It.IsAny<CancellationToken?>()),
+            Times.Once);
+
+        _historyRepositoryMock.Verify(
+            x => x.AddAsync(It.IsAny<ClassificationHistory>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ClassifyInvoiceAsync_ExceptionThrown_RecordsErrorWithMessageAndReturnsErrorResult()
+    {
+        // Arrange
+        var invoice = new ReceivedInvoice
+        {
+            InvoiceNumber = "INV-004",
+            InvoiceDate = DateTime.UtcNow,
+            CompanyName = "Test Company",
+            Description = "Test Invoice with Exception"
+        };
+
+        var currentUser = new CurrentUser("user-3", "error-user", "error@test.com", true);
+        ClassificationHistory? capturedHistory = null;
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(currentUser);
+
+        _ruleRepositoryMock
+            .Setup(x => x.GetActiveRulesOrderedAsync())
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        _historyRepositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<ClassificationHistory>()))
+            .Callback<ClassificationHistory>(h => capturedHistory = h)
+            .ReturnsAsync((ClassificationHistory h) => h);
+
+        // Act
+        var result = await _sut.ClassifyInvoiceAsync(invoice);
+
+        // Assert
+        result.Result.Should().Be(ClassificationResult.Error);
+        result.RuleId.Should().BeNull();
+        result.AccountingTemplateCode.Should().BeNull();
+        result.Department.Should().BeNull();
+        result.ErrorMessage.Should().Contain("Exception during classification")
+            .And.Contain("Database connection failed");
+
+        capturedHistory.Should().NotBeNull();
+        capturedHistory.AbraInvoiceId.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceNumber.Should().Be(invoice.InvoiceNumber);
+        capturedHistory.InvoiceDate.Should().Be(invoice.InvoiceDate);
+        capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
+        capturedHistory.Description.Should().Be(invoice.Description);
+        capturedHistory.Result.Should().Be(ClassificationResult.Error);
+        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ClassificationRuleId.Should().BeNull();
+        capturedHistory.AccountingTemplateCode.Should().BeNull();
+        capturedHistory.Department.Should().BeNull();
+        capturedHistory.ErrorMessage.Should().Contain("Exception during classification")
+            .And.Contain("Database connection failed");
+
+        _historyRepositoryMock.Verify(
+            x => x.AddAsync(It.IsAny<ClassificationHistory>()),
+            Times.Once);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Error classifying invoice")),
+                It.IsAny<InvalidOperationException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION

Added four unit tests for `InvoiceClassificationService.ClassifyInvoiceAsync` to close a critical coverage gap in the automated invoice routing pipeline. The service previously had zero unit test coverage despite being the core decision component that writes to the accounting history audit table on every processed invoice.

Tests cover: no-rule-matched → manual review, rule matched + ABRA success, rule matched + ABRA failure (with the documented DTO/history asymmetry on `AccountingTemplateCode`), and exception catch. Every test asserts that `RecordClassificationHistory` was invoked with the correct `ClassificationResult` status, using Callback-captured history objects for clear assertion diffs.

### Changes
- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs` — new file: 340-line xUnit test class, 4 Fact methods, Moq + FluentAssertions, matching conventions of sibling `ClassifyInvoicesHandlerTests`

---

Closes #2750

### Tokens used
9538194
