### PR TITLE
feat: Unit tests for ProcessDailyConsumptionHandler

### DIFF
--- a/artifacts/feat-coverage-gap-packingmaterials-processdai/arch-review.r1.md
+++ b/artifacts/feat-coverage-gap-packingmaterials-processdai/arch-review.r1.md
@@ -1,0 +1,177 @@
+# Architecture Review: Unit tests for ProcessDailyConsumptionHandler
+
+## Skip Design: true
+
+Backend-only test addition. No UI, no new visual components, no changes to public contracts.
+
+## Architectural Fit Assessment
+
+The feature aligns with the project's testing strategy (`docs/architecture/testing-strategy.md`): xUnit + FluentAssertions + Moq, AAA structure, behavior-named tests. The handler under test is a standard MediatR handler with two injected dependencies (`IConsumptionCalculationService`, `ILogger<ProcessDailyConsumptionHandler>`) and four observable branches. The test surface is small and self-contained — exactly the unit-test sweet spot the strategy targets.
+
+However, **the spec contains three factual errors that conflict with the actual codebase**. They must be corrected before implementation, otherwise the tests will not compile.
+
+Main integration points:
+- `Anela.Heblo.Tests` test project (`backend/test/Anela.Heblo.Tests`) — already references Moq, NSubstitute, FluentAssertions, xUnit; no new packages needed.
+- Existing PackingMaterials test folder (`backend/test/Anela.Heblo.Tests/Features/PackingMaterials`) — flat layout, hand-rolled mocks for the repository/invoice-source surfaces. The handler under test does **not** touch those collaborators, so the hand-rolled mocks are not relevant here.
+- `IConsumptionCalculationService` interface — sole production collaborator that needs mocking.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ProcessDailyConsumptionHandlerTests  (new, xUnit test class)
+    │
+    ├── Mock<IConsumptionCalculationService>   (Moq)
+    │     └── stubs ProcessDailyConsumptionAsync per scenario
+    │
+    ├── Mock<ILogger<ProcessDailyConsumptionHandler>>   (Moq)
+    │     └── Verify(...) used only for the exception path (FR-4)
+    │
+    └── SUT: ProcessDailyConsumptionHandler
+            └── invoked directly via Handle(request, CancellationToken.None)
+```
+
+No MediatR pipeline, no DI container, no HTTP. The handler is instantiated by `new` with the two mocks.
+
+### Key Design Decisions
+
+#### Decision 1: Mocking library — Moq, not the hand-rolled `MockLogger<T>`
+**Options considered:**
+- (a) Reuse the existing hand-rolled `MockLogger<T>` in the PackingMaterials test folder and add a hand-rolled `MockConsumptionCalculationService`.
+- (b) Use `Mock<IConsumptionCalculationService>` and `Mock<ILogger<...>>` via Moq.
+- (c) Use NSubstitute (also referenced by the project).
+
+**Chosen approach:** (b) Moq.
+
+**Rationale:**
+- FR-4 requires verifying an error-level log entry was emitted. The current `MockLogger<T>` is a no-op (`Log` method does nothing) and cannot satisfy that assertion without modification.
+- Moq is already used by the neighboring backend handler tests (e.g. `Features/Packaging/FillTrackingNumbersJobTests.cs` — same project, same style of MediatR-adjacent handler).
+- The PackingMaterials folder's hand-rolled mocks (`MockPackingMaterialRepository`, `MockInvoiceConsumptionSource`) exist because those interfaces have stateful behavior worth simulating; `IConsumptionCalculationService` here only needs four scripted returns and one throw — no state machine, no benefit from a hand-rolled class.
+- Mixing Moq into the PackingMaterials folder is consistent with project-wide convention. The spec's "use whatever the surrounding tests use" is ambiguous here because the surrounding tests use *both* hand-rolled mocks *and* `MockLogger<T>` — but neither pattern fits the verification need.
+
+#### Decision 2: Test file location — flat under `Features/PackingMaterials/`, not in a nested `UseCases/ProcessDailyConsumption/` subfolder
+**Options considered:**
+- (a) Mirror source structure: `test/.../Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionHandlerTests.cs` (what the spec proposes).
+- (b) Match existing convention: `test/.../Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs`.
+
+**Chosen approach:** (b).
+
+**Rationale:** The entire existing `Features/PackingMaterials/` test folder is flat — `GetConsumptionHistoryHandlerTests.cs`, `AllocationHandlerTests.cs`, `PackingMaterialCrudHandlerTests.cs` etc. all sit at the top level despite their sources living in per-use-case subfolders. Introducing a nested `UseCases/ProcessDailyConsumption/` directory for a single file breaks convention without benefit. Other feature folders (`Features/Packaging`, `Features/Journal`) follow the same flat pattern.
+
+#### Decision 3: Logger double — `Mock<ILogger<T>>` with `Verify`, not a custom capturing logger
+**Options considered:**
+- (a) Extend the existing `MockLogger<T>` to capture log entries in a list.
+- (b) Use `Mock<ILogger<ProcessDailyConsumptionHandler>>` and `Verify(x => x.Log(LogLevel.Error, ...))`.
+- (c) Use `NullLogger<T>.Instance` and don't verify the log (drop the log-emission assertion from FR-4).
+
+**Chosen approach:** (b).
+
+**Rationale:** Moq's `ILogger` verification pattern is idiomatic and already used by `FillTrackingNumbersJobTests`. Verification reads:
+```
+loggerMock.Verify(
+    x => x.Log(
+        LogLevel.Error,
+        It.IsAny<EventId>(),
+        It.IsAny<It.IsAnyType>(),
+        It.Is<Exception>(e => e is InvalidOperationException),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+    Times.Once);
+```
+This keeps FR-4's "an error-level log entry is emitted" acceptance criterion testable without modifying existing infrastructure.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create exactly one new file:
+
+```
+backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+```
+
+No new folders. No changes to `Anela.Heblo.Tests.csproj` (Moq, FluentAssertions, xUnit already referenced).
+
+### Interfaces and Contracts
+
+The SUT and its collaborators (verified against source):
+
+```csharp
+// Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/
+public class ProcessDailyConsumptionRequest : IRequest<ProcessDailyConsumptionResponse>
+{
+    public DateOnly ProcessingDate { get; set; }    // NOTE: DateOnly, not DateTime
+}
+
+public class ProcessDailyConsumptionResponse : BaseResponse   // Success comes from BaseResponse
+{
+    public DateOnly ProcessedDate { get; set; }
+    public int MaterialsProcessed { get; set; }
+    public string Message { get; set; } = string.Empty;
+}
+
+// Application/Features/PackingMaterials/Services/IConsumptionCalculationService.cs
+public interface IConsumptionCalculationService
+{
+    Task<ProcessDailyConsumptionResult> ProcessDailyConsumptionAsync(
+        DateOnly processingDate,                            // DateOnly
+        CancellationToken cancellationToken = default);
+    // (HasDayAlreadyBeenProcessedAsync exists but is not exercised by the handler)
+}
+```
+
+`ProcessDailyConsumptionResult` exposes `WasRun` (bool) and `MaterialsProcessed` (int) — confirm exact property names and accessibility when stubbing.
+
+### Data Flow
+
+```
+Test                                Handler                       Mocked Service
+  │                                    │                                  │
+  ├─ new Mock<IConsumptionCalc...>()   │                                  │
+  ├─ Setup(... )─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─▶│
+  ├─ new Mock<ILogger<...>>()          │                                  │
+  ├─ new ProcessDailyConsumptionHandler(svcMock.Object, logMock.Object)   │
+  │                                    │                                  │
+  ├─ Handle(request, CancellationToken.None) ───────────────────────────▶ │
+  │                                    │ ProcessDailyConsumptionAsync ──▶ │
+  │                                    │ ◀── result (WasRun, MatProc)     │
+  │ ◀──── Response (Success, Message, MaterialsProcessed, ProcessedDate)  │
+  │                                    │                                  │
+  ├─ FluentAssertions on response      │                                  │
+  └─ Moq Verify on svcMock + logMock   │                                  │
+```
+
+Four test methods, each scripts the mock differently and asserts on `response` + `Verify`:
+
+| Test | Mock setup | Asserts on response | Mock verification |
+|---|---|---|---|
+| `Handle_ReturnsFailure_WhenAlreadyProcessed` | Returns `WasRun=false`, `MaterialsProcessed=42` (non-zero on purpose) | `Success=false`, `MaterialsProcessed=0`, `Message` contains "already processed" + date | svc called once with exact date & token |
+| `Handle_ReturnsSuccess_WhenMaterialsUpdated` | Returns `WasRun=true`, `MaterialsProcessed=5` | `Success=true`, `MaterialsProcessed=5`, `Message` contains date + "5" + "updated" | svc called once |
+| `Handle_ReturnsSuccessWithZeroCount_WhenNoInvoicesFound` | Returns `WasRun=true`, `MaterialsProcessed=0` | `Success=true`, `MaterialsProcessed=0`, `Message` contains date + "no invoices" | svc called once |
+| `Handle_ReturnsGenericError_WhenServiceThrows` | Throws `InvalidOperationException("secret database connection string")` | `Success=false`, `MaterialsProcessed=0`, `Message` is the generic literal and does **not** contain "secret database connection string" | logger.Log called once with `LogLevel.Error` and the same exception instance |
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `ProcessDailyConsumptionResult` may be a constructor-only `record` with positional parameters, blocking `new ProcessDailyConsumptionResult { WasRun = true, MaterialsProcessed = 5 }`. | LOW | Inspect the type when implementing; use the appropriate constructor or `with`-syntax. The shape is internal-application, no DTO/contract concerns. |
+| Message-content assertions (`Message.Should().Contain("already processed")`) couple tests to log/message wording, which may evolve. | LOW | Use `Contain` with stable substrings ("already processed", "no invoices", the date), not full-string equality. Avoid asserting on exact punctuation or casing beyond what the handler guarantees. |
+| Moq's `ILogger.Verify` signature is verbose and easy to typo; a wrong `It.IsAny<It.IsAnyType>()` produces a confusing mismatch. | LOW | Extract a small local helper in the test class (`VerifyErrorLogged(loggerMock, expectedException)`) so the verbose Moq expression appears once. |
+| Spec's FR-5 path (`UseCases/ProcessDailyConsumption/` subfolder) is wrong; a developer following the spec literally would create an inconsistent folder. | MEDIUM | This review's Decision 2 overrides FR-5. The amendment must be reflected in any prompt that drives implementation. |
+| Spec's FR-1 acceptance criterion ("mock invoked with the request's `ProcessingDate` and the supplied `CancellationToken`") treats `ProcessingDate` as `DateTime`; the actual type is `DateOnly`. | MEDIUM | Use `DateOnly` throughout the test. See Specification Amendments. |
+
+## Specification Amendments
+
+The spec must be corrected on three points before implementation:
+
+1. **Date type (FR-1 / FR-2 / FR-3 / FR-4 / "API / Interface Design"):** Every reference to `DateTime` for `ProcessingDate` and the service signature must be `DateOnly`. The actual production types are `DateOnly` (verified in `ProcessDailyConsumptionRequest.cs` and `IConsumptionCalculationService.cs`). Tests must construct `new DateOnly(2026, 1, 15)`-style values, and the mock setup signature must be `Setup(s => s.ProcessDailyConsumptionAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))`.
+
+2. **Test file location (FR-5):** Replace `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionHandlerTests.cs` with `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs`. The flat layout matches every other handler test in the folder (`GetConsumptionHistoryHandlerTests.cs`, `AllocationHandlerTests.cs`, etc.).
+
+3. **Mocking library (NFR-4 / "Dependencies"):** Resolve the "Moq or NSubstitute, whichever the surrounding tests use" ambiguity by mandating **Moq** for this file. Rationale: (a) Moq is the convention for handler tests in adjacent feature folders (`Features/Packaging/FillTrackingNumbersJobTests.cs`); (b) the existing `MockLogger<T>` in the PackingMaterials folder is a no-op and cannot satisfy FR-4's log-verification requirement; (c) Moq is already referenced in `Anela.Heblo.Tests.csproj` — no new package.
+
+All other functional/non-functional requirements stand unchanged.
+
+## Prerequisites
+
+None. The test project already references Moq 4.20.72, FluentAssertions 6.12.0, xUnit 2.9.2, and `Microsoft.Extensions.Logging.Abstractions` is transitively available. No migrations, no config, no infrastructure work required. Implementation can begin immediately once the three spec amendments above are accepted.

--- a/artifacts/feat-coverage-gap-packingmaterials-processdai/brief.md
+++ b/artifacts/feat-coverage-gap-packingmaterials-processdai/brief.md
@@ -1,0 +1,21 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionHandler.cs`
+
+## Coverage
+Zero tests. Not referenced in any test file.
+
+## What's not tested
+Three paths:
+1. **`result.WasRun == false`** — the service reports this date was already processed; handler returns `Success=false` with an idempotency message; no materials count is reported
+2. **`result.WasRun == true`, `MaterialsProcessed == 0`** — processing ran but found no invoices; returns `Success=true` with a "no invoices found" message
+3. **`result.WasRun == true`, `MaterialsProcessed > 0`** — normal success path; returns `Success=true` with a materials-updated message
+4. **Exception** — returns `Success=false` with a generic error message (exception detail is suppressed from the response)
+
+## Why it matters
+The `WasRun == false` guard is the idempotency gate preventing double-processing of daily consumption. If it stops working (e.g. the service interface changes), the same day's consumption gets processed multiple times, producing inflated packing material deductions. No test currently asserts this guard fires correctly.
+
+## Suggested approach
+Unit-test with a mocked `IConsumptionCalculationService`. Four tests, one per path. Assert `Success`, `MaterialsProcessed`, and `Message` on each. ~1 hour.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-08. Based on CI run #27104028537 (6568feba33640ae063b2cb6af3c81da31b3720e1)._

--- a/artifacts/feat-coverage-gap-packingmaterials-processdai/impl/main.r1.md
+++ b/artifacts/feat-coverage-gap-packingmaterials-processdai/impl/main.r1.md
@@ -1,0 +1,49 @@
+All tasks complete. Here is the output summary:
+
+---
+
+# Implementation: Unit tests for ProcessDailyConsumptionHandler
+
+## What was implemented
+
+Four characterization unit tests that lock in all four observable branches of `ProcessDailyConsumptionHandler.Handle`: the idempotency gate (`WasRun=false`), the success path with materials updated, the success path with no invoices, and the exception catch with non-leaking error message and verified error log emission.
+
+## Files created/modified
+
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs` — new file with test class, `MakeSut()` helper, 4 `[Fact]` tests, and `VerifyErrorLogged` Moq helper
+
+## Tests
+
+`ProcessDailyConsumptionHandlerTests.cs`:
+- `Handle_ReturnsFailure_WhenAlreadyProcessed` — FR-1: idempotency gate, WasRun=false forces Success=false, MaterialsProcessed=0 regardless of service result
+- `Handle_ReturnsSuccess_WhenMaterialsUpdated` — FR-2: WasRun=true with N=5 materials, count propagated, message contains date+count+"materials updated"
+- `Handle_ReturnsSuccessWithZeroCount_WhenNoInvoicesFound` — FR-3: WasRun=true with MaterialsProcessed=0, Success=true, message contains "No invoices"
+- `Handle_ReturnsGenericError_WhenServiceThrows` — FR-4: exception caught, generic message emitted, secret not leaked, LogLevel.Error verified via Moq ILogger.Verify
+
+## How to verify
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProcessDailyConsumptionHandlerTests"
+# Expected: Passed: 4, Failed: 0, Skipped: 0
+```
+
+## Notes
+
+- FR-6 verified: `git diff --name-only main...HEAD -- 'backend/src/**'` returned empty — zero production files touched
+- Full PackingMaterials regression: all 70 tests pass (66 pre-existing + 4 new)
+- One MEDIUM finding from the final review was addressed inline: tightened `"already processed"` to `"was already processed"` to pin the idempotency semantic more precisely
+- No new NuGet packages added — Moq 4.20.72, FluentAssertions 6.12.0, xUnit 2.9.2 were already present
+
+## PR Summary
+
+Added four characterization unit tests for `ProcessDailyConsumptionHandler` to prevent silent regressions in the idempotency guard, success message contract, and exception-suppression behavior. The handler had zero test coverage; these tests achieve 100% branch coverage.
+
+Uses Moq for `IConsumptionCalculationService` and `ILogger<ProcessDailyConsumptionHandler>` (no new packages), with a small `VerifyErrorLogged` helper to encapsulate the verbose Moq ILogger.Verify expression. All tests are in-memory and run in under 50 ms total.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs` — new test file: 4 tests + MakeSut() + VerifyErrorLogged helper
+
+## Status
+
+DONE

--- a/artifacts/feat-coverage-gap-packingmaterials-processdai/spec.r1.md
+++ b/artifacts/feat-coverage-gap-packingmaterials-processdai/spec.r1.md
@@ -1,0 +1,145 @@
+```markdown
+# Specification: Unit tests for ProcessDailyConsumptionHandler
+
+## Summary
+Add focused unit-test coverage for `ProcessDailyConsumptionHandler`, the MediatR handler that drives daily packing-material consumption processing. The handler currently has zero tests; this spec defines the four behavioral paths that must be locked in so the idempotency guard and response-shape contract cannot regress silently.
+
+## Background
+`ProcessDailyConsumptionHandler` orchestrates `IConsumptionCalculationService.ProcessDailyConsumptionAsync` and translates its result into a `ProcessDailyConsumptionResponse`. It is the entry point for the daily packing-material consumption job, and its `result.WasRun == false` branch is the **idempotency gate** that prevents the same date from being processed twice. A regression here would inflate packing-material deductions for every day the job re-runs.
+
+The handler is not referenced by any existing test file. CI run #27104028537 (commit 6568feba) flagged the gap on 2026-06-08 via the weekly coverage-gap routine.
+
+The handler currently exhibits four observable behaviors:
+
+1. **Already processed** — service returns `WasRun = false`; handler returns `Success = false`, `MaterialsProcessed = 0`, message stating the date was already processed.
+2. **Ran, no invoices** — service returns `WasRun = true`, `MaterialsProcessed = 0`; handler returns `Success = true`, `MaterialsProcessed = 0`, "no invoices found" message.
+3. **Ran, materials updated** — service returns `WasRun = true`, `MaterialsProcessed > 0`; handler returns `Success = true`, materials count propagated, "successfully processed … N materials updated" message.
+4. **Service throws** — handler logs the exception and returns `Success = false`, `MaterialsProcessed = 0`, a generic error message that **does not leak the exception detail**.
+
+## Functional Requirements
+
+### FR-1: Idempotency-gate test (`WasRun == false`)
+A unit test must assert that when `IConsumptionCalculationService.ProcessDailyConsumptionAsync` returns a result with `WasRun = false`, the handler produces a response with `Success = false`, `MaterialsProcessed = 0`, `ProcessedDate` equal to the request date, and a `Message` that explicitly identifies the date as already processed.
+
+**Acceptance criteria:**
+- Mocked service returns a result with `WasRun = false` (any `MaterialsProcessed` value, including non-zero, to prove the handler does not trust that field when `WasRun = false`).
+- Response `Success` is `false`.
+- Response `MaterialsProcessed` is `0`.
+- Response `ProcessedDate` equals the input `ProcessingDate`.
+- Response `Message` contains the processing date and indicates idempotency (e.g. contains "already processed").
+- The mock is invoked exactly once with the request's `ProcessingDate` and the supplied `CancellationToken`.
+
+### FR-2: Successful run with materials updated (`WasRun == true`, `MaterialsProcessed > 0`)
+A unit test must assert the normal success path where the service reports a positive materials-processed count.
+
+**Acceptance criteria:**
+- Mocked service returns `WasRun = true`, `MaterialsProcessed = N` where `N > 0` (use a non-trivial value such as 5).
+- Response `Success` is `true`.
+- Response `MaterialsProcessed` equals `N`.
+- Response `ProcessedDate` equals the input `ProcessingDate`.
+- Response `Message` references both the date and the `N` materials updated.
+
+### FR-3: Successful run with no invoices (`WasRun == true`, `MaterialsProcessed == 0`)
+A unit test must assert the success path where processing executed but found nothing to update.
+
+**Acceptance criteria:**
+- Mocked service returns `WasRun = true`, `MaterialsProcessed = 0`.
+- Response `Success` is `true` (the run is considered successful even with zero materials).
+- Response `MaterialsProcessed` is `0`.
+- Response `ProcessedDate` equals the input `ProcessingDate`.
+- Response `Message` indicates "no invoices" / "no materials were updated" semantics and includes the date.
+
+### FR-4: Exception handling test
+A unit test must assert that exceptions thrown by the service are caught, logged, and converted into a non-leaking error response.
+
+**Acceptance criteria:**
+- Mocked service throws an exception with an identifiable inner message (e.g. `InvalidOperationException("secret database connection string")`).
+- The handler does **not** propagate the exception (the test does not expect a thrown exception).
+- Response `Success` is `false`.
+- Response `MaterialsProcessed` is `0`.
+- Response `ProcessedDate` equals the input `ProcessingDate`.
+- Response `Message` is generic and does **not** contain the exception's message text or stack trace.
+- An error-level log entry is emitted (verified via a mocked/captured `ILogger<ProcessDailyConsumptionHandler>`).
+
+### FR-5: Test file placement and naming
+The new tests must live alongside other backend unit tests for the PackingMaterials feature, following the existing test-project conventions.
+
+**Acceptance criteria:**
+- A new test file `ProcessDailyConsumptionHandlerTests.cs` is added under the backend unit-test project's `Features/PackingMaterials/UseCases/ProcessDailyConsumption/` folder (mirroring the source structure).
+- Test class name: `ProcessDailyConsumptionHandlerTests`.
+- Each test method names the behavior under test (e.g. `Handle_ReturnsFailure_WhenAlreadyProcessed`, `Handle_ReturnsSuccess_WhenMaterialsUpdated`, `Handle_ReturnsSuccessWithZeroCount_WhenNoInvoicesFound`, `Handle_ReturnsGenericError_WhenServiceThrows`).
+- Tests follow AAA (Arrange-Act-Assert) structure.
+
+### FR-6: No production code changes
+This task is test-only. The handler's behavior must not change.
+
+**Acceptance criteria:**
+- No edits to `ProcessDailyConsumptionHandler.cs`, `ProcessDailyConsumptionRequest`, `ProcessDailyConsumptionResponse`, `IConsumptionCalculationService`, or any other production file.
+- Only test-project files and (if absolutely required) test-project package references are modified.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Each test runs in under 100 ms; full new test class runs in under 1 second.
+- Tests must be fully in-memory — no database, no HTTP, no file I/O.
+
+### NFR-2: Security
+- No real credentials, connection strings, or tokens appear in test fixtures.
+- The exception-handling test must affirmatively assert the response message does **not** leak exception details (defense in depth against information disclosure).
+
+### NFR-3: Reliability and isolation
+- Tests must be deterministic and independent: no shared mutable state, no ordering dependencies, no reliance on wall-clock time beyond a fixed `DateTime` value passed into the request.
+- Tests must pass under `dotnet test` both locally and in CI.
+
+### NFR-4: Maintainability
+- Use the test stack already established in the repository's backend unit-test project (xUnit + FluentAssertions + the project's existing mocking library — Moq or NSubstitute, whichever the surrounding tests use).
+- No new mocking library introduced for this task.
+- Test names describe behavior, not implementation, per `csharp-testing.md`.
+
+### NFR-5: Coverage contribution
+- The four tests must cover all four branches of `ProcessDailyConsumptionHandler.Handle`: the `!result.WasRun` early return, the `MaterialsProcessed > 0` message arm, the `MaterialsProcessed == 0` message arm, and the `catch` block.
+- After the change, branch coverage of `ProcessDailyConsumptionHandler` must be 100%.
+
+## Data Model
+No data-model changes. Tests interact only with the existing in-memory types:
+
+- `ProcessDailyConsumptionRequest` — input carrying `ProcessingDate`.
+- `ProcessDailyConsumptionResponse` — output carrying `Success`, `ProcessedDate`, `MaterialsProcessed`, `Message`.
+- The result type returned by `IConsumptionCalculationService.ProcessDailyConsumptionAsync` — exposing `WasRun` and `MaterialsProcessed`.
+
+## API / Interface Design
+No API changes. Tests exercise the MediatR handler directly by invoking `Handle(request, cancellationToken)`; they do not go through the MediatR pipeline or HTTP.
+
+The collaborator surface mocked in each test:
+
+```
+IConsumptionCalculationService
+  Task<{result with WasRun, MaterialsProcessed}> ProcessDailyConsumptionAsync(
+      DateTime processingDate,
+      CancellationToken cancellationToken)
+```
+
+A captured/mocked `ILogger<ProcessDailyConsumptionHandler>` is wired in for verification in the exception-path test (info-level logs may be ignored).
+
+## Dependencies
+- Existing backend unit-test project (xUnit-based).
+- FluentAssertions (already in use across the repo).
+- The repo's established mocking library (Moq or NSubstitute — pick whichever the neighboring PackingMaterials handler tests use; do not introduce a second one).
+- `Microsoft.Extensions.Logging.Abstractions` for an `ILogger<>` test double (already transitively available).
+
+No new NuGet packages should be required.
+
+## Out of Scope
+- Integration tests, end-to-end tests, or HTTP-level tests for this handler.
+- Tests for `IConsumptionCalculationService` itself or any downstream collaborator (invoice fetch, material repository, persistence).
+- Refactoring the handler — e.g., extracting message strings, returning typed result objects, surfacing exception detail differently.
+- Changes to logging structure or log-message text.
+- Localization of response messages.
+- Performance/load tests.
+- Adding feature-flag gating to the handler.
+- Backfilling tests for unrelated PackingMaterials handlers.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-coverage-gap-packingmaterials-processdai/task-plan.r1.md
+++ b/artifacts/feat-coverage-gap-packingmaterials-processdai/task-plan.r1.md
@@ -1,0 +1,17 @@
+Plan saved to `docs/superpowers/plans/2026-06-11-process-daily-consumption-handler-tests.md`.
+
+**Summary of the plan (5 tasks, ~25 minutes of work):**
+
+1. **Task 1 — Scaffold + idempotency test (FR-1):** Create the test file with a `MakeSut()` helper using `Mock<IConsumptionCalculationService>` + `Mock<ILogger<…>>`, plus the `Handle_ReturnsFailure_WhenAlreadyProcessed` test. Service stub returns `WasRun=false, MaterialsProcessed=42` to prove the handler ignores the count when the date was already processed.
+2. **Task 2 — Success with N materials (FR-2):** Append `Handle_ReturnsSuccess_WhenMaterialsUpdated`, asserting the count is propagated and message contains date, N, and "materials updated".
+3. **Task 3 — Success with no invoices (FR-3):** Append `Handle_ReturnsSuccessWithZeroCount_WhenNoInvoicesFound`, asserting `Success=true` with `MaterialsProcessed=0` and message contains "No invoices".
+4. **Task 4 — Exception path (FR-4 + NFR-2):** Append `Handle_ReturnsGenericError_WhenServiceThrows`, asserting the generic message literal, affirmative absence of the secret/exception-type-name, and a single `LogLevel.Error` `Verify` carrying the same exception instance (via a small `VerifyErrorLogged` helper).
+5. **Task 5 — Final validation:** Run `dotnet format`, full `ProcessDailyConsumptionHandlerTests` filter run, `git diff --name-only main...HEAD -- 'backend/src/**'` to enforce FR-6 (no prod changes), and full PackingMaterials regression sweep.
+
+**Key adjustments baked in from the arch review:**
+- `DateOnly` everywhere (not `DateTime`).
+- Flat folder path `Features/PackingMaterials/` (not nested `UseCases/ProcessDailyConsumption/`).
+- Moq for both service and logger (the existing `MockLogger<T>` is a no-op and can't satisfy the log-verification requirement).
+- `ProcessDailyConsumptionResult` is a `sealed record` with **positional** constructor — flagged with an explicit warning so the engineer doesn't try object-initializer syntax.
+
+Each task commits independently with conventional `test(packingmaterials): …` messages, giving four behavioral commits + one optional formatting commit.

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
@@ -43,7 +43,7 @@ public class ProcessDailyConsumptionHandlerTests
         response.Success.Should().BeFalse();
         response.MaterialsProcessed.Should().Be(0);
         response.ProcessedDate.Should().Be(TestDate);
-        response.Message.Should().Contain("already processed");
+        response.Message.Should().Contain("was already processed");
         response.Message.Should().Contain(TestDate.ToString());
 
         service.Verify(

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
@@ -1,0 +1,53 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Services;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.ProcessDailyConsumption;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class ProcessDailyConsumptionHandlerTests
+{
+    private static readonly DateOnly TestDate = new(2026, 1, 15);
+
+    private static (
+        ProcessDailyConsumptionHandler Sut,
+        Mock<IConsumptionCalculationService> Service,
+        Mock<ILogger<ProcessDailyConsumptionHandler>> Logger)
+        MakeSut()
+    {
+        var service = new Mock<IConsumptionCalculationService>();
+        var logger = new Mock<ILogger<ProcessDailyConsumptionHandler>>();
+        var sut = new ProcessDailyConsumptionHandler(service.Object, logger.Object);
+        return (sut, service, logger);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenAlreadyProcessed()
+    {
+        // Arrange
+        var (sut, service, _) = MakeSut();
+        // MaterialsProcessed=42 on the service result proves the handler ignores it
+        // when WasRun=false (it must force MaterialsProcessed to 0 in the response).
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessDailyConsumptionResult(WasRun: false, MaterialsProcessed: 42));
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.MaterialsProcessed.Should().Be(0);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Contain("already processed");
+        response.Message.Should().Contain(TestDate.ToString());
+
+        service.Verify(
+            s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
@@ -50,4 +50,32 @@ public class ProcessDailyConsumptionHandlerTests
             s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenMaterialsUpdated()
+    {
+        // Arrange
+        const int materialsUpdated = 5;
+        var (sut, service, _) = MakeSut();
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessDailyConsumptionResult(WasRun: true, MaterialsProcessed: materialsUpdated));
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.MaterialsProcessed.Should().Be(materialsUpdated);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Contain(TestDate.ToString());
+        response.Message.Should().Contain(materialsUpdated.ToString());
+        response.Message.Should().Contain("materials updated");
+
+        service.Verify(
+            s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
@@ -104,4 +104,49 @@ public class ProcessDailyConsumptionHandlerTests
             s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_ReturnsGenericError_WhenServiceThrows()
+    {
+        // Arrange
+        const string secretDetail = "secret database connection string";
+        var thrown = new InvalidOperationException(secretDetail);
+
+        var (sut, service, logger) = MakeSut();
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert — response shape
+        response.Success.Should().BeFalse();
+        response.MaterialsProcessed.Should().Be(0);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Be("An unexpected error occurred while processing daily consumption.");
+
+        // Defense-in-depth: the secret must not leak into the message
+        response.Message.Should().NotContain(secretDetail);
+        response.Message.Should().NotContain(nameof(InvalidOperationException));
+
+        // Logger contract: an Error-level entry was emitted with the same exception instance
+        VerifyErrorLogged(logger, thrown);
+    }
+
+    private static void VerifyErrorLogged(
+        Mock<ILogger<ProcessDailyConsumptionHandler>> logger,
+        Exception expected)
+    {
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                expected,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
@@ -78,4 +78,30 @@ public class ProcessDailyConsumptionHandlerTests
             s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccessWithZeroCount_WhenNoInvoicesFound()
+    {
+        // Arrange
+        var (sut, service, _) = MakeSut();
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessDailyConsumptionResult(WasRun: true, MaterialsProcessed: 0));
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.MaterialsProcessed.Should().Be(0);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Contain("No invoices");
+        response.Message.Should().Contain(TestDate.ToString());
+
+        service.Verify(
+            s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/docs/superpowers/plans/2026-06-11-process-daily-consumption-handler-tests.md
+++ b/docs/superpowers/plans/2026-06-11-process-daily-consumption-handler-tests.md
@@ -1,0 +1,432 @@
+# ProcessDailyConsumptionHandler Unit Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four xUnit characterization tests that lock in the current behavior of `ProcessDailyConsumptionHandler` so its idempotency guard, success/no-invoice messaging, and exception-suppression cannot regress silently.
+
+**Architecture:** A single new test file under `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/` mocks `IConsumptionCalculationService` and `ILogger<ProcessDailyConsumptionHandler>` with Moq, instantiates the handler directly, and asserts response shape + a `LogLevel.Error` log entry via FluentAssertions and `Mock.Verify`. No new packages, no nested folders, no production code touched.
+
+**Tech Stack:** xUnit 2.9.2, FluentAssertions 6.12.0, Moq 4.20.72, `Microsoft.Extensions.Logging.Abstractions` (all already referenced by `Anela.Heblo.Tests.csproj`).
+
+---
+
+## Context
+
+The production code (`backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/`) is **already complete and shipped**. This is **characterization testing**, not classic TDD: each test is written to lock in the handler's *current observable behavior*. Therefore the rhythm is:
+
+1. Add the test.
+2. Run it — it should PASS the first time (you are characterizing existing behavior).
+3. If it fails, **read the failure carefully** — either the test assertion is wrong about what the handler does, or there is a real handler bug. Fix the test only after confirming what the source actually emits. Never edit the handler in this task.
+4. Commit.
+
+### Authoritative source-of-truth references (read before writing tests)
+
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionHandler.cs` — handler with the four branches under test.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionRequest.cs` — `class`, single property `DateOnly ProcessingDate`.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionResponse.cs` — `class : BaseResponse` with `DateOnly ProcessedDate`, `int MaterialsProcessed`, `string Message`.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Services/IConsumptionCalculationService.cs` — the only collaborator we mock.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Services/ProcessDailyConsumptionResult.cs` — `sealed record (bool WasRun, int MaterialsProcessed)` with **positional constructor**; construct via `new ProcessDailyConsumptionResult(true, 5)`, NOT via object-initializer syntax.
+- `backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs` — reference style for Moq-based handler tests in this repo. Read it before starting Task 1.
+
+### Exact message strings the handler emits (copy from source for assertions)
+
+| Branch | Exact message format |
+|---|---|
+| `!result.WasRun` | `$"Daily consumption for {request.ProcessingDate} was already processed"` |
+| `WasRun=true, MaterialsProcessed > 0` | `$"Daily consumption successfully processed for {request.ProcessingDate}. {result.MaterialsProcessed} materials updated."` |
+| `WasRun=true, MaterialsProcessed == 0` | `$"No invoices found for {request.ProcessingDate} — no materials were updated."` (note: that is an em-dash `—`, not a hyphen) |
+| Exception caught | `"An unexpected error occurred while processing daily consumption."` (no exception detail leaked) |
+
+Assertions must use **substring `Contain`**, not full-string equality, except for the exception-path message where the literal must be matched and the leaked exception text must be affirmatively absent.
+
+### Exact logger error call to verify (FR-4)
+
+```csharp
+_logger.LogError(ex, "Error processing daily consumption for {Date}", request.ProcessingDate);
+```
+
+Moq verification target: `LogLevel.Error` was emitted exactly once with the thrown exception instance attached.
+
+---
+
+## File Structure
+
+Create exactly one new file:
+
+```
+backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+```
+
+No new folders, no project-file edits, no production-source edits.
+
+---
+
+## Task 1: Scaffold the test class and add the idempotency test (FR-1)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs`
+
+**FR mapped:** FR-1 (idempotency gate), FR-5 (file location + naming), FR-6 (test-only).
+
+- [ ] **Step 1: Create the file with the test class skeleton, shared SUT builder, and the FR-1 test**
+
+Path: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs`
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Services;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.ProcessDailyConsumption;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class ProcessDailyConsumptionHandlerTests
+{
+    private static readonly DateOnly TestDate = new(2026, 1, 15);
+
+    private static (
+        ProcessDailyConsumptionHandler Sut,
+        Mock<IConsumptionCalculationService> Service,
+        Mock<ILogger<ProcessDailyConsumptionHandler>> Logger)
+        MakeSut()
+    {
+        var service = new Mock<IConsumptionCalculationService>();
+        var logger = new Mock<ILogger<ProcessDailyConsumptionHandler>>();
+        var sut = new ProcessDailyConsumptionHandler(service.Object, logger.Object);
+        return (sut, service, logger);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenAlreadyProcessed()
+    {
+        // Arrange
+        var (sut, service, _) = MakeSut();
+        // MaterialsProcessed=42 on the service result proves the handler ignores it
+        // when WasRun=false (it must force MaterialsProcessed to 0 in the response).
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessDailyConsumptionResult(WasRun: false, MaterialsProcessed: 42));
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.MaterialsProcessed.Should().Be(0);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Contain("already processed");
+        response.Message.Should().Contain(TestDate.ToString());
+
+        service.Verify(
+            s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Build the test project to catch type errors early**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds. If it fails on `ProcessDailyConsumptionResult`, double-check it is constructed via the positional `record` constructor (`new ProcessDailyConsumptionResult(WasRun: false, MaterialsProcessed: 42)`), not an object-initializer.
+
+- [ ] **Step 3: Run the test and confirm it passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProcessDailyConsumptionHandlerTests.Handle_ReturnsFailure_WhenAlreadyProcessed" \
+  --no-build
+```
+
+Expected: `Passed: 1`. If it fails, re-read the handler's `!result.WasRun` branch and adjust the assertion to match the actual emitted text — do **not** change the handler.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+git commit -m "test(packingmaterials): cover ProcessDailyConsumption idempotency gate"
+```
+
+---
+
+## Task 2: Add success-with-materials-updated test (FR-2)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs`
+
+**FR mapped:** FR-2.
+
+- [ ] **Step 1: Append the FR-2 test method to the existing `ProcessDailyConsumptionHandlerTests` class**
+
+Insert this method directly below `Handle_ReturnsFailure_WhenAlreadyProcessed`, inside the same class:
+
+```csharp
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenMaterialsUpdated()
+    {
+        // Arrange
+        const int materialsUpdated = 5;
+        var (sut, service, _) = MakeSut();
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessDailyConsumptionResult(WasRun: true, MaterialsProcessed: materialsUpdated));
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.MaterialsProcessed.Should().Be(materialsUpdated);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Contain(TestDate.ToString());
+        response.Message.Should().Contain(materialsUpdated.ToString());
+        response.Message.Should().Contain("materials updated");
+
+        service.Verify(
+            s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run the new test and confirm it passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProcessDailyConsumptionHandlerTests.Handle_ReturnsSuccess_WhenMaterialsUpdated"
+```
+
+Expected: `Passed: 1`. If `Contain("materials updated")` fails, inspect the exact handler message (`$"Daily consumption successfully processed for {request.ProcessingDate}. {result.MaterialsProcessed} materials updated."`) — the substring is lower-case and includes the trailing word "updated".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+git commit -m "test(packingmaterials): cover ProcessDailyConsumption success with N materials"
+```
+
+---
+
+## Task 3: Add success-with-no-invoices test (FR-3)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs`
+
+**FR mapped:** FR-3.
+
+- [ ] **Step 1: Append the FR-3 test method to the existing class**
+
+Insert directly below the FR-2 test:
+
+```csharp
+    [Fact]
+    public async Task Handle_ReturnsSuccessWithZeroCount_WhenNoInvoicesFound()
+    {
+        // Arrange
+        var (sut, service, _) = MakeSut();
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessDailyConsumptionResult(WasRun: true, MaterialsProcessed: 0));
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.MaterialsProcessed.Should().Be(0);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Contain("No invoices");
+        response.Message.Should().Contain(TestDate.ToString());
+
+        service.Verify(
+            s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run the new test and confirm it passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProcessDailyConsumptionHandlerTests.Handle_ReturnsSuccessWithZeroCount_WhenNoInvoicesFound"
+```
+
+Expected: `Passed: 1`. The handler emits `$"No invoices found for {date} — no materials were updated."`, so `Contain("No invoices")` is a stable, casing-correct substring.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+git commit -m "test(packingmaterials): cover ProcessDailyConsumption no-invoices success path"
+```
+
+---
+
+## Task 4: Add exception-handling test with non-leaking message + log verification (FR-4)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs`
+
+**FR mapped:** FR-4, NFR-2 (no exception detail leaks).
+
+- [ ] **Step 1: Append the FR-4 test method AND a small Moq logger-verification helper**
+
+Insert below the FR-3 test, still inside the same class:
+
+```csharp
+    [Fact]
+    public async Task Handle_ReturnsGenericError_WhenServiceThrows()
+    {
+        // Arrange
+        const string secretDetail = "secret database connection string";
+        var thrown = new InvalidOperationException(secretDetail);
+
+        var (sut, service, logger) = MakeSut();
+        service
+            .Setup(s => s.ProcessDailyConsumptionAsync(TestDate, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+
+        var request = new ProcessDailyConsumptionRequest { ProcessingDate = TestDate };
+
+        // Act
+        var response = await sut.Handle(request, CancellationToken.None);
+
+        // Assert — response shape
+        response.Success.Should().BeFalse();
+        response.MaterialsProcessed.Should().Be(0);
+        response.ProcessedDate.Should().Be(TestDate);
+        response.Message.Should().Be("An unexpected error occurred while processing daily consumption.");
+
+        // Defense-in-depth: the secret must not leak into the message
+        response.Message.Should().NotContain(secretDetail);
+        response.Message.Should().NotContain(nameof(InvalidOperationException));
+
+        // Logger contract: an Error-level entry was emitted with the same exception instance
+        VerifyErrorLogged(logger, thrown);
+    }
+
+    private static void VerifyErrorLogged(
+        Mock<ILogger<ProcessDailyConsumptionHandler>> logger,
+        Exception expected)
+    {
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                expected,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 2: Build to catch any Moq generic-argument typos in the verify expression**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds. If you see `CS0411` ("type arguments cannot be inferred") on the `logger.Verify(...)` call, the `It.IsAnyType` lines are wrong — copy them verbatim from the snippet above.
+
+- [ ] **Step 3: Run the new test and confirm it passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProcessDailyConsumptionHandlerTests.Handle_ReturnsGenericError_WhenServiceThrows"
+```
+
+Expected: `Passed: 1`. If `VerifyErrorLogged` fails with "expected invocation on the mock once, but was 0 times", confirm the handler's `catch` block still calls `_logger.LogError(ex, ...)`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+git commit -m "test(packingmaterials): cover ProcessDailyConsumption exception path (no leak, error log)"
+```
+
+---
+
+## Task 5: Final validation — format, full-class run, sanity-check the production source is untouched
+
+**Files:**
+- Modify (formatting only): `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs` (if `dotnet format` rewrites whitespace).
+
+**FR mapped:** FR-5 (naming + AAA), FR-6 (no prod changes), NFR-3 (deterministic), NFR-5 (full 4-branch coverage).
+
+- [ ] **Step 1: Run `dotnet format` against the test project to apply analyzer fixes**
+
+```bash
+dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: exit 0; either no changes or whitespace-only changes in the new test file.
+
+- [ ] **Step 2: Run the full `ProcessDailyConsumptionHandlerTests` class**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProcessDailyConsumptionHandlerTests"
+```
+
+Expected: `Passed: 4, Failed: 0, Skipped: 0`. Total wall-clock under 1 second per NFR-1.
+
+- [ ] **Step 3: Sanity-check that no production file was modified**
+
+```bash
+git diff --name-only main...HEAD -- 'backend/src/**'
+```
+
+Expected: empty output. If anything in `backend/src/` shows up, FR-6 has been violated — revert those changes before continuing.
+
+- [ ] **Step 4: Run the full PackingMaterials test folder to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Features.PackingMaterials"
+```
+
+Expected: all tests pass (the new four plus every pre-existing PackingMaterials test).
+
+- [ ] **Step 5: Commit any formatter changes (only if `git status` is non-empty)**
+
+```bash
+git status --short
+```
+
+If `git status` shows changes:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs
+git commit -m "chore: apply dotnet format to ProcessDailyConsumptionHandlerTests"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Self-Review Notes (from the plan author)
+
+- **Spec FR-1 coverage** — Task 1 asserts `Success=false`, `MaterialsProcessed=0`, `ProcessedDate==input`, `Message` contains "already processed", and verifies the mock was called exactly once with the exact `DateOnly` and any `CancellationToken`. ✅
+- **Spec FR-2 coverage** — Task 2 uses `materialsUpdated=5`, asserts the count is propagated and the message contains the date, the number, and "materials updated". ✅
+- **Spec FR-3 coverage** — Task 3 asserts the success-with-zero-count semantics and contains "No invoices" (matches the handler's exact casing). ✅
+- **Spec FR-4 coverage** — Task 4 asserts the exact generic message string, affirmatively asserts the secret does **not** leak (NFR-2), and verifies a single `LogLevel.Error` call carrying the same exception instance. ✅
+- **Spec FR-5 coverage** — File at flat `Features/PackingMaterials/` path matching every other handler test in the folder; class `ProcessDailyConsumptionHandlerTests`; methods named per the spec; AAA layout. The architecture review's Decision 2 overrides the spec's nested `UseCases/ProcessDailyConsumption/` suggestion. ✅
+- **Spec FR-6 coverage** — Task 5 Step 3 explicitly diffs `backend/src/` against `main` and fails the task if anything appears. ✅
+- **NFR-1 (perf)** — Pure in-memory mocks; the full filter run should comfortably stay under 1 second. ✅
+- **NFR-2 (security)** — `secretDetail` and `nameof(InvalidOperationException)` are both asserted absent from the response message. ✅
+- **NFR-3 (isolation)** — `MakeSut()` constructs a fresh handler + fresh mocks per test; no shared mutable state; `TestDate` is a `const`-equivalent `static readonly`. ✅
+- **NFR-4 (maintainability)** — Single mocking library (Moq), already in `Anela.Heblo.Tests.csproj`. No NuGet additions. ✅
+- **NFR-5 (coverage)** — Four tests = four handler branches: `!WasRun` early return, `MaterialsProcessed > 0` arm, `MaterialsProcessed == 0` arm, `catch` block. 100% branch coverage of `ProcessDailyConsumptionHandler.Handle`. ✅
+- **Placeholder scan** — Every step shows the exact code / command / expected output. No "TBD", no "add appropriate handling", no "similar to". ✅
+- **Type consistency** — Throughout the plan: `DateOnly` (not `DateTime`), `ProcessDailyConsumptionResult` constructed via positional `record` syntax (not object initializer), `Mock<ILogger<ProcessDailyConsumptionHandler>>` (not `MockLogger<T>` no-op), `It.IsAnyType` in the verify expression. All consistent across Tasks 1–5. ✅


### PR DESCRIPTION

Added four characterization unit tests for `ProcessDailyConsumptionHandler` to prevent silent regressions in the idempotency guard, success message contract, and exception-suppression behavior. The handler had zero test coverage; these tests achieve 100% branch coverage.

Uses Moq for `IConsumptionCalculationService` and `ILogger<ProcessDailyConsumptionHandler>` (no new packages), with a small `VerifyErrorLogged` helper to encapsulate the verbose Moq ILogger.Verify expression. All tests are in-memory and run in under 50 ms total.

### Changes
- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ProcessDailyConsumptionHandlerTests.cs` — new test file: 4 tests + MakeSut() + VerifyErrorLogged helper

---

Closes #2754

### Tokens used
10635388
