### PR TITLE
feat(access): highlight permissions inherited from nested groups in group editor

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetGroups/GetGroupsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetGroups/GetGroupsHandler.cs
@@ -22,6 +22,8 @@ public class GetGroupsHandler : IRequestHandler<GetGroupsRequest, GetGroupsRespo
                 PermissionCount = g.Permissions.Count,
                 ParentCount = g.Parents.Count,
                 MemberCount = g.UserGroups.Count,
+                Permissions = g.Permissions.Select(p => p.PermissionValue).OrderBy(v => v).ToList(),
+                ParentGroupIds = g.Parents.Select(p => p.ParentGroupId).ToList(),
             }).OrderBy(g => g.Name).ToList(),
         };
     }

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GroupDtos.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GroupDtos.cs
@@ -8,6 +8,8 @@ public class GroupSummaryDto
     public int PermissionCount { get; set; }
     public int ParentCount { get; set; }
     public int MemberCount { get; set; }
+    public List<string> Permissions { get; set; } = new();
+    public List<Guid> ParentGroupIds { get; set; } = new();
 }
 
 public class GroupDetailDto

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -14939,6 +14939,8 @@ export class GroupSummaryDto implements IGroupSummaryDto {
     permissionCount?: number;
     parentCount?: number;
     memberCount?: number;
+    permissions?: string[];
+    parentGroupIds?: string[];
 
     constructor(data?: IGroupSummaryDto) {
         if (data) {
@@ -14957,6 +14959,16 @@ export class GroupSummaryDto implements IGroupSummaryDto {
             this.permissionCount = _data["permissionCount"];
             this.parentCount = _data["parentCount"];
             this.memberCount = _data["memberCount"];
+            if (Array.isArray(_data["permissions"])) {
+                this.permissions = [] as any;
+                for (let item of _data["permissions"])
+                    this.permissions!.push(item);
+            }
+            if (Array.isArray(_data["parentGroupIds"])) {
+                this.parentGroupIds = [] as any;
+                for (let item of _data["parentGroupIds"])
+                    this.parentGroupIds!.push(item);
+            }
         }
     }
 
@@ -14975,6 +14987,16 @@ export class GroupSummaryDto implements IGroupSummaryDto {
         data["permissionCount"] = this.permissionCount;
         data["parentCount"] = this.parentCount;
         data["memberCount"] = this.memberCount;
+        if (Array.isArray(this.permissions)) {
+            data["permissions"] = [];
+            for (let item of this.permissions)
+                data["permissions"].push(item);
+        }
+        if (Array.isArray(this.parentGroupIds)) {
+            data["parentGroupIds"] = [];
+            for (let item of this.parentGroupIds)
+                data["parentGroupIds"].push(item);
+        }
         return data;
     }
 }
@@ -14986,6 +15008,8 @@ export interface IGroupSummaryDto {
     permissionCount?: number;
     parentCount?: number;
     memberCount?: number;
+    permissions?: string[];
+    parentGroupIds?: string[];
 }
 
 export class GetGroupDetailResponse extends BaseResponse implements IGetGroupDetailResponse {
@@ -32586,6 +32610,7 @@ export interface IGetOrderTrackingNumberResponse extends IBaseResponse {
 
 export class GetPackingDashboardResponse extends BaseResponse implements IGetPackingDashboardResponse {
     ordersBeingPackedCount?: number | undefined;
+    ordersBeingPackedCountLastSync?: Date | undefined;
     totalOrdersPackedToday?: number;
     packedByPacker?: PackerStatsDto[];
 
@@ -32597,6 +32622,7 @@ export class GetPackingDashboardResponse extends BaseResponse implements IGetPac
         super.init(_data);
         if (_data) {
             this.ordersBeingPackedCount = _data["ordersBeingPackedCount"];
+            this.ordersBeingPackedCountLastSync = _data["ordersBeingPackedCountLastSync"] ? new Date(_data["ordersBeingPackedCountLastSync"].toString()) : <any>undefined;
             this.totalOrdersPackedToday = _data["totalOrdersPackedToday"];
             if (Array.isArray(_data["packedByPacker"])) {
                 this.packedByPacker = [] as any;
@@ -32616,6 +32642,7 @@ export class GetPackingDashboardResponse extends BaseResponse implements IGetPac
     override toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
         data["ordersBeingPackedCount"] = this.ordersBeingPackedCount;
+        data["ordersBeingPackedCountLastSync"] = this.ordersBeingPackedCountLastSync ? this.ordersBeingPackedCountLastSync.toISOString() : <any>undefined;
         data["totalOrdersPackedToday"] = this.totalOrdersPackedToday;
         if (Array.isArray(this.packedByPacker)) {
             data["packedByPacker"] = [];
@@ -32629,6 +32656,7 @@ export class GetPackingDashboardResponse extends BaseResponse implements IGetPac
 
 export interface IGetPackingDashboardResponse extends IBaseResponse {
     ordersBeingPackedCount?: number | undefined;
+    ordersBeingPackedCountLastSync?: Date | undefined;
     totalOrdersPackedToday?: number;
     packedByPacker?: PackerStatsDto[];
 }

--- a/frontend/src/components/access-management/PermissionPicker.tsx
+++ b/frontend/src/components/access-management/PermissionPicker.tsx
@@ -6,9 +6,10 @@ interface PermissionPickerProps {
   value: string[];
   onChange: (permissions: string[]) => void;
   fillHeight?: boolean;
+  inheritedIds?: Set<string>;
 }
 
-export default function PermissionPicker({ value, onChange, fillHeight }: PermissionPickerProps) {
+export default function PermissionPicker({ value, onChange, fillHeight, inheritedIds }: PermissionPickerProps) {
   const catalogue = useCatalogue();
 
   const { items, sectionByPermission } = useMemo(() => {
@@ -39,6 +40,8 @@ export default function PermissionPicker({ value, onChange, fillHeight }: Permis
       fillHeight={fillHeight}
       searchable
       searchPlaceholder="Search permissions…"
+      highlightedIds={inheritedIds ? Array.from(inheritedIds) : undefined}
+      highlightLabel="inherited"
     />
   );
 }

--- a/frontend/src/components/access-management/TransferList.tsx
+++ b/frontend/src/components/access-management/TransferList.tsx
@@ -28,6 +28,8 @@ interface TransferListProps {
   fillHeight?: boolean;
   searchable?: boolean;
   searchPlaceholder?: string;
+  highlightedIds?: string[];
+  highlightLabel?: string;
 }
 
 function matchesQuery(item: TransferItem, query: string): boolean {
@@ -41,6 +43,8 @@ interface ItemRowProps {
   item: TransferItem;
   direction: "assign" | "remove";
   onMove: () => void;
+  highlighted?: boolean;
+  highlightLabel?: string;
 }
 
 function buildGroups(
@@ -56,23 +60,37 @@ function buildGroups(
   return map;
 }
 
-function ItemRow({ item, direction, onMove }: ItemRowProps) {
+function ItemRow({
+  item,
+  direction,
+  onMove,
+  highlighted,
+  highlightLabel,
+}: ItemRowProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({ id: item.id });
   const style = transform
     ? { transform: CSS.Transform.toString(transform) }
     : undefined;
+  const rowColors = highlighted
+    ? "border-emerald-200 bg-emerald-50 hover:bg-emerald-100"
+    : "border-gray-200 bg-white hover:bg-gray-50";
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex items-center justify-between px-3 py-2 rounded border border-gray-200 bg-white hover:bg-gray-50 cursor-grab${isDragging ? " opacity-50" : ""}`}
+      className={`flex items-center justify-between px-3 py-2 rounded border ${rowColors} cursor-grab${isDragging ? " opacity-50" : ""}`}
       {...attributes}
       {...listeners}
     >
       <div className="flex flex-col min-w-0 flex-1">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm text-gray-900 truncate">{item.label}</span>
+          {highlighted && highlightLabel && (
+            <span className="flex-shrink-0 text-xs px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 font-medium">
+              {highlightLabel}
+            </span>
+          )}
           {item.badge && (
             <span className="flex-shrink-0 text-xs px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 font-medium">
               {item.badge}
@@ -165,7 +183,10 @@ function TransferList({
   fillHeight,
   searchable,
   searchPlaceholder = "Search…",
+  highlightedIds,
+  highlightLabel,
 }: TransferListProps) {
+  const highlighted = new Set(highlightedIds);
   // A small activation distance keeps the per-row +/− button clicks from being
   // swallowed by the drag sensor — a plain click no longer starts a drag.
   const sensors = useSensors(
@@ -243,6 +264,8 @@ function TransferList({
                           item={item}
                           direction="assign"
                           onMove={() => handleAssign(item.id)}
+                          highlighted={highlighted.has(item.id)}
+                          highlightLabel={highlightLabel}
                         />
                       ))}
                     </div>
@@ -254,6 +277,8 @@ function TransferList({
                     item={item}
                     direction="assign"
                     onMove={() => handleAssign(item.id)}
+                    highlighted={highlighted.has(item.id)}
+                    highlightLabel={highlightLabel}
                   />
                 ))}
           </DropZone>
@@ -272,6 +297,8 @@ function TransferList({
                 item={item}
                 direction="remove"
                 onMove={() => handleRemove(item.id)}
+                highlighted={highlighted.has(item.id)}
+                highlightLabel={highlightLabel}
               />
             ))}
           </DropZone>

--- a/frontend/src/components/access-management/groupClosure.test.ts
+++ b/frontend/src/components/access-management/groupClosure.test.ts
@@ -1,0 +1,87 @@
+import { resolveInheritedPermissions, GroupNode } from "./groupClosure";
+
+describe("resolveInheritedPermissions", () => {
+  test("returns empty set when no parent groups are selected", () => {
+    const groups: GroupNode[] = [
+      { id: "a", permissions: ["x.read"], parentGroupIds: [] },
+    ];
+
+    const result = resolveInheritedPermissions([], groups);
+
+    expect(result.size).toBe(0);
+  });
+
+  test("includes direct permissions of selected parent groups", () => {
+    const groups: GroupNode[] = [
+      { id: "parent", permissions: ["x.read", "x.write"], parentGroupIds: [] },
+    ];
+
+    const result = resolveInheritedPermissions(["parent"], groups);
+
+    expect(Array.from(result).sort()).toEqual(["x.read", "x.write"]);
+  });
+
+  test("walks a deep chain A→B→C and unions all permissions", () => {
+    const groups: GroupNode[] = [
+      { id: "a", permissions: ["a.read"], parentGroupIds: ["b"] },
+      { id: "b", permissions: ["b.read"], parentGroupIds: ["c"] },
+      { id: "c", permissions: ["c.read"], parentGroupIds: [] },
+    ];
+
+    const result = resolveInheritedPermissions(["a"], groups);
+
+    expect(Array.from(result).sort()).toEqual(["a.read", "b.read", "c.read"]);
+  });
+
+  test("counts a diamond shared ancestor only once", () => {
+    const groups: GroupNode[] = [
+      { id: "a", permissions: ["a.read"], parentGroupIds: ["b", "c"] },
+      { id: "b", permissions: ["b.read"], parentGroupIds: ["d"] },
+      { id: "c", permissions: ["c.read"], parentGroupIds: ["d"] },
+      { id: "d", permissions: ["d.read"], parentGroupIds: [] },
+    ];
+
+    const result = resolveInheritedPermissions(["a"], groups);
+
+    expect(Array.from(result).sort()).toEqual([
+      "a.read",
+      "b.read",
+      "c.read",
+      "d.read",
+    ]);
+  });
+
+  test("terminates safely on a cycle", () => {
+    const groups: GroupNode[] = [
+      { id: "a", permissions: ["a.read"], parentGroupIds: ["b"] },
+      { id: "b", permissions: ["b.read"], parentGroupIds: ["a"] },
+    ];
+
+    const result = resolveInheritedPermissions(["a"], groups);
+
+    expect(Array.from(result).sort()).toEqual(["a.read", "b.read"]);
+  });
+
+  test("excludes the editing group's own permissions (only parents are seeded)", () => {
+    const groups: GroupNode[] = [
+      { id: "self", permissions: ["self.read"], parentGroupIds: ["parent"] },
+      { id: "parent", permissions: ["parent.read"], parentGroupIds: [] },
+    ];
+
+    // Seeded with the parent ids only, as GroupDetailPage does.
+    const result = resolveInheritedPermissions(["parent"], groups);
+
+    expect(Array.from(result)).toEqual(["parent.read"]);
+    expect(result.has("self.read")).toBe(false);
+  });
+
+  test("ignores selected ids that are not present in the graph", () => {
+    const groups: GroupNode[] = [
+      { id: "a", permissions: ["a.read"], parentGroupIds: [] },
+    ];
+
+    const result = resolveInheritedPermissions(["missing"], groups);
+
+    expect(result.size).toBe(0);
+  });
+});

--- a/frontend/src/components/access-management/groupClosure.ts
+++ b/frontend/src/components/access-management/groupClosure.ts
@@ -1,0 +1,37 @@
+export type GroupNode = {
+  id: string;
+  permissions: string[];
+  parentGroupIds: string[];
+};
+
+/**
+ * Cycle-safe transitive closure of group nesting → set of inherited permissions.
+ *
+ * TS port of backend GroupClosure.Resolve. Seeds the traversal with the selected
+ * parent (included) group IDs only, so the result contains permissions inherited
+ * from nested groups — never the editing group's own direct permissions.
+ */
+export function resolveInheritedPermissions(
+  selectedParentIds: string[],
+  groups: GroupNode[],
+): Set<string> {
+  const groupsById = new Map(groups.map((g) => [g.id, g]));
+
+  const visited = new Set<string>();
+  const queue: string[] = [...selectedParentIds];
+  const result = new Set<string>();
+
+  while (queue.length > 0) {
+    const groupId = queue.shift()!;
+    if (visited.has(groupId)) continue; // already processed → cycle/diamond safe
+    visited.add(groupId);
+
+    const group = groupsById.get(groupId);
+    if (!group) continue;
+
+    for (const permission of group.permissions) result.add(permission);
+    for (const parentId of group.parentGroupIds) queue.push(parentId);
+  }
+
+  return result;
+}

--- a/frontend/src/pages/GroupDetailPage.tsx
+++ b/frontend/src/pages/GroupDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   useGroup,
@@ -19,6 +19,7 @@ import PermissionPicker from "../components/access-management/PermissionPicker";
 import IncludedGroupsPicker from "../components/access-management/IncludedGroupsPicker";
 import MembersPicker from "../components/access-management/MembersPicker";
 import EntraMemberSearch from "../components/access-management/EntraMemberSearch";
+import { resolveInheritedPermissions } from "../components/access-management/groupClosure";
 
 interface GroupDraft {
   name: string;
@@ -89,7 +90,7 @@ export default function GroupDetailPage() {
   const groupQuery = useGroup(isCreateMode ? null : id);
   const usersQuery = useUsers();
   useCatalogue();
-  useGroups();
+  const groupsQuery = useGroups();
 
   const updateGroup = useUpdateGroup();
   const createGroup = useCreateGroup();
@@ -132,6 +133,18 @@ export default function GroupDetailPage() {
 
   const updateDraft = (patch: Partial<GroupDraft>) =>
     setDraft((prev) => (prev ? { ...prev, ...patch } : prev));
+
+  // Permissions already covered by the currently selected included groups
+  // (transitive closure over their parents). Recomputes live as included
+  // groups change, so the highlight updates without saving.
+  const inheritedPermissionIds = useMemo(() => {
+    const graph = (groupsQuery.data?.groups ?? []).map((g) => ({
+      id: g.id ?? "",
+      permissions: g.permissions ?? [],
+      parentGroupIds: g.parentGroupIds ?? [],
+    }));
+    return resolveInheritedPermissions(draft?.parentGroupIds ?? [], graph);
+  }, [groupsQuery.data, draft?.parentGroupIds]);
 
   const onSave = async () => {
     if (!draft) return;
@@ -306,6 +319,7 @@ export default function GroupDetailPage() {
               value={draft.permissions}
               onChange={(permissions) => updateDraft({ permissions })}
               fillHeight
+              inheritedIds={inheritedPermissionIds}
             />
           </div>
         </section>


### PR DESCRIPTION
When editing an access group, permissions already inherited from its included (nested) groups now render with a green tint and an "inherited" badge in both columns of the permission picker, so it's clear which permissions are redundant to assign directly. `GroupSummaryDto` now exposes each group's direct permissions and parent IDs, letting the editor compute the transitive closure of inherited permissions on the frontend (a cycle/diamond-safe BFS port of the backend `GroupClosure`). The highlight recomputes live as included groups are added or removed, without saving. The regenerated OpenAPI client also picked up an unrelated `ordersBeingPackedCountLastSync` field that was stale on `main`. Verified with `dotnet build`/`format`, the Authorization test suite (109 passed), `npm run build`/`lint`, and new unit tests for the closure util.