### PR TITLE
feat(auth): include required permission in 403 response body

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Identity.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
 using Anela.Heblo.API.Infrastructure.Authentication;
 using Anela.Heblo.API.Infrastructure;
 using Anela.Heblo.Domain.Features.Configuration;
@@ -113,5 +114,9 @@ public static class AuthenticationExtensions
         });
 
         services.AddScoped<Microsoft.AspNetCore.Authentication.IClaimsTransformation, PermissionClaimsTransformation>();
+
+        // Replace the bare 403 from the authorization middleware with a structured body naming the
+        // missing permission(s). Covers both mock and real auth — both call this method.
+        services.AddSingleton<IAuthorizationMiddlewareResultHandler, PermissionAuthorizationResultHandler>();
     }
 }

--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionAuthorizationResultHandler.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/PermissionAuthorizationResultHandler.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.API.Infrastructure.Authentication;
+
+/// <summary>
+/// Augments the bare 403 produced by ASP.NET Core's authorization middleware with a structured
+/// <see cref="BaseResponse"/>-shaped body that names the permission(s) the caller is missing.
+/// Anonymous requests (401 challenge) and permission-less forbids fall through to the framework
+/// default handler unchanged.
+/// </summary>
+public sealed class PermissionAuthorizationResultHandler : IAuthorizationMiddlewareResultHandler
+{
+    private readonly IAuthorizationMiddlewareResultHandler _fallback;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public PermissionAuthorizationResultHandler(IOptions<JsonOptions> jsonOptions)
+        : this(jsonOptions, new AuthorizationMiddlewareResultHandler())
+    {
+    }
+
+    internal PermissionAuthorizationResultHandler(
+        IOptions<JsonOptions> jsonOptions,
+        IAuthorizationMiddlewareResultHandler fallback)
+    {
+        _jsonOptions = jsonOptions.Value.JsonSerializerOptions;
+        _fallback = fallback;
+    }
+
+    public async Task HandleAsync(
+        RequestDelegate next,
+        HttpContext context,
+        AuthorizationPolicy policy,
+        PolicyAuthorizationResult authorizeResult)
+    {
+        if (authorizeResult.Forbidden && authorizeResult.AuthorizationFailure is not null)
+        {
+            var requiredPermissions = authorizeResult.AuthorizationFailure.FailedRequirements
+                .OfType<RolesAuthorizationRequirement>()
+                .SelectMany(requirement => requirement.AllowedRoles)
+                .Where(role => role != AccessRoles.Base)
+                .Distinct()
+                .ToArray();
+
+            if (requiredPermissions.Length > 0)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                context.Response.ContentType = "application/json";
+
+                // Anonymous object mirrors the BaseResponse envelope (success/errorCode/params) so the
+                // frontend treats it as a structured error. BaseResponse itself is abstract and cannot
+                // be instantiated here.
+                var payload = new
+                {
+                    success = false,
+                    errorCode = ErrorCodes.InsufficientPermissions,
+                    @params = new Dictionary<string, string>
+                    {
+                        ["requiredPermission"] = string.Join(", ", requiredPermissions),
+                    },
+                };
+
+                await context.Response.WriteAsync(
+                    JsonSerializer.Serialize(payload, _jsonOptions),
+                    context.RequestAborted);
+                return;
+            }
+        }
+
+        await _fallback.HandleAsync(next, context, policy, authorizeResult);
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -41,6 +41,8 @@ public enum ErrorCodes
     Forbidden = 0014,
     [HttpStatusCode(HttpStatusCode.Unauthorized)]
     TokenExpired = 0015,
+    [HttpStatusCode(HttpStatusCode.Forbidden)]
+    InsufficientPermissions = 0016,
     [HttpStatusCode(HttpStatusCode.InternalServerError)]
     Exception = 0099,
 

--- a/backend/test/Anela.Heblo.Tests/Authorization/PermissionAuthorizationResultHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/PermissionAuthorizationResultHandlerTests.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Anela.Heblo.API.Infrastructure.Authentication;
+using Anela.Heblo.Domain.Features.Authorization;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class PermissionAuthorizationResultHandlerTests
+{
+    private sealed class SpyFallbackHandler : IAuthorizationMiddlewareResultHandler
+    {
+        public bool WasCalled { get; private set; }
+
+        public Task HandleAsync(
+            RequestDelegate next,
+            HttpContext context,
+            AuthorizationPolicy policy,
+            PolicyAuthorizationResult authorizeResult)
+        {
+            WasCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static PermissionAuthorizationResultHandler CreateHandler(IAuthorizationMiddlewareResultHandler fallback)
+    {
+        var options = new Microsoft.AspNetCore.Mvc.JsonOptions();
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+        return new PermissionAuthorizationResultHandler(Options.Create(options), fallback);
+    }
+
+    private static (HttpContext Context, MemoryStream Body) CreateContext()
+    {
+        var context = new DefaultHttpContext();
+        var body = new MemoryStream();
+        context.Response.Body = body;
+        return (context, body);
+    }
+
+    private static PolicyAuthorizationResult ForbiddenWithRoles(params string[] allowedRoles)
+    {
+        var requirement = new RolesAuthorizationRequirement(allowedRoles);
+        var failure = AuthorizationFailure.Failed(new IAuthorizationRequirement[] { requirement });
+        return PolicyAuthorizationResult.Forbid(failure);
+    }
+
+    private static async Task<string> ReadBodyAsync(MemoryStream body)
+    {
+        body.Position = 0;
+        using var reader = new StreamReader(body, leaveOpen: true);
+        return await reader.ReadToEndAsync();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WritesRequiredPermission_WhenForbiddenWithRoleRequirement()
+    {
+        // Arrange
+        var fallback = new SpyFallbackHandler();
+        var handler = CreateHandler(fallback);
+        var (context, body) = CreateContext();
+        var policy = new AuthorizationPolicyBuilder().RequireRole(AccessRoles.ProductsCatalogWrite).Build();
+        var result = ForbiddenWithRoles(AccessRoles.ProductsCatalogWrite);
+
+        // Act
+        await handler.HandleAsync(_ => Task.CompletedTask, context, policy, result);
+
+        // Assert
+        context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        fallback.WasCalled.Should().BeFalse();
+
+        using var doc = JsonDocument.Parse(await ReadBodyAsync(body));
+        doc.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("errorCode").GetString().Should().Be("InsufficientPermissions");
+        doc.RootElement.GetProperty("params").GetProperty("requiredPermission").GetString()
+            .Should().Be(AccessRoles.ProductsCatalogWrite);
+    }
+
+    [Fact]
+    public async Task HandleAsync_JoinsMultiplePermissions_WithOrSemantics()
+    {
+        // Arrange
+        var fallback = new SpyFallbackHandler();
+        var handler = CreateHandler(fallback);
+        var (context, body) = CreateContext();
+        var policy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();
+        var result = ForbiddenWithRoles(AccessRoles.JobsTriggerRead, AccessRoles.JobsDisableRead);
+
+        // Act
+        await handler.HandleAsync(_ => Task.CompletedTask, context, policy, result);
+
+        // Assert
+        using var doc = JsonDocument.Parse(await ReadBodyAsync(body));
+        doc.RootElement.GetProperty("params").GetProperty("requiredPermission").GetString()
+            .Should().Be($"{AccessRoles.JobsTriggerRead}, {AccessRoles.JobsDisableRead}");
+    }
+
+    [Fact]
+    public async Task HandleAsync_FiltersBaseRole_AndDelegatesToFallback_WhenNoFeaturePermissionRemains()
+    {
+        // Arrange — failing only on the baseline role carries no meaningful "required permission"
+        var fallback = new SpyFallbackHandler();
+        var handler = CreateHandler(fallback);
+        var (context, body) = CreateContext();
+        var policy = new AuthorizationPolicyBuilder().RequireRole(AccessRoles.Base).Build();
+        var result = ForbiddenWithRoles(AccessRoles.Base);
+
+        // Act
+        await handler.HandleAsync(_ => Task.CompletedTask, context, policy, result);
+
+        // Assert
+        fallback.WasCalled.Should().BeTrue();
+        (await ReadBodyAsync(body)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_DelegatesToFallback_WhenChallenged()
+    {
+        // Arrange — anonymous request (401 challenge) must keep the framework default behavior
+        var fallback = new SpyFallbackHandler();
+        var handler = CreateHandler(fallback);
+        var (context, body) = CreateContext();
+        var policy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();
+        var result = PolicyAuthorizationResult.Challenge();
+
+        // Act
+        await handler.HandleAsync(_ => Task.CompletedTask, context, policy, result);
+
+        // Assert
+        fallback.WasCalled.Should().BeTrue();
+        (await ReadBodyAsync(body)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_DelegatesToFallback_WhenSucceeded()
+    {
+        // Arrange
+        var fallback = new SpyFallbackHandler();
+        var handler = CreateHandler(fallback);
+        var (context, body) = CreateContext();
+        var policy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();
+        var result = PolicyAuthorizationResult.Success();
+
+        // Act
+        await handler.HandleAsync(_ => Task.CompletedTask, context, policy, result);
+
+        // Assert
+        fallback.WasCalled.Should().BeTrue();
+        (await ReadBodyAsync(body)).Should().BeEmpty();
+    }
+}

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -13015,6 +13015,7 @@ export enum ErrorCodes {
     Unauthorized = "Unauthorized",
     Forbidden = "Forbidden",
     TokenExpired = "TokenExpired",
+    InsufficientPermissions = "InsufficientPermissions",
     Exception = "Exception",
     PurchaseOrderNotFound = "PurchaseOrderNotFound",
     SupplierNotFound = "SupplierNotFound",
@@ -32586,6 +32587,7 @@ export interface IGetOrderTrackingNumberResponse extends IBaseResponse {
 
 export class GetPackingDashboardResponse extends BaseResponse implements IGetPackingDashboardResponse {
     ordersBeingPackedCount?: number | undefined;
+    ordersBeingPackedCountLastSync?: Date | undefined;
     totalOrdersPackedToday?: number;
     packedByPacker?: PackerStatsDto[];
 
@@ -32597,6 +32599,7 @@ export class GetPackingDashboardResponse extends BaseResponse implements IGetPac
         super.init(_data);
         if (_data) {
             this.ordersBeingPackedCount = _data["ordersBeingPackedCount"];
+            this.ordersBeingPackedCountLastSync = _data["ordersBeingPackedCountLastSync"] ? new Date(_data["ordersBeingPackedCountLastSync"].toString()) : <any>undefined;
             this.totalOrdersPackedToday = _data["totalOrdersPackedToday"];
             if (Array.isArray(_data["packedByPacker"])) {
                 this.packedByPacker = [] as any;
@@ -32616,6 +32619,7 @@ export class GetPackingDashboardResponse extends BaseResponse implements IGetPac
     override toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
         data["ordersBeingPackedCount"] = this.ordersBeingPackedCount;
+        data["ordersBeingPackedCountLastSync"] = this.ordersBeingPackedCountLastSync ? this.ordersBeingPackedCountLastSync.toISOString() : <any>undefined;
         data["totalOrdersPackedToday"] = this.totalOrdersPackedToday;
         if (Array.isArray(this.packedByPacker)) {
             data["packedByPacker"] = [];
@@ -32629,6 +32633,7 @@ export class GetPackingDashboardResponse extends BaseResponse implements IGetPac
 
 export interface IGetPackingDashboardResponse extends IBaseResponse {
     ordersBeingPackedCount?: number | undefined;
+    ordersBeingPackedCountLastSync?: Date | undefined;
     totalOrdersPackedToday?: number;
     packedByPacker?: PackerStatsDto[];
 }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -86,6 +86,8 @@ const resources = {
         ConfigurationError: "Chyba konfigurace",
         Unauthorized: "Neautorizovaný přístup",
         Forbidden: "Přístup zakázán",
+        InsufficientPermissions:
+          "Přístup zakázán. Chybí oprávnění: {requiredPermission}",
         TokenExpired: "Token vypršel",
         Exception: "Výjimka aplikace",
 


### PR DESCRIPTION
## Summary

When a user calls a `[FeatureAuthorize]`-guarded endpoint without the needed permission, ASP.NET Core's authorization middleware previously returned a bare 403 with no body, so the UI could only show a generic "Přístup zakázán" toast. This PR adds a custom `IAuthorizationMiddlewareResultHandler` that augments the 403 with a structured `BaseResponse`-shaped body (`success`/`errorCode`/`params`) naming the missing permission(s) — anonymous (401 challenge) and permission-less business forbids still fall through to the framework default. A new `InsufficientPermissions` error code plus its Czech translation lets the existing frontend error pipeline surface a user-facing message identifying the required permission (e.g. "Přístup zakázán. Chybí oprávnění: products.catalog.write"), and the generated OpenAPI client was regenerated to expose the new code.

## Test plan

- [x] `dotnet build` (0 errors) and `dotnet format` (clean)
- [x] New `PermissionAuthorizationResultHandlerTests` (5/5) cover the happy path, multi-permission OR join, base-role filtering, and challenge/success delegation
- [x] Authorization suite (113 pass) and `LocalizationCoverageTests` (2 pass) green
- [x] Frontend `npm run build` compiles successfully