### PR TITLE
feat: Unit tests for GetUserEffectivePermissionsHandler

### DIFF
--- a/artifacts/feat-coverage-gap-authorization-getusereffect/arch-review.r1.md
+++ b/artifacts/feat-coverage-gap-authorization-getusereffect/arch-review.r1.md
@@ -1,0 +1,250 @@
+# Architecture Review: Unit tests for GetUserEffectivePermissionsHandler
+
+## Skip Design: true
+
+This is a test-only addition. No production code changes, no UI, no new endpoints, no infrastructure. The work consists of one new `.cs` test file inside an existing test project.
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with existing conventions in the Authorization slice:
+
+- The handler under test (`backend/src/.../GetUserEffectivePermissions/GetUserEffectivePermissionsHandler.cs`) depends only on `IAuthorizationRepository`, which is already trivially mockable via Moq (used in `GetMeHandlerTests`, `AddGroupMemberHandlerTests`, `AssignUserGroupsHandlerTests`, etc.).
+- The test project `Anela.Heblo.Tests` already references `Anela.Heblo.Application`, `Anela.Heblo.Domain`, and `Anela.Heblo.Persistence` — verified via `SetUserCanPackHandlerTests.cs` which imports `Anela.Heblo.Persistence.Features.Authorization`. No new project references are needed; the test can resolve `IAuthorizationRepository`, `GroupClosure`, entity types, and `AccessRoles.Base`.
+- The closest stylistic siblings (`GetMeHandlerTests.cs`, `SetUserCanPackHandlerTests.cs`) confirm the pattern: terse, inline Arrange in each `[Fact]`, no shared fixtures, FluentAssertions for asserts, Moq for the dependency.
+- The chosen unit-test boundary (handler + mocked repo) is correct. Going through `WebApplicationFactory` would couple this test to MediatR pipeline, DI, claims transformation, and EF — none of which is what the coverage gap is about. The handler's three branches are pure in-memory logic; a unit test is the right granularity.
+
+There are no conflicting patterns. The proposal does not introduce new abstractions, helpers, or fixtures.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/test/Anela.Heblo.Tests/Authorization/
+└── GetUserEffectivePermissionsHandlerTests.cs   [NEW]
+        │
+        ├── builds Mock<IAuthorizationRepository>
+        ├── constructs GetUserEffectivePermissionsHandler directly
+        ├── invokes handler.Handle(request, CancellationToken.None)
+        └── asserts on GetUserEffectivePermissionsResponse
+                       (Success, ErrorCode, Permissions)
+```
+
+No diagrams of production wiring change. The test stands alone.
+
+### Key Design Decisions
+
+#### Decision 1: Moq for the repository (not a fake or test double class)
+
+**Options considered:**
+1. `Mock<IAuthorizationRepository>` — Moq, same as `GetMeHandlerTests` and most sibling handler tests.
+2. Hand-rolled `FakeAuthorizationRepository` implementing the interface.
+3. EF Core InMemory + real `AuthorizationRepository` (as `SetUserCanPackHandlerTests` does).
+
+**Chosen approach:** Moq, default loose behavior, with `Verify(..., Times.Never)` for the negative-interaction assertions on `GetGroupGraphAsync`.
+
+**Rationale:** FR-2 and FR-3 require asserting that `GetGroupGraphAsync` was **not** called. Moq's `Verify(..., Times.Never())` is the cleanest mechanism for this. A hand-rolled fake would need an explicit call counter, which is dead weight. An InMemory DB would actually execute graph queries and cannot prove the short-circuit. Moq matches the prevailing style for pure-handler tests in this folder.
+
+#### Decision 2: MockBehavior — Loose, not Strict
+
+**Options considered:**
+1. Default loose — unmocked calls return defaults; `Verify` is used to pin down "never called".
+2. `MockBehavior.Strict` — every interaction must be pre-configured.
+
+**Chosen approach:** Loose. Use `Verify(repo => repo.GetGroupGraphAsync(It.IsAny<CancellationToken>()), Times.Never)` in FR-2 and FR-3.
+
+**Rationale:** Strict mode makes the "graph was not loaded" assertion implicit (any unconfigured call would throw) but conflates two failure modes: a missing setup vs. a real regression. Explicit `Times.Never` makes the security-critical assertion in FR-3 visible at the assert site, which is exactly where a future reader will look. `GetMeHandlerTests` uses Strict on the resolver because it's expected to be unused for SuperUser — that pattern works there because there's only one method on the interface; here `IAuthorizationRepository` has 13 methods and we'd need many setups.
+
+#### Decision 3: Inline test data construction (no builders)
+
+**Chosen approach:** Construct `AppUser`, `UserGroup`, `GroupPermission`, `GroupParent` instances inline in each `[Fact]` using property initializers, mirroring `GetMeHandlerTests` and `GroupClosureTests`.
+
+**Rationale:** Spec FR-5 explicitly requires this and the surrounding folder confirms it as the norm. A builder would obscure exactly what differs between the three test cases (it's the discriminating state — `IsActive`, the presence of `UserGroups`, the contents of the graph — and that should be visible at the call site).
+
+#### Decision 4: Ordering assertion uses `Should().Equal(...)`, not `BeEquivalentTo`
+
+**Chosen approach:** `response.Permissions.Should().Equal(new[] { AccessRoles.Base, "permA", "permB", "permC" })`.
+
+**Rationale:** The handler's final `OrderBy(p => p).ToList()` is a contract the spec pins down. `BeEquivalentTo` would pass even if a future change accidentally returned an unsorted list. `Equal` enforces both content and order. (Note: `OrderBy(p => p)` on strings uses the default culture-aware comparer, not ordinal. For the ASCII-only test inputs in FR-4, ordinal and culture-aware ordering produce the same result, so the assertion is safe — but see Specification Amendments below.)
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+One new file, no other changes:
+
+```
+backend/test/Anela.Heblo.Tests/Authorization/
+  GetUserEffectivePermissionsHandlerTests.cs   [NEW]
+```
+
+Namespace: `Anela.Heblo.Tests.Authorization` (matches sibling files).
+
+### Interfaces and Contracts
+
+The test consumes existing public surface only:
+
+```csharp
+// Application layer
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetUserEffectivePermissions;
+using Anela.Heblo.Application.Shared;     // ErrorCodes
+
+// Domain layer
+using Anela.Heblo.Domain.Features.Authorization;            // IAuthorizationRepository, AccessRoles
+using Anela.Heblo.Domain.Features.Authorization.Entities;   // AppUser, UserGroup, GroupPermission, GroupParent
+
+// Test plumbing
+using FluentAssertions;
+using Moq;
+using Xunit;
+```
+
+Key contract surface the tests bind to:
+
+| Member | Signature | Why it matters |
+|---|---|---|
+| `IAuthorizationRepository.GetUserByIdAsync` | `Task<AppUser?> (Guid, CancellationToken)` | First call — drives branches (1) vs (2)/(3). |
+| `IAuthorizationRepository.GetGroupGraphAsync` | `Task<(List<GroupPermission>, List<GroupParent>)> (CancellationToken)` | Only called on the active path. `Times.Never` proves the short-circuit. |
+| `GetUserEffectivePermissionsResponse` | `bool Success`, `ErrorCodes? ErrorCode`, `List<string> Permissions` | Inherits `BaseResponse`. `ErrorCode` is the property name (verified). |
+| `ErrorCodes.AuthorizationUserNotFound` | enum value 3202 | Confirmed in `ErrorCodes.cs:395`. |
+| `AccessRoles.Base` | `const string = "heblo_user"` | Confirmed in `AccessRoles.generated.cs:6`. |
+
+### Data Flow
+
+**FR-2 (user not found):**
+```
+request{UserId} → repo.GetUserByIdAsync → null
+                ↓
+                return GetUserEffectivePermissionsResponse(ErrorCodes.AuthorizationUserNotFound)
+                ↓
+                Assert: Success==false, ErrorCode==AuthorizationUserNotFound
+                Verify: GetGroupGraphAsync never called
+```
+
+**FR-3 (inactive user — security-critical):**
+```
+request{UserId} → repo.GetUserByIdAsync → AppUser{ IsActive=false, UserGroups=[{GroupId=G1}] }
+                ↓
+                return new GetUserEffectivePermissionsResponse { Permissions = new() }
+                ↓
+                Assert: Success==true, ErrorCode==null, Permissions empty
+                Assert: Permissions does NOT contain AccessRoles.Base
+                Verify: GetGroupGraphAsync never called
+```
+
+**FR-4 (active user):**
+```
+request{UserId} → repo.GetUserByIdAsync → AppUser{ IsActive=true, UserGroups=[{GroupId=G1}] }
+                → repo.GetGroupGraphAsync → (
+                       perms:   [(G1,"permB"), (G1,"permA"), (G2,"permC")],
+                       parents: [(G1,G2)]
+                  )
+                → GroupClosure.Resolve({G1}, perms, parents) → {permA, permB, permC}
+                → union with AccessRoles.Base = "heblo_user"
+                → OrderBy ascending
+                ↓
+                Assert: Permissions.Equal(["heblo_user", "permA", "permB", "permC"])
+```
+
+### Test skeleton (illustrative — for the implementer)
+
+```csharp
+public class GetUserEffectivePermissionsHandlerTests
+{
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsAuthorizationUserNotFound()
+    {
+        var userId = Guid.NewGuid();
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AppUser?)null);
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(new GetUserEffectivePermissionsRequest { UserId = userId }, default);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.AuthorizationUserNotFound);
+        repo.Verify(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InactiveUser_ReturnsEmptyPermissionsAndDoesNotLoadGraph()
+    {
+        var userId = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId, Email = "u@x.cz", DisplayName = "U", IsActive = false,
+            UserGroups = new List<UserGroup> { new() { UserId = userId, GroupId = Guid.NewGuid() } }
+        };
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(new GetUserEffectivePermissionsRequest { UserId = userId }, default);
+
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Permissions.Should().BeEmpty();
+        response.Permissions.Should().NotContain(AccessRoles.Base);
+        repo.Verify(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ActiveUser_ReturnsMergedSortedPermissionsIncludingBase()
+    {
+        var userId = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId, Email = "u@x.cz", DisplayName = "U", IsActive = true,
+            UserGroups = new List<UserGroup> { new() { UserId = userId, GroupId = g1 } }
+        };
+        var perms = new List<GroupPermission>
+        {
+            new() { GroupId = g1, PermissionValue = "permB" },
+            new() { GroupId = g1, PermissionValue = "permA" },
+            new() { GroupId = g2, PermissionValue = "permC" }
+        };
+        var parents = new List<GroupParent> { new() { GroupId = g1, ParentGroupId = g2 } };
+
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        repo.Setup(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>())).ReturnsAsync((perms, parents));
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(new GetUserEffectivePermissionsRequest { UserId = userId }, default);
+
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Permissions.Should().Equal(AccessRoles.Base, "permA", "permB", "permC");
+    }
+}
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| String ordering of `OrderBy(p => p)` is culture-aware, not ordinal. A future change to test inputs with non-ASCII or special characters could make `Should().Equal(...)` brittle. | Low | Test inputs are strict ASCII (`heblo_user`, `permA`/`B`/`C`). Document this in a one-line note inside the FR-4 test arrangement (or simply choose inputs that keep ordinal == culture). Do NOT change handler behavior. |
+| `Times.Never` on `GetGroupGraphAsync` is the load-bearing assertion for the security guard. A test author could be tempted to drop it as "implementation detail". | High (security-regression) | Spec FR-3 explicitly calls this out as security-critical. The assertion is paired with the `NotContain(AccessRoles.Base)` check — both must remain. Note this in a brief inline comment ONLY if review otherwise misses it (per global no-comments rule, prefer a self-evident test name like `Handle_InactiveUser_ReturnsEmptyPermissionsAndDoesNotLoadGraph`). |
+| `MockBehavior.Loose` means a misspelled setup silently returns a default — could mask a regression where `GetUserByIdAsync` is called with a different argument. | Low | Setup uses the exact `userId` (not `It.IsAny<Guid>()`), so a regression that changes the call signature would return `null` and FR-3 / FR-4 would fail visibly. |
+| Test could fail under a future change to `GroupClosure.Resolve` ordering, even though that's not what we're testing. | Low | `GroupClosure.Resolve` returns a `HashSet<string>` per `GroupClosureTests`; the handler re-orders with `OrderBy` after merging. Our assertion is on the handler's final list, not on `Resolve`'s output, so this is robust. |
+| The test does not pin down "request's `CancellationToken` is propagated to the repository". | Low | Not in scope per the spec. Sibling tests don't do this either. Skip. |
+
+## Specification Amendments
+
+1. **Minor clarification on ordering language (FR-4):** The spec says "ordered ascending by ordinal string comparison". The handler actually uses `OrderBy(p => p)`, which is **culture-aware** (`Comparer<string>.Default`), not ordinal. For the chosen ASCII test inputs the two orderings agree, so no test change is needed. Suggest updating the spec language to "ordered ascending using the default string comparer (culture-aware)" to avoid implying the handler does ordinal sorting. If anyone later wants ordinal stability in production, that's a separate change to the handler.
+
+2. **FR-4 dedup edge case (already noted as optional):** Adding a fourth `[Fact]` for "AccessRoles.Base appears once even when a group also grants it" is genuinely cheap (~10 lines) and pins down the `HashSet` dedup behavior that FR-4 currently only covers implicitly. Recommend promoting this from "if needed" to a fourth `[Fact]` — keeps each fact single-purpose and avoids overloading the FR-4 test with two assertions.
+
+3. **No change needed for `ErrorCode` field name:** The spec hedges with "use whatever the base `BaseResponse` exposes". Confirmed: it is `ErrorCode` (nullable `ErrorCodes?`), assertion is `response.ErrorCode.Should().Be(ErrorCodes.AuthorizationUserNotFound)`. Spec can be tightened.
+
+## Prerequisites
+
+None. All required dependencies are already in place:
+
+- `IAuthorizationRepository`, all four entity types, `GroupClosure`, `AccessRoles.Base`, `ErrorCodes.AuthorizationUserNotFound`, and `BaseResponse.{Success, ErrorCode}` exist on `main` (verified in source).
+- `xUnit`, `Moq`, `FluentAssertions` are referenced by `Anela.Heblo.Tests` and used by every sibling handler test in the same folder.
+- No migrations, no Key Vault entries, no DI registrations, no config flags.
+- Validation steps from `CLAUDE.md`: `dotnet build` + `dotnet format` + `dotnet test --no-build` against the new file's project. No frontend impact.

--- a/artifacts/feat-coverage-gap-authorization-getusereffect/brief.md
+++ b/artifacts/feat-coverage-gap-authorization-getusereffect/brief.md
@@ -1,0 +1,22 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetUserEffectivePermissions/GetUserEffectivePermissionsHandler.cs`
+
+## Coverage
+Zero direct tests. The Authorization module has broad test coverage via `AuthorizationIntegrationTests.cs` and handler-specific files, but `GetUserEffectivePermissionsHandler` is not referenced in any test file.
+
+## What's not tested
+Three paths:
+1. **User not found** — returns error response with `AuthorizationUserNotFound`
+2. **User found but `IsActive == false`** — returns a response with an empty permissions list (silently, no error code)
+3. **Active user** — resolves group closure, merges with `AccessRoles.Base`, returns ordered permission list
+
+The inactive-user path (case 2) is the most security-relevant: a deactivated user must receive zero permissions. If this condition is accidentally removed or inverted, deactivated users retain their old permission set and no test fails.
+
+## Why it matters
+Access control correctness depends on this handler. The `IsActive` guard is the sole barrier between a deactivated user and their previously assigned permissions. A regression here is silent — the system continues operating normally while the wrong users have access.
+
+## Suggested approach
+Unit-test the handler with a mocked `IAuthorizationRepository`. Three tests: user not found returns error; inactive user returns empty list; active user returns merged + sorted permissions. ~1 hour.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-08. Based on CI run #27104028537 (6568feba33640ae063b2cb6af3c81da31b3720e1)._

--- a/artifacts/feat-coverage-gap-authorization-getusereffect/impl/main.r1.md
+++ b/artifacts/feat-coverage-gap-authorization-getusereffect/impl/main.r1.md
@@ -1,0 +1,54 @@
+All 5 tasks complete. Here is the output artifact:
+
+---
+
+# Implementation: GetUserEffectivePermissionsHandler Unit Tests
+
+## What was implemented
+
+Four xUnit `[Fact]` tests that characterize and lock in all three branches of `GetUserEffectivePermissionsHandler`, plus a dedicated dedup edge case for `AccessRoles.Base`. These are characterization tests on existing production behavior — all four passed green on first run. No production code was changed.
+
+## Files created/modified
+
+- `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs` — new test class with 4 `[Fact]` methods covering FR-2, FR-3 (security-critical), FR-4, and the Base-dedup edge case
+
+## Tests
+
+`backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`:
+- `Handle_UserNotFound_ReturnsAuthorizationUserNotFoundAndDoesNotLoadGraph` — FR-2: null user → error code + graph never loaded
+- `Handle_InactiveUser_ReturnsEmptyPermissionsAndDoesNotLoadGraph` — FR-3 (security): inactive user → empty permissions, no `AccessRoles.Base`, graph never loaded (all three assertions required by NFR-2)
+- `Handle_ActiveUser_ReturnsMergedDistinctSortedPermissionsIncludingBase` — FR-4: parent-edge graph resolves transitively, permissions merged with Base, sorted ascending
+- `Handle_ActiveUser_WhenGroupAlsoGrantsBase_BaseAppearsOnlyOnce` — dedup edge: Base granted by group + union still yields single occurrence
+
+## How to verify
+
+```bash
+# From repo root / worktree root
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetUserEffectivePermissionsHandlerTests" \
+  --no-build -v minimal
+# Expected: 4 passed in ~100ms
+
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Authorization" \
+  --no-build -v minimal
+# Expected: 111 passed (existing 107 + 4 new), 1 skipped, 0 failed
+```
+
+## Notes
+
+- The `NotContain(AccessRoles.Base)` assertion in FR-3 is deliberately kept alongside `BeEmpty()` — the spec (NFR-2) explicitly requires all three security assertions present together, even though `BeEmpty()` logically subsumes it.
+- No production code under `backend/src/` was modified (verified by `git diff --name-only main...HEAD -- backend/src/` returning empty).
+- Two commits on the branch: initial test class + fix for missing `ErrorCode.Should().BeNull()` in the dedup fact.
+
+## PR Summary
+
+Adds a focused unit-test class for `GetUserEffectivePermissionsHandler` — the Authorization use case that resolves effective permissions for a given user. Before this change there were zero direct handler tests, meaning the security-critical `IsActive` short-circuit had no regression protection.
+
+The four `[Fact]` methods lock in all three handler branches (user-not-found, inactive-user, active-user) and a dedup edge case for `AccessRoles.Base`. FR-3 (`Handle_InactiveUser_*`) is the load-bearing security test: it asserts empty permissions, absence of `AccessRoles.Base`, and that the group-permission graph is never loaded — any future refactor that moves the graph query above the `IsActive` guard will fail this test explicitly.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs` — new xUnit test class (147 lines) with 4 `[Fact]` methods; uses `Mock<IAuthorizationRepository>` with `Times.Never` for negative-interaction assertions; inline data construction matching sibling test style
+
+## Status
+DONE

--- a/artifacts/feat-coverage-gap-authorization-getusereffect/spec.r1.md
+++ b/artifacts/feat-coverage-gap-authorization-getusereffect/spec.r1.md
@@ -1,0 +1,123 @@
+# Specification: Unit tests for GetUserEffectivePermissionsHandler
+
+## Summary
+Add unit-test coverage for `GetUserEffectivePermissionsHandler` in the Authorization slice. The handler currently has zero direct tests despite gating effective-permission resolution, including the security-critical `IsActive` short-circuit that denies all permissions to deactivated users. This work adds a focused xUnit test class that locks in the three observable behaviors of the handler against a mocked repository.
+
+## Background
+`GetUserEffectivePermissionsHandler` (`backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetUserEffectivePermissions/GetUserEffectivePermissionsHandler.cs`) is the use case the Authorization module exposes to compute the effective permission list for a given user id. It is invoked through MediatR and depends on `IAuthorizationRepository` for user lookup and the full group graph (group→permission and group→parent edges). The handler then delegates transitive closure to `GroupClosure.Resolve` and merges the seed permission `AccessRoles.Base` before returning a sorted list.
+
+The handler has three logical branches:
+1. `GetUserByIdAsync` returns `null` → response with `ErrorCodes.AuthorizationUserNotFound`.
+2. `user.IsActive == false` → response with an empty `Permissions` list and no error code (silent deny).
+3. Active user → resolve closure of `UserGroups → GroupId`, union with `AccessRoles.Base`, return distinct list ordered by `OrderBy(p => p)`.
+
+Branch (2) is the only barrier that prevents a deactivated user from retaining a previously assigned permission set. There is no test today that fails if the `!user.IsActive` guard is removed, inverted, or accidentally short-circuited. The weekly coverage-gap routine identified this on 2026-06-08 (CI run #27104028537, commit 6568feba) and filed it because the regression mode is silent — production keeps responding 200, just with the wrong permissions.
+
+Existing Authorization-module tests live under `backend/test/Anela.Heblo.Tests/Authorization/` and follow xUnit + Moq + FluentAssertions conventions (see `GetMeHandlerTests.cs` as the closest stylistic reference).
+
+## Functional Requirements
+
+### FR-1: Test class wiring
+A new test class `GetUserEffectivePermissionsHandlerTests` is added under `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`. It uses xUnit (`[Fact]`), FluentAssertions, and Moq, matching the rest of the Authorization test folder.
+
+**Acceptance criteria:**
+- File path: `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`.
+- Namespace: `Anela.Heblo.Tests.Authorization`.
+- Class is `public` and contains at least the three `[Fact]` methods defined in FR-2..FR-4.
+- All tests pass with `dotnet test --no-build` from the worktree root.
+- Tests follow Arrange / Act / Assert with descriptive method names (`MethodUnderTest_State_ExpectedResult` style used elsewhere in the folder).
+
+### FR-2: User-not-found path returns AuthorizationUserNotFound
+Verify that when `IAuthorizationRepository.GetUserByIdAsync` returns `null`, the handler returns a response whose error code is `ErrorCodes.AuthorizationUserNotFound` and which has no permissions populated.
+
+**Acceptance criteria:**
+- Arrange: `Mock<IAuthorizationRepository>` returns `(AppUser?)null` for the request's `UserId`.
+- Act: invoke `Handle` with a `GetUserEffectivePermissionsRequest { UserId = <some Guid> }`.
+- Assert: `response.Success == false` and `response.ErrorCode == ErrorCodes.AuthorizationUserNotFound` (use whatever the base `BaseResponse` exposes — assert against the same field used by `GetMeHandlerTests` and siblings; if `ErrorCode` is the property, assert it equals `ErrorCodes.AuthorizationUserNotFound`).
+- Assert: `GetGroupGraphAsync` was NEVER called (the handler must not load the graph for a non-existent user). Use `Mock.Verify(..., Times.Never)`.
+
+### FR-3: Inactive-user path returns empty permission list silently (security-critical)
+Verify that when the user exists but `IsActive == false`, the handler returns a response with an empty `Permissions` list and no error code. Even if the user has groups assigned, none of them must be resolved into permissions, and `AccessRoles.Base` must NOT be included.
+
+**Acceptance criteria:**
+- Arrange: repository returns an `AppUser` with `IsActive = false` and a non-empty `UserGroups` collection (at least one `UserGroup` with an arbitrary `GroupId`) so the test would catch a regression that forgets the guard.
+- Act: invoke `Handle`.
+- Assert: `response.Permissions` is not null and is empty (`Permissions.Should().BeEmpty()`).
+- Assert: `response.Success == true` (no error code set — the inactive path is intentionally silent per the current implementation).
+- Assert: `GetGroupGraphAsync` was NEVER called (`Times.Never`). This pins down the short-circuit behavior — if a future refactor moves the graph load before the `IsActive` check, this test fails.
+- Assert: `Permissions` does NOT contain `AccessRoles.Base`. This is the explicit anti-regression assertion for the security guard.
+
+### FR-4: Active-user path returns merged, deduplicated, sorted permissions including AccessRoles.Base
+Verify that for an active user with one or more group memberships, the handler:
+- Resolves the group closure via `GroupClosure.Resolve` (transitively through `GroupParent` edges),
+- Unions the resolved permissions with `AccessRoles.Base`,
+- Deduplicates,
+- Returns the result ordered ascending by ordinal string comparison.
+
+**Acceptance criteria:**
+- Arrange: repository returns an `AppUser` with `IsActive = true` and `UserGroups` containing one group `G1`.
+- Arrange: `GetGroupGraphAsync` returns:
+  - `GroupPermission` rows: `(G1, "permB")`, `(G1, "permA")`, `(G2, "permC")`.
+  - `GroupParent` rows: `(G1, G2)` so closure pulls in `permC` from the parent.
+- Act: invoke `Handle`.
+- Assert: `response.Success == true`, no error code.
+- Assert: `response.Permissions` equals exactly `[AccessRoles.Base, "permA", "permB", "permC"]` in that order (ordinal ascending). Use `Should().Equal(...)` to assert order, not `BeEquivalentTo`.
+- Assert: there are no duplicates if `AccessRoles.Base` is also produced by a group permission row (covered implicitly — if needed, add a small additional fact for the dedup edge: include `AccessRoles.Base` as a `GroupPermission` and confirm it appears only once).
+
+### FR-5: Test data builders stay local to the test file
+Do not introduce shared test fixtures or builders outside this file. Inline the construction of `AppUser`, `UserGroup`, `GroupPermission`, and `GroupParent` instances. This keeps the diff surgical and matches the style of `GetMeHandlerTests`.
+
+**Acceptance criteria:**
+- No new files outside `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`.
+- No changes to existing production code under `backend/src/`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Tests must run in under 200 ms per fact on a developer machine. The handler is pure CPU/in-memory with a mocked repository — no I/O, no DB, no `WebApplicationFactory`.
+- Total addition to `dotnet test` wall time: < 1 s.
+
+### NFR-2: Security
+- The inactive-user test (FR-3) is treated as a security regression test. Its assertions must explicitly check both "empty permissions" AND "graph was not loaded" AND "AccessRoles.Base is absent". Removing any one of these weakens the guard.
+- Tests must not require, log, or contain real Entra object ids, emails, or tokens. Use placeholder values (`"oid-x"`, `"u@x.cz"`) consistent with sibling tests.
+
+### NFR-3: Maintainability
+- Follow the coding conventions enforced in the rest of the test folder: xUnit `[Fact]`, FluentAssertions, Moq with default loose behavior (or `MockBehavior.Strict` only where verifying "never called" interactions).
+- Test method names describe behavior, not implementation (e.g. `Handle_InactiveUser_ReturnsEmptyPermissionsAndDoesNotLoadGraph`).
+- No comments explaining what well-named asserts already convey.
+
+## Data Model
+No data-model changes. Tests construct in-memory instances of existing types only:
+- `AppUser` (`backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/AppUser.cs`) — set `Id`, `Email`, `DisplayName`, `IsActive`, `UserGroups`.
+- `UserGroup`, `PermissionGroup`, `GroupPermission`, `GroupParent` (siblings in `Entities/`).
+- `AccessRoles` (`backend/src/Anela.Heblo.Domain/Features/Authorization/` — generated by AccessMatrixGen) — read `AccessRoles.Base` only.
+- `ErrorCodes` (`backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`) — read `AuthorizationUserNotFound` only.
+
+## API / Interface Design
+No public API changes. The handler signature stays:
+
+```csharp
+Task<GetUserEffectivePermissionsResponse> Handle(
+    GetUserEffectivePermissionsRequest request,
+    CancellationToken ct);
+```
+
+Tests invoke `Handle` directly on a manually constructed `GetUserEffectivePermissionsHandler(repoMock.Object)` instance. No MediatR pipeline, no DI container.
+
+## Dependencies
+- xUnit 2.x (already in test project).
+- Moq (already in test project — see `GetMeHandlerTests`).
+- FluentAssertions (already in test project).
+- No new NuGet packages.
+
+## Out of Scope
+- Integration tests through `WebApplicationFactory` — `AuthorizationIntegrationTests.cs` already covers the HTTP boundary broadly; this gap is specifically about handler-level isolation.
+- Refactoring the handler to emit an explicit error code for the inactive path. The current behavior (silent empty list) is a deliberate product decision and is what these tests pin down. Changing that behavior is a separate work item.
+- Tests for `GroupClosure.Resolve` itself (cycle handling, diamond handling). The handler tests only need a small graph that exercises the union/order/dedup contract.
+- Tests for the request/response DTOs.
+- Adding `[Theory]` parameterization — three discrete `[Fact]`s are clearer for these branches.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-coverage-gap-authorization-getusereffect/task-plan.r1.md
+++ b/artifacts/feat-coverage-gap-authorization-getusereffect/task-plan.r1.md
@@ -1,0 +1,13 @@
+Plan saved to `docs/superpowers/plans/2026-06-11-authorization-effective-permissions-handler-tests.md`.
+
+**Summary**
+
+Five-task plan covering the surgical addition of one new test file at `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`:
+
+- **Task 1:** Scaffold the file + first `[Fact]` for user-not-found (FR-2).
+- **Task 2:** Inactive-user fact (FR-3) — the security-critical guard, with all three required assertions (empty permissions, no `AccessRoles.Base`, `GetGroupGraphAsync` never called).
+- **Task 3:** Active-user merge/dedup/sort fact (FR-4), using a parent-edge graph to prove closure resolution.
+- **Task 4:** Dedicated dedup-of-`AccessRoles.Base` fact (arch-review amendment 2, promoted from optional).
+- **Task 5:** Full validation — run all four facts, `dotnet format`, confirm no `backend/src/` changes, regression-check sibling Authorization tests.
+
+Each task contains complete code, exact `dotnet` commands, expected output, and a commit. Tests are characterization tests on existing handler behavior, so they should pass green on first run (any failure indicates an unintended production regression or a typo in the assertions). Verified all referenced types, properties, and constants against the actual source files in the worktree before writing the plan.

--- a/backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
@@ -139,6 +139,7 @@ public class GetUserEffectivePermissionsHandlerTests
             CancellationToken.None);
 
         response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
         response.Permissions.Should().Equal(AccessRoles.Base, "permX");
         response.Permissions.Count(p => p == AccessRoles.Base).Should().Be(1);
     }

--- a/backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
@@ -1,0 +1,145 @@
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetUserEffectivePermissions;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class GetUserEffectivePermissionsHandlerTests
+{
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsAuthorizationUserNotFoundAndDoesNotLoadGraph()
+    {
+        var userId = Guid.NewGuid();
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AppUser?)null);
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.AuthorizationUserNotFound);
+        repo.Verify(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InactiveUser_ReturnsEmptyPermissionsAndDoesNotLoadGraph()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId,
+            Email = "u@x.cz",
+            DisplayName = "U",
+            IsActive = false,
+            UserGroups = new List<UserGroup>
+            {
+                new() { UserId = userId, GroupId = groupId }
+            }
+        };
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Permissions.Should().BeEmpty();
+        response.Permissions.Should().NotContain(AccessRoles.Base);
+        repo.Verify(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ActiveUser_ReturnsMergedDistinctSortedPermissionsIncludingBase()
+    {
+        var userId = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId,
+            Email = "u@x.cz",
+            DisplayName = "U",
+            IsActive = true,
+            UserGroups = new List<UserGroup>
+            {
+                new() { UserId = userId, GroupId = g1 }
+            }
+        };
+        var perms = new List<GroupPermission>
+        {
+            new() { GroupId = g1, PermissionValue = "permB" },
+            new() { GroupId = g1, PermissionValue = "permA" },
+            new() { GroupId = g2, PermissionValue = "permC" }
+        };
+        var parents = new List<GroupParent>
+        {
+            new() { GroupId = g1, ParentGroupId = g2 }
+        };
+
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        repo.Setup(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((perms, parents));
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Permissions.Should().Equal(AccessRoles.Base, "permA", "permB", "permC");
+    }
+
+    [Fact]
+    public async Task Handle_ActiveUser_WhenGroupAlsoGrantsBase_BaseAppearsOnlyOnce()
+    {
+        var userId = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId,
+            Email = "u@x.cz",
+            DisplayName = "U",
+            IsActive = true,
+            UserGroups = new List<UserGroup>
+            {
+                new() { UserId = userId, GroupId = g1 }
+            }
+        };
+        var perms = new List<GroupPermission>
+        {
+            new() { GroupId = g1, PermissionValue = AccessRoles.Base },
+            new() { GroupId = g1, PermissionValue = "permX" }
+        };
+        var parents = new List<GroupParent>();
+
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        repo.Setup(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((perms, parents));
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Permissions.Should().Equal(AccessRoles.Base, "permX");
+        response.Permissions.Count(p => p == AccessRoles.Base).Should().Be(1);
+    }
+}

--- a/docs/superpowers/plans/2026-06-11-authorization-effective-permissions-handler-tests.md
+++ b/docs/superpowers/plans/2026-06-11-authorization-effective-permissions-handler-tests.md
@@ -1,0 +1,419 @@
+# Authorization — GetUserEffectivePermissionsHandler Unit Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four xUnit `[Fact]` tests for `GetUserEffectivePermissionsHandler` to characterize and lock in its three branches (user-not-found, inactive-user, active-user) plus the dedup edge for `AccessRoles.Base`. These are characterization tests on existing production behavior — they MUST pass green on first run against the unchanged handler. Their value is regression protection going forward, especially the security-critical `IsActive` short-circuit.
+
+**Architecture:** One new test file under `backend/test/Anela.Heblo.Tests/Authorization/`. No production code changes. Pure handler-in-isolation tests using `Mock<IAuthorizationRepository>` (default loose behavior, `Verify(..., Times.Never)` for negative-interaction assertions), inline data construction, FluentAssertions. Mirrors `GetMeHandlerTests.cs` style.
+
+**Tech Stack:** xUnit, FluentAssertions, Moq — all already referenced by `Anela.Heblo.Tests`.
+
+---
+
+## File Structure
+
+**New file:**
+- `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs` — test class containing four `[Fact]` methods, one per branch.
+
+**Existing files referenced (no edits):**
+- `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetUserEffectivePermissions/GetUserEffectivePermissionsHandler.cs` — system under test.
+- `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetUserEffectivePermissions/GetUserEffectivePermissionsRequest.cs` — request DTO; `UserId` property.
+- `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetUserEffectivePermissions/GetUserEffectivePermissionsResponse.cs` — response DTO; `Permissions` list, inherits `BaseResponse` (`Success`, `ErrorCode`).
+- `backend/src/Anela.Heblo.Domain/Features/Authorization/IAuthorizationRepository.cs` — repository interface; relevant methods `GetUserByIdAsync(Guid, CancellationToken)` and `GetGroupGraphAsync(CancellationToken)` returning `(List<GroupPermission>, List<GroupParent>)`.
+- `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/AppUser.cs` — has settable properties `Id`, `Email`, `DisplayName`, `IsActive`, `UserGroups`.
+- `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/UserGroup.cs` — `UserId`, `GroupId`.
+- `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/GroupPermission.cs` — `GroupId`, `PermissionValue`.
+- `backend/src/Anela.Heblo.Domain/Features/Authorization/Entities/GroupParent.cs` — `GroupId`, `ParentGroupId`.
+- `backend/src/Anela.Heblo.Domain/Features/Authorization/AccessRoles.generated.cs` — `AccessRoles.Base = "heblo_user"`.
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` — `AuthorizationUserNotFound = 3202`.
+- `backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs` — `bool Success`, `ErrorCodes? ErrorCode`.
+
+**Reference for style (sibling tests):**
+- `backend/test/Anela.Heblo.Tests/Authorization/GetMeHandlerTests.cs` — closest stylistic match.
+
+---
+
+## Task 1: Scaffold test class with user-not-found fact (FR-2)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`
+
+- [ ] **Step 1: Create the file with the namespace, usings, class, and the first `[Fact]`**
+
+Write the file with these exact contents:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetUserEffectivePermissions;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class GetUserEffectivePermissionsHandlerTests
+{
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsAuthorizationUserNotFoundAndDoesNotLoadGraph()
+    {
+        var userId = Guid.NewGuid();
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AppUser?)null);
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.AuthorizationUserNotFound);
+        repo.Verify(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}
+```
+
+- [ ] **Step 2: Build the test project**
+
+Run from the worktree root:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: Build succeeds (0 errors).
+
+If the build fails on missing usings, recheck Step 1 against the file paths listed under "File Structure". Do not add project references — `Anela.Heblo.Tests` already references `Application`, `Domain`, and `Persistence`.
+
+- [ ] **Step 3: Run the new fact and verify it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetUserEffectivePermissionsHandlerTests.Handle_UserNotFound_ReturnsAuthorizationUserNotFoundAndDoesNotLoadGraph" \
+  --no-build -v minimal
+```
+
+Expected: 1 passed, 0 failed.
+
+Rationale for "expected PASS" rather than "expected FAIL": these are characterization tests on already-shipped production behavior. The handler at `GetUserEffectivePermissionsHandler.cs:18-19` already returns `new GetUserEffectivePermissionsResponse(ErrorCodes.AuthorizationUserNotFound)` for a null user. A failing test here would mean either (a) the assertion is wrong, or (b) the implementation was silently changed — either way, stop and investigate before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
+git commit -m "test(authorization): cover GetUserEffectivePermissionsHandler user-not-found path"
+```
+
+---
+
+## Task 2: Add inactive-user fact (FR-3, security-critical)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`
+
+This fact is the security regression test. It must assert (a) empty permissions, (b) `AccessRoles.Base` absent, and (c) `GetGroupGraphAsync` never called. All three together are the guard. If any future refactor moves the graph load above the `IsActive` check, this test fails — that is the point.
+
+- [ ] **Step 1: Add the second `[Fact]` method below the first one inside the class**
+
+Insert the following method immediately before the closing brace of the `GetUserEffectivePermissionsHandlerTests` class (i.e., after the first fact's closing brace):
+
+```csharp
+    [Fact]
+    public async Task Handle_InactiveUser_ReturnsEmptyPermissionsAndDoesNotLoadGraph()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId,
+            Email = "u@x.cz",
+            DisplayName = "U",
+            IsActive = false,
+            UserGroups = new List<UserGroup>
+            {
+                new() { UserId = userId, GroupId = groupId }
+            }
+        };
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Permissions.Should().BeEmpty();
+        response.Permissions.Should().NotContain(AccessRoles.Base);
+        repo.Verify(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run the new fact and verify it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetUserEffectivePermissionsHandlerTests.Handle_InactiveUser_ReturnsEmptyPermissionsAndDoesNotLoadGraph" \
+  --no-build -v minimal
+```
+
+Expected: 1 passed, 0 failed.
+
+If this fact fails, the `!user.IsActive` guard at `GetUserEffectivePermissionsHandler.cs:21-22` may have regressed — STOP and report before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
+git commit -m "test(authorization): cover inactive-user short-circuit (security regression)"
+```
+
+---
+
+## Task 3: Add active-user merge/sort fact (FR-4)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`
+
+This fact exercises the full active path: `GetGroupGraphAsync` is called, the closure (`GroupClosure.Resolve`) pulls in parent-group permissions, `AccessRoles.Base` is unioned in, the result is deduplicated by `HashSet<string>`, and the final list is ordered via `OrderBy(p => p)`.
+
+Group setup chosen so that the closure produces 3 permissions ("permA", "permB", "permC") via one parent edge:
+- `UserGroups` → `G1` directly.
+- `GroupPermission`: `(G1, "permB")`, `(G1, "permA")`, `(G2, "permC")` — note the deliberately out-of-order seed to prove the `OrderBy` is doing real work.
+- `GroupParent`: `(G1 → G2)` — so closure visits G1 then G2, picking up `permC` transitively.
+
+Expected final order (default `OrderBy(p => p)` string comparison, culture-aware but identical to ordinal for ASCII inputs): `["heblo_user", "permA", "permB", "permC"]`.
+
+- [ ] **Step 1: Add the third `[Fact]` method**
+
+Insert immediately after the second fact:
+
+```csharp
+    [Fact]
+    public async Task Handle_ActiveUser_ReturnsMergedDistinctSortedPermissionsIncludingBase()
+    {
+        var userId = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId,
+            Email = "u@x.cz",
+            DisplayName = "U",
+            IsActive = true,
+            UserGroups = new List<UserGroup>
+            {
+                new() { UserId = userId, GroupId = g1 }
+            }
+        };
+        var perms = new List<GroupPermission>
+        {
+            new() { GroupId = g1, PermissionValue = "permB" },
+            new() { GroupId = g1, PermissionValue = "permA" },
+            new() { GroupId = g2, PermissionValue = "permC" }
+        };
+        var parents = new List<GroupParent>
+        {
+            new() { GroupId = g1, ParentGroupId = g2 }
+        };
+
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        repo.Setup(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((perms, parents));
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Permissions.Should().Equal(AccessRoles.Base, "permA", "permB", "permC");
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run the new fact and verify it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetUserEffectivePermissionsHandlerTests.Handle_ActiveUser_ReturnsMergedDistinctSortedPermissionsIncludingBase" \
+  --no-build -v minimal
+```
+
+Expected: 1 passed, 0 failed.
+
+If this fact fails on ordering, double-check the expected sequence: `AccessRoles.Base` is `"heblo_user"` which sorts before `"permA"`/`"permB"`/`"permC"` in both ordinal and culture-aware comparison ('h' < 'p').
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
+git commit -m "test(authorization): cover active-user permission merge/dedup/sort"
+```
+
+---
+
+## Task 4: Add dedup-of-Base fact (arch-review amendment)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs`
+
+The arch review recommended promoting the dedup-edge note from "if needed" to a dedicated fourth `[Fact]`. This pins down `HashSet` dedup behavior when a group explicitly grants `AccessRoles.Base` — it must still appear exactly once in the output.
+
+- [ ] **Step 1: Add the fourth `[Fact]` method**
+
+Insert immediately after the third fact:
+
+```csharp
+    [Fact]
+    public async Task Handle_ActiveUser_WhenGroupAlsoGrantsBase_BaseAppearsOnlyOnce()
+    {
+        var userId = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var user = new AppUser
+        {
+            Id = userId,
+            Email = "u@x.cz",
+            DisplayName = "U",
+            IsActive = true,
+            UserGroups = new List<UserGroup>
+            {
+                new() { UserId = userId, GroupId = g1 }
+            }
+        };
+        var perms = new List<GroupPermission>
+        {
+            new() { GroupId = g1, PermissionValue = AccessRoles.Base },
+            new() { GroupId = g1, PermissionValue = "permX" }
+        };
+        var parents = new List<GroupParent>();
+
+        var repo = new Mock<IAuthorizationRepository>();
+        repo.Setup(r => r.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        repo.Setup(r => r.GetGroupGraphAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((perms, parents));
+
+        var handler = new GetUserEffectivePermissionsHandler(repo.Object);
+        var response = await handler.Handle(
+            new GetUserEffectivePermissionsRequest { UserId = userId },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Permissions.Should().Equal(AccessRoles.Base, "permX");
+        response.Permissions.Count(p => p == AccessRoles.Base).Should().Be(1);
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run the new fact and verify it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetUserEffectivePermissionsHandlerTests.Handle_ActiveUser_WhenGroupAlsoGrantsBase_BaseAppearsOnlyOnce" \
+  --no-build -v minimal
+```
+
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
+git commit -m "test(authorization): pin down AccessRoles.Base dedup when group also grants it"
+```
+
+---
+
+## Task 5: Run the full class + project validation
+
+**Files:**
+- No edits. Validation only.
+
+- [ ] **Step 1: Run all four facts together**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetUserEffectivePermissionsHandlerTests" \
+  --no-build -v minimal
+```
+
+Expected: 4 passed, 0 failed. Total elapsed under 1 second.
+
+- [ ] **Step 2: Run `dotnet format` on the new file**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs
+```
+
+Expected: Exits 0 with no changes (or applies whitespace normalization). If formatting changed the file, stage and amend the last commit.
+
+- [ ] **Step 3: Confirm no production code under `backend/src/` was modified**
+
+```bash
+git diff --name-only main...HEAD -- backend/src/
+```
+
+Expected: empty output. If any `backend/src/` file appears, this plan was violated — STOP and report.
+
+- [ ] **Step 4: Run the full Authorization test folder to confirm no regressions in sibling tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Authorization" \
+  --no-build -v minimal
+```
+
+Expected: All Authorization-namespace tests pass (existing count + 4 new = total).
+
+No further commits in this task — validation only.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- FR-1 (test class wiring): Task 1 creates the file at the exact path, in the exact namespace, with `[Fact]` methods following the `MethodUnderTest_State_ExpectedResult` style. ✓
+- FR-2 (user-not-found): Task 1 fact asserts `Success==false`, `ErrorCode==AuthorizationUserNotFound`, and `GetGroupGraphAsync` never called. ✓
+- FR-3 (inactive-user, security-critical): Task 2 fact asserts empty permissions, `AccessRoles.Base` not contained, and `GetGroupGraphAsync` never called — all three guards present per spec. ✓
+- FR-4 (active-user merge/sort): Task 3 fact uses `Should().Equal(...)` (order-preserving) against `[AccessRoles.Base, "permA", "permB", "permC"]` with a parent-graph edge to prove closure resolution. ✓
+- FR-4 dedup edge (arch-review promotion): Task 4 is a dedicated fourth fact. ✓
+- FR-5 (no shared fixtures): All construction is inline; no new files outside the single test file; no production-code changes (validated by Task 5 Step 3). ✓
+- NFR-1 (performance < 200ms/fact, < 1s total): Task 5 Step 1 expects total elapsed < 1s. Each fact is in-memory, mocked. ✓
+- NFR-2 (security): FR-3 assertions cover all three required dimensions. Placeholder identifiers (`"u@x.cz"`, no real tokens) used throughout. ✓
+- NFR-3 (maintainability): xUnit + FluentAssertions + Moq loose, method names describe behavior, no needless comments. ✓
+
+**Placeholder scan:** No "TBD"/"add appropriate"/"similar to" — every step has the literal code or command.
+
+**Type consistency:** `AppUser` properties (`Id`, `Email`, `DisplayName`, `IsActive`, `UserGroups`), `UserGroup` (`UserId`, `GroupId`), `GroupPermission` (`GroupId`, `PermissionValue`), `GroupParent` (`GroupId`, `ParentGroupId`), `GetUserEffectivePermissionsRequest.UserId`, `GetUserEffectivePermissionsResponse.{Success, ErrorCode, Permissions}`, `IAuthorizationRepository.{GetUserByIdAsync(Guid, CancellationToken), GetGroupGraphAsync(CancellationToken)}` — all verified against source files listed in "File Structure" and used consistently across Tasks 1–4.
+
+**Ordering caveat (per arch-review):** `OrderBy(p => p)` on strings uses the default culture-aware comparer, not ordinal. For the test inputs (`heblo_user`, `permA`, `permB`, `permC`, `permX`) the two orderings agree. No test change is needed; no comment is added (per project no-comments rule — the test name and inputs are self-explanatory).


### PR DESCRIPTION

Adds a focused unit-test class for `GetUserEffectivePermissionsHandler` — the Authorization use case that resolves effective permissions for a given user. Before this change there were zero direct handler tests, meaning the security-critical `IsActive` short-circuit had no regression protection.

The four `[Fact]` methods lock in all three handler branches (user-not-found, inactive-user, active-user) and a dedup edge case for `AccessRoles.Base`. FR-3 (`Handle_InactiveUser_*`) is the load-bearing security test: it asserts empty permissions, absence of `AccessRoles.Base`, and that the group-permission graph is never loaded — any future refactor that moves the graph query above the `IsActive` guard will fail this test explicitly.

### Changes
- `backend/test/Anela.Heblo.Tests/Authorization/GetUserEffectivePermissionsHandlerTests.cs` — new xUnit test class (147 lines) with 4 `[Fact]` methods; uses `Mock<IAuthorizationRepository>` with `Times.Never` for negative-interaction assertions; inline data construction matching sibling test style

---

Closes #2751

### Tokens used
9242789
