### PR TITLE
feat(access): URL-driven user/group tabs and unsaved-changes confirmation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -489,6 +489,18 @@ function App() {
                         <Route path="/admin/feature-flags" element={guard("/admin/feature-flags", <FeatureFlagsAdminPage />)} />
                         <Route
                           path="/admin/access"
+                          element={<Navigate to="/admin/access/users" replace />}
+                        />
+                        <Route
+                          path="/admin/access/users"
+                          element={
+                            <RequireMenuPath path="/admin/access">
+                              <AccessManagementPage />
+                            </RequireMenuPath>
+                          }
+                        />
+                        <Route
+                          path="/admin/access/groups"
                           element={
                             <RequireMenuPath path="/admin/access">
                               <AccessManagementPage />

--- a/frontend/src/components/dialogs/UnsavedChangesDialog.tsx
+++ b/frontend/src/components/dialogs/UnsavedChangesDialog.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { AlertTriangle, X } from "lucide-react";
+
+interface UnsavedChangesDialogProps {
+  isOpen: boolean;
+  isSaving: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+  onKeepEditing: () => void;
+}
+
+const UnsavedChangesDialog: React.FC<UnsavedChangesDialogProps> = ({
+  isOpen,
+  isSaving,
+  onSave,
+  onDiscard,
+  onKeepEditing,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        onClick={onKeepEditing}
+      />
+
+      {/* Dialog */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div className="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+          {/* Close button */}
+          <button
+            onClick={onKeepEditing}
+            className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+
+          {/* Icon */}
+          <div className="flex items-center justify-center w-12 h-12 mx-auto bg-yellow-100 rounded-full mb-4">
+            <AlertTriangle className="h-6 w-6 text-yellow-600" />
+          </div>
+
+          {/* Title */}
+          <h3 className="text-lg font-semibold text-gray-900 text-center mb-2">
+            Unsaved changes
+          </h3>
+
+          {/* Message */}
+          <div className="text-sm text-gray-600 text-center mb-6">
+            <p>You have unsaved changes. Save them before leaving?</p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              onClick={onKeepEditing}
+              disabled={isSaving}
+              className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
+            >
+              Keep editing
+            </button>
+            <button
+              onClick={onDiscard}
+              disabled={isSaving}
+              className="flex-1 px-4 py-2 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50 transition-colors disabled:opacity-50"
+            >
+              Discard changes
+            </button>
+            <button
+              onClick={onSave}
+              disabled={isSaving}
+              className="flex-1 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors disabled:opacity-50"
+            >
+              {isSaving ? "Saving…" : "Save changes"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UnsavedChangesDialog;

--- a/frontend/src/components/dialogs/UnsavedChangesDialog.tsx
+++ b/frontend/src/components/dialogs/UnsavedChangesDialog.tsx
@@ -23,7 +23,7 @@ const UnsavedChangesDialog: React.FC<UnsavedChangesDialogProps> = ({
       {/* Backdrop */}
       <div
         className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
-        onClick={onKeepEditing}
+        onClick={isSaving ? undefined : onKeepEditing}
       />
 
       {/* Dialog */}

--- a/frontend/src/hooks/__tests__/useUnsavedChangesDialog.test.tsx
+++ b/frontend/src/hooks/__tests__/useUnsavedChangesDialog.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { draftsEqual, useUnsavedChangesDialog } from "../useUnsavedChangesDialog";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
+beforeEach(() => mockNavigate.mockClear());
+
+describe("draftsEqual", () => {
+  it("treats array fields as order-insensitive", () => {
+    expect(draftsEqual({ ids: ["a", "b"] }, { ids: ["b", "a"] })).toBe(true);
+  });
+
+  it("detects scalar field differences", () => {
+    expect(draftsEqual({ name: "x" }, { name: "y" })).toBe(false);
+  });
+
+  it("detects array membership differences", () => {
+    expect(draftsEqual({ ids: ["a"] }, { ids: ["a", "b"] })).toBe(false);
+  });
+
+  it("returns false when one side is null", () => {
+    expect(draftsEqual(null, { name: "x" })).toBe(false);
+  });
+});
+
+describe("useUnsavedChangesDialog", () => {
+  it("navigates immediately when not dirty", () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useUnsavedChangesDialog(false, save), { wrapper });
+
+    act(() => result.current.requestNavigation("/dest"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/dest");
+    expect(result.current.dialogProps.isOpen).toBe(false);
+  });
+
+  it("opens the dialog instead of navigating when dirty", () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useUnsavedChangesDialog(true, save), { wrapper });
+
+    act(() => result.current.requestNavigation("/dest"));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(result.current.dialogProps.isOpen).toBe(true);
+  });
+
+  it("Discard navigates to the pending destination", () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useUnsavedChangesDialog(true, save), { wrapper });
+
+    act(() => result.current.requestNavigation("/dest"));
+    act(() => result.current.dialogProps.onDiscard());
+
+    expect(mockNavigate).toHaveBeenCalledWith("/dest");
+    expect(result.current.dialogProps.isOpen).toBe(false);
+  });
+
+  it("Keep editing closes the dialog without navigating", () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useUnsavedChangesDialog(true, save), { wrapper });
+
+    act(() => result.current.requestNavigation("/dest"));
+    act(() => result.current.dialogProps.onKeepEditing());
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(result.current.dialogProps.isOpen).toBe(false);
+  });
+
+  it("Save navigates only when save resolves true", async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useUnsavedChangesDialog(true, save), { wrapper });
+
+    act(() => result.current.requestNavigation("/dest"));
+    await act(async () => {
+      await result.current.dialogProps.onSave();
+    });
+
+    expect(save).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/dest");
+    expect(result.current.dialogProps.isOpen).toBe(false);
+  });
+
+  it("Save keeps the dialog open when save resolves false", async () => {
+    const save = jest.fn().mockResolvedValue(false);
+    const { result } = renderHook(() => useUnsavedChangesDialog(true, save), { wrapper });
+
+    act(() => result.current.requestNavigation("/dest"));
+    await act(async () => {
+      await result.current.dialogProps.onSave();
+    });
+
+    expect(save).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(result.current.dialogProps.isOpen).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useUnsavedChangesDialog.ts
+++ b/frontend/src/hooks/useUnsavedChangesDialog.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+/**
+ * Compares two draft objects for equality, treating array fields as
+ * order-insensitive (e.g. permission/group id lists). Avoids false "dirty"
+ * positives when the user reorders items without changing the set.
+ */
+export function draftsEqual<T extends object>(
+  a: T | null,
+  b: T | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+
+  const aRec = a as Record<string, unknown>;
+  const bRec = b as Record<string, unknown>;
+  const keys = Object.keys(aRec);
+  if (keys.length !== Object.keys(bRec).length) return false;
+
+  return keys.every((key) => {
+    const av = aRec[key];
+    const bv = bRec[key];
+    if (Array.isArray(av) && Array.isArray(bv)) {
+      if (av.length !== bv.length) return false;
+      const sortedA = [...av].sort();
+      const sortedB = [...bv].sort();
+      return sortedA.every((v, i) => v === sortedB[i]);
+    }
+    return av === bv;
+  });
+}
+
+interface UnsavedChangesDialogState {
+  dialogProps: {
+    isOpen: boolean;
+    isSaving: boolean;
+    onSave: () => void;
+    onDiscard: () => void;
+    onKeepEditing: () => void;
+  };
+  requestNavigation: (to: string) => void;
+}
+
+/**
+ * Intercepts explicit "leave the editor" navigations (Cancel / ← back) when the
+ * form has unsaved changes, surfacing a Save / Discard / Keep editing dialog.
+ * Also registers a `beforeunload` prompt to cover hard refresh / tab close.
+ *
+ * Note: this does NOT guard sidebar-menu clicks or in-app browser Back — the app
+ * uses BrowserRouter, where react-router's useBlocker is a no-op. Route those
+ * "leave" buttons through `requestNavigation` instead of calling navigate directly.
+ */
+export function useUnsavedChangesDialog(
+  isDirty: boolean,
+  save: () => Promise<boolean>,
+): UnsavedChangesDialogState {
+  const navigate = useNavigate();
+  const [pendingTo, setPendingTo] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const requestNavigation = (to: string) => {
+    if (isDirty) {
+      setPendingTo(to);
+    } else {
+      navigate(to);
+    }
+  };
+
+  const onKeepEditing = () => setPendingTo(null);
+
+  const onDiscard = () => {
+    const to = pendingTo;
+    setPendingTo(null);
+    if (to) navigate(to);
+  };
+
+  const onSave = async () => {
+    setIsSaving(true);
+    const ok = await save();
+    setIsSaving(false);
+    if (!ok) return; // stay open so the user sees the validation/save error
+    const to = pendingTo;
+    setPendingTo(null);
+    if (to) navigate(to);
+  };
+
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  return {
+    dialogProps: { isOpen: pendingTo !== null, isSaving, onSave, onDiscard, onKeepEditing },
+    requestNavigation,
+  };
+}

--- a/frontend/src/pages/AccessManagementPage.tsx
+++ b/frontend/src/pages/AccessManagementPage.tsx
@@ -1,11 +1,16 @@
-import React, { useState } from "react";
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { PAGE_CONTAINER_HEIGHT } from "../constants/layout";
 import { useScreenView } from "../telemetry/useScreenView";
 import GroupsGrid from "../components/pages/access/GroupsGrid";
 import UsersGrid from "../components/pages/access/UsersGrid";
 
 export default function AccessManagementPage() {
-  const [tab, setTab] = useState<"users" | "groups">("users");
+  const location = useLocation();
+  const navigate = useNavigate();
+  const tab: "users" | "groups" = location.pathname.endsWith("/groups")
+    ? "groups"
+    : "users";
 
   useScreenView("Admin", "AccessManagement");
 
@@ -18,7 +23,7 @@ export default function AccessManagementPage() {
       <div className="flex-shrink-0 border-b border-gray-200 mb-4">
         <nav className="flex gap-6" aria-label="Tabs">
           <button
-            onClick={() => setTab("users")}
+            onClick={() => navigate("/admin/access/users")}
             className={`py-2 text-sm font-medium border-b-2 transition-colors ${
               tab === "users"
                 ? "border-indigo-500 text-indigo-600"
@@ -28,7 +33,7 @@ export default function AccessManagementPage() {
             Users
           </button>
           <button
-            onClick={() => setTab("groups")}
+            onClick={() => navigate("/admin/access/groups")}
             className={`py-2 text-sm font-medium border-b-2 transition-colors ${
               tab === "groups"
                 ? "border-indigo-500 text-indigo-600"

--- a/frontend/src/pages/GroupDetailPage.tsx
+++ b/frontend/src/pages/GroupDetailPage.tsx
@@ -19,6 +19,11 @@ import PermissionPicker from "../components/access-management/PermissionPicker";
 import IncludedGroupsPicker from "../components/access-management/IncludedGroupsPicker";
 import MembersPicker from "../components/access-management/MembersPicker";
 import EntraMemberSearch from "../components/access-management/EntraMemberSearch";
+import UnsavedChangesDialog from "../components/dialogs/UnsavedChangesDialog";
+import {
+  draftsEqual,
+  useUnsavedChangesDialog,
+} from "../hooks/useUnsavedChangesDialog";
 
 interface GroupDraft {
   name: string;
@@ -133,11 +138,11 @@ export default function GroupDetailPage() {
   const updateDraft = (patch: Partial<GroupDraft>) =>
     setDraft((prev) => (prev ? { ...prev, ...patch } : prev));
 
-  const onSave = async () => {
-    if (!draft) return;
+  const onSave = async (): Promise<boolean> => {
+    if (!draft) return false;
     if (!draft.name.trim()) {
       toast.showError("Validation error", "Group name is required");
-      return;
+      return false;
     }
 
     try {
@@ -151,8 +156,9 @@ export default function GroupDetailPage() {
           }),
         );
         toast.showSuccess("Group created", "The new group has been saved");
+        setOriginal(draft);
         navigate(`/admin/access/groups/${result.id}`);
-        return;
+        return true;
       }
 
       await updateGroup.mutateAsync({
@@ -184,6 +190,7 @@ export default function GroupDetailPage() {
 
       toast.showSuccess("Saved", "Group updated successfully");
       setOriginal(draft);
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("AuthorizationGroupCycleDetected")) {
@@ -197,10 +204,17 @@ export default function GroupDetailPage() {
           "An error occurred while saving changes",
         );
       }
+      return false;
     }
   };
 
-  const onCancel = () => navigate("/admin/access");
+  const isDirty = !draftsEqual(draft, original);
+  const { dialogProps, requestNavigation } = useUnsavedChangesDialog(
+    isDirty,
+    onSave,
+  );
+
+  const onCancel = () => requestNavigation("/admin/access/groups");
 
   const isSaving =
     updateGroup.isPending ||
@@ -354,6 +368,8 @@ export default function GroupDetailPage() {
           </section>
         )}
       </div>
+
+      <UnsavedChangesDialog {...dialogProps} />
     </div>
   );
 }

--- a/frontend/src/pages/UserDetailPage.tsx
+++ b/frontend/src/pages/UserDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import {
   useUsers,
   useAssignUserGroups,
@@ -10,6 +10,11 @@ import {
 import { AssignUserGroupsRequest, SetUserActiveRequest, UpdateUserRequest } from "../api/generated/api-client";
 import { useToast } from "../contexts/ToastContext";
 import GroupsPicker from "../components/access-management/GroupsPicker";
+import UnsavedChangesDialog from "../components/dialogs/UnsavedChangesDialog";
+import {
+  draftsEqual,
+  useUnsavedChangesDialog,
+} from "../hooks/useUnsavedChangesDialog";
 
 interface UserDraft {
   displayName: string;
@@ -20,7 +25,6 @@ interface UserDraft {
 
 export default function UserDetailPage() {
   const { id = "" } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const toast = useToast();
 
   const usersQuery = useUsers();
@@ -30,6 +34,7 @@ export default function UserDetailPage() {
   const updateUser = useUpdateUser();
 
   const [draft, setDraft] = useState<UserDraft | null>(null);
+  const [original, setOriginal] = useState<UserDraft | null>(null);
   const initialized = useRef(false);
 
   const user = usersQuery.data?.users?.find((u) => u.id === id);
@@ -45,17 +50,18 @@ export default function UserDetailPage() {
       groupIds: user.groupIds ?? [],
     };
     setDraft(d);
+    setOriginal(d);
     initialized.current = true;
   }, [user]);
 
   const updateDraft = (patch: Partial<UserDraft>) =>
     setDraft((prev) => (prev ? { ...prev, ...patch } : prev));
 
-  const onSave = async () => {
-    if (!draft) return;
+  const onSave = async (): Promise<boolean> => {
+    if (!draft) return false;
     if (!draft.displayName.trim()) {
       toast.showError("Save failed", "Display name is required");
-      return;
+      return false;
     }
     const [profileResult, groupResult] = await Promise.allSettled([
       updateUser.mutateAsync({
@@ -79,10 +85,18 @@ export default function UserDetailPage() {
       const part =
         profileFailed && groupFailed ? "changes" : profileFailed ? "profile" : "group assignment";
       toast.showError("Save failed", `Could not save ${part}. Please try again.`);
-      return;
+      return false;
     }
     toast.showSuccess("Saved", "User updated successfully");
+    setOriginal(draft);
+    return true;
   };
+
+  const isDirty = !draftsEqual(draft, original);
+  const { dialogProps, requestNavigation } = useUnsavedChangesDialog(
+    isDirty,
+    onSave,
+  );
 
   const onToggleActive = async () => {
     if (!user?.id) return;
@@ -126,7 +140,7 @@ export default function UserDetailPage() {
       <div className="flex items-center gap-4">
         <button
           type="button"
-          onClick={() => navigate("/admin/access")}
+          onClick={() => requestNavigation("/admin/access/users")}
           className="text-gray-500 hover:text-gray-700 text-sm"
         >
           ← Access management
@@ -223,13 +237,15 @@ export default function UserDetailPage() {
         </button>
         <button
           type="button"
-          onClick={() => navigate("/admin/access")}
+          onClick={() => requestNavigation("/admin/access/users")}
           disabled={isSaving}
           className="px-5 py-2 border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
         >
           Cancel
         </button>
       </div>
+
+      <UnsavedChangesDialog {...dialogProps} />
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/AccessManagementPage.test.tsx
+++ b/frontend/src/pages/__tests__/AccessManagementPage.test.tsx
@@ -45,55 +45,69 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate,
 }));
 
-const renderPage = () =>
+const renderPage = (path = "/admin/access/users") =>
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[path]}>
       <AccessManagementPage />
     </MemoryRouter>
   );
 
 beforeEach(() => mockNavigate.mockClear());
 
-const goToGroups = () => fireEvent.click(screen.getByRole("button", { name: "Groups" }));
-
 describe("AccessManagementPage", () => {
-  it("shows the Users tab by default", () => {
-    renderPage();
+  it("shows the Users tab on the /users route", () => {
+    renderPage("/admin/access/users");
     expect(screen.getByText("Alice")).toBeInTheDocument();
     expect(screen.queryByText("Spravce")).not.toBeInTheDocument();
   });
 
+  it("shows the Groups tab on the /groups route", () => {
+    renderPage("/admin/access/groups");
+    expect(screen.getByText("Spravce")).toBeInTheDocument();
+    expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+  });
+
+  it("clicking the Groups tab navigates to its URL", () => {
+    renderPage("/admin/access/users");
+    fireEvent.click(screen.getByRole("button", { name: "Groups" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups");
+  });
+
+  it("clicking the Users tab navigates to its URL", () => {
+    renderPage("/admin/access/groups");
+    fireEvent.click(screen.getByRole("button", { name: "Users" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users");
+  });
+
   it("clicking a user name navigates to the user detail page", () => {
-    renderPage();
+    renderPage("/admin/access/users");
     fireEvent.click(screen.getByRole("button", { name: "Alice" }));
     expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users/user-1");
   });
 
   it("clicking Edit icon in Users tab navigates to user detail page", () => {
-    renderPage();
+    renderPage("/admin/access/users");
     fireEvent.click(screen.getByRole("button", { name: /edit alice/i }));
     expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users/user-1");
   });
 
-  it("switching to Groups renders the group and its delete button", () => {
-    renderPage();
-    goToGroups();
+  it("Groups tab renders the group and its delete button", () => {
+    renderPage("/admin/access/groups");
     expect(screen.getByText("Spravce")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /delete spravce/i })).toBeInTheDocument();
   });
 
   it("the New group button lives in the Groups tab and navigates to the create page", () => {
-    renderPage();
+    renderPage("/admin/access/users");
     expect(screen.queryByRole("button", { name: /new group/i })).not.toBeInTheDocument();
 
-    goToGroups();
+    renderPage("/admin/access/groups");
     fireEvent.click(screen.getByRole("button", { name: /new group/i }));
     expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/new");
   });
 
   it("clicking the group name navigates to the group detail page", () => {
-    renderPage();
-    goToGroups();
+    renderPage("/admin/access/groups");
     fireEvent.click(screen.getByText("Spravce"));
     expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups/1");
   });

--- a/frontend/src/pages/__tests__/GroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/GroupDetailPage.test.tsx
@@ -196,11 +196,36 @@ describe("GroupDetailPage", () => {
     });
   });
 
-  it("Cancel navigates back to the access management list", async () => {
+  it("Cancel with no changes navigates straight to the Groups tab", async () => {
     renderWithRoute("group-1");
     await screen.findByDisplayValue("Test Group");
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
-    expect(mockNavigate).toHaveBeenCalledWith("/admin/access");
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups");
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+  });
+
+  it("Cancel with unsaved changes opens the dialog; Discard navigates to the Groups tab", async () => {
+    renderWithRoute("group-1");
+    await screen.findByDisplayValue("Test Group");
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Changed" } });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /discard changes/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/groups");
+  });
+
+  it("Keep editing dismisses the dialog without navigating", async () => {
+    renderWithRoute("group-1");
+    await screen.findByDisplayValue("Test Group");
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Changed" } });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    fireEvent.click(screen.getByRole("button", { name: /keep editing/i }));
+
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("create mode (id=new) renders empty form and Save calls createGroup then navigates", async () => {

--- a/frontend/src/pages/__tests__/UserDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/UserDetailPage.test.tsx
@@ -157,10 +157,39 @@ describe("UserDetailPage", () => {
     expect(screen.getByText("orders.write")).toBeInTheDocument();
   });
 
-  it("Cancel navigates back to access management", async () => {
+  it("Cancel with no changes navigates straight to the Users tab", async () => {
     renderWithRoute("user-1");
     await screen.findByText("Alice");
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
-    expect(mockNavigate).toHaveBeenCalledWith("/admin/access");
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users");
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+  });
+
+  it("Cancel with unsaved changes opens the dialog; Discard navigates to the Users tab", async () => {
+    renderWithRoute("user-1");
+    await screen.findByText("Alice");
+    fireEvent.change(screen.getByDisplayValue("Alice"), {
+      target: { value: "Alice Updated" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /discard changes/i }));
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/access/users");
+  });
+
+  it("Keep editing dismisses the dialog without navigating", async () => {
+    renderWithRoute("user-1");
+    await screen.findByText("Alice");
+    fireEvent.change(screen.getByDisplayValue("Alice"), {
+      target: { value: "Alice Updated" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    fireEvent.click(screen.getByRole("button", { name: /keep editing/i }));
+
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Gives the Access Management Users and Groups tabs distinct path-based URLs (`/admin/access/users` and `/admin/access/groups`), so the active tab is linkable and is preserved when returning from a detail editor — fixing the previous fallback to the Users tab after editing a group. Adds a **Save changes / Discard changes / Keep editing** confirmation dialog that intercepts the Cancel and ← back buttons whenever a user or group editor has unsaved changes, backed by a reusable `useUnsavedChangesDialog` hook (with a `beforeunload` prompt for hard refresh/close) and a shared order-insensitive dirty check. Note: because the app uses `BrowserRouter` (where react-router's `useBlocker` is a no-op), the guard covers the explicit Cancel/back buttons only — leaving via the sidebar menu or in-app browser Back is intentionally not guarded.

## Test plan

- [x] `npm run build` passes
- [x] Frontend unit tests pass (46 tests across the access suites, incl. new `useUnsavedChangesDialog` suite)
- [ ] Manual: edit a group → Cancel → Discard lands on the Groups tab; Save persists then lands on Groups; Keep editing stays; unedited editor navigates with no dialog; repeat for a user → lands on Users tab