### PR TITLE
feat: Remove Manual `.refetch()` Calls from JournalList

### DIFF
--- a/artifacts/feat-arch-review-journal-journallist-calls-re/arch-review.r1.md
+++ b/artifacts/feat-arch-review-journal-journallist-calls-re/arch-review.r1.md
@@ -1,0 +1,165 @@
+# Architecture Review: Remove Manual `.refetch()` Calls from JournalList
+
+## Skip Design: true
+
+No visual or layout changes. This is a pure client-side refactor of query orchestration; the rendered UI, modal flow, pagination footer, and filter controls are unchanged.
+
+## Architectural Fit Assessment
+
+The proposed change **strengthens** existing patterns rather than introducing new ones. The codebase already uses React Query's key-change refetch as the standard mechanism across `useJournal.ts`, with explicit JSDoc on `useSearchJournalEntries` (lines 44–53) prohibiting the very anti-pattern this refactor removes. Mutation hooks (`useCreateJournalEntry`, `useUpdateJournalEntry`, `useDeleteJournalEntry`) already invalidate the `entries`, `search`, and `byProduct` query namespaces in their `onSuccess` callbacks (`useJournal.ts:98–108, 126–139, 151–161`), so post-mutation freshness is already guaranteed without `handleCloseModal` doing anything.
+
+Integration points:
+- **`JournalList.tsx` only** — three handlers. No props, no hook signatures, no module boundaries cross.
+- **Tests at `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx`** — three existing tests (`should handle search input and apply search`, `should handle Enter key press in search input`, `should clear search and return to normal mode`) currently assert `mockRefetch.toHaveBeenCalled()` and **must be rewritten** to assert key-driven hook re-invocation instead. This pattern is already established in the file: `re-invokes the search hook with the new pageNumber when paginating in search mode` (lines 485–528) checks the hook's `mock.calls`, not `.refetch()`.
+
+Note: actual line numbers in the source are slightly off from those quoted in `spec.r1.md` (e.g. `handleApplyFilters` is at lines 208–219, not 214–216). The function targets are unambiguous; the line offsets are immaterial.
+
+One spec inaccuracy: the file lives at `frontend/src/components/pages/Journal/JournalList.tsx`, not `frontend/src/components/journal/JournalList.tsx` as written in the spec.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+User action (filter / clear / modal close)
+        │
+        ▼
+  setState(...) calls          ← only mechanism that triggers refetch
+        │
+        ▼
+  React commit phase
+        │
+        ▼
+  useJournalEntries / useSearchJournalEntries re-evaluate
+        │  (queryKey changes because params object changes)
+        ▼
+  React Query auto-refetch with CORRECT params
+        │
+        ▼
+  Cache update → table re-renders with correct rows
+```
+
+For modal-close after a mutation, the path is:
+
+```
+Mutation success in modal
+        │
+        ▼
+  useXxxJournalEntry.onSuccess → queryClient.invalidateQueries
+        │
+        ▼
+  Active queries refetch
+        │
+        ▼
+  Modal closes (handleCloseModal does NOT call refetch)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Trust React Query's key-change refetch, do not orchestrate it manually
+
+**Options considered:**
+- A: Remove `.refetch()` calls; rely on key-change refetch (proposed).
+- B: Keep `.refetch()` but defer it via `setTimeout(0)` or `useEffect` to fire after state commits.
+- C: Migrate to a single unified query hook that internally decides search vs. browse.
+
+**Chosen approach:** A.
+
+**Rationale:** B preserves the redundancy (two mechanisms doing the same job) and reintroduces the JSDoc contract violation in a more subtle form. C is out of scope per the spec and would be a larger refactor with no current benefit. A is the documented contract and is already used by every other consumer of these hooks.
+
+#### Decision 2: Drop `async` from handlers that no longer await anything
+
+**Options considered:**
+- A: Make `handleApplyFilters` and `handleClearFilters` synchronous (remove `async`).
+- B: Keep them `async` for symmetry/future use.
+
+**Chosen approach:** A.
+
+**Rationale:** YAGNI. Once the `await` is gone, the `async` is dead syntax. `handleKeyDown` calls `handleApplyFilters()` without awaiting it — already correct for a sync handler. No call site needs the returned promise.
+
+#### Decision 3: Test strategy mirrors the existing key-change pattern
+
+**Options considered:**
+- A: Update the three `.toHaveBeenCalled()` assertions to inspect hook `mock.calls` for the updated params (matches lines 485–528 of the existing test file).
+- B: Add a fetch-mock-level assertion counting HTTP requests.
+
+**Chosen approach:** A.
+
+**Rationale:** The hooks are already mocked in `JournalList.test.tsx`; the real React Query client never runs there. Asserting on hook call arguments is consistent with the file's existing pattern, requires no test infrastructure change, and is what the spec's "exactly one network call" requirement actually reduces to under the existing mocking strategy. B would require a meaningful test rewrite (real `QueryClient`, MSW or fetch-mock) which is out of scope.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files, no moves. All changes confined to two files:
+
+- `frontend/src/components/pages/Journal/JournalList.tsx` — remove three `.refetch()` blocks, drop redundant `async` keywords.
+- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — update three existing tests; optionally add a focused regression test asserting that `useSearchJournalEntries` / `useJournalEntries` are re-invoked with the new params after filter apply, clear, and modal close.
+
+### Interfaces and Contracts
+
+No public interface changes. All affected items are file-local:
+
+- `handleApplyFilters: () => void` (was `async () => Promise<void>`)
+- `handleClearFilters: () => void` (was `async () => Promise<void>`)
+- `handleCloseModal: () => void` (unchanged signature; body shrinks)
+
+External contracts preserved:
+- `<JournalEntryModal onClose={handleCloseModal} />` — `onClose` is typed as `() => void`; passing a sync function is unchanged.
+- Keyboard handler `handleKeyDown` already calls `handleApplyFilters()` without awaiting; no change needed.
+
+### Data Flow
+
+**Filter apply (after refactor):**
+1. User clicks "Filtrovat" or presses Enter.
+2. `handleApplyFilters` runs three `setState` calls: `setSearchTextFilter(text)`, `setIsSearchMode(text.trim() !== "")`, `setPageNumber(1)`.
+3. React batches and commits.
+4. `useSearchJournalEntries` re-renders with new params → `queryKey` changes → React Query fires the search request **once** (gated by `enabled = isSearchMode`).
+5. If the user cleared the input (`isSearchMode` becomes `false`), `useJournalEntries` is the active query and may already have cached data for the current page; if not, it fetches.
+
+**Filter clear:**
+1. `handleClearFilters` sets input, filter, search-mode, and page back to defaults.
+2. `useSearchJournalEntries` disables (`enabled = false`); `useJournalEntries` becomes the current query and re-renders with `pageNumber: 1` → fires once if not cached.
+
+**Modal close after create/update/delete:**
+1. Modal's mutation hook hits `onSuccess` → invalidates `entries`, `search`, `byProduct` keys.
+2. React Query refetches active queries automatically.
+3. `handleCloseModal` only resets `isModalOpen` and `editingEntryId` — no `.refetch()`.
+
+**Modal close on cancel (no mutation):**
+1. No invalidation fired by any mutation.
+2. `handleCloseModal` does not refetch.
+3. Net network requests: zero (correct behavior; the data on screen is what was on screen).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing tests asserting `mockRefetch.toHaveBeenCalled()` fail after the change | High | Rewrite the three tests at `JournalList.test.tsx:236, 267, 294` to assert on the hook's `mock.calls` (params object) — pattern already used at lines 485–528. This is mandatory work, not optional. |
+| Browse query (`useJournalEntries`) does not invalidate when the modal closes without a mutation, leaving stale data visible if external changes occurred | Low | Acceptable. There is no concurrent-edit story in the Journal module today, and the previous unconditional refetch was a workaround, not a feature. If staleness ever becomes a concern, the right fix is `refetchOnWindowFocus` or a focused invalidation in a future change — not restoring the anti-pattern. |
+| `handleApplyFilters` called with the same `searchTextInput` value twice in a row produces the same `params` object identity but different React Query `queryKey` array — and React Query may not refetch | Low | The `params` object is reconstructed on every render and the `queryKey` is `[...QUERY_KEYS.journal, "search", params]`. React Query uses deep equality (`isEqual`) on keys, so an identical filter applied twice will **not** refetch. This is correct behavior (no duplicate request for identical state) and matches the spec's "exactly one network call" requirement. No mitigation required, but document this in the test assertions. |
+| `setPageNumber(1)` is a no-op if the user is already on page 1, and `setIsSearchMode(true)` may be a no-op if already in search mode — only the search-text change drives the key change | Low | Even when only one of the three setStates produces a value change, React Query still re-evaluates the `queryKey` on the next render and compares deep-equality. If nothing meaningful changed, no refetch fires — which is correct. The spec's "exactly one network call" requirement is upheld. |
+| Removing `async` from a handler that an existing or future caller awaits | Low | `handleKeyDown` and the `<button onClick={handleApplyFilters}>` JSX do not await. No other call sites exist. Verified by `grep`. |
+
+## Specification Amendments
+
+1. **File path correction.** The spec writes the path as `frontend/src/components/journal/JournalList.tsx`; the actual path is `frontend/src/components/pages/Journal/JournalList.tsx`. Update both `Background` and `Functional Requirements` sections.
+
+2. **Line numbers are advisory.** The spec cites lines 214–216, 233–237, 282–287; actual ranges in the current file are 208–219, 229–237, 278–287. Replace fixed line citations with handler-name references (`handleApplyFilters`, `handleClearFilters`, `handleCloseModal`) to avoid drift.
+
+3. **Test rewrite is required, not optional.** NFR-4 frames tests as "add or update." Three existing tests (`should handle search input and apply search`, `should handle Enter key press in search input`, `should clear search and return to normal mode`) directly assert `mockRefetch.toHaveBeenCalled()` and will fail after the refactor. Reclassify this as a mandatory edit and reuse the existing key-change assertion pattern from lines 485–528 of the test file.
+
+4. **Drop `async` keywords as part of the change.** FR-4 mentions "any now-unused `async`/`await` keywords" as mechanical follow-ups. Make this explicit: `handleApplyFilters` and `handleClearFilters` become synchronous.
+
+5. **No new fetch-mock or MSW infrastructure.** The "exactly one network call" acceptance criteria under FR-1/FR-2/FR-3 should be reinterpreted in the unit-test layer as "the relevant hook is invoked with the new params at most once per state transition." Real network counting belongs to E2E coverage (already out of scope per the spec).
+
+## Prerequisites
+
+None.
+
+- No migrations, config, or infrastructure changes required.
+- React Query is already configured project-wide.
+- Mutation `onSuccess` invalidation is already in place in `useJournal.ts`.
+- The `enabled` gate on `useSearchJournalEntries` is already in place.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-journal-journallist-calls-re/brief.md
+++ b/artifacts/feat-arch-review-journal-journallist-calls-re/brief.md
@@ -1,0 +1,28 @@
+## Module
+Journal
+
+## Finding
+`JournalList.tsx` calls `.refetch()` manually on the React Query objects immediately after setting React state in three places:
+
+- `handleApplyFilters` (line 214–216): `await searchQuery.refetch()` / `await entriesQuery.refetch()` after `setSearchTextFilter`, `setIsSearchMode`, `setPageNumber`.
+- `handleClearFilters` (line 233–237): `await entriesQuery.refetch()` after `setSearchTextInput`, `setSearchTextFilter`, `setIsSearchMode`, `setPageNumber`.
+- `handleCloseModal` (line 282–287): `searchQuery.refetch()` / `entriesQuery.refetch()` after the modal close.
+
+The `useSearchJournalEntries` hook's own JSDoc (`frontend/src/api/hooks/useJournal.ts`, lines 46–51) explicitly warns against this:
+
+> "callers should rely on key-change refetch rather than calling `.refetch()` manually after changing state"
+
+The reason is timing: React state updates are batched and asynchronous. When `.refetch()` is called immediately after `setState`, the query key has **not yet changed** — the refetch fires with the old parameters. React then re-renders with the new state, the key changes, and React Query fires a second fetch with the correct parameters. The result is two network requests: one with stale parameters (which may briefly populate the table with wrong data) and one with the correct parameters.
+
+## Why it matters
+- **Stale data flash**: the first refetch returns old results into the query cache, which React Query displays before the second (correct) fetch completes.
+- **Double requests**: every filter apply, clear, and modal close sends an extra network request.
+- **Contract violation**: the hook's documentation is the contract between the hook and its callers. Three callers already violate it, increasing the risk that future callers follow the same pattern.
+
+## Suggested fix
+Remove all manual `.refetch()` calls from `handleApplyFilters`, `handleClearFilters`, and `handleCloseModal`. React Query will automatically re-fetch when the query key changes (driven by the state updates that are already there). The `enabled` parameter on `useSearchJournalEntries` already gates the search query; the browse query has no `enabled` guard and will refetch on any key change.
+
+For `handleCloseModal`, if a refetch after save is genuinely needed, `onSuccess` in the mutation's `useCreateJournalEntry` / `useUpdateJournalEntry` / `useDeleteJournalEntry` hooks already calls `queryClient.invalidateQueries`, which is the correct mechanism.
+
+---
+_Filed by daily arch-review routine on 2026-06-10._

--- a/artifacts/feat-arch-review-journal-journallist-calls-re/impl/main.r1.md
+++ b/artifacts/feat-arch-review-journal-journallist-calls-re/impl/main.r1.md
@@ -1,0 +1,66 @@
+---
+
+# Implementation: Remove Manual `.refetch()` Calls from JournalList
+
+## What was implemented
+
+Removed all 5 manual `.refetch()` call sites from three handlers in `JournalList.tsx`:
+- `handleApplyFilters`: dropped the `if/else refetch` block + `async`
+- `handleClearFilters`: dropped the `await entriesQuery.refetch()` + `async`
+- `handleCloseModal`: dropped the `if/else refetch` block
+
+React Query's existing key-change refetch mechanism handles all refetching automatically. Post-mutation freshness continues to be handled by `queryClient.invalidateQueries` in the mutation hooks' `onSuccess` callbacks.
+
+Three existing tests that asserted `mockRefetch.toHaveBeenCalled()` were rewritten to assert hook re-invocation with correct params (the pattern established at JournalList.test.tsx:485–528). One new regression test locks in the `handleCloseModal` no-refetch contract.
+
+## Files created/modified
+
+- `frontend/src/components/pages/Journal/JournalList.tsx` — removed 3 refetch blocks, dropped `async` from 2 handlers (~20 line reduction)
+- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — rewrote 3 tests + added 1 regression test; fixed `testing-library/no-wait-for-multiple-assertions` lint rule in new test
+
+## Tests
+
+- 22 tests total, all passing
+- 3 rewritten tests: assert `useSearchJournalEntries`/`useJournalEntries` re-invocation with correct params using `mock.calls`
+- 1 new regression test: "does not call refetch on entriesQuery or searchQuery when the modal closes" — was red before source fix, green after
+
+## How to verify
+
+From `frontend/`:
+```bash
+node_modules/.bin/react-scripts test --testPathPattern=JournalList.test.tsx --watchAll=false
+# Expected: 22 passed, 0 failed
+```
+
+Check no `.refetch(` calls remain:
+```bash
+grep -n "\.refetch(" src/components/pages/Journal/JournalList.tsx
+# Expected: no output
+```
+
+Surgical diff check:
+```bash
+git diff --stat main...HEAD -- frontend/src/components/pages/Journal/
+# Expected: only JournalList.tsx and __tests__/JournalList.test.tsx
+```
+
+## Notes
+
+- The implementer subagent batched all 4 test changes into one commit instead of 4 separate commits — the code is correct, just the commit granularity differs from the plan
+- A `testing-library/no-wait-for-multiple-assertions` lint violation was introduced in the new regression test (two `expect` inside `waitFor`) and fixed before final commit — this is a new lint error vs. baseline, corrected immediately
+- All other lint errors in the output are pre-existing in unrelated files; the two changed files are lint-clean
+- Worktree required `npm install --legacy-peer-deps` as `node_modules` was absent (package includes `@microsoft/applicationinsights-web` not in a stale symlink)
+
+## PR Summary
+
+Removed three manual `.refetch()` invocations from `JournalList.tsx` that fired React Query refetches immediately after `setState`, violating the hook contract and causing double network requests with stale-data flashes. React Query's automatic key-change refetch already handles all cases; the manual calls were redundant anti-patterns.
+
+Three existing tests that asserted `mockRefetch.toHaveBeenCalled()` were rewritten to assert hook re-invocation with correct params (matching the pattern already established in the file for sort/pagination tests). One new regression test verifies `handleCloseModal` no longer triggers refetch.
+
+### Changes
+- `frontend/src/components/pages/Journal/JournalList.tsx` — removed refetch blocks from `handleApplyFilters`, `handleClearFilters`, `handleCloseModal`; dropped now-dead `async` from first two handlers
+- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — rewrote 3 tests from `mockRefetch.toHaveBeenCalled()` to hook `mock.calls` param assertions; added regression test for `handleCloseModal`
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-journal-journallist-calls-re/spec.r1.md
+++ b/artifacts/feat-arch-review-journal-journallist-calls-re/spec.r1.md
@@ -1,0 +1,100 @@
+# Specification: Remove Manual `.refetch()` Calls from JournalList
+
+## Summary
+Remove three manual `.refetch()` invocations from `JournalList.tsx` that fire React Query refetches immediately after `setState`, violating the documented contract of `useSearchJournalEntries` and causing double network requests with stale-data flashes. Rely on React Query's automatic key-change refetch behavior, which is already in place.
+
+## Background
+The Journal module's list page (`frontend/src/components/journal/JournalList.tsx`) currently mixes two refetch mechanisms: React Query's automatic key-change refetch and manual `.refetch()` calls. Because React state updates are batched and asynchronous, calling `.refetch()` immediately after `setState` fires the network request with the **previous** query parameters. React then re-renders, the query key actually changes, and React Query fires a **second** request with the correct parameters.
+
+This produces two observable defects:
+1. **Stale-data flash** — the first (wrong-parameter) response lands in the cache before the correct response, briefly painting incorrect rows in the table.
+2. **Duplicate network traffic** — every filter apply, filter clear, and modal close generates an unnecessary request.
+
+The `useSearchJournalEntries` hook's JSDoc (`frontend/src/api/hooks/useJournal.ts` lines 46–51) explicitly warns callers against this pattern. Three call sites in `JournalList.tsx` already violate it; leaving them in place normalizes the anti-pattern for future callers.
+
+## Functional Requirements
+
+### FR-1: Remove manual refetch from `handleApplyFilters`
+Delete the `await searchQuery.refetch()` and `await entriesQuery.refetch()` calls at `JournalList.tsx` lines 214–216. The existing `setSearchTextFilter`, `setIsSearchMode`, and `setPageNumber` state updates already change the React Query key(s); React Query will automatically refetch with the correct parameters on the next render.
+
+**Acceptance criteria:**
+- No `.refetch()` calls remain inside `handleApplyFilters`.
+- Applying a filter triggers exactly one network request (verifiable in browser DevTools → Network).
+- The journal entry table updates to the filtered results without a stale-data flash.
+- The function signature and external behavior (UX-visible side effects) are unchanged.
+
+### FR-2: Remove manual refetch from `handleClearFilters`
+Delete the `await entriesQuery.refetch()` call at `JournalList.tsx` lines 233–237. The existing `setSearchTextInput`, `setSearchTextFilter`, `setIsSearchMode`, and `setPageNumber` state updates already drive the query key change.
+
+**Acceptance criteria:**
+- No `.refetch()` calls remain inside `handleClearFilters`.
+- Clearing filters triggers exactly one network request.
+- The table returns to the unfiltered/browse view without a stale-data flash.
+
+### FR-3: Remove manual refetch from `handleCloseModal`
+Delete the `searchQuery.refetch()` and `entriesQuery.refetch()` calls at `JournalList.tsx` lines 282–287. Cache invalidation after a create/update/delete is already handled by `queryClient.invalidateQueries` inside the `onSuccess` callbacks of `useCreateJournalEntry`, `useUpdateJournalEntry`, and `useDeleteJournalEntry`. The modal close itself does not require any explicit refetch.
+
+**Acceptance criteria:**
+- No `.refetch()` calls remain inside `handleCloseModal`.
+- After creating a new entry and closing the modal, the new entry appears in the list (driven by mutation `onSuccess` → `invalidateQueries`).
+- After editing an existing entry and closing the modal, the updated entry is reflected in the list.
+- After deleting an entry and closing the modal, the entry is no longer in the list.
+- Closing the modal without saving (cancel) does not trigger any network request beyond what was already implicit before the change.
+
+### FR-4: Preserve unchanged behavior in all other paths
+No other functions, hooks, or components in `JournalList.tsx` should be modified beyond removing the three refetch calls and any now-unused `async`/`await` keywords or variable destructuring that becomes dead code as a direct result.
+
+**Acceptance criteria:**
+- The diff is limited to the three identified locations plus mechanical follow-ups (e.g., dropping `async` on a handler that no longer awaits anything).
+- No changes to `useJournal.ts`, the mutation hooks, or any other Journal module file are made.
+- Pagination, sorting, search-mode toggling, and modal open/edit/delete flows continue to work as before.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Eliminate one redundant HTTP request per filter apply, filter clear, and post-mutation modal close.
+- No regression in perceived responsiveness — the React Query key-change path must produce a network request promptly after state commits (this is the default React Query behavior; no configuration changes required).
+
+### NFR-2: Correctness
+- The journal list must never display results computed from stale filter parameters, even transiently. The fix must remove the stale-data flash window entirely.
+
+### NFR-3: Maintainability
+- The hook contract documented in `useJournal.ts` JSDoc is honored by all current callers, removing a misleading precedent.
+
+### NFR-4: Test coverage
+- Existing unit tests for `JournalList.tsx` must continue to pass.
+- Add or update tests (Jest + React Testing Library) that assert exactly one network call per filter-apply, filter-clear, and post-mutation modal close sequence, using a mocked React Query client or fetch mock.
+
+## Data Model
+No data model changes. This is a frontend refactor that affects only client-side query orchestration.
+
+## API / Interface Design
+No backend API changes. No changes to hook signatures, component props, or public exports.
+
+**Internal call-flow change (per affected handler):**
+
+Before:
+1. `setState(…)` (1..N times)
+2. `await someQuery.refetch()` ← fires with stale params
+3. React re-renders, key changes, React Query fires again with new params
+
+After:
+1. `setState(…)` (1..N times)
+2. React re-renders, key changes, React Query fires exactly once with new params
+
+## Dependencies
+- React Query (`@tanstack/react-query`) — relies on existing `queryKey` change detection.
+- Existing hooks `useSearchJournalEntries`, `useJournalEntries`, `useCreateJournalEntry`, `useUpdateJournalEntry`, `useDeleteJournalEntry` in `frontend/src/api/hooks/useJournal.ts` — no modifications expected.
+
+## Out of Scope
+- Refactoring or restructuring `JournalList.tsx` beyond the three minimal edits.
+- Changing the `useSearchJournalEntries` or `useJournalEntries` hook internals.
+- Adjusting the mutation hooks' `onSuccess` invalidation behavior.
+- Auditing other modules for the same anti-pattern (this spec is scoped to the Journal list).
+- Documentation updates beyond the code itself; the existing JSDoc warning already covers the rationale.
+- Behavioral changes to pagination, search debounce, or modal lifecycle outside the three refetch removals.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-journal-journallist-calls-re/task-plan.r1.md
+++ b/artifacts/feat-arch-review-journal-journallist-calls-re/task-plan.r1.md
@@ -1,0 +1,13 @@
+Plan saved to `docs/superpowers/plans/2026-06-11-journal-list-remove-manual-refetch.md`.
+
+**Summary of the plan:**
+
+The plan is structured as 7 tasks (0 through 6) with tight, TDD-style steps:
+
+- **Task 0** — Verify starting state: confirm the three `.refetch()` call sites and three target tests exist, and the existing test suite is green.
+- **Tasks 1–3** — Rewrite the three existing tests (`should handle search input and apply search`, `should handle Enter key press in search input`, `should clear search and return to normal mode`) to assert on hook re-invocation with the new params object — matching the existing pattern at `JournalList.test.tsx:485–528`. These tests pass against the **unchanged** source (they assert on something that already happens), so each gets its own commit.
+- **Task 4** — Add a new failing regression test for `handleCloseModal`. This test FAILS against the unchanged source (refetch is called), proving it actually exercises the handler. Committed red.
+- **Task 5** — Strip the three `.refetch()` blocks, drop `async` from the two handlers that no longer await. Verifications grep for residual `.refetch(` and `async`. The Task 4 red test turns green here.
+- **Task 6** — `npm run build`, `npm run lint`, surgical-diff check (only the two expected files appear in `git diff --stat`), and a final full-suite test run.
+
+The plan also includes an explicit spec→task mapping table at the end covering all FRs (FR-1 through FR-4), NFRs (NFR-1 through NFR-4), and all five spec amendments from the architecture review.

--- a/docs/superpowers/plans/2026-06-11-journal-list-remove-manual-refetch.md
+++ b/docs/superpowers/plans/2026-06-11-journal-list-remove-manual-refetch.md
@@ -1,0 +1,624 @@
+# Remove Manual `.refetch()` Calls from JournalList Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove three manual `.refetch()` invocations from `JournalList.tsx` so that React Query's automatic key-change refetch is the sole refetch mechanism, eliminating duplicate network calls and stale-data flashes.
+
+**Architecture:** Pure client-side refactor of query orchestration. Strip three `.refetch()` blocks from the three handlers (`handleApplyFilters`, `handleClearFilters`, `handleCloseModal`), drop the now-dead `async` keywords, and rewrite three existing tests that asserted on `mockRefetch.toHaveBeenCalled()` to instead assert on hook re-invocation with the new params object (matching the pattern already established at `JournalList.test.tsx:485–528`). No hook signatures, no public interfaces, no API contracts change.
+
+**Tech Stack:** React 18, TypeScript, `@tanstack/react-query` v5 (already configured), Jest 29 + React Testing Library, `JournalList.tsx` (page component), `useJournal.ts` (existing hook module — not modified).
+
+---
+
+## File Structure
+
+Only two files are touched. No new files, no moves.
+
+- **Modify** `frontend/src/components/pages/Journal/JournalList.tsx`
+  - `handleApplyFilters` (lines 208–219): drop the body's `if/else refetch` block (lines 213–218); remove `async`.
+  - `handleClearFilters` (lines 229–237): drop the trailing `await entriesQuery.refetch()` (lines 235–236); remove `async`.
+  - `handleCloseModal` (lines 278–287): drop the trailing `if/else refetch` block (lines 281–286).
+- **Modify** `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx`
+  - Rewrite test `should handle search input and apply search` (lines 236–265).
+  - Rewrite test `should handle Enter key press in search input` (lines 267–292).
+  - Rewrite test `should clear search and return to normal mode` (lines 294–341).
+  - Add one new test for `handleCloseModal` to lock in the regression coverage required by spec FR-3.
+
+Files **not** touched (verify by `git diff --stat` after task 6):
+- `frontend/src/api/hooks/useJournal.ts`
+- `frontend/src/components/JournalEntryModal.tsx`
+- any other Journal-module file
+
+---
+
+## Pre-flight Verification
+
+### Task 0: Confirm the starting state
+
+**Files:**
+- Read: `frontend/src/components/pages/Journal/JournalList.tsx`
+- Read: `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx`
+
+- [ ] **Step 1: Verify the three target call sites exist**
+
+Run:
+```bash
+grep -n "refetch" frontend/src/components/pages/Journal/JournalList.tsx
+```
+
+Expected output (line numbers approximate; handler-name attribution is authoritative):
+```
+215:      await searchQuery.refetch();
+217:      await entriesQuery.refetch();
+236:    await entriesQuery.refetch();
+283:      searchQuery.refetch();
+285:      entriesQuery.refetch();
+```
+
+If the number of lines or the handler context differs, STOP and reconcile with the spec before continuing — drift means the source has changed since the plan was written.
+
+- [ ] **Step 2: Verify the three target tests exist**
+
+Run:
+```bash
+grep -n "mockSearchRefetch\|mockRefetch" frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+```
+
+Expected: matches inside the three test bodies on lines roughly 236–341. If absent, STOP and reconcile.
+
+- [ ] **Step 3: Verify the existing test suite is green before touching anything**
+
+Run from `frontend/`:
+```bash
+npm test -- --testPathPattern=JournalList.test.tsx --watchAll=false
+```
+
+Expected: all tests pass. If any fail, STOP — fix the pre-existing failures or escalate before modifying the file.
+
+---
+
+## Test-First Refactor
+
+### Task 1: Rewrite test `should handle search input and apply search`
+
+**Goal:** Assert that clicking "Filtrovat" causes `useSearchJournalEntries` to be re-invoked with the new `searchText`, `pageNumber: 1`, and `enabled = true`. Remove the `mockSearchRefetch` assertion.
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` (lines 236–265)
+
+- [ ] **Step 1: Replace the test body**
+
+Replace the entire test (lines 236–265) with:
+
+```typescript
+  it("re-invokes the search hook with the new searchText and enabled=true when applying filters", async () => {
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 1,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    const filterButton = screen.getByText("Filtrovat");
+
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(filterButton);
+
+    let searchParams: any;
+    let searchEnabled: any;
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      searchParams = lastCall?.[0];
+      searchEnabled = lastCall?.[1];
+
+      expect(searchEnabled).toBe(true);
+    });
+
+    expect(searchParams).toMatchObject({
+      searchText: "skincare",
+      pageNumber: 1,
+    });
+  });
+```
+
+- [ ] **Step 2: Run the rewritten test against the **unchanged** source**
+
+Run from `frontend/`:
+```bash
+npm test -- --testPathPattern=JournalList.test.tsx -t "re-invokes the search hook with the new searchText" --watchAll=false
+```
+
+Expected: **PASS**. Rationale: the assertion targets hook re-invocation, which already happens because the `setState` calls fire regardless of whether `.refetch()` is also called. The test must be green *before* the source change so we know the source change didn't break it later.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+git commit -m "test: assert search hook re-invocation on filter apply instead of mockRefetch"
+```
+
+---
+
+### Task 2: Rewrite test `should handle Enter key press in search input`
+
+**Goal:** Assert the same hook-reinvocation contract for the Enter-key path.
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` (lines 267–292)
+
+- [ ] **Step 1: Replace the test body**
+
+Replace the entire test with:
+
+```typescript
+  it("re-invokes the search hook with the new searchText when Enter is pressed in the search input", async () => {
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [],
+        totalCount: 0,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 0,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+
+    fireEvent.change(searchInput, { target: { value: "test search" } });
+    fireEvent.keyDown(searchInput, { key: "Enter", code: "Enter" });
+
+    let searchParams: any;
+    let searchEnabled: any;
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      searchParams = lastCall?.[0];
+      searchEnabled = lastCall?.[1];
+
+      expect(searchEnabled).toBe(true);
+    });
+
+    expect(searchParams).toMatchObject({
+      searchText: "test search",
+      pageNumber: 1,
+    });
+  });
+```
+
+- [ ] **Step 2: Run the rewritten test against the **unchanged** source**
+
+Run:
+```bash
+npm test -- --testPathPattern=JournalList.test.tsx -t "re-invokes the search hook with the new searchText when Enter" --watchAll=false
+```
+
+Expected: **PASS**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+git commit -m "test: assert search hook re-invocation on Enter key press"
+```
+
+---
+
+### Task 3: Rewrite test `should clear search and return to normal mode`
+
+**Goal:** Assert that clicking "Vymazat" exits search mode by passing `enabled = false` to `useSearchJournalEntries` and re-invoking `useJournalEntries` with `pageNumber: 1`. No `mockRefetch` assertion.
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` (lines 294–341)
+
+- [ ] **Step 1: Replace the test body**
+
+Replace the entire test with:
+
+```typescript
+  it("disables the search hook and re-invokes the entries hook when filters are cleared", async () => {
+    mockUseJournalHooks.useJournalEntries.mockReturnValue({
+      data: {
+        entries: mockJournalEntries,
+        totalCount: 2,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 1,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+    fireEvent.keyDown(searchInput, { key: "Enter" });
+
+    await waitFor(() => {
+      const lastSearchCall = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls.at(-1);
+      expect(lastSearchCall?.[1]).toBe(true);
+    });
+
+    // Clear filters.
+    const clearButton = screen.getByText("Vymazat");
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      const lastSearchCall = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls.at(-1);
+      expect(lastSearchCall?.[1]).toBe(false);
+    });
+
+    const lastEntriesCall = (mockUseJournalHooks.useJournalEntries as jest.Mock).mock.calls.at(-1);
+    expect(lastEntriesCall?.[0]).toMatchObject({
+      pageNumber: 1,
+    });
+
+    // The search input should also be cleared visually.
+    expect(searchInput).toHaveValue("");
+  });
+```
+
+- [ ] **Step 2: Run the rewritten test against the **unchanged** source**
+
+Run:
+```bash
+npm test -- --testPathPattern=JournalList.test.tsx -t "disables the search hook and re-invokes the entries hook" --watchAll=false
+```
+
+Expected: **PASS**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+git commit -m "test: assert entries hook re-invocation and search disabled on clear filters"
+```
+
+---
+
+### Task 4: Add regression test for `handleCloseModal` not calling refetch
+
+**Goal:** Lock in spec FR-3: after the source change, `handleCloseModal` must NOT cause an additional invocation of `useJournalEntries` or `useSearchJournalEntries` beyond what the modal-open/close React state transition naturally produces. Today (before the source change) the test FAILS because the source calls `.refetch()`. After Task 5 it PASSES because the source no longer does.
+
+This is a "red-then-green" test by design — it is the verification step for FR-3.
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` (add as last test inside `describe("JournalList", ...)`)
+
+- [ ] **Step 1: Add the test before the closing `});` of the `describe` block**
+
+Insert the following test immediately before the final `});` of the `describe("JournalList", ...)` block (around current line 615):
+
+```typescript
+  it("does not call refetch on entriesQuery or searchQuery when the modal closes", async () => {
+    const entriesRefetch = jest.fn().mockResolvedValue({});
+    const searchRefetch = jest.fn().mockResolvedValue({});
+
+    mockUseJournalHooks.useJournalEntries.mockReturnValue({
+      data: {
+        entries: mockJournalEntries,
+        totalCount: 2,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: entriesRefetch,
+    } as any);
+
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [],
+        totalCount: 0,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 0,
+      },
+      isLoading: false,
+      error: null,
+      refetch: searchRefetch,
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Open the "new entry" modal.
+    fireEvent.click(screen.getByTestId("add-journal-entry"));
+
+    // Close the modal: dispatch Escape on the document body — the modal listens for Escape
+    // and calls its onClose prop, which is JournalList's handleCloseModal.
+    // (We avoid clicking inside the modal because the modal's internals are not under test here.)
+    fireEvent.keyDown(document.body, { key: "Escape", code: "Escape" });
+
+    // Allow any pending state updates / effects to flush.
+    await waitFor(() => {
+      // Sanity: refetch on entries / search must remain at zero invocations from handleCloseModal.
+      expect(entriesRefetch).not.toHaveBeenCalled();
+      expect(searchRefetch).not.toHaveBeenCalled();
+    });
+  });
+```
+
+- [ ] **Step 2: Run the new test against the **unchanged** source — expect FAIL**
+
+Run:
+```bash
+npm test -- --testPathPattern=JournalList.test.tsx -t "does not call refetch on entriesQuery or searchQuery when the modal closes" --watchAll=false
+```
+
+Expected: **FAIL** with one of:
+- `expected jest.fn() not to be called, but was called 1 time` on `entriesRefetch`, OR
+- the modal's Escape handler doesn't fire (in which case verify the modal is actually mounting — render output should contain it). If the modal does not respond to Escape, fall back to an alternate close trigger: query for the modal's close button by `data-testid` or `aria-label` and click it instead. Adjust the test to use whatever close affordance the modal exposes. Acceptance is: the modal closes AND `entriesRefetch` is called once with the unchanged source.
+
+If after a reasonable substitution (clicking the modal's close button) the test still does not fail, STOP and inspect: it likely means the modal isn't being mounted by the test, in which case the test must first assert that the modal is visible before triggering close. Do not skip this red-state check — without it we have no proof the new test exercises the handler.
+
+- [ ] **Step 3: Commit (red)**
+
+```bash
+git add frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+git commit -m "test: add failing regression for handleCloseModal not calling refetch"
+```
+
+---
+
+## Source Refactor
+
+### Task 5: Strip `.refetch()` from all three handlers and drop dead `async`
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/JournalList.tsx` (handlers `handleApplyFilters`, `handleClearFilters`, `handleCloseModal`)
+
+- [ ] **Step 1: Replace `handleApplyFilters`**
+
+Find this block (currently lines 208–219):
+
+```typescript
+  // Handler for applying filters
+  const handleApplyFilters = async () => {
+    setSearchTextFilter(searchTextInput);
+    setIsSearchMode(searchTextInput.trim() !== "");
+    setPageNumber(1); // Reset to first page when applying filters
+
+    // Force data reload by refetching
+    if (searchTextInput.trim()) {
+      await searchQuery.refetch();
+    } else {
+      await entriesQuery.refetch();
+    }
+  };
+```
+
+Replace with:
+
+```typescript
+  // Handler for applying filters
+  const handleApplyFilters = () => {
+    setSearchTextFilter(searchTextInput);
+    setIsSearchMode(searchTextInput.trim() !== "");
+    setPageNumber(1); // Reset to first page when applying filters
+  };
+```
+
+- [ ] **Step 2: Replace `handleClearFilters`**
+
+Find this block (currently lines 229–237):
+
+```typescript
+  // Handler for clearing all filters
+  const handleClearFilters = async () => {
+    setSearchTextInput("");
+    setSearchTextFilter("");
+    setIsSearchMode(false);
+    setPageNumber(1); // Reset to first page when clearing filters
+
+    // Force data reload by refetching
+    await entriesQuery.refetch();
+  };
+```
+
+Replace with:
+
+```typescript
+  // Handler for clearing all filters
+  const handleClearFilters = () => {
+    setSearchTextInput("");
+    setSearchTextFilter("");
+    setIsSearchMode(false);
+    setPageNumber(1); // Reset to first page when clearing filters
+  };
+```
+
+- [ ] **Step 3: Replace `handleCloseModal`**
+
+Find this block (currently lines 278–287):
+
+```typescript
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setEditingEntryId(null);
+    // Refetch data after modal closes
+    if (isSearchMode) {
+      searchQuery.refetch();
+    } else {
+      entriesQuery.refetch();
+    }
+  };
+```
+
+Replace with:
+
+```typescript
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setEditingEntryId(null);
+  };
+```
+
+- [ ] **Step 4: Verify `searchQuery` and `entriesQuery` are still used elsewhere**
+
+Run:
+```bash
+grep -n "searchQuery\|entriesQuery" frontend/src/components/pages/Journal/JournalList.tsx
+```
+
+Expected: lines around 182 (`entriesQuery = useJournalEntries(...)`), 189 (`searchQuery = useSearchJournalEntries(...)`), and 200 (`currentQuery = isSearchMode ? searchQuery : entriesQuery`). All three are still consumed by `currentQuery`, so do NOT remove the variable bindings.
+
+- [ ] **Step 5: Verify no `.refetch(` calls remain in the file**
+
+Run:
+```bash
+grep -n "\.refetch(" frontend/src/components/pages/Journal/JournalList.tsx
+```
+
+Expected: **no output** (zero matches).
+
+- [ ] **Step 6: Verify no stray `async` keywords remain on the touched handlers**
+
+Run:
+```bash
+grep -nE "const handle(ApplyFilters|ClearFilters|CloseModal) = (async )?\(\)" frontend/src/components/pages/Journal/JournalList.tsx
+```
+
+Expected: three matches, none containing `async`.
+
+- [ ] **Step 7: Run all four tests touched by tasks 1–4 — expect all PASS**
+
+Run:
+```bash
+npm test -- --testPathPattern=JournalList.test.tsx --watchAll=false
+```
+
+Expected: **all tests in the suite pass**, including the four that were touched (re-invocation x3 + no-refetch regression x1) and the pre-existing tests around sort/pagination.
+
+If a test fails, do NOT modify the test — investigate the source. The only legitimate failure modes after this refactor are:
+- A test that was relying on the side effect of `.refetch()` (none should — the four we touched are the only ones with refetch assertions).
+- A pre-existing flaky test (re-run once before reporting).
+
+- [ ] **Step 8: Commit (green)**
+
+```bash
+git add frontend/src/components/pages/Journal/JournalList.tsx
+git commit -m "refactor: remove manual .refetch() from JournalList handlers
+
+Rely on React Query's key-change refetch instead. Eliminates duplicate
+network requests and stale-data flashes from handleApplyFilters,
+handleClearFilters, and handleCloseModal. handleApplyFilters and
+handleClearFilters are now synchronous since they no longer await."
+```
+
+---
+
+## Validation
+
+### Task 6: Whole-file build & lint pass
+
+**Files:** none modified.
+
+- [ ] **Step 1: TypeScript build**
+
+Run from `frontend/`:
+```bash
+npm run build
+```
+
+Expected: clean build, no TypeScript errors. The signature changes (`async () => Promise<void>` → `() => void`) on `handleApplyFilters` and `handleClearFilters` should not introduce any errors because:
+- `handleKeyDown` calls `handleApplyFilters()` without awaiting it (line 224 — unchanged).
+- The "Filtrovat" and "Vymazat" buttons consume the handler via `onClick={...}` (the `onClick` prop type is `(e: MouseEvent) => void`, which accepts a void-returning function).
+- `handleCloseModal` was already non-async; modal `onClose: () => void` is unchanged.
+
+If a TypeScript error appears around any of those call sites, STOP — something in the surrounding code has drifted.
+
+- [ ] **Step 2: ESLint**
+
+Run from `frontend/`:
+```bash
+npm run lint
+```
+
+Expected: no new lint errors or warnings. The refactor should reduce lint pressure (no more unused `await`, no async-without-await complaints) rather than add to it.
+
+- [ ] **Step 3: Confirm the diff is surgical**
+
+Run:
+```bash
+git diff --stat main...HEAD -- frontend/src/components/pages/Journal/
+```
+
+Expected: only two files in the diff:
+- `frontend/src/components/pages/Journal/JournalList.tsx` — approximately 8 insertions / 16 deletions
+- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — approximately 100 insertions / 100 deletions (three rewrites + one addition)
+
+If `useJournal.ts`, `JournalEntryModal.tsx`, or any other file appears in the diff, STOP and reconcile against spec FR-4 ("no changes to `useJournal.ts`, the mutation hooks, or any other Journal module file").
+
+- [ ] **Step 4: Final full-suite test run**
+
+Run:
+```bash
+npm test -- --testPathPattern=JournalList.test.tsx --watchAll=false
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit (only if Step 2 added lint auto-fixes; otherwise skip)**
+
+If `npm run lint` made any auto-fix edits:
+
+```bash
+git add -u
+git commit -m "chore: apply lint auto-fixes after refetch removal"
+```
+
+Otherwise skip this step — no commit needed.
+
+---
+
+## Self-Review Mapping (spec → task)
+
+| Spec section | Implemented by |
+|--------------|----------------|
+| FR-1 (remove refetch from `handleApplyFilters`) | Task 5, Step 1 |
+| FR-1 acceptance (exactly one hook invocation, no stale flash) | Tasks 1 & 4 |
+| FR-2 (remove refetch from `handleClearFilters`) | Task 5, Step 2 |
+| FR-2 acceptance | Task 3 |
+| FR-3 (remove refetch from `handleCloseModal`) | Task 5, Step 3 |
+| FR-3 acceptance (mutation `onSuccess` → invalidation already in place; cancel-close = zero network) | Task 4 |
+| FR-4 (no changes outside the three handlers; drop dead `async`) | Task 5 + Task 6, Step 3 |
+| NFR-1 (one HTTP call per state transition) | Task 6, Step 4 (proven indirectly via hook-invocation assertions) |
+| NFR-2 (no stale-data flash) | Achieved by the refactor itself — there is no longer a wrong-params request to land first |
+| NFR-3 (honor JSDoc contract) | Task 5 |
+| NFR-4 (existing tests pass, new/updated tests cover the new behavior) | Tasks 1–4, validated by Task 6 Step 4 |
+| Arch amendment 1 (file-path correction) | Reflected throughout this plan (`frontend/src/components/pages/Journal/JournalList.tsx`) |
+| Arch amendment 2 (line numbers advisory, handler names authoritative) | Each task names the handler explicitly |
+| Arch amendment 3 (test rewrite is mandatory) | Tasks 1–3 are mandatory rewrites |
+| Arch amendment 4 (drop `async` keywords) | Task 5, Steps 1–2, verified Step 6 |
+| Arch amendment 5 (no fetch-mock infrastructure) | Tests assert on hook `mock.calls`, no MSW / fetch-mock added |

--- a/frontend/src/components/pages/Journal/JournalList.tsx
+++ b/frontend/src/components/pages/Journal/JournalList.tsx
@@ -205,17 +205,10 @@ const JournalList: React.FC = () => {
   const error = currentQuery.error;
 
   // Handler for applying filters
-  const handleApplyFilters = async () => {
+  const handleApplyFilters = () => {
     setSearchTextFilter(searchTextInput);
     setIsSearchMode(searchTextInput.trim() !== "");
     setPageNumber(1); // Reset to first page when applying filters
-
-    // Force data reload by refetching
-    if (searchTextInput.trim()) {
-      await searchQuery.refetch();
-    } else {
-      await entriesQuery.refetch();
-    }
   };
 
   // Handler for Enter key press
@@ -226,14 +219,11 @@ const JournalList: React.FC = () => {
   };
 
   // Handler for clearing all filters
-  const handleClearFilters = async () => {
+  const handleClearFilters = () => {
     setSearchTextInput("");
     setSearchTextFilter("");
     setIsSearchMode(false);
     setPageNumber(1); // Reset to first page when clearing filters
-
-    // Force data reload by refetching
-    await entriesQuery.refetch();
   };
 
   // Sorting handler
@@ -278,12 +268,6 @@ const JournalList: React.FC = () => {
   const handleCloseModal = () => {
     setIsModalOpen(false);
     setEditingEntryId(null);
-    // Refetch data after modal closes
-    if (isSearchMode) {
-      searchQuery.refetch();
-    } else {
-      entriesQuery.refetch();
-    }
   };
 
   // Loading state

--- a/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+++ b/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
@@ -233,80 +233,7 @@ describe("JournalList", () => {
     expect(screen.getByText("Vytvořit první záznam")).toBeInTheDocument();
   });
 
-  it("should handle search input and apply search", async () => {
-    const mockSearchRefetch = jest.fn().mockResolvedValue({});
-    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
-      data: {
-        entries: [mockJournalEntries[0]], // Return first entry as search result
-        totalCount: 1,
-        currentPage: 1,
-        pageSize: 20,
-        totalPages: 1,
-      },
-      isLoading: false,
-      error: null,
-      refetch: mockSearchRefetch,
-    } as any);
-
-    render(<JournalList />, { wrapper: createWrapper });
-
-    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
-    const filterButton = screen.getByText("Filtrovat");
-
-    fireEvent.change(searchInput, { target: { value: "skincare" } });
-    fireEvent.click(filterButton);
-
-    await waitFor(() => {
-      expect(mockSearchRefetch).toHaveBeenCalled();
-    });
-
-    // Basic test - component should render search input
-    expect(searchInput).toBeInTheDocument();
-  });
-
-  it("should handle Enter key press in search input", async () => {
-    const mockSearchRefetch = jest.fn().mockResolvedValue({});
-    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
-      data: {
-        entries: [],
-        totalCount: 0,
-        currentPage: 1,
-        pageSize: 20,
-        totalPages: 0,
-      },
-      isLoading: false,
-      error: null,
-      refetch: mockSearchRefetch,
-    } as any);
-
-    render(<JournalList />, { wrapper: createWrapper });
-
-    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
-
-    fireEvent.change(searchInput, { target: { value: "test search" } });
-    fireEvent.keyDown(searchInput, { key: "Enter", code: "Enter" });
-
-    await waitFor(() => {
-      expect(mockSearchRefetch).toHaveBeenCalled();
-    });
-  });
-
-  it("should clear search and return to normal mode", async () => {
-    const mockRefetch = jest.fn().mockResolvedValue({});
-    mockUseJournalHooks.useJournalEntries.mockReturnValue({
-      data: {
-        entries: mockJournalEntries,
-        totalCount: 2,
-        currentPage: 1,
-        pageSize: 20,
-        totalPages: 1,
-      },
-      isLoading: false,
-      error: null,
-      refetch: mockRefetch,
-    } as any);
-
-    // Start with search mode active
+  it("re-invokes the search hook with the new searchText and enabled=true when applying filters", async () => {
     mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
       data: {
         entries: [mockJournalEntries[0]],
@@ -317,27 +244,127 @@ describe("JournalList", () => {
       },
       isLoading: false,
       error: null,
-      refetch: jest.fn(),
+      refetch: jest.fn().mockResolvedValue({}),
     } as any);
 
     render(<JournalList />, { wrapper: createWrapper });
 
-    // Trigger search first
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    const filterButton = screen.getByText("Filtrovat");
+
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(filterButton);
+
+    let searchParams: any;
+    let searchEnabled: any;
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      searchParams = lastCall?.[0];
+      searchEnabled = lastCall?.[1];
+
+      expect(searchEnabled).toBe(true);
+    });
+
+    expect(searchParams).toMatchObject({
+      searchText: "skincare",
+      pageNumber: 1,
+    });
+  });
+
+  it("re-invokes the search hook with the new searchText when Enter is pressed in the search input", async () => {
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [],
+        totalCount: 0,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 0,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+
+    fireEvent.change(searchInput, { target: { value: "test search" } });
+    fireEvent.keyDown(searchInput, { key: "Enter", code: "Enter" });
+
+    let searchParams: any;
+    let searchEnabled: any;
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      searchParams = lastCall?.[0];
+      searchEnabled = lastCall?.[1];
+
+      expect(searchEnabled).toBe(true);
+    });
+
+    expect(searchParams).toMatchObject({
+      searchText: "test search",
+      pageNumber: 1,
+    });
+  });
+
+  it("disables the search hook and re-invokes the entries hook when filters are cleared", async () => {
+    mockUseJournalHooks.useJournalEntries.mockReturnValue({
+      data: {
+        entries: mockJournalEntries,
+        totalCount: 2,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 1,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
     const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
     fireEvent.change(searchInput, { target: { value: "test" } });
     fireEvent.keyDown(searchInput, { key: "Enter" });
 
     await waitFor(() => {
-      expect(screen.getByText("Vymazat")).toBeInTheDocument();
+      const lastSearchCall = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls.at(-1);
+      expect(lastSearchCall?.[1]).toBe(true);
     });
 
-    // Clear search
+    // Clear filters.
     const clearButton = screen.getByText("Vymazat");
     fireEvent.click(clearButton);
 
     await waitFor(() => {
-      expect(mockRefetch).toHaveBeenCalled();
+      const lastSearchCall = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls.at(-1);
+      expect(lastSearchCall?.[1]).toBe(false);
     });
+
+    const lastEntriesCall = (mockUseJournalHooks.useJournalEntries as jest.Mock).mock.calls.at(-1);
+    expect(lastEntriesCall?.[0]).toMatchObject({
+      pageNumber: 1,
+    });
+
+    // The search input should also be cleared visually.
+    expect(searchInput).toHaveValue("");
   });
 
   it("should open new journal entry modal", () => {
@@ -610,6 +637,55 @@ describe("JournalList", () => {
       searchText: "skincare",
       pageSize: 50,
       pageNumber: 1, // page-size change must reset to page 1
+    });
+  });
+
+  it("does not call refetch on entriesQuery or searchQuery when the modal closes", async () => {
+    const entriesRefetch = jest.fn().mockResolvedValue({});
+    const searchRefetch = jest.fn().mockResolvedValue({});
+
+    mockUseJournalHooks.useJournalEntries.mockReturnValue({
+      data: {
+        entries: mockJournalEntries,
+        totalCount: 2,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: entriesRefetch,
+    } as any);
+
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [],
+        totalCount: 0,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 0,
+      },
+      isLoading: false,
+      error: null,
+      refetch: searchRefetch,
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Open the "new entry" modal.
+    fireEvent.click(screen.getByTestId("add-journal-entry"));
+
+    // Close the modal via the JournalEntryModal onClose prop.
+    // The modal is rendered as <JournalEntryModal isOpen={isModalOpen} onClose={handleCloseModal} ...>
+    // Try Escape first; if that doesn't trigger handleCloseModal, find the close button.
+    fireEvent.keyDown(document.body, { key: "Escape", code: "Escape" });
+
+    // Allow any pending state updates / effects to flush.
+    await waitFor(() => {
+      // With unchanged source, refetch IS called (test is red/failing before the source fix).
+      // After Task 5 source fix, refetch is NOT called (test turns green).
+      expect(entriesRefetch).not.toHaveBeenCalled();
+      expect(searchRefetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+++ b/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
@@ -681,11 +681,9 @@ describe("JournalList", () => {
     fireEvent.keyDown(document.body, { key: "Escape", code: "Escape" });
 
     // Allow any pending state updates / effects to flush.
-    await waitFor(() => {
-      // With unchanged source, refetch IS called (test is red/failing before the source fix).
-      // After Task 5 source fix, refetch is NOT called (test turns green).
-      expect(entriesRefetch).not.toHaveBeenCalled();
-      expect(searchRefetch).not.toHaveBeenCalled();
-    });
+    // With unchanged source, refetch IS called (test is red/failing before the source fix).
+    // After Task 5 source fix, refetch is NOT called (test turns green).
+    await waitFor(() => expect(entriesRefetch).not.toHaveBeenCalled());
+    expect(searchRefetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

Removed three manual `.refetch()` invocations from `JournalList.tsx` that fired React Query refetches immediately after `setState`, violating the hook contract and causing double network requests with stale-data flashes. React Query's automatic key-change refetch already handles all cases; the manual calls were redundant anti-patterns.

Three existing tests that asserted `mockRefetch.toHaveBeenCalled()` were rewritten to assert hook re-invocation with correct params (matching the pattern already established in the file for sort/pagination tests). One new regression test verifies `handleCloseModal` no longer triggers refetch.

### Changes
- `frontend/src/components/pages/Journal/JournalList.tsx` — removed refetch blocks from `handleApplyFilters`, `handleClearFilters`, `handleCloseModal`; dropped now-dead `async` from first two handlers
- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — rewrote 3 tests from `mockRefetch.toHaveBeenCalled()` to hook `mock.calls` param assertions; added regression test for `handleCloseModal`

---

Closes #2865

### Tokens used
12266075
