### PR TITLE
feat: add Vyřizuje se order count to packing dashboard and tile

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
@@ -44,6 +44,12 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
         return response.Data.Paginator.TotalCount;
     }
 
+    public async Task<int> GetOrdersBeingProcessedCountAsync(CancellationToken ct = default)
+    {
+        var response = await _orderClient.GetOrdersByStatusAsync(_orderSettings.ProcessingStateId, page: 1, ct);
+        return response.Data.Paginator.TotalCount;
+    }
+
     public async Task<PackingOrder?> GetPackingOrderAsync(string code, CancellationToken ct = default)
     {
         ExpeditionOrderDetail detail;

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
@@ -51,8 +51,8 @@ public class PackingStatsTile : ITile
             try
             {
                 ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
-                ordersBeingProcessedCount = await _packingOrderClient.GetOrdersBeingProcessedCountAsync(cancellationToken);
                 ordersBeingPackedCountLastSync = now;
+                ordersBeingProcessedCount = await _packingOrderClient.GetOrdersBeingProcessedCountAsync(cancellationToken);
             }
             catch (Exception ex)
             {

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/DashboardTiles/PackingStatsTile.cs
@@ -46,15 +46,17 @@ public class PackingStatsTile : ITile
             var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(start, end, cancellationToken);
 
             int? ordersBeingPackedCount = null;
+            int? ordersBeingProcessedCount = null;
             DateTimeOffset? ordersBeingPackedCountLastSync = null;
             try
             {
                 ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
+                ordersBeingProcessedCount = await _packingOrderClient.GetOrdersBeingProcessedCountAsync(cancellationToken);
                 ordersBeingPackedCountLastSync = now;
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to retrieve orders-being-packed count from Shoptet");
+                _logger.LogWarning(ex, "Failed to retrieve order counts from Shoptet");
             }
 
             var packers = byPacker
@@ -72,6 +74,7 @@ public class PackingStatsTile : ITile
                 data = new
                 {
                     ordersBeingPackedCount,
+                    ordersBeingProcessedCount,
                     ordersBeingPackedCountLastSync,
                     totalOrdersPackedToday = total,
                     packedByPacker = packers,

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
@@ -40,8 +40,8 @@ public class GetPackingDashboardHandler : IRequestHandler<GetPackingDashboardReq
         try
         {
             ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
-            ordersBeingProcessedCount = await _packingOrderClient.GetOrdersBeingProcessedCountAsync(cancellationToken);
             ordersBeingPackedCountLastSync = now;
+            ordersBeingProcessedCount = await _packingOrderClient.GetOrdersBeingProcessedCountAsync(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardHandler.cs
@@ -35,20 +35,23 @@ public class GetPackingDashboardHandler : IRequestHandler<GetPackingDashboardReq
         var (total, byPacker) = await _repo.GetPackedTodayByPackerAsync(start, end, cancellationToken);
 
         int? ordersBeingPackedCount = null;
+        int? ordersBeingProcessedCount = null;
         DateTimeOffset? ordersBeingPackedCountLastSync = null;
         try
         {
             ordersBeingPackedCount = await _packingOrderClient.GetOrdersBeingPackedCountAsync(cancellationToken);
+            ordersBeingProcessedCount = await _packingOrderClient.GetOrdersBeingProcessedCountAsync(cancellationToken);
             ordersBeingPackedCountLastSync = now;
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to retrieve orders-being-packed count from Shoptet; dashboard will show null");
+            _logger.LogWarning(ex, "Failed to retrieve order counts from Shoptet; dashboard will show null");
         }
 
         return new GetPackingDashboardResponse
         {
             OrdersBeingPackedCount = ordersBeingPackedCount,
+            OrdersBeingProcessedCount = ordersBeingProcessedCount,
             OrdersBeingPackedCountLastSync = ordersBeingPackedCountLastSync,
             TotalOrdersPackedToday = total,
             PackedByPacker = byPacker

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingDashboard/GetPackingDashboardResponse.cs
@@ -5,6 +5,7 @@ namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboar
 public class GetPackingDashboardResponse : BaseResponse
 {
     public int? OrdersBeingPackedCount { get; set; }
+    public int? OrdersBeingProcessedCount { get; set; }
     public DateTimeOffset? OrdersBeingPackedCountLastSync { get; set; }
     public int TotalOrdersPackedToday { get; set; }
     public List<PackerStatsDto> PackedByPacker { get; set; } = new();

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/IPackingOrderClient.cs
@@ -17,6 +17,11 @@ public interface IPackingOrderClient
     /// Returns the total count of orders currently in the configured packing state ("Balí se").
     /// </summary>
     Task<int> GetOrdersBeingPackedCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the total count of orders currently in the configured processing state ("Vyřizuje se").
+    /// </summary>
+    Task<int> GetOrdersBeingProcessedCountAsync(CancellationToken ct = default);
 }
 
 /// <summary>Packing view of an eshop order. Internal contract — not an API DTO.</summary>

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs
@@ -28,4 +28,11 @@ public class ShoptetOrdersSettings
     /// Defaults to 52 ("Zabaleno").
     /// </summary>
     public int PackedStateId { get; set; } = 52;
+
+    /// <summary>
+    /// Shoptet order status ID representing the "Vyřizuje se" (being processed) state.
+    /// These orders later transition into the packing state; the count is surfaced on the
+    /// packing dashboard as an "incoming work" indicator. Defaults to -2.
+    /// </summary>
+    public int ProcessingStateId { get; set; } = -2;
 }

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs
@@ -32,7 +32,8 @@ public class ShoptetOrdersSettings
     /// <summary>
     /// Shoptet order status ID representing the "Vyřizuje se" (being processed) state.
     /// These orders later transition into the packing state; the count is surfaced on the
-    /// packing dashboard as an "incoming work" indicator. Defaults to -2.
+    /// packing dashboard as an "incoming work" indicator.
+    /// Configure the actual value in user secrets / Azure App Config per environment.
     /// </summary>
-    public int ProcessingStateId { get; set; } = -2;
+    public int ProcessingStateId { get; set; }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingDashboardHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingDashboardHandlerTests.cs
@@ -35,7 +35,8 @@ public class GetPackingDashboardHandlerTests
         out Mock<IPackageRepository> repo,
         out Mock<IPackingOrderClient> packingClient,
         (int TotalDistinctOrders, IReadOnlyList<PackerPackingSummary> ByPacker) repoResult,
-        int shoptetCount = 5)
+        int shoptetCount = 5,
+        int processingCount = 7)
     {
         repo = new Mock<IPackageRepository>();
         repo.Setup(r => r.GetPackedTodayByPackerAsync(
@@ -45,6 +46,8 @@ public class GetPackingDashboardHandlerTests
         packingClient = new Mock<IPackingOrderClient>();
         packingClient.Setup(c => c.GetOrdersBeingPackedCountAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(shoptetCount);
+        packingClient.Setup(c => c.GetOrdersBeingProcessedCountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(processingCount);
 
         return new GetPackingDashboardHandler(
             repo.Object,
@@ -63,7 +66,7 @@ public class GetPackingDashboardHandlerTests
             new(packerId, "Alice", 4),
             new(null, "Bob", 2),
         };
-        var sut = MakeSut(out _, out _, (6, byPacker), shoptetCount: 3);
+        var sut = MakeSut(out _, out _, (6, byPacker), shoptetCount: 3, processingCount: 9);
 
         // Act
         var result = await sut.Handle(new GetPackingDashboardRequest(), CancellationToken.None);
@@ -72,6 +75,7 @@ public class GetPackingDashboardHandlerTests
         result.Success.Should().BeTrue();
         result.TotalOrdersPackedToday.Should().Be(6);
         result.OrdersBeingPackedCount.Should().Be(3);
+        result.OrdersBeingProcessedCount.Should().Be(9);
         result.PackedByPacker.Should().HaveCount(2);
         result.PackedByPacker[0].PackerId.Should().Be(packerId);
         result.PackedByPacker[0].PackerName.Should().Be("Alice");
@@ -106,9 +110,10 @@ public class GetPackingDashboardHandlerTests
         // Act
         var result = await sut.Handle(new GetPackingDashboardRequest(), CancellationToken.None);
 
-        // Assert — dashboard still succeeds, count is null
+        // Assert — dashboard still succeeds, counts are null
         result.Success.Should().BeTrue();
         result.OrdersBeingPackedCount.Should().BeNull();
+        result.OrdersBeingProcessedCount.Should().BeNull();
         result.TotalOrdersPackedToday.Should().Be(2);
     }
 

--- a/frontend/src/api/hooks/usePackingDashboard.ts
+++ b/frontend/src/api/hooks/usePackingDashboard.ts
@@ -9,6 +9,7 @@ export type PackerStatsDto = {
 
 export type GetPackingDashboardResponse = {
   ordersBeingPackedCount: number | null;
+  ordersBeingProcessedCount: number | null;
   ordersBeingPackedCountLastSync: string | null;
   totalOrdersPackedToday: number;
   packedByPacker: PackerStatsDto[];

--- a/frontend/src/components/baleni/BaleniHome.tsx
+++ b/frontend/src/components/baleni/BaleniHome.tsx
@@ -67,7 +67,13 @@ const BaleniHome: React.FC = () => {
     <div className="pt-4 space-y-8">
       <section>
         <h2 className="text-lg font-semibold text-neutral-slate mb-4">Přehled</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          <StatCard
+            label="Vyřizuje se (Shoptet)"
+            value={data?.ordersBeingProcessedCount ?? '—'}
+            loading={isLoading}
+            syncTime={data?.ordersBeingPackedCountLastSync}
+          />
           <StatCard
             label="Balí se (Shoptet)"
             value={data?.ordersBeingPackedCount ?? '—'}

--- a/frontend/src/components/dashboard/tiles/PackingStatsTile.tsx
+++ b/frontend/src/components/dashboard/tiles/PackingStatsTile.tsx
@@ -9,6 +9,7 @@ interface PackerStat {
 
 interface PackingStatsData {
   ordersBeingPackedCount: number | null;
+  ordersBeingProcessedCount: number | null;
   ordersBeingPackedCountLastSync: string | null;
   totalOrdersPackedToday: number;
   packedByPacker: PackerStat[];
@@ -48,7 +49,18 @@ export const PackingStatsTile: React.FC<PackingStatsTileProps> = ({ data }) => {
       onClick={isClickable ? () => navigate('/baleni') : undefined}
       title={data.drillDown?.tooltip}
     >
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-3 gap-3">
+        <div className="bg-secondary-blue-pale rounded-lg p-3 text-center">
+          <p className="text-xs text-neutral-gray mb-1">Vyřizuje se</p>
+          <p className="text-2xl font-bold text-primary-blue">
+            {stats.ordersBeingProcessedCount ?? '—'}
+          </p>
+          {stats.ordersBeingPackedCountLastSync && (
+            <p className="text-xs text-neutral-gray mt-1">
+              sync {new Date(stats.ordersBeingPackedCountLastSync).toLocaleTimeString('cs-CZ', { hour: '2-digit', minute: '2-digit' })}
+            </p>
+          )}
+        </div>
         <div className="bg-secondary-blue-pale rounded-lg p-3 text-center">
           <p className="text-xs text-neutral-gray mb-1">Balí se</p>
           <p className="text-2xl font-bold text-primary-blue">


### PR DESCRIPTION
Surfaces the count of Shoptet orders in the **"Vyřizuje se"** (being processed, status `-2`) state alongside the existing "Balí se" count, both on the `/baleni` overview page and the packing dashboard tile. The backend mirrors the existing "Balí se" mechanism: a new `ProcessingStateId` setting (default `-2`), a `GetOrdersBeingProcessedCountAsync` method on `IPackingOrderClient`, and a new nullable `OrdersBeingProcessedCount` field fetched in the same try/catch so a Shoptet outage still leaves the dashboard loadable. The frontend adds a third "Vyřizuje se (Shoptet)" stat card / tile cell (grids widened to 3 columns), sharing the existing sync timestamp. Handler tests were updated with the new mock setup and assertions, including the null-on-outage case. Validated with `dotnet build`/`test` (28 passing) and `npm run build`/`lint` (no new issues).