### PR TITLE
feat(dashboard): add packing stats dashboard tile

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
@@ -1,0 +1,99 @@
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Domain.Features.Packaging;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Packaging.DashboardTiles;
+
+[TileId("packingstats")]
+public class PackingStatsTile : ITile
+{
+    private readonly IPackageRepository _repo;
+    private readonly IPackingOrderClient _packingOrderClient;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PackingStatsTile> _logger;
+
+    public string Title => "Stav balení";
+    public string Description => "Balí se, zabaleno dnes a statistiky baličů";
+    public TileSize Size => TileSize.Medium;
+    public TileCategory Category => TileCategory.Orders;
+    public bool DefaultEnabled => true;
+    public bool AutoShow => true;
+    public string[] RequiredPermissions => Array.Empty<string>();
+
+    public PackingStatsTile(
+        IPackageRepository repo,
+        IPackingOrderClient packingOrderClient,
+        TimeProvider timeProvider,
+        ILogger<PackingStatsTile> logger)
+    {
+        _repo = repo;
+        _packingOrderClient = packingOrderClient;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<object> LoadDataAsync(
+        Dictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var now = _timeProvider.GetLocalNow();
+            var start = new DateTimeOffset(now.Date, now.Offset);
+            var end = start.AddDays(1);
+
+            var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(start, end, cancellationToken);
+
+            int? ordersBeingPackedCount = null;
+            try
+            {
+                ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to retrieve orders-being-packed count from Shoptet");
+            }
+
+            var packers = byPacker
+                .Select(p => new
+                {
+                    packerId = p.PackedByUserId,
+                    packerName = p.PackedBy ?? "Neznámý",
+                    orderCount = p.DistinctOrderCount,
+                })
+                .ToList();
+
+            return new
+            {
+                status = "success",
+                data = new
+                {
+                    ordersBeingPackedCount,
+                    totalOrdersPackedToday = total,
+                    packedByPacker = packers,
+                },
+                metadata = new
+                {
+                    lastUpdated = now,
+                    source = "PackageRepository"
+                },
+                drillDown = new
+                {
+                    filters = new { },
+                    enabled = true,
+                    tooltip = "Přejít do modulu Balení"
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load packing stats tile data");
+            return new
+            {
+                status = "error",
+                error = "Nepodařilo se načíst data balení"
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
@@ -46,9 +46,11 @@ public class PackingStatsTile : ITile
             var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(start, end, cancellationToken);
 
             int? ordersBeingPackedCount = null;
+            DateTimeOffset? ordersBeingPackedCountLastSync = null;
             try
             {
                 ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
+                ordersBeingPackedCountLastSync = now;
             }
             catch (Exception ex)
             {
@@ -70,6 +72,7 @@ public class PackingStatsTile : ITile
                 data = new
                 {
                     ordersBeingPackedCount,
+                    ordersBeingPackedCountLastSync,
                     totalOrdersPackedToday = total,
                     packedByPacker = packers,
                 },

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/PackagingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/PackagingModule.cs
@@ -1,10 +1,12 @@
 using Anela.Heblo.Application.Common.Behaviors;
+using Anela.Heblo.Application.Features.Packaging.DashboardTiles;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackages;
 using Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
 using Anela.Heblo.Application.Features.Packaging.Validators;
 using Anela.Heblo.Domain.Features.Packaging;
 using Anela.Heblo.Persistence.Repositories.Packaging;
+using Anela.Heblo.Xcc.Services.Dashboard;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +34,8 @@ public static class PackagingModule
         services.AddScoped<
             IPipelineBehavior<GetOrderTrackingNumberRequest, GetOrderTrackingNumberResponse>,
             ValidationBehavior<GetOrderTrackingNumberRequest, GetOrderTrackingNumberResponse>>();
+
+        services.RegisterTile<PackingStatsTile>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
@@ -35,9 +35,11 @@ public class GetPackingDashboardHandler : IRequestHandler<GetPackingDashboardReq
         var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(start, end, cancellationToken);
 
         int? ordersBeingPackedCount = null;
+        DateTimeOffset? ordersBeingPackedCountLastSync = null;
         try
         {
             ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
+            ordersBeingPackedCountLastSync = now;
         }
         catch (Exception ex)
         {
@@ -47,6 +49,7 @@ public class GetPackingDashboardHandler : IRequestHandler<GetPackingDashboardReq
         return new GetPackingDashboardResponse
         {
             OrdersBeingPackedCount = ordersBeingPackedCount,
+            OrdersBeingPackedCountLastSync = ordersBeingPackedCountLastSync,
             TotalOrdersPackedToday = total,
             PackedByPacker = byPacker
                 .Select(p => new PackerStatsDto

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardResponse.cs
@@ -5,6 +5,7 @@ namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboar
 public class GetPackingDashboardResponse : BaseResponse
 {
     public int? OrdersBeingPackedCount { get; set; }
+    public DateTimeOffset? OrdersBeingPackedCountLastSync { get; set; }
     public int TotalOrdersPackedToday { get; set; }
     public List<PackerStatsDto> PackedByPacker { get; set; } = new();
 

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -293,6 +293,10 @@ public class ModuleBoundariesTests
         // GetPackingDashboardHandler consumes IPackingOrderClient to read the orders-being-packed
         // count for the dashboard (no ShoptetOrders DTOs cross the boundary — the call returns int?).
         "Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard.GetPackingDashboardHandler -> Anela.Heblo.Application.Features.ShoptetOrders.IPackingOrderClient",
+
+        // PackingStatsTile is a dashboard tile that mirrors GetPackingDashboardHandler's logic;
+        // it consumes only IPackingOrderClient (returns int?) — no ShoptetOrders DTOs cross the boundary.
+        "Anela.Heblo.Application.Features.Packaging.DashboardTiles.PackingStatsTile -> Anela.Heblo.Application.Features.ShoptetOrders.IPackingOrderClient",
     };
 
     public static TheoryData<ModuleBoundaryRule> Rules() => new()

--- a/frontend/src/api/hooks/usePackingDashboard.ts
+++ b/frontend/src/api/hooks/usePackingDashboard.ts
@@ -9,6 +9,7 @@ export type PackerStatsDto = {
 
 export type GetPackingDashboardResponse = {
   ordersBeingPackedCount: number | null;
+  ordersBeingPackedCountLastSync: string | null;
   totalOrdersPackedToday: number;
   packedByPacker: PackerStatsDto[];
 };

--- a/frontend/src/components/baleni/BaleniHome.tsx
+++ b/frontend/src/components/baleni/BaleniHome.tsx
@@ -36,17 +36,25 @@ const TILES: BaleniTile[] = [
   },
 ];
 
-const StatCard: React.FC<{ label: string; value: React.ReactNode; loading: boolean }> = ({
-  label,
-  value,
-  loading,
-}) => (
+const StatCard: React.FC<{
+  label: string;
+  value: React.ReactNode;
+  loading: boolean;
+  syncTime?: string | null;
+}> = ({ label, value, loading, syncTime }) => (
   <div className="bg-white border border-border-light rounded-xl p-6 shadow-soft">
     <p className="text-sm text-neutral-gray mb-2">{label}</p>
     {loading ? (
       <div className="h-10 w-24 bg-secondary-blue-pale rounded animate-pulse" />
     ) : (
-      <p className="text-4xl font-bold text-primary-blue">{value}</p>
+      <>
+        <p className="text-4xl font-bold text-primary-blue">{value}</p>
+        {syncTime && (
+          <p className="text-xs text-neutral-gray mt-2">
+            sync {new Date(syncTime).toLocaleTimeString('cs-CZ', { hour: '2-digit', minute: '2-digit' })}
+          </p>
+        )}
+      </>
     )}
   </div>
 );
@@ -64,6 +72,7 @@ const BaleniHome: React.FC = () => {
             label="Balí se (Shoptet)"
             value={data?.ordersBeingPackedCount ?? '—'}
             loading={isLoading}
+            syncTime={data?.ordersBeingPackedCountLastSync}
           />
           <StatCard
             label="Zabaleno dnes"

--- a/frontend/src/components/dashboard/tiles/PackingStatsTile.tsx
+++ b/frontend/src/components/dashboard/tiles/PackingStatsTile.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface PackerStat {
+  packerId: string | null;
+  packerName: string;
+  orderCount: number;
+}
+
+interface PackingStatsData {
+  ordersBeingPackedCount: number | null;
+  totalOrdersPackedToday: number;
+  packedByPacker: PackerStat[];
+}
+
+interface PackingStatsTileProps {
+  data: {
+    status: string;
+    error?: string;
+    data?: PackingStatsData;
+    drillDown?: {
+      enabled: boolean;
+      tooltip?: string;
+    };
+  };
+}
+
+export const PackingStatsTile: React.FC<PackingStatsTileProps> = ({ data }) => {
+  const navigate = useNavigate();
+
+  if (data.status === 'error') {
+    return (
+      <div className="h-full flex items-center justify-center text-center">
+        <p className="text-red-600 text-sm">{data.error || 'Chyba při načítání dat'}</p>
+      </div>
+    );
+  }
+
+  const stats = data.data;
+  if (!stats) return null;
+
+  const isClickable = data.drillDown?.enabled ?? false;
+
+  return (
+    <div
+      className={`h-full flex flex-col gap-3 ${isClickable ? 'cursor-pointer' : ''}`}
+      onClick={isClickable ? () => navigate('/baleni') : undefined}
+      title={data.drillDown?.tooltip}
+    >
+      <div className="grid grid-cols-2 gap-3">
+        <div className="bg-secondary-blue-pale rounded-lg p-3 text-center">
+          <p className="text-xs text-neutral-gray mb-1">Balí se</p>
+          <p className="text-2xl font-bold text-primary-blue">
+            {stats.ordersBeingPackedCount ?? '—'}
+          </p>
+        </div>
+        <div className="bg-secondary-blue-pale rounded-lg p-3 text-center">
+          <p className="text-xs text-neutral-gray mb-1">Zabaleno dnes</p>
+          <p className="text-2xl font-bold text-primary-blue">
+            {stats.totalOrdersPackedToday}
+          </p>
+        </div>
+      </div>
+
+      {stats.packedByPacker.length > 0 && (
+        <ul className="space-y-1 flex-1 overflow-y-auto">
+          {stats.packedByPacker.map((p) => (
+            <li
+              key={p.packerId ?? p.packerName}
+              className="flex items-center justify-between py-1.5 px-2 bg-secondary-blue-pale rounded"
+            >
+              <span className="text-xs font-medium text-neutral-slate truncate">{p.packerName}</span>
+              <span className="text-xs font-bold text-primary-blue ml-2 flex-shrink-0">{p.orderCount}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {stats.packedByPacker.length === 0 && (
+        <p className="text-xs text-neutral-gray italic">Dnes zatím nikdo nezabalil žádnou objednávku.</p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/tiles/PackingStatsTile.tsx
+++ b/frontend/src/components/dashboard/tiles/PackingStatsTile.tsx
@@ -9,6 +9,7 @@ interface PackerStat {
 
 interface PackingStatsData {
   ordersBeingPackedCount: number | null;
+  ordersBeingPackedCountLastSync: string | null;
   totalOrdersPackedToday: number;
   packedByPacker: PackerStat[];
 }
@@ -53,6 +54,11 @@ export const PackingStatsTile: React.FC<PackingStatsTileProps> = ({ data }) => {
           <p className="text-2xl font-bold text-primary-blue">
             {stats.ordersBeingPackedCount ?? '—'}
           </p>
+          {stats.ordersBeingPackedCountLastSync && (
+            <p className="text-xs text-neutral-gray mt-1">
+              sync {new Date(stats.ordersBeingPackedCountLastSync).toLocaleTimeString('cs-CZ', { hour: '2-digit', minute: '2-digit' })}
+            </p>
+          )}
         </div>
         <div className="bg-secondary-blue-pale rounded-lg p-3 text-center">
           <p className="text-xs text-neutral-gray mb-1">Zabaleno dnes</p>

--- a/frontend/src/components/dashboard/tiles/TileContent.tsx
+++ b/frontend/src/components/dashboard/tiles/TileContent.tsx
@@ -13,6 +13,7 @@ import { DataQualityTile } from './DataQualityTile';
 import { DqtYesterdayStatusTile } from './DqtYesterdayStatusTile';
 import { WeatherForecastTile } from './WeatherForecastTile';
 import { FailedJobsTile } from './FailedJobsTile';
+import { PackingStatsTile } from './PackingStatsTile';
 import { DefaultTile } from './DefaultTile';
 import { Truck, PackageCheck, Package, FileText, Landmark, ClipboardList, Beaker, AlertTriangle, Gift } from 'lucide-react';
 
@@ -81,6 +82,8 @@ export const TileContent: React.FC<TileContentProps> = ({ tile }) => {
       return <WeatherForecastTile data={tile.data} />;
     case 'failedjobs':
       return <FailedJobsTile data={tile.data} />;
+    case 'packingstats':
+      return <PackingStatsTile data={tile.data} />;
     default:
       return <DefaultTile data={tile.data} />;
   }


### PR DESCRIPTION
## Summary

- Adds `PackingStatsTile` (BE + FE) showing orders-being-packed (Shoptet), total packed today, and a per-packer breakdown
- Registers the tile in `PackagingModule` (`TileCategory.Orders`, `TileSize.Medium`, enabled by default)
- Adds `PackingStatsTile` to the `PackagingShoptetOrdersAllowlist` in the architecture boundary test (same justification as `GetPackingDashboardHandler` — only `IPackingOrderClient` crosses, no ShoptetOrders DTOs)

## Test plan

- [ ] Dashboard settings show "Stav balení" tile under Orders category
- [ ] Tile displays "Balí se" and "Zabaleno dnes" counts correctly
- [ ] Per-packer list renders and matches BaleniHome overview
- [ ] Clicking the tile navigates to `/baleni`
- [ ] Architecture test `ModuleBoundariesTests` passes