### PR TITLE
feat: Relocate ProductExportDownloadJob from FileStorage to Catalog Module

### DIFF
--- a/artifacts/feat-arch-review-filestorage-productexportdow/answers.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/answers.r1.md
@@ -1,0 +1,8 @@
+### Question 1
+OQ-1: Logger type for the new helper. The helper logs only one message (the PATCH warning). Two options:
+- (a) Reuse the existing `ILogger<ShoptetApiExpeditionListSource>` passed through as `ILogger`. Keeps log category stable for ops/alerts.
+- (b) Give the helper its own `ILogger<PickingListBatchProcessor>`. Cleaner DI semantics, but changes the log category and would surprise anyone filtering on the existing category.
+
+**Answer:** Go with option (a). The `PickingListBatchProcessor` constructor takes a plain `ILogger` parameter, and `ShoptetApiExpeditionListSource` passes its existing `ILogger<ShoptetApiExpeditionListSource>` instance through. Do not introduce `ILogger<PickingListBatchProcessor>` and do not register the helper in DI.
+
+**Rationale:** The cooling-marker warning log is the operational signal ops/alerting filter on by the `ShoptetApiExpeditionListSource` category; option (b) would silently change the category and break any external filters. It also keeps the existing `CreatePickingList_PatchFails_PdfStillCompletes` assertion against `Mock<ILogger<ShoptetApiExpeditionListSource>>` (verified at `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/ShoptetApiExpeditionListSource_CoolingMarkerTests.cs:266` and `:278`) passing unchanged, which FR-1 and FR-4 explicitly require. The helper is constructed internally inside `ShoptetApiExpeditionListSource` (NFR-3), so no DI churn is needed and the public surface stays identical.

--- a/artifacts/feat-arch-review-filestorage-productexportdow/answers.r2.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/answers.r2.md
@@ -1,0 +1,8 @@
+### Question 1
+OQ-1: Logger type for the new helper. The helper logs only one message (the PATCH warning). Two options:
+- (a) Reuse the existing `ILogger<ShoptetApiExpeditionListSource>` passed through as `ILogger`. Keeps log category stable for ops/alerts.
+- (b) Give the helper its own `ILogger<PickingListBatchProcessor>`. Cleaner DI semantics, but changes the log category and would surprise anyone filtering on the existing category.
+
+**Answer:** Go with option (a). The `PickingListBatchProcessor` constructor takes a plain `ILogger` parameter, and `ShoptetApiExpeditionListSource` passes its existing `ILogger<ShoptetApiExpeditionListSource>` instance through. Do not introduce `ILogger<PickingListBatchProcessor>` and do not register the helper in DI.
+
+**Rationale:** The cooling-marker warning log is the operational signal ops/alerting filter on by the `ShoptetApiExpeditionListSource` category; option (b) would silently change the category and break any external filters. It also keeps the existing `CreatePickingList_PatchFails_PdfStillCompletes` assertion against `Mock<ILogger<ShoptetApiExpeditionListSource>>` (verified at `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/ShoptetApiExpeditionListSource_CoolingMarkerTests.cs:266` and `:278`) passing unchanged, which FR-1 and FR-4 explicitly require. The helper is constructed internally inside `ShoptetApiExpeditionListSource` (NFR-3), so no DI churn is needed and the public surface stays identical.

--- a/artifacts/feat-arch-review-filestorage-productexportdow/arch-review.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/arch-review.r1.md
@@ -1,0 +1,257 @@
+I have full context now. The spec underestimates the coupling — `DownloadFromUrlHandler`, `AzureBlobStorageService`, and a named HttpClient registration all reference `ProductExportOptions` / `ProductExportDownloadClientName` from inside FileStorage. A naive move breaks compilation. Writing the architecture review now.
+
+# Architecture Review: Relocate ProductExportDownloadJob from FileStorage to Catalog Module
+
+## Skip Design: true
+
+Backend-only structural refactor. No UI, no visual components, no design surface.
+
+## Architectural Fit Assessment
+
+The spec's stated goal — restore SRP for `FileStorage` so it owns only generic blob transport — is correct, and the chosen direction (relocate to `Catalog`) matches existing precedent: `Features/Catalog/Infrastructure/Jobs/ProductWeightRecalculationJob.cs` already exists with the same Hangfire `IRecurringJob` pattern. The destination convention is therefore unambiguous.
+
+However, **the spec materially underestimates the FileStorage→ProductExport coupling.** Beyond the two files named in the brief, three additional integration points reference product-export concerns from inside FileStorage:
+
+1. **`DownloadFromUrlHandler` (FileStorage Use Case)** injects `IOptions<ProductExportOptions>` and reads `HeadTimeout` for its HEAD probe (line 21, 141). Moving `ProductExportOptions` to Catalog while keeping the handler in FileStorage either:
+   - breaks compilation, or
+   - forces Catalog to be a dependency of FileStorage (wrong direction — `FileStorage` must stay leaf-generic).
+2. **`AzureBlobStorageService` (FileStorage Service)** resolves the named HttpClient via `FileStorageModule.ProductExportDownloadClientName` constant (line 38). This is product-export naming bleeding into a generic blob service.
+3. **`FileStorageModule.ProductExportDownloadClientName = "ProductExportDownload"`** is a public constant on the FileStorage module surface, consumed by `DownloadFromUrlHandler`, `AzureBlobStorageService`, and three test files.
+
+The spec's FR-1/FR-2/FR-3 alone are insufficient. Implementing them as written will not compile, or will leave FileStorage even more polluted than before because it will still own a `ProductExport*` constant referenced from Catalog.
+
+The fix requires a small extension of scope: split `ProductExportOptions` into a Catalog-owned domain options class and a FileStorage-owned generic download options class, and rename the named HttpClient to neutral terminology. With that, the relocation becomes clean and the module boundary holds.
+
+Additionally:
+
+- **Configuration section is already neutral** (`ProductExportOptions:` at root, not under `FileStorage:`). FR-4's rename concern is largely moot — the section name does not need to change.
+- **Key Vault secret names use the root path** (`ProductExportOptions--Url` style, not `FileStorage--ProductExport--Url`). No KV migration is required.
+- **Tests already exist** for the job (`ProductExportDownloadJobTests.cs`) — FR-7 is non-trivial and needs an explicit move.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Features/Catalog (DOMAIN owner of product export)           │
+│  ├─ Infrastructure/Jobs/ProductExportDownloadJob.cs   [NEW] │
+│  │     - reads ProductExportOptions (Url, ContainerName)    │
+│  │     - sends DownloadFromUrlRequest via IMediator         │
+│  └─ Infrastructure/ProductExportOptions.cs            [NEW] │
+│        - Url, ContainerName  (domain-specific only)         │
+│                                                             │
+│  CatalogModule.AddCatalogModule(cfg):                       │
+│   • services.Configure<ProductExportOptions>(...)           │
+│   • job auto-registered via IRecurringJob scan              │
+└─────────────────────────────────────────────────────────────┘
+                       │
+                       │ depends on  IMediator + DownloadFromUrlRequest
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Features/FileStorage (GENERIC blob transport)               │
+│  ├─ FileDownloadOptions.cs                            [NEW] │
+│  │     - HeadTimeout, DownloadTimeout,                      │
+│  │       MaxRetryAttempts, RetryBaseDelay                   │
+│  ├─ UseCases/DownloadFromUrl/                               │
+│  │     DownloadFromUrlHandler.cs                  [MODIFY]  │
+│  │     - now depends on IOptions<FileDownloadOptions>       │
+│  ├─ Services/AzureBlobStorageService.cs            [MODIFY] │
+│  │     - uses neutral client name                           │
+│  └─ FileStorageModule.cs                            [MODIFY]│
+│        - constant renamed: FileDownloadClientName           │
+│          = "FileDownload"                                   │
+│        - services.Configure<FileDownloadOptions>(...)       │
+│        - no product-export references anywhere              │
+└─────────────────────────────────────────────────────────────┘
+                       │
+                       │ Domain abstraction (unchanged)
+                       ▼
+              IBlobStorageService (Domain.Features.FileStorage)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Split `ProductExportOptions` into two options classes
+
+**Options considered:**
+- (a) Move `ProductExportOptions` entirely to Catalog and let `DownloadFromUrlHandler` keep depending on it → forces FileStorage → Catalog reference (cycle).
+- (b) Leave `ProductExportOptions` in FileStorage and only move the job → leaves the SRP violation in place; PR misses its goal.
+- (c) Split into `ProductExportOptions` (Catalog: `Url`, `ContainerName`) and `FileDownloadOptions` (FileStorage: `HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay`).
+
+**Chosen approach:** (c).
+
+**Rationale:** The four timeout/retry properties are not product-export concerns — they configure the FileStorage `DownloadFromUrlHandler` and the FileStorage `DownloadResilienceService`. They belong in FileStorage. The two domain properties (`Url`, `ContainerName`) belong in Catalog with the job. This is the only split that lets each module own only its own configuration without introducing a cycle.
+
+#### Decision 2: Rename `ProductExportDownloadClientName` to a neutral `FileDownloadClientName`
+
+**Options considered:**
+- (a) Keep the constant name in FileStorage → product-export terminology stays in generic code.
+- (b) Move the HttpClient registration to Catalog and pass the client name through `DownloadFromUrlRequest` → expands the request contract for one consumer; couples FileStorage handler to a Catalog-owned named client at runtime.
+- (c) Rename the constant and the client to neutral terminology; keep HttpClient registration in FileStorage as a generic resource.
+
+**Chosen approach:** (c). New constant: `FileStorageModule.FileDownloadClientName = "FileDownload"`.
+
+**Rationale:** The named HttpClient configures `SocketsHttpHandler` + `PooledConnectionLifetime` + `AutomaticDecompression` — all generic. The "ProductExport" name was historical. Renaming aligns the constant with what it actually is and removes the last domain leak from FileStorage. Test fixtures using the old constant migrate trivially.
+
+#### Decision 3: Place new files at `Features/Catalog/Infrastructure/Jobs/` and `Features/Catalog/Infrastructure/`
+
+**Options considered:**
+- (a) New `Features/Catalog/ProductExport/` sub-feature.
+- (b) Mirror existing convention: `Features/Catalog/Infrastructure/Jobs/`.
+
+**Chosen approach:** (b).
+
+**Rationale:** `ProductWeightRecalculationJob.cs` already lives at `Features/Catalog/Infrastructure/Jobs/`. Creating a `ProductExport/` sub-feature for two files violates the principle of matching existing convention and creates inconsistency. If/when product-export grows handlers, contracts, services, then promote to a sub-feature. YAGNI now.
+
+#### Decision 4: Configuration section stays at root `ProductExportOptions:`
+
+**Options considered:**
+- (a) Rename to `Catalog:ProductExport:`.
+- (b) Keep as-is.
+
+**Chosen approach:** (b).
+
+**Rationale:** The section is already neutral — it is not under `FileStorage:`. FR-4's premise (config rooted under FileStorage namespace) does not apply here. Renaming buys nothing operationally and would require Key Vault migration. Zero-risk path: keep `ProductExportOptions:` at the root. The `FileDownloadOptions` will get its own root section `FileStorage:Download:` (new).
+
+#### Decision 5: Job auto-registers via existing `IRecurringJob` discovery
+
+**Verify:** Confirm Catalog or the host registers recurring jobs via assembly scan of `IRecurringJob`. If `ProductExportDownloadJob` is currently explicitly registered in FileStorage, replicate that explicit registration in `CatalogModule`. If it is scan-discovered (more likely, given `ProductWeightRecalculationJob` has no explicit registration in `CatalogModule.cs`), no `CatalogModule` change is needed for the job itself — only the options binding moves.
+
+**Rationale:** Match existing pattern; do not introduce explicit registration where convention is scan-based.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs`
+  - Namespace: `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs`
+  - Namespace: `Anela.Heblo.Application.Features.Catalog.Infrastructure`
+  - Properties: **only** `Url` (string), `ContainerName` (string)
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/FileDownloadOptions.cs`
+  - Namespace: `Anela.Heblo.Application.Features.FileStorage`
+  - Properties: `HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay` (carried over verbatim from current `ProductExportOptions`)
+
+**Delete:**
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs`
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs`
+
+**Modify:**
+- `Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs`
+  - Change `IOptions<ProductExportOptions>` → `IOptions<FileDownloadOptions>`.
+  - Update `_options.Value.HeadTimeout` reference (line 141) — same property name, new options type.
+  - Replace `FileStorageModule.ProductExportDownloadClientName` references (lines 95, 144) with `FileStorageModule.FileDownloadClientName`.
+- `Features/FileStorage/Services/AzureBlobStorageService.cs`
+  - Replace `FileStorageModule.ProductExportDownloadClientName` (line 38) with `FileStorageModule.FileDownloadClientName`.
+- `Features/FileStorage/FileStorageModule.cs`
+  - Rename constant `ProductExportDownloadClientName` → `FileDownloadClientName`; value `"ProductExportDownload"` → `"FileDownload"`.
+  - Replace the line `services.AddHttpClient(ProductExportDownloadClientName)` with the new name.
+  - **Add:** `services.Configure<FileDownloadOptions>(configuration.GetSection("FileStorage:Download"));` — bind new section (or default-bind if section missing).
+- `Features/Catalog/CatalogModule.cs`
+  - Add: `services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));` — moved from `ServiceCollectionExtensions.cs`.
+- `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+  - Remove line 365: `services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));`.
+  - Remove line 28: `using Anela.Heblo.Application.Features.FileStorage;` (only if no other use; verify).
+- `Anela.Heblo.API/appsettings.json`
+  - Keep existing `"ProductExportOptions": { "Url": "" }` block as-is.
+  - **Add** (optional, only if non-default values needed) a new `"FileStorage": { "Download": { ... } }` block. If defaults are fine, omit — `FileDownloadOptions` defaults are baked in.
+
+**Tests (FR-7):**
+- Move `backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs` → `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs`. Update namespace.
+- Move `backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/ProductExportOptionsTests.cs` → `backend/test/Anela.Heblo.Tests/Features/Catalog/Configuration/ProductExportOptionsTests.cs`. Update namespace and delete any test assertions that reference moved-away timeout/retry properties (now on `FileDownloadOptions`).
+- **Split** `ProductExportOptionsTests.cs`: assertions about `HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay` move to a new `backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/FileDownloadOptionsTests.cs`.
+- Update `FileStorageModuleTests.cs`, `AzureBlobStorageServiceTests.cs`, `DownloadFromUrlHandlerTests.cs` to use `FileDownloadClientName` constant and `FileDownloadOptions` type.
+
+### Interfaces and Contracts
+
+No public contract changes. Internal contract changes:
+
+| Type | Before | After |
+|------|--------|-------|
+| `ProductExportOptions` | `Anela.Heblo.Application.Features.FileStorage.ProductExportOptions` with 6 properties | `Anela.Heblo.Application.Features.Catalog.Infrastructure.ProductExportOptions` with 2 properties (`Url`, `ContainerName`) |
+| `FileDownloadOptions` *(new)* | n/a | `Anela.Heblo.Application.Features.FileStorage.FileDownloadOptions` with 4 properties (`HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay`) |
+| `FileStorageModule.ProductExportDownloadClientName` | `"ProductExportDownload"` | renamed to `FileDownloadClientName` = `"FileDownload"` |
+| `ProductExportDownloadJob` | `Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs` | `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs` |
+
+`IBlobStorageService` (Domain) — unchanged.
+`DownloadFromUrlRequest` / `DownloadFromUrlResponse` (FileStorage MediatR contracts) — unchanged.
+`IRecurringJob` (Domain.Features.BackgroundJobs) — unchanged.
+
+### Data Flow
+
+For the daily product-export run:
+
+```
+Hangfire scheduler (cron "0 2 * * *")
+    │
+    ▼
+ProductExportDownloadJob.ExecuteAsync           [Catalog.Infrastructure.Jobs]
+    │  reads IOptions<ProductExportOptions>     [Catalog.Infrastructure]
+    │  → Url, ContainerName
+    │  builds fileName = "products_{timestamp}.csv"
+    │
+    ▼
+IMediator.Send(DownloadFromUrlRequest)          [FileStorage MediatR contract]
+    │
+    ▼
+DownloadFromUrlHandler.Handle                   [FileStorage.UseCases.DownloadFromUrl]
+    │  reads IOptions<FileDownloadOptions>      [FileStorage]
+    │  → HeadTimeout, DownloadTimeout, retry policy
+    │  HEAD probe via "FileDownload" HttpClient
+    │  → IBlobStorageService.DownloadFromUrlAsync
+    │
+    ▼
+AzureBlobStorageService                          [FileStorage.Services]
+    │  resolves "FileDownload" HttpClient
+    │  streams body to Azure Blob container
+    │
+    ▼
+Blob: <container>/products_{timestamp}.csv
+```
+
+Module-direction invariant: **Catalog → FileStorage only (via MediatR + Domain abstraction). FileStorage knows nothing about Catalog.** After the refactor, this holds cleanly.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Naive move per spec FR-1/FR-2 alone breaks compilation because `DownloadFromUrlHandler` references `ProductExportOptions` | **High** | Implement Decision 1 (split options) and Decision 2 (rename HttpClient constant) as part of this PR. Spec amendments below codify these. |
+| Renaming the named HttpClient breaks any external code path or in-flight request that resolves it by string | Low | Single repo, all references already inventoried (4 files in src, 3 test files). Solution-wide replace is safe; `dotnet build` will catch any miss. |
+| Hangfire recurring-job state under the old job name persists in storage if the `JobName` metadata changes | Low | **Do not change** `Metadata.JobName = "product-export-download"` — it's the Hangfire identity. Namespace change does not affect Hangfire's job key. Verify in test. |
+| `ILogger<T>` category name changes from `FileStorage.Infrastructure.Jobs.ProductExportDownloadJob` to `Catalog.Infrastructure.Jobs.ProductExportDownloadJob` may break log queries | Low | Confirmed in spec NFR-4 / open question 3 as accepted. Note in PR description for ops awareness. |
+| `ProductExportOptions` split could miss a downstream consumer that reads the old combined shape | Medium | Solution-wide grep confirms only `DownloadFromUrlHandler.HeadTimeout` consumes the timeout properties outside the job itself. Job consumes only `Url` + `ContainerName`. Mitigation is explicit: grep `_options.Value\.` against the original class to enumerate all property reads. |
+| `IRecurringJob` registration assumption (scan vs explicit) may be wrong, causing the job to not run after move | Medium | Before deleting the old file, verify how `ProductWeightRecalculationJob` is wired (likely scan via `IRecurringJob` discovery in the host). If explicit, replicate explicit registration in `CatalogModule`. Smoke test: start API in Development, confirm the job appears in Hangfire dashboard. |
+| Tests that previously asserted timeout properties on `ProductExportOptions` will fail when properties move to `FileDownloadOptions` | Low | Split `ProductExportOptionsTests.cs` accordingly (see implementation guidance). |
+| `appsettings.json` has `ProductExportOptions` listed but no top-level `FileStorage:Download` section — defaults must be safe | Low | The four timeout/retry defaults in current `ProductExportOptions` are already correct production values; preserve them as defaults on `FileDownloadOptions`. No appsettings change required for `FileDownloadOptions` unless tuning. |
+
+## Specification Amendments
+
+The spec must be updated to reflect the broader coupling. Recommended amendments:
+
+**Amend FR-2 (relocate `ProductExportOptions`):** Split the class. Move only `Url` and `ContainerName` to Catalog as the new `ProductExportOptions`. Move `HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay` into a new FileStorage-owned `FileDownloadOptions` class. Update `DownloadFromUrlHandler` constructor and all references accordingly. Update split tests.
+
+**Add FR-2a (rename FileStorage named HttpClient constant):** Rename `FileStorageModule.ProductExportDownloadClientName` to `FileStorageModule.FileDownloadClientName`, value from `"ProductExportDownload"` to `"FileDownload"`. Update `DownloadFromUrlHandler`, `AzureBlobStorageService`, and three test files. This completes the SRP cleanup of FileStorage.
+
+**Amend FR-3 (DI registration move):** The current registration of `ProductExportOptions` lives in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` line 365 (not in `FileStorageModule.cs`). Move that line into `CatalogModule.AddCatalogModule`. `FileStorageModule` gains a new `services.Configure<FileDownloadOptions>(...)` line. Confirm whether `ProductExportDownloadJob` is currently explicitly registered or scan-discovered; replicate the same pattern in Catalog.
+
+**Resolve FR-4 (config section rename):** Not required. The current section path `ProductExportOptions:` is at the config root, not under `FileStorage:`. No appsettings rename, no Key Vault migration needed. Optionally add a new `FileStorage:Download` section for `FileDownloadOptions` if defaults need to be tuned per environment; otherwise omit and let class defaults apply.
+
+**Confirm Open Question 3 (log category):** Accepted as-is. Category name changes from `Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs.ProductExportDownloadJob` to `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs.ProductExportDownloadJob`. PR description must note this for ops; no log query is known to depend on the old category in this solo-dev project.
+
+**Resolve Open Question 4 (tests):** Tests exist at `backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs` and `backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/ProductExportOptionsTests.cs`. Both move to corresponding Catalog test paths; `ProductExportOptionsTests` is split (timeout/retry assertions migrate to a new `FileDownloadOptionsTests.cs` in FileStorage tests).
+
+**Resolve Open Question 5 (other domain leaks in FileStorage):** Inventory complete. After this PR, FileStorage will contain: `IBlobStorageService` impl, `DownloadFromUrl` use case, `DownloadResilienceService`, `FileDownloadOptions`, named HttpClient `"FileDownload"`. All generic. No further moves recommended in this PR.
+
+## Prerequisites
+
+None. All changes are within a single solution, no infrastructure, no migration, no external coordination required.
+
+- No DB migrations.
+- No Key Vault secret renames (section name unchanged).
+- No external API contract changes.
+- No Azure resource changes (blob container name preserved via `ProductExportOptions.ContainerName` value).
+- No CI/CD pipeline changes.
+
+Smoke check before merge: start the API locally in Development, open the Hangfire dashboard, confirm `product-export-download` recurring job is registered with the same `JobName` and cron expression. Run `dotnet build` and `dotnet test` — both must pass clean.

--- a/artifacts/feat-arch-review-filestorage-productexportdow/brief.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/brief.md
@@ -1,0 +1,25 @@
+## Module
+FileStorage
+
+## Finding
+`ProductExportDownloadJob` (and its companion `ProductExportOptions`) live inside the `FileStorage` module:
+
+```
+backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs
+backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs
+```
+
+The job's logic is entirely product-export domain: it knows the export URL (`ProductExportOptions.Url`), the target blob container for product data (`ProductExportOptions.ContainerName`), and the output filename format (`products_{timestamp}.csv`). None of this is generic file-storage infrastructure — it is Shoptet/Catalog business logic that happens to use `IBlobStorageService` as a transport.
+
+As a result, the `FileStorage` module cannot be treated as a reusable, stable infrastructure module: changes to the product-export business rules (new URL, different filename convention, additional post-processing) require editing a module named "FileStorage." The module also carries `ProductExportOptions` in its root namespace, polluting what should be a generic infrastructure API.
+
+## Why it matters
+SRP — the module has two unrelated reasons to change: (1) how blobs are stored/retrieved, and (2) how product export downloads are scheduled and named. This split will grow over time if more domain-specific jobs are added here.
+
+## Suggested fix
+Move `ProductExportDownloadJob` and `ProductExportOptions` to the module that owns the product-export domain (currently `Catalog` or a dedicated `ShoptetOrders`/`Catalog` feature). The job can continue to inject `IBlobStorageService` (cross-module via the Domain interface — already the correct pattern). `FileStorageModule` registration of the job is then removed, and the receiving module's `Module.cs` registers it instead.
+
+This is a move, not a rewrite — the handler logic is unchanged.
+
+---
+_Filed by daily arch-review routine on 2026-06-05._

--- a/artifacts/feat-arch-review-filestorage-productexportdow/impl/main.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/impl/main.r1.md
@@ -1,0 +1,1 @@
+All four test runs completed with exit code 0. The branch is ready.

--- a/artifacts/feat-arch-review-filestorage-productexportdow/spec.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/spec.r1.md
@@ -1,0 +1,171 @@
+# Specification: Relocate ProductExportDownloadJob from FileStorage to Catalog Module
+
+## Summary
+Move `ProductExportDownloadJob` and `ProductExportOptions` out of the `FileStorage` module and into the `Catalog` module, which owns the product-export domain. This restores Single Responsibility for the `FileStorage` module (generic blob transport) and consolidates Shoptet/Catalog product-export business logic in the module that owns it. No behavior changes — pure relocation and DI re-wiring.
+
+## Background
+A daily architecture review (2026-06-05) flagged that `ProductExportDownloadJob` and its `ProductExportOptions` live under `backend/src/Anela.Heblo.Application/Features/FileStorage/`. The job's logic is entirely product-export domain:
+
+- It knows the Shoptet product-export URL (`ProductExportOptions.Url`).
+- It targets a specific product-data blob container (`ProductExportOptions.ContainerName`).
+- It enforces a product-export filename convention (`products_{timestamp}.csv`).
+
+None of this is generic file-storage infrastructure. The job uses `IBlobStorageService` only as a transport. Hosting the job in `FileStorage` means:
+
+1. **SRP violation** — the `FileStorage` module now has two unrelated reasons to change: blob storage mechanics, and product-export scheduling/naming/URL rules.
+2. **Namespace pollution** — `ProductExportOptions` sits in the root namespace of what should be a generic infrastructure module, leaking domain configuration into infrastructure.
+3. **Future drift risk** — if more domain-specific jobs accumulate here, `FileStorage` becomes a junk drawer rather than a stable, reusable infrastructure module.
+
+The fix is structural: relocate the two files to the `Catalog` module (or its product-export sub-feature), update DI registration, and leave logic untouched. `IBlobStorageService` continues to be consumed cross-module via its Domain interface — the existing and correct cross-module pattern.
+
+## Functional Requirements
+
+### FR-1: Relocate ProductExportDownloadJob to the Catalog module
+Move `ProductExportDownloadJob.cs` from `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/` to an appropriate location inside `backend/src/Anela.Heblo.Application/Features/Catalog/` that mirrors the Catalog module's existing layout for background jobs / infrastructure (e.g. `Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs`).
+
+**Acceptance criteria:**
+- The file no longer exists under `Features/FileStorage/Infrastructure/Jobs/`.
+- The file exists under `Features/Catalog/` in the location that matches Catalog's existing folder convention for jobs/infrastructure.
+- The class namespace is updated to match its new folder (e.g. `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`).
+- The class body, including dependencies, scheduling, blob writes, and filename format `products_{timestamp}.csv`, is byte-for-byte unchanged apart from `using` directives and the namespace declaration.
+
+### FR-2: Relocate ProductExportOptions to the Catalog module
+Move `ProductExportOptions.cs` from `backend/src/Anela.Heblo.Application/Features/FileStorage/` to the Catalog module, alongside or near `ProductExportDownloadJob`. It must no longer sit in the FileStorage root namespace.
+
+**Acceptance criteria:**
+- The file no longer exists under `Features/FileStorage/`.
+- The file exists in the Catalog module at a location consistent with how other option/config classes are placed there (e.g. `Features/Catalog/ProductExportOptions.cs` or `Features/Catalog/Infrastructure/ProductExportOptions.cs`).
+- Namespace updated to a `Catalog`-rooted namespace.
+- The class definition (properties `Url`, `ContainerName`, and any others currently on it) is unchanged.
+
+### FR-3: Update dependency injection registration
+The job and its options are currently registered in `FileStorageModule` (or equivalent `Module.cs` for FileStorage). Registration must move to the Catalog module's `Module.cs`.
+
+**Acceptance criteria:**
+- `FileStorageModule` (or its `Module.cs`) no longer references `ProductExportDownloadJob` or `ProductExportOptions`.
+- The Catalog module's `Module.cs` registers:
+  - `ProductExportDownloadJob` with the same lifetime/registration it previously had in `FileStorageModule`.
+  - `ProductExportOptions` bound from configuration with the same configuration section/path it previously used.
+- If `FileStorageModule` previously registered any scheduling/hosted-service wiring for this job, that wiring moves to the Catalog module as well.
+- DI container resolves the job successfully at application startup (no missing-service exceptions).
+
+### FR-4: Update configuration section ownership (if scoped to FileStorage)
+If `ProductExportOptions` was bound from a configuration section named under `FileStorage:` (e.g. `FileStorage:ProductExport`), the section path should move to a Catalog-owned key (e.g. `Catalog:ProductExport` or `ProductExport`) to avoid leaving Catalog config under a FileStorage namespace.
+
+**Acceptance criteria:**
+- The configuration section path used to bind `ProductExportOptions` is no longer rooted under `FileStorage:`.
+- `appsettings.json`, `appsettings.Development.json`, `appsettings.Staging.json`, `appsettings.Production.json`, and any other settings files in the repo are updated to the new section path.
+- Any Azure Key Vault secret names that referenced the old path (using `--` separators, e.g. `FileStorage--ProductExport--Url`) are migrated or the binding remains backward-compatible. The chosen strategy is documented in the PR description.
+- Assumption (note in Open Questions): if the existing section path is already neutral or already domain-named, no rename is required — only the binding registration moves.
+
+### FR-5: Update all references and using directives
+Any other file in the solution that references `ProductExportDownloadJob` or `ProductExportOptions` must be updated to the new namespace.
+
+**Acceptance criteria:**
+- A solution-wide search for `ProductExportDownloadJob` and `ProductExportOptions` returns only references that point to the new Catalog namespace.
+- `Anela.Heblo.Application.Features.FileStorage` is no longer imported via `using` anywhere on behalf of these two types.
+- Solution builds cleanly: `dotnet build` succeeds with zero new warnings or errors.
+
+### FR-6: Preserve cross-module access to `IBlobStorageService`
+`ProductExportDownloadJob` must continue to depend on `IBlobStorageService` via its Domain interface — the existing correct cross-module pattern. No copy of the interface or implementation moves with the job.
+
+**Acceptance criteria:**
+- `IBlobStorageService` remains defined and implemented in its current location (FileStorage Domain/Infrastructure).
+- The relocated job injects `IBlobStorageService` via constructor exactly as before.
+- No new project references are introduced that would create a Catalog → FileStorage Infrastructure dependency. Catalog continues to depend only on the FileStorage Domain abstraction it already depends on (or via the shared Application/Domain assembly, matching the project's existing module-boundary pattern).
+
+### FR-7: Test relocation and continued green status
+Any existing tests for `ProductExportDownloadJob` (unit or integration) must be moved to the Catalog test project (if they live in a FileStorage test folder/project today) and must continue to pass.
+
+**Acceptance criteria:**
+- Test files that exclusively target `ProductExportDownloadJob` or `ProductExportOptions` are relocated to the Catalog test project/folder structure.
+- Test namespaces are updated to match.
+- `dotnet test` passes for the full backend test suite with zero new failures.
+- If no tests exist for this job today, this requirement is satisfied trivially and noted in the PR description; no new tests are required by this change since logic is unchanged. (See Open Questions on whether to add minimum coverage opportunistically.)
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance change expected or permitted. The job's scheduling, execution path, and blob I/O remain identical. No new allocations, no added indirection, no changed lifetime.
+
+### NFR-2: Security
+No security surface change. The job continues to read its Shoptet export URL and storage credentials from configuration (which in this project means Azure Key Vault in staging/production). If the configuration section path changes (FR-4), the migration must not regress secret resolution in any environment.
+
+**Acceptance criteria:**
+- No secret values are committed to source.
+- Key Vault secret names continue to resolve, either by retaining the old path or by adding the new path before removing the old one.
+- Staging deployment of this branch successfully resolves `ProductExportOptions.Url` and `ProductExportOptions.ContainerName` at startup.
+
+### NFR-3: Maintainability / Architectural cleanliness
+This is the entire point of the change.
+
+**Acceptance criteria:**
+- After the change, `Features/FileStorage/` contains only generic blob-storage abstractions and implementations — no domain-specific jobs or options.
+- `Features/Catalog/` now owns `ProductExportDownloadJob` and `ProductExportOptions` alongside other Catalog product-export concerns.
+- Adding a new generic FileStorage capability no longer requires touching Catalog code; changing the product-export URL/filename no longer requires editing the FileStorage module.
+
+### NFR-4: Backward compatibility at runtime
+The change must be invisible to operators and downstream consumers of the exported blobs.
+
+**Acceptance criteria:**
+- Exported blob filename format remains `products_{timestamp}.csv`.
+- Exported blobs land in the same container they did before (`ProductExportOptions.ContainerName` value unchanged).
+- Scheduling cadence is unchanged.
+- No log message format/scope changes beyond the unavoidable namespace change in default `ILogger<T>` category names. (See Open Questions if log category stability matters to existing log alerts.)
+
+## Data Model
+No data model changes. Configuration option shape is unchanged:
+
+- `ProductExportOptions`
+  - `Url` (string) — Shoptet product export URL
+  - `ContainerName` (string) — target blob container for product-export CSV
+  - (Any additional properties currently on the class — preserved as-is)
+
+The only data-shape-adjacent change is the **configuration section path** that binds these options (see FR-4).
+
+## API / Interface Design
+
+### Public API
+No public HTTP API or MediatR contract changes.
+
+### Internal module surface
+- **Before:** `FileStorage` module exposes/registers `ProductExportDownloadJob` and `ProductExportOptions`.
+- **After:** `Catalog` module exposes/registers `ProductExportDownloadJob` and `ProductExportOptions`. `FileStorage` module exposes only generic blob storage abstractions.
+
+### Module boundary
+- `Catalog` depends on the `IBlobStorageService` Domain interface — already an established cross-module pattern in this codebase.
+- `FileStorage` no longer depends on or knows about Catalog concerns.
+
+### File moves (concrete)
+| From | To |
+| --- | --- |
+| `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs` | `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs` (final path to match Catalog's existing convention) |
+| `backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs` | `backend/src/Anela.Heblo.Application/Features/Catalog/ProductExportOptions.cs` (final path to match Catalog's existing convention) |
+| FileStorage module's DI registration block for the job & options | Catalog module's `Module.cs` |
+| Any existing tests for these types under a FileStorage test project | Corresponding Catalog test project |
+
+## Dependencies
+- `IBlobStorageService` (Domain abstraction) — remains in FileStorage, consumed by relocated job. No change.
+- Configuration system (`IOptions<ProductExportOptions>`) — already in use; binding registration moves to Catalog module.
+- Azure Key Vault (staging/production) — must continue to resolve the URL and container name secrets; affects the FR-4 migration strategy.
+- Existing job-scheduling infrastructure (Quartz / Hangfire / `IHostedService` / whatever pattern the project uses today) — unchanged; only the registration call-site moves.
+- No new NuGet packages.
+
+## Out of Scope
+- Refactoring `ProductExportDownloadJob` logic (URL handling, filename format, error handling, retry policy).
+- Changing the scheduling cadence or trigger mechanism.
+- Changing `IBlobStorageService` interface, implementation, or its module location.
+- Renaming `ProductExportOptions` properties.
+- Adding new tests beyond relocating existing ones (unless trivially required for the relocated registration to be verifiable — see Open Questions).
+- Migrating other domain-specific jobs that may also live in `FileStorage`. If others are discovered, they are a separate change with their own brief.
+- Any change to the Shoptet integration itself.
+- Documentation updates beyond updating `CLAUDE.md` documentation map or architecture docs *only if* a doc explicitly references the old FileStorage location of these types. No broad doc rewrites.
+
+## Open Questions
+1. **Catalog sub-feature placement.** The `Catalog` module may have multiple sub-features (e.g. product catalog, product export, Shoptet integration). Should the relocated files live under a `Catalog/ProductExport/` sub-feature folder, or at the Catalog feature root mirroring the existing convention? Assumption: follow whatever pattern Catalog's other infrastructure/job files already use; if a `ProductExport` sub-feature exists, use it.
+2. **Configuration section rename (FR-4).** Is the current `ProductExportOptions` bound from a section under `FileStorage:` today? If yes, do we rename the section (cleaner, but requires Key Vault secret rename and a coordinated deploy) or keep the old path (technically leaves a `FileStorage:` config remnant in Catalog code, but zero ops risk)? Default assumption: keep the old path if it's already neutral or domain-named; rename only if the existing path is explicitly under `FileStorage:`, and document the Key Vault migration steps in the PR.
+3. **Log category continuity (NFR-4).** The default `ILogger<ProductExportDownloadJob>` category name will change because of the namespace move (`...FileStorage.Infrastructure.Jobs.ProductExportDownloadJob` → `...Catalog.Infrastructure.Jobs.ProductExportDownloadJob`). If any production log alerts or queries match on the old category, they need updating. Confirm whether this matters operationally; default assumption: not load-bearing, change accepted.
+4. **Tests today.** Do unit/integration tests for `ProductExportDownloadJob` currently exist, and if so where? This affects the size of FR-7. If none exist, should a minimal smoke test be added for the relocated DI registration (verifying the job resolves from the container)? Default assumption: no new tests required; existing ones, if any, are moved.
+5. **Other domain-specific items in FileStorage.** While moving these two files, are there other domain-specific options/jobs hiding in `Features/FileStorage/` that should be flagged in the PR description (without being fixed in this change)? Default: list any discovered, do not move them in this PR.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-arch-review-filestorage-productexportdow/spec.r2.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/spec.r2.md
@@ -1,0 +1,173 @@
+# Specification: Relocate ProductExportDownloadJob from FileStorage to Catalog Module
+
+## Summary
+Move `ProductExportDownloadJob` and `ProductExportOptions` out of the `FileStorage` module and into the `Catalog` module, which owns the product-export domain. This restores Single Responsibility for the `FileStorage` module (generic blob transport) and consolidates Shoptet/Catalog product-export business logic in the module that owns it. No behavior changes — pure relocation and DI re-wiring.
+
+## Background
+A daily architecture review (2026-06-05) flagged that `ProductExportDownloadJob` and its `ProductExportOptions` live under `backend/src/Anela.Heblo.Application/Features/FileStorage/`. The job's logic is entirely product-export domain:
+
+- It knows the Shoptet product-export URL (`ProductExportOptions.Url`).
+- It targets a specific product-data blob container (`ProductExportOptions.ContainerName`).
+- It enforces a product-export filename convention (`products_{timestamp}.csv`).
+
+None of this is generic file-storage infrastructure. The job uses `IBlobStorageService` only as a transport. Hosting the job in `FileStorage` means:
+
+1. **SRP violation** — the `FileStorage` module now has two unrelated reasons to change: blob storage mechanics, and product-export scheduling/naming/URL rules.
+2. **Namespace pollution** — `ProductExportOptions` sits in the root namespace of what should be a generic infrastructure module, leaking domain configuration into infrastructure.
+3. **Future drift risk** — if more domain-specific jobs accumulate here, `FileStorage` becomes a junk drawer rather than a stable, reusable infrastructure module.
+
+The fix is structural: relocate the two files to the `Catalog` module (or its product-export sub-feature), update DI registration, and leave logic untouched. `IBlobStorageService` continues to be consumed cross-module via its Domain interface — the existing and correct cross-module pattern.
+
+## Functional Requirements
+
+### FR-1: Relocate ProductExportDownloadJob to the Catalog module
+Move `ProductExportDownloadJob.cs` from `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/` to an appropriate location inside `backend/src/Anela.Heblo.Application/Features/Catalog/` that mirrors the Catalog module's existing layout for background jobs / infrastructure (e.g. `Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs`).
+
+**Acceptance criteria:**
+- The file no longer exists under `Features/FileStorage/Infrastructure/Jobs/`.
+- The file exists under `Features/Catalog/` in the location that matches Catalog's existing folder convention for jobs/infrastructure.
+- The class namespace is updated to match its new folder (e.g. `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`).
+- The class body, including dependencies, scheduling, blob writes, and filename format `products_{timestamp}.csv`, is byte-for-byte unchanged apart from `using` directives and the namespace declaration.
+
+### FR-2: Relocate ProductExportOptions to the Catalog module
+Move `ProductExportOptions.cs` from `backend/src/Anela.Heblo.Application/Features/FileStorage/` to the Catalog module, alongside or near `ProductExportDownloadJob`. It must no longer sit in the FileStorage root namespace.
+
+**Acceptance criteria:**
+- The file no longer exists under `Features/FileStorage/`.
+- The file exists in the Catalog module at a location consistent with how other option/config classes are placed there (e.g. `Features/Catalog/ProductExportOptions.cs` or `Features/Catalog/Infrastructure/ProductExportOptions.cs`).
+- Namespace updated to a `Catalog`-rooted namespace.
+- The class definition (properties `Url`, `ContainerName`, and any others currently on it) is unchanged.
+
+### FR-3: Update dependency injection registration
+The job and its options are currently registered in `FileStorageModule` (or equivalent `Module.cs` for FileStorage). Registration must move to the Catalog module's `Module.cs`.
+
+**Acceptance criteria:**
+- `FileStorageModule` (or its `Module.cs`) no longer references `ProductExportDownloadJob` or `ProductExportOptions`.
+- The Catalog module's `Module.cs` registers:
+  - `ProductExportDownloadJob` with the same lifetime/registration it previously had in `FileStorageModule`.
+  - `ProductExportOptions` bound from configuration with the same configuration section/path it previously used.
+- If `FileStorageModule` previously registered any scheduling/hosted-service wiring for this job, that wiring moves to the Catalog module as well.
+- DI container resolves the job successfully at application startup (no missing-service exceptions).
+
+### FR-4: Update configuration section ownership (if scoped to FileStorage)
+If `ProductExportOptions` was bound from a configuration section named under `FileStorage:` (e.g. `FileStorage:ProductExport`), the section path should move to a Catalog-owned key (e.g. `Catalog:ProductExport` or `ProductExport`) to avoid leaving Catalog config under a FileStorage namespace.
+
+**Acceptance criteria:**
+- The configuration section path used to bind `ProductExportOptions` is no longer rooted under `FileStorage:`.
+- `appsettings.json`, `appsettings.Development.json`, `appsettings.Staging.json`, `appsettings.Production.json`, and any other settings files in the repo are updated to the new section path.
+- Any Azure Key Vault secret names that referenced the old path (using `--` separators, e.g. `FileStorage--ProductExport--Url`) are migrated or the binding remains backward-compatible. The chosen strategy is documented in the PR description.
+- Assumption (note in Open Questions): if the existing section path is already neutral or already domain-named, no rename is required — only the binding registration moves.
+
+### FR-5: Update all references and using directives
+Any other file in the solution that references `ProductExportDownloadJob` or `ProductExportOptions` must be updated to the new namespace.
+
+**Acceptance criteria:**
+- A solution-wide search for `ProductExportDownloadJob` and `ProductExportOptions` returns only references that point to the new Catalog namespace.
+- `Anela.Heblo.Application.Features.FileStorage` is no longer imported via `using` anywhere on behalf of these two types.
+- Solution builds cleanly: `dotnet build` succeeds with zero new warnings or errors.
+
+### FR-6: Preserve cross-module access to `IBlobStorageService`
+`ProductExportDownloadJob` must continue to depend on `IBlobStorageService` via its Domain interface — the existing correct cross-module pattern. No copy of the interface or implementation moves with the job.
+
+**Acceptance criteria:**
+- `IBlobStorageService` remains defined and implemented in its current location (FileStorage Domain/Infrastructure).
+- The relocated job injects `IBlobStorageService` via constructor exactly as before.
+- No new project references are introduced that would create a Catalog → FileStorage Infrastructure dependency. Catalog continues to depend only on the FileStorage Domain abstraction it already depends on (or via the shared Application/Domain assembly, matching the project's existing module-boundary pattern).
+
+### FR-7: Test relocation and continued green status
+Any existing tests for `ProductExportDownloadJob` (unit or integration) must be moved to the Catalog test project (if they live in a FileStorage test folder/project today) and must continue to pass.
+
+**Acceptance criteria:**
+- Test files that exclusively target `ProductExportDownloadJob` or `ProductExportOptions` are relocated to the Catalog test project/folder structure.
+- Test namespaces are updated to match.
+- `dotnet test` passes for the full backend test suite with zero new failures.
+- If no tests exist for this job today, this requirement is satisfied trivially and noted in the PR description; no new tests are required by this change since logic is unchanged. (See Open Questions on whether to add minimum coverage opportunistically.)
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance change expected or permitted. The job's scheduling, execution path, and blob I/O remain identical. No new allocations, no added indirection, no changed lifetime.
+
+### NFR-2: Security
+No security surface change. The job continues to read its Shoptet export URL and storage credentials from configuration (which in this project means Azure Key Vault in staging/production). If the configuration section path changes (FR-4), the migration must not regress secret resolution in any environment.
+
+**Acceptance criteria:**
+- No secret values are committed to source.
+- Key Vault secret names continue to resolve, either by retaining the old path or by adding the new path before removing the old one.
+- Staging deployment of this branch successfully resolves `ProductExportOptions.Url` and `ProductExportOptions.ContainerName` at startup.
+
+### NFR-3: Maintainability / Architectural cleanliness
+This is the entire point of the change.
+
+**Acceptance criteria:**
+- After the change, `Features/FileStorage/` contains only generic blob-storage abstractions and implementations — no domain-specific jobs or options.
+- `Features/Catalog/` now owns `ProductExportDownloadJob` and `ProductExportOptions` alongside other Catalog product-export concerns.
+- Adding a new generic FileStorage capability no longer requires touching Catalog code; changing the product-export URL/filename no longer requires editing the FileStorage module.
+
+### NFR-4: Backward compatibility at runtime
+The change must be invisible to operators and downstream consumers of the exported blobs.
+
+**Acceptance criteria:**
+- Exported blob filename format remains `products_{timestamp}.csv`.
+- Exported blobs land in the same container they did before (`ProductExportOptions.ContainerName` value unchanged).
+- Scheduling cadence is unchanged.
+- No log message format/scope changes beyond the unavoidable namespace change in default `ILogger<T>` category names. (See Open Questions if log category stability matters to existing log alerts.)
+
+## Data Model
+No data model changes. Configuration option shape is unchanged:
+
+- `ProductExportOptions`
+  - `Url` (string) — Shoptet product export URL
+  - `ContainerName` (string) — target blob container for product-export CSV
+  - (Any additional properties currently on the class — preserved as-is)
+
+The only data-shape-adjacent change is the **configuration section path** that binds these options (see FR-4).
+
+## API / Interface Design
+
+### Public API
+No public HTTP API or MediatR contract changes.
+
+### Internal module surface
+- **Before:** `FileStorage` module exposes/registers `ProductExportDownloadJob` and `ProductExportOptions`.
+- **After:** `Catalog` module exposes/registers `ProductExportDownloadJob` and `ProductExportOptions`. `FileStorage` module exposes only generic blob storage abstractions.
+
+### Module boundary
+- `Catalog` depends on the `IBlobStorageService` Domain interface — already an established cross-module pattern in this codebase.
+- `FileStorage` no longer depends on or knows about Catalog concerns.
+
+### File moves (concrete)
+| From | To |
+| --- | --- |
+| `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs` | `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs` (final path to match Catalog's existing convention) |
+| `backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs` | `backend/src/Anela.Heblo.Application/Features/Catalog/ProductExportOptions.cs` (final path to match Catalog's existing convention) |
+| FileStorage module's DI registration block for the job & options | Catalog module's `Module.cs` |
+| Any existing tests for these types under a FileStorage test project | Corresponding Catalog test project |
+
+## Dependencies
+- `IBlobStorageService` (Domain abstraction) — remains in FileStorage, consumed by relocated job. No change.
+- Configuration system (`IOptions<ProductExportOptions>`) — already in use; binding registration moves to Catalog module.
+- Azure Key Vault (staging/production) — must continue to resolve the URL and container name secrets; affects the FR-4 migration strategy.
+- Existing job-scheduling infrastructure (Quartz / Hangfire / `IHostedService` / whatever pattern the project uses today) — unchanged; only the registration call-site moves.
+- No new NuGet packages.
+
+## Out of Scope
+- Refactoring `ProductExportDownloadJob` logic (URL handling, filename format, error handling, retry policy).
+- Changing the scheduling cadence or trigger mechanism.
+- Changing `IBlobStorageService` interface, implementation, or its module location.
+- Renaming `ProductExportOptions` properties.
+- Adding new tests beyond relocating existing ones (unless trivially required for the relocated registration to be verifiable — see Open Questions).
+- Migrating other domain-specific jobs that may also live in `FileStorage`. If others are discovered, they are a separate change with their own brief.
+- Any change to the Shoptet integration itself.
+- Documentation updates beyond updating `CLAUDE.md` documentation map or architecture docs *only if* a doc explicitly references the old FileStorage location of these types. No broad doc rewrites.
+
+## Open Questions
+1. **Catalog sub-feature placement.** The `Catalog` module may have multiple sub-features (e.g. product catalog, product export, Shoptet integration). Should the relocated files live under a `Catalog/ProductExport/` sub-feature folder, or at the Catalog feature root mirroring the existing convention? Assumption: follow whatever pattern Catalog's other infrastructure/job files already use; if a `ProductExport` sub-feature exists, use it.
+2. **Configuration section rename (FR-4).** Is the current `ProductExportOptions` bound from a section under `FileStorage:` today? If yes, do we rename the section (cleaner, but requires Key Vault secret rename and a coordinated deploy) or keep the old path (technically leaves a `FileStorage:` config remnant in Catalog code, but zero ops risk)? Default assumption: keep the old path if it's already neutral or domain-named; rename only if the existing path is explicitly under `FileStorage:`, and document the Key Vault migration steps in the PR.
+3. **Log category continuity (NFR-4).** The default `ILogger<ProductExportDownloadJob>` category name will change because of the namespace move (`...FileStorage.Infrastructure.Jobs.ProductExportDownloadJob` → `...Catalog.Infrastructure.Jobs.ProductExportDownloadJob`). If any production log alerts or queries match on the old category, they need updating. Confirm whether this matters operationally; default assumption: not load-bearing, change accepted.
+4. **Tests today.** Do unit/integration tests for `ProductExportDownloadJob` currently exist, and if so where? This affects the size of FR-7. If none exist, should a minimal smoke test be added for the relocated DI registration (verifying the job resolves from the container)? Default assumption: no new tests required; existing ones, if any, are moved.
+5. **Other domain-specific items in FileStorage.** While moving these two files, are there other domain-specific options/jobs hiding in `Features/FileStorage/` that should be flagged in the PR description (without being fixed in this change)? Default: list any discovered, do not move them in this PR.
+
+> **Note on `answers.r1.md`:** The provided revision-1 answer file addresses a different feature (a `PickingListBatchProcessor` / `ShoptetApiExpeditionListSource` cooling-marker PATCH logger choice) and does not correspond to any of the open questions above. It has therefore been ignored. The five open questions remain open and need clarification before implementation.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-arch-review-filestorage-productexportdow/spec.r3.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/spec.r3.md
@@ -1,0 +1,173 @@
+# Specification: Relocate ProductExportDownloadJob from FileStorage to Catalog Module
+
+## Summary
+Move `ProductExportDownloadJob` and `ProductExportOptions` out of the `FileStorage` module and into the `Catalog` module, which owns the product-export domain. This restores Single Responsibility for the `FileStorage` module (generic blob transport) and consolidates Shoptet/Catalog product-export business logic in the module that owns it. No behavior changes — pure relocation and DI re-wiring.
+
+## Background
+A daily architecture review (2026-06-05) flagged that `ProductExportDownloadJob` and its `ProductExportOptions` live under `backend/src/Anela.Heblo.Application/Features/FileStorage/`. The job's logic is entirely product-export domain:
+
+- It knows the Shoptet product-export URL (`ProductExportOptions.Url`).
+- It targets a specific product-data blob container (`ProductExportOptions.ContainerName`).
+- It enforces a product-export filename convention (`products_{timestamp}.csv`).
+
+None of this is generic file-storage infrastructure. The job uses `IBlobStorageService` only as a transport. Hosting the job in `FileStorage` means:
+
+1. **SRP violation** — the `FileStorage` module now has two unrelated reasons to change: blob storage mechanics, and product-export scheduling/naming/URL rules.
+2. **Namespace pollution** — `ProductExportOptions` sits in the root namespace of what should be a generic infrastructure module, leaking domain configuration into infrastructure.
+3. **Future drift risk** — if more domain-specific jobs accumulate here, `FileStorage` becomes a junk drawer rather than a stable, reusable infrastructure module.
+
+The fix is structural: relocate the two files to the `Catalog` module (or its product-export sub-feature), update DI registration, and leave logic untouched. `IBlobStorageService` continues to be consumed cross-module via its Domain interface — the existing and correct cross-module pattern.
+
+## Functional Requirements
+
+### FR-1: Relocate ProductExportDownloadJob to the Catalog module
+Move `ProductExportDownloadJob.cs` from `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/` to an appropriate location inside `backend/src/Anela.Heblo.Application/Features/Catalog/` that mirrors the Catalog module's existing layout for background jobs / infrastructure (e.g. `Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs`).
+
+**Acceptance criteria:**
+- The file no longer exists under `Features/FileStorage/Infrastructure/Jobs/`.
+- The file exists under `Features/Catalog/` in the location that matches Catalog's existing folder convention for jobs/infrastructure.
+- The class namespace is updated to match its new folder (e.g. `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`).
+- The class body, including dependencies, scheduling, blob writes, and filename format `products_{timestamp}.csv`, is byte-for-byte unchanged apart from `using` directives and the namespace declaration.
+
+### FR-2: Relocate ProductExportOptions to the Catalog module
+Move `ProductExportOptions.cs` from `backend/src/Anela.Heblo.Application/Features/FileStorage/` to the Catalog module, alongside or near `ProductExportDownloadJob`. It must no longer sit in the FileStorage root namespace.
+
+**Acceptance criteria:**
+- The file no longer exists under `Features/FileStorage/`.
+- The file exists in the Catalog module at a location consistent with how other option/config classes are placed there (e.g. `Features/Catalog/ProductExportOptions.cs` or `Features/Catalog/Infrastructure/ProductExportOptions.cs`).
+- Namespace updated to a `Catalog`-rooted namespace.
+- The class definition (properties `Url`, `ContainerName`, and any others currently on it) is unchanged.
+
+### FR-3: Update dependency injection registration
+The job and its options are currently registered in `FileStorageModule` (or equivalent `Module.cs` for FileStorage). Registration must move to the Catalog module's `Module.cs`.
+
+**Acceptance criteria:**
+- `FileStorageModule` (or its `Module.cs`) no longer references `ProductExportDownloadJob` or `ProductExportOptions`.
+- The Catalog module's `Module.cs` registers:
+  - `ProductExportDownloadJob` with the same lifetime/registration it previously had in `FileStorageModule`.
+  - `ProductExportOptions` bound from configuration with the same configuration section/path it previously used.
+- If `FileStorageModule` previously registered any scheduling/hosted-service wiring for this job, that wiring moves to the Catalog module as well.
+- DI container resolves the job successfully at application startup (no missing-service exceptions).
+
+### FR-4: Update configuration section ownership (if scoped to FileStorage)
+If `ProductExportOptions` was bound from a configuration section named under `FileStorage:` (e.g. `FileStorage:ProductExport`), the section path should move to a Catalog-owned key (e.g. `Catalog:ProductExport` or `ProductExport`) to avoid leaving Catalog config under a FileStorage namespace.
+
+**Acceptance criteria:**
+- The configuration section path used to bind `ProductExportOptions` is no longer rooted under `FileStorage:`.
+- `appsettings.json`, `appsettings.Development.json`, `appsettings.Staging.json`, `appsettings.Production.json`, and any other settings files in the repo are updated to the new section path.
+- Any Azure Key Vault secret names that referenced the old path (using `--` separators, e.g. `FileStorage--ProductExport--Url`) are migrated or the binding remains backward-compatible. The chosen strategy is documented in the PR description.
+- Assumption (note in Open Questions): if the existing section path is already neutral or already domain-named, no rename is required — only the binding registration moves.
+
+### FR-5: Update all references and using directives
+Any other file in the solution that references `ProductExportDownloadJob` or `ProductExportOptions` must be updated to the new namespace.
+
+**Acceptance criteria:**
+- A solution-wide search for `ProductExportDownloadJob` and `ProductExportOptions` returns only references that point to the new Catalog namespace.
+- `Anela.Heblo.Application.Features.FileStorage` is no longer imported via `using` anywhere on behalf of these two types.
+- Solution builds cleanly: `dotnet build` succeeds with zero new warnings or errors.
+
+### FR-6: Preserve cross-module access to `IBlobStorageService`
+`ProductExportDownloadJob` must continue to depend on `IBlobStorageService` via its Domain interface — the existing correct cross-module pattern. No copy of the interface or implementation moves with the job.
+
+**Acceptance criteria:**
+- `IBlobStorageService` remains defined and implemented in its current location (FileStorage Domain/Infrastructure).
+- The relocated job injects `IBlobStorageService` via constructor exactly as before.
+- No new project references are introduced that would create a Catalog → FileStorage Infrastructure dependency. Catalog continues to depend only on the FileStorage Domain abstraction it already depends on (or via the shared Application/Domain assembly, matching the project's existing module-boundary pattern).
+
+### FR-7: Test relocation and continued green status
+Any existing tests for `ProductExportDownloadJob` (unit or integration) must be moved to the Catalog test project (if they live in a FileStorage test folder/project today) and must continue to pass.
+
+**Acceptance criteria:**
+- Test files that exclusively target `ProductExportDownloadJob` or `ProductExportOptions` are relocated to the Catalog test project/folder structure.
+- Test namespaces are updated to match.
+- `dotnet test` passes for the full backend test suite with zero new failures.
+- If no tests exist for this job today, this requirement is satisfied trivially and noted in the PR description; no new tests are required by this change since logic is unchanged. (See Open Questions on whether to add minimum coverage opportunistically.)
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance change expected or permitted. The job's scheduling, execution path, and blob I/O remain identical. No new allocations, no added indirection, no changed lifetime.
+
+### NFR-2: Security
+No security surface change. The job continues to read its Shoptet export URL and storage credentials from configuration (which in this project means Azure Key Vault in staging/production). If the configuration section path changes (FR-4), the migration must not regress secret resolution in any environment.
+
+**Acceptance criteria:**
+- No secret values are committed to source.
+- Key Vault secret names continue to resolve, either by retaining the old path or by adding the new path before removing the old one.
+- Staging deployment of this branch successfully resolves `ProductExportOptions.Url` and `ProductExportOptions.ContainerName` at startup.
+
+### NFR-3: Maintainability / Architectural cleanliness
+This is the entire point of the change.
+
+**Acceptance criteria:**
+- After the change, `Features/FileStorage/` contains only generic blob-storage abstractions and implementations — no domain-specific jobs or options.
+- `Features/Catalog/` now owns `ProductExportDownloadJob` and `ProductExportOptions` alongside other Catalog product-export concerns.
+- Adding a new generic FileStorage capability no longer requires touching Catalog code; changing the product-export URL/filename no longer requires editing the FileStorage module.
+
+### NFR-4: Backward compatibility at runtime
+The change must be invisible to operators and downstream consumers of the exported blobs.
+
+**Acceptance criteria:**
+- Exported blob filename format remains `products_{timestamp}.csv`.
+- Exported blobs land in the same container they did before (`ProductExportOptions.ContainerName` value unchanged).
+- Scheduling cadence is unchanged.
+- No log message format/scope changes beyond the unavoidable namespace change in default `ILogger<T>` category names. (See Open Questions if log category stability matters to existing log alerts.)
+
+## Data Model
+No data model changes. Configuration option shape is unchanged:
+
+- `ProductExportOptions`
+  - `Url` (string) — Shoptet product export URL
+  - `ContainerName` (string) — target blob container for product-export CSV
+  - (Any additional properties currently on the class — preserved as-is)
+
+The only data-shape-adjacent change is the **configuration section path** that binds these options (see FR-4).
+
+## API / Interface Design
+
+### Public API
+No public HTTP API or MediatR contract changes.
+
+### Internal module surface
+- **Before:** `FileStorage` module exposes/registers `ProductExportDownloadJob` and `ProductExportOptions`.
+- **After:** `Catalog` module exposes/registers `ProductExportDownloadJob` and `ProductExportOptions`. `FileStorage` module exposes only generic blob storage abstractions.
+
+### Module boundary
+- `Catalog` depends on the `IBlobStorageService` Domain interface — already an established cross-module pattern in this codebase.
+- `FileStorage` no longer depends on or knows about Catalog concerns.
+
+### File moves (concrete)
+| From | To |
+| --- | --- |
+| `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs` | `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs` (final path to match Catalog's existing convention) |
+| `backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs` | `backend/src/Anela.Heblo.Application/Features/Catalog/ProductExportOptions.cs` (final path to match Catalog's existing convention) |
+| FileStorage module's DI registration block for the job & options | Catalog module's `Module.cs` |
+| Any existing tests for these types under a FileStorage test project | Corresponding Catalog test project |
+
+## Dependencies
+- `IBlobStorageService` (Domain abstraction) — remains in FileStorage, consumed by relocated job. No change.
+- Configuration system (`IOptions<ProductExportOptions>`) — already in use; binding registration moves to Catalog module.
+- Azure Key Vault (staging/production) — must continue to resolve the URL and container name secrets; affects the FR-4 migration strategy.
+- Existing job-scheduling infrastructure (Quartz / Hangfire / `IHostedService` / whatever pattern the project uses today) — unchanged; only the registration call-site moves.
+- No new NuGet packages.
+
+## Out of Scope
+- Refactoring `ProductExportDownloadJob` logic (URL handling, filename format, error handling, retry policy).
+- Changing the scheduling cadence or trigger mechanism.
+- Changing `IBlobStorageService` interface, implementation, or its module location.
+- Renaming `ProductExportOptions` properties.
+- Adding new tests beyond relocating existing ones (unless trivially required for the relocated registration to be verifiable — see Open Questions).
+- Migrating other domain-specific jobs that may also live in `FileStorage`. If others are discovered, they are a separate change with their own brief.
+- Any change to the Shoptet integration itself.
+- Documentation updates beyond updating `CLAUDE.md` documentation map or architecture docs *only if* a doc explicitly references the old FileStorage location of these types. No broad doc rewrites.
+
+## Open Questions
+1. **Catalog sub-feature placement.** The `Catalog` module may have multiple sub-features (e.g. product catalog, product export, Shoptet integration). Should the relocated files live under a `Catalog/ProductExport/` sub-feature folder, or at the Catalog feature root mirroring the existing convention? Assumption: follow whatever pattern Catalog's other infrastructure/job files already use; if a `ProductExport` sub-feature exists, use it.
+2. **Configuration section rename (FR-4).** Is the current `ProductExportOptions` bound from a section under `FileStorage:` today? If yes, do we rename the section (cleaner, but requires Key Vault secret rename and a coordinated deploy) or keep the old path (technically leaves a `FileStorage:` config remnant in Catalog code, but zero ops risk)? Default assumption: keep the old path if it's already neutral or domain-named; rename only if the existing path is explicitly under `FileStorage:`, and document the Key Vault migration steps in the PR.
+3. **Log category continuity (NFR-4).** The default `ILogger<ProductExportDownloadJob>` category name will change because of the namespace move (`...FileStorage.Infrastructure.Jobs.ProductExportDownloadJob` → `...Catalog.Infrastructure.Jobs.ProductExportDownloadJob`). If any production log alerts or queries match on the old category, they need updating. Confirm whether this matters operationally; default assumption: not load-bearing, change accepted.
+4. **Tests today.** Do unit/integration tests for `ProductExportDownloadJob` currently exist, and if so where? This affects the size of FR-7. If none exist, should a minimal smoke test be added for the relocated DI registration (verifying the job resolves from the container)? Default assumption: no new tests required; existing ones, if any, are moved.
+5. **Other domain-specific items in FileStorage.** While moving these two files, are there other domain-specific options/jobs hiding in `Features/FileStorage/` that should be flagged in the PR description (without being fixed in this change)? Default: list any discovered, do not move them in this PR.
+
+> **Note on `answers.r1.md` and `answers.r2.md`:** Both provided answer files address a different feature (a `PickingListBatchProcessor` / `ShoptetApiExpeditionListSource` cooling-marker PATCH logger choice) and do not correspond to any of the open questions above. They have therefore been ignored. The five open questions remain open and need clarification before implementation.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-arch-review-filestorage-productexportdow/task-plan.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportdow/task-plan.r1.md
@@ -1,0 +1,18 @@
+Plan saved to `docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md`.
+
+## Summary
+
+The plan decomposes the relocation into **13 bite-sized tasks**, ordered so the solution builds and the test suite stays green at every commit boundary:
+
+1. **Tasks 1–2** — introduce `FileDownloadOptions` in FileStorage and register it.
+2. **Tasks 3–4** — migrate the two FileStorage consumers (`DownloadFromUrlHandler`, `DownloadResilienceService`) to use `FileDownloadOptions`. The arch review missed that `DownloadResilienceService` also injects `ProductExportOptions` — confirmed via grep, handled in Task 4.
+3. **Tasks 5–7** — replace `ProductExportOptionsTests` with `FileDownloadOptionsTests`, slim `ProductExportOptions` to `Url`+`ContainerName`, and repair `FileStorageModuleTests`.
+4. **Task 8** — rename `ProductExportDownloadClientName` → `FileDownloadClientName` across 4 source + 3 test files.
+5. **Tasks 9–11** — relocate `ProductExportOptions` and `ProductExportDownloadJob` to the Catalog namespace; move DI registration from `ServiceCollectionExtensions` to `CatalogModule`.
+6. **Task 12** — relocate the job tests to mirror the source.
+7. **Task 13** — final greps, build, full test suite, manual Hangfire dashboard smoke check, and a PR-description template.
+
+Key facts verified against the codebase before writing:
+- `IRecurringJob` is auto-discovered via assembly scan (`ServiceCollectionExtensions.cs:373`), so the job needs no explicit registration in `CatalogModule`.
+- Config section `ProductExportOptions:` is already at the root, not under `FileStorage:` — no rename, no Key Vault migration.
+- `DownloadResilienceService` is a second hidden consumer of the options class (only the handler was flagged in the arch review).

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -25,7 +25,6 @@ using Anela.Heblo.API.PDFPrints;
 using Anela.Heblo.Application.Features.BackgroundJobs.Services;
 using Anela.Heblo.Adapters.FileSystem;
 using Anela.Heblo.API.Features.ExpeditionList;
-using Anela.Heblo.Application.Features.Catalog.Infrastructure;
 using Anela.Heblo.Application.Shared.Printing;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetSemiproductRecipePdf;
@@ -362,7 +361,6 @@ public static class ServiceCollectionExtensions
 
         // Register configuration options
         services.Configure<HangfireOptions>(configuration.GetSection(HangfireOptions.ConfigurationKey));
-        services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
 
         return services;
     }

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ using Anela.Heblo.API.PDFPrints;
 using Anela.Heblo.Application.Features.BackgroundJobs.Services;
 using Anela.Heblo.Adapters.FileSystem;
 using Anela.Heblo.API.Features.ExpeditionList;
-using Anela.Heblo.Application.Features.FileStorage;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
 using Anela.Heblo.Application.Shared.Printing;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetSemiproductRecipePdf;

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -111,6 +111,8 @@ public static class CatalogModule
             configuration.GetSection(CatalogCacheOptions.SectionName).Bind(options);
         });
 
+        services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+
         // Register AutoMapper for catalog mappings
         services.AddAutoMapper(cfg => { }, typeof(CatalogModule));
 

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Anela.Heblo.Application.Features.Catalog.Infrastructure;
 using Anela.Heblo.Application.Features.FileStorage.UseCases.DownloadFromUrl;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Xcc.Telemetry;
@@ -12,7 +11,7 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs;
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs;
 
 [AutomaticRetry(Attempts = 0)]
 public sealed class ProductExportDownloadJob : IRecurringJob

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs
@@ -1,4 +1,4 @@
-namespace Anela.Heblo.Application.Features.FileStorage;
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
 
 public class ProductExportOptions
 {

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/FileDownloadOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/FileDownloadOptions.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Application.Features.FileStorage;
+
+public class FileDownloadOptions
+{
+    public TimeSpan HeadTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    public TimeSpan DownloadTimeout { get; set; } = TimeSpan.FromSeconds(120);
+
+    public int MaxRetryAttempts { get; set; } = 3;
+
+    public TimeSpan RetryBaseDelay { get; set; } = TimeSpan.FromSeconds(2);
+}

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
@@ -10,7 +10,7 @@ namespace Anela.Heblo.Application.Features.FileStorage;
 
 public static class FileStorageModule
 {
-    public const string ProductExportDownloadClientName = "ProductExportDownload";
+    public const string FileDownloadClientName = "FileDownload";
 
     public static IServiceCollection AddFileStorageModule(this IServiceCollection services, IConfiguration configuration)
     {
@@ -32,7 +32,7 @@ public static class FileStorageModule
         // PooledConnectionLifetime recycles sockets and refreshes DNS every 5 minutes,
         // preventing the stale-socket and DNS-pinning problems of a long-lived singleton HttpClient.
         // AutomaticDecompression handles gzip/brotli responses from the export URL transparently.
-        services.AddHttpClient(ProductExportDownloadClientName)
+        services.AddHttpClient(FileDownloadClientName)
             .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
             {
                 PooledConnectionLifetime = TimeSpan.FromMinutes(5),

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
@@ -55,6 +55,8 @@ public static class FileStorageModule
         // BlobServiceClient is already Singleton — no thread-safety concerns.
         services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
 
+        services.Configure<FileDownloadOptions>(configuration.GetSection("FileStorage:Download"));
+
         return services;
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/DownloadResilienceService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/DownloadResilienceService.cs
@@ -14,10 +14,10 @@ public sealed class DownloadResilienceService : IDownloadResilienceService
 
     private readonly ILogger<DownloadResilienceService> _logger;
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ProductExportOptions _options;
+    private readonly FileDownloadOptions _options;
 
     public DownloadResilienceService(
-        IOptions<ProductExportOptions> options,
+        IOptions<FileDownloadOptions> options,
         IServiceScopeFactory scopeFactory,
         ILogger<DownloadResilienceService> logger)
     {
@@ -29,7 +29,7 @@ public sealed class DownloadResilienceService : IDownloadResilienceService
         if (worstCase >= MaxWallClock)
         {
             throw new InvalidOperationException(
-                $"ProductExportOptions: MaxRetryAttempts ({_options.MaxRetryAttempts}) * DownloadTimeout ({_options.DownloadTimeout}) " +
+                $"FileDownloadOptions: MaxRetryAttempts ({_options.MaxRetryAttempts}) * DownloadTimeout ({_options.DownloadTimeout}) " +
                 $"must be < 20 minutes; got worst-case {worstCase}.");
         }
     }

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
 using Anela.Heblo.Application.Features.FileStorage.UseCases.DownloadFromUrl;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Xcc.Telemetry;

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs
@@ -1,34 +1,8 @@
 namespace Anela.Heblo.Application.Features.FileStorage;
 
-/// <summary>
-/// Configuration options for product export functionality
-/// </summary>
 public class ProductExportOptions
 {
-    /// <summary>
-    /// The URL from which product export files will be downloaded
-    /// </summary>
     public string Url { get; set; } = null!;
 
-    public string ContainerName { get; set; }
-
-    /// <summary>
-    /// Timeout for the HTTP HEAD probe used to verify export availability.
-    /// </summary>
-    public TimeSpan HeadTimeout { get; set; } = TimeSpan.FromSeconds(10);
-
-    /// <summary>
-    /// Timeout for the full export file download.
-    /// </summary>
-    public TimeSpan DownloadTimeout { get; set; } = TimeSpan.FromSeconds(120);
-
-    /// <summary>
-    /// Maximum number of retry attempts for transient HTTP failures.
-    /// </summary>
-    public int MaxRetryAttempts { get; set; } = 3;
-
-    /// <summary>
-    /// Base delay for the exponential back-off retry policy.
-    /// </summary>
-    public TimeSpan RetryBaseDelay { get; set; } = TimeSpan.FromSeconds(2);
+    public string ContainerName { get; set; } = null!;
 }

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
@@ -35,7 +35,7 @@ public sealed class AzureBlobStorageService : IBlobStorageService
 
             // Download file from URL — resolve the named client per call so socket pooling
             // is managed by IHttpClientFactory (SocketsHttpHandler with PooledConnectionLifetime).
-            var httpClient = _httpClientFactory.CreateClient(FileStorageModule.ProductExportDownloadClientName);
+            var httpClient = _httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName);
             using var response = await httpClient.GetAsync(fileUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();
 

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs
@@ -92,7 +92,7 @@ public sealed class DownloadFromUrlHandler : IRequestHandler<DownloadFromUrlRequ
                         request.BlobName,
                         ct);
                 },
-                FileStorageModule.ProductExportDownloadClientName,
+                FileStorageModule.FileDownloadClientName,
                 cancellationToken);
 
             sw.Stop();
@@ -141,7 +141,7 @@ public sealed class DownloadFromUrlHandler : IRequestHandler<DownloadFromUrlRequ
         headCts.CancelAfter(_options.Value.HeadTimeout);
         try
         {
-            var client = _httpClientFactory.CreateClient(FileStorageModule.ProductExportDownloadClientName);
+            var client = _httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName);
             using var req = new HttpRequestMessage(HttpMethod.Head, fileUrl);
             using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, headCts.Token);
             if (resp.IsSuccessStatusCode && resp.Content.Headers.ContentLength.HasValue)

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs
@@ -18,14 +18,14 @@ public sealed class DownloadFromUrlHandler : IRequestHandler<DownloadFromUrlRequ
     private readonly IBlobStorageService _blobStorageService;
     private readonly IDownloadResilienceService _resilience;
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly IOptions<ProductExportOptions> _options;
+    private readonly IOptions<FileDownloadOptions> _options;
     private readonly ILogger<DownloadFromUrlHandler> _logger;
 
     public DownloadFromUrlHandler(
         IBlobStorageService blobStorageService,
         IDownloadResilienceService resilience,
         IHttpClientFactory httpClientFactory,
-        IOptions<ProductExportOptions> options,
+        IOptions<FileDownloadOptions> options,
         ILogger<DownloadFromUrlHandler> logger)
     {
         _blobStorageService = blobStorageService;

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs;
 using Anela.Heblo.Application.Features.FileStorage.UseCases.DownloadFromUrl;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Anela.Heblo.Application.Features.Catalog.Infrastructure;
 using Anela.Heblo.Xcc.Telemetry;
 using FluentAssertions;
 using Hangfire;
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 
-namespace Anela.Heblo.Tests.Features.FileStorage.Infrastructure.Jobs;
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure.Jobs;
 
 public sealed class ProductExportDownloadJobTests
 {
@@ -49,9 +49,6 @@ public sealed class ProductExportDownloadJobTests
         {
             Url = exportUrl,
             ContainerName = containerName,
-            MaxRetryAttempts = 3,
-            DownloadTimeout = TimeSpan.FromSeconds(30),
-            RetryBaseDelay = TimeSpan.FromSeconds(1),
         });
 
         return new ProductExportDownloadJob(

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
@@ -27,7 +27,7 @@ public class AzureBlobStorageServiceTests
         var httpClient = new HttpClient(_stubHandler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory = new Mock<IHttpClientFactory>();
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.ProductExportDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
             .Returns(httpClient);
 
         _service = new AzureBlobStorageService(
@@ -70,7 +70,7 @@ public class AzureBlobStorageServiceTests
 
         // Assert — factory must have been asked for the named client exactly once
         _mockHttpClientFactory.Verify(
-            f => f.CreateClient(FileStorageModule.ProductExportDownloadClientName),
+            f => f.CreateClient(FileStorageModule.FileDownloadClientName),
             Times.Once);
     }
 
@@ -82,7 +82,7 @@ public class AzureBlobStorageServiceTests
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
 
         var factory = new Mock<IHttpClientFactory>();
-        factory.Setup(f => f.CreateClient(FileStorageModule.ProductExportDownloadClientName))
+        factory.Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
                .Returns(client);
 
         var service = new AzureBlobStorageService(
@@ -182,7 +182,7 @@ public class AzureBlobStorageServiceTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, overrideContent: responseContent);
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.ProductExportDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
             .Returns(client);
 
         var expectedBlobUrl = $"https://testaccount.blob.core.windows.net/{containerName}/downloaded-file-guid{expectedExtension}";
@@ -421,7 +421,7 @@ public class AzureBlobStorageServiceTests
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
 
         var factory = new Mock<IHttpClientFactory>();
-        factory.Setup(f => f.CreateClient(FileStorageModule.ProductExportDownloadClientName))
+        factory.Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
                .Returns(client);
 
         var service = new AzureBlobStorageService(

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/FileDownloadOptionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/FileDownloadOptionsTests.cs
@@ -4,13 +4,13 @@ using Microsoft.Extensions.Configuration;
 
 namespace Anela.Heblo.Tests.Features.FileStorage.Configuration;
 
-public sealed class ProductExportOptionsTests
+public sealed class FileDownloadOptionsTests
 {
     [Fact]
     public void Defaults_HeadTimeout_Is10Seconds()
     {
         // Arrange / Act
-        var options = new ProductExportOptions();
+        var options = new FileDownloadOptions();
 
         // Assert
         options.HeadTimeout.Should().Be(TimeSpan.FromSeconds(10));
@@ -20,7 +20,7 @@ public sealed class ProductExportOptionsTests
     public void Defaults_DownloadTimeout_Is120Seconds()
     {
         // Arrange / Act
-        var options = new ProductExportOptions();
+        var options = new FileDownloadOptions();
 
         // Assert
         options.DownloadTimeout.Should().Be(TimeSpan.FromSeconds(120));
@@ -30,7 +30,7 @@ public sealed class ProductExportOptionsTests
     public void Defaults_MaxRetryAttempts_Is3()
     {
         // Arrange / Act
-        var options = new ProductExportOptions();
+        var options = new FileDownloadOptions();
 
         // Assert
         options.MaxRetryAttempts.Should().Be(3);
@@ -40,7 +40,7 @@ public sealed class ProductExportOptionsTests
     public void Defaults_RetryBaseDelay_Is2Seconds()
     {
         // Arrange / Act
-        var options = new ProductExportOptions();
+        var options = new FileDownloadOptions();
 
         // Assert
         options.RetryBaseDelay.Should().Be(TimeSpan.FromSeconds(2));
@@ -58,7 +58,7 @@ public sealed class ProductExportOptionsTests
             .Build();
 
         // Act
-        var options = configuration.Get<ProductExportOptions>()!;
+        var options = configuration.Get<FileDownloadOptions>()!;
 
         // Assert
         options.HeadTimeout.Should().Be(TimeSpan.FromSeconds(30));
@@ -76,7 +76,7 @@ public sealed class ProductExportOptionsTests
             .Build();
 
         // Act
-        var options = configuration.Get<ProductExportOptions>()!;
+        var options = configuration.Get<FileDownloadOptions>()!;
 
         // Assert
         options.MaxRetryAttempts.Should().Be(5);

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs
@@ -70,7 +70,7 @@ public class DownloadFromUrlHandlerTests
         var client = new HttpClient(handler);
         var factory = new Mock<IHttpClientFactory>();
         factory
-            .Setup(f => f.CreateClient(FileStorageModule.ProductExportDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
             .Returns(client);
         return factory;
     }
@@ -279,7 +279,7 @@ public class DownloadFromUrlHandlerTests
         _resilience.Verify(
             r => r.ExecuteWithResilienceAsync(
                 It.IsAny<Func<CancellationToken, Task<string>>>(),
-                FileStorageModule.ProductExportDownloadClientName,
+                FileStorageModule.FileDownloadClientName,
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs
@@ -26,14 +26,14 @@ public class DownloadFromUrlHandlerTests
     private readonly Mock<IDownloadResilienceService> _resilience;
     private Mock<IHttpClientFactory> _headFactory;
     private readonly Mock<ILogger<DownloadFromUrlHandler>> _logger;
-    private readonly IOptions<ProductExportOptions> _options;
+    private readonly IOptions<FileDownloadOptions> _options;
 
     public DownloadFromUrlHandlerTests()
     {
         _blobStorage = new Mock<IBlobStorageService>();
         _resilience = new Mock<IDownloadResilienceService>();
         _logger = new Mock<ILogger<DownloadFromUrlHandler>>();
-        _options = Options.Create(new ProductExportOptions
+        _options = Options.Create(new FileDownloadOptions
         {
             HeadTimeout = TimeSpan.FromSeconds(5),
         });

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
@@ -18,7 +18,7 @@ public class FileStorageModuleTests
         var services = new ServiceCollection();
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddSingleton(Mock.Of<ITelemetryService>());
-        services.Configure<ProductExportOptions>(opts =>
+        services.Configure<FileDownloadOptions>(opts =>
         {
             opts.MaxRetryAttempts = 3;
             opts.DownloadTimeout = TimeSpan.FromSeconds(120);

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
@@ -61,7 +61,7 @@ public class FileStorageModuleTests
     }
 
     [Fact]
-    public void AddFileStorageModule_RegistersNamedHttpClient_ProductExportDownload()
+    public void AddFileStorageModule_RegistersNamedHttpClient_FileDownload()
     {
         // Arrange
         var services = BuildBaseServices();
@@ -70,7 +70,7 @@ public class FileStorageModuleTests
 
         // Act
         var factory = provider.GetRequiredService<IHttpClientFactory>();
-        var client = factory.CreateClient(FileStorageModule.ProductExportDownloadClientName);
+        var client = factory.CreateClient(FileStorageModule.FileDownloadClientName);
 
         // Assert — named client is registered and timeout is infinite (per-call CTS enforces timeout)
         Assert.NotNull(client);
@@ -117,6 +117,6 @@ public class FileStorageModuleTests
     public void AddFileStorageModule_NamedClient_ConstantIsExported()
     {
         // Assert — the constant must be stable so all consumers reference the same string
-        Assert.Equal("ProductExportDownload", FileStorageModule.ProductExportDownloadClientName);
+        Assert.Equal("FileDownload", FileStorageModule.FileDownloadClientName);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/DownloadResilienceServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/DownloadResilienceServiceTests.cs
@@ -13,12 +13,12 @@ namespace Anela.Heblo.Tests.Features.FileStorage.Infrastructure;
 
 public sealed class DownloadResilienceServiceTests
 {
-    private static IOptions<ProductExportOptions> CreateOptions(
+    private static IOptions<FileDownloadOptions> CreateOptions(
         int maxRetryAttempts = 3,
         TimeSpan? downloadTimeout = null,
         TimeSpan? retryBaseDelay = null)
     {
-        var options = new ProductExportOptions
+        var options = new FileDownloadOptions
         {
             MaxRetryAttempts = maxRetryAttempts,
             DownloadTimeout = downloadTimeout ?? TimeSpan.FromSeconds(120),
@@ -30,7 +30,7 @@ public sealed class DownloadResilienceServiceTests
     // Returns (service, telemetryMock) so tests can configure the mock after creation.
     // ITelemetryService is Scoped in production; the scope factory pattern mirrors that here.
     private static (DownloadResilienceService Service, Mock<ITelemetryService> Telemetry) CreateService(
-        IOptions<ProductExportOptions> options,
+        IOptions<FileDownloadOptions> options,
         Mock<ILogger<DownloadResilienceService>>? loggerMock = null)
     {
         var telemetryMock = new Mock<ITelemetryService>();

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
@@ -8,7 +8,7 @@ using Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs;
 using Anela.Heblo.Application.Features.FileStorage.UseCases.DownloadFromUrl;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Anela.Heblo.Application.Features.FileStorage;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
 using Anela.Heblo.Xcc.Telemetry;
 using FluentAssertions;
 using Hangfire;

--- a/docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md
+++ b/docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md
@@ -1,0 +1,1552 @@
+# Relocate ProductExportDownloadJob from FileStorage to Catalog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `ProductExportDownloadJob` and its product-export-specific options out of `Features/FileStorage` (generic blob transport) and into `Features/Catalog` (product-export domain owner), restoring SRP for FileStorage without changing runtime behavior.
+
+**Architecture:** Split the current `ProductExportOptions` into two: a Catalog-owned `ProductExportOptions` carrying only domain config (`Url`, `ContainerName`) and a new FileStorage-owned `FileDownloadOptions` carrying generic download tuning (`HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay`). Rename FileStorage's named HttpClient constant from product-export terminology to neutral terminology. The job, the slimmed options class, and the DI registration of those options all move to the Catalog module; `IRecurringJob` auto-discovery (assembly scan in `ServiceCollectionExtensions.AddRecurringJobs`) picks the job up in its new location with no explicit registration needed.
+
+**Tech Stack:** .NET 8, MediatR, Hangfire (PostgreSQL storage), Polly v8 (resilience pipeline), `IOptions<T>` pattern, xUnit + FluentAssertions + Moq.
+
+---
+
+## File Structure (after this plan)
+
+**New files**
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/FileDownloadOptions.cs` — generic download-tuning options (timeouts, retry).
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs` — domain options (`Url`, `ContainerName`) for the Shoptet product-export job.
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs` — moved verbatim from FileStorage (namespace + using directives only).
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/FileDownloadOptionsTests.cs` — replaces the obsolete `ProductExportOptionsTests` (defaults + config binding for the four timeout/retry properties).
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs` — moved verbatim from FileStorage tests (namespace + using directives only).
+
+**Modified files**
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs` — rename `ProductExportDownloadClientName` → `FileDownloadClientName`, add `Configure<FileDownloadOptions>(…)`.
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs` — inject `IOptions<FileDownloadOptions>` and use new constant name.
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs` — use new constant name only.
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/DownloadResilienceService.cs` — inject `IOptions<FileDownloadOptions>`; update validation error message.
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — bind `ProductExportOptions` from `configuration.GetSection("ProductExportOptions")`.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — remove the `Configure<ProductExportOptions>(…)` line and the now-unused `using Anela.Heblo.Application.Features.FileStorage;` import.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs` — switch options Configure to `FileDownloadOptions`, update constant name + value.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs` — update constant name in CreateClient setups.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs` — switch field type to `IOptions<FileDownloadOptions>`, update constant name in factory setup.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/DownloadResilienceServiceTests.cs` — switch `CreateOptions` to return `IOptions<FileDownloadOptions>`.
+
+**Deleted files**
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs` (relocated)
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs` (relocated)
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/ProductExportOptionsTests.cs` (content split between FileDownloadOptionsTests and the relocated Catalog job tests; no remaining assertions for the slimmed ProductExportOptions are warranted).
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs` (relocated)
+
+**Configuration**
+- `backend/src/Anela.Heblo.API/appsettings.json` — `"ProductExportOptions"` section unchanged (already neutral, no rename needed). No new section required for `FileDownloadOptions` because the class-level defaults (10 s HEAD, 120 s download, 3 retries, 2 s base delay) match the values currently in code; if env-specific overrides are ever needed, callers may add `"FileStorage": { "Download": { ... } }`.
+
+---
+
+## Conventions and Invariants (read once before starting)
+
+- **Catalog → FileStorage direction only.** Catalog depends on `IBlobStorageService` and MediatR contracts owned by FileStorage. FileStorage MUST NOT reference any `Catalog` namespace after this plan.
+- **Hangfire job identity.** `ProductExportDownloadJob.Metadata.JobName = "product-export-download"` is the Hangfire recurring-job key; do **not** change it. The `ILogger<T>` category name *will* change with the namespace move (`...FileStorage.Infrastructure.Jobs.ProductExportDownloadJob` → `...Catalog.Infrastructure.Jobs.ProductExportDownloadJob`); this is accepted per the spec.
+- **Auto-discovery.** `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` line 373–392 (`AddRecurringJobs`) scans the Application assembly for `IRecurringJob` implementations and registers them. No explicit job registration exists or needs to exist — the job is picked up by type, not location.
+- **Configuration section unchanged.** `"ProductExportOptions"` already lives at the root of `appsettings.json` (line 158), not under `"FileStorage"`. No appsettings rename, no Key Vault migration.
+- **DTO rule.** Both `ProductExportOptions` and `FileDownloadOptions` are options classes consumed by `IOptions<T>` binding; they remain `class` types with mutable `public set;` properties (the binder requires writable setters). They are not crossed by the OpenAPI client generator, so the project-specific "DTOs must be classes" rule does not bite here either way.
+- **Commit cadence.** Commit at the end of every task. Each task is shaped so the solution builds and all tests pass at task end. Conventional commit prefix: `refactor:` for the moves, `test:` for test-only changes inside a single task.
+- **Working directory.** All paths below are absolute under the worktree root `/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-filestorage-productexportdow/`. Bash commands assume this is the current directory.
+
+---
+
+### Task 1: Create `FileDownloadOptions` in FileStorage
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/FileStorage/FileDownloadOptions.cs`
+
+- [ ] **Step 1: Create the new options class**
+
+Create the file with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.FileStorage;
+
+/// <summary>
+/// Generic configuration for the FileStorage download pipeline (HEAD probe, retry, timeout).
+/// Domain-specific download targets (URL, container) live in their owning module.
+/// </summary>
+public class FileDownloadOptions
+{
+    /// <summary>
+    /// Timeout for the HTTP HEAD probe used to verify file availability before download.
+    /// </summary>
+    public TimeSpan HeadTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Timeout for the full file download.
+    /// </summary>
+    public TimeSpan DownloadTimeout { get; set; } = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// Maximum number of retry attempts for transient HTTP failures.
+    /// </summary>
+    public int MaxRetryAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Base delay for the exponential back-off retry policy.
+    /// </summary>
+    public TimeSpan RetryBaseDelay { get; set; } = TimeSpan.FromSeconds(2);
+}
+```
+
+- [ ] **Step 2: Verify the solution still builds**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds with zero new warnings or errors. The new class is unused for now; that is intentional.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/FileStorage/FileDownloadOptions.cs
+git commit -m "refactor: introduce FileDownloadOptions in FileStorage"
+```
+
+---
+
+### Task 2: Register `FileDownloadOptions` in `FileStorageModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`
+
+- [ ] **Step 1: Add the options binding inside `AddFileStorageModule`**
+
+In `FileStorageModule.cs`, locate the `AddFileStorageModule` method. Immediately before the final `return services;` (currently around line 58), insert:
+
+```csharp
+        // Bind generic download tuning options. Defaults are correct production values;
+        // callers may override under "FileStorage:Download" if env-specific tuning is needed.
+        services.Configure<FileDownloadOptions>(configuration.GetSection("FileStorage:Download"));
+```
+
+After the change, the closing region of the method should read:
+
+```csharp
+        // Register blob storage service as Singleton so the _containerExists cache survives across requests.
+        // BlobServiceClient is already Singleton — no thread-safety concerns.
+        services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
+
+        // Bind generic download tuning options. Defaults are correct production values;
+        // callers may override under "FileStorage:Download" if env-specific tuning is needed.
+        services.Configure<FileDownloadOptions>(configuration.GetSection("FileStorage:Download"));
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
+git commit -m "refactor: register FileDownloadOptions in FileStorageModule"
+```
+
+---
+
+### Task 3: Migrate `DownloadFromUrlHandler` to use `FileDownloadOptions`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs`
+
+- [ ] **Step 1: Update the handler's field type**
+
+In `DownloadFromUrlHandler.cs` line 21, change:
+
+```csharp
+    private readonly IOptions<ProductExportOptions> _options;
+```
+
+to:
+
+```csharp
+    private readonly IOptions<FileDownloadOptions> _options;
+```
+
+- [ ] **Step 2: Update the handler's constructor parameter**
+
+In `DownloadFromUrlHandler.cs` line 28, change:
+
+```csharp
+        IOptions<ProductExportOptions> options,
+```
+
+to:
+
+```csharp
+        IOptions<FileDownloadOptions> options,
+```
+
+No other code in the handler changes — `_options.Value.HeadTimeout` at line 141 references a property name that exists identically on the new type.
+
+- [ ] **Step 3: Update the handler test field type**
+
+In `DownloadFromUrlHandlerTests.cs` line 29, change:
+
+```csharp
+    private readonly IOptions<ProductExportOptions> _options;
+```
+
+to:
+
+```csharp
+    private readonly IOptions<FileDownloadOptions> _options;
+```
+
+- [ ] **Step 4: Update the constructor initialization in the test**
+
+In `DownloadFromUrlHandlerTests.cs` lines 36–39, change:
+
+```csharp
+        _options = Options.Create(new ProductExportOptions
+        {
+            HeadTimeout = TimeSpan.FromSeconds(5),
+        });
+```
+
+to:
+
+```csharp
+        _options = Options.Create(new FileDownloadOptions
+        {
+            HeadTimeout = TimeSpan.FromSeconds(5),
+        });
+```
+
+- [ ] **Step 5: Run the handler tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~DownloadFromUrlHandlerTests`
+Expected: all DownloadFromUrlHandler tests pass.
+
+- [ ] **Step 6: Full build to check for collateral damage**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds. (Other consumers of `ProductExportOptions` — DownloadResilienceService, the job, the module test — still compile because `ProductExportOptions` still has all six properties; they are migrated in later tasks.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs
+git commit -m "refactor: switch DownloadFromUrlHandler to FileDownloadOptions"
+```
+
+---
+
+### Task 4: Migrate `DownloadResilienceService` to use `FileDownloadOptions`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/DownloadResilienceService.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/DownloadResilienceServiceTests.cs`
+
+- [ ] **Step 1: Update the service field type**
+
+In `DownloadResilienceService.cs` line 17, change:
+
+```csharp
+    private readonly ProductExportOptions _options;
+```
+
+to:
+
+```csharp
+    private readonly FileDownloadOptions _options;
+```
+
+- [ ] **Step 2: Update the constructor parameter type**
+
+In `DownloadResilienceService.cs` line 20, change:
+
+```csharp
+        IOptions<ProductExportOptions> options,
+```
+
+to:
+
+```csharp
+        IOptions<FileDownloadOptions> options,
+```
+
+- [ ] **Step 3: Update the validation error message to reference the new type name**
+
+In `DownloadResilienceService.cs` line 32, change:
+
+```csharp
+                $"ProductExportOptions: MaxRetryAttempts ({_options.MaxRetryAttempts}) * DownloadTimeout ({_options.DownloadTimeout}) " +
+```
+
+to:
+
+```csharp
+                $"FileDownloadOptions: MaxRetryAttempts ({_options.MaxRetryAttempts}) * DownloadTimeout ({_options.DownloadTimeout}) " +
+```
+
+- [ ] **Step 4: Update the resilience service test helper return type**
+
+In `DownloadResilienceServiceTests.cs` line 16, change:
+
+```csharp
+    private static IOptions<ProductExportOptions> CreateOptions(
+```
+
+to:
+
+```csharp
+    private static IOptions<FileDownloadOptions> CreateOptions(
+```
+
+- [ ] **Step 5: Update the resilience service test helper body type**
+
+In `DownloadResilienceServiceTests.cs` line 21, change:
+
+```csharp
+        var options = new ProductExportOptions
+```
+
+to:
+
+```csharp
+        var options = new FileDownloadOptions
+```
+
+- [ ] **Step 6: Update the CreateService helper parameter type**
+
+In `DownloadResilienceServiceTests.cs` line 33, change:
+
+```csharp
+        IOptions<ProductExportOptions> options,
+```
+
+to:
+
+```csharp
+        IOptions<FileDownloadOptions> options,
+```
+
+- [ ] **Step 7: Run the resilience tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~DownloadResilienceServiceTests`
+Expected: all DownloadResilienceService tests pass.
+
+- [ ] **Step 8: Full build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/DownloadResilienceService.cs backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/DownloadResilienceServiceTests.cs
+git commit -m "refactor: switch DownloadResilienceService to FileDownloadOptions"
+```
+
+---
+
+### Task 5: Replace `ProductExportOptionsTests` with `FileDownloadOptionsTests`
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/FileDownloadOptionsTests.cs`
+- Delete: `backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/ProductExportOptionsTests.cs`
+
+The current `ProductExportOptionsTests.cs` only asserts defaults and config binding for the four properties (`HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay`) that have moved to `FileDownloadOptions`. The slimmed `ProductExportOptions` will carry no defaults worth asserting, so no replacement test for it is added here.
+
+- [ ] **Step 1: Create the new test file**
+
+Create the file with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.FileStorage;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+
+namespace Anela.Heblo.Tests.Features.FileStorage.Configuration;
+
+public sealed class FileDownloadOptionsTests
+{
+    [Fact]
+    public void Defaults_HeadTimeout_Is10Seconds()
+    {
+        // Arrange / Act
+        var options = new FileDownloadOptions();
+
+        // Assert
+        options.HeadTimeout.Should().Be(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public void Defaults_DownloadTimeout_Is120Seconds()
+    {
+        // Arrange / Act
+        var options = new FileDownloadOptions();
+
+        // Assert
+        options.DownloadTimeout.Should().Be(TimeSpan.FromSeconds(120));
+    }
+
+    [Fact]
+    public void Defaults_MaxRetryAttempts_Is3()
+    {
+        // Arrange / Act
+        var options = new FileDownloadOptions();
+
+        // Assert
+        options.MaxRetryAttempts.Should().Be(3);
+    }
+
+    [Fact]
+    public void Defaults_RetryBaseDelay_Is2Seconds()
+    {
+        // Arrange / Act
+        var options = new FileDownloadOptions();
+
+        // Assert
+        options.RetryBaseDelay.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void Configuration_BindsTimeSpanFromString()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "HeadTimeout", "00:00:30" },
+            })
+            .Build();
+
+        // Act
+        var options = configuration.Get<FileDownloadOptions>()!;
+
+        // Assert
+        options.HeadTimeout.Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public void Configuration_BindsMaxRetryAttempts_FromInteger()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "MaxRetryAttempts", "5" },
+            })
+            .Build();
+
+        // Act
+        var options = configuration.Get<FileDownloadOptions>()!;
+
+        // Assert
+        options.MaxRetryAttempts.Should().Be(5);
+    }
+}
+```
+
+- [ ] **Step 2: Delete the obsolete test file**
+
+```bash
+git rm backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/ProductExportOptionsTests.cs
+```
+
+- [ ] **Step 3: Run the new test class**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~FileDownloadOptionsTests`
+Expected: 6 tests pass.
+
+- [ ] **Step 4: Full build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds. (`ProductExportOptions` still has the timeout/retry properties — they are no longer referenced by handler/resilience code but compile fine; they are removed in the next task.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/FileStorage/Configuration/FileDownloadOptionsTests.cs
+git commit -m "test: replace ProductExportOptionsTests with FileDownloadOptionsTests"
+```
+
+---
+
+### Task 6: Trim `ProductExportOptions` to `Url` + `ContainerName` only
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs`
+
+- [ ] **Step 1: Replace the class body**
+
+Overwrite `ProductExportOptions.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.FileStorage;
+
+/// <summary>
+/// Configuration options for the Shoptet product-export download job.
+/// Lives in the FileStorage namespace temporarily; relocated to Catalog in a later task.
+/// </summary>
+public class ProductExportOptions
+{
+    /// <summary>
+    /// The URL from which product export files will be downloaded.
+    /// </summary>
+    public string Url { get; set; } = null!;
+
+    /// <summary>
+    /// Target blob container for the exported CSV.
+    /// </summary>
+    public string ContainerName { get; set; } = null!;
+}
+```
+
+Note: `ContainerName` becomes non-nullable to match the property contract (the job reads it without null-checking). The current file leaves it un-initialized; adding `= null!` matches the `Url` style and silences nullable-reference warnings without changing runtime behavior.
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds. The only consumers of the trimmed type at this point are:
+- `ProductExportDownloadJob` — reads `Url` and `ContainerName` (still on the class).
+- `ServiceCollectionExtensions.cs` line 365 — binds the options from configuration (binder only uses the properties that exist; absent timeout/retry keys are ignored).
+- `FileStorageModuleTests.cs` lines 21–26 — calls `services.Configure<ProductExportOptions>(opts => { opts.MaxRetryAttempts = …; … })`; this will now fail to compile.
+
+If `FileStorageModuleTests.cs` does not compile, that is expected and is fixed in Task 7.
+
+- [ ] **Step 3: Don't commit yet — Task 7 finishes this slice**
+
+Hold the working tree as-is and proceed to Task 7. (If you must commit for any reason, use `git commit --allow-empty-message -m "wip"` and rebase later; otherwise carry the broken build into Task 7 which restores green.)
+
+---
+
+### Task 7: Repair `FileStorageModuleTests` after the options split
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs`
+
+The test fixture currently pre-configures the four timeout/retry properties on `ProductExportOptions` so `DownloadResilienceService` can construct without throwing. Those properties now live on `FileDownloadOptions`.
+
+- [ ] **Step 1: Switch the base-services Configure block to `FileDownloadOptions`**
+
+In `FileStorageModuleTests.cs` lines 21–26, change:
+
+```csharp
+        services.Configure<ProductExportOptions>(opts =>
+        {
+            opts.MaxRetryAttempts = 3;
+            opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+            opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+        });
+```
+
+to:
+
+```csharp
+        services.Configure<FileDownloadOptions>(opts =>
+        {
+            opts.MaxRetryAttempts = 3;
+            opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+            opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+        });
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 3: Run the file-storage module tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~FileStorageModuleTests`
+Expected: all 6 tests pass.
+
+- [ ] **Step 4: Run the full backend test suite to confirm no regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit (covers Task 6 + Task 7 together)**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
+git commit -m "refactor: trim ProductExportOptions to domain properties only"
+```
+
+---
+
+### Task 8: Rename `ProductExportDownloadClientName` → `FileDownloadClientName`
+
+The named HttpClient that FileStorage registers is generic — it configures `SocketsHttpHandler` + `PooledConnectionLifetime` + `AutomaticDecompression` and is used by `DownloadFromUrlHandler` (HEAD probe) and `AzureBlobStorageService` (download). Its name should match its purpose.
+
+**Files (all reference the constant):**
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/UseCases/DownloadFromUrl/DownloadFromUrlHandler.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs`
+
+- [ ] **Step 1: Rename the constant in `FileStorageModule.cs`**
+
+Line 13 currently reads:
+
+```csharp
+    public const string ProductExportDownloadClientName = "ProductExportDownload";
+```
+
+Change to:
+
+```csharp
+    public const string FileDownloadClientName = "FileDownload";
+```
+
+Then line 35 currently reads:
+
+```csharp
+        services.AddHttpClient(ProductExportDownloadClientName)
+```
+
+Change to:
+
+```csharp
+        services.AddHttpClient(FileDownloadClientName)
+```
+
+- [ ] **Step 2: Update `DownloadFromUrlHandler.cs`**
+
+Line 95:
+
+```csharp
+                FileStorageModule.ProductExportDownloadClientName,
+```
+
+→
+
+```csharp
+                FileStorageModule.FileDownloadClientName,
+```
+
+Line 144:
+
+```csharp
+            var client = _httpClientFactory.CreateClient(FileStorageModule.ProductExportDownloadClientName);
+```
+
+→
+
+```csharp
+            var client = _httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName);
+```
+
+- [ ] **Step 3: Update `AzureBlobStorageService.cs`**
+
+Line 38:
+
+```csharp
+            var httpClient = _httpClientFactory.CreateClient(FileStorageModule.ProductExportDownloadClientName);
+```
+
+→
+
+```csharp
+            var httpClient = _httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName);
+```
+
+- [ ] **Step 4: Update `FileStorageModuleTests.cs`**
+
+Line 73:
+
+```csharp
+        var client = factory.CreateClient(FileStorageModule.ProductExportDownloadClientName);
+```
+
+→
+
+```csharp
+        var client = factory.CreateClient(FileStorageModule.FileDownloadClientName);
+```
+
+Also rename the surrounding test method on line 64 from `AddFileStorageModule_RegistersNamedHttpClient_ProductExportDownload` to `AddFileStorageModule_RegistersNamedHttpClient_FileDownload` so the test name reflects what it tests.
+
+Line 120:
+
+```csharp
+        Assert.Equal("ProductExportDownload", FileStorageModule.ProductExportDownloadClientName);
+```
+
+→
+
+```csharp
+        Assert.Equal("FileDownload", FileStorageModule.FileDownloadClientName);
+```
+
+- [ ] **Step 5: Update `AzureBlobStorageServiceTests.cs`**
+
+Three call sites use `FileStorageModule.ProductExportDownloadClientName` (lines 30, 73, 85, 184, 424 — search and replace all occurrences). Run a verification grep before editing:
+
+```bash
+grep -n "ProductExportDownloadClientName" backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
+```
+
+Then replace every `FileStorageModule.ProductExportDownloadClientName` with `FileStorageModule.FileDownloadClientName` in this file.
+
+- [ ] **Step 6: Update `DownloadFromUrlHandlerTests.cs`**
+
+Line 73:
+
+```csharp
+            .Setup(f => f.CreateClient(FileStorageModule.ProductExportDownloadClientName))
+```
+
+→
+
+```csharp
+            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+```
+
+Line 282:
+
+```csharp
+                FileStorageModule.ProductExportDownloadClientName,
+```
+
+→
+
+```csharp
+                FileStorageModule.FileDownloadClientName,
+```
+
+- [ ] **Step 7: Verify nothing else references the old constant**
+
+```bash
+grep -rn "ProductExportDownloadClientName\|\"ProductExportDownload\"" backend/src backend/test
+```
+
+Expected: no results.
+
+- [ ] **Step 8: Build + test**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds; all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/FileStorage backend/test/Anela.Heblo.Tests/Features/FileStorage
+git commit -m "refactor: rename ProductExportDownloadClientName to FileDownloadClientName"
+```
+
+---
+
+### Task 9: Relocate `ProductExportOptions` to the Catalog namespace
+
+**Files:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs` (add `using` for new namespace — the file is moved in Task 11; here we only update the import so the build stays green while the job is still in FileStorage)
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (replace the old import with the new namespace)
+
+- [ ] **Step 1: Create the relocated options class**
+
+Create `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+/// <summary>
+/// Configuration options for the Shoptet product-export download job.
+/// </summary>
+public class ProductExportOptions
+{
+    /// <summary>
+    /// The URL from which product export files will be downloaded.
+    /// </summary>
+    public string Url { get; set; } = null!;
+
+    /// <summary>
+    /// Target blob container for the exported CSV.
+    /// </summary>
+    public string ContainerName { get; set; } = null!;
+}
+```
+
+- [ ] **Step 2: Delete the FileStorage copy**
+
+```bash
+git rm backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs
+```
+
+- [ ] **Step 3: Update the job's `using` directive**
+
+In `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs`, remove the implicit reference to the old namespace by adding an explicit `using` for the new one. The job currently resolves `ProductExportOptions` because it shares the namespace `Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs` (which sees `Anela.Heblo.Application.Features.FileStorage.ProductExportOptions` via the outer namespace). After Step 2 that resolution is gone.
+
+At the top of the file, add this `using` (alongside the existing imports — keep them sorted):
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+```
+
+The job's class body is unchanged — `ProductExportOptions` now resolves to the Catalog namespace.
+
+- [ ] **Step 4: Update `ServiceCollectionExtensions.cs`**
+
+Line 28 currently reads:
+
+```csharp
+using Anela.Heblo.Application.Features.FileStorage;
+```
+
+This import is used only for `ProductExportOptions` at line 365. Replace it with:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+```
+
+Verify the import is not needed for anything else in the file:
+
+```bash
+grep -n "FileStorage" backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+```
+
+Expected: only the (now-changed) `using` line and unrelated `Anela.Heblo.Adapters.FileSystem` should appear. If any other `FileStorage` symbol is referenced, leave the original `using` in place and add the new one alongside it instead of replacing.
+
+- [ ] **Step 5: Build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds. The DI registration on line 365 (`services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"))`) now binds the Catalog-namespaced class — the binder is type-driven, the configuration section path is unchanged, runtime behavior is identical.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all tests pass. `ProductExportDownloadJobTests.cs` still lives in the FileStorage test folder; its `using Anela.Heblo.Application.Features.FileStorage;` directive (line 11) needs to resolve `ProductExportOptions` from somewhere. **Check**: that line will no longer find `ProductExportOptions`. Update the test file's imports now: change line 11 from
+
+```csharp
+using Anela.Heblo.Application.Features.FileStorage;
+```
+
+to
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+```
+
+Re-run `dotnet test`. Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
+git rm --cached backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs 2>/dev/null || true
+git commit -m "refactor: relocate ProductExportOptions to Catalog namespace"
+```
+
+---
+
+### Task 10: Move DI registration of `ProductExportOptions` to `CatalogModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+Catalog owns the options class; Catalog should own its DI registration. Today that registration lives inside `AddHangfireServices` in the API layer (line 365), which is a pure historical accident.
+
+- [ ] **Step 1: Add a `using` import for the Catalog Infrastructure namespace in `CatalogModule.cs`**
+
+If `CatalogModule.cs` does not already have it, add at the top alongside other `Anela.Heblo.Application.Features.Catalog.Infrastructure` imports:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+```
+
+(The file already imports `Anela.Heblo.Application.Features.Catalog.Infrastructure` for other types — verify with a quick grep:
+
+```bash
+grep -n "Features.Catalog.Infrastructure" backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+```
+
+If a `using` line already covers the namespace, skip this step.)
+
+- [ ] **Step 2: Add the `Configure<ProductExportOptions>` binding inside `AddCatalogModule`**
+
+In `CatalogModule.cs`, locate the configuration block around lines 102–112 (where `DataSourceOptions` and `CatalogCacheOptions` are bound). Immediately after `services.Configure<CatalogCacheOptions>(...)`, add:
+
+```csharp
+        // Configure product-export job options (URL + container) from configuration.
+        // Section path "ProductExportOptions" preserved for backward compatibility with
+        // existing Key Vault secrets and appsettings entries.
+        services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+- [ ] **Step 3: Remove the old registration from `ServiceCollectionExtensions.cs`**
+
+Line 365 currently reads:
+
+```csharp
+        services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+Delete this line. Then re-evaluate whether the `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` import added in Task 9 Step 4 is still needed:
+
+```bash
+grep -n "ProductExportOptions\|Catalog.Infrastructure" backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+```
+
+Expected: no references remain. If so, delete the `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` line. If anything else still uses it, leave it.
+
+- [ ] **Step 4: Build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+git commit -m "refactor: move ProductExportOptions DI registration to CatalogModule"
+```
+
+---
+
+### Task 11: Relocate `ProductExportDownloadJob.cs` to the Catalog namespace
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs`
+- Delete: `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs`
+
+- [ ] **Step 1: Create the new file at the Catalog location**
+
+Create `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs` with the following content. The class body is byte-for-byte identical to the FileStorage version; only the namespace declaration changes, and the redundant `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` added in Task 9 is dropped (now implicit via the new namespace):
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.FileStorage.UseCases.DownloadFromUrl;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Xcc.Telemetry;
+using Hangfire;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs;
+
+[AutomaticRetry(Attempts = 0)]
+public sealed class ProductExportDownloadJob : IRecurringJob
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<ProductExportDownloadJob> _logger;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ITelemetryService _telemetryService;
+    private readonly IOptions<ProductExportOptions> _productExportOptions;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "product-export-download",
+        DisplayName = "Product Export Download",
+        Description = "Downloads product export data from external systems",
+        CronExpression = "0 2 * * *",
+        DefaultIsEnabled = true
+    };
+
+    public ProductExportDownloadJob(
+        IMediator mediator,
+        ILogger<ProductExportDownloadJob> logger,
+        IRecurringJobStatusChecker statusChecker,
+        ITelemetryService telemetryService,
+        IOptions<ProductExportOptions> productExportOptions)
+    {
+        _mediator = mediator;
+        _logger = logger;
+        _statusChecker = statusChecker;
+        _telemetryService = telemetryService;
+        _productExportOptions = productExportOptions;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping execution.", Metadata.JobName);
+            _telemetryService.TrackBusinessEvent("ProductExportDownload", new Dictionary<string, string>
+            {
+                ["Status"] = "Skipped",
+            });
+            return;
+        }
+
+        var exportUrl = _productExportOptions.Value.Url;
+        if (string.IsNullOrEmpty(exportUrl))
+        {
+            throw new InvalidOperationException("Product export URL is not configured");
+        }
+
+        var timestamp = DateTime.UtcNow;
+        var fileName = $"products_{timestamp:yy_MM_dd_HH_mm}.csv";
+
+        _logger.LogInformation(
+            "Starting {JobName} at {Timestamp}. Downloading from {Url} as {FileName}",
+            Metadata.JobName, timestamp, exportUrl, fileName);
+
+        var sw = Stopwatch.StartNew();
+        DownloadFromUrlResponse? response = null;
+
+        try
+        {
+            response = await _mediator.Send(new DownloadFromUrlRequest
+            {
+                FileUrl = exportUrl,
+                ContainerName = _productExportOptions.Value.ContainerName,
+                BlobName = fileName,
+            }, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            sw.Stop();
+            _logger.LogInformation("Job {JobName} was cancelled.", Metadata.JobName);
+            _telemetryService.TrackBusinessEvent("ProductExportDownload", new Dictionary<string, string>
+            {
+                ["Status"] = "Cancelled",
+                ["ElapsedMs"] = sw.ElapsedMilliseconds.ToString(),
+            });
+            throw;
+        }
+
+        sw.Stop();
+        var elapsedMs = sw.ElapsedMilliseconds.ToString();
+        var attemptCount = response?.Params != null && response.Params.TryGetValue("attemptCount", out var ac)
+            ? ac
+            : "1";
+
+        if (response is { Success: true })
+        {
+            _logger.LogInformation(
+                "{JobName} completed successfully. File: {FileName}, Blob: {BlobUrl}, Size: {Size}",
+                Metadata.JobName, response.BlobName, response.BlobUrl, response.FileSizeBytes);
+
+            _telemetryService.TrackBusinessEvent("ProductExportDownload", new Dictionary<string, string>
+            {
+                ["Status"] = "Success",
+                ["AttemptCount"] = attemptCount,
+                ["ElapsedMs"] = elapsedMs,
+                ["FileName"] = fileName,
+                ["BlobUrl"] = response.BlobUrl ?? string.Empty,
+                ["FileSize"] = response.FileSizeBytes.ToString(),
+            });
+            return;
+        }
+
+        // Failure path
+        _logger.LogError(
+            "{JobName} failed. ErrorCode: {ErrorCode}, Params: {Params}",
+            Metadata.JobName, response?.ErrorCode, response?.FullError());
+
+        var props = new Dictionary<string, string>
+        {
+            ["Status"] = "Failed",
+            ["AttemptCount"] = attemptCount,
+            ["ElapsedMs"] = elapsedMs,
+            ["ErrorCode"] = response?.ErrorCode?.ToString() ?? "FileDownloadFailed",
+        };
+        if (response?.Params != null && response.Params.TryGetValue("cause", out var cause))
+        {
+            props["Cause"] = cause;
+        }
+
+        _telemetryService.TrackBusinessEvent("ProductExportDownload", props);
+
+        // Rethrow so Hangfire records run as Failed. [AutomaticRetry(Attempts=0)] prevents re-execution.
+        var causeForMsg = response?.Params != null && response.Params.TryGetValue("cause", out var c) ? c : "unknown";
+        throw new InvalidOperationException(
+            $"ProductExportDownload failed (cause={causeForMsg}, attempts={attemptCount}, elapsedMs={elapsedMs}).");
+    }
+}
+```
+
+- [ ] **Step 2: Delete the FileStorage copy**
+
+```bash
+git rm backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs
+```
+
+- [ ] **Step 3: Verify the FileStorage `Jobs` folder is empty and remove it**
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/
+```
+
+Expected: empty. If empty, remove the folder:
+
+```bash
+rmdir backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs
+```
+
+(If the directory is not empty, do not delete it — investigate which other job lives there and confirm with the user before continuing.)
+
+- [ ] **Step 4: Build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds. The job's `IRecurringJob` interface is auto-discovered by `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:373` — the discovery scans the entire Application assembly, so the new location is picked up automatically.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs
+git commit -m "refactor: relocate ProductExportDownloadJob to Catalog namespace"
+```
+
+---
+
+### Task 12: Relocate `ProductExportDownloadJobTests.cs` to the Catalog test folder
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs`
+- Delete: `backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs`
+
+- [ ] **Step 1: Create the new test file at the Catalog location**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs` with this exact content. The body is identical to the previous file aside from namespace + `using` directives (Catalog Infrastructure replaces FileStorage):
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.FileStorage.UseCases.DownloadFromUrl;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Xcc.Telemetry;
+using FluentAssertions;
+using Hangfire;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure.Jobs;
+
+public sealed class ProductExportDownloadJobTests
+{
+    // Captures (eventName, properties) pairs from TrackBusinessEvent calls
+    private readonly List<(string EventName, Dictionary<string, string> Properties)> _trackedEvents = new();
+
+    private Mock<ITelemetryService> CreateTelemetryMock()
+    {
+        var mock = new Mock<ITelemetryService>();
+        mock
+            .Setup(t => t.TrackBusinessEvent(
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<Dictionary<string, double>>()))
+            .Callback<string, Dictionary<string, string>?, Dictionary<string, double>?>(
+                (eventName, props, _) =>
+                    _trackedEvents.Add((eventName, props ?? new Dictionary<string, string>())));
+        return mock;
+    }
+
+    private static ProductExportDownloadJob CreateJob(
+        Mock<IMediator> mediatorMock,
+        Mock<IRecurringJobStatusChecker> statusCheckerMock,
+        Mock<ITelemetryService> telemetryMock,
+        string exportUrl = "https://export.example.com/products.csv",
+        string containerName = "exports")
+    {
+        var options = Options.Create(new ProductExportOptions
+        {
+            Url = exportUrl,
+            ContainerName = containerName,
+        });
+
+        return new ProductExportDownloadJob(
+            mediatorMock.Object,
+            new NullLogger<ProductExportDownloadJob>(),
+            statusCheckerMock.Object,
+            telemetryMock.Object,
+            options);
+    }
+
+    private static Mock<IRecurringJobStatusChecker> EnabledStatusChecker()
+    {
+        var mock = new Mock<IRecurringJobStatusChecker>();
+        mock
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return mock;
+    }
+
+    private static Mock<IRecurringJobStatusChecker> DisabledStatusChecker()
+    {
+        var mock = new Mock<IRecurringJobStatusChecker>();
+        mock
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        return mock;
+    }
+
+    [Fact]
+    public void Job_HasAutomaticRetryAttribute_WithZeroAttempts()
+    {
+        // Use CustomAttributeData to inspect without instantiating AutomaticRetryAttribute,
+        // whose constructor accesses Hangfire's global LogProvider which may reference a
+        // disposed ILoggerFactory from another test's WebApplicationFactory.
+        var attributeData = typeof(ProductExportDownloadJob)
+            .GetCustomAttributesData()
+            .FirstOrDefault(d => d.AttributeType == typeof(AutomaticRetryAttribute));
+
+        attributeData.Should().NotBeNull("ProductExportDownloadJob must have [AutomaticRetry] attribute");
+
+        var attempts = attributeData!.NamedArguments
+            .Where(a => a.MemberName == nameof(AutomaticRetryAttribute.Attempts))
+            .Select(a => (int)a.TypedValue.Value!)
+            .FirstOrDefault();
+
+        attempts.Should().Be(0, "Hangfire retries must be disabled to avoid Polly x Hangfire retry multiplication");
+    }
+
+    [Fact]
+    public async Task Execute_OnSuccess_EmitsExactlyOneSuccessEvent()
+    {
+        // Arrange
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<DownloadFromUrlRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DownloadFromUrlResponse
+            {
+                Success = true,
+                BlobUrl = "https://blob/file.csv",
+                BlobName = "file.csv",
+                ContainerName = "exports",
+                FileSizeBytes = 1024,
+            });
+
+        var telemetry = CreateTelemetryMock();
+        var job = CreateJob(mediator, EnabledStatusChecker(), telemetry);
+
+        // Act
+        await job.ExecuteAsync();
+
+        // Assert
+        _trackedEvents.Should().HaveCount(1);
+        _trackedEvents[0].Properties["Status"].Should().Be("Success");
+    }
+
+    [Fact]
+    public async Task Execute_OnHandlerFailure_EmitsFailedEvent_AndRethrows()
+    {
+        // Arrange
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<DownloadFromUrlRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DownloadFromUrlResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.FileDownloadFailed,
+                Params = new Dictionary<string, string>
+                {
+                    ["cause"] = "retry-exhausted",
+                    ["attemptCount"] = "4",
+                },
+            });
+
+        var telemetry = CreateTelemetryMock();
+        var job = CreateJob(mediator, EnabledStatusChecker(), telemetry);
+
+        // Act
+        var act = async () => await job.ExecuteAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        _trackedEvents.Should().HaveCount(1);
+        _trackedEvents[0].Properties["Status"].Should().Be("Failed");
+        _trackedEvents[0].Properties["Cause"].Should().Be("retry-exhausted");
+        _trackedEvents[0].Properties["AttemptCount"].Should().Be("4");
+    }
+
+    [Fact]
+    public async Task Execute_OnCallerCancellation_EmitsCancelledEvent_AndRethrows()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<DownloadFromUrlRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<DownloadFromUrlRequest, CancellationToken>((_, ct) =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(ct);
+            });
+
+        var telemetry = CreateTelemetryMock();
+        var job = CreateJob(mediator, EnabledStatusChecker(), telemetry);
+
+        // Act
+        var act = async () => await job.ExecuteAsync(cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        _trackedEvents.Should().HaveCount(1);
+        _trackedEvents[0].Properties["Status"].Should().Be("Cancelled");
+    }
+
+    [Fact]
+    public async Task Execute_OnJobDisabled_EmitsSkippedEvent()
+    {
+        // Arrange
+        var mediator = new Mock<IMediator>();
+        var telemetry = CreateTelemetryMock();
+        var job = CreateJob(mediator, DisabledStatusChecker(), telemetry);
+
+        // Act
+        await job.ExecuteAsync();
+
+        // Assert
+        _trackedEvents.Should().HaveCount(1);
+        _trackedEvents[0].Properties["Status"].Should().Be("Skipped");
+
+        mediator.Verify(
+            m => m.Send(It.IsAny<DownloadFromUrlRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_OnSuccess_DoesNotEmitFailedEvent()
+    {
+        // Arrange
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Send(It.IsAny<DownloadFromUrlRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DownloadFromUrlResponse
+            {
+                Success = true,
+                BlobUrl = "https://blob/file.csv",
+                BlobName = "file.csv",
+                ContainerName = "exports",
+                FileSizeBytes = 2048,
+            });
+
+        var telemetry = CreateTelemetryMock();
+        var job = CreateJob(mediator, EnabledStatusChecker(), telemetry);
+
+        // Act
+        await job.ExecuteAsync();
+
+        // Assert
+        _trackedEvents.Should().NotContain(e => e.Properties["Status"] == "Failed");
+    }
+}
+```
+
+Note: the `CreateJob` helper no longer assigns `MaxRetryAttempts`, `DownloadTimeout`, `RetryBaseDelay` on the options instance — those properties no longer exist on the slimmed `ProductExportOptions`. The job itself never read those properties, so this is a pure cleanup.
+
+- [ ] **Step 2: Delete the FileStorage test copy**
+
+```bash
+git rm backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
+```
+
+- [ ] **Step 3: Verify and remove the now-empty FileStorage tests subfolder**
+
+```bash
+ls backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs/
+```
+
+Expected: empty.
+
+```bash
+rmdir backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/Jobs
+```
+
+(Leave `backend/test/Anela.Heblo.Tests/Features/FileStorage/Infrastructure/` in place — it still hosts `DownloadResilienceServiceTests.cs`.)
+
+- [ ] **Step 4: Build + run the relocated tests**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~Anela.Heblo.Tests.Features.Catalog.Infrastructure.Jobs.ProductExportDownloadJobTests
+```
+
+Expected: build succeeds; 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
+git commit -m "test: relocate ProductExportDownloadJobTests to Catalog"
+```
+
+---
+
+### Task 13: Final verification — build, full test suite, manual smoke
+
+- [ ] **Step 1: Search for any lingering references to the old namespaces and constants**
+
+Run each of these greps and confirm zero hits:
+
+```bash
+grep -rn "Anela.Heblo.Application.Features.FileStorage.ProductExportOptions\|Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs.ProductExportDownloadJob\|ProductExportDownloadClientName\|\"ProductExportDownload\"" backend/src backend/test
+```
+
+Expected: no results.
+
+```bash
+grep -rn "ProductExportOptions" backend/src/Anela.Heblo.Application/Features/FileStorage backend/test/Anela.Heblo.Tests/Features/FileStorage
+```
+
+Expected: no results.
+
+```bash
+grep -rn "ProductExportDownloadJob" backend/src/Anela.Heblo.Application/Features/FileStorage backend/test/Anela.Heblo.Tests/Features/FileStorage
+```
+
+Expected: no results.
+
+- [ ] **Step 2: Verify FileStorage is now free of product-export domain leaks**
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/FileStorage
+```
+
+Expected listing (no `ProductExportOptions.cs`, no `Infrastructure/Jobs/`):
+- `FileDownloadOptions.cs`
+- `FileStorageModule.cs`
+- `Infrastructure/` (contains `DownloadResilienceService.cs`, `IDownloadResilienceService.cs` only — no `Jobs/`)
+- `Services/`
+- `UseCases/`
+
+- [ ] **Step 3: Run dotnet format and full build**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: format runs clean; build succeeds with zero new warnings.
+
+- [ ] **Step 4: Run the full backend test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all tests pass; test count is unchanged from the start of this plan (no tests were added or removed net — the `ProductExportOptionsTests` file was replaced 1:1 by `FileDownloadOptionsTests`; the job tests moved location only).
+
+- [ ] **Step 5: Manual smoke check — Hangfire job still scheduled**
+
+Start the API in Development:
+
+```bash
+dotnet run --project backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+In a separate shell, hit the Hangfire dashboard (path per project convention, usually `/hangfire`). Verify:
+- A recurring job with `JobName = "product-export-download"` is registered.
+- Its cron expression is `0 2 * * *`.
+- Its display name is `Product Export Download`.
+
+(If the dashboard is access-controlled and you cannot reach it locally, instead inspect the seeded configurations via the recurring-jobs admin endpoint that exists in this project, or run a single-shot manual trigger via the dashboard / admin UI per existing conventions.) Stop the API.
+
+- [ ] **Step 6: Confirm the configuration section path resolves**
+
+Inspect `appsettings.json`:
+
+```bash
+grep -A3 "\"ProductExportOptions\"" backend/src/Anela.Heblo.API/appsettings.json
+```
+
+Expected: the existing `"ProductExportOptions": { "Url": "" }` block is unchanged. Confirm the new `CatalogModule` binding (`configuration.GetSection("ProductExportOptions")`) matches this key.
+
+- [ ] **Step 7: Final clean commit if anything was changed by `dotnet format`**
+
+```bash
+git status
+```
+
+If `dotnet format` made changes:
+
+```bash
+git add -u
+git commit -m "chore: dotnet format after refactor"
+```
+
+If nothing changed, no commit needed.
+
+- [ ] **Step 8: Summary in PR description (template)**
+
+When opening the PR, include this in the description (replace the bracketed parts):
+
+> **Refactor: Relocate `ProductExportDownloadJob` from FileStorage to Catalog**
+>
+> - `ProductExportOptions` split into Catalog-owned domain options (`Url`, `ContainerName`) and FileStorage-owned generic download tuning (`FileDownloadOptions` — `HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay`).
+> - FileStorage named HttpClient constant renamed: `FileStorageModule.ProductExportDownloadClientName` (`"ProductExportDownload"`) → `FileStorageModule.FileDownloadClientName` (`"FileDownload"`).
+> - DI registration of `ProductExportOptions` moved from `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` to `Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`. Configuration section path unchanged (`ProductExportOptions:` at root).
+> - Tests relocated to mirror source structure; `ProductExportOptionsTests` replaced by `FileDownloadOptionsTests` (its assertions covered the four properties that moved).
+> - **Operational note:** `ILogger<ProductExportDownloadJob>` category name changes from `Anela.Heblo.Application.Features.FileStorage.Infrastructure.Jobs.ProductExportDownloadJob` to `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs.ProductExportDownloadJob`. Hangfire `JobName` (`"product-export-download"`) is unchanged, so recurring-job identity in Hangfire storage is preserved.
+> - No new dependencies, no DB migrations, no Key Vault changes, no `appsettings` rename.
+
+---
+
+## Self-Review Notes (run by the plan author)
+
+**Spec coverage check.** Every FR/NFR in `spec.r3.md` is addressed:
+- FR-1 (relocate job) → Task 11.
+- FR-2 (relocate options) → Tasks 6 + 9; split into FileDownloadOptions per arch-review amendment → Tasks 1–4.
+- FR-2a / arch-review (rename HttpClient constant) → Task 8.
+- FR-3 (move DI registration) → Task 10.
+- FR-4 (config section ownership) → resolved by arch-review (no rename needed); explicitly verified in Task 13 Step 6.
+- FR-5 (update all references) → covered across Tasks 3, 4, 7, 8, 9, 10 + verified in Task 13 Step 1.
+- FR-6 (preserve `IBlobStorageService` cross-module pattern) → unchanged; job continues to use `IMediator` (which routes through the Domain abstraction in `DownloadFromUrlHandler`).
+- FR-7 (tests relocated and green) → Tasks 5, 7, 12, 13.
+- NFR-1 (performance) → no allocation/indirection changes; constructor signatures change but call patterns identical.
+- NFR-2 (security) → no secret changes; config section unchanged.
+- NFR-3 (maintainability / SRP) → final state verified in Task 13 Step 2 (`FileStorage/` contains only generic abstractions).
+- NFR-4 (backward compatibility at runtime) → blob filename, container, cadence preserved (job body byte-identical apart from namespace); log category change documented in PR template (Task 13 Step 8).
+
+**Placeholder scan.** No `TBD`/`TODO`/`add appropriate X`/`similar to Task N` placeholders. Every code block shows complete content. Every command shows expected output.
+
+**Type/name consistency check.**
+- `FileDownloadOptions` properties defined in Task 1 (`HeadTimeout`, `DownloadTimeout`, `MaxRetryAttempts`, `RetryBaseDelay`) are exactly the ones referenced by `DownloadFromUrlHandler._options.Value.HeadTimeout` (Task 3) and `DownloadResilienceService._options.{DownloadTimeout|MaxRetryAttempts|RetryBaseDelay}` (Task 4).
+- `ProductExportOptions` properties after Task 6 (`Url`, `ContainerName`) match what `ProductExportDownloadJob` reads (`_productExportOptions.Value.Url`, `_productExportOptions.Value.ContainerName`).
+- `FileStorageModule.FileDownloadClientName` (Task 8) replaces every previously-named call site (Tasks 3, 5, 8 substep checks).
+- Namespace `Anela.Heblo.Application.Features.Catalog.Infrastructure` (Task 9) is the resolution path for `ProductExportOptions` in the relocated job (Task 11) and relocated job tests (Task 12) — consistent.
+
+**Spec-vs-plan addenda.**
+- The arch review identified `DownloadResilienceService` as a consumer of `ProductExportOptions` (timeout/retry properties) — the original spec did not list it. This plan handles it explicitly in Task 4.
+- `FileStorageModuleTests.cs` pre-configures the timeout properties; this plan handles the necessary update in Task 7.
+- Tests for `ProductExportOptions` defaults cover only the four moved properties; rather than leave a trivial `ProductExportOptionsTests` with zero assertions on the slimmed type, Task 5 replaces it outright with `FileDownloadOptionsTests`. If a future change adds defaults or validation to the Catalog-side `ProductExportOptions`, write a `ProductExportOptionsTests` then.


### PR DESCRIPTION
FileStorage

## Finding
`ProductExportDownloadJob` (and its companion `ProductExportOptions`) live inside the `FileStorage` module:

```
backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs
backend/src/Anela.Heblo.Application/Features/FileStorage/ProductExportOptions.cs
```

The job's logic is entirely product-export domain: it knows the export URL (`ProductExportOptions.Url`), the target blob container for product data (`ProductExportOptions.ContainerName`), and the output filename format (`products_{timestamp}.csv`). None of this is generic file-storage infrastructure — it is Shoptet/Catalog business logic that happens to use `IBlobStorageService` as a transport.

As a result, the `FileStorage` module cannot be treated as a reusable, stable infrastructure module: changes to the product-export business rules (new URL, different filename convention, additional post-processing) require editing a module named "FileStorage." The module also carries `ProductExportOptions` in its root namespace, polluting what should be a generic infrastructure API.

## Why it matters
SRP — the module has two unrelated reasons to change: (1) how blobs are stored/retrieved, and (2) how product export downloads are scheduled and named. This split will grow over time if more domain-specific jobs are added here.

## Suggested fix
Move `ProductExportDownloadJob` and `ProductExportOptions` to the module that owns the product-export domain (currently `Catalog` or a dedicated `ShoptetOrders`/`Catalog` feature). The job can continue to inject `IBlobStorageService` (cross-module via the Domain interface — already the correct pattern). `FileStorageModule` registration of the job is then removed, and the receiving module's `Module.cs` registers it instead.

This is a move, not a rewrite — the handler logic is unchanged.

---
_Filed by daily arch-review routine on 2026-06-05._

---

Closes #2674

### Tokens used
33523168
