### PR TITLE
feat: user management grid and wide-screen access group detail

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10974,16 +10974,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -22254,7 +22244,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -20,7 +20,9 @@ const Layout: React.FC<LayoutProps> = ({ children, statusBar }) => {
     location.pathname === "/customer/smartsupp";
 
   // Pages that manage their own internal scroll — no padding wrapper, main is overflow-hidden
-  const isFullHeightPage = location.pathname === "/customer/smartsupp";
+  const isFullHeightPage =
+    location.pathname === "/customer/smartsupp" ||
+    location.pathname.startsWith("/admin/access/groups/");
 
   return (
     <div className="h-[calc(100vh-2rem)] md:h-[calc(100vh-1.5rem)] bg-gray-50 flex flex-col overflow-hidden">

--- a/frontend/src/components/access-management/IncludedGroupsPicker.tsx
+++ b/frontend/src/components/access-management/IncludedGroupsPicker.tsx
@@ -6,9 +6,10 @@ interface IncludedGroupsPickerProps {
   currentGroupId: string;
   value: string[];
   onChange: (groupIds: string[]) => void;
+  fillHeight?: boolean;
 }
 
-export default function IncludedGroupsPicker({ currentGroupId, value, onChange }: IncludedGroupsPickerProps) {
+export default function IncludedGroupsPicker({ currentGroupId, value, onChange, fillHeight }: IncludedGroupsPickerProps) {
   const groups = useGroups();
 
   const items: TransferItem[] = useMemo(
@@ -27,6 +28,9 @@ export default function IncludedGroupsPicker({ currentGroupId, value, onChange }
       assignedIds={value}
       onChange={onChange}
       labels={{ available: "Available groups", assigned: "Included groups" }}
+      fillHeight={fillHeight}
+      searchable
+      searchPlaceholder="Search groups…"
     />
   );
 }

--- a/frontend/src/components/access-management/MembersPicker.tsx
+++ b/frontend/src/components/access-management/MembersPicker.tsx
@@ -5,9 +5,10 @@ import TransferList, { TransferItem } from "./TransferList";
 interface MembersPickerProps {
   value: string[];
   onChange: (userIds: string[]) => void;
+  fillHeight?: boolean;
 }
 
-export default function MembersPicker({ value, onChange }: MembersPickerProps) {
+export default function MembersPicker({ value, onChange, fillHeight }: MembersPickerProps) {
   const users = useUsers();
 
   const items: TransferItem[] = useMemo(
@@ -29,6 +30,7 @@ export default function MembersPicker({ value, onChange }: MembersPickerProps) {
       assignedIds={value}
       onChange={onChange}
       labels={{ available: "All users", assigned: "Members" }}
+      fillHeight={fillHeight}
     />
   );
 }

--- a/frontend/src/components/access-management/PermissionPicker.tsx
+++ b/frontend/src/components/access-management/PermissionPicker.tsx
@@ -5,9 +5,10 @@ import TransferList, { TransferItem } from "./TransferList";
 interface PermissionPickerProps {
   value: string[];
   onChange: (permissions: string[]) => void;
+  fillHeight?: boolean;
 }
 
-export default function PermissionPicker({ value, onChange }: PermissionPickerProps) {
+export default function PermissionPicker({ value, onChange, fillHeight }: PermissionPickerProps) {
   const catalogue = useCatalogue();
 
   const { items, sectionByPermission } = useMemo(() => {
@@ -35,6 +36,9 @@ export default function PermissionPicker({ value, onChange }: PermissionPickerPr
       onChange={onChange}
       groupBy={(item) => sectionByPermission[item.id] ?? ""}
       labels={{ available: "Available permissions", assigned: "Assigned permissions" }}
+      fillHeight={fillHeight}
+      searchable
+      searchPlaceholder="Search permissions…"
     />
   );
 }

--- a/frontend/src/components/access-management/TransferList.tsx
+++ b/frontend/src/components/access-management/TransferList.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { Search } from "lucide-react";
 import {
   DndContext,
   useDroppable,
@@ -24,6 +25,16 @@ interface TransferListProps {
   onChange: (ids: string[]) => void;
   groupBy?: (item: TransferItem) => string;
   labels?: { available?: string; assigned?: string };
+  fillHeight?: boolean;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+}
+
+function matchesQuery(item: TransferItem, query: string): boolean {
+  return (
+    item.label.toLowerCase().includes(query) ||
+    (item.sublabel?.toLowerCase().includes(query) ?? false)
+  );
 }
 
 interface ItemRowProps {
@@ -34,7 +45,7 @@ interface ItemRowProps {
 
 function buildGroups(
   items: TransferItem[],
-  groupByFn: (item: TransferItem) => string
+  groupByFn: (item: TransferItem) => string,
 ): Map<string, TransferItem[]> {
   const map = new Map<string, TransferItem[]>();
   for (const item of items) {
@@ -48,7 +59,9 @@ function buildGroups(
 function ItemRow({ item, direction, onMove }: ItemRowProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({ id: item.id });
-  const style = transform ? { transform: CSS.Transform.toString(transform) } : undefined;
+  const style = transform
+    ? { transform: CSS.Transform.toString(transform) }
+    : undefined;
   return (
     <div
       ref={setNodeRef}
@@ -67,7 +80,9 @@ function ItemRow({ item, direction, onMove }: ItemRowProps) {
           )}
         </div>
         {item.sublabel && (
-          <span className="text-xs text-gray-500 truncate">{item.sublabel}</span>
+          <span className="text-xs text-gray-500 truncate">
+            {item.sublabel}
+          </span>
         )}
       </div>
       <button
@@ -76,7 +91,11 @@ function ItemRow({ item, direction, onMove }: ItemRowProps) {
           e.stopPropagation();
           onMove();
         }}
-        aria-label={direction === "assign" ? `Assign ${item.label}` : `Remove ${item.label}`}
+        aria-label={
+          direction === "assign"
+            ? `Assign ${item.label}`
+            : `Remove ${item.label}`
+        }
         className={`ml-3 flex-shrink-0 w-6 h-6 rounded flex items-center justify-center text-sm font-bold ${
           direction === "assign"
             ? "text-indigo-600 hover:bg-indigo-100"
@@ -87,7 +106,7 @@ function ItemRow({ item, direction, onMove }: ItemRowProps) {
       </button>
     </div>
   );
-};
+}
 
 interface DropZoneProps {
   id: string;
@@ -96,6 +115,7 @@ interface DropZoneProps {
   children: React.ReactNode;
   isEmpty: boolean;
   variant: "left" | "right";
+  fillHeight?: boolean;
 }
 
 function DropZone({
@@ -105,31 +125,36 @@ function DropZone({
   children,
   isEmpty,
   variant,
+  fillHeight,
 }: DropZoneProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   return (
     <div
       ref={setNodeRef}
-      className={`border rounded-lg p-3 min-h-48 ${
+      className={`border rounded-lg p-3 ${fillHeight ? "flex flex-col h-full min-h-0" : "min-h-48"} ${
         isOver
           ? "bg-indigo-50 border-indigo-400"
           : variant === "left"
-          ? "border-gray-300 bg-gray-50"
-          : "border-gray-300 bg-white"
+            ? "border-gray-300 bg-gray-50"
+            : "border-gray-300 bg-white"
       }`}
     >
       <div className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">
         {label}
       </div>
-      <div className="space-y-1">
+      <div
+        className={`space-y-1 ${fillHeight ? "flex-1 min-h-0 overflow-y-auto" : ""}`}
+      >
         {children}
         {isEmpty && (
-          <div className="text-sm text-gray-400 text-center py-6">{emptyMessage}</div>
+          <div className="text-sm text-gray-400 text-center py-6">
+            {emptyMessage}
+          </div>
         )}
       </div>
     </div>
   );
-};
+}
 
 function TransferList({
   available,
@@ -137,11 +162,26 @@ function TransferList({
   onChange,
   groupBy,
   labels = {},
+  fillHeight,
+  searchable,
+  searchPlaceholder = "Search…",
 }: TransferListProps) {
-  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  // A small activation distance keeps the per-row +/− button clicks from being
+  // swallowed by the drag sensor — a plain click no longer starts a drag.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor),
+  );
 
-  const availableItems = available.filter((item) => !assignedIds.includes(item.id));
-  const assignedItems = available.filter((item) => assignedIds.includes(item.id));
+  const [query, setQuery] = useState("");
+  const trimmedQuery = query.trim().toLowerCase();
+
+  const availableItems = available
+    .filter((item) => !assignedIds.includes(item.id))
+    .filter((item) => !trimmedQuery || matchesQuery(item, trimmedQuery));
+  const assignedItems = available
+    .filter((item) => assignedIds.includes(item.id))
+    .filter((item) => !trimmedQuery || matchesQuery(item, trimmedQuery));
 
   const handleAssign = (id: string) => onChange([...assignedIds, id]);
   const handleRemove = (id: string) =>
@@ -163,59 +203,82 @@ function TransferList({
 
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-      <div className="grid grid-cols-2 gap-4">
-        <DropZone
-          id="available"
-          label={labels.available ?? "Available"}
-          emptyMessage="All items assigned"
-          isEmpty={availableItems.length === 0}
-          variant="left"
-        >
-          {availableGroups
-            ? Array.from(availableGroups.entries()).map(([section, sectionItems]) => (
-                <div key={section}>
-                  <div className="text-xs font-medium text-gray-500 px-1 pt-3 pb-0.5 first:pt-0">
-                    {section}
-                  </div>
-                  {sectionItems.map((item) => (
-                    <ItemRow
-                      key={item.id}
-                      item={item}
-                      direction="assign"
-                      onMove={() => handleAssign(item.id)}
-                    />
-                  ))}
-                </div>
-              ))
-            : availableItems.map((item) => (
-                <ItemRow
-                  key={item.id}
-                  item={item}
-                  direction="assign"
-                  onMove={() => handleAssign(item.id)}
-                />
-              ))}
-        </DropZone>
-
-        <DropZone
-          id="assigned"
-          label={labels.assigned ?? "Assigned"}
-          emptyMessage="None assigned"
-          isEmpty={assignedItems.length === 0}
-          variant="right"
-        >
-          {assignedItems.map((item) => (
-            <ItemRow
-              key={item.id}
-              item={item}
-              direction="remove"
-              onMove={() => handleRemove(item.id)}
+      <div className={fillHeight ? "flex flex-col h-full min-h-0" : ""}>
+        {searchable && (
+          <div className="relative mb-3 flex-shrink-0">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <Search className="h-4 w-4 text-gray-400" />
+            </div>
+            <input
+              type="text"
+              aria-label={searchPlaceholder}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={searchPlaceholder}
+              className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 text-sm border border-gray-300 rounded-md"
             />
-          ))}
-        </DropZone>
+          </div>
+        )}
+        <div
+          className={`grid grid-cols-2 gap-4${fillHeight ? " flex-1 min-h-0" : ""}`}
+        >
+          <DropZone
+            id="available"
+            label={labels.available ?? "Available"}
+            emptyMessage="All items assigned"
+            isEmpty={availableItems.length === 0}
+            variant="left"
+            fillHeight={fillHeight}
+          >
+            {availableGroups
+              ? Array.from(availableGroups.entries()).map(
+                  ([section, sectionItems]) => (
+                    <div key={section}>
+                      <div className="text-xs font-medium text-gray-500 px-1 pt-3 pb-0.5 first:pt-0">
+                        {section}
+                      </div>
+                      {sectionItems.map((item) => (
+                        <ItemRow
+                          key={item.id}
+                          item={item}
+                          direction="assign"
+                          onMove={() => handleAssign(item.id)}
+                        />
+                      ))}
+                    </div>
+                  ),
+                )
+              : availableItems.map((item) => (
+                  <ItemRow
+                    key={item.id}
+                    item={item}
+                    direction="assign"
+                    onMove={() => handleAssign(item.id)}
+                  />
+                ))}
+          </DropZone>
+
+          <DropZone
+            id="assigned"
+            label={labels.assigned ?? "Assigned"}
+            emptyMessage="None assigned"
+            isEmpty={assignedItems.length === 0}
+            variant="right"
+            fillHeight={fillHeight}
+          >
+            {assignedItems.map((item) => (
+              <ItemRow
+                key={item.id}
+                item={item}
+                direction="remove"
+                onMove={() => handleRemove(item.id)}
+              />
+            ))}
+          </DropZone>
+        </div>
       </div>
     </DndContext>
   );
-};
+}
 
 export default TransferList;

--- a/frontend/src/components/pages/access/GroupsGrid.tsx
+++ b/frontend/src/components/pages/access/GroupsGrid.tsx
@@ -1,0 +1,191 @@
+import React, { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Edit, Filter, Search } from "lucide-react";
+import {
+  useGroups,
+  useCatalogue,
+  useDeleteGroup,
+} from "../../../api/hooks/useAccessManagement";
+import { GroupSummaryDto } from "../../../api/generated/api-client";
+import Pagination from "../../common/Pagination";
+import LoadingState from "../../common/LoadingState";
+import ErrorState from "../../common/ErrorState";
+import SortableHeader from "./SortableHeader";
+import { useClientGrid } from "./useClientGrid";
+
+// Stable sort-value accessor (declared at module scope for useClientGrid memoization).
+const getGroupSortValue = (group: GroupSummaryDto, column: string) => {
+  switch (column) {
+    case "name":
+      return group.name?.toLowerCase();
+    case "description":
+      return group.description?.toLowerCase();
+    case "permissions":
+      return group.permissionCount ?? 0;
+    case "members":
+      return group.memberCount ?? 0;
+    case "parents":
+      return group.parentCount ?? 0;
+    default:
+      return undefined;
+  }
+};
+
+const GroupsGrid: React.FC = () => {
+  const navigate = useNavigate();
+  const groups = useGroups();
+  const catalogue = useCatalogue();
+  const deleteGroup = useDeleteGroup();
+
+  const [search, setSearch] = useState("");
+
+  const allGroups = useMemo(() => groups.data?.groups ?? [], [groups.data]);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return allGroups;
+    return allGroups.filter((g) => {
+      const name = (g.name ?? "").toLowerCase();
+      const description = (g.description ?? "").toLowerCase();
+      return name.includes(query) || description.includes(query);
+    });
+  }, [allGroups, search]);
+
+  const grid = useClientGrid(filtered, getGroupSortValue, { defaultSortBy: "name" });
+
+  if (groups.isLoading) {
+    return <LoadingState message="Loading groups…" className="flex-1" />;
+  }
+
+  if (groups.isError) {
+    return <ErrorState message="Failed to load groups." className="flex-1" />;
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {/* Filters */}
+      <div className="flex-shrink-0 bg-white shadow rounded-lg p-4 mb-4">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-3 flex-1 min-w-0 flex-wrap">
+            <div className="flex items-center">
+              <Filter className="h-4 w-4 text-gray-400 mr-2" />
+              <span className="text-sm font-medium text-gray-900">Filters:</span>
+            </div>
+            <div className="flex-1 max-w-xs">
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <Search className="h-4 w-4 text-gray-400" />
+                </div>
+                <input
+                  type="text"
+                  aria-label="Search groups"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 sm:text-sm border-gray-300 rounded-md"
+                  placeholder="Name or description…"
+                />
+              </div>
+            </div>
+          </div>
+
+          <button
+            onClick={() => navigate("/admin/access/groups/new")}
+            className="px-4 py-2 bg-indigo-600 text-white rounded text-sm font-medium hover:bg-indigo-700"
+            aria-label="New group"
+          >
+            New group
+          </button>
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0">
+        <div className="flex-1 overflow-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50 sticky top-0 z-10">
+              <tr>
+                <SortableHeader column="name" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Name
+                </SortableHeader>
+                <SortableHeader column="description" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Description
+                </SortableHeader>
+                <SortableHeader column="permissions" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Permissions
+                </SortableHeader>
+                <SortableHeader column="members" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Members
+                </SortableHeader>
+                <SortableHeader column="parents" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Parents
+                </SortableHeader>
+                <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {grid.pageItems.map((g) => (
+                <tr key={g.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                    <button
+                      onClick={() => g.id && navigate(`/admin/access/groups/${g.id}`)}
+                      className="text-gray-900 hover:text-indigo-600 text-left"
+                    >
+                      {g.name}
+                    </button>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">{g.description}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{g.permissionCount}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{g.memberCount}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{g.parentCount}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        onClick={() => g.id && navigate(`/admin/access/groups/${g.id}`)}
+                        className="p-2 text-gray-400 hover:text-indigo-600 rounded-lg hover:bg-gray-50"
+                        aria-label={`Edit ${g.name}`}
+                      >
+                        <Edit className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => g.id && deleteGroup.mutate(g.id)}
+                        disabled={deleteGroup.isPending}
+                        className="text-sm text-red-600 hover:underline"
+                        aria-label={`Delete ${g.name}`}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {grid.totalCount === 0 && (
+            <div className="text-center py-8">
+              <p className="text-gray-500">No groups found.</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Pagination
+        totalCount={grid.totalCount}
+        pageNumber={grid.pageNumber}
+        pageSize={grid.pageSize}
+        totalPages={grid.totalPages}
+        onPageChange={grid.handlePageChange}
+        onPageSizeChange={grid.handlePageSizeChange}
+        isFiltered={Boolean(search)}
+      />
+
+      <p className="flex-shrink-0 mt-2 text-xs text-gray-400">
+        {catalogue.data?.permissions?.length ?? 0} permissions available.
+      </p>
+    </div>
+  );
+};
+
+export default GroupsGrid;

--- a/frontend/src/components/pages/access/SortableHeader.tsx
+++ b/frontend/src/components/pages/access/SortableHeader.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { ChevronUp, ChevronDown } from "lucide-react";
+
+interface SortableHeaderProps {
+  column: string;
+  sortBy: string;
+  sortDescending: boolean;
+  onSort: (column: string) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+// Shared click-to-sort table header used by the access-management grids.
+// Mirrors the SortableHeader pattern from CatalogList.
+const SortableHeader: React.FC<SortableHeaderProps> = ({
+  column,
+  sortBy,
+  sortDescending,
+  onSort,
+  children,
+  className = "",
+}) => {
+  const isActive = sortBy === column;
+  const isAscending = isActive && !sortDescending;
+  const isDescending = isActive && sortDescending;
+
+  return (
+    <th
+      scope="col"
+      className={`px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none ${className}`}
+      onClick={() => onSort(column)}
+    >
+      <div className="flex items-center space-x-1">
+        <span>{children}</span>
+        <div className="flex flex-col">
+          <ChevronUp
+            className={`h-3 w-3 ${isAscending ? "text-indigo-600" : "text-gray-300"}`}
+          />
+          <ChevronDown
+            className={`h-3 w-3 -mt-1 ${isDescending ? "text-indigo-600" : "text-gray-300"}`}
+          />
+        </div>
+      </div>
+    </th>
+  );
+};
+
+export default SortableHeader;

--- a/frontend/src/components/pages/access/UsersGrid.tsx
+++ b/frontend/src/components/pages/access/UsersGrid.tsx
@@ -1,0 +1,329 @@
+import React, { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Edit, Filter, Search } from "lucide-react";
+import {
+  useUsers,
+  useSetUserActive,
+  useSetUserCanPack,
+  useCreateLocalUser,
+} from "../../../api/hooks/useAccessManagement";
+import { AppUserDto, SetUserActiveRequest } from "../../../api/generated/api-client";
+import Pagination from "../../common/Pagination";
+import LoadingState from "../../common/LoadingState";
+import ErrorState from "../../common/ErrorState";
+import SortableHeader from "./SortableHeader";
+import { useClientGrid } from "./useClientGrid";
+
+type SourceFilter = "" | "Local" | "Entra";
+
+const SOURCE_OPTIONS: { value: SourceFilter; label: string }[] = [
+  { value: "", label: "All" },
+  { value: "Entra", label: "Entra" },
+  { value: "Local", label: "Local" },
+];
+
+// Stable sort-value accessor (declared at module scope for useClientGrid memoization).
+const getUserSortValue = (user: AppUserDto, column: string) => {
+  switch (column) {
+    case "displayName":
+      return user.displayName?.toLowerCase();
+    case "email":
+      return user.email?.toLowerCase();
+    case "source":
+      return user.source;
+    case "groups":
+      return user.groupIds?.length ?? 0;
+    case "lastLoginAt":
+      return user.lastLoginAt ? user.lastLoginAt.getTime() : 0;
+    default:
+      return undefined;
+  }
+};
+
+const formatLastLogin = (date?: Date): string =>
+  date
+    ? date.toLocaleDateString("cs-CZ", {
+        day: "numeric",
+        month: "numeric",
+        year: "numeric",
+      })
+    : "";
+
+const UsersGrid: React.FC = () => {
+  const navigate = useNavigate();
+  const users = useUsers();
+  const setActive = useSetUserActive();
+  const setCanPack = useSetUserCanPack();
+  const createLocalUser = useCreateLocalUser();
+
+  const [search, setSearch] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("");
+  const [showDisabled, setShowDisabled] = useState(false);
+  const [packersOnly, setPackersOnly] = useState(false);
+  const [newLocalName, setNewLocalName] = useState("");
+
+  const allUsers = useMemo(() => users.data?.users ?? [], [users.data]);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return allUsers.filter((u) => {
+      if (!showDisabled && u.isActive === false) return false;
+      if (sourceFilter && u.source !== sourceFilter) return false;
+      if (packersOnly && !u.canPack) return false;
+      if (query) {
+        const name = (u.displayName ?? "").toLowerCase();
+        const email = (u.email ?? "").toLowerCase();
+        if (!name.includes(query) && !email.includes(query)) return false;
+      }
+      return true;
+    });
+  }, [allUsers, search, sourceFilter, showDisabled, packersOnly]);
+
+  const grid = useClientGrid(filtered, getUserSortValue, {
+    defaultSortBy: "displayName",
+  });
+
+  const isFiltered = Boolean(search || sourceFilter || packersOnly || showDisabled);
+
+  const handleCreateLocalUser = (event: React.FormEvent) => {
+    event.preventDefault();
+    const name = newLocalName.trim();
+    if (name) {
+      createLocalUser.mutate(name, { onSuccess: () => setNewLocalName("") });
+    }
+  };
+
+  if (users.isLoading) {
+    return <LoadingState message="Loading users…" className="flex-1" />;
+  }
+
+  if (users.isError) {
+    return <ErrorState message="Failed to load users." className="flex-1" />;
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {/* Filters + create form */}
+      <div className="flex-shrink-0 bg-white shadow rounded-lg p-4 mb-4 space-y-3">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div className="flex items-center gap-3 flex-1 min-w-0 flex-wrap">
+            <div className="flex items-center">
+              <Filter className="h-4 w-4 text-gray-400 mr-2" />
+              <span className="text-sm font-medium text-gray-900">Filters:</span>
+            </div>
+
+            <div className="flex-1 max-w-xs">
+              <div className="relative">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <Search className="h-4 w-4 text-gray-400" />
+                </div>
+                <input
+                  type="text"
+                  aria-label="Search users"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 sm:text-sm border-gray-300 rounded-md"
+                  placeholder="Name or email…"
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-700">Source:</span>
+              <div className="inline-flex rounded-md shadow-sm" role="group" aria-label="Source">
+                {SOURCE_OPTIONS.map((option, index) => {
+                  const isActive = sourceFilter === option.value;
+                  const isFirst = index === 0;
+                  const isLast = index === SOURCE_OPTIONS.length - 1;
+                  return (
+                    <button
+                      key={option.label}
+                      type="button"
+                      onClick={() => setSourceFilter(option.value)}
+                      aria-pressed={isActive}
+                      className={`px-3 py-2 text-sm font-medium border border-gray-300 ${isFirst ? "rounded-l-md" : "-ml-px"} ${isLast ? "rounded-r-md" : ""} ${
+                        isActive
+                          ? "z-10 bg-indigo-600 text-white border-indigo-600"
+                          : "bg-white text-gray-700 hover:bg-gray-50"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={showDisabled}
+                onChange={(e) => setShowDisabled(e.target.checked)}
+                className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              Show disabled
+            </label>
+
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={packersOnly}
+                onChange={(e) => setPackersOnly(e.target.checked)}
+                className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              Packers only
+            </label>
+          </div>
+
+          <form className="flex items-center gap-2" onSubmit={handleCreateLocalUser}>
+            <input
+              value={newLocalName}
+              onChange={(e) => setNewLocalName(e.target.value)}
+              placeholder="New local operator name"
+              className="rounded border border-gray-300 px-3 py-2 text-sm"
+            />
+            <button
+              type="submit"
+              disabled={createLocalUser.isPending}
+              className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              Create local operator
+            </button>
+          </form>
+        </div>
+
+        {createLocalUser.isError && (
+          <p className="text-sm text-red-600">Failed to create operator. Please try again.</p>
+        )}
+        {setCanPack.isError && (
+          <p className="text-sm text-red-600">Failed to update packing permission. Please try again.</p>
+        )}
+      </div>
+
+      {/* Grid */}
+      <div className="flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0">
+        <div className="flex-1 overflow-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50 sticky top-0 z-10">
+              <tr>
+                <SortableHeader column="displayName" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Name
+                </SortableHeader>
+                <SortableHeader column="email" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Email
+                </SortableHeader>
+                <SortableHeader column="source" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Source
+                </SortableHeader>
+                <SortableHeader column="groups" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Groups
+                </SortableHeader>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Packer
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Status
+                </th>
+                <SortableHeader column="lastLoginAt" sortBy={grid.sortBy} sortDescending={grid.sortDescending} onSort={grid.handleSort}>
+                  Last login
+                </SortableHeader>
+                <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {grid.pageItems.map((u) => (
+                <tr key={u.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                    <button
+                      onClick={() => u.id && navigate(`/admin/access/users/${u.id}`)}
+                      className="text-gray-900 hover:text-indigo-600 text-left"
+                    >
+                      {u.displayName}
+                    </button>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{u.email}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm">
+                    {u.source === "Local" ? (
+                      <span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">Local</span>
+                    ) : (
+                      <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">Entra</span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{u.groupIds?.length ?? 0}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm">
+                    {u.canPack ? (
+                      <span className="rounded bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700">Packer</span>
+                    ) : (
+                      <span className="text-gray-400">—</span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm">
+                    {u.isActive ? (
+                      <span className="rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Active</span>
+                    ) : (
+                      <span className="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">Disabled</span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatLastLogin(u.lastLoginAt)}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        onClick={() => u.id && setCanPack.mutate({ id: u.id, canPack: !u.canPack })}
+                        disabled={setCanPack.isPending && setCanPack.variables?.id === u.id}
+                        className={`text-sm ${u.canPack ? "text-indigo-600" : "text-gray-500"} hover:underline`}
+                        aria-label={`Toggle can pack ${u.displayName}`}
+                      >
+                        {u.canPack ? "Packer ✓" : "Make packer"}
+                      </button>
+                      <button
+                        onClick={() => u.id && navigate(`/admin/access/users/${u.id}`)}
+                        className="p-2 text-gray-400 hover:text-indigo-600 rounded-lg hover:bg-gray-50"
+                        aria-label={`Edit ${u.displayName}`}
+                      >
+                        <Edit className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() =>
+                          u.id &&
+                          setActive.mutate({
+                            id: u.id,
+                            request: new SetUserActiveRequest({ userId: u.id, isActive: !u.isActive }),
+                          })
+                        }
+                        disabled={setActive.isPending}
+                        className={`text-sm ${u.isActive ? "text-red-600" : "text-green-600"} hover:underline`}
+                        aria-label={`Toggle active ${u.displayName}`}
+                      >
+                        {u.isActive ? "Disable" : "Enable"}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {grid.totalCount === 0 && (
+            <div className="text-center py-8">
+              <p className="text-gray-500">No users found.</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Pagination
+        totalCount={grid.totalCount}
+        pageNumber={grid.pageNumber}
+        pageSize={grid.pageSize}
+        totalPages={grid.totalPages}
+        onPageChange={grid.handlePageChange}
+        onPageSizeChange={grid.handlePageSizeChange}
+        isFiltered={isFiltered}
+      />
+    </div>
+  );
+};
+
+export default UsersGrid;

--- a/frontend/src/components/pages/access/UsersGrid.tsx
+++ b/frontend/src/components/pages/access/UsersGrid.tsx
@@ -292,7 +292,7 @@ const UsersGrid: React.FC = () => {
                             request: new SetUserActiveRequest({ userId: u.id, isActive: !u.isActive }),
                           })
                         }
-                        disabled={setActive.isPending}
+                        disabled={setActive.isPending && setActive.variables?.id === u.id}
                         className={`text-sm ${u.isActive ? "text-red-600" : "text-green-600"} hover:underline`}
                         aria-label={`Toggle active ${u.displayName}`}
                       >

--- a/frontend/src/components/pages/access/__tests__/GroupsGrid.test.tsx
+++ b/frontend/src/components/pages/access/__tests__/GroupsGrid.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import GroupsGrid from "../GroupsGrid";
+
+const mockNavigate = jest.fn();
+const mockDeleteGroupMutate = jest.fn();
+
+let mockGroupsData: { groups: unknown[] } = { groups: [] };
+
+jest.mock("../../../../api/hooks/useAccessManagement", () => ({
+  useGroups: () => ({ data: mockGroupsData, isLoading: false, isError: false }),
+  useCatalogue: () => ({ data: { permissions: ["catalog.read", "catalog.write"] } }),
+  useDeleteGroup: () => ({ mutate: mockDeleteGroupMutate, isPending: false }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const group = (overrides: Record<string, unknown>) => ({
+  id: "id",
+  name: "Group",
+  description: "",
+  permissionCount: 0,
+  parentCount: 0,
+  memberCount: 0,
+  ...overrides,
+});
+
+const renderGrid = () =>
+  render(
+    <MemoryRouter>
+      <GroupsGrid />
+    </MemoryRouter>,
+  );
+
+const dataRowNames = () =>
+  screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => within(row).getAllByRole("button")[0].textContent);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGroupsData = { groups: [] };
+});
+
+describe("GroupsGrid", () => {
+  it("searches by name or description", () => {
+    mockGroupsData = {
+      groups: [
+        group({ id: "a", name: "Admins", description: "full access" }),
+        group({ id: "b", name: "Readers", description: "view only" }),
+      ],
+    };
+    renderGrid();
+
+    fireEvent.change(screen.getByLabelText("Search groups"), {
+      target: { value: "view only" },
+    });
+
+    expect(screen.queryByText("Admins")).not.toBeInTheDocument();
+    expect(screen.getByText("Readers")).toBeInTheDocument();
+  });
+
+  it("sorts by a column when its header is clicked", () => {
+    mockGroupsData = {
+      groups: [
+        group({ id: "a", name: "Beta" }),
+        group({ id: "b", name: "Alpha" }),
+      ],
+    };
+    renderGrid();
+
+    // Default sort is by name ascending.
+    expect(dataRowNames()).toEqual(["Alpha", "Beta"]);
+
+    // Click the Name header to flip to descending.
+    fireEvent.click(screen.getByText("Name"));
+    expect(dataRowNames()).toEqual(["Beta", "Alpha"]);
+  });
+
+  it("wires up edit and delete row actions", () => {
+    mockGroupsData = { groups: [group({ id: "a", name: "Admins" })] };
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit admins/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/a");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete admins/i }));
+    expect(mockDeleteGroupMutate).toHaveBeenCalledWith("a");
+  });
+
+  it("navigates to the create page from the New group button", () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: /new group/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/new");
+  });
+
+  it("shows the available permission count", () => {
+    mockGroupsData = { groups: [group({ id: "a", name: "Admins" })] };
+    renderGrid();
+
+    expect(screen.getByText(/2 permissions available/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/pages/access/__tests__/UsersGrid.test.tsx
+++ b/frontend/src/components/pages/access/__tests__/UsersGrid.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import UsersGrid from "../UsersGrid";
+
+const mockNavigate = jest.fn();
+const mockSetActiveMutate = jest.fn();
+const mockSetCanPackMutate = jest.fn();
+const mockCreateLocalUserMutate = jest.fn();
+
+let mockUsersData: { users: unknown[] } = { users: [] };
+
+jest.mock("../../../../api/hooks/useAccessManagement", () => ({
+  useUsers: () => ({ data: mockUsersData, isLoading: false, isError: false }),
+  useSetUserActive: () => ({ mutate: mockSetActiveMutate, isPending: false }),
+  useSetUserCanPack: () => ({ mutate: mockSetCanPackMutate, isPending: false, isError: false }),
+  useCreateLocalUser: () => ({ mutate: mockCreateLocalUserMutate, isPending: false, isError: false }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const user = (overrides: Record<string, unknown>) => ({
+  id: "id",
+  displayName: "Name",
+  email: "name@test.com",
+  source: "Entra",
+  isActive: true,
+  canPack: false,
+  groupIds: [],
+  lastLoginAt: undefined,
+  ...overrides,
+});
+
+const renderGrid = () =>
+  render(
+    <MemoryRouter>
+      <UsersGrid />
+    </MemoryRouter>,
+  );
+
+const dataRowCount = () =>
+  screen.getAllByRole("row").length - 1; // minus header row
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUsersData = { users: [] };
+});
+
+describe("UsersGrid", () => {
+  it("hides disabled users by default and reveals them via the toggle", () => {
+    mockUsersData = {
+      users: [
+        user({ id: "a", displayName: "Alice", isActive: true }),
+        user({ id: "b", displayName: "Bob", isActive: false }),
+      ],
+    };
+    renderGrid();
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Show disabled"));
+
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("filters by source", () => {
+    mockUsersData = {
+      users: [
+        user({ id: "a", displayName: "Alice", source: "Entra" }),
+        user({ id: "b", displayName: "Bob", source: "Local" }),
+      ],
+    };
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Local" }));
+
+    expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("filters by source to Entra and back to all", () => {
+    mockUsersData = {
+      users: [
+        user({ id: "a", displayName: "Alice", source: "Entra" }),
+        user({ id: "b", displayName: "Bob", source: "Local" }),
+      ],
+    };
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Entra" }));
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("searches by name or email", () => {
+    mockUsersData = {
+      users: [
+        user({ id: "a", displayName: "Alice", email: "alice@test.com" }),
+        user({ id: "b", displayName: "Bob", email: "bob@example.com" }),
+      ],
+    };
+    renderGrid();
+
+    const search = screen.getByLabelText("Search users");
+    fireEvent.change(search, { target: { value: "example.com" } });
+
+    expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("filters to packers only", () => {
+    mockUsersData = {
+      users: [
+        user({ id: "a", displayName: "Alice", canPack: true }),
+        user({ id: "b", displayName: "Bob", canPack: false }),
+      ],
+    };
+    renderGrid();
+
+    fireEvent.click(screen.getByLabelText("Packers only"));
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+  });
+
+  it("pages results, showing 20 per page by default", () => {
+    mockUsersData = {
+      users: Array.from({ length: 25 }, (_, i) =>
+        user({ id: `u${i}`, displayName: `User${String(i).padStart(2, "0")}` }),
+      ),
+    };
+    renderGrid();
+
+    expect(dataRowCount()).toBe(20);
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    expect(dataRowCount()).toBe(5);
+  });
+
+  it("toggles can-pack and active state through row actions", () => {
+    mockUsersData = {
+      users: [user({ id: "a", displayName: "Alice", canPack: false, isActive: true })],
+    };
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle can pack alice/i }));
+    expect(mockSetCanPackMutate).toHaveBeenCalledWith({ id: "a", canPack: true });
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle active alice/i }));
+    expect(mockSetActiveMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "a" }),
+    );
+  });
+
+  it("navigates to the user detail page from the name", () => {
+    mockUsersData = { users: [user({ id: "a", displayName: "Alice" })] };
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Alice" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users/a");
+  });
+
+  it("creates a local operator from the form", () => {
+    renderGrid();
+
+    fireEvent.change(screen.getByPlaceholderText("New local operator name"), {
+      target: { value: "  New Op  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create local operator/i }));
+
+    expect(mockCreateLocalUserMutate).toHaveBeenCalledWith("New Op", expect.anything());
+  });
+});

--- a/frontend/src/components/pages/access/useClientGrid.ts
+++ b/frontend/src/components/pages/access/useClientGrid.ts
@@ -1,0 +1,96 @@
+import { useMemo, useState } from "react";
+
+type SortValue = string | number | undefined | null;
+
+export interface ClientGrid<T> {
+  sortBy: string;
+  sortDescending: boolean;
+  pageNumber: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+  pageItems: T[];
+  handleSort: (column: string) => void;
+  handlePageChange: (page: number) => void;
+  handlePageSizeChange: (size: number) => void;
+}
+
+interface ClientGridOptions {
+  defaultSortBy?: string;
+  defaultPageSize?: number;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+
+// Client-side sort + paging for the small access-management lists.
+// `getSortValue` must be a stable reference (declare it at module scope) so the
+// memoized sort does not recompute on every render.
+export function useClientGrid<T>(
+  items: T[],
+  getSortValue: (item: T, column: string) => SortValue,
+  options: ClientGridOptions = {},
+): ClientGrid<T> {
+  const [sortBy, setSortBy] = useState(options.defaultSortBy ?? "");
+  const [sortDescending, setSortDescending] = useState(false);
+  const [pageNumber, setPageNumber] = useState(1);
+  const [pageSize, setPageSize] = useState(options.defaultPageSize ?? DEFAULT_PAGE_SIZE);
+
+  const sorted = useMemo(() => {
+    if (!sortBy) return items;
+    return [...items].sort((a, b) => {
+      const result = compareValues(getSortValue(a, sortBy), getSortValue(b, sortBy));
+      return sortDescending ? -result : result;
+    });
+  }, [items, sortBy, sortDescending, getSortValue]);
+
+  const totalCount = sorted.length;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const safePage = Math.min(pageNumber, totalPages);
+
+  const pageItems = useMemo(
+    () => sorted.slice((safePage - 1) * pageSize, safePage * pageSize),
+    [sorted, safePage, pageSize],
+  );
+
+  const handleSort = (column: string) => {
+    if (sortBy === column) {
+      setSortDescending((descending) => !descending);
+    } else {
+      setSortBy(column);
+      setSortDescending(false);
+    }
+    setPageNumber(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setPageNumber(page);
+    }
+  };
+
+  const handlePageSizeChange = (size: number) => {
+    setPageSize(size);
+    setPageNumber(1);
+  };
+
+  return {
+    sortBy,
+    sortDescending,
+    pageNumber: safePage,
+    pageSize,
+    totalCount,
+    totalPages,
+    pageItems,
+    handleSort,
+    handlePageChange,
+    handlePageSizeChange,
+  };
+}
+
+function compareValues(a: SortValue, b: SortValue): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return -1;
+  if (b == null) return 1;
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  return String(a).localeCompare(String(b), "cs");
+}

--- a/frontend/src/components/pages/access/useClientGrid.ts
+++ b/frontend/src/components/pages/access/useClientGrid.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type SortValue = string | number | undefined | null;
 
@@ -34,6 +34,10 @@ export function useClientGrid<T>(
   const [sortDescending, setSortDescending] = useState(false);
   const [pageNumber, setPageNumber] = useState(1);
   const [pageSize, setPageSize] = useState(options.defaultPageSize ?? DEFAULT_PAGE_SIZE);
+
+  useEffect(() => {
+    setPageNumber(1);
+  }, [items]);
 
   const sorted = useMemo(() => {
     if (!sortBy) return items;

--- a/frontend/src/pages/AccessManagementPage.tsx
+++ b/frontend/src/pages/AccessManagementPage.tsx
@@ -1,190 +1,46 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Edit } from "lucide-react";
-import {
-  useGroups,
-  useUsers,
-  useCatalogue,
-  useDeleteGroup,
-  useSetUserActive,
-  useSetUserCanPack,
-  useCreateLocalUser,
-} from "../api/hooks/useAccessManagement";
-import { SetUserActiveRequest } from "../api/generated/api-client";
+import { PAGE_CONTAINER_HEIGHT } from "../constants/layout";
+import { useScreenView } from "../telemetry/useScreenView";
+import GroupsGrid from "../components/pages/access/GroupsGrid";
+import UsersGrid from "../components/pages/access/UsersGrid";
 
 export default function AccessManagementPage() {
-  const [tab, setTab] = useState<"groups" | "users">("groups");
-  const navigate = useNavigate();
-  const groups = useGroups();
-  const users = useUsers();
-  const catalogue = useCatalogue();
-  const deleteGroup = useDeleteGroup();
-  const setActive = useSetUserActive();
-  const setCanPack = useSetUserCanPack();
-  const createLocalUser = useCreateLocalUser();
-  const [newLocalName, setNewLocalName] = useState("");
+  const [tab, setTab] = useState<"users" | "groups">("users");
+
+  useScreenView("Admin", "AccessManagement");
 
   return (
-    <div className="p-8 max-w-5xl mx-auto">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-semibold text-gray-900">Access management</h1>
-        <button
-          onClick={() => navigate("/admin/access/groups/new")}
-          className="px-4 py-2 bg-indigo-600 text-white rounded text-sm font-medium hover:bg-indigo-700"
-          aria-label="New group"
-        >
-          New group
-        </button>
+    <div className="flex flex-col w-full" style={{ height: PAGE_CONTAINER_HEIGHT }}>
+      <div className="flex-shrink-0 mb-3">
+        <h1 className="text-lg font-semibold text-gray-900">Access management</h1>
       </div>
 
-      <div className="flex gap-2 mb-6">
-        <button
-          onClick={() => setTab("groups")}
-          className={`px-4 py-2 rounded ${tab === "groups" ? "bg-indigo-600 text-white" : "bg-gray-100"}`}
-        >
-          Groups
-        </button>
-        <button
-          onClick={() => setTab("users")}
-          className={`px-4 py-2 rounded ${tab === "users" ? "bg-indigo-600 text-white" : "bg-gray-100"}`}
-        >
-          Users
-        </button>
-      </div>
-
-      {tab === "groups" && (
-        <div className="space-y-3">
-          {groups.isLoading && <div className="text-gray-500">Loading groups…</div>}
-          {groups.data?.groups?.map((g) => (
-            <div
-              key={g.id}
-              className="flex items-center justify-between bg-white border border-gray-200 rounded-lg p-4"
-            >
-              <div className="min-w-0 flex-1">
-                <button
-                  onClick={() => g.id && navigate(`/admin/access/groups/${g.id}`)}
-                  className="font-medium text-gray-900 hover:text-indigo-600 text-left"
-                >
-                  {g.name}
-                </button>
-                <p className="text-sm text-gray-500">
-                  {g.permissionCount} permissions · {g.memberCount} members
-                </p>
-              </div>
-              <div className="flex items-center gap-2 ml-4">
-                <button
-                  onClick={() => g.id && navigate(`/admin/access/groups/${g.id}`)}
-                  className="p-2 text-gray-400 hover:text-indigo-600 rounded-lg hover:bg-gray-50"
-                  aria-label={`Edit ${g.name}`}
-                >
-                  <Edit className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={() => g.id && deleteGroup.mutate(g.id)}
-                  disabled={deleteGroup.isPending}
-                  className="text-sm text-red-600 hover:underline"
-                  aria-label={`Delete ${g.name}`}
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
-          ))}
-          <p className="text-xs text-gray-400">
-            {catalogue.data?.permissions?.length ?? 0} permissions available.
-          </p>
-        </div>
-      )}
-
-      {tab === "users" && (
-        <div className="space-y-3">
-          {setCanPack.isError && (
-            <p className="mb-2 text-sm text-red-600">Failed to update packing permission. Please try again.</p>
-          )}
-          <form
-            className="mb-4 flex items-center gap-2"
-            onSubmit={(e) => {
-              e.preventDefault();
-              const name = newLocalName.trim();
-              if (name) {
-                createLocalUser.mutate(name, {
-                  onSuccess: () => setNewLocalName(""),
-                });
-              }
-            }}
+      <div className="flex-shrink-0 border-b border-gray-200 mb-4">
+        <nav className="flex gap-6" aria-label="Tabs">
+          <button
+            onClick={() => setTab("users")}
+            className={`py-2 text-sm font-medium border-b-2 transition-colors ${
+              tab === "users"
+                ? "border-indigo-500 text-indigo-600"
+                : "border-transparent text-gray-500 hover:text-gray-700"
+            }`}
           >
-            <input
-              value={newLocalName}
-              onChange={(e) => setNewLocalName(e.target.value)}
-              placeholder="New local operator name"
-              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm"
-            />
-            <button
-              type="submit"
-              disabled={createLocalUser.isPending}
-              className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-            >
-              Create local operator
-            </button>
-          </form>
-          {createLocalUser.isError && (
-            <p className="mt-1 text-sm text-red-600">Failed to create operator. Please try again.</p>
-          )}
-          {users.isLoading && <div className="text-gray-500">Loading users…</div>}
-          {users.data?.users?.map((u) => (
-            <div
-              key={u.id}
-              className="flex items-center justify-between bg-white border border-gray-200 rounded-lg p-4"
-            >
-              <div className="min-w-0 flex-1">
-                <button
-                  onClick={() => u.id && navigate(`/admin/access/users/${u.id}`)}
-                  className="font-medium text-gray-900 hover:text-indigo-600 text-left"
-                >
-                  {u.displayName}
-                </button>
-                <p className="text-sm text-gray-500">
-                  {u.email} · {u.groupIds?.length ?? 0} groups
-                </p>
-              </div>
-              <div className="flex items-center gap-2 ml-4">
-                {u.source === "Local" && (
-                  <span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">Local</span>
-                )}
-                <button
-                  onClick={() => u.id && setCanPack.mutate({ id: u.id, canPack: !u.canPack })}
-                  disabled={setCanPack.isPending && setCanPack.variables?.id === u.id}
-                  className={`text-sm ${u.canPack ? "text-indigo-600" : "text-gray-500"} hover:underline`}
-                  aria-label={`Toggle can pack ${u.displayName}`}
-                >
-                  {u.canPack ? "Packer ✓" : "Make packer"}
-                </button>
-                <button
-                  onClick={() => u.id && navigate(`/admin/access/users/${u.id}`)}
-                  className="p-2 text-gray-400 hover:text-indigo-600 rounded-lg hover:bg-gray-50"
-                  aria-label={`Edit ${u.displayName}`}
-                >
-                  <Edit className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={() =>
-                    u.id &&
-                    setActive.mutate({
-                      id: u.id,
-                      request: new SetUserActiveRequest({ userId: u.id, isActive: !u.isActive }),
-                    })
-                  }
-                  disabled={setActive.isPending}
-                  className={`text-sm ${u.isActive ? "text-red-600" : "text-green-600"} hover:underline`}
-                  aria-label={`Toggle active ${u.email}`}
-                >
-                  {u.isActive ? "Disable" : "Enable"}
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+            Users
+          </button>
+          <button
+            onClick={() => setTab("groups")}
+            className={`py-2 text-sm font-medium border-b-2 transition-colors ${
+              tab === "groups"
+                ? "border-indigo-500 text-indigo-600"
+                : "border-transparent text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            Groups
+          </button>
+        </nav>
+      </div>
+
+      {tab === "users" ? <UsersGrid /> : <GroupsGrid />}
     </div>
   );
 }

--- a/frontend/src/pages/GroupDetailPage.tsx
+++ b/frontend/src/pages/GroupDetailPage.tsx
@@ -40,11 +40,14 @@ function buildMemberMutationArgs(
   draft: { memberUserIds: string[] },
   original: { memberUserIds: string[] } | null,
   groupId: string,
-  allUsers: Array<{ id?: string | null; groupIds?: string[] | null }>
+  allUsers: Array<{ id?: string | null; groupIds?: string[] | null }>,
 ): Array<{ id: string; request: { userId: string; groupIds: string[] } }> {
   const originalIds = new Set(original?.memberUserIds ?? []);
   const newIds = new Set(draft.memberUserIds);
-  const result: Array<{ id: string; request: { userId: string; groupIds: string[] } }> = [];
+  const result: Array<{
+    id: string;
+    request: { userId: string; groupIds: string[] };
+  }> = [];
 
   for (const userId of draft.memberUserIds) {
     if (!originalIds.has(userId)) {
@@ -64,7 +67,10 @@ function buildMemberMutationArgs(
       if (user?.id) {
         result.push({
           id: userId,
-          request: { userId, groupIds: (user.groupIds ?? []).filter((g) => g !== groupId) },
+          request: {
+            userId,
+            groupIds: (user.groupIds ?? []).filter((g) => g !== groupId),
+          },
         });
       }
     }
@@ -142,7 +148,7 @@ export default function GroupDetailPage() {
             description: draft.description,
             permissions: draft.permissions,
             parentGroupIds: draft.parentGroupIds,
-          })
+          }),
         );
         toast.showSuccess("Group created", "The new group has been saved");
         navigate(`/admin/access/groups/${result.id}`);
@@ -161,14 +167,19 @@ export default function GroupDetailPage() {
       });
 
       const { data: freshUsersData } = await usersQuery.refetch();
-      const memberArgs = buildMemberMutationArgs(draft, original, id, freshUsersData?.users ?? []);
+      const memberArgs = buildMemberMutationArgs(
+        draft,
+        original,
+        id,
+        freshUsersData?.users ?? [],
+      );
       await Promise.all(
         memberArgs.map(({ id: userId, request }) =>
           assignUserGroups.mutateAsync({
             id: userId,
             request: new AssignUserGroupsRequest(request),
-          })
-        )
+          }),
+        ),
       );
 
       toast.showSuccess("Saved", "Group updated successfully");
@@ -176,21 +187,31 @@ export default function GroupDetailPage() {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("AuthorizationGroupCycleDetected")) {
-        toast.showError("Cycle detected", "This would create a circular group dependency");
+        toast.showError(
+          "Cycle detected",
+          "This would create a circular group dependency",
+        );
       } else {
-        toast.showError("Save failed", "An error occurred while saving changes");
+        toast.showError(
+          "Save failed",
+          "An error occurred while saving changes",
+        );
       }
     }
   };
 
   const onCancel = () => navigate("/admin/access");
 
-  const isSaving = updateGroup.isPending || createGroup.isPending || assignUserGroups.isPending;
-  const isLoading = !isCreateMode && (groupQuery.isLoading || usersQuery.isLoading);
+  const isSaving =
+    updateGroup.isPending ||
+    createGroup.isPending ||
+    assignUserGroups.isPending;
+  const isLoading =
+    !isCreateMode && (groupQuery.isLoading || usersQuery.isLoading);
 
   if (isLoading) {
     return (
-      <div className="p-8 max-w-5xl mx-auto">
+      <div className="flex flex-col h-full w-full p-3 md:p-4">
         <div className="text-gray-500">Loading group…</div>
       </div>
     );
@@ -199,105 +220,139 @@ export default function GroupDetailPage() {
   if (!draft) return null;
 
   return (
-    <div className="p-8 max-w-5xl mx-auto space-y-8">
-      <div className="flex items-center gap-4">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="text-gray-500 hover:text-gray-700 text-sm"
-        >
-          ← Access management
-        </button>
-        <h1 className="text-2xl font-semibold text-gray-900">
-          {isCreateMode ? "New group" : "Edit group"}
-        </h1>
-      </div>
-
-      <div className="space-y-4">
-        <div>
-          <label htmlFor="group-name" className="block text-sm font-medium text-gray-700 mb-1">
-            Name
-          </label>
-          <input
-            id="group-name"
-            type="text"
-            value={draft.name}
-            onChange={(e) => updateDraft({ name: e.target.value })}
-            aria-label="Name"
-            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+    <div className="flex flex-col h-full w-full p-3 md:p-4">
+      <div className="flex-shrink-0 flex items-center justify-between gap-4 mb-3">
+        <div className="flex items-center gap-4 min-w-0">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-gray-500 hover:text-gray-700 text-sm flex-shrink-0"
+          >
+            ← Access management
+          </button>
+          <h1 className="text-2xl font-semibold text-gray-900 truncate">
+            {isCreateMode ? "New group" : "Edit group"}
+          </h1>
         </div>
-        <div>
-          <label htmlFor="group-desc" className="block text-sm font-medium text-gray-700 mb-1">
-            Description
-          </label>
-          <input
-            id="group-desc"
-            type="text"
-            value={draft.description}
-            onChange={(e) => updateDraft({ description: e.target.value })}
-            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+        <div className="flex gap-3 flex-shrink-0">
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={isSaving}
+            className="px-5 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {isSaving ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isSaving}
+            className="px-5 py-2 border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
         </div>
       </div>
 
-      <section>
-        <h2 className="text-lg font-medium text-gray-900 mb-3">Permissions</h2>
-        <PermissionPicker
-          value={draft.permissions}
-          onChange={(permissions) => updateDraft({ permissions })}
-        />
-      </section>
+      <div className="flex-shrink-0 bg-white shadow rounded-lg p-4 mb-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label
+              htmlFor="group-name"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Name
+            </label>
+            <input
+              id="group-name"
+              type="text"
+              value={draft.name}
+              onChange={(e) => updateDraft({ name: e.target.value })}
+              aria-label="Name"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="group-desc"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Description
+            </label>
+            <input
+              id="group-desc"
+              type="text"
+              value={draft.description}
+              onChange={(e) => updateDraft({ description: e.target.value })}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+      </div>
 
-      {!isCreateMode && (
-        <section>
-          <h2 className="text-lg font-medium text-gray-900 mb-3">Included groups</h2>
-          <p className="text-sm text-gray-500 mb-3">
-            Groups in the right column are building blocks of this group — their permissions are
-            inherited.
-          </p>
-          <IncludedGroupsPicker
-            currentGroupId={id}
-            value={draft.parentGroupIds}
-            onChange={(parentGroupIds) => updateDraft({ parentGroupIds })}
-          />
+      <div
+        className={`flex-1 min-h-0 grid gap-4 ${
+          isCreateMode
+            ? "grid-cols-1 grid-rows-1"
+            : "grid-cols-1 xl:grid-cols-3 xl:grid-rows-1"
+        }`}
+      >
+        <section className="bg-white shadow rounded-lg p-4 flex flex-col min-h-0">
+          <h2 className="text-lg font-medium text-gray-900 mb-3 flex-shrink-0">
+            Permissions
+          </h2>
+          <div className="flex-1 min-h-0">
+            <PermissionPicker
+              value={draft.permissions}
+              onChange={(permissions) => updateDraft({ permissions })}
+              fillHeight
+            />
+          </div>
         </section>
-      )}
 
-      <section>
-        <h2 className="text-lg font-medium text-gray-900 mb-3">Members</h2>
         {!isCreateMode && (
-          <EntraMemberSearch
-            groupId={id}
-            currentMemberIds={draft.memberUserIds}
-            onMemberAdded={(userId) =>
-              updateDraft({ memberUserIds: [...draft.memberUserIds, userId] })
-            }
-          />
+          <section className="bg-white shadow rounded-lg p-4 flex flex-col min-h-0">
+            <div className="flex-shrink-0">
+              <h2 className="text-lg font-medium text-gray-900 mb-1">
+                Included groups
+              </h2>
+              <p className="text-sm text-gray-500 mb-3">
+                Groups in the right column are building blocks of this group —
+                their permissions are inherited.
+              </p>
+            </div>
+            <div className="flex-1 min-h-0">
+              <IncludedGroupsPicker
+                currentGroupId={id}
+                value={draft.parentGroupIds}
+                onChange={(parentGroupIds) => updateDraft({ parentGroupIds })}
+                fillHeight
+              />
+            </div>
+          </section>
         )}
-        <MembersPicker
-          value={draft.memberUserIds}
-          onChange={(memberUserIds) => updateDraft({ memberUserIds })}
-        />
-      </section>
 
-      <div className="flex gap-3 pt-4 border-t border-gray-200">
-        <button
-          type="button"
-          onClick={onSave}
-          disabled={isSaving}
-          className="px-5 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
-        >
-          {isSaving ? "Saving…" : "Save"}
-        </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={isSaving}
-          className="px-5 py-2 border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
-        >
-          Cancel
-        </button>
+        {!isCreateMode && (
+          <section className="bg-white shadow rounded-lg p-4 flex flex-col min-h-0">
+            <h2 className="text-lg font-medium text-gray-900 mb-3 flex-shrink-0">
+              Members
+            </h2>
+            <EntraMemberSearch
+              groupId={id}
+              currentMemberIds={draft.memberUserIds}
+              onMemberAdded={(userId) =>
+                updateDraft({ memberUserIds: [...draft.memberUserIds, userId] })
+              }
+            />
+            <div className="flex-1 min-h-0">
+              <MembersPicker
+                value={draft.memberUserIds}
+                onChange={(memberUserIds) => updateDraft({ memberUserIds })}
+                fillHeight
+              />
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/__tests__/AccessManagementPage.test.tsx
+++ b/frontend/src/pages/__tests__/AccessManagementPage.test.tsx
@@ -54,43 +54,47 @@ const renderPage = () =>
 
 beforeEach(() => mockNavigate.mockClear());
 
+const goToGroups = () => fireEvent.click(screen.getByRole("button", { name: "Groups" }));
+
 describe("AccessManagementPage", () => {
-  it("renders groups tab with group name and delete button", () => {
+  it("shows the Users tab by default", () => {
     renderPage();
-    expect(screen.getByText("Spravce")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /delete spravce/i })).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.queryByText("Spravce")).not.toBeInTheDocument();
   });
 
-  it("clicking the group name navigates to the group detail page", () => {
+  it("clicking a user name navigates to the user detail page", () => {
     renderPage();
-    fireEvent.click(screen.getByText("Spravce"));
-    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/1");
-  });
-
-  it("clicking the Edit button navigates to the group detail page", () => {
-    renderPage();
-    fireEvent.click(screen.getByRole("button", { name: /edit spravce/i }));
-    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/1");
-  });
-
-  it("clicking New group navigates to the create page", () => {
-    renderPage();
-    fireEvent.click(screen.getByRole("button", { name: /new group/i }));
-    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/new");
-  });
-
-  it("clicking a user name in Users tab navigates to user detail page", () => {
-    renderPage();
-    fireEvent.click(screen.getByRole("button", { name: /users/i }));
-    const aliceButtons = screen.getAllByRole("button", { name: /alice/i });
-    fireEvent.click(aliceButtons[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Alice" }));
     expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users/user-1");
   });
 
   it("clicking Edit icon in Users tab navigates to user detail page", () => {
     renderPage();
-    fireEvent.click(screen.getByRole("button", { name: /users/i }));
     fireEvent.click(screen.getByRole("button", { name: /edit alice/i }));
     expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users/user-1");
+  });
+
+  it("switching to Groups renders the group and its delete button", () => {
+    renderPage();
+    goToGroups();
+    expect(screen.getByText("Spravce")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete spravce/i })).toBeInTheDocument();
+  });
+
+  it("the New group button lives in the Groups tab and navigates to the create page", () => {
+    renderPage();
+    expect(screen.queryByRole("button", { name: /new group/i })).not.toBeInTheDocument();
+
+    goToGroups();
+    fireEvent.click(screen.getByRole("button", { name: /new group/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/new");
+  });
+
+  it("clicking the group name navigates to the group detail page", () => {
+    renderPage();
+    goToGroups();
+    fireEvent.click(screen.getByText("Spravce"));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/1");
   });
 });


### PR DESCRIPTION
Adds a tabbed Access Management page with dedicated **Users** and **Groups** grids (client-side sorting, filtering, and pagination via a shared `useClientGrid` hook and `SortableHeader`). Redesigns the group detail into a full-width, full-height **3-column layout** (Permissions | Included groups | Members) where each column scrolls internally instead of the whole page, with Save/Cancel pinned in a sticky top-right header. Adds a local search bar to the Permissions and Included-groups transfer lists (matching the Users filter) and makes the transfer lists fill their column height. Fixes the per-row `+`/`−` buttons that were being swallowed by `@dnd-kit` drag by giving the pointer sensor an activation distance. Registers `/admin/access/groups/*` as a full-height page in the Layout so the columns bound their height correctly.

Verified live in the running app and via `npm run build` + the access-management test suites (46 tests passing).