### PR TITLE
feat(feedback): show resolved user name for AI tool usage

### DIFF
--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Common;
 using Anela.Heblo.Application.Common.TimePeriods;
+using Anela.Heblo.Application.Shared.Users;
 using Anela.Heblo.Application.Features.FeatureFlags;
 using Anela.Heblo.Application.Features.Configuration;
 using Anela.Heblo.Application.Shared.Rag;
@@ -66,6 +67,9 @@ public static class ApplicationModule
 
         // Register shared time period services
         services.AddScoped<ITimePeriodResolver, TimePeriodResolver>();
+
+        // Register shared user display-name resolver (used by feedback list handlers)
+        services.AddScoped<IUserDisplayNameResolver, UserDisplayNameResolver>();
 
         // Background refresh system, hydration, and service readiness tracking are handled by XCC module
 

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs
@@ -29,7 +29,10 @@ public sealed class GetArticleFeedbackListHandler
         var pageSize = AllowedPageSizes.Contains(request.PageSize) ? request.PageSize : 20;
         var sortBy = AllowedSortColumns.Contains(request.SortBy) ? request.SortBy : "CreatedAt";
 
-        var pagedTask = _repository.GetFeedbackPagedAsync(
+        // Queries run sequentially: they share the scoped DbContext, which EF Core
+        // forbids issuing concurrent operations on (a Task.WhenAll here throws
+        // "A second operation was started on this context instance").
+        var (items, totalCount) = await _repository.GetFeedbackPagedAsync(
             request.HasFeedback,
             request.RequestedBy,
             sortBy,
@@ -37,12 +40,8 @@ public sealed class GetArticleFeedbackListHandler
             page,
             pageSize,
             ct);
-        var statsTask = _repository.GetFeedbackStatsAsync(ct);
 
-        await Task.WhenAll(pagedTask, statsTask);
-
-        var (items, totalCount) = pagedTask.Result;
-        var stats = statsTask.Result;
+        var stats = await _repository.GetFeedbackStatsAsync(ct);
 
         var userNames = await _userDisplayNameResolver.ResolveAsync(
             items.Select(a => a.RequestedBy).Where(id => id is not null)!,

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Shared.Users;
 using Anela.Heblo.Domain.Features.Article;
 using MediatR;
 
@@ -10,10 +11,14 @@ public sealed class GetArticleFeedbackListHandler
     private static readonly string[] AllowedSortColumns = ["CreatedAt", "PrecisionScore", "StyleScore"];
 
     private readonly IArticleRepository _repository;
+    private readonly IUserDisplayNameResolver _userDisplayNameResolver;
 
-    public GetArticleFeedbackListHandler(IArticleRepository repository)
+    public GetArticleFeedbackListHandler(
+        IArticleRepository repository,
+        IUserDisplayNameResolver userDisplayNameResolver)
     {
         _repository = repository;
+        _userDisplayNameResolver = userDisplayNameResolver;
     }
 
     public async Task<GetArticleFeedbackListResponse> Handle(
@@ -39,6 +44,10 @@ public sealed class GetArticleFeedbackListHandler
         var (items, totalCount) = pagedTask.Result;
         var stats = statsTask.Result;
 
+        var userNames = await _userDisplayNameResolver.ResolveAsync(
+            items.Select(a => a.RequestedBy).Where(id => id is not null)!,
+            ct);
+
         return new GetArticleFeedbackListResponse
         {
             Items = items.Select(a => new ArticleFeedbackSummary
@@ -47,6 +56,7 @@ public sealed class GetArticleFeedbackListHandler
                 Title = a.Title,
                 Topic = a.Topic,
                 RequestedBy = a.RequestedBy,
+                UserName = a.RequestedBy is not null ? userNames.GetValueOrDefault(a.RequestedBy) : null,
                 CreatedAt = a.CreatedAt,
                 PrecisionScore = a.PrecisionScore,
                 StyleScore = a.StyleScore,

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListRequest.cs
@@ -36,6 +36,7 @@ public class ArticleFeedbackSummary
     public string? Title { get; set; }
     public string Topic { get; set; } = string.Empty;
     public string? RequestedBy { get; set; }
+    public string? UserName { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public int? PrecisionScore { get; set; }
     public int? StyleScore { get; set; }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetFeedbackList/GetFeedbackListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetFeedbackList/GetFeedbackListHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Shared.Users;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using MediatR;
 
@@ -9,10 +10,14 @@ public class GetFeedbackListHandler : IRequestHandler<GetFeedbackListRequest, Ge
     private static readonly string[] AllowedSortColumns = ["CreatedAt", "PrecisionScore", "StyleScore"];
 
     private readonly IKnowledgeBaseRepository _repository;
+    private readonly IUserDisplayNameResolver _userDisplayNameResolver;
 
-    public GetFeedbackListHandler(IKnowledgeBaseRepository repository)
+    public GetFeedbackListHandler(
+        IKnowledgeBaseRepository repository,
+        IUserDisplayNameResolver userDisplayNameResolver)
     {
         _repository = repository;
+        _userDisplayNameResolver = userDisplayNameResolver;
     }
 
     public async Task<GetFeedbackListResponse> Handle(
@@ -34,6 +39,10 @@ public class GetFeedbackListHandler : IRequestHandler<GetFeedbackListRequest, Ge
 
         var stats = await _repository.GetFeedbackStatsAsync(cancellationToken);
 
+        var userNames = await _userDisplayNameResolver.ResolveAsync(
+            logs.Select(l => l.UserId).Where(id => id is not null)!,
+            cancellationToken);
+
         return new GetFeedbackListResponse
         {
             Logs = logs.Select(l => new FeedbackLogSummary
@@ -46,6 +55,7 @@ public class GetFeedbackListHandler : IRequestHandler<GetFeedbackListRequest, Ge
                 DurationMs = l.DurationMs,
                 CreatedAt = l.CreatedAt,
                 UserId = l.UserId,
+                UserName = l.UserId is not null ? userNames.GetValueOrDefault(l.UserId) : null,
                 PrecisionScore = l.PrecisionScore,
                 StyleScore = l.StyleScore,
                 FeedbackComment = l.FeedbackComment,

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetFeedbackList/GetFeedbackListRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetFeedbackList/GetFeedbackListRequest.cs
@@ -33,6 +33,7 @@ public class FeedbackLogSummary
     public long DurationMs { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public string? UserId { get; set; }
+    public string? UserName { get; set; }
     public int? PrecisionScore { get; set; }
     public int? StyleScore { get; set; }
     public string? FeedbackComment { get; set; }

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Shared.Users;
 using Anela.Heblo.Domain.Features.Leaflet;
 using MediatR;
 
@@ -10,10 +11,14 @@ public class GetLeafletFeedbackListHandler
     private static readonly string[] AllowedSortColumns = ["CreatedAt", "PrecisionScore", "StyleScore"];
 
     private readonly ILeafletGenerationRepository _repository;
+    private readonly IUserDisplayNameResolver _userDisplayNameResolver;
 
-    public GetLeafletFeedbackListHandler(ILeafletGenerationRepository repository)
+    public GetLeafletFeedbackListHandler(
+        ILeafletGenerationRepository repository,
+        IUserDisplayNameResolver userDisplayNameResolver)
     {
         _repository = repository;
+        _userDisplayNameResolver = userDisplayNameResolver;
     }
 
     public async Task<GetLeafletFeedbackListResponse> Handle(
@@ -30,6 +35,10 @@ public class GetLeafletFeedbackListHandler
 
         var stats = await _repository.GetGenerationStatsAsync(cancellationToken);
 
+        var userNames = await _userDisplayNameResolver.ResolveAsync(
+            items.Select(g => g.UserId).Where(id => id is not null)!,
+            cancellationToken);
+
         return new GetLeafletFeedbackListResponse
         {
             Items = items.Select(g => new LeafletFeedbackSummary
@@ -44,6 +53,7 @@ public class GetLeafletFeedbackListHandler
                 DurationMs = g.DurationMs,
                 CreatedAt = g.CreatedAt,
                 UserId = g.UserId,
+                UserName = g.UserId is not null ? userNames.GetValueOrDefault(g.UserId) : null,
                 PrecisionScore = g.PrecisionScore,
                 StyleScore = g.StyleScore,
                 FeedbackComment = g.FeedbackComment,

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListRequest.cs
@@ -35,6 +35,7 @@ public class LeafletFeedbackSummary
     public long DurationMs { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public string? UserId { get; set; }
+    public string? UserName { get; set; }
     public int? PrecisionScore { get; set; }
     public int? StyleScore { get; set; }
     public string? FeedbackComment { get; set; }

--- a/backend/src/Anela.Heblo.Application/Shared/Users/IUserDisplayNameResolver.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Users/IUserDisplayNameResolver.cs
@@ -1,0 +1,16 @@
+namespace Anela.Heblo.Application.Shared.Users;
+
+/// <summary>
+/// Resolves user identifiers (Entra object id or email, as stored by the LLM tools)
+/// into human-readable display names. Cross-cutting, read-only, stateless.
+/// </summary>
+public interface IUserDisplayNameResolver
+{
+    /// <summary>
+    /// Maps each supplied identifier to a display name (DisplayName, falling back to Email).
+    /// Identifiers with no matching user resolve to <c>null</c>.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, string?>> ResolveAsync(
+        IEnumerable<string> identifiers,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Application/Shared/Users/UserDisplayNameResolver.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Users/UserDisplayNameResolver.cs
@@ -1,0 +1,83 @@
+using Anela.Heblo.Domain.Features.Authorization;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Anela.Heblo.Application.Shared.Users;
+
+/// <summary>
+/// Resolves user identifiers to display names by looking up the AppUser directory.
+/// The directory is small and changes rarely, so the whole identifier→name lookup is
+/// cached briefly to avoid a full-table scan on every feedback page load.
+/// </summary>
+public sealed class UserDisplayNameResolver : IUserDisplayNameResolver
+{
+    private const string CacheKey = "UserDisplayNameResolver:Lookup";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    private readonly IAuthorizationRepository _repository;
+    private readonly IMemoryCache _cache;
+
+    public UserDisplayNameResolver(IAuthorizationRepository repository, IMemoryCache cache)
+    {
+        _repository = repository;
+        _cache = cache;
+    }
+
+    public async Task<IReadOnlyDictionary<string, string?>> ResolveAsync(
+        IEnumerable<string> identifiers,
+        CancellationToken cancellationToken = default)
+    {
+        var distinct = identifiers
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (distinct.Count == 0)
+        {
+            return new Dictionary<string, string?>();
+        }
+
+        var lookup = await GetLookupAsync(cancellationToken);
+
+        var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var id in distinct)
+        {
+            result[id] = lookup.TryGetValue(id, out var name) ? name : null;
+        }
+
+        return result;
+    }
+
+    /// <summary>Cached identifier→display name map, keyed by both Entra object id and email.</summary>
+    private async Task<IReadOnlyDictionary<string, string>> GetLookupAsync(CancellationToken cancellationToken)
+    {
+        if (_cache.TryGetValue(CacheKey, out IReadOnlyDictionary<string, string>? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var users = await _repository.GetAllUsersAsync(cancellationToken);
+
+        var lookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var user in users)
+        {
+            var displayName = !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName : user.Email;
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(user.EntraObjectId))
+            {
+                lookup[user.EntraObjectId] = displayName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(user.Email))
+            {
+                lookup[user.Email] = displayName;
+            }
+        }
+
+        _cache.Set(CacheKey, (IReadOnlyDictionary<string, string>)lookup, CacheTtl);
+        return lookup;
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.Article.UseCases.GetFeedbackList;
+using Anela.Heblo.Application.Shared.Users;
 using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
 using Moq;
@@ -8,8 +9,17 @@ namespace Anela.Heblo.Tests.Article.UseCases;
 public class GetArticleFeedbackListHandlerTests
 {
     private readonly Mock<IArticleRepository> _repository = new();
+    private readonly Mock<IUserDisplayNameResolver> _userDisplayNameResolver = new();
 
-    private GetArticleFeedbackListHandler CreateHandler() => new(_repository.Object);
+    public GetArticleFeedbackListHandlerTests()
+    {
+        _userDisplayNameResolver
+            .Setup(r => r.ResolveAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, string?>)new Dictionary<string, string?>());
+    }
+
+    private GetArticleFeedbackListHandler CreateHandler() =>
+        new(_repository.Object, _userDisplayNameResolver.Object);
 
     [Fact]
     public async Task Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults()
@@ -48,6 +58,38 @@ public class GetArticleFeedbackListHandlerTests
         response.Stats.TotalWithFeedback.Should().Be(4);
         response.Stats.AvgPrecisionScore.Should().Be(4.5);
         response.Stats.AvgStyleScore.Should().Be(4.0);
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesUserNameFromRequestedBy()
+    {
+        var article = new ArticleFeedbackProjection(
+            Id: Guid.NewGuid(),
+            Title: "Sun care title",
+            Topic: "Sun care",
+            RequestedBy: "alice@anela.cz",
+            CreatedAt: DateTimeOffset.UtcNow,
+            PrecisionScore: 4,
+            StyleScore: 5,
+            FeedbackComment: "ok");
+
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)new[] { article }, 1));
+        _repository.Setup(r => r.GetFeedbackStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ArticleFeedbackStats(1, 1, 4.0, 5.0));
+        _userDisplayNameResolver
+            .Setup(r => r.ResolveAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, string?>)new Dictionary<string, string?>
+            {
+                ["alice@anela.cz"] = "Alice Example",
+            });
+
+        var response = await CreateHandler().Handle(new GetArticleFeedbackListRequest(), default);
+
+        response.Items[0].UserName.Should().Be("Alice Example");
+        response.Items[0].RequestedBy.Should().Be("alice@anela.cz");
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+using Anela.Heblo.Application.Shared.Users;
 using Anela.Heblo.Domain.Features.Leaflet;
 using Moq;
 using Xunit;
@@ -8,6 +9,14 @@ namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
 public class GetLeafletFeedbackListHandlerTests
 {
     private readonly Mock<ILeafletGenerationRepository> _repo = new();
+    private readonly Mock<IUserDisplayNameResolver> _userDisplayNameResolver = new();
+
+    public GetLeafletFeedbackListHandlerTests()
+    {
+        _userDisplayNameResolver
+            .Setup(r => r.ResolveAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, string?>)new Dictionary<string, string?>());
+    }
 
     private static LeafletGeneration MakeGeneration(bool hasFeedback = false) =>
         new()
@@ -39,7 +48,8 @@ public class GetLeafletFeedbackListHandlerTests
             .ReturnsAsync(stats ?? DefaultStats());
     }
 
-    private GetLeafletFeedbackListHandler CreateHandler() => new(_repo.Object);
+    private GetLeafletFeedbackListHandler CreateHandler() =>
+        new(_repo.Object, _userDisplayNameResolver.Object);
 
     [Fact]
     public async Task Handle_ReturnsMappedGenerations()
@@ -61,6 +71,24 @@ public class GetLeafletFeedbackListHandlerTests
         Assert.Equal(gen.PrecisionScore, dto.PrecisionScore);
         Assert.Equal(gen.StyleScore, dto.StyleScore);
         Assert.True(dto.HasFeedback);
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesUserNameFromResolver()
+    {
+        var gen = MakeGeneration(hasFeedback: true); // UserId = "user-1"
+        SetupRepo([gen]);
+        _userDisplayNameResolver
+            .Setup(r => r.ResolveAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, string?>)new Dictionary<string, string?>
+            {
+                ["user-1"] = "Alice Example",
+            });
+
+        var result = await CreateHandler().Handle(new GetLeafletFeedbackListRequest(), default);
+
+        Assert.Equal("Alice Example", result.Items[0].UserName);
+        Assert.Equal("user-1", result.Items[0].UserId);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetFeedbackListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetFeedbackListHandlerTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.GetFeedbackList;
+using Anela.Heblo.Application.Shared.Users;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Moq;
 using Xunit;
@@ -8,6 +9,14 @@ namespace Anela.Heblo.Tests.KnowledgeBase.UseCases;
 public class GetFeedbackListHandlerTests
 {
     private readonly Mock<IKnowledgeBaseRepository> _repository = new();
+    private readonly Mock<IUserDisplayNameResolver> _userDisplayNameResolver = new();
+
+    public GetFeedbackListHandlerTests()
+    {
+        _userDisplayNameResolver
+            .Setup(r => r.ResolveAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, string?>)new Dictionary<string, string?>());
+    }
 
     private static KnowledgeBaseQuestionLog MakeLog(
         bool hasFeedback = false,
@@ -63,7 +72,7 @@ public class GetFeedbackListHandlerTests
         var log = MakeLog(hasFeedback: true);
         SetupRepository([log]);
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         var result = await handler.Handle(new GetFeedbackListRequest(), default);
 
         Assert.True(result.Success);
@@ -93,7 +102,7 @@ public class GetFeedbackListHandlerTests
         };
         SetupRepository([], stats: stats);
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         var result = await handler.Handle(new GetFeedbackListRequest(), default);
 
         Assert.Equal(42, result.Stats.TotalQuestions);
@@ -108,7 +117,7 @@ public class GetFeedbackListHandlerTests
         var logs = Enumerable.Range(1, 10).Select(_ => MakeLog()).ToList();
         SetupRepository(logs, totalCount: 35);
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         var result = await handler.Handle(
             new GetFeedbackListRequest { PageNumber = 2, PageSize = 10 },
             default);
@@ -129,7 +138,7 @@ public class GetFeedbackListHandlerTests
     {
         SetupRepository([]);
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         var result = await handler.Handle(
             new GetFeedbackListRequest { PageSize = requested },
             default);
@@ -145,7 +154,7 @@ public class GetFeedbackListHandlerTests
     {
         SetupRepository([]);
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         var result = await handler.Handle(
             new GetFeedbackListRequest { PageNumber = requested },
             default);
@@ -178,7 +187,7 @@ public class GetFeedbackListHandlerTests
             .Setup(r => r.GetFeedbackStatsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(DefaultStats());
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         await handler.Handle(new GetFeedbackListRequest { SortBy = requested }, default);
 
         Assert.Equal(expected, capturedSortBy);
@@ -218,7 +227,7 @@ public class GetFeedbackListHandlerTests
             .Setup(r => r.GetFeedbackStatsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(DefaultStats());
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         await handler.Handle(new GetFeedbackListRequest
         {
             HasFeedback = true,
@@ -242,7 +251,7 @@ public class GetFeedbackListHandlerTests
     {
         SetupRepository([], totalCount: 25);
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         var result = await handler.Handle(
             new GetFeedbackListRequest { PageSize = 10 },
             default);
@@ -251,12 +260,43 @@ public class GetFeedbackListHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ResolvesUserNameFromResolver()
+    {
+        var log = MakeLog(hasFeedback: true); // UserId = "user-1"
+        SetupRepository([log]);
+        _userDisplayNameResolver
+            .Setup(r => r.ResolveAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, string?>)new Dictionary<string, string?>
+            {
+                ["user-1"] = "Alice Example",
+            });
+
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
+        var result = await handler.Handle(new GetFeedbackListRequest(), default);
+
+        Assert.Equal("Alice Example", result.Logs[0].UserName);
+        Assert.Equal("user-1", result.Logs[0].UserId);
+    }
+
+    [Fact]
+    public async Task Handle_UserNameNull_WhenUserNotResolved()
+    {
+        var log = MakeLog(hasFeedback: true); // UserId = "user-1", resolver returns empty by default
+        SetupRepository([log]);
+
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
+        var result = await handler.Handle(new GetFeedbackListRequest(), default);
+
+        Assert.Null(result.Logs[0].UserName);
+    }
+
+    [Fact]
     public async Task Handle_LogWithoutFeedbackHasHasFeedbackFalse()
     {
         var log = MakeLog(hasFeedback: false);
         SetupRepository([log]);
 
-        var handler = new GetFeedbackListHandler(_repository.Object);
+        var handler = new GetFeedbackListHandler(_repository.Object, _userDisplayNameResolver.Object);
         var result = await handler.Handle(new GetFeedbackListRequest(), default);
 
         Assert.False(result.Logs[0].HasFeedback);

--- a/backend/test/Anela.Heblo.Tests/Shared/Users/UserDisplayNameResolverTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Shared/Users/UserDisplayNameResolverTests.cs
@@ -1,0 +1,94 @@
+using Anela.Heblo.Application.Shared.Users;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Authorization.Entities;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Shared.Users;
+
+public class UserDisplayNameResolverTests
+{
+    private readonly Mock<IAuthorizationRepository> _repository = new();
+
+    private UserDisplayNameResolver CreateResolver() =>
+        new(_repository.Object, new MemoryCache(new MemoryCacheOptions()));
+
+    private void SetupUsers(params AppUser[] users) =>
+        _repository
+            .Setup(r => r.GetAllUsersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(users.ToList());
+
+    private static AppUser User(string? entraObjectId, string email, string displayName) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            EntraObjectId = entraObjectId,
+            Email = email,
+            DisplayName = displayName,
+        };
+
+    [Fact]
+    public async Task ResolveAsync_MapsEntraObjectIdToDisplayName()
+    {
+        SetupUsers(User("oid-1", "alice@anela.cz", "Alice Example"));
+
+        var result = await CreateResolver().ResolveAsync(["oid-1"]);
+
+        result["oid-1"].Should().Be("Alice Example");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_MapsEmailIdentifierToDisplayName()
+    {
+        // Article stores RequestedBy which may be an email rather than the Entra object id.
+        SetupUsers(User("oid-1", "alice@anela.cz", "Alice Example"));
+
+        var result = await CreateResolver().ResolveAsync(["alice@anela.cz"]);
+
+        result["alice@anela.cz"].Should().Be("Alice Example");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_UnknownIdentifier_ResolvesToNull()
+    {
+        SetupUsers(User("oid-1", "alice@anela.cz", "Alice Example"));
+
+        var result = await CreateResolver().ResolveAsync(["oid-unknown"]);
+
+        result.Should().ContainKey("oid-unknown");
+        result["oid-unknown"].Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_FallsBackToEmail_WhenDisplayNameMissing()
+    {
+        SetupUsers(User("oid-1", "alice@anela.cz", "   "));
+
+        var result = await CreateResolver().ResolveAsync(["oid-1"]);
+
+        result["oid-1"].Should().Be("alice@anela.cz");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_EmptyInput_DoesNotQueryRepository()
+    {
+        var result = await CreateResolver().ResolveAsync([]);
+
+        result.Should().BeEmpty();
+        _repository.Verify(r => r.GetAllUsersAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CachesLookup_AcrossCalls()
+    {
+        SetupUsers(User("oid-1", "alice@anela.cz", "Alice Example"));
+        var resolver = CreateResolver();
+
+        await resolver.ResolveAsync(["oid-1"]);
+        await resolver.ResolveAsync(["oid-1"]);
+
+        _repository.Verify(r => r.GetAllUsersAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -14465,6 +14465,7 @@ export class ArticleFeedbackSummary implements IArticleFeedbackSummary {
     title?: string | undefined;
     topic?: string;
     requestedBy?: string | undefined;
+    userName?: string | undefined;
     createdAt?: Date;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
@@ -14485,6 +14486,7 @@ export class ArticleFeedbackSummary implements IArticleFeedbackSummary {
             this.title = _data["title"];
             this.topic = _data["topic"];
             this.requestedBy = _data["requestedBy"];
+            this.userName = _data["userName"];
             this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
             this.precisionScore = _data["precisionScore"];
             this.styleScore = _data["styleScore"];
@@ -14505,6 +14507,7 @@ export class ArticleFeedbackSummary implements IArticleFeedbackSummary {
         data["title"] = this.title;
         data["topic"] = this.topic;
         data["requestedBy"] = this.requestedBy;
+        data["userName"] = this.userName;
         data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
         data["precisionScore"] = this.precisionScore;
         data["styleScore"] = this.styleScore;
@@ -14518,6 +14521,7 @@ export interface IArticleFeedbackSummary {
     title?: string | undefined;
     topic?: string;
     requestedBy?: string | undefined;
+    userName?: string | undefined;
     createdAt?: Date;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
@@ -23584,6 +23588,7 @@ export class FeedbackLogSummary implements IFeedbackLogSummary {
     durationMs?: number;
     createdAt?: Date;
     userId?: string | undefined;
+    userName?: string | undefined;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
     feedbackComment?: string | undefined;
@@ -23608,6 +23613,7 @@ export class FeedbackLogSummary implements IFeedbackLogSummary {
             this.durationMs = _data["durationMs"];
             this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
             this.userId = _data["userId"];
+            this.userName = _data["userName"];
             this.precisionScore = _data["precisionScore"];
             this.styleScore = _data["styleScore"];
             this.feedbackComment = _data["feedbackComment"];
@@ -23632,6 +23638,7 @@ export class FeedbackLogSummary implements IFeedbackLogSummary {
         data["durationMs"] = this.durationMs;
         data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
         data["userId"] = this.userId;
+        data["userName"] = this.userName;
         data["precisionScore"] = this.precisionScore;
         data["styleScore"] = this.styleScore;
         data["feedbackComment"] = this.feedbackComment;
@@ -23649,6 +23656,7 @@ export interface IFeedbackLogSummary {
     durationMs?: number;
     createdAt?: Date;
     userId?: string | undefined;
+    userName?: string | undefined;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
     feedbackComment?: string | undefined;
@@ -24337,6 +24345,7 @@ export class LeafletFeedbackSummary implements ILeafletFeedbackSummary {
     durationMs?: number;
     createdAt?: Date;
     userId?: string | undefined;
+    userName?: string | undefined;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
     feedbackComment?: string | undefined;
@@ -24363,6 +24372,7 @@ export class LeafletFeedbackSummary implements ILeafletFeedbackSummary {
             this.durationMs = _data["durationMs"];
             this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
             this.userId = _data["userId"];
+            this.userName = _data["userName"];
             this.precisionScore = _data["precisionScore"];
             this.styleScore = _data["styleScore"];
             this.feedbackComment = _data["feedbackComment"];
@@ -24389,6 +24399,7 @@ export class LeafletFeedbackSummary implements ILeafletFeedbackSummary {
         data["durationMs"] = this.durationMs;
         data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
         data["userId"] = this.userId;
+        data["userName"] = this.userName;
         data["precisionScore"] = this.precisionScore;
         data["styleScore"] = this.styleScore;
         data["feedbackComment"] = this.feedbackComment;
@@ -24408,6 +24419,7 @@ export interface ILeafletFeedbackSummary {
     durationMs?: number;
     createdAt?: Date;
     userId?: string | undefined;
+    userName?: string | undefined;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
     feedbackComment?: string | undefined;

--- a/frontend/src/api/hooks/useArticles.ts
+++ b/frontend/src/api/hooks/useArticles.ts
@@ -84,6 +84,7 @@ export interface ArticleFeedbackSummary {
   topic: string;
   title: string | null;
   requestedBy: string;
+  userName: string | null;
   createdAt: string | null;
   precisionScore: number | null;
   styleScore: number | null;
@@ -262,6 +263,7 @@ export const useArticleFeedbackListQuery = (params: ArticleFeedbackListParams = 
           topic: item.topic ?? '',
           title: item.title ?? null,
           requestedBy: item.requestedBy ?? '',
+          userName: item.userName ?? null,
           createdAt: item.createdAt?.toISOString() ?? null,
           precisionScore: item.precisionScore ?? null,
           styleScore: item.styleScore ?? null,

--- a/frontend/src/api/hooks/useKnowledgeBase.ts
+++ b/frontend/src/api/hooks/useKnowledgeBase.ts
@@ -97,6 +97,7 @@ export interface FeedbackLogSummary {
   durationMs: number;
   createdAt: string;
   userId: string | null;
+  userName: string | null;
   precisionScore: number | null;
   styleScore: number | null;
   feedbackComment: string | null;

--- a/frontend/src/api/hooks/useLeaflet.ts
+++ b/frontend/src/api/hooks/useLeaflet.ts
@@ -85,6 +85,7 @@ export interface LeafletFeedbackSummary {
   durationMs: number;
   createdAt: string;
   userId: string | null;
+  userName: string | null;
   precisionScore: number | null;
   styleScore: number | null;
   feedbackComment: string | null;

--- a/frontend/src/components/feedback/GenericFeedbackDetailModal.tsx
+++ b/frontend/src/components/feedback/GenericFeedbackDetailModal.tsx
@@ -45,10 +45,10 @@ const GenericFeedbackDetailModal: React.FC<Props> = ({ detail, onClose, primaryL
               <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Datum</p>
               <p className="text-gray-900">{formatDateTime(detail.createdAt)}</p>
             </div>
-            {detail.userId && (
+            {(detail.userName ?? detail.userId) && (
               <div>
                 <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Uživatel</p>
-                <p className="text-gray-900 break-all">{detail.userId}</p>
+                <p className="text-gray-900 break-all">{detail.userName ?? detail.userId}</p>
               </div>
             )}
           </div>

--- a/frontend/src/components/feedback/GenericFeedbackTable.tsx
+++ b/frontend/src/components/feedback/GenericFeedbackTable.tsx
@@ -60,6 +60,9 @@ const GenericFeedbackTable: React.FC<Props> = ({
               <th className="px-4 py-3 text-left font-medium text-gray-500 uppercase tracking-wide text-xs">
                 {primaryLabel}
               </th>
+              <th className="px-4 py-3 text-left font-medium text-gray-500 uppercase tracking-wide text-xs whitespace-nowrap">
+                Uživatel
+              </th>
               <th className="px-4 py-3 text-center font-medium text-gray-500 uppercase tracking-wide text-xs whitespace-nowrap">
                 Přesnost
               </th>
@@ -83,6 +86,9 @@ const GenericFeedbackTable: React.FC<Props> = ({
                 </td>
                 <td className="px-4 py-3 text-gray-900 max-w-xs">
                   <span className="line-clamp-2">{row.primaryText}</span>
+                </td>
+                <td className="px-4 py-3 text-gray-600 whitespace-nowrap">
+                  {row.userName ?? row.userId ?? '–'}
                 </td>
                 <td className="px-4 py-3 text-center">
                   <ScoreCell score={row.precisionScore} />

--- a/frontend/src/components/feedback/__tests__/GenericFeedbackTable.test.tsx
+++ b/frontend/src/components/feedback/__tests__/GenericFeedbackTable.test.tsx
@@ -9,6 +9,8 @@ const rows: FeedbackRow[] = [
     primaryText: 'Jak funguje věrnostní program?',
     secondaryText: 'Věrnostní program nabízí slevy.',
     createdAt: '2026-01-15T10:30:00Z',
+    userName: 'Alice Example',
+    userId: 'oid-1',
     precisionScore: 4,
     styleScore: null,
     hasFeedback: true,
@@ -17,6 +19,7 @@ const rows: FeedbackRow[] = [
     id: 'row-2',
     primaryText: 'Co jsou produktové kategorie?',
     createdAt: '2026-01-16T08:00:00Z',
+    userId: 'oid-2',
     precisionScore: null,
     styleScore: null,
     hasFeedback: false,
@@ -46,6 +49,33 @@ test('renders rows with primary text', () => {
   render(<GenericFeedbackTable {...defaultProps} />);
   expect(screen.getByText('Jak funguje věrnostní program?')).toBeInTheDocument();
   expect(screen.getByText('Co jsou produktové kategorie?')).toBeInTheDocument();
+});
+
+test('renders user column header', () => {
+  render(<GenericFeedbackTable {...defaultProps} />);
+  expect(screen.getByText('Uživatel')).toBeInTheDocument();
+});
+
+test('renders resolved userName, falling back to userId', () => {
+  render(<GenericFeedbackTable {...defaultProps} />);
+  expect(screen.getByText('Alice Example')).toBeInTheDocument(); // row-1 has a name
+  expect(screen.getByText('oid-2')).toBeInTheDocument();         // row-2 falls back to id
+});
+
+test('renders dash when row has no user', () => {
+  const rowsNoUser: FeedbackRow[] = [
+    {
+      id: 'r',
+      primaryText: 'x',
+      createdAt: '2026-01-15T10:30:00Z',
+      precisionScore: 3,
+      styleScore: 2,
+      hasFeedback: true,
+    },
+  ];
+  render(<GenericFeedbackTable {...defaultProps} rows={rowsNoUser} totalCount={1} />);
+  // scores are present, so the only dash rendered is the empty user cell
+  expect(screen.getByText('–')).toBeInTheDocument();
 });
 
 test('shows "Ano" badge for rows with feedback', () => {

--- a/frontend/src/components/feedback/adapters/__tests__/useKbFeedbackAdapter.test.ts
+++ b/frontend/src/components/feedback/adapters/__tests__/useKbFeedbackAdapter.test.ts
@@ -14,6 +14,7 @@ const mockLog = {
   durationMs: 1200,
   createdAt: '2026-01-15T10:30:00Z',
   userId: 'user@anela.cz',
+  userName: 'User Example',
   precisionScore: 4,
   styleScore: 3,
   feedbackComment: 'Výborná odpověď.',
@@ -64,6 +65,11 @@ test('maps truncated answer to secondaryText', () => {
 test('maps userId', () => {
   const { result } = renderHook(() => useKbFeedbackAdapter(params));
   expect(result.current.rows[0].userId).toBe('user@anela.cz');
+});
+
+test('maps userName', () => {
+  const { result } = renderHook(() => useKbFeedbackAdapter(params));
+  expect(result.current.rows[0].userName).toBe('User Example');
 });
 
 test('maps totalQuestions to totalItems in stats', () => {

--- a/frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts
+++ b/frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts
@@ -18,6 +18,7 @@ export function useArticleFeedbackAdapter(params: GenericFeedbackParams) {
     secondaryText: article.topic,
     createdAt: article.createdAt ?? '',
     userId: article.requestedBy,
+    userName: article.userName ?? undefined,
     precisionScore: article.precisionScore,
     styleScore: article.styleScore,
     hasFeedback: article.hasComment,

--- a/frontend/src/components/feedback/adapters/useKbFeedbackAdapter.ts
+++ b/frontend/src/components/feedback/adapters/useKbFeedbackAdapter.ts
@@ -17,6 +17,7 @@ export function useKbFeedbackAdapter(params: GenericFeedbackParams) {
     secondaryText: log.answer ?? '',
     createdAt: log.createdAt,
     userId: log.userId ?? undefined,
+    userName: log.userName ?? undefined,
     precisionScore: log.precisionScore,
     styleScore: log.styleScore,
     hasFeedback: log.hasFeedback,

--- a/frontend/src/components/feedback/adapters/useLeafletFeedbackAdapter.ts
+++ b/frontend/src/components/feedback/adapters/useLeafletFeedbackAdapter.ts
@@ -17,6 +17,7 @@ export function useLeafletFeedbackAdapter(params: GenericFeedbackParams) {
     secondaryText: item.finalMarkdown ?? '',
     createdAt: item.createdAt,
     userId: item.userId ?? undefined,
+    userName: item.userName ?? undefined,
     precisionScore: item.precisionScore,
     styleScore: item.styleScore,
     hasFeedback: item.hasFeedback,

--- a/frontend/src/components/feedback/types.ts
+++ b/frontend/src/components/feedback/types.ts
@@ -14,6 +14,7 @@ export interface FeedbackRow {
   secondaryText?: string;
   createdAt: string;
   userId?: string;
+  userName?: string;
   precisionScore?: number | null;
   styleScore?: number | null;
   hasFeedback: boolean;


### PR DESCRIPTION
The user who triggered each AI tool (Knowledge Base, Articles, Leaflets) was already captured but shown only as a raw Entra object id inside the detail modal. This adds a shared, cached `IUserDisplayNameResolver` that resolves the stored id/email into a human-readable display name, used by the three feedback-list handlers (read-time resolution, so existing historical rows resolve too). The resolved name is exposed via a new `UserName` DTO field and rendered as a new "Uživatel" column in the feedback table, with the detail modal preferring the name and falling back to the id. Frontend client was regenerated to expose the field and the adapters/hook interfaces map it through. Covered by new backend unit tests (resolver + three handlers) and frontend table/adapter tests.