### PR TITLE
feat: Remove Dead Query Methods from `IIssuedInvoiceRepository`

### DIFF
--- a/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/arch-review.r1.md
+++ b/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/arch-review.r1.md
@@ -1,0 +1,104 @@
+I've verified the spec against the codebase. The five "Find*" methods are referenced only in the three files the spec targets, `CreateTestSyncData()` is shared with retained tests (must stay), and `SetLastSyncTime()` is used only by the to-be-removed `FindStaleInvoicesAsync` test (becomes dead code).
+
+# Architecture Review: Remove Dead Query Methods from `IIssuedInvoiceRepository`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+The change strengthens existing patterns and introduces nothing new. The Invoices module already follows the project's Vertical Slice + Clean Architecture layout, with the repository contract in `Application/Features/Invoices/Contracts/` and the EF Core implementation in `Application/Features/Invoices/Infrastructure/`. All production consumers — `GetIssuedInvoicesListHandler`, `GetIssuedInvoiceSyncStatsHandler`, `GetIssuedInvoiceDetailHandler`, `InvoiceImportService`, `InvoiceConsumptionSourceAdapter` — drive their queries through `GetPaginatedAsync`, `GetSyncStatsAsync`, `GetByIdAsync`, `GetByIdWithSyncHistoryAsync`, and `GetHeadersByDateAsync`. A targeted grep across `backend/` confirms the five removal candidates are referenced only in the three files the spec touches. Removing them is therefore a contract narrowing that aligns the interface with actual use-cases (ISP/YAGNI) without affecting integration points.
+
+There is one secondary consumer worth naming: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` references the type `IIssuedInvoiceRepository` for boundary assertions. This test asserts placement/visibility of the type, not specific members, so it remains green.
+
+## Proposed Architecture
+
+### Component Overview
+```
+Application/Features/Invoices/
+├── Contracts/
+│   └── IIssuedInvoiceRepository  ── narrowed: 4 specialized + IRepository<,> base
+├── Infrastructure/
+│   └── IssuedInvoiceRepository   ── 5 method bodies removed; remaining methods untouched
+└── UseCases/, Services/, Infrastructure/ adapters  ── no edits (already use retained API)
+
+test/Anela.Heblo.Tests/Features/Invoices/
+└── IssuedInvoiceRepositoryTests   ── 7 [Fact] methods + SetLastSyncTime helper removed
+```
+
+No new components, no DI changes, no controller/contract changes.
+
+### Key Design Decisions
+
+#### Decision 1: Pure deletion vs. `[Obsolete]` deprecation window
+**Options considered:**
+1. Mark methods `[Obsolete]` and remove later.
+2. Delete outright (spec's approach).
+
+**Chosen approach:** Delete outright.
+
+**Rationale:** The methods are repository-internal — no public API, no NuGet consumers, no cross-module callers. Deprecation provides value only when external clients exist. Reversibility is trivial (single-file git revert), so the cost of restoration if needed is negligible.
+
+#### Decision 2: Helper-method cleanup scope
+**Options considered:**
+1. Delete only the seven `[Fact]` methods listed in FR-3.
+2. Also delete private helpers that become unreferenced after the test removal.
+
+**Chosen approach:** Delete helpers that become dead.
+
+**Rationale:** `SetLastSyncTime` (line 458) is used **only** by `FindStaleInvoicesAsync_WithStaleInvoices_ReturnsUnsyncedAndOldSynced`. After that test goes, the helper is dead reflection-based code and should be removed in the same commit — leaving it would re-create the YAGNI smell on a smaller scale and is explicitly within the spec's intent ("arrange-only helper code that exists solely to support these tests"). `CreateTestSyncData` (line 445) **must remain** — it is still used by `GetByIdWithSyncHistoryAsync_…`, `GetSyncStatsAsync_…`, and the two `GetPaginatedAsync_…` sync/error tests.
+
+#### Decision 3: `using` directive cleanup
+**Options considered:** Re-run `dotnet format` to drop newly-unused imports vs. manual review.
+
+**Chosen approach:** Trust `dotnet format` + verify with `--verify-no-changes`.
+
+**Rationale:** In `IssuedInvoiceRepository.cs`, every current `using` (`Microsoft.EntityFrameworkCore`, `Microsoft.Extensions.Logging`, the project namespaces) is still required by retained methods. No drift expected, but `dotnet format` is the project's enforced gate per NFR-1.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No structural change. Edits are confined to three existing files:
+- `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs` — remove method declarations + XML doc-comment blocks at lines 13–16, 18–21, 23–26, 28–31, 38–41.
+- `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs` — remove method bodies at lines 37–88.
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs` — remove seven `[Fact]` methods at lines 119–164, 166–187, 189–214, 216–243, 285–326, and the `SetLastSyncTime` helper at lines 458–462.
+
+### Interfaces and Contracts
+Post-change `IIssuedInvoiceRepository` shape:
+```csharp
+public interface IIssuedInvoiceRepository : IRepository<IssuedInvoice, string>
+{
+    Task<IssuedInvoice?> GetByIdWithSyncHistoryAsync(string id, CancellationToken ct = default);
+    Task<IssuedInvoiceSyncStats> GetSyncStatsAsync(DateTime fromDate, DateTime toDate, CancellationToken ct = default);
+    Task<PaginatedResult<IssuedInvoice>> GetPaginatedAsync(IssuedInvoiceFilters filters, CancellationToken ct = default);
+    Task<IEnumerable<IssuedInvoice>> GetHeadersByDateAsync(DateOnly date, CancellationToken ct = default);
+}
+```
+All existing parameter names and types (`cancellationToken` per repo convention, not `ct`) are preserved verbatim from the current file — do not introduce stylistic edits during the deletion.
+
+### Data Flow
+Unchanged for every production path. Filtering on the live read path continues to flow:
+```
+Controller/MediatR → GetIssuedInvoicesListHandler → IIssuedInvoiceRepository.GetPaginatedAsync(IssuedInvoiceFilters) → EF Core query
+```
+Sync stats, detail lookup, header-by-date, and import paths likewise route through their existing retained methods.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Hidden caller via reflection or DI extension | Low | `grep -r` across `backend/` shows zero non-test references; no `nameof(...)` or string-keyed lookups found. |
+| Removing `SetLastSyncTime` breaks an unrelated test | Low | Verified: it is referenced only on lines 224 & 228, both inside the to-be-deleted `FindStaleInvoicesAsync_…` test. |
+| `dotnet format` reformats adjacent code, violating "Surgical diff" (NFR-4) | Low–Medium | The repo's existing files are already formatted; run `dotnet format --verify-no-changes` after the edit and revert any incidental changes outside the three target files. |
+| OpenAPI/TS-client regeneration triggered by build | Very Low | The removed methods are not exposed via controllers/handlers — the OpenAPI surface is unaffected. CI generation will produce a no-op diff. |
+| Coverage report visibly drops | Low (cosmetic) | Expected and acceptable — only deleted-method coverage disappears. Document briefly in the PR description. |
+| Architecture boundary test (`ModuleBoundariesTests`) fails | Very Low | The test asserts type placement, not member counts; the interface type itself is retained. |
+
+## Specification Amendments
+The spec is sound. Two small refinements should be folded in to avoid ambiguity during implementation:
+
+1. **FR-3 — name the helper explicitly.** The spec says "arrange-only helper code that exists solely to support these tests … must be removed together." Make this concrete: also remove `private static void SetLastSyncTime(IssuedInvoice invoice, DateTime syncTime)` at lines 458–462. Keep `CreateTestSyncData` (line 445) — it is shared with retained tests.
+
+2. **FR-4 — clarify scope of "untouched."** `git diff` is expected to show edits to **three files**: the interface, the repository implementation, and the test file. Adding "no other files in the repo may show modifications" makes the surgical-diff requirement objectively verifiable.
+
+No other changes to the spec are warranted; functional and non-functional requirements remain accurate and complete.
+
+## Prerequisites
+None. No migration, configuration change, infrastructure update, feature flag, or coordinated rollout is required. The change is a single self-contained commit and is fully reversible by `git revert`. Implementation can begin immediately and proceed under the project's standard validation gates (`dotnet build`, `dotnet format --verify-no-changes`, `dotnet test`).

--- a/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/brief.md
+++ b/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/brief.md
@@ -1,0 +1,28 @@
+## Module
+Invoices
+
+## Finding
+`IIssuedInvoiceRepository` (`Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs`) declares five methods that have **no callers in production code**:
+
+| Method | Lines |
+|--------|-------|
+| `FindBySyncStatusAsync` | line 16 |
+| `FindByInvoiceDateRangeAsync` | line 21 |
+| `FindByCustomerNameAsync` | line 26 |
+| `FindWithCriticalErrorsAsync` | line 31 |
+| `FindStaleInvoicesAsync` | line 41 |
+
+The only files that call these methods are in `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs`. No handler, service, or adapter in the production tree uses them.
+
+All live filtering is handled through `GetPaginatedAsync` (used by `GetIssuedInvoicesListHandler`) and purpose-specific methods (`GetSyncStatsAsync`, `GetByIdWithSyncHistoryAsync`, `GetHeadersByDateAsync`) that each have a production caller.
+
+## Why it matters
+- **YAGNI**: the interface contract exposes capabilities no current feature needs.
+- **ISP**: any future test double (mock or fake) for `IIssuedInvoiceRepository` must stub five dead methods, adding noise and coupling to the test setup.
+- **Readability**: future maintainers can't tell which query methods are actually part of the domain use-cases and which are speculative leftovers.
+
+## Suggested fix
+Remove the five methods from `IIssuedInvoiceRepository` and their corresponding implementations in `IssuedInvoiceRepository.cs` (lines 37–88). Remove the test cases that exercise them in `IssuedInvoiceRepositoryTests.cs`. If a future use-case genuinely needs one of these queries it can be re-added at that point, as a concrete driven-by-feature addition.
+
+---
+_Filed by daily arch-review routine on 2026-06-09._

--- a/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/impl/main.r1.md
+++ b/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/impl/main.r1.md
@@ -1,0 +1,48 @@
+All three tasks complete. Here's the output summary:
+
+---
+
+# Implementation: Remove Dead Query Methods from `IIssuedInvoiceRepository`
+
+## What was implemented
+
+Removed 5 unused `Find*` query methods from `IIssuedInvoiceRepository` (interface declarations + XML doc comments), their EF Core implementations in `IssuedInvoiceRepository`, and the 7 unit tests + 1 orphan private helper that exercised them. Pure deletion — no behavior changed.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs` — removed 5 Find* method declarations with XML doc comments; 4 retained members remain
+- `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs` — removed 5 Find* method bodies; all retained members and `using` directives untouched
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs` — removed 7 `[Fact]` methods + `SetLastSyncTime` private helper; `CreateTestSyncData` and 10 retained test methods untouched
+
+## Tests
+
+All 10 remaining tests in `IssuedInvoiceRepositoryTests` pass. Full backend suite passes with 0 errors. Test count dropped by exactly 7 from baseline (as expected).
+
+## How to verify
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+dotnet test backend/Anela.Heblo.sln --no-build
+grep -rnE "FindBySyncStatusAsync|FindByInvoiceDateRangeAsync|FindByCustomerNameAsync|FindWithCriticalErrorsAsync|FindStaleInvoicesAsync" backend/
+# → no output expected
+```
+
+## Notes
+
+- Commit `ebb10632` on branch `feat-arch-review-invoices-iissuedinvoicerepos`, 253 lines deleted, 0 added
+- One pre-existing build warning (unrelated to this change) was present before and after — not introduced by this PR
+- `docs/superpowers/plans/2026-06-11-remove-dead-issuedinvoicerepository-find-methods.md` remains untracked (not committed per surgical-diff requirement)
+
+## PR Summary
+
+Removed 5 speculative `Find*` query methods from `IIssuedInvoiceRepository` that had no production callers — all live filtering already flows through `GetPaginatedAsync`. This narrows the interface contract to the 4 methods actually used, eliminating YAGNI surface area that forced any test double or alternative implementation to stub dead APIs.
+
+The change is a pure deletion across 3 files: interface declarations, EF Core implementations, and the unit tests that covered the removed methods. The `SetLastSyncTime` reflection-based helper (only used by the now-deleted stale-invoice test) was removed alongside. Build, formatting, and full test suite all clean.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs` — removed 5 `Find*` declarations and their XML doc-comment blocks
+- `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs` — removed 5 `Find*` implementation bodies
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs` — removed 7 `[Fact]` test methods and the `SetLastSyncTime` private helper
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/spec.r1.md
+++ b/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/spec.r1.md
@@ -1,0 +1,154 @@
+# Specification: Remove Dead Query Methods from `IIssuedInvoiceRepository`
+
+## Summary
+Remove five unused query methods (`FindBySyncStatusAsync`, `FindByInvoiceDateRangeAsync`, `FindByCustomerNameAsync`, `FindWithCriticalErrorsAsync`, `FindStaleInvoicesAsync`) from `IIssuedInvoiceRepository`, their EF Core implementations in `IssuedInvoiceRepository`, and the unit tests that exercise them. The methods have no production callers — all live filtering happens through `GetPaginatedAsync`. This is a YAGNI/ISP cleanup that shrinks the contract to what current use-cases actually need.
+
+## Background
+A daily architecture review (`brief.md`, 2026-06-09) identified that `IIssuedInvoiceRepository` exposes five "Find*" methods whose only callers are the repository's own xUnit test class. Production code paths (`GetIssuedInvoicesListHandler`, `GetIssuedInvoiceSyncStatsHandler`, `GetIssuedInvoiceDetailHandler`, `InvoiceImportService`, `InvoiceConsumptionSourceAdapter`) rely exclusively on `GetPaginatedAsync`, `GetSyncStatsAsync`, `GetByIdAsync`, `GetByIdWithSyncHistoryAsync`, and `GetHeadersByDateAsync`.
+
+Keeping the speculative API on the interface:
+- **Violates YAGNI** — surface area without a real consumer.
+- **Violates ISP** — any future test double or alternative implementation (e.g. a fake/mock for handler tests) must stub five methods nobody calls.
+- **Hurts readability** — future maintainers cannot distinguish domain-driven query methods from leftovers when reading the interface.
+
+The fix is non-functional: removing dead code on the interface and its implementation does not change observable system behavior. If a real use-case appears later, the method can be re-added on demand as a feature-driven addition.
+
+## Functional Requirements
+
+### FR-1: Remove unused query methods from the interface
+Delete the five unused method declarations from `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs`:
+- `FindBySyncStatusAsync` (line 16)
+- `FindByInvoiceDateRangeAsync` (line 21)
+- `FindByCustomerNameAsync` (line 26)
+- `FindWithCriticalErrorsAsync` (line 31)
+- `FindStaleInvoicesAsync` (line 41)
+
+Their preceding XML doc-comment blocks must be removed together with the signatures. The remaining members on the interface — `GetByIdWithSyncHistoryAsync`, `GetSyncStatsAsync`, `GetPaginatedAsync`, `GetHeadersByDateAsync`, and inherited `IRepository<IssuedInvoice, string>` members — stay unchanged.
+
+**Acceptance criteria:**
+- `IIssuedInvoiceRepository.cs` no longer contains the five method declarations or their XML doc-comments.
+- File compiles (`dotnet build` succeeds for the `Anela.Heblo.Application` project).
+- A textual search across `backend/src/` and `backend/test/` for each removed method name returns zero matches.
+
+### FR-2: Remove the matching implementations from the EF Core repository
+Delete the five corresponding implementations from `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs`:
+- `FindBySyncStatusAsync` (lines 37–49)
+- `FindByInvoiceDateRangeAsync` (lines 51–57)
+- `FindByCustomerNameAsync` (lines 59–72)
+- `FindWithCriticalErrorsAsync` (lines 74–80)
+- `FindStaleInvoicesAsync` (lines 82–88)
+
+All other repository members — `GetByIdAsync`, `GetByIdWithSyncHistoryAsync`, `GetSyncStatsAsync`, `AddAsync`, `UpdateAsync`, `GetPaginatedAsync`, `GetHeadersByDateAsync`, `ApplySorting` — must remain unchanged. The class must still implement `IIssuedInvoiceRepository`.
+
+**Acceptance criteria:**
+- `IssuedInvoiceRepository.cs` no longer contains the five method bodies.
+- File compiles and the class still satisfies its interface (verified by `dotnet build`).
+- Remaining public/override members compile and behave identically (no edits to retained methods).
+- No new `using` directives become unused; remove `using` lines that are no longer referenced after deletion. Run `dotnet format` to confirm cleanup.
+
+### FR-3: Remove the tests covering the deleted methods
+Delete the test methods that exercise the removed repository APIs from `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs`:
+- `FindBySyncStatusAsync_WithSyncedFilter_ReturnsOnlySynced` (line 120)
+- `FindBySyncStatusAsync_WithNullFilter_ReturnsAll` (line 145)
+- `FindByInvoiceDateRangeAsync_WithDateRange_ReturnsFilteredInvoices` (line 167)
+- `FindWithCriticalErrorsAsync_WithErrorTypes_ReturnsOnlyCriticalErrors` (line 190)
+- `FindStaleInvoicesAsync_WithStaleInvoices_ReturnsUnsyncedAndOldSynced` (line 217)
+- `FindByCustomerNameAsync_WithPartialName_ReturnsMatchingInvoices` (line 286)
+- `FindByCustomerNameAsync_WithEmptyName_ReturnsEmpty` (line 312)
+
+Their `[Fact]` attributes and any arrange-only helper code that exists solely to support these tests (i.e. is not referenced by any retained test method) must be removed together.
+
+**Acceptance criteria:**
+- The seven test methods are gone from `IssuedInvoiceRepositoryTests.cs`.
+- All remaining tests in that file still compile and pass (`dotnet test --filter "FullyQualifiedName~IssuedInvoiceRepositoryTests"`).
+- The whole backend test suite passes (`dotnet test`).
+- Test coverage for `IssuedInvoiceRepository` does not drop for the retained methods; only the deleted-method coverage disappears.
+
+### FR-4: Preserve all retained behavior
+The change must be a pure removal. No edits to:
+- `GetIssuedInvoicesListHandler` or any other handler.
+- `IssuedInvoiceFilters`, `PaginatedResult<T>`, or any DTO.
+- `InvoicesModule.cs` DI registrations.
+- `GetPaginatedAsync`, `GetSyncStatsAsync`, `GetByIdAsync`, `GetByIdWithSyncHistoryAsync`, `GetHeadersByDateAsync`, `AddAsync`, `UpdateAsync`, or `ApplySorting`.
+- Any frontend code, OpenAPI contract, or generated client (the removed methods are repository-internal — they have no controller or DTO surface).
+
+**Acceptance criteria:**
+- `git diff` after the change shows only edits to the three files listed in FR-1, FR-2, FR-3.
+- No regenerated OpenAPI/TypeScript-client artifacts appear in the diff.
+- `dotnet build` and `dotnet format` are clean.
+- All pre-existing tests (unit + integration) pass.
+
+## Non-Functional Requirements
+
+### NFR-1: Build & static-analysis cleanliness
+After the change:
+- `dotnet build` must succeed for the entire solution with no new warnings.
+- `dotnet format --verify-no-changes` must report no formatting drift.
+- Nullable-reference-type analysis must remain clean (no new `CS86xx` warnings introduced).
+
+### NFR-2: Test stability
+- `dotnet test` for the `Anela.Heblo.Tests` project must pass with the same green status as before the change, minus the seven deleted test cases.
+- No remaining test must depend on the deleted methods, directly or transitively.
+
+### NFR-3: Reversibility
+The change is purely additive in reverse — re-adding any removed method later requires only restoring the declaration, body, and (optionally) test. Therefore no migration, feature flag, or deprecation window is needed.
+
+### NFR-4: Surgical diff
+Per project guideline "Surgical changes": touch only the three files identified. Do not reformat, rename, or refactor adjacent code, even if tempted.
+
+## Data Model
+No data-model changes. The `IssuedInvoice` entity, `IssuedInvoiceSyncStats`, `IssuedInvoiceFilters`, `PaginatedResult<T>`, and the EF Core `ApplicationDbContext` schema are untouched. No migration is required.
+
+## API / Interface Design
+
+### Before
+```csharp
+public interface IIssuedInvoiceRepository : IRepository<IssuedInvoice, string>
+{
+    Task<IEnumerable<IssuedInvoice>> FindBySyncStatusAsync(bool? isSynced, CancellationToken ct = default);
+    Task<IEnumerable<IssuedInvoice>> FindByInvoiceDateRangeAsync(DateTime fromDate, DateTime toDate, CancellationToken ct = default);
+    Task<IEnumerable<IssuedInvoice>> FindByCustomerNameAsync(string customerName, CancellationToken ct = default);
+    Task<IEnumerable<IssuedInvoice>> FindWithCriticalErrorsAsync(CancellationToken ct = default);
+    Task<IssuedInvoice?> GetByIdWithSyncHistoryAsync(string id, CancellationToken ct = default);
+    Task<IEnumerable<IssuedInvoice>> FindStaleInvoicesAsync(DateTime beforeDate, CancellationToken ct = default);
+    Task<IssuedInvoiceSyncStats> GetSyncStatsAsync(DateTime fromDate, DateTime toDate, CancellationToken ct = default);
+    Task<PaginatedResult<IssuedInvoice>> GetPaginatedAsync(IssuedInvoiceFilters filters, CancellationToken ct = default);
+    Task<IEnumerable<IssuedInvoice>> GetHeadersByDateAsync(DateOnly date, CancellationToken ct = default);
+}
+```
+
+### After
+```csharp
+public interface IIssuedInvoiceRepository : IRepository<IssuedInvoice, string>
+{
+    Task<IssuedInvoice?> GetByIdWithSyncHistoryAsync(string id, CancellationToken ct = default);
+    Task<IssuedInvoiceSyncStats> GetSyncStatsAsync(DateTime fromDate, DateTime toDate, CancellationToken ct = default);
+    Task<PaginatedResult<IssuedInvoice>> GetPaginatedAsync(IssuedInvoiceFilters filters, CancellationToken ct = default);
+    Task<IEnumerable<IssuedInvoice>> GetHeadersByDateAsync(DateOnly date, CancellationToken ct = default);
+}
+```
+
+No public HTTP endpoint, MediatR contract, or MVC controller signature changes. No UI flow changes.
+
+## Dependencies
+None new. The change touches only:
+- `Anela.Heblo.Application` project (interface + implementation, same assembly per the post-relocation Clean Architecture layout).
+- `Anela.Heblo.Tests` project (one test file).
+
+No external services, NuGet packages, configuration values, secrets, environment variables, or Azure Key Vault entries are affected.
+
+## Out of Scope
+- Adding new repository methods or expanding `GetPaginatedAsync` filtering.
+- Refactoring `IssuedInvoiceFilters` or `PaginatedResult<T>`.
+- Touching other repositories (`IssuedInvoiceRepository` only).
+- Editing handlers, services, adapters, or the DI module.
+- Regenerating or modifying the OpenAPI client.
+- Database schema or EF Core migrations.
+- Frontend changes.
+- Replacing other "Find*" methods elsewhere in the codebase.
+- Re-formatting `IssuedInvoiceRepositoryTests.cs` beyond removing the seven test methods.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/task-plan.r1.md
+++ b/artifacts/feat-arch-review-invoices-iissuedinvoicerepos/task-plan.r1.md
@@ -1,0 +1,6 @@
+Plan saved to `docs/superpowers/plans/2026-06-11-remove-dead-issuedinvoicerepository-find-methods.md` and mirrored to `artifacts/feat-arch-review-invoices-iissuedinvoicerepos/plan.r1.md`.
+
+Three tasks, all bite-sized:
+1. **Delete obsolete tests + orphan `SetLastSyncTime` helper** — 12 steps, intermediate compile state stays green because production code still satisfies the interface.
+2. **Delete interface declarations + EF Core implementations atomically** — 6 steps, must land together to avoid `CS0535`; gates with build, `dotnet format --verify-no-changes`, full test suite.
+3. **Final verification + single commit** — 5 steps, enforces the surgical-diff requirement (exactly three files modified) and asserts test count drops by exactly 7.

--- a/backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs
@@ -11,34 +11,9 @@ namespace Anela.Heblo.Application.Features.Invoices.Contracts;
 public interface IIssuedInvoiceRepository : IRepository<IssuedInvoice, string>
 {
     /// <summary>
-    /// Finds invoices by their synchronization status
-    /// </summary>
-    Task<IEnumerable<IssuedInvoice>> FindBySyncStatusAsync(bool? isSynced, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Finds invoices within a date range
-    /// </summary>
-    Task<IEnumerable<IssuedInvoice>> FindByInvoiceDateRangeAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Finds invoices by customer name (partial match)
-    /// </summary>
-    Task<IEnumerable<IssuedInvoice>> FindByCustomerNameAsync(string customerName, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Finds invoices with sync errors (excluding invoice paired errors)
-    /// </summary>
-    Task<IEnumerable<IssuedInvoice>> FindWithCriticalErrorsAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Gets an invoice with its complete sync history
     /// </summary>
     Task<IssuedInvoice?> GetByIdWithSyncHistoryAsync(string id, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Gets invoices that were last synced before a specific date
-    /// </summary>
-    Task<IEnumerable<IssuedInvoice>> FindStaleInvoicesAsync(DateTime beforeDate, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets sync statistics for a date range

--- a/backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs
@@ -34,59 +34,6 @@ public class IssuedInvoiceRepository : BaseRepository<IssuedInvoice, string>, II
             .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
     }
 
-    public async Task<IEnumerable<IssuedInvoice>> FindBySyncStatusAsync(bool? isSynced, CancellationToken cancellationToken = default)
-    {
-        var query = DbSet.AsQueryable();
-
-        if (isSynced.HasValue)
-        {
-            query = query.Where(x => x.IsSynced == isSynced.Value);
-        }
-
-        return await query
-            .OrderByDescending(x => x.InvoiceDate)
-            .ToListAsync(cancellationToken);
-    }
-
-    public async Task<IEnumerable<IssuedInvoice>> FindByInvoiceDateRangeAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
-    {
-        return await DbSet
-            .Where(x => x.InvoiceDate >= fromDate.Date && x.InvoiceDate <= toDate.Date)
-            .OrderByDescending(x => x.InvoiceDate)
-            .ToListAsync(cancellationToken);
-    }
-
-    public async Task<IEnumerable<IssuedInvoice>> FindByCustomerNameAsync(string customerName, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(customerName))
-        {
-            return new List<IssuedInvoice>();
-        }
-
-        var searchTerm = customerName.Trim().ToLower();
-
-        return await DbSet
-            .Where(x => x.CustomerName != null && x.CustomerName.ToLower().Contains(searchTerm))
-            .OrderByDescending(x => x.InvoiceDate)
-            .ToListAsync(cancellationToken);
-    }
-
-    public async Task<IEnumerable<IssuedInvoice>> FindWithCriticalErrorsAsync(CancellationToken cancellationToken = default)
-    {
-        return await DbSet
-            .Where(x => x.ErrorType != null && x.ErrorType != IssuedInvoiceErrorType.InvoicePaired)
-            .OrderByDescending(x => x.LastSyncTime ?? x.InvoiceDate)
-            .ToListAsync(cancellationToken);
-    }
-
-    public async Task<IEnumerable<IssuedInvoice>> FindStaleInvoicesAsync(DateTime beforeDate, CancellationToken cancellationToken = default)
-    {
-        return await DbSet
-            .Where(x => !x.IsSynced || (x.LastSyncTime.HasValue && x.LastSyncTime.Value < beforeDate))
-            .OrderByDescending(x => x.InvoiceDate)
-            .ToListAsync(cancellationToken);
-    }
-
     public async Task<IssuedInvoiceSyncStats> GetSyncStatsAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
     {
         var query = DbSet.Where(x => x.InvoiceDate >= fromDate.Date && x.InvoiceDate <= toDate.Date);

--- a/backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs
@@ -117,132 +117,6 @@ public class IssuedInvoiceRepositoryTests : IDisposable
     }
 
     [Fact]
-    public async Task FindBySyncStatusAsync_WithSyncedFilter_ReturnsOnlySynced()
-    {
-        // Arrange
-        var syncedInvoice = new IssuedInvoice { Id = "INV-SYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        syncedInvoice.SyncSucceeded(CreateTestSyncData());
-
-        var unsyncedInvoice = new IssuedInvoice { Id = "INV-UNSYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-
-        await _repository.AddAsync(syncedInvoice);
-        await _repository.AddAsync(unsyncedInvoice);
-        await _repository.SaveChangesAsync();
-
-        // Act
-        var syncedResult = await _repository.FindBySyncStatusAsync(true);
-        var unsyncedResult = await _repository.FindBySyncStatusAsync(false);
-
-        // Assert
-        Assert.Single(syncedResult);
-        Assert.Equal("INV-SYNCED", syncedResult.First().Id);
-
-        Assert.Single(unsyncedResult);
-        Assert.Equal("INV-UNSYNCED", unsyncedResult.First().Id);
-    }
-
-    [Fact]
-    public async Task FindBySyncStatusAsync_WithNullFilter_ReturnsAll()
-    {
-        // Arrange
-        var syncedInvoice = new IssuedInvoice { Id = "INV-SYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        syncedInvoice.SyncSucceeded(CreateTestSyncData());
-
-        var unsyncedInvoice = new IssuedInvoice { Id = "INV-UNSYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-
-        await _repository.AddAsync(syncedInvoice);
-        await _repository.AddAsync(unsyncedInvoice);
-        await _repository.SaveChangesAsync();
-
-        // Act
-        var result = await _repository.FindBySyncStatusAsync(null);
-
-        // Assert
-        Assert.Equal(2, result.Count());
-        Assert.Contains(result, i => i.Id == "INV-SYNCED");
-        Assert.Contains(result, i => i.Id == "INV-UNSYNCED");
-    }
-
-    [Fact]
-    public async Task FindByInvoiceDateRangeAsync_WithDateRange_ReturnsFilteredInvoices()
-    {
-        // Arrange
-        var invoice1 = new IssuedInvoice { Id = "INV-OLD", InvoiceDate = DateTime.Today.AddDays(-10), DueDate = DateTime.Today.AddDays(20), TaxDate = DateTime.Today.AddDays(-10) };
-        var invoice2 = new IssuedInvoice { Id = "INV-RECENT", InvoiceDate = DateTime.Today.AddDays(-2), DueDate = DateTime.Today.AddDays(28), TaxDate = DateTime.Today.AddDays(-2) };
-        var invoice3 = new IssuedInvoice { Id = "INV-FUTURE", InvoiceDate = DateTime.Today.AddDays(5), DueDate = DateTime.Today.AddDays(35), TaxDate = DateTime.Today.AddDays(5) };
-
-        await _repository.AddAsync(invoice1);
-        await _repository.AddAsync(invoice2);
-        await _repository.AddAsync(invoice3);
-        await _repository.SaveChangesAsync();
-
-        // Act
-        var result = await _repository.FindByInvoiceDateRangeAsync(
-            DateTime.Today.AddDays(-5),
-            DateTime.Today);
-
-        // Assert
-        Assert.Single(result);
-        Assert.Equal("INV-RECENT", result.First().Id);
-    }
-
-    [Fact]
-    public async Task FindWithCriticalErrorsAsync_WithErrorTypes_ReturnsOnlyCriticalErrors()
-    {
-        // Arrange
-        var criticalErrorInvoice = new IssuedInvoice { Id = "INV-CRITICAL", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        criticalErrorInvoice.SyncFailed(CreateTestSyncData(), "Critical error");
-
-        var pairedInvoice = new IssuedInvoice { Id = "INV-PAIRED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        pairedInvoice.SyncFailed(CreateTestSyncData(), new IssuedInvoiceError { ErrorType = IssuedInvoiceErrorType.InvoicePaired, Message = "Invoice paired" }); // Not critical
-
-        var successInvoice = new IssuedInvoice { Id = "INV-SUCCESS", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        successInvoice.SyncSucceeded(CreateTestSyncData());
-
-        await _repository.AddAsync(criticalErrorInvoice);
-        await _repository.AddAsync(pairedInvoice);
-        await _repository.AddAsync(successInvoice);
-        await _repository.SaveChangesAsync();
-
-        // Act
-        var result = await _repository.FindWithCriticalErrorsAsync();
-
-        // Assert
-        Assert.Single(result);
-        Assert.Equal("INV-CRITICAL", result.First().Id);
-        // Should not include paired invoice (not critical) or success invoice
-    }
-
-    [Fact]
-    public async Task FindStaleInvoicesAsync_WithStaleInvoices_ReturnsUnsyncedAndOldSynced()
-    {
-        // Arrange
-        var unsyncedInvoice = new IssuedInvoice { Id = "INV-UNSYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-
-        var oldSyncedInvoice = new IssuedInvoice { Id = "INV-OLD-SYNC", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        oldSyncedInvoice.SyncSucceeded(CreateTestSyncData());
-        SetLastSyncTime(oldSyncedInvoice, DateTime.UtcNow.AddDays(-10));
-
-        var recentSyncedInvoice = new IssuedInvoice { Id = "INV-RECENT-SYNC", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        recentSyncedInvoice.SyncSucceeded(CreateTestSyncData());
-        SetLastSyncTime(recentSyncedInvoice, DateTime.UtcNow.AddHours(-1));
-
-        await _repository.AddAsync(unsyncedInvoice);
-        await _repository.AddAsync(oldSyncedInvoice);
-        await _repository.AddAsync(recentSyncedInvoice);
-        await _repository.SaveChangesAsync();
-
-        // Act
-        var result = await _repository.FindStaleInvoicesAsync(DateTime.UtcNow.AddDays(-5));
-
-        // Assert
-        Assert.Equal(2, result.Count());
-        Assert.Contains(result, i => i.Id == "INV-UNSYNCED");
-        Assert.Contains(result, i => i.Id == "INV-OLD-SYNC");
-        Assert.DoesNotContain(result, i => i.Id == "INV-RECENT-SYNC");
-    }
-
-    [Fact]
     public async Task GetSyncStatsAsync_WithVariousInvoices_ReturnsAccurateStats()
     {
         // Arrange
@@ -280,49 +154,6 @@ public class IssuedInvoiceRepositoryTests : IDisposable
         Assert.Equal(3, stats.UnsyncedInvoices); // Unsynced, error, paired
         Assert.Equal(2, stats.InvoicesWithErrors); // Error and paired
         Assert.Equal(1, stats.CriticalErrors); // Only error invoice (paired is not critical)
-    }
-
-    [Fact]
-    public async Task FindByCustomerNameAsync_WithPartialName_ReturnsMatchingInvoices()
-    {
-        // Arrange
-        var invoice1 = new IssuedInvoice { Id = "INV-001", CustomerName = "ACME Corporation", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        var invoice2 = new IssuedInvoice { Id = "INV-002", CustomerName = "Beta Corp", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        var invoice3 = new IssuedInvoice { Id = "INV-003", CustomerName = "ACME Industries", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        var invoice4 = new IssuedInvoice { Id = "INV-004", CustomerName = null, InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-
-        await _repository.AddAsync(invoice1);
-        await _repository.AddAsync(invoice2);
-        await _repository.AddAsync(invoice3);
-        await _repository.AddAsync(invoice4);
-        await _repository.SaveChangesAsync();
-
-        // Act
-        var result = await _repository.FindByCustomerNameAsync("ACME");
-
-        // Assert
-        Assert.Equal(2, result.Count());
-        Assert.Contains(result, i => i.Id == "INV-001");
-        Assert.Contains(result, i => i.Id == "INV-003");
-        Assert.DoesNotContain(result, i => i.Id == "INV-002");
-        Assert.DoesNotContain(result, i => i.Id == "INV-004");
-    }
-
-    [Fact]
-    public async Task FindByCustomerNameAsync_WithEmptyName_ReturnsEmpty()
-    {
-        // Arrange
-        var invoice = new IssuedInvoice { Id = "INV-001", CustomerName = "Test Customer", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
-        await _repository.AddAsync(invoice);
-        await _repository.SaveChangesAsync();
-
-        // Act
-        var result1 = await _repository.FindByCustomerNameAsync("");
-        var result2 = await _repository.FindByCustomerNameAsync("   ");
-
-        // Assert
-        Assert.Empty(result1);
-        Assert.Empty(result2);
     }
 
     [Fact]
@@ -453,12 +284,6 @@ public class IssuedInvoiceRepositoryTests : IDisposable
                 CurrencyCode = "CZK"
             }
         };
-    }
-
-    private static void SetLastSyncTime(IssuedInvoice invoice, DateTime syncTime)
-    {
-        var property = typeof(IssuedInvoice).GetProperty("LastSyncTime");
-        property?.SetValue(invoice, syncTime);
     }
 
     public void Dispose()

--- a/docs/superpowers/plans/2026-06-11-remove-dead-issuedinvoicerepository-find-methods.md
+++ b/docs/superpowers/plans/2026-06-11-remove-dead-issuedinvoicerepository-find-methods.md
@@ -1,0 +1,548 @@
+# Remove Dead Query Methods from `IIssuedInvoiceRepository` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove five unused `Find*` query methods from `IIssuedInvoiceRepository`, their EF Core implementations, and the seven unit tests that exercise them — narrowing the contract to the four members production code actually uses.
+
+**Architecture:** Pure deletion across three files in the Invoices module: the contract (`IIssuedInvoiceRepository.cs`), the EF Core implementation (`IssuedInvoiceRepository.cs`), and the unit test class (`IssuedInvoiceRepositoryTests.cs`). No new components, no DI changes, no controller/contract changes. The change is one self-contained commit and fully reversible by `git revert`.
+
+**Tech Stack:** .NET 8 / C# 12, EF Core 8 (`Microsoft.EntityFrameworkCore`), xUnit 2.x with `Microsoft.EntityFrameworkCore.InMemory`, Moq.
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs` | Modify | Delete 5 method declarations + their XML doc comments. Retain `GetByIdWithSyncHistoryAsync`, `GetSyncStatsAsync`, `GetPaginatedAsync`, `GetHeadersByDateAsync`. |
+| `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs` | Modify | Delete 5 method bodies (lines 37–88). Retain `GetByIdAsync`, `GetByIdWithSyncHistoryAsync`, `GetSyncStatsAsync`, `AddAsync`, `UpdateAsync`, `GetPaginatedAsync`, `GetHeadersByDateAsync`, `ApplySorting`. |
+| `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs` | Modify | Delete 7 `[Fact]` test methods covering removed APIs + private helper `SetLastSyncTime` (no remaining caller). Retain `CreateTestSyncData` (still used by retained tests). |
+
+**Removal order matters for compilation:**
+1. Tests first (no production-code coupling; intermediate state stays green).
+2. Interface + implementation **together** in one task (deleting either alone would either leave dead public methods or break the `IIssuedInvoiceRepository` interface contract). Both edits land in the same task and are validated as a unit before commit.
+
+---
+
+## Task 1: Delete obsolete unit tests and the now-orphan helper
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs`
+
+**Removals:**
+- `FindBySyncStatusAsync_WithSyncedFilter_ReturnsOnlySynced` (lines 119–142)
+- `FindBySyncStatusAsync_WithNullFilter_ReturnsAll` (lines 144–164)
+- `FindByInvoiceDateRangeAsync_WithDateRange_ReturnsFilteredInvoices` (lines 166–187)
+- `FindWithCriticalErrorsAsync_WithErrorTypes_ReturnsOnlyCriticalErrors` (lines 189–214)
+- `FindStaleInvoicesAsync_WithStaleInvoices_ReturnsUnsyncedAndOldSynced` (lines 216–243)
+- `FindByCustomerNameAsync_WithPartialName_ReturnsMatchingInvoices` (lines 285–309)
+- `FindByCustomerNameAsync_WithEmptyName_ReturnsEmpty` (lines 311–326)
+- Private helper `SetLastSyncTime` (lines 458–462) — used only inside `FindStaleInvoicesAsync_…`
+
+**Retain:**
+- All other `[Fact]` methods, including the two `GetByIdAsync_…`, `GetByIdWithSyncHistoryAsync_…`, `GetSyncStatsAsync_…`, three `GetPaginatedAsync_…`, `AddAsync_…`, `UpdateAsync_…`.
+- The `CreateTestSyncData` helper (lines 445–456) — still called from `GetByIdWithSyncHistoryAsync_…`, `GetSyncStatsAsync_…`, and three `GetPaginatedAsync_…` tests.
+- The constructor, `Dispose`, and all fields.
+
+---
+
+- [ ] **Step 1: Open the test file and confirm baseline**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~IssuedInvoiceRepositoryTests" --no-restore`
+Expected: All tests green (this is the pre-change baseline — captures the current passing set so the delta after deletion is purely "fewer tests, same green").
+
+- [ ] **Step 2: Delete `FindBySyncStatusAsync_WithSyncedFilter_ReturnsOnlySynced`**
+
+In `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs`, remove the exact block (including the `[Fact]` attribute on line 119, the blank line above it, and trailing blank line up to but not including the next `[Fact]`):
+
+```csharp
+    [Fact]
+    public async Task FindBySyncStatusAsync_WithSyncedFilter_ReturnsOnlySynced()
+    {
+        // Arrange
+        var syncedInvoice = new IssuedInvoice { Id = "INV-SYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        syncedInvoice.SyncSucceeded(CreateTestSyncData());
+
+        var unsyncedInvoice = new IssuedInvoice { Id = "INV-UNSYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+
+        await _repository.AddAsync(syncedInvoice);
+        await _repository.AddAsync(unsyncedInvoice);
+        await _repository.SaveChangesAsync();
+
+        // Act
+        var syncedResult = await _repository.FindBySyncStatusAsync(true);
+        var unsyncedResult = await _repository.FindBySyncStatusAsync(false);
+
+        // Assert
+        Assert.Single(syncedResult);
+        Assert.Equal("INV-SYNCED", syncedResult.First().Id);
+
+        Assert.Single(unsyncedResult);
+        Assert.Equal("INV-UNSYNCED", unsyncedResult.First().Id);
+    }
+```
+
+- [ ] **Step 3: Delete `FindBySyncStatusAsync_WithNullFilter_ReturnsAll`**
+
+Remove the exact block:
+
+```csharp
+    [Fact]
+    public async Task FindBySyncStatusAsync_WithNullFilter_ReturnsAll()
+    {
+        // Arrange
+        var syncedInvoice = new IssuedInvoice { Id = "INV-SYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        syncedInvoice.SyncSucceeded(CreateTestSyncData());
+
+        var unsyncedInvoice = new IssuedInvoice { Id = "INV-UNSYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+
+        await _repository.AddAsync(syncedInvoice);
+        await _repository.AddAsync(unsyncedInvoice);
+        await _repository.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.FindBySyncStatusAsync(null);
+
+        // Assert
+        Assert.Equal(2, result.Count());
+        Assert.Contains(result, i => i.Id == "INV-SYNCED");
+        Assert.Contains(result, i => i.Id == "INV-UNSYNCED");
+    }
+```
+
+- [ ] **Step 4: Delete `FindByInvoiceDateRangeAsync_WithDateRange_ReturnsFilteredInvoices`**
+
+Remove the exact block:
+
+```csharp
+    [Fact]
+    public async Task FindByInvoiceDateRangeAsync_WithDateRange_ReturnsFilteredInvoices()
+    {
+        // Arrange
+        var invoice1 = new IssuedInvoice { Id = "INV-OLD", InvoiceDate = DateTime.Today.AddDays(-10), DueDate = DateTime.Today.AddDays(20), TaxDate = DateTime.Today.AddDays(-10) };
+        var invoice2 = new IssuedInvoice { Id = "INV-RECENT", InvoiceDate = DateTime.Today.AddDays(-2), DueDate = DateTime.Today.AddDays(28), TaxDate = DateTime.Today.AddDays(-2) };
+        var invoice3 = new IssuedInvoice { Id = "INV-FUTURE", InvoiceDate = DateTime.Today.AddDays(5), DueDate = DateTime.Today.AddDays(35), TaxDate = DateTime.Today.AddDays(5) };
+
+        await _repository.AddAsync(invoice1);
+        await _repository.AddAsync(invoice2);
+        await _repository.AddAsync(invoice3);
+        await _repository.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.FindByInvoiceDateRangeAsync(
+            DateTime.Today.AddDays(-5),
+            DateTime.Today);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("INV-RECENT", result.First().Id);
+    }
+```
+
+- [ ] **Step 5: Delete `FindWithCriticalErrorsAsync_WithErrorTypes_ReturnsOnlyCriticalErrors`**
+
+Remove the exact block:
+
+```csharp
+    [Fact]
+    public async Task FindWithCriticalErrorsAsync_WithErrorTypes_ReturnsOnlyCriticalErrors()
+    {
+        // Arrange
+        var criticalErrorInvoice = new IssuedInvoice { Id = "INV-CRITICAL", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        criticalErrorInvoice.SyncFailed(CreateTestSyncData(), "Critical error");
+
+        var pairedInvoice = new IssuedInvoice { Id = "INV-PAIRED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        pairedInvoice.SyncFailed(CreateTestSyncData(), new IssuedInvoiceError { ErrorType = IssuedInvoiceErrorType.InvoicePaired, Message = "Invoice paired" }); // Not critical
+
+        var successInvoice = new IssuedInvoice { Id = "INV-SUCCESS", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        successInvoice.SyncSucceeded(CreateTestSyncData());
+
+        await _repository.AddAsync(criticalErrorInvoice);
+        await _repository.AddAsync(pairedInvoice);
+        await _repository.AddAsync(successInvoice);
+        await _repository.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.FindWithCriticalErrorsAsync();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("INV-CRITICAL", result.First().Id);
+        // Should not include paired invoice (not critical) or success invoice
+    }
+```
+
+- [ ] **Step 6: Delete `FindStaleInvoicesAsync_WithStaleInvoices_ReturnsUnsyncedAndOldSynced`**
+
+Remove the exact block:
+
+```csharp
+    [Fact]
+    public async Task FindStaleInvoicesAsync_WithStaleInvoices_ReturnsUnsyncedAndOldSynced()
+    {
+        // Arrange
+        var unsyncedInvoice = new IssuedInvoice { Id = "INV-UNSYNCED", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+
+        var oldSyncedInvoice = new IssuedInvoice { Id = "INV-OLD-SYNC", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        oldSyncedInvoice.SyncSucceeded(CreateTestSyncData());
+        SetLastSyncTime(oldSyncedInvoice, DateTime.UtcNow.AddDays(-10));
+
+        var recentSyncedInvoice = new IssuedInvoice { Id = "INV-RECENT-SYNC", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        recentSyncedInvoice.SyncSucceeded(CreateTestSyncData());
+        SetLastSyncTime(recentSyncedInvoice, DateTime.UtcNow.AddHours(-1));
+
+        await _repository.AddAsync(unsyncedInvoice);
+        await _repository.AddAsync(oldSyncedInvoice);
+        await _repository.AddAsync(recentSyncedInvoice);
+        await _repository.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.FindStaleInvoicesAsync(DateTime.UtcNow.AddDays(-5));
+
+        // Assert
+        Assert.Equal(2, result.Count());
+        Assert.Contains(result, i => i.Id == "INV-UNSYNCED");
+        Assert.Contains(result, i => i.Id == "INV-OLD-SYNC");
+        Assert.DoesNotContain(result, i => i.Id == "INV-RECENT-SYNC");
+    }
+```
+
+- [ ] **Step 7: Delete `FindByCustomerNameAsync_WithPartialName_ReturnsMatchingInvoices`**
+
+Remove the exact block:
+
+```csharp
+    [Fact]
+    public async Task FindByCustomerNameAsync_WithPartialName_ReturnsMatchingInvoices()
+    {
+        // Arrange
+        var invoice1 = new IssuedInvoice { Id = "INV-001", CustomerName = "ACME Corporation", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        var invoice2 = new IssuedInvoice { Id = "INV-002", CustomerName = "Beta Corp", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        var invoice3 = new IssuedInvoice { Id = "INV-003", CustomerName = "ACME Industries", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        var invoice4 = new IssuedInvoice { Id = "INV-004", CustomerName = null, InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+
+        await _repository.AddAsync(invoice1);
+        await _repository.AddAsync(invoice2);
+        await _repository.AddAsync(invoice3);
+        await _repository.AddAsync(invoice4);
+        await _repository.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.FindByCustomerNameAsync("ACME");
+
+        // Assert
+        Assert.Equal(2, result.Count());
+        Assert.Contains(result, i => i.Id == "INV-001");
+        Assert.Contains(result, i => i.Id == "INV-003");
+        Assert.DoesNotContain(result, i => i.Id == "INV-002");
+        Assert.DoesNotContain(result, i => i.Id == "INV-004");
+    }
+```
+
+- [ ] **Step 8: Delete `FindByCustomerNameAsync_WithEmptyName_ReturnsEmpty`**
+
+Remove the exact block:
+
+```csharp
+    [Fact]
+    public async Task FindByCustomerNameAsync_WithEmptyName_ReturnsEmpty()
+    {
+        // Arrange
+        var invoice = new IssuedInvoice { Id = "INV-001", CustomerName = "Test Customer", InvoiceDate = DateTime.Today, DueDate = DateTime.Today.AddDays(30), TaxDate = DateTime.Today };
+        await _repository.AddAsync(invoice);
+        await _repository.SaveChangesAsync();
+
+        // Act
+        var result1 = await _repository.FindByCustomerNameAsync("");
+        var result2 = await _repository.FindByCustomerNameAsync("   ");
+
+        // Assert
+        Assert.Empty(result1);
+        Assert.Empty(result2);
+    }
+```
+
+- [ ] **Step 9: Delete the now-orphan `SetLastSyncTime` private helper**
+
+The reflection-based helper at lines 458–462 was used **only** by `FindStaleInvoicesAsync_…` (now deleted in Step 6). Remove the exact block:
+
+```csharp
+    private static void SetLastSyncTime(IssuedInvoice invoice, DateTime syncTime)
+    {
+        var property = typeof(IssuedInvoice).GetProperty("LastSyncTime");
+        property?.SetValue(invoice, syncTime);
+    }
+```
+
+`CreateTestSyncData` must remain untouched — it is still referenced by retained tests at lines 103, 254, 259, 262, 368, 397, 400 of the original file.
+
+- [ ] **Step 10: Verify no leftover references to the deleted helper or to the deleted method names exist in the test file**
+
+Run (from repo root):
+
+```bash
+grep -nE "SetLastSyncTime|FindBySyncStatusAsync|FindByInvoiceDateRangeAsync|FindByCustomerNameAsync|FindWithCriticalErrorsAsync|FindStaleInvoicesAsync" \
+  backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs
+```
+
+Expected output: empty (no lines, exit code 1 from grep is fine here).
+
+- [ ] **Step 11: Build the test project to confirm it still compiles (interface methods still exist; production code unchanged)**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-restore`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 12: Run the remaining tests in `IssuedInvoiceRepositoryTests` to confirm green**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~IssuedInvoiceRepositoryTests" --no-build`
+Expected: All retained tests pass (`AddAsync_…`, `UpdateAsync_…`, two `GetByIdAsync_…`, `GetByIdWithSyncHistoryAsync_…`, `GetSyncStatsAsync_…`, three `GetPaginatedAsync_…`). Total count is 7 fewer than the baseline in Step 1.
+
+---
+
+## Task 2: Delete the five interface method declarations and their implementations together
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs`
+
+**Why these two edits must land in the same task:** if the interface methods are removed without removing the implementation, the implementation simply has extra public methods (compiles but is ugly intermediate state and creates an unstable in-between commit). If the implementation methods are removed without removing the interface methods, `IssuedInvoiceRepository` no longer satisfies `IIssuedInvoiceRepository` and the solution will not compile. They must be deleted as one unit before the build/test gate runs.
+
+---
+
+- [ ] **Step 1: Remove the five method declarations + their XML doc comments from `IIssuedInvoiceRepository.cs`**
+
+In `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs`, remove the following five blocks (each is an XML doc comment block followed by the method declaration and its trailing blank line):
+
+```csharp
+    /// <summary>
+    /// Finds invoices by their synchronization status
+    /// </summary>
+    Task<IEnumerable<IssuedInvoice>> FindBySyncStatusAsync(bool? isSynced, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds invoices within a date range
+    /// </summary>
+    Task<IEnumerable<IssuedInvoice>> FindByInvoiceDateRangeAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds invoices by customer name (partial match)
+    /// </summary>
+    Task<IEnumerable<IssuedInvoice>> FindByCustomerNameAsync(string customerName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds invoices with sync errors (excluding invoice paired errors)
+    /// </summary>
+    Task<IEnumerable<IssuedInvoice>> FindWithCriticalErrorsAsync(CancellationToken cancellationToken = default);
+```
+
+and the fifth, located between `GetByIdWithSyncHistoryAsync` and `GetSyncStatsAsync`:
+
+```csharp
+    /// <summary>
+    /// Gets invoices that were last synced before a specific date
+    /// </summary>
+    Task<IEnumerable<IssuedInvoice>> FindStaleInvoicesAsync(DateTime beforeDate, CancellationToken cancellationToken = default);
+
+```
+
+After this step, the resulting interface body must be exactly:
+
+```csharp
+public interface IIssuedInvoiceRepository : IRepository<IssuedInvoice, string>
+{
+    /// <summary>
+    /// Gets an invoice with its complete sync history
+    /// </summary>
+    Task<IssuedInvoice?> GetByIdWithSyncHistoryAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets sync statistics for a date range
+    /// </summary>
+    Task<IssuedInvoiceSyncStats> GetSyncStatsAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets paginated and filtered list of issued invoices with sorting
+    /// </summary>
+    Task<PaginatedResult<IssuedInvoice>> GetPaginatedAsync(IssuedInvoiceFilters filters, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets invoice headers for a specific date
+    /// </summary>
+    Task<IEnumerable<IssuedInvoice>> GetHeadersByDateAsync(DateOnly date, CancellationToken cancellationToken = default);
+}
+```
+
+The `using` directives at the top of the file (`Anela.Heblo.Application.Shared`, `Anela.Heblo.Domain.Features.Invoices`, `Anela.Heblo.Xcc.Persistance`) and the file-scoped namespace declaration are still required by the retained members; leave them untouched.
+
+- [ ] **Step 2: Remove the five implementation method bodies from `IssuedInvoiceRepository.cs`**
+
+In `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs`, remove lines 37–88 (the five consecutive method bodies for `FindBySyncStatusAsync`, `FindByInvoiceDateRangeAsync`, `FindByCustomerNameAsync`, `FindWithCriticalErrorsAsync`, `FindStaleInvoicesAsync`):
+
+```csharp
+    public async Task<IEnumerable<IssuedInvoice>> FindBySyncStatusAsync(bool? isSynced, CancellationToken cancellationToken = default)
+    {
+        var query = DbSet.AsQueryable();
+
+        if (isSynced.HasValue)
+        {
+            query = query.Where(x => x.IsSynced == isSynced.Value);
+        }
+
+        return await query
+            .OrderByDescending(x => x.InvoiceDate)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<IssuedInvoice>> FindByInvoiceDateRangeAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
+    {
+        return await DbSet
+            .Where(x => x.InvoiceDate >= fromDate.Date && x.InvoiceDate <= toDate.Date)
+            .OrderByDescending(x => x.InvoiceDate)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<IssuedInvoice>> FindByCustomerNameAsync(string customerName, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(customerName))
+        {
+            return new List<IssuedInvoice>();
+        }
+
+        var searchTerm = customerName.Trim().ToLower();
+
+        return await DbSet
+            .Where(x => x.CustomerName != null && x.CustomerName.ToLower().Contains(searchTerm))
+            .OrderByDescending(x => x.InvoiceDate)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<IssuedInvoice>> FindWithCriticalErrorsAsync(CancellationToken cancellationToken = default)
+    {
+        return await DbSet
+            .Where(x => x.ErrorType != null && x.ErrorType != IssuedInvoiceErrorType.InvoicePaired)
+            .OrderByDescending(x => x.LastSyncTime ?? x.InvoiceDate)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<IssuedInvoice>> FindStaleInvoicesAsync(DateTime beforeDate, CancellationToken cancellationToken = default)
+    {
+        return await DbSet
+            .Where(x => !x.IsSynced || (x.LastSyncTime.HasValue && x.LastSyncTime.Value < beforeDate))
+            .OrderByDescending(x => x.InvoiceDate)
+            .ToListAsync(cancellationToken);
+    }
+
+```
+
+After this step, the structure of `IssuedInvoiceRepository.cs` between `GetByIdWithSyncHistoryAsync` (which retains its body at the original lines 30–35) and `GetSyncStatsAsync` (original lines 90–113) should be a single blank line separator — no `Find*` methods between them.
+
+`using` directives are still all required: `Microsoft.EntityFrameworkCore` (still used by `Include`, `FirstOrDefaultAsync`, `ToListAsync`, `EF.Functions.ILike`, `CountAsync`, `MaxAsync`), `Microsoft.Extensions.Logging` (still used by `_logger.LogInformation`), the four project namespaces (Application.Features.Invoices.Contracts, Application.Shared, Domain.Features.Invoices, Persistence, Persistence.Repositories) are all still referenced by retained members. Do not edit the `using` block.
+
+- [ ] **Step 3: Verify no source file outside the three target files references any of the five removed method names**
+
+Run (from repo root):
+
+```bash
+grep -rnE "FindBySyncStatusAsync|FindByInvoiceDateRangeAsync|FindByCustomerNameAsync|FindWithCriticalErrorsAsync|FindStaleInvoicesAsync" backend/
+```
+
+Expected output: empty (exit 1 from grep). If any line appears in a file other than the two now-edited source files (which should not contain them anymore either), stop and investigate — the spec asserts zero non-test references and Task 1 already removed the test references.
+
+- [ ] **Step 4: Build the entire backend solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`. In particular, no `CS0535` "does not implement interface member" errors (which would mean the interface and implementation got out of sync), and no new `CS86xx` nullable warnings.
+
+- [ ] **Step 5: Verify formatting is clean**
+
+Run: `dotnet format backend/Anela.Heblo.sln --verify-no-changes`
+Expected: exit code 0, no output about files that would be changed. If it reports drift, run `dotnet format backend/Anela.Heblo.sln` and re-run with `--verify-no-changes` to confirm. Per NFR-4 (Surgical diff), only the three target files should appear in any formatting changes.
+
+- [ ] **Step 6: Run the full backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln --no-build`
+Expected: all tests pass; total count is exactly 7 fewer than the pre-change baseline (the seven tests deleted in Task 1). Architecture tests (`backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`) — which assert placement of the `IIssuedInvoiceRepository` type, not its members — remain green.
+
+---
+
+## Task 3: Final verification and commit
+
+**Files:** none (verification + commit only).
+
+---
+
+- [ ] **Step 1: Confirm the diff touches exactly three files**
+
+Run: `git status --short`
+Expected (file order may vary):
+
+```
+ M backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs
+ M backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs
+ M backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs
+```
+
+No untracked files. No other modified files. If anything else appears (e.g. an auto-regenerated OpenAPI client or a `dotnet format` cleanup of an unrelated file), revert those changes — the surgical-diff requirement (FR-4, NFR-4) forbids them.
+
+- [ ] **Step 2: Inspect the diff itself for unintended edits**
+
+Run: `git diff`
+Expected: only deletions in the three files listed above. No additions other than what fall naturally out of removing lines (e.g. zero added lines, or only whitespace-only adjustments inside the interface body where the deleted blocks used to be). No edits to retained methods, `using` directives, namespace, class declaration, or formatting of unrelated code.
+
+- [ ] **Step 3: Re-run the validation gates one final time**
+
+Run, in this order:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: each command exits 0; build reports `0 Warning(s) 0 Error(s)`; format reports nothing to change; tests all pass with the count exactly 7 lower than baseline.
+
+- [ ] **Step 4: Stage and commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs \
+        backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs \
+        backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs
+git commit -m "refactor: remove unused Find* methods from IIssuedInvoiceRepository
+
+The five Find* query methods (FindBySyncStatusAsync, FindByInvoiceDateRangeAsync,
+FindByCustomerNameAsync, FindWithCriticalErrorsAsync, FindStaleInvoicesAsync) had
+no production callers — all live filtering goes through GetPaginatedAsync. Drop
+them from the interface, the EF Core implementation, and the unit tests that
+exercised them. Also remove the now-orphan SetLastSyncTime test helper used only
+by the deleted FindStaleInvoicesAsync test. YAGNI/ISP cleanup; reversible by
+git revert."
+```
+
+Expected: commit created, hook-driven checks (if any) pass. If a pre-commit hook fails, fix the underlying issue and create a new commit (do not amend).
+
+- [ ] **Step 5: Confirm clean working tree**
+
+Run: `git status`
+Expected: `nothing to commit, working tree clean`. The branch now contains a single self-contained commit implementing the spec.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 (remove 5 interface declarations + doc comments) — Task 2 / Step 1.
+- FR-2 (remove 5 implementation bodies, keep `using` directives that remain in use) — Task 2 / Step 2 and Step 5 (`dotnet format` gate).
+- FR-3 (remove 7 named test methods + orphan helper) — Task 1 / Steps 2–9.
+- FR-4 (no other files touched, no OpenAPI/client regeneration, build + format clean, tests pass) — Task 3 / Steps 1–3.
+- NFR-1 (build & analysis cleanliness) — Task 2 / Steps 4–5 and Task 3 / Step 3.
+- NFR-2 (test stability, count drops by exactly 7) — Task 1 / Step 12, Task 2 / Step 6, Task 3 / Step 3.
+- NFR-3 (reversibility) — Single commit in Task 3 / Step 4; `git revert` restores all three files atomically.
+- NFR-4 (surgical diff to exactly three files) — Task 3 / Steps 1–2 enforce this explicitly.
+- Arch-review amendment 1 (delete `SetLastSyncTime` helper) — Task 1 / Step 9.
+- Arch-review amendment 2 (no other files in repo may show modifications) — Task 3 / Step 1.
+
+**Placeholder scan:** No TBD / TODO / "appropriate error handling" / "similar to Task N" markers. All code blocks shown literally. All file paths absolute from repo root.
+
+**Type & name consistency:** All five removed method names and the helper name `SetLastSyncTime` are spelled identically every time they appear (interface declaration, implementation body, test usages, grep verifications, commit message). All retained method names (`GetByIdWithSyncHistoryAsync`, `GetSyncStatsAsync`, `GetPaginatedAsync`, `GetHeadersByDateAsync`, `GetByIdAsync`, `AddAsync`, `UpdateAsync`, `ApplySorting`, `CreateTestSyncData`) likewise spelled identically across tasks.


### PR DESCRIPTION

Removed 5 speculative `Find*` query methods from `IIssuedInvoiceRepository` that had no production callers — all live filtering already flows through `GetPaginatedAsync`. This narrows the interface contract to the 4 methods actually used, eliminating YAGNI surface area that forced any test double or alternative implementation to stub dead APIs.

The change is a pure deletion across 3 files: interface declarations, EF Core implementations, and the unit tests that covered the removed methods. The `SetLastSyncTime` reflection-based helper (only used by the now-deleted stale-invoice test) was removed alongside. Build, formatting, and full test suite all clean.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Invoices/Contracts/IIssuedInvoiceRepository.cs` — removed 5 `Find*` declarations and their XML doc-comment blocks
- `backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/IssuedInvoiceRepository.cs` — removed 5 `Find*` implementation bodies
- `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryTests.cs` — removed 7 `[Fact]` test methods and the `SetLastSyncTime` private helper

---

Closes #2841

### Tokens used
7194068
