### PR TITLE
feat: Externalize Product Mapping Codes for Invoice Import Transformation

### DIFF
--- a/artifacts/feat-arch-review-invoices-product-mapping-con/arch-review.r1.md
+++ b/artifacts/feat-arch-review-invoices-product-mapping-con/arch-review.r1.md
@@ -1,0 +1,187 @@
+Now I have enough context to write the architecture review.
+
+# Architecture Review: Externalize Product Mapping Codes for Invoice Import Transformation
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This refactor is a textbook fit for the codebase's existing Options pattern. The repo already standardizes on `*Options.cs` classes with a `SectionName` constant, bound via `services.AddOptions<T>().Bind(...).ValidateDataAnnotations().ValidateOnStart()` — see `MeetingTasksOptions`/`MeetingTasksModule` (`backend/src/Anela.Heblo.Application/Features/MeetingTasks/`), and the analogous pattern across `Bank`, `Catalog`, `Photobank`, `Article`, `Leaflet`, `Manufacture`, `OrgChart`, etc. The Invoices module is currently one of a small minority that does not accept `IConfiguration`; this change brings it into line with `ApplicationModule.cs:78-118`.
+
+Integration points are minimal and contained:
+1. `InvoicesModule.AddInvoicesModule(...)` — signature change.
+2. `ApplicationModule.cs:95` — single call site update.
+3. `appsettings.json` — additive config section.
+4. New `ProductMappingOptions.cs` — new file, follows `MeetingTasksOptions.cs` style.
+
+No domain-model, persistence, MediatR contract, or public API changes. The transformation class itself (`ProductMappingIssuedInvoiceImportTransformation.cs`) is untouched — its existing two-string constructor is exactly the seam this refactor uses.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+appsettings.json
+  └─ "ProductMapping": { "ShoptetCode": "1287", "ErpCode": "SLU000001" }
+                │
+                ▼   bound via .AddOptions<T>().Bind(...).ValidateDataAnnotations().ValidateOnStart()
+ProductMappingOptions   (new, Features/Invoices/ProductMappingOptions.cs)
+                │
+                ▼   resolved by DI factory (IOptions<ProductMappingOptions>)
+InvoicesModule.AddInvoicesModule(IServiceCollection, IConfiguration)
+                │
+                ▼   constructs Transient instance per resolution
+ProductMappingIssuedInvoiceImportTransformation(opts.ShoptetCode, opts.ErpCode)
+                │
+                ▼   enumerated by import pipeline alongside two siblings
+IEnumerable<IIssuedInvoiceImportTransformation> consumers (InvoiceImportService)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Options class location
+**Options considered:** (a) Place `ProductMappingOptions.cs` at the module root next to `InvoicesModule.cs`, mirroring `MeetingTasksOptions.cs`. (b) Place it under `Infrastructure/Transformations/` next to the consuming class.
+**Chosen approach:** (a) — module root.
+**Rationale:** Every existing options class in the codebase lives at module root (`MeetingTasksOptions.cs`, `OrgChartOptions.cs`, `CatalogCacheOptions.cs`, `PhotobankOptions.cs`, etc.). Consistency wins over physical co-location with the consumer. The options class is a configuration contract, not infrastructure plumbing.
+
+#### Decision 2: Bind-and-validate vs. eager `.Value` resolution at registration time
+**Options considered:** (a) Resolve `IOptions<ProductMappingOptions>.Value` inside the DI factory lambda (lazy, per-instantiation). (b) Resolve `configuration.GetSection(...).Get<ProductMappingOptions>()` once at registration time and capture in a closure.
+**Chosen approach:** (a) — resolve `IOptions<T>` lazily inside the factory.
+**Rationale:** Lazy resolution honors `ValidateOnStart()` and integrates with the host's options validation pipeline. Eager binding at registration time bypasses validation and short-circuits the options system. `IOptions<T>` resolution is O(1) and cached; the cost is negligible.
+
+#### Decision 3: Pass `IConfiguration` to `AddInvoicesModule` (signature change) vs. resolving from `IServiceProvider` inside the factory
+**Options considered:** (a) Change `AddInvoicesModule` signature to accept `IConfiguration`. (b) Keep the no-arg signature and resolve `IConfiguration` via `provider.GetRequiredService<IConfiguration>()` inside the transformation factory.
+**Chosen approach:** (a) — signature change, accept `IConfiguration`.
+**Rationale:** Every other configuration-bound module in `ApplicationModule.cs` takes `IConfiguration` explicitly. Hiding the configuration dependency inside the DI lambda is non-idiomatic and prevents the bind/validate pipeline from running at startup. The single call site is updated in the same PR; there is no external consumer.
+
+#### Decision 4: Single-mapping options shape vs. list-of-mappings shape
+**Options considered:** (a) `ProductMappingOptions { string ShoptetCode; string ErpCode; }` — exactly mirrors current behavior. (b) `ProductMappingOptions { List<Mapping> Mappings; }` — more general.
+**Chosen approach:** (a) — single mapping.
+**Rationale:** YAGNI. The spec explicitly puts list-of-mappings out of scope. The transformation class today maps one pair; expanding to a list would require also changing the transformation class and the registration cardinality (one transformation per mapping). Defer until business needs it.
+
+#### Decision 5: Validation strategy
+**Options considered:** (a) `[Required]` data annotations on both properties + `.ValidateDataAnnotations().ValidateOnStart()`. (b) Add a custom `.Validate(...)` lambda that also rejects whitespace-only values.
+**Chosen approach:** (a) — data annotations only.
+**Rationale:** `[Required]` on `string` rejects null and empty string, which is sufficient for the stated failure mode ("silently corrupt data via empty codes"). Whitespace-only values are an extremely unlikely operator typo and not called out in the spec. Match the simpler `MeetingTasksOptions` approach.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Invoices/
+├── InvoicesModule.cs                   ← modified (signature + registration)
+├── ProductMappingOptions.cs            ← NEW
+├── Contracts/
+├── Infrastructure/
+│   └── Transformations/
+│       └── ProductMappingIssuedInvoiceImportTransformation.cs   ← UNCHANGED
+└── ...
+
+backend/src/Anela.Heblo.Application/
+└── ApplicationModule.cs                ← modified (line 95: pass `configuration`)
+
+backend/src/Anela.Heblo.API/
+└── appsettings.json                    ← modified (add "ProductMapping" section)
+
+backend/test/Anela.Heblo.Tests/Features/Invoices/
+└── InvoicesModuleTests.cs              ← NEW (wiring tests; FR-6)
+```
+
+### Interfaces and Contracts
+
+**New file** — `ProductMappingOptions.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.Invoices;
+
+public class ProductMappingOptions
+{
+    public const string SectionName = "ProductMapping";
+
+    [Required]
+    public string ShoptetCode { get; set; } = string.Empty;
+
+    [Required]
+    public string ErpCode { get; set; } = string.Empty;
+}
+```
+
+**Modified** — `InvoicesModule.cs` (relevant section only):
+
+```csharp
+public static IServiceCollection AddInvoicesModule(
+    this IServiceCollection services,
+    IConfiguration configuration)
+{
+    services.AddOptions<ProductMappingOptions>()
+        .Bind(configuration.GetSection(ProductMappingOptions.SectionName))
+        .ValidateDataAnnotations()
+        .ValidateOnStart();
+
+    // ... existing registrations unchanged ...
+
+    services.AddTransient<IIssuedInvoiceImportTransformation, GiftWithoutVATIssuedInvoiceImportTransformation>();
+    services.AddTransient<IIssuedInvoiceImportTransformation, RemoveDAtTheEndOfProductCodeIssuedInvoiceImportTransformation>();
+    services.AddTransient<IIssuedInvoiceImportTransformation>(provider =>
+    {
+        var opts = provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value;
+        return new ProductMappingIssuedInvoiceImportTransformation(opts.ShoptetCode, opts.ErpCode);
+    });
+
+    return services;
+}
+```
+
+Required new `using`s: `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Options`.
+
+**Modified** — `ApplicationModule.cs:95`:
+
+```csharp
+services.AddInvoicesModule(configuration);
+```
+
+### Data Flow
+
+Startup:
+1. Host builds `IConfiguration` from `appsettings.json` + environment-specific overrides.
+2. `ApplicationModule.AddApplicationServices` calls `AddInvoicesModule(configuration)`.
+3. `AddOptions<ProductMappingOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()` registers the options binding + a startup validation hook.
+4. Host runs startup validation. If `ProductMapping` is missing or fields are empty, `OptionsValidationException` is thrown and the app fails to start.
+
+Runtime (per invoice import):
+1. `InvoiceImportService` resolves `IEnumerable<IIssuedInvoiceImportTransformation>`.
+2. For each Transient registration, DI invokes the factory. The product-mapping factory resolves `IOptions<ProductMappingOptions>`, reads `.Value` (cached singleton), and constructs the transformation.
+3. Transformations run in registration order: `GiftWithoutVAT` → `RemoveDAtTheEnd` → `ProductMapping`. Order is preserved.
+4. Each invoice item with `Code == opts.ShoptetCode` has its code rewritten to `opts.ErpCode`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Startup validation triggers in test environments that don't supply `ProductMapping` (causing unrelated test failures across the API project's `WebApplicationFactory`-based suites). | Medium | Add `"ProductMapping"` section to `appsettings.Test.json` (and `appsettings.Conductor.json` if it is used as a base for `WebApplicationFactory`). Audit all `appsettings.*.json` files used at test startup before declaring done. **This is the most likely landmine** — the spec says "no other appsettings.*.json is changed" but that assumption may not survive contact with the test bootstrap. |
+| Transformation registration order changes silently between PR branches due to file-level edits, altering import behavior. | Low | Preserve the literal order: `GiftWithoutVAT` (line 53), `RemoveDAtTheEnd` (line 54), `ProductMapping` (line 57-58). Add an explicit code comment if order is significant for correctness (the chained transformations may not be order-dependent, but preserving today's order is the safe default). |
+| Removing the no-arg `AddInvoicesModule()` overload silently breaks an unknown caller (e.g., test fixture). | Low | Grep the entire repo for `AddInvoicesModule()` before merge. The spec asserts the only known caller is `ApplicationModule.cs:95`; verify. |
+| `IOptions<T>` injected via `provider.GetRequiredService<IOptions<...>>()` is captured in the factory closure but resolved per-Transient — fine for correctness but could mask subsequent options-binding bugs (e.g., a future switch to `IOptionsMonitor`). | Low | Use `IOptions<T>` (not `IOptionsSnapshot` or `IOptionsMonitor`) — values are static for the process lifetime; no hot-reload requested. Document the choice with a one-line comment in the factory if it aids future maintainers, but only if non-obvious. |
+
+## Specification Amendments
+
+1. **FR-3 amendment (test settings).** The spec asserts "No other `appsettings.*.json` file is changed." Verify against test bootstrap behavior before locking this in. If `Anela.Heblo.API`'s `WebApplicationFactory` is used by any integration test and `appsettings.Test.json` overrides the base file completely (or is loaded in a context where `appsettings.json` isn't), the `ProductMapping` section must also be present there to avoid `OptionsValidationException` at test startup. **Action for implementer:** add the same `ProductMapping` block to `appsettings.Test.json` if any of `InvoiceImportIntegrationTests` or other `WebApplicationFactory`-based tests in `backend/test/Anela.Heblo.Tests/` boot the full host. Otherwise leave it out.
+
+2. **FR-6 clarification (second test).** The spec asks for a test that "asserts that omitting the `ProductMapping` section causes the host build / options validation to fail." Note that `.ValidateOnStart()` only triggers on `IHost.StartAsync()`, not on `ServiceCollection.BuildServiceProvider()`. The test must therefore:
+   - Use `Host.CreateDefaultBuilder()` + `host.StartAsync()` (or a minimal equivalent), **or**
+   - Manually invoke the validation by resolving `IOptions<ProductMappingOptions>.Value` after building the provider and asserting `OptionsValidationException` is thrown. The second approach is simpler and sufficient for proving the wiring.
+
+3. **No other amendments.** The remaining FRs and NFRs are accurate, executable, and consistent with codebase conventions.
+
+## Prerequisites
+
+None. The codebase already has:
+- `Microsoft.Extensions.Options` and `Microsoft.Extensions.Configuration` transitively referenced in `Anela.Heblo.Application` (used by all other options-pattern modules).
+- `System.ComponentModel.DataAnnotations` available (used by `MeetingTasksOptions`).
+- An established Options pattern with `SectionName` constants, `AddOptions<T>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`, and identically-shaped sibling modules to copy from.
+- The transformation class's constructor already accepts both codes — the necessary seam exists and is unchanged by this work.
+
+Implementation can start immediately.

--- a/artifacts/feat-arch-review-invoices-product-mapping-con/brief.md
+++ b/artifacts/feat-arch-review-invoices-product-mapping-con/brief.md
@@ -1,0 +1,39 @@
+## Module
+Invoices
+
+## Finding
+`InvoicesModule.cs` lines 57–58 register a product-mapping transformation with product codes baked directly into the DI factory lambda:
+
+```csharp
+services.AddTransient<IIssuedInvoiceImportTransformation>(provider =>
+    new ProductMappingIssuedInvoiceImportTransformation("1287", "SLU000001"));
+```
+
+`"1287"` is a Shoptet product code and `"SLU000001"` is an ABRA Flexi product code. These are business-domain values, not infrastructure wiring.
+
+## Why it matters
+- Changing either product code requires modifying C# source, rebuilding, and redeploying — there is no way to update it through configuration.
+- DI registration files are not where business-rule constants are expected to live; reviewers and maintainers will not look there when the mapping breaks.
+- `ProductMappingIssuedInvoiceImportTransformation` likely already accepts the codes as constructor parameters specifically to keep them injectable, yet the only call site defeats that by hard-coding the values.
+
+## Suggested fix
+Introduce an options class, e.g. `ProductMappingOptions` with `ShoptetCode` and `ErpCode` properties, bind it from `appsettings.json` via `IOptions<ProductMappingOptions>`, and inject it into the factory:
+
+```csharp
+// appsettings.json
+"ProductMapping": {
+  "ShoptetCode": "1287",
+  "ErpCode": "SLU000001"
+}
+
+// InvoicesModule.cs
+services.AddTransient<IIssuedInvoiceImportTransformation>(provider => {
+    var opts = provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value;
+    return new ProductMappingIssuedInvoiceImportTransformation(opts.ShoptetCode, opts.ErpCode);
+});
+```
+
+The actual secret/value goes into Azure Key Vault if it is environment-specific, or into the shared `appsettings.json` if it is stable across environments. Either way it is no longer in compiled code.
+
+---
+_Filed by daily arch-review routine on 2026-06-09._

--- a/artifacts/feat-arch-review-invoices-product-mapping-con/impl/main.r1.md
+++ b/artifacts/feat-arch-review-invoices-product-mapping-con/impl/main.r1.md
@@ -1,0 +1,64 @@
+All 4 implementation commits are on the branch. Here is the output summary:
+
+---
+
+# Implementation: Externalize Product Mapping Codes for Invoice Import Transformation
+
+## What was implemented
+
+Moved the hard-coded Shoptet→ERP product code mapping (`"1287"` → `"SLU000001"`) out of `InvoicesModule.cs`'s DI factory lambda into a strongly-typed `ProductMappingOptions` class bound from `appsettings.json`, matching the Options pattern established by `MeetingTasksOptions` and peers. Startup validation via `.ValidateDataAnnotations().ValidateOnStart()` ensures the application fails fast with a clear error if the `ProductMapping` section is missing or its required fields are empty.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs` — new options POCO with `[Required]` `ShoptetCode`/`ErpCode` properties and `SectionName = "ProductMapping"` constant
+- `backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs` — signature changed to accept `IConfiguration`, options binding wired, factory lambda now resolves `IOptions<ProductMappingOptions>` instead of using literals
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — single-line update: `AddInvoicesModule()` → `AddInvoicesModule(configuration)`
+- `backend/src/Anela.Heblo.API/appsettings.json` — `ProductMapping` section added adjacent to `InvoiceImport` with production-equivalent values
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs` — new test class with 4 tests: 2 wiring tests (happy path) and 2 startup-validation tests (OptionsValidationException scenarios)
+
+## Tests
+
+- `InvoicesModuleTests.cs` — 4 tests, all pass:
+  - `AddInvoicesModule_BindsProductMappingOptions_AndTransformationUsesThem` — end-to-end: resolves the transformation, runs it against a test invoice, asserts code rewrite
+  - `AddInvoicesModule_RegistersOptions_BoundFromConfiguration` — asserts IOptions resolves with configured values
+  - `AddInvoicesModule_ThrowsOptionsValidationException_WhenProductMappingSectionMissing` — missing section → OptionsValidationException naming both fields
+  - `AddInvoicesModule_ThrowsOptionsValidationException_WhenShoptetCodeEmpty` — empty ShoptetCode → OptionsValidationException
+- `ProductMappingIssuedInvoiceImportTransformationTests.cs` — 6 pre-existing tests unchanged, all pass
+
+## How to verify
+
+```bash
+# No literals remain in module
+grep -c '"1287"\|"SLU000001"' backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs
+# Expected: 0
+
+# All 4 new wiring/validation tests pass
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Invoices.InvoicesModuleTests"
+
+# Pre-existing transformation tests pass (unchanged)
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProductMappingIssuedInvoiceImportTransformationTests"
+
+# Full invoice test suite (64 tests)
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Invoices"
+```
+
+## Notes
+
+No deviations from the spec. The `HebloWebApplicationFactory` layers `appsettings.Test.json` on top of `appsettings.json` (not replacing it), so the `ProductMapping` section in `appsettings.json` is inherited by all integration tests — no change to `appsettings.Test.json` was needed. All 64 invoice tests (including `InvoiceImportIntegrationTests`) passed without modification.
+
+## PR Summary
+
+Externalizes two hard-coded business reference values (`"1287"`, `"SLU000001"`) from `InvoicesModule.cs` into a `ProductMappingOptions` class bound from `appsettings.json`, following the established Options pattern used across all other feature modules. The product codes can now be changed via configuration without a rebuild. Startup validation via `[Required]` + `ValidateOnStart()` prevents silent registration of a transformation with empty codes.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs` — new options POCO
+- `backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs` — signature update, options binding, factory refactored
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — pass `configuration` to `AddInvoicesModule`
+- `backend/src/Anela.Heblo.API/appsettings.json` — `ProductMapping` section with production values
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs` — 4 new wiring/validation tests
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-invoices-product-mapping-con/spec.r1.md
+++ b/artifacts/feat-arch-review-invoices-product-mapping-con/spec.r1.md
@@ -1,0 +1,137 @@
+Now I have all the context I need to write a thorough spec.
+
+# Specification: Externalize Product Mapping Codes for Invoice Import Transformation
+
+## Summary
+The `ProductMappingIssuedInvoiceImportTransformation` is currently registered in `InvoicesModule.cs` with two product codes (`"1287"` and `"SLU000001"`) hard-coded in the DI factory lambda. This spec extracts those business-domain values into a strongly-typed `ProductMappingOptions` class bound from `appsettings.json`, aligning the module with the established Options pattern already used elsewhere in the codebase (e.g., `MeetingTasksOptions`, `OrgChartOptions`, `CatalogCacheOptions`).
+
+## Background
+Daily architecture review flagged `backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs:57-58`:
+
+```csharp
+services.AddTransient<IIssuedInvoiceImportTransformation>(provider =>
+    new ProductMappingIssuedInvoiceImportTransformation("1287", "SLU000001"));
+```
+
+- `"1287"` is a Shoptet product code; `"SLU000001"` is an ABRA Flexi (ERP) product code.
+- These are business mapping values, not infrastructure wiring; they have no business being in a DI registration file.
+- Changing either code today requires editing C# source, rebuilding, and redeploying. There is no operational path to update the mapping when business needs change.
+- The transformation class already accepts both codes via constructor parameters (`ProductMappingIssuedInvoiceImportTransformation.cs:11`), so the seam exists — the call site simply defeats it.
+- The codebase already has a well-established Options pattern with `SectionName` constants, `AddOptions<T>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`, and dedicated `*Options.cs` files in each feature module. This change brings the Invoices module in line with that convention.
+
+## Functional Requirements
+
+### FR-1: Introduce `ProductMappingOptions` class
+Create a new strongly-typed options class to hold the Shoptet→ERP product code mapping.
+
+**Acceptance criteria:**
+- New file `backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs` exists.
+- Class name: `ProductMappingOptions`.
+- Public `const string SectionName = "ProductMapping";`.
+- Property `ShoptetCode` (string), marked `[Required]`, no default value other than `string.Empty` initializer.
+- Property `ErpCode` (string), marked `[Required]`, no default value other than `string.Empty` initializer.
+- File matches the style of `MeetingTasksOptions.cs` (uses `System.ComponentModel.DataAnnotations`, public class, properties with `get; set;`).
+
+### FR-2: Bind `ProductMappingOptions` from configuration in `InvoicesModule`
+Wire the options class into DI and bind it to the `ProductMapping` configuration section. Mirror the pattern used by `MeetingTasksModule`.
+
+**Acceptance criteria:**
+- `InvoicesModule.AddInvoicesModule` signature changes to `AddInvoicesModule(this IServiceCollection services, IConfiguration configuration)`.
+- The call site in `ApplicationModule.cs:95` is updated to pass `configuration`.
+- `services.AddOptions<ProductMappingOptions>().Bind(configuration.GetSection(ProductMappingOptions.SectionName)).ValidateDataAnnotations().ValidateOnStart()` is invoked before the transformation registration.
+- The `ProductMappingIssuedInvoiceImportTransformation` registration factory resolves `IOptions<ProductMappingOptions>` from the provider and passes `opts.ShoptetCode` and `opts.ErpCode` to the constructor.
+- Hard-coded literals `"1287"` and `"SLU000001"` no longer appear anywhere in `InvoicesModule.cs`.
+
+### FR-3: Add `ProductMapping` section to `appsettings.json`
+Provide the production-equivalent values in the base configuration file so the application boots with the same mapping behavior as today.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.API/appsettings.json` includes a top-level `ProductMapping` section with `"ShoptetCode": "1287"` and `"ErpCode": "SLU000001"`.
+- The section is placed near other Shoptet/Invoice-related sections (e.g., adjacent to `InvoiceImport`) for discoverability.
+- No other `appsettings.*.json` file is changed (the existing values stay environment-agnostic and stable across environments — see Open Questions if this assumption is invalid).
+
+### FR-4: Preserve runtime behavior
+The change must be purely a refactor — invoice import behavior must be byte-for-byte identical to the current production behavior.
+
+**Acceptance criteria:**
+- After the change, importing an invoice with an item whose `Code == "1287"` still results in that item's code being rewritten to `"SLU000001"`.
+- All other items are passed through unchanged.
+- The transformation is still registered as `Transient` and as one of the `IIssuedInvoiceImportTransformation` instances enumerated by the import pipeline (registration order vs. siblings `GiftWithoutVATIssuedInvoiceImportTransformation` and `RemoveDAtTheEndOfProductCodeIssuedInvoiceImportTransformation` is preserved).
+
+### FR-5: Startup validation on misconfiguration
+If the `ProductMapping` section is missing or its required fields are empty, the application must fail fast at startup with a clear, actionable error message, rather than silently registering a transformation with empty strings.
+
+**Acceptance criteria:**
+- `.ValidateDataAnnotations().ValidateOnStart()` is configured on the options binding.
+- Removing `ProductMapping` from `appsettings.json` causes the application to throw `OptionsValidationException` (or equivalent) during startup, naming the missing fields.
+- The error surfaces before the first invoice import is attempted.
+
+### FR-6: Unit-test the wiring
+Confirm via tests that the options are bound and consumed correctly.
+
+**Acceptance criteria:**
+- A new test (xUnit, in `backend/test/Anela.Heblo.Tests/Features/Invoices/`) builds a `ServiceCollection`, calls `AddInvoicesModule` with an `IConfiguration` containing a `ProductMapping` section with test values, resolves `IEnumerable<IIssuedInvoiceImportTransformation>`, and asserts that the `ProductMappingIssuedInvoiceImportTransformation` instance rewrites the configured `ShoptetCode` to the configured `ErpCode`.
+- A second test asserts that omitting the `ProductMapping` section causes the host build / options validation to fail.
+- Existing `ProductMappingIssuedInvoiceImportTransformationTests` (which test the transformation class directly with hard-coded `TEST001` / `NEW001`) remain unchanged and continue to pass — the transformation class's contract is not modified.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. The options instance is resolved once per `Transient` instantiation of the transformation (one DI resolution per invoice import). `IOptions<T>` resolution is O(1) and cached by the host.
+
+### NFR-2: Security
+- The product codes are not secrets — they are business reference data. They belong in `appsettings.json`, not Azure Key Vault.
+- No new attack surface is introduced.
+- Validation prevents the transformation from running with empty/null codes, which would silently corrupt data.
+
+### NFR-3: Maintainability
+- Eliminates the inconsistency where one of three `IIssuedInvoiceImportTransformation` registrations uses a factory lambda with literals while the other two use the standard `AddTransient<TService, TImpl>()` overload.
+- Makes the mapping discoverable by configuration reviewers who scan `appsettings.json`, not by source-code archaeologists who happen to open `InvoicesModule.cs`.
+- Brings the Invoices module's DI signature in line with peer modules that take `IConfiguration` (the majority — see `ApplicationModule.cs:80-109`).
+
+### NFR-4: Backward compatibility (configuration)
+A clean cutover. The DI signature for `AddInvoicesModule` changes (no overload preserved), and the only known caller (`ApplicationModule.cs:95`) is updated in the same change. There are no external consumers of this extension method.
+
+## Data Model
+
+### `ProductMappingOptions`
+| Property      | Type     | Required | Description                                                                 |
+|---------------|----------|----------|-----------------------------------------------------------------------------|
+| `ShoptetCode` | `string` | Yes      | Product code as it appears on incoming Shoptet invoice line items.          |
+| `ErpCode`     | `string` | Yes      | Product code to substitute, matching the corresponding ABRA Flexi product.  |
+
+Bound from configuration section `ProductMapping`. No persistence — values live entirely in configuration.
+
+## API / Interface Design
+
+No public HTTP API changes. No MediatR contract changes.
+
+### Internal changes
+- `InvoicesModule.AddInvoicesModule(this IServiceCollection)` → `InvoicesModule.AddInvoicesModule(this IServiceCollection, IConfiguration)`.
+- `ApplicationModule.cs:95` updated: `services.AddInvoicesModule(configuration);`.
+
+### Configuration schema (added to `appsettings.json`)
+```json
+"ProductMapping": {
+  "ShoptetCode": "1287",
+  "ErpCode": "SLU000001"
+}
+```
+
+## Dependencies
+- `Microsoft.Extensions.Options` and `Microsoft.Extensions.Configuration` — already transitively referenced by `Anela.Heblo.Application`.
+- `System.ComponentModel.DataAnnotations` for `[Required]` — already used by `MeetingTasksOptions`.
+- No new NuGet packages.
+
+## Out of Scope
+- Supporting **multiple** product-code mappings. The transformation class today maps exactly one Shoptet code to one ERP code, and the brief asks only to externalize those two values. Extending to a list of mappings (e.g., `"Mappings": [{ "ShoptetCode": "...", "ErpCode": "..." }, ...]`) is a separate feature.
+- Reading the mapping from Key Vault. The codes are not secrets and the brief explicitly says `appsettings.json` is acceptable when stable across environments.
+- Hot-reloading / `IOptionsMonitor`. The mapping is read once at transformation construction; runtime reconfiguration is not requested.
+- UI for managing product mappings. Out of scope for this refactor.
+- Refactoring the other two transformations (`GiftWithoutVATIssuedInvoiceImportTransformation`, `RemoveDAtTheEndOfProductCodeIssuedInvoiceImportTransformation`). They do not currently embed business literals in their DI registration and are not flagged by the brief.
+- Renaming `InvoiceImport` config section or any unrelated invoice configuration.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-invoices-product-mapping-con/task-plan.r1.md
+++ b/artifacts/feat-arch-review-invoices-product-mapping-con/task-plan.r1.md
@@ -1,0 +1,14 @@
+Self-review passed — all 6 FRs trace to specific tasks, no placeholders, types/method signatures (`ProductMappingOptions.ShoptetCode`/`ErpCode`/`SectionName`, `AddInvoicesModule(IServiceCollection, IConfiguration)`, `InvoicesModuleTests`) stay consistent across Tasks 1→5.
+
+Plan saved to `docs/superpowers/plans/2026-06-11-externalize-product-mapping-codes.md`.
+
+**Summary of the 6-task implementation plan:**
+
+1. **Task 1** — Create `ProductMappingOptions.cs` POCO with `[Required]` `ShoptetCode` and `ErpCode` plus `SectionName = "ProductMapping"`.
+2. **Task 2** — Write a failing wiring test (TDD red) — fails at compile because `AddInvoicesModule` doesn't take `IConfiguration` yet.
+3. **Task 3** — Refactor `InvoicesModule` to accept `IConfiguration`, bind options with `.ValidateDataAnnotations().ValidateOnStart()`, switch the product-mapping factory to resolve `IOptions<ProductMappingOptions>`; update `ApplicationModule.cs:95`. Test passes (TDD green).
+4. **Task 4** — Add `"ProductMapping": { "ShoptetCode": "1287", "ErpCode": "SLU000001" }` to `appsettings.json` adjacent to `InvoiceImport`, then verify `WebApplicationFactory`-based integration tests still boot.
+5. **Task 5** — Add FR-5 startup-validation tests proving `OptionsValidationException` fires on missing section and empty `ShoptetCode`.
+6. **Task 6** — Regression gate: assert no `"1287"`/`"SLU000001"` literals remain in `InvoicesModule.cs`, run the pre-existing transformation tests + full backend suite, run `dotnet format`.
+
+Each task ends with its own commit so progress is bisectable. The arch review's two amendments (FR-3 test-settings audit, FR-6 validation-test mechanism) are addressed inline: `HebloWebApplicationFactory` layers `appsettings.Test.json` on top of `appsettings.json` (verified by reading the factory at line 39), so no separate test-settings edit is needed; and the validation tests use `provider.GetRequiredService<IOptions<...>>().Value` to trigger `DataAnnotation` validation without requiring `IHost.StartAsync()`.

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -300,6 +300,10 @@
     "MinimumDailyThreshold": 10,
     "DefaultDaysBack": 30
   },
+  "ProductMapping": {
+    "ShoptetCode": "1287",
+    "ErpCode": "SLU000001"
+  },
   "BackgroundRefresh": {
     "ICatalogRepository": {
       "RefreshTransportData": {

--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -92,7 +92,7 @@ public static class ApplicationModule
         services.AddOrgChartServices(configuration);
         services.AddInvoiceClassificationModule();
         services.AddPackingMaterialsModule();
-        services.AddInvoicesModule();
+        services.AddInvoicesModule(configuration);
         services.AddKnowledgeBaseModule(configuration);
         services.AddCatalogDocumentsModule(configuration);
         services.AddLeafletModule(configuration);

--- a/backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Anela.Heblo.Application.Features.DataQuality.Contracts;
 using Anela.Heblo.Application.Features.Invoices.Contracts;
 using Anela.Heblo.Application.Features.Invoices.Infrastructure;
@@ -15,8 +17,18 @@ namespace Anela.Heblo.Application.Features.Invoices;
 /// </summary>
 public static class InvoicesModule
 {
-    public static IServiceCollection AddInvoicesModule(this IServiceCollection services)
+    public static IServiceCollection AddInvoicesModule(
+        this IServiceCollection services,
+        IConfiguration configuration)
     {
+        // Bind ProductMappingOptions from configuration and validate at startup so
+        // a missing or incomplete "ProductMapping" section fails fast instead of
+        // silently registering a transformation with empty codes.
+        services.AddOptions<ProductMappingOptions>()
+            .Bind(configuration.GetSection(ProductMappingOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
         // Register repositories
         services.AddScoped<IIssuedInvoiceRepository, IssuedInvoiceRepository>();
 
@@ -49,13 +61,15 @@ public static class InvoicesModule
         // Register FlexiBee client (from SDK)
         // Note: IIssuedInvoiceClient registration should be done in Flexi adapter module
 
-        // Register transformations
+        // Register transformations — preserve registration order; the import pipeline
+        // enumerates IEnumerable<IIssuedInvoiceImportTransformation> in this order.
         services.AddTransient<IIssuedInvoiceImportTransformation, GiftWithoutVATIssuedInvoiceImportTransformation>();
         services.AddTransient<IIssuedInvoiceImportTransformation, RemoveDAtTheEndOfProductCodeIssuedInvoiceImportTransformation>();
-
-        // Product mapping transformations can be registered based on configuration
         services.AddTransient<IIssuedInvoiceImportTransformation>(provider =>
-            new ProductMappingIssuedInvoiceImportTransformation("1287", "SLU000001"));
+        {
+            var opts = provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value;
+            return new ProductMappingIssuedInvoiceImportTransformation(opts.ShoptetCode, opts.ErpCode);
+        });
 
         // MediatR handlers are automatically registered by MediatR scan
 

--- a/backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.Invoices;
+
+public class ProductMappingOptions
+{
+    public const string SectionName = "ProductMapping";
+
+    [Required]
+    public string ShoptetCode { get; set; } = string.Empty;
+
+    [Required]
+    public string ErpCode { get; set; } = string.Empty;
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs
@@ -1,0 +1,80 @@
+using Anela.Heblo.Application.Features.Invoices;
+using Anela.Heblo.Application.Features.Invoices.Infrastructure;
+using Anela.Heblo.Domain.Features.Invoices;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Invoices;
+
+public class InvoicesModuleTests
+{
+    private const string TestShoptetCode = "TEST-SHOPTET";
+    private const string TestErpCode = "TEST-ERP";
+
+    [Fact]
+    public async Task AddInvoicesModule_BindsProductMappingOptions_AndTransformationUsesThem()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductMapping:ShoptetCode"] = TestShoptetCode,
+                ["ProductMapping:ErpCode"] = TestErpCode,
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act — find the product-mapping transformation and run it against an invoice
+        // whose only item carries the configured Shoptet code.
+        var transformations = provider.GetServices<IIssuedInvoiceImportTransformation>().ToList();
+        var productMapping = transformations
+            .OfType<Anela.Heblo.Application.Features.Invoices.Infrastructure.Transformations.ProductMappingIssuedInvoiceImportTransformation>()
+            .Single();
+
+        var invoice = new IssuedInvoiceDetail
+        {
+            Items = new List<IssuedInvoiceDetailItem>
+            {
+                new IssuedInvoiceDetailItem { Code = TestShoptetCode, Name = "Test Product" }
+            }
+        };
+
+        var result = await productMapping.TransformAsync(invoice);
+
+        // Assert
+        Assert.Equal(TestErpCode, result.Items.Single().Code);
+    }
+
+    [Fact]
+    public void AddInvoicesModule_RegistersOptions_BoundFromConfiguration()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductMapping:ShoptetCode"] = TestShoptetCode,
+                ["ProductMapping:ErpCode"] = TestErpCode,
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var opts = provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value;
+
+        // Assert
+        Assert.Equal(TestShoptetCode, opts.ShoptetCode);
+        Assert.Equal(TestErpCode, opts.ErpCode);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs
@@ -77,4 +77,47 @@ public class InvoicesModuleTests
         Assert.Equal(TestShoptetCode, opts.ShoptetCode);
         Assert.Equal(TestErpCode, opts.ErpCode);
     }
+
+    [Fact]
+    public void AddInvoicesModule_ThrowsOptionsValidationException_WhenProductMappingSectionMissing()
+    {
+        // Arrange — empty configuration: no ProductMapping section at all
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act + Assert — resolving .Value fires DataAnnotation validation
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value);
+
+        Assert.Contains(nameof(ProductMappingOptions.ShoptetCode), string.Join("|", ex.Failures));
+        Assert.Contains(nameof(ProductMappingOptions.ErpCode), string.Join("|", ex.Failures));
+    }
+
+    [Fact]
+    public void AddInvoicesModule_ThrowsOptionsValidationException_WhenShoptetCodeEmpty()
+    {
+        // Arrange — ProductMapping section present, ShoptetCode is empty string
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductMapping:ShoptetCode"] = "",
+                ["ProductMapping:ErpCode"] = "SLU000001",
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act + Assert
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value);
+
+        Assert.Contains(nameof(ProductMappingOptions.ShoptetCode), string.Join("|", ex.Failures));
+    }
 }

--- a/docs/superpowers/plans/2026-06-11-externalize-product-mapping-codes.md
+++ b/docs/superpowers/plans/2026-06-11-externalize-product-mapping-codes.md
@@ -1,0 +1,506 @@
+# Externalize Product Mapping Codes for Invoice Import Transformation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the hard-coded Shoptet→ERP product code mapping (`"1287"` → `"SLU000001"`) out of `InvoicesModule.cs`'s DI factory lambda and into a strongly-typed `ProductMappingOptions` class bound from `appsettings.json`, matching the Options pattern already used by `MeetingTasksOptions`, `OrgChartOptions`, etc.
+
+**Architecture:** Net-new POCO `ProductMappingOptions` with `[Required]` data annotations, bound via `services.AddOptions<T>().Bind(...).ValidateDataAnnotations().ValidateOnStart()` in a re-signatured `AddInvoicesModule(IServiceCollection, IConfiguration)`. The transformation's existing two-string constructor stays unchanged — its DI factory now resolves `IOptions<ProductMappingOptions>` instead of using literals. The single call site in `ApplicationModule.cs:95` is updated to pass `configuration`. Behavior is identical to today; the only operational change is that the codes can now be tuned via configuration without a rebuild.
+
+**Tech Stack:** .NET 8, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Configuration`, `System.ComponentModel.DataAnnotations`, xUnit, `Microsoft.Extensions.DependencyInjection`. No new NuGet packages.
+
+---
+
+## Pre-Flight Context (read before starting)
+
+- **Spec:** Both Shoptet (`"1287"`) and ERP (`"SLU000001"`) codes are business reference data, not secrets — they belong in `appsettings.json`, not Key Vault.
+- **Sibling pattern to copy:** `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksOptions.cs` (the POCO) and `MeetingTasksModule.cs:14-21` (the binding). Use these as the literal template.
+- **Transformation class is UNCHANGED:** `ProductMappingIssuedInvoiceImportTransformation.cs` already accepts the two codes via constructor. Do not touch it; the seam already exists. Existing tests (`ProductMappingIssuedInvoiceImportTransformationTests.cs`) continue to use hard-coded `TEST001`/`NEW001` and must keep passing.
+- **Test bootstrap:** `HebloWebApplicationFactory.cs:39` calls `builder.UseEnvironment("Test")`. ASP.NET Core's default host layers `appsettings.Test.json` **on top of** `appsettings.json` — it does not replace it. So once `ProductMapping` lives in the base `appsettings.json`, all `WebApplicationFactory`-based integration tests will inherit it. No change to `appsettings.Test.json` is required.
+- **Registration order matters for visual/audit reasons** (not correctness — the three transformations operate on different codes). Preserve today's order: `GiftWithoutVAT` → `RemoveDAtTheEnd` → `ProductMapping`.
+
+---
+
+### Task 1: Create the `ProductMappingOptions` class
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs`
+
+This is a plain options POCO with two `[Required]` strings — no behavior to test in isolation. The class is exercised end-to-end by the wiring test in Task 3.
+
+- [ ] **Step 1: Create the options class**
+
+Write to `backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.Invoices;
+
+public class ProductMappingOptions
+{
+    public const string SectionName = "ProductMapping";
+
+    [Required]
+    public string ShoptetCode { get; set; } = string.Empty;
+
+    [Required]
+    public string ErpCode { get; set; } = string.Empty;
+}
+```
+
+- [ ] **Step 2: Verify the project compiles**
+
+Run from repo root:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+Expected: `Build succeeded. 0 Error(s)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs
+git commit -m "feat: add ProductMappingOptions class for invoice import transformation"
+```
+
+---
+
+### Task 2: Write the failing wiring test
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs`
+
+This test pins down FR-2 and FR-6: after `AddInvoicesModule(configuration)` is called with a config that contains a `ProductMapping` section, the resolved `IEnumerable<IIssuedInvoiceImportTransformation>` must include a `ProductMappingIssuedInvoiceImportTransformation` that rewrites the configured `ShoptetCode` to the configured `ErpCode`. It will not compile today because `AddInvoicesModule` does not yet take an `IConfiguration` — that's the failure we want.
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Write to `backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Invoices;
+using Anela.Heblo.Application.Features.Invoices.Infrastructure;
+using Anela.Heblo.Domain.Features.Invoices;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Invoices;
+
+public class InvoicesModuleTests
+{
+    private const string TestShoptetCode = "TEST-SHOPTET";
+    private const string TestErpCode = "TEST-ERP";
+
+    [Fact]
+    public async Task AddInvoicesModule_BindsProductMappingOptions_AndTransformationUsesThem()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductMapping:ShoptetCode"] = TestShoptetCode,
+                ["ProductMapping:ErpCode"] = TestErpCode,
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act — find the product-mapping transformation and run it against an invoice
+        // whose only item carries the configured Shoptet code.
+        var transformations = provider.GetServices<IIssuedInvoiceImportTransformation>().ToList();
+        var productMapping = transformations
+            .OfType<Anela.Heblo.Application.Features.Invoices.Infrastructure.Transformations.ProductMappingIssuedInvoiceImportTransformation>()
+            .Single();
+
+        var invoice = new IssuedInvoiceDetail
+        {
+            Items = new List<IssuedInvoiceDetailItem>
+            {
+                new IssuedInvoiceDetailItem { Code = TestShoptetCode, Name = "Test Product" }
+            }
+        };
+
+        var result = await productMapping.TransformAsync(invoice);
+
+        // Assert
+        Assert.Equal(TestErpCode, result.Items.Single().Code);
+    }
+
+    [Fact]
+    public void AddInvoicesModule_RegistersOptions_BoundFromConfiguration()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductMapping:ShoptetCode"] = TestShoptetCode,
+                ["ProductMapping:ErpCode"] = TestErpCode,
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var opts = provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value;
+
+        // Assert
+        Assert.Equal(TestShoptetCode, opts.ShoptetCode);
+        Assert.Equal(TestErpCode, opts.ErpCode);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm a compile-time failure**
+
+Run from repo root:
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: compile error — something like `CS1501: No overload for method 'AddInvoicesModule' takes 1 arguments` (because the current signature has no `IConfiguration` parameter and we're trying to pass one). This proves the test will exercise the signature change.
+
+> Do NOT commit yet — the codebase does not build. Proceed to Task 3 to make it build and pass.
+
+---
+
+### Task 3: Refactor `InvoicesModule` to bind options and update the call site
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs`
+- Modify: `backend/src/Anela.Heblo.Application/ApplicationModule.cs:95`
+
+This task makes the failing test from Task 2 pass. It changes `AddInvoicesModule`'s signature to accept `IConfiguration`, binds `ProductMappingOptions` with `ValidateDataAnnotations().ValidateOnStart()`, switches the product-mapping factory to resolve `IOptions<ProductMappingOptions>`, and updates the one call site.
+
+- [ ] **Step 1: Update `InvoicesModule.cs`**
+
+Replace the entire content of `backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs` with:
+
+```csharp
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using Anela.Heblo.Application.Features.Invoices.Contracts;
+using Anela.Heblo.Application.Features.Invoices.Infrastructure;
+using Anela.Heblo.Application.Features.Invoices.Infrastructure.Transformations;
+using Anela.Heblo.Application.Features.Invoices.Services;
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Bank;
+
+namespace Anela.Heblo.Application.Features.Invoices;
+
+/// <summary>
+/// Module for registering Invoice-related services
+/// </summary>
+public static class InvoicesModule
+{
+    public static IServiceCollection AddInvoicesModule(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Bind ProductMappingOptions from configuration and validate at startup so
+        // a missing or incomplete "ProductMapping" section fails fast instead of
+        // silently registering a transformation with empty codes.
+        services.AddOptions<ProductMappingOptions>()
+            .Bind(configuration.GetSection(ProductMappingOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        // Register repositories
+        services.AddScoped<IIssuedInvoiceRepository, IssuedInvoiceRepository>();
+
+        // Cross-module contract: Invoices implements PackingMaterials' IInvoiceConsumptionSource
+        // via an adapter. DI registration owned by provider (Invoices), not consumer
+        // (PackingMaterials) — keeps the dependency direction inverted properly.
+        services.AddScoped<IInvoiceConsumptionSource, InvoiceConsumptionSourceAdapter>();
+
+        // Cross-module contract: Invoices implements Analytics' IInvoiceImportStatisticsSource
+        // via an adapter. DI registration owned by provider (Invoices), not consumer
+        // (Analytics) — mirrors the IInvoiceConsumptionSource pattern above. Scoped because
+        // the adapter wraps ApplicationDbContext (also Scoped).
+        services.AddScoped<IInvoiceImportStatisticsSource, InvoiceImportStatisticsSourceAdapter>();
+
+        // Cross-module contracts: Invoices implements DataQuality's IInvoiceShoptetSource
+        // and IInvoiceErpClient via adapters. Lifetimes mirror the wrapped services exactly:
+        //   - IIssuedInvoiceSource is registered Singleton in Program.cs:119, so the adapter
+        //     must also be Singleton (and DataQuality consumers must resolve it from a Scoped
+        //     scope as usual — Singleton from Scoped is legal, the inverse is captive).
+        //   - IIssuedInvoiceClient is registered Scoped in FlexiAdapterServiceCollectionExtensions.cs:93,
+        //     so the adapter must also be Scoped.
+        services.AddSingleton<IInvoiceShoptetSource, InvoiceShoptetSourceAdapter>();
+        services.AddScoped<IInvoiceErpClient, InvoiceErpClientAdapter>();
+
+        // Register services
+        services.AddScoped<IInvoiceImportService, InvoiceImportService>();
+
+        // Hangfire jobs are now automatically discovered via IRecurringJob interface
+
+        // Register FlexiBee client (from SDK)
+        // Note: IIssuedInvoiceClient registration should be done in Flexi adapter module
+
+        // Register transformations — preserve registration order; the import pipeline
+        // enumerates IEnumerable<IIssuedInvoiceImportTransformation> in this order.
+        services.AddTransient<IIssuedInvoiceImportTransformation, GiftWithoutVATIssuedInvoiceImportTransformation>();
+        services.AddTransient<IIssuedInvoiceImportTransformation, RemoveDAtTheEndOfProductCodeIssuedInvoiceImportTransformation>();
+        services.AddTransient<IIssuedInvoiceImportTransformation>(provider =>
+        {
+            var opts = provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value;
+            return new ProductMappingIssuedInvoiceImportTransformation(opts.ShoptetCode, opts.ErpCode);
+        });
+
+        // MediatR handlers are automatically registered by MediatR scan
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Update the call site in `ApplicationModule.cs`**
+
+In `backend/src/Anela.Heblo.Application/ApplicationModule.cs`, change line 95 from:
+
+```csharp
+        services.AddInvoicesModule();
+```
+
+to:
+
+```csharp
+        services.AddInvoicesModule(configuration);
+```
+
+- [ ] **Step 3: Build the solution to verify both files compile**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded. 0 Error(s)`.
+
+- [ ] **Step 4: Run the wiring tests from Task 2 and confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Invoices.InvoicesModuleTests" \
+  --no-build
+```
+Expected: 2 passed, 0 failed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs \
+        backend/src/Anela.Heblo.Application/ApplicationModule.cs \
+        backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs
+git commit -m "refactor: bind ProductMappingOptions from configuration in InvoicesModule"
+```
+
+---
+
+### Task 4: Add the `ProductMapping` section to `appsettings.json`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/appsettings.json`
+
+The wiring tests in Task 3 already pass because they build their own `IConfiguration`. But the running application boots from `appsettings.json` and, with `ValidateOnStart()` now active, will throw `OptionsValidationException` at startup unless the `ProductMapping` section is present. This task adds the production-equivalent values so behavior is byte-for-byte identical to today (`"1287"` → `"SLU000001"`). Place it adjacent to the existing `InvoiceImport` section (`appsettings.json:299-302`) for discoverability.
+
+- [ ] **Step 1: Add the `ProductMapping` section**
+
+In `backend/src/Anela.Heblo.API/appsettings.json`, find the existing `InvoiceImport` block (around line 299):
+
+```json
+  "InvoiceImport": {
+    "MinimumDailyThreshold": 10,
+    "DefaultDaysBack": 30
+  },
+```
+
+Insert a new `ProductMapping` block immediately after it:
+
+```json
+  "InvoiceImport": {
+    "MinimumDailyThreshold": 10,
+    "DefaultDaysBack": 30
+  },
+  "ProductMapping": {
+    "ShoptetCode": "1287",
+    "ErpCode": "SLU000001"
+  },
+```
+
+- [ ] **Step 2: Verify the JSON is well-formed**
+
+```bash
+python3 -c "import json; json.load(open('backend/src/Anela.Heblo.API/appsettings.json'))" && echo OK
+```
+Expected: `OK` (and no JSON parsing error). The file contains `//` comments on a few lines — `python3 -c "import json; ..."` will fail on those if present in the section you edited. The `InvoiceImport` block does not contain comments, so inserting clean JSON next to it is safe. If `python3` reports a comment-related error elsewhere in the file (e.g. on existing lines like `appsettings.json:525`), that error is pre-existing and unrelated to your edit — ignore.
+
+- [ ] **Step 3: Build and run the full test project to confirm the WebApplicationFactory-based tests still boot**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Invoices" \
+  --no-build
+```
+Expected: all invoice tests pass, including `InvoiceImportIntegrationTests` (which boots `HebloWebApplicationFactory` and would now fail at host startup if `ProductMapping` were missing).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/appsettings.json
+git commit -m "feat: add ProductMapping section to appsettings.json"
+```
+
+---
+
+### Task 5: Add the failing startup-validation test (FR-5)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs`
+
+FR-5 requires that the application fail fast at startup if `ProductMapping` is missing or its required fields are empty. The arch review's FR-6 clarification notes that `.ValidateOnStart()` only fires on `IHost.StartAsync()`, but the simpler equivalent is to build a provider and resolve `IOptions<ProductMappingOptions>.Value` — this triggers the data-annotation validator and throws `OptionsValidationException`. Use that.
+
+- [ ] **Step 1: Append the validation tests to `InvoicesModuleTests.cs`**
+
+Add the following two tests to the existing `InvoicesModuleTests` class (before the closing `}`):
+
+```csharp
+    [Fact]
+    public void AddInvoicesModule_ThrowsOptionsValidationException_WhenProductMappingSectionMissing()
+    {
+        // Arrange — empty configuration: no ProductMapping section at all
+        var configuration = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act + Assert — resolving .Value fires DataAnnotation validation
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value);
+
+        Assert.Contains(nameof(ProductMappingOptions.ShoptetCode), string.Join("|", ex.Failures));
+        Assert.Contains(nameof(ProductMappingOptions.ErpCode), string.Join("|", ex.Failures));
+    }
+
+    [Fact]
+    public void AddInvoicesModule_ThrowsOptionsValidationException_WhenShoptetCodeEmpty()
+    {
+        // Arrange — ProductMapping section present, ShoptetCode is empty string
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductMapping:ShoptetCode"] = "",
+                ["ProductMapping:ErpCode"] = "SLU000001",
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddInvoicesModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act + Assert
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ProductMappingOptions>>().Value);
+
+        Assert.Contains(nameof(ProductMappingOptions.ShoptetCode), string.Join("|", ex.Failures));
+    }
+```
+
+- [ ] **Step 2: Run the validation tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Invoices.InvoicesModuleTests"
+```
+Expected: 4 passed (the 2 from Task 2 plus the 2 new ones), 0 failed. These pass on the first run because Task 3 already added `.ValidateDataAnnotations()`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs
+git commit -m "test: add ProductMappingOptions startup-validation tests"
+```
+
+---
+
+### Task 6: Confirm pre-existing tests still pass and no literals remain
+
+**Files:** (read-only verification)
+- Verify: `backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs`
+- Verify: `backend/test/Anela.Heblo.Tests/Features/Invoices/Infrastructure/Transformations/ProductMappingIssuedInvoiceImportTransformationTests.cs`
+
+Belt-and-braces gate before declaring done. FR-4 ("preserve runtime behavior") and FR-6's "existing tests remain unchanged and continue to pass" must be verified end-to-end.
+
+- [ ] **Step 1: Confirm the literals are gone**
+
+```bash
+grep -n '"1287"\|"SLU000001"' backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs
+```
+Expected: no output (zero matches). The literals must only live in `appsettings.json` now.
+
+- [ ] **Step 2: Run the pre-existing transformation tests (must still pass — they use TEST001/NEW001)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProductMappingIssuedInvoiceImportTransformationTests"
+```
+Expected: 6 passed, 0 failed. These tests instantiate the transformation directly via its constructor — they should be unaffected by the wiring refactor.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+Expected: full suite passes. Pay attention to any `OptionsValidationException` failures in `WebApplicationFactory`-based integration tests across other feature modules — those would signal that `appsettings.Test.json` overrides `appsettings.json` for some module in a way that strips the `ProductMapping` section. (It shouldn't — `appsettings.Test.json` is layered, not replaced — but verify.)
+
+- [ ] **Step 4: Format the touched C# files**
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs \
+            backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs \
+            backend/src/Anela.Heblo.Application/ApplicationModule.cs \
+            backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs
+```
+Expected: no errors. Any formatting changes are stage-and-commit material.
+
+- [ ] **Step 5: Commit any formatting changes (skip if working tree is clean)**
+
+```bash
+git status --short
+# If anything is modified:
+git add -A
+git commit -m "style: dotnet format invoices module options refactor"
+```
+
+---
+
+## Spec Coverage Recap
+
+| FR  | Requirement | Task(s) |
+|-----|-------------|---------|
+| FR-1 | New `ProductMappingOptions` class with `[Required]` props and `SectionName` constant | Task 1 |
+| FR-2 | `InvoicesModule` accepts `IConfiguration`, binds options, factory uses `IOptions<T>`, `ApplicationModule.cs:95` updated | Task 3 |
+| FR-3 | `ProductMapping` section added to `appsettings.json` adjacent to `InvoiceImport` | Task 4 |
+| FR-4 | Runtime behavior unchanged (`"1287"` → `"SLU000001"`, transformation Transient, registration order preserved) | Task 3 (order comment), Task 4 (production-equivalent values), Task 6 (regression check) |
+| FR-5 | Startup validation via `.ValidateDataAnnotations().ValidateOnStart()` | Task 3 (wiring), Task 5 (proof tests) |
+| FR-6 | Wiring tests + validation tests; existing direct-class transformation tests untouched | Task 2 (wiring tests), Task 5 (validation tests), Task 6 (existing tests verified) |
+| NFR-3 | Brings Invoices module in line with peer-module Options pattern | Task 3 |
+
+## Risk Recap (from arch review)
+
+- **Test settings override risk:** Mitigated by reading `HebloWebApplicationFactory.cs:39` — uses `UseEnvironment("Test")` which layers `appsettings.Test.json` on top of `appsettings.json`, so the `ProductMapping` section added in Task 4 is inherited by all integration tests. No edits to `appsettings.Test.json` needed. Verified in Task 6, Step 3.
+- **Registration order silently changing:** Mitigated by preserving the literal order in Task 3 and adding an inline comment.
+- **Unknown caller of `AddInvoicesModule()`:** `grep -rn "AddInvoicesModule" backend/` returns only `InvoicesModule.cs` (definition) and `ApplicationModule.cs` (call site). No test fixture calls it directly. Safe to break the no-arg signature.


### PR DESCRIPTION

Externalizes two hard-coded business reference values (`"1287"`, `"SLU000001"`) from `InvoicesModule.cs` into a `ProductMappingOptions` class bound from `appsettings.json`, following the established Options pattern used across all other feature modules. The product codes can now be changed via configuration without a rebuild. Startup validation via `[Required]` + `ValidateOnStart()` prevents silent registration of a transformation with empty codes.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Invoices/ProductMappingOptions.cs` — new options POCO
- `backend/src/Anela.Heblo.Application/Features/Invoices/InvoicesModule.cs` — signature update, options binding, factory refactored
- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — pass `configuration` to `AddInvoicesModule`
- `backend/src/Anela.Heblo.API/appsettings.json` — `ProductMapping` section with production values
- `backend/test/Anela.Heblo.Tests/Features/Invoices/InvoicesModuleTests.cs` — 4 new wiring/validation tests

---

Closes #2842

### Tokens used
14979803
