### PR TITLE
feat: Unit test coverage for `RetryStockUpOperationHandler`

### DIFF
--- a/artifacts/feat-coverage-gap-catalog-retrystockupoperati/arch-review.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-retrystockupoperati/arch-review.r1.md
@@ -1,0 +1,173 @@
+I have enough context to produce the review. The handler is straightforward, the spec is precise, and the proposed test placement matches existing conventions exactly.
+
+```markdown
+# Architecture Review: Unit test coverage for `RetryStockUpOperationHandler`
+
+## Skip Design: true
+
+No UI, no visual components, no API contract changes. Pure test-code addition inside the existing backend test project.
+
+## Architectural Fit Assessment
+
+The proposal is a textbook fit and requires zero structural deviation.
+
+- The handler under test (`backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/RetryStockUpOperation/RetryStockUpOperationHandler.cs`) is a vanilla MediatR `IRequestHandler` in the Vertical Slice + Clean Architecture layout. Its only collaborators are `IStockUpOperationRepository` (a domain port) and `ILogger<T>`. Both are trivial to mock.
+- The sibling handler `AcceptStockUpOperationHandler` already has an established, mature test fixture (`backend/test/Anela.Heblo.Tests/Features/Catalog/AcceptStockUpOperationHandlerTests.cs`) using xUnit + Moq + plain `Assert.*`. The spec correctly designates this as the style reference. The new file should be a near-twin in shape (constructor-injected mocks, AAA layout, identical logger-verification idiom).
+- The domain entity `StockUpOperation` exposes a public constructor and public state-transition methods (`MarkAsSubmitted`, `MarkAsCompleted`, `MarkAsFailed`) that let tests arrange any state in `Pending`, `Submitted`, `Completed`, or `Failed` without reflection or test doubles — the spec leverages this correctly.
+- Integration points are limited to the single test file. No solution/project file edits are needed; the test discovery is convention-based.
+
+The only real architectural tension is the spec's chosen proxy for distinguishing `Reset()` vs `ForceReset()` (assert on `LogLevel.Warning`). This is forced by the fact that `Reset` and `ForceReset` are non-virtual methods on a concrete entity, so a Moq spy is impossible without changing production code. The log-level signal is one line above the `ForceReset()` call in the handler, making it a tight and acceptable proxy. We confirm this trade-off below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+                ┌───────────────────────────────────────────────────────┐
+                │ RetryStockUpOperationHandlerTests   (xUnit class)     │
+                │                                                       │
+                │  ctor: builds Mock<IStockUpOperationRepository>,      │
+                │        Mock<ILogger<RetryStockUpOperationHandler>>,   │
+                │        and the SUT instance.                          │
+                │                                                       │
+                │  5 [Fact] methods, one per branch in spec.            │
+                └───────────────┬───────────────────────┬───────────────┘
+                                │                       │
+                       arranges │                       │ asserts on
+                                ▼                       ▼
+                ┌──────────────────────────┐  ┌──────────────────────────┐
+                │ StockUpOperation         │  │ Mock<IStockUpOperation-  │
+                │ (real domain entity,     │  │ Repository>              │
+                │  state set via public    │  │ - GetByIdAsync           │
+                │  Mark* methods)          │  │ - SaveChangesAsync       │
+                └──────────────────────────┘  └──────────────────────────┘
+                                                        │
+                                                        ▼
+                                            ┌──────────────────────────┐
+                                            │ Mock<ILogger<...>>       │
+                                            │ Verify LogLevel.Warning  │
+                                            │ Times.Once / Times.Never │
+                                            └──────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Use a real `StockUpOperation` instance, not a mock
+
+**Options considered:**
+- (A) Mock `StockUpOperation` (would require it to be virtual or extracted to an interface).
+- (B) Use a real entity, arrange state via public `MarkAs*` methods.
+
+**Chosen approach:** (B). Match the existing `AcceptStockUpOperationHandlerTests` pattern.
+
+**Rationale:** The entity has no infrastructure dependencies; constructing it is cheap and deterministic. Mocking the entity would require production-code changes (interface extraction or virtualization) explicitly ruled out by the brief. Using the real entity also lets the tests assert on the observable post-state (`State == Pending`, `SubmittedAt == null`, etc.), which is a stronger guarantee than a mock verification of "the method was called."
+
+#### Decision 2: Detect the `Reset` vs `ForceReset` branch via the `Warning` log
+
+**Options considered:**
+- (A) Spy on the domain method directly (impossible — `Reset`/`ForceReset` are non-virtual on a concrete class).
+- (B) Refactor the handler to take a strategy/policy and mock that (out of scope per brief).
+- (C) Assert on the `LogLevel.Warning` Moq verification (`Times.Once` for ForceReset branch, `Times.Never` for Reset branch).
+
+**Chosen approach:** (C).
+
+**Rationale:** The handler emits exactly one `LogLevel.Warning` line ("Force resetting stuck operation …") **only** on the ForceReset branch. This is the only test-observable signal that does not require production-code change. The other log lines in the handler are `LogLevel.Information`, so a `LogLevel.Warning` `Times.Once` / `Times.Never` assertion is a clean, unambiguous proxy. The risk is that a future refactor could remove or re-level the warning log; the spec acknowledges this trade-off and tests for the existing handler exactly as-is.
+
+#### Decision 3: Fixed timestamp constant; no `DateTime.UtcNow`
+
+**Options considered:** Use `DateTime.UtcNow` (matches `AcceptStockUpOperationHandlerTests`) vs use a fixed constant.
+
+**Chosen approach:** Fixed constant `static readonly DateTime FixedNow = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)` (per NFR-2).
+
+**Rationale:** Determinism. The handler's behavior does not depend on the clock, but the test should not depend on `DateTime.UtcNow` either — this is a project-wide hygiene improvement over the older `AcceptStockUpOperationHandlerTests` pattern and worth seeding here. **Note:** this is a deliberate, *minor* deviation from the neighbour file; flagged here so reviewers don't treat it as an inconsistency.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Single new file, no project file change:
+
+```
+backend/test/Anela.Heblo.Tests/Features/Catalog/
+└── RetryStockUpOperationHandlerTests.cs   ← NEW (mirrors AcceptStockUpOperationHandlerTests.cs)
+```
+
+Namespace: `Anela.Heblo.Tests.Features.Catalog` (matches sibling files).
+
+### Interfaces and Contracts
+
+No new interfaces. The test depends only on these existing types:
+
+| Symbol | Location | Use in test |
+|---|---|---|
+| `RetryStockUpOperationHandler` | `Application/Features/Catalog/UseCases/RetryStockUpOperation/` | SUT, constructed once per test instance |
+| `RetryStockUpOperationRequest` | same | Built per test with target `OperationId` |
+| `RetryStockUpOperationResponse` | same | Asserted: `Success`, `Status`, `ErrorMessage` |
+| `StockUpOperation` | `Domain/Features/Catalog/Stock/` | Real entity; state set via `MarkAsSubmitted` / `MarkAsCompleted` / `MarkAsFailed` |
+| `StockUpOperationState` | same | Enum: `Pending`, `Submitted`, `Completed`, `Failed` |
+| `StockUpResultStatus` | `Application/Features/Catalog/Services/StockUpOperationResult.cs` | Enum: `Failed`, `AlreadyCompleted`, `InProgress` |
+| `IStockUpOperationRepository` | `Domain/Features/Catalog/Stock/` | Mocked; only `GetByIdAsync` and `SaveChangesAsync` are exercised |
+
+`StockUpOperation` constructor signature confirmed (verified in code):
+`(string documentNumber, string productCode, int amount, StockUpSourceType sourceType, int sourceId)`.
+
+### Data Flow
+
+Per-test flow (representative — FR-4, Submitted → ForceReset):
+
+```
+Arrange:
+  op = new StockUpOperation("DOC-001", "PROD-001", 10, StockUpSourceType.TransportBox, 1)
+  op.MarkAsSubmitted(FixedNow)
+  _repositoryMock.GetByIdAsync(1, *) ⇒ op
+  request = new RetryStockUpOperationRequest { OperationId = 1 }
+
+Act:
+  response = await _handler.Handle(request, CancellationToken.None)
+
+Assert (observable contract):
+  response.Success == true
+  response.Status == StockUpResultStatus.InProgress
+  response.ErrorMessage is null
+  op.State == StockUpOperationState.Pending
+  op.SubmittedAt is null
+  op.CompletedAt is null
+  _repositoryMock.Verify SaveChangesAsync — Times.Once
+  _loggerMock.Verify  LogLevel.Warning — Times.Once   ← proves ForceReset branch
+```
+
+For FR-3 (Failed → Reset), the only flow difference is `MarkAsFailed(FixedNow, "API timeout")` in Arrange and `LogLevel.Warning — Times.Never` in Assert.
+
+For FR-1/FR-2 (not-found, already-completed): no state mutation, no `SaveChangesAsync` call, error message contents asserted via `Assert.Contains`.
+
+For FR-5 (Pending → ForceReset): no Mark* call in Arrange (constructor leaves the operation in `Pending`); rest mirrors FR-4.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| The `LogLevel.Warning` proxy could rot if the handler stops emitting the warning. | Medium | Add a one-line comment in the FR-3 and FR-4 test methods explicitly tying the `Warning` count assertion to "this is how we detect the `Reset` vs `ForceReset` branch." A future maintainer who removes or downgrades the log line will see the assertion break and the comment will explain why it matters. |
+| Future refactor extracts the branch into a strategy/policy and the log line disappears. | Low | Same comment serves as a notice; consider in a follow-up making the branch directly observable (out of scope per brief). |
+| Assertion on operation post-state (e.g. `SubmittedAt == null`) effectively re-tests domain behavior already covered by `StockUpOperationTests`. | Low | Accept duplication — these assertions in the handler tests guard against an accidental `op.Reset()` removal in the handler; they are guarding the handler's *use* of the domain, not the domain itself. |
+| `Pending` Submitted timestamp deletions: spec implies `SubmittedAt` is `null` after Pending→ForceReset, but `Pending` operations never had a `SubmittedAt`. | Trivial | The assertion still passes (`null == null`); no change needed, but document the redundancy in a code comment if it's confusing on review. |
+| `StockUpResultStatus.InProgress` location (Application/Features/Catalog/Services/) — easy to miss for `using` directives. | Trivial | Include `using Anela.Heblo.Application.Features.Catalog.Services;` in the test file (same as sibling). |
+
+## Specification Amendments
+
+The spec is implementation-ready. Two minor clarifications worth folding back:
+
+1. **FR-5 assertion list:** Add `SaveChangesAsync` is called exactly once (the FR-5 acceptance criteria say "asserts the same response shape as FR-4" but do not explicitly list the `SaveChangesAsync` verification; FR-4 has it but the reuse-by-reference is slightly ambiguous). Trivial editorial fix.
+2. **FR-3 / FR-4 log assertion intent comment:** The spec specifies the assertion but does not require a code comment explaining *why* `Warning` count = branch selection. Strongly recommend the implementation include a one-line comment at each of those Verify calls so the proxy is self-documenting (per the Medium risk above). Optional, but cheap.
+
+No other changes. The spec correctly states **Status: COMPLETE** and the open-questions section is appropriately empty.
+
+## Prerequisites
+
+None. Everything required exists today:
+
+- Test project `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` already references xUnit, Moq, and `Microsoft.Extensions.Logging.Abstractions` (verified via the existing `AcceptStockUpOperationHandlerTests.cs`).
+- All production types (`RetryStockUpOperationHandler`, `StockUpOperation`, `IStockUpOperationRepository`, `StockUpOperationState`, `StockUpResultStatus`, `RetryStockUpOperationRequest`, `RetryStockUpOperationResponse`) are in place.
+- No migrations, config, infrastructure, or feature flags needed.
+
+Implementation can begin immediately; the deliverable is a single new file with five `[Fact]` methods, expected to build clean with nullable enabled and execute in well under 200 ms.
+```

--- a/artifacts/feat-coverage-gap-catalog-retrystockupoperati/brief.md
+++ b/artifacts/feat-coverage-gap-catalog-retrystockupoperati/brief.md
@@ -1,0 +1,23 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/RetryStockUpOperation/RetryStockUpOperationHandler.cs`
+
+## Coverage
+Zero tests. Not referenced in any test file.
+
+## What's not tested
+Four branches:
+1. **Operation not found** — returns `Success=false`, `Status=Failed`
+2. **Operation already `Completed`** — returns `Success=false`, `Status=AlreadyCompleted` (cannot retry completed ops)
+3. **Operation in `Failed` state** — calls `operation.Reset()`, then saves; returns `InProgress`
+4. **Operation in any other stuck state** (e.g. `Submitted`) — calls `operation.ForceReset()` with a warning log; returns `InProgress`
+
+The distinction between `Reset()` and `ForceReset()` is the operative business rule. Both converge on the same response shape, so swapping them or always calling one would produce no observable test failure without explicit assertions on which method was invoked.
+
+## Why it matters
+Stuck stock-up operations block warehouse processes. If `ForceReset` is never called for stuck `Submitted` operations (e.g. because the condition is wrong), those operations stay stuck indefinitely. Conversely, calling `ForceReset` on a `Failed` operation may bypass state guards that `Reset` enforces.
+
+## Suggested approach
+Unit-test with a mocked `IStockUpOperationRepository`. Four tests covering each branch; for the state-machine tests, use a spy/mock to assert which reset method is called. ~1.5 hours.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-08. Based on CI run #27104028537 (6568feba33640ae063b2cb6af3c81da31b3720e1)._

--- a/artifacts/feat-coverage-gap-catalog-retrystockupoperati/impl/main.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-retrystockupoperati/impl/main.r1.md
@@ -1,0 +1,41 @@
+All tasks complete. Here is the output summary:
+
+---
+
+# Implementation: RetryStockUpOperationHandler unit test coverage
+
+## What was implemented
+Added a complete xUnit test class with 5 `[Fact]` methods that pin down all four behavioral branches of `RetryStockUpOperationHandler`: not-found, already-completed, Failed→Reset (no warning), and non-Completed→ForceReset (warning emitted). The `Reset` vs `ForceReset` branch is distinguished via `LogLevel.Warning` count assertions (`Times.Never` / `Times.Once`), which is the agreed proxy since the domain methods are non-virtual.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs` — new test class with 5 [Fact] methods covering FR-1 through FR-5
+
+## Tests
+All 5 tests pass in 61 ms (well under the 200 ms NFR-3 target):
+- `Handle_WhenOperationNotFound_ReturnsFailure` (FR-1)
+- `Handle_WhenOperationIsCompleted_ReturnsAlreadyCompleted` (FR-2)
+- `Handle_WhenOperationIsFailed_CallsResetAndReturnsInProgress` (FR-3)
+- `Handle_WhenOperationIsSubmitted_CallsForceResetAndReturnsInProgress` (FR-4)
+- `Handle_WhenOperationIsPending_CallsForceResetAndReturnsInProgress` (FR-5)
+
+## How to verify
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~RetryStockUpOperationHandlerTests"
+# Expected: Passed: 5, Failed: 0
+```
+
+## Notes
+- Used `FixedNow = new DateTime(2026, 1, 1, ...)` constant (deliberate improvement over sibling `AcceptStockUpOperationHandlerTests` which uses `DateTime.UtcNow`)
+- Build produces 222 pre-existing warnings (none introduced by this file)
+- Both spec compliance and code quality reviews passed with no issues
+- Commit: `c9318c64` on `feat-coverage-gap-catalog-retrystockupoperati`
+
+## PR Summary
+Added five xUnit tests that achieve 100% branch coverage of `RetryStockUpOperationHandler.Handle`, locking in the critical `Reset` vs `ForceReset` routing decision via `LogLevel.Warning` count assertions — the only non-invasive branch detection signal available without modifying production code. Tests use real `StockUpOperation` domain entity (state arranged via public `MarkAs*` methods) and mock only `IStockUpOperationRepository` and `ILogger`.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs` — new test class covering all four handler branches (not-found, already-completed, Failed→Reset, non-Completed→ForceReset)
+
+## Status
+DONE

--- a/artifacts/feat-coverage-gap-catalog-retrystockupoperati/spec.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-retrystockupoperati/spec.r1.md
@@ -1,0 +1,159 @@
+# Specification: Unit test coverage for `RetryStockUpOperationHandler`
+
+## Summary
+Add a complete unit test suite for `RetryStockUpOperationHandler` (currently zero coverage) that locks in the four-branch behavior of the retry workflow: not-found, already-completed, normal `Reset` of a Failed operation, and `ForceReset` of any other non-Completed (stuck) state. The decisive business rule under test is the choice between `Reset()` and `ForceReset()`; tests must fail if that branch is swapped.
+
+## Background
+`RetryStockUpOperationHandler` is the manual-intervention escape hatch for stuck stock-up operations that block warehouse processes. The handler routes operations differently depending on their state: a `Failed` operation uses domain method `Reset()` (which enforces the state guard `state == Failed`), while any other non-Completed state (e.g. `Submitted`, `Pending`) is treated as "stuck" and is forced back to `Pending` via `ForceReset()` plus a warning log.
+
+If the branch condition is wrong (or `Reset`/`ForceReset` are swapped), one of two regressions happens:
+- Stuck `Submitted` operations are routed to `Reset()`, which throws — retries silently fail and the operation stays stuck.
+- `Failed` operations are routed to `ForceReset()`, bypassing the state guard that `Reset` enforces.
+
+Both `Reset()` and `ForceReset()` converge on the same response (`Status=InProgress`), so without explicit assertions on _which_ method ran, swapping them produces no observable test failure. The test suite must close that gap.
+
+## Functional Requirements
+
+### FR-1: Test — operation not found
+The handler returns a failure response when the repository returns no operation for the requested `OperationId`.
+
+**Acceptance criteria:**
+- A test named `Handle_WhenOperationNotFound_ReturnsFailure` exists in `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`.
+- `IStockUpOperationRepository.GetByIdAsync` is mocked to return `null`.
+- Asserts `response.Success == false`.
+- Asserts `response.Status == StockUpResultStatus.Failed`.
+- Asserts `response.ErrorMessage` contains the requested `OperationId` value.
+- Asserts `SaveChangesAsync` is never called.
+
+### FR-2: Test — operation already completed
+The handler rejects retry attempts on operations already in `Completed` state without mutating the entity or persisting.
+
+**Acceptance criteria:**
+- A test named `Handle_WhenOperationIsCompleted_ReturnsAlreadyCompleted` exists.
+- Arrange creates a `StockUpOperation`, calls `MarkAsCompleted(...)` to put it in `Completed` state.
+- Asserts `response.Success == false`.
+- Asserts `response.Status == StockUpResultStatus.AlreadyCompleted`.
+- Asserts `response.ErrorMessage` contains the operation's `DocumentNumber`.
+- Asserts operation state is unchanged (`StockUpOperationState.Completed`).
+- Asserts `SaveChangesAsync` is never called.
+
+### FR-3: Test — Failed operation calls `Reset()`
+For a `Failed` operation, the handler invokes the domain method `Reset()` (not `ForceReset()`), persists, and returns `InProgress`.
+
+**Acceptance criteria:**
+- A test named `Handle_WhenOperationIsFailed_CallsResetAndReturnsInProgress` exists.
+- Arrange creates an operation and calls `MarkAsFailed(timestamp, "some error")`.
+- Asserts `response.Success == true`.
+- Asserts `response.Status == StockUpResultStatus.InProgress`.
+- Asserts `response.ErrorMessage` is `null`.
+- Asserts the resulting operation state is `Pending`, `SubmittedAt` is `null`, `CompletedAt` is `null`, and `ErrorMessage` is `null` (the observable Reset post-state).
+- Asserts `SaveChangesAsync` is called exactly once.
+- Asserts that **no `LogLevel.Warning` entry** is emitted by the handler. This is the test-observable signal that `Reset()` (not `ForceReset()`) was taken: the handler logs a `Warning` only on the ForceReset branch.
+
+### FR-4: Test — Submitted (stuck) operation calls `ForceReset()` with warning
+For a `Submitted` operation (the canonical stuck case), the handler invokes `ForceReset()` with a warning log, persists, and returns `InProgress`.
+
+**Acceptance criteria:**
+- A test named `Handle_WhenOperationIsSubmitted_CallsForceResetAndReturnsInProgress` exists.
+- Arrange creates an operation and calls `MarkAsSubmitted(timestamp)`.
+- Asserts `response.Success == true`.
+- Asserts `response.Status == StockUpResultStatus.InProgress`.
+- Asserts `response.ErrorMessage` is `null`.
+- Asserts the resulting operation state is `Pending`, `SubmittedAt` is `null`, `CompletedAt` is `null`.
+- Asserts `SaveChangesAsync` is called exactly once.
+- Asserts that **exactly one `LogLevel.Warning` entry** is emitted by the handler (the "Force resetting stuck operation" log). This is the test-observable signal that `ForceReset()` was taken.
+- Note: the alternative — asserting that `Reset()` is NOT invoked — is not directly possible because the domain method is non-virtual on a concrete entity. The Warning-log assertion is the substitute and is acceptable because it lives one line above the `ForceReset()` call in the handler.
+
+### FR-5: Test — Pending (stuck) operation also calls `ForceReset()`
+A `Pending` operation (rare but valid stuck case — e.g. retry hit before the background task picked it up) takes the `ForceReset` branch.
+
+**Acceptance criteria:**
+- A test named `Handle_WhenOperationIsPending_CallsForceResetAndReturnsInProgress` exists.
+- Arrange creates a fresh `StockUpOperation` (constructor leaves it in `Pending`).
+- Asserts the same response shape as FR-4 (`Success == true`, `Status == InProgress`, no `ErrorMessage`).
+- Asserts state remains `Pending` after handling.
+- Asserts exactly one `LogLevel.Warning` entry is emitted.
+- Asserts `SaveChangesAsync` is called exactly once.
+- Rationale: parametrising the stuck-state branch over more than one input state catches an off-by-one branch error like `if (state == Submitted)` instead of `if (state == Failed)`.
+
+## Non-Functional Requirements
+
+### NFR-1: Test discipline
+- Use the project's established test stack: **xUnit** + **Moq** + plain `Assert.*` assertions. Follow the pattern of `backend/test/Anela.Heblo.Tests/Features/Catalog/AcceptStockUpOperationHandlerTests.cs`.
+- Follow the AAA layout (`// Arrange`, `// Act`, `// Assert`) with descriptive `MethodUnderTest_GivenCondition_ExpectsBehavior` naming, matching neighbour test files.
+- Use a per-class shared `Mock<IStockUpOperationRepository>`, `Mock<ILogger<RetryStockUpOperationHandler>>`, and handler instance constructed in the test class constructor (mirrors `AcceptStockUpOperationHandlerTests`).
+- The new test file must build with no warnings under the existing nullable-reference-types settings.
+
+### NFR-2: Determinism and isolation
+- No real database, no `Testcontainers`, no shared mutable state between tests. Pure in-process unit tests.
+- Use a fixed timestamp constant (e.g. `new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)`) when arranging operations — do not call `DateTime.UtcNow`.
+
+### NFR-3: Performance
+- The full new test class must complete in under 200 ms on a developer workstation. There is no I/O.
+
+### NFR-4: Coverage
+- After this work, line coverage of `RetryStockUpOperationHandler.Handle` must be 100% (all four branches plus the entry path).
+- The test class itself must contribute to the project's 80% minimum coverage requirement.
+
+## Data Model
+No data model changes. Tests rely on the existing domain types:
+- `StockUpOperation` (entity, `backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperation.cs`)
+- `StockUpOperationState` (enum: `Pending`, `Submitted`, `Completed`, `Failed`)
+- `StockUpResultStatus` (enum, including `Failed`, `AlreadyCompleted`, `InProgress`)
+- `IStockUpOperationRepository` (only `GetByIdAsync` and `SaveChangesAsync` are used by the handler)
+
+## API / Interface Design
+
+### Test file
+`backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`
+
+### Class shape
+```csharp
+public class RetryStockUpOperationHandlerTests
+{
+    private readonly Mock<IStockUpOperationRepository> _repositoryMock;
+    private readonly Mock<ILogger<RetryStockUpOperationHandler>> _loggerMock;
+    private readonly RetryStockUpOperationHandler _handler;
+    private static readonly DateTime FixedNow = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public RetryStockUpOperationHandlerTests() { /* construct mocks + handler */ }
+
+    [Fact] public async Task Handle_WhenOperationNotFound_ReturnsFailure() { /* FR-1 */ }
+    [Fact] public async Task Handle_WhenOperationIsCompleted_ReturnsAlreadyCompleted() { /* FR-2 */ }
+    [Fact] public async Task Handle_WhenOperationIsFailed_CallsResetAndReturnsInProgress() { /* FR-3 */ }
+    [Fact] public async Task Handle_WhenOperationIsSubmitted_CallsForceResetAndReturnsInProgress() { /* FR-4 */ }
+    [Fact] public async Task Handle_WhenOperationIsPending_CallsForceResetAndReturnsInProgress() { /* FR-5 */ }
+}
+```
+
+### Logger verification helper
+The standard `ILogger` Moq verification idiom (matches existing tests):
+```csharp
+_loggerMock.Verify(
+    x => x.Log(
+        LogLevel.Warning,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((v, t) => true),
+        It.IsAny<Exception>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+    Times.Once); // or Times.Never for FR-3
+```
+
+## Dependencies
+- **Project**: `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+- **NuGet packages** (already present in the project): `xunit`, `Moq`, `Microsoft.Extensions.Logging.Abstractions`.
+- **Source under test**: no changes to production code expected. If the handler is modified to make `Reset`/`ForceReset` directly verifiable (e.g. by extracting a strategy or moving the choice to a virtual method), that is out of scope here — the log-level assertion is the agreed proxy.
+- **Reference test for style**: `backend/test/Anela.Heblo.Tests/Features/Catalog/AcceptStockUpOperationHandlerTests.cs`.
+
+## Out of Scope
+- Modifying `RetryStockUpOperationHandler.cs` or any production code.
+- Integration tests against a real database, Testcontainers, or a real `IStockUpOperationRepository` implementation.
+- Tests for the upstream MediatR pipeline (validation behaviors, controllers, request DTO binding).
+- Tests for sibling handlers (`AcceptStockUpOperationHandler`, `GetStockUpOperationsHandler`, etc.) — already covered or out of scope.
+- Tests for the domain methods `Reset()` and `ForceReset()` themselves — covered by `StockUpOperationTests` in `backend/test/Anela.Heblo.Tests/Features/Catalog/Stock/StockUpOperationTests.cs`.
+- Verifying exception/error paths from `SaveChangesAsync` (the handler currently does not catch them and the brief lists only four branches).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-coverage-gap-catalog-retrystockupoperati/task-plan.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-retrystockupoperati/task-plan.r1.md
@@ -1,0 +1,3 @@
+Plan saved to `docs/superpowers/plans/2026-06-11-catalog-retrystockupoperation-tests.md`.
+
+Summary: 7 tasks, ~30 steps total. Task 1 lays down the test class skeleton (mocks, ctor, `FixedNow` constant). Tasks 2-6 add one `[Fact]` per spec FR with full code, a targeted `dotnet test --filter` step, and a focused commit message. Task 7 runs the full class, `dotnet format`, and a clean build to satisfy the project's pre-completion checklist. Both architectural amendments from the review (FR-5's explicit `SaveChangesAsync` Times.Once assertion and the inline comments explaining the Warning-count proxy) are folded into the relevant tasks.

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Catalog.UseCases.RetryStockUpOperation;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+public class RetryStockUpOperationHandlerTests
+{
+    private readonly Mock<IStockUpOperationRepository> _repositoryMock;
+    private readonly Mock<ILogger<RetryStockUpOperationHandler>> _loggerMock;
+    private readonly RetryStockUpOperationHandler _handler;
+    private static readonly DateTime FixedNow = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public RetryStockUpOperationHandlerTests()
+    {
+        _repositoryMock = new Mock<IStockUpOperationRepository>();
+        _loggerMock = new Mock<ILogger<RetryStockUpOperationHandler>>();
+        _handler = new RetryStockUpOperationHandler(
+            _repositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOperationNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var request = new RetryStockUpOperationRequest { OperationId = 999 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockUpOperation?)null);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(StockUpResultStatus.Failed, response.Status);
+        Assert.Contains("999", response.ErrorMessage);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOperationIsCompleted_ReturnsAlreadyCompleted()
+    {
+        // Arrange
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+        operation.MarkAsCompleted(FixedNow);
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(StockUpResultStatus.AlreadyCompleted, response.Status);
+        Assert.Contains("DOC-001", response.ErrorMessage);
+        Assert.Equal(StockUpOperationState.Completed, operation.State);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOperationIsFailed_CallsResetAndReturnsInProgress()
+    {
+        // Arrange
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+        operation.MarkAsFailed(FixedNow, "some error");
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(StockUpResultStatus.InProgress, response.Status);
+        Assert.Null(response.ErrorMessage);
+
+        // Observable Reset() post-state
+        Assert.Equal(StockUpOperationState.Pending, operation.State);
+        Assert.Null(operation.SubmittedAt);
+        Assert.Null(operation.CompletedAt);
+        Assert.Null(operation.ErrorMessage);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Branch selection signal: handler emits NO Warning on the Reset branch.
+        // If this assertion ever fails, the handler has been switched to ForceReset
+        // (or someone introduced a new Warning above this call site).
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOperationIsSubmitted_CallsForceResetAndReturnsInProgress()
+    {
+        // Arrange
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+        operation.MarkAsSubmitted(FixedNow);
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(StockUpResultStatus.InProgress, response.Status);
+        Assert.Null(response.ErrorMessage);
+
+        // Observable ForceReset() post-state
+        Assert.Equal(StockUpOperationState.Pending, operation.State);
+        Assert.Null(operation.SubmittedAt);
+        Assert.Null(operation.CompletedAt);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Branch selection signal: the handler emits exactly one Warning
+        // immediately before calling ForceReset(). If this drops to Times.Never,
+        // the branch swap regression has landed.
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOperationIsPending_CallsForceResetAndReturnsInProgress()
+    {
+        // Arrange — constructor leaves the operation in Pending state; no Mark* call needed.
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(StockUpResultStatus.InProgress, response.Status);
+        Assert.Null(response.ErrorMessage);
+
+        // State remains Pending after ForceReset (Pending -> Pending is valid).
+        Assert.Equal(StockUpOperationState.Pending, operation.State);
+        Assert.Null(operation.SubmittedAt); // Pending operations never had SubmittedAt; harmless redundancy.
+        Assert.Null(operation.CompletedAt);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Branch selection signal — same proxy as the Submitted case.
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/docs/superpowers/plans/2026-06-11-catalog-retrystockupoperation-tests.md
+++ b/docs/superpowers/plans/2026-06-11-catalog-retrystockupoperation-tests.md
@@ -1,0 +1,487 @@
+# RetryStockUpOperationHandler Test Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a unit-test class that pins down all four behavior branches of `RetryStockUpOperationHandler` (not-found, already-completed, Failed→Reset, non-Completed→ForceReset) so a future regression in branch selection or `Reset`/`ForceReset` choice fails the build.
+
+**Architecture:** Single new xUnit test file in `backend/test/Anela.Heblo.Tests/Features/Catalog/`. Real `StockUpOperation` entity (state arranged via public `MarkAs*` methods); Moq for `IStockUpOperationRepository` and `ILogger<RetryStockUpOperationHandler>`. The `Reset` vs `ForceReset` branch is distinguished by asserting on `LogLevel.Warning` count — the handler emits exactly one Warning on the ForceReset branch and zero on the Reset branch.
+
+**Tech Stack:** xUnit, Moq, `Microsoft.Extensions.Logging.Abstractions`, plain `Assert.*` (matches sibling `AcceptStockUpOperationHandlerTests.cs` — do NOT switch to FluentAssertions even though it appears in global rules; project convention here uses `Assert.*`).
+
+---
+
+## File Structure
+
+Single new file. No project file edits — test discovery is convention-based.
+
+```
+backend/test/Anela.Heblo.Tests/Features/Catalog/
+└── RetryStockUpOperationHandlerTests.cs   ← NEW (5 [Fact] methods)
+```
+
+Reference for style (read first if unfamiliar): `backend/test/Anela.Heblo.Tests/Features/Catalog/AcceptStockUpOperationHandlerTests.cs`.
+
+---
+
+## Pre-flight: Verify the handler under test
+
+Before writing tests, open `backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/RetryStockUpOperation/RetryStockUpOperationHandler.cs` and confirm:
+
+1. Not-found error string is exactly: `$"Operation with ID {request.OperationId} not found"`.
+2. Already-completed error string is exactly: `$"Operation {operation.DocumentNumber} is already completed and cannot be retried"`.
+3. The branch order is: `if (operation.State == StockUpOperationState.Failed) operation.Reset(); else { _logger.LogWarning(...); operation.ForceReset(); }`.
+
+If any of these differ, **stop and update the test arrange/assert strings to match the production code** — do not modify the handler.
+
+Also confirm the domain entity at `backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperation.cs` exposes:
+- `public StockUpOperation(string documentNumber, string productCode, int amount, StockUpSourceType sourceType, int sourceId)` (constructor leaves state as `Pending`).
+- `public void MarkAsSubmitted(DateTime timestamp)` (requires current state `Pending`).
+- `public void MarkAsCompleted(DateTime timestamp)` (requires current state `Submitted` or `Pending`).
+- `public void MarkAsFailed(DateTime timestamp, string errorMessage)` (no state guard; non-empty `errorMessage` required).
+
+---
+
+## Task 1: Create the test class skeleton
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`
+
+- [ ] **Step 1: Create the file with using directives, namespace, class, and constructor**
+
+```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Catalog.UseCases.RetryStockUpOperation;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+public class RetryStockUpOperationHandlerTests
+{
+    private readonly Mock<IStockUpOperationRepository> _repositoryMock;
+    private readonly Mock<ILogger<RetryStockUpOperationHandler>> _loggerMock;
+    private readonly RetryStockUpOperationHandler _handler;
+    private static readonly DateTime FixedNow = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public RetryStockUpOperationHandlerTests()
+    {
+        _repositoryMock = new Mock<IStockUpOperationRepository>();
+        _loggerMock = new Mock<ILogger<RetryStockUpOperationHandler>>();
+        _handler = new RetryStockUpOperationHandler(
+            _repositoryMock.Object,
+            _loggerMock.Object);
+    }
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: Build succeeded, 0 errors, 0 warnings.
+
+If a warning appears (nullable, unused using, etc.), fix it before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+git commit -m "test(catalog): add RetryStockUpOperationHandlerTests skeleton"
+```
+
+---
+
+## Task 2: FR-1 — operation not found returns failure
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`
+
+- [ ] **Step 1: Add the [Fact] method inside the class (after the constructor)**
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenOperationNotFound_ReturnsFailure()
+    {
+        // Arrange
+        var request = new RetryStockUpOperationRequest { OperationId = 999 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockUpOperation?)null);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(StockUpResultStatus.Failed, response.Status);
+        Assert.Contains("999", response.ErrorMessage);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RetryStockUpOperationHandlerTests.Handle_WhenOperationNotFound_ReturnsFailure"`
+Expected: `Passed: 1`. If the test fails, the production not-found message has drifted — update `Assert.Contains` to match the current handler text, not the other way around.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+git commit -m "test(catalog): RetryStockUpOperationHandler returns failure when not found"
+```
+
+---
+
+## Task 3: FR-2 — already-completed operation is rejected
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`
+
+- [ ] **Step 1: Add the [Fact] method**
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenOperationIsCompleted_ReturnsAlreadyCompleted()
+    {
+        // Arrange
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+        operation.MarkAsCompleted(FixedNow); // Pending -> Completed (allowed by domain)
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(StockUpResultStatus.AlreadyCompleted, response.Status);
+        Assert.Contains("DOC-001", response.ErrorMessage);
+        Assert.Equal(StockUpOperationState.Completed, operation.State);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RetryStockUpOperationHandlerTests.Handle_WhenOperationIsCompleted_ReturnsAlreadyCompleted"`
+Expected: `Passed: 1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+git commit -m "test(catalog): RetryStockUpOperationHandler rejects completed operations"
+```
+
+---
+
+## Task 4: FR-3 — Failed operation routes through `Reset()` (no Warning)
+
+This test pins down the critical branch decision: a `Failed` operation must go through `Reset()`, which is observable by the **absence** of any `LogLevel.Warning` entry.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`
+
+- [ ] **Step 1: Add the [Fact] method**
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenOperationIsFailed_CallsResetAndReturnsInProgress()
+    {
+        // Arrange
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+        operation.MarkAsFailed(FixedNow, "some error");
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(StockUpResultStatus.InProgress, response.Status);
+        Assert.Null(response.ErrorMessage);
+
+        // Observable Reset() post-state
+        Assert.Equal(StockUpOperationState.Pending, operation.State);
+        Assert.Null(operation.SubmittedAt);
+        Assert.Null(operation.CompletedAt);
+        Assert.Null(operation.ErrorMessage);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Branch selection signal: handler emits NO Warning on the Reset branch.
+        // If this assertion ever fails, the handler has been switched to ForceReset
+        // (or someone introduced a new Warning above this call site).
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RetryStockUpOperationHandlerTests.Handle_WhenOperationIsFailed_CallsResetAndReturnsInProgress"`
+Expected: `Passed: 1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+git commit -m "test(catalog): RetryStockUpOperationHandler routes Failed through Reset"
+```
+
+---
+
+## Task 5: FR-4 — Submitted operation routes through `ForceReset()` (Warning emitted)
+
+This test pins down the second side of the branch: a `Submitted` (stuck) operation must go through `ForceReset()`, observable by **exactly one** `LogLevel.Warning` entry.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`
+
+- [ ] **Step 1: Add the [Fact] method**
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenOperationIsSubmitted_CallsForceResetAndReturnsInProgress()
+    {
+        // Arrange
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+        operation.MarkAsSubmitted(FixedNow);
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(StockUpResultStatus.InProgress, response.Status);
+        Assert.Null(response.ErrorMessage);
+
+        // Observable ForceReset() post-state
+        Assert.Equal(StockUpOperationState.Pending, operation.State);
+        Assert.Null(operation.SubmittedAt);
+        Assert.Null(operation.CompletedAt);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Branch selection signal: the handler emits exactly one Warning
+        // immediately before calling ForceReset(). If this drops to Times.Never,
+        // the branch swap regression has landed.
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RetryStockUpOperationHandlerTests.Handle_WhenOperationIsSubmitted_CallsForceResetAndReturnsInProgress"`
+Expected: `Passed: 1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+git commit -m "test(catalog): RetryStockUpOperationHandler routes Submitted through ForceReset"
+```
+
+---
+
+## Task 6: FR-5 — Pending (stuck) operation also routes through `ForceReset()`
+
+Parametrizing the stuck-state branch over a second input (`Pending`) catches an off-by-one branch error like `if (state == Submitted)` (instead of the current `if (state == Failed)`).
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs`
+
+- [ ] **Step 1: Add the [Fact] method**
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenOperationIsPending_CallsForceResetAndReturnsInProgress()
+    {
+        // Arrange — constructor leaves the operation in Pending state; no Mark* call needed.
+        var operation = new StockUpOperation(
+            "DOC-001",
+            "PROD-001",
+            10,
+            StockUpSourceType.TransportBox,
+            1);
+
+        var request = new RetryStockUpOperationRequest { OperationId = 1 };
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operation);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(StockUpResultStatus.InProgress, response.Status);
+        Assert.Null(response.ErrorMessage);
+
+        // State remains Pending after ForceReset (Pending -> Pending is valid).
+        Assert.Equal(StockUpOperationState.Pending, operation.State);
+        Assert.Null(operation.SubmittedAt); // Pending operations never had SubmittedAt; harmless redundancy.
+        Assert.Null(operation.CompletedAt);
+
+        _repositoryMock.Verify(
+            r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Branch selection signal — same proxy as the Submitted case.
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RetryStockUpOperationHandlerTests.Handle_WhenOperationIsPending_CallsForceResetAndReturnsInProgress"`
+Expected: `Passed: 1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+git commit -m "test(catalog): RetryStockUpOperationHandler routes Pending through ForceReset"
+```
+
+---
+
+## Task 7: Final validation — class-level test run, format, build
+
+**Files:**
+- Possibly modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs` (formatting only)
+
+- [ ] **Step 1: Run the full test class**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RetryStockUpOperationHandlerTests"`
+Expected: `Passed: 5, Failed: 0, Skipped: 0`. Wall-clock under 200 ms (NFR-3).
+
+- [ ] **Step 2: Run `dotnet format` on the test project**
+
+Run: `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: command succeeds with exit code 0. If the new file is reformatted, that is fine — review the diff with `git diff`.
+
+- [ ] **Step 3: Confirm the broader test project still builds clean**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-incremental`
+Expected: Build succeeded, 0 errors, 0 warnings.
+
+- [ ] **Step 4: Commit any formatting changes (skip if `git status` is clean)**
+
+```bash
+git status
+# If RetryStockUpOperationHandlerTests.cs shows modifications:
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs
+git commit -m "test(catalog): dotnet format RetryStockUpOperationHandlerTests"
+```
+
+---
+
+## Self-Review Checklist (done by the plan author)
+
+**Spec coverage**
+- FR-1 → Task 2 ✓
+- FR-2 → Task 3 ✓
+- FR-3 → Task 4 (Warning Times.Never assertion) ✓
+- FR-4 → Task 5 (Warning Times.Once assertion) ✓
+- FR-5 → Task 6 (Warning Times.Once on Pending) ✓
+- NFR-1 (xUnit + Moq + Assert.*, AAA layout, naming, shared mocks in ctor) → Tasks 1–6 ✓
+- NFR-2 (`FixedNow` constant, no `DateTime.UtcNow`, no DB) → Task 1 declares constant; all subsequent tasks use it ✓
+- NFR-3 (under 200 ms, no I/O) → Task 7 verifies ✓
+- NFR-4 (100% line coverage of `Handle`) → all four branches plus entry path are exercised by Tasks 2/3/4/5/6 ✓
+
+**Architecture amendments folded in**
+- FR-5 explicit `SaveChangesAsync` Times.Once assertion (arch review §"Specification Amendments" item 1) → Task 6 Step 1 ✓
+- Inline comments explaining the Warning-count branch proxy (arch review §"Specification Amendments" item 2) → present in Tasks 4 and 5 ✓
+- `using Anela.Heblo.Application.Features.Catalog.Services;` to reach `StockUpResultStatus` (arch review §"Risks and Mitigations" final row) → Task 1 Step 1 ✓
+
+**Placeholder scan**
+- No "TBD", "TODO", "similar to Task N", or generic error-handling stubs. Every test method body is fully written out.
+
+**Type / name consistency**
+- `RetryStockUpOperationRequest.OperationId` used uniformly (matches `AcceptStockUpOperationRequest.OperationId` in sibling test).
+- `RetryStockUpOperationResponse` fields: `Success`, `Status`, `ErrorMessage` — checked in every test.
+- `IStockUpOperationRepository.GetByIdAsync(int, CancellationToken)` and `.SaveChangesAsync(CancellationToken)` are the only repository methods touched, consistent across tasks.
+- `StockUpOperation` constructor argument order `(documentNumber, productCode, amount, sourceType, sourceId)` identical in all tasks.
+- `FixedNow` declared in Task 1 and consumed in Tasks 3 / 4 (and not needed in Tasks 2 / 6).
+
+Plan is internally consistent and complete.


### PR DESCRIPTION
Added five xUnit tests that achieve 100% branch coverage of `RetryStockUpOperationHandler.Handle`, locking in the critical `Reset` vs `ForceReset` routing decision via `LogLevel.Warning` count assertions — the only non-invasive branch detection signal available without modifying production code. Tests use real `StockUpOperation` domain entity (state arranged via public `MarkAs*` methods) and mock only `IStockUpOperationRepository` and `ILogger`.

### Changes
- `backend/test/Anela.Heblo.Tests/Features/Catalog/RetryStockUpOperationHandlerTests.cs` — new test class covering all four handler branches (not-found, already-completed, Failed→Reset, non-Completed→ForceReset)

---

Closes #2752

### Tokens used
6782320
