### PR TITLE
feat: Consistent TimeProvider Usage in Manufacture Order Handlers

### DIFF
--- a/artifacts/feat-arch-review-manufacture-datetime-utcnow-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-manufacture-datetime-utcnow-/arch-review.r1.md
@@ -1,0 +1,143 @@
+# Architecture Review: Consistent TimeProvider Usage in Manufacture Order Handlers
+
+## Skip Design: true
+
+This is a backend-only, surgical refactor. No new visual components, screens, or layout changes.
+
+## Architectural Fit Assessment
+
+The change aligns perfectly with the existing pattern. `TimeProvider` is registered once in DI as `TimeProvider.System` (singleton) in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:128` and injected through handler constructors across the Manufacture, Logistics, Catalog, and Dashboard slices. All three target handlers already accept `TimeProvider` and use `_timeProvider.GetUtcNow().DateTime` correctly for adjacent fields — so the proposed replacement is the explicit completion of an already-applied convention, not a new architectural direction.
+
+Main integration points:
+
+- **Handler constructors** — already inject `TimeProvider`; no DI changes needed.
+- **Test suites** — `Mock<TimeProvider>` from Moq is the established project convention (see `CreateNewTransportBoxHandlerAuditFieldsTests.cs:24`, `DuplicateManufactureOrderHandlerTests.cs:24`). The spec's mention of `Microsoft.Extensions.TimeProvider.Testing` does NOT match the codebase — that NuGet package is not referenced anywhere. The hand-rolled `FakeTimeProvider` subclass in `GetPackingDashboardHandlerTests.cs:18-32` is a special case for time-zone-sensitive code (`GetLocalNow`) and does not apply here.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ASP.NET Core DI container
+  └── TimeProvider.System  (singleton, registered once)
+        │
+        ▼  (constructor injection — already in place)
+  ┌─────────────────────────────────────────────────────┐
+  │ CreateManufactureOrderHandler                       │
+  │   _timeProvider.GetUtcNow().DateTime → CreatedDate  │ ← change L46
+  │   _timeProvider.GetUtcNow().DateTime → StateChangedAt│ ← change L52
+  ├─────────────────────────────────────────────────────┤
+  │ DuplicateManufactureOrderHandler                    │
+  │   _timeProvider.GetUtcNow().DateTime → CreatedDate  │ ← change L47
+  │   _timeProvider.GetUtcNow().DateTime → StateChangedAt│ ← change L52
+  ├─────────────────────────────────────────────────────┤
+  │ UpdateManufactureOrderHandler                       │
+  │   _timeProvider.GetUtcNow().DateTime → note.CreatedAt│ ← change L145
+  └─────────────────────────────────────────────────────┘
+```
+
+No new components, no new abstractions, no surface-area changes.
+
+### Key Design Decisions
+
+#### Decision 1: Inline replacement vs. local variable extraction
+**Options considered:**
+- (A) Replace each `DateTime.UtcNow` with an inline `_timeProvider.GetUtcNow().DateTime` call.
+- (B) Capture once at method start: `var now = _timeProvider.GetUtcNow().DateTime;` and reuse.
+- (C) Add a project-wide extension/helper such as `_timeProvider.UtcNow()`.
+
+**Chosen approach:** (A) Inline replacement per occurrence.
+
+**Rationale:** Matches the surrounding style — `CreateManufactureOrderHandler.cs:62-63` and `DuplicateManufactureOrderHandler.cs:41,57,59` already call `_timeProvider.GetUtcNow().DateTime` inline rather than caching it. The spec is explicit that helper extraction is out of scope. Caching the value (B) would change observable behavior: today the handler reads the clock multiple times within a method; collapsing to a single read is a separate, non-trivial decision and is not part of the brief.
+
+#### Decision 2: Test double — `Mock<TimeProvider>` vs. `FakeTimeProvider` package
+**Options considered:**
+- (A) Use `Mock<TimeProvider>` with `_timeProviderMock.Setup(x => x.GetUtcNow()).Returns(fixed)`.
+- (B) Add `Microsoft.Extensions.TimeProvider.Testing` NuGet package and use the framework's `FakeTimeProvider`.
+- (C) Hand-roll a `FakeTimeProvider : TimeProvider` subclass per test file.
+
+**Chosen approach:** (A) `Mock<TimeProvider>`.
+
+**Rationale:** This is the dominant convention in the test suite (used in 10+ files surveyed across Transport, Catalog, Dashboard, and Manufacture). `DuplicateManufactureOrderHandlerTests` already uses this exact pattern with `FixedNow = new DateTimeOffset(2026, 6, 8, 10, 0, 0, TimeSpan.Zero)`. Adding a new NuGet dependency for one test change is unjustified, and the spec's listing of `Microsoft.Extensions.TimeProvider.Testing` as a dependency is incorrect for this codebase — it is not present in any `.csproj`. The hand-rolled subclass (C) is reserved for time-zone-sensitive tests that need a non-virtual `GetLocalNow()` override.
+
+#### Decision 3: How to assert the frozen timestamp
+**Options considered:**
+- (A) Compare to `FixedNow.UtcDateTime` directly.
+- (B) Compare with tolerance (e.g., `BeCloseTo`).
+
+**Chosen approach:** (A) Exact equality.
+
+**Rationale:** With a mocked `TimeProvider`, the handler will read the exact `DateTimeOffset` returned by `Setup`. There is no clock drift to tolerate. Exact equality (`Should().Be(FixedNow.UtcDateTime)`) gives the strongest regression signal — any reintroduction of `DateTime.UtcNow` will produce a divergence on the next test run.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. All changes confined to:
+
+```
+backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/
+  ├── CreateManufactureOrder/CreateManufactureOrderHandler.cs       (2 line edits)
+  ├── DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs (2 line edits)
+  └── UpdateManufactureOrder/UpdateManufactureOrderHandler.cs       (1 line edit)
+
+backend/test/Anela.Heblo.Tests/Features/Manufacture/
+  ├── CreateManufactureOrderHandlerTests.cs       (switch TimeProvider.System → Mock<TimeProvider>; add assertion test)
+  ├── CreateManufactureOrderHandlerSinglePhaseTests.cs  (same — verify if it also constructs the handler)
+  ├── DuplicateManufactureOrderHandlerTests.cs    (add new assertions — mock already in place)
+  └── UpdateManufactureOrderHandlerTests.cs       (switch TimeProvider.System → Mock<TimeProvider>; add assertion test)
+```
+
+### Interfaces and Contracts
+
+No interface or contract changes. The MediatR commands, responses, DTOs, repository interfaces, and DI registrations remain untouched. The five edits are pure value-source substitutions.
+
+### Data Flow
+
+For the create flow:
+```
+Request → Handler.Handle()
+         → _timeProvider.GetUtcNow().DateTime   (was: DateTime.UtcNow)
+         → ManufactureOrder { CreatedDate, StateChangedAt = <that value> }
+         → _repository.AddOrderAsync(order)
+         → Response
+```
+
+For the test path:
+```
+Mock<TimeProvider>.Setup(x => x.GetUtcNow()).Returns(FixedNow)
+         → injected into Handler
+         → Handler reads FixedNow.UtcDateTime
+         → captured order.CreatedDate == FixedNow.UtcDateTime  ✓
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing tests in `CreateManufactureOrderHandlerTests` and `UpdateManufactureOrderHandlerTests` use `TimeProvider.System` and may have implicit assertions that compare timestamps to `DateTime.UtcNow`. Swapping in `Mock<TimeProvider>` could break them. | Low | Scan existing tests for `DateTime.UtcNow`, `BeCloseTo`, or `BeOnOrBefore` assertions on `CreatedDate`/`StateChangedAt`/`CreatedAt` before changing the constructor. Adjust each to compare against the mocked `FixedNow.UtcDateTime`. |
+| Spec lists `Microsoft.Extensions.TimeProvider.Testing` as a dependency, but it is not in any `.csproj`. A developer following the spec verbatim might add the package needlessly. | Low | Use `Mock<TimeProvider>` instead — see Specification Amendments below. |
+| Future `DateTime.UtcNow` reintroductions in the same handlers will silently re-break time-freezing. | Medium | Tests added under FR-4 must compare to the exact mocked timestamp so any reintroduction fails the assertion. Optionally add a follow-up ticket for a Roslyn analyzer (explicitly out of scope here per spec). |
+| `_timeProvider.GetUtcNow()` called multiple times in one method body can return different values under a wall-clock provider; the change does not collapse these calls. | Low | Accepted per Decision 1 — preserves current behavior. The mocked provider returns a deterministic value, so tests are unaffected. |
+
+## Specification Amendments
+
+1. **Correct the test-double dependency.** Replace the spec's `Dependencies` reference to `Microsoft.Extensions.TimeProvider.Testing` with:
+   > `Moq` — for `Mock<TimeProvider>`; already in use throughout the test suite. No new NuGet packages required.
+
+2. **Update FR-4 acceptance criteria** to reflect that two of the three existing test classes (`CreateManufactureOrderHandlerTests`, `UpdateManufactureOrderHandlerTests`) currently inject `TimeProvider.System` and must be migrated to `Mock<TimeProvider>` before the frozen-timestamp assertions can be added. `DuplicateManufactureOrderHandlerTests` already injects a mocked `TimeProvider` and only needs the new assertions added.
+
+3. **Add a clarifying note on `DateTimeOffset` → `DateTime` conversion.** The replacement value is `_timeProvider.GetUtcNow().DateTime`, which discards the offset. Since the property type is `DateTime` (not `DateTimeOffset`), the test should assert `Should().Be(FixedNow.UtcDateTime)` rather than `FixedNow.DateTime` to avoid accidental kind mismatch (`UtcDateTime` is guaranteed `DateTimeKind.Utc`).
+
+4. **Verify `CreateManufactureOrderHandlerSinglePhaseTests.cs` is also addressed.** It is in the same module and likely constructs the handler with `TimeProvider.System`; if so, FR-4 applies to it implicitly. The spec should either name it explicitly or state that single-phase coverage piggy-backs on the multi-phase test changes.
+
+## Prerequisites
+
+None. All required infrastructure is already in place:
+
+- TimeProvider.System registered as singleton DI (verified at `ServiceCollectionExtensions.cs:128`).
+- TimeProvider already injected into the three target handlers.
+- Moq referenced by the test project and used for `Mock<TimeProvider>` in adjacent suites.
+- No migrations, no config changes, no infrastructure changes.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-manufacture-datetime-utcnow-/brief.md
+++ b/artifacts/feat-arch-review-manufacture-datetime-utcnow-/brief.md
@@ -1,0 +1,37 @@
+## Module
+Manufacture
+
+## Finding
+Three handlers inject `TimeProvider` and use it correctly for some fields, then fall back to `DateTime.UtcNow` for others in the same method body:
+
+| File | Line(s) | Field(s) bypassed |
+|------|---------|-------------------|
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` | 46, 52 | `CreatedDate`, `StateChangedAt` |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` | 47, 52 | `CreatedDate`, `StateChangedAt` |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs` | 145 | note `CreatedAt` |
+
+In all three cases `_timeProvider` is already injected and is used correctly in the same method (e.g. `CreateManufactureOrderHandler` uses it on lines 62–63 for `GetDefaultExpiration`/`GetDefaultLot`; `UpdateManufactureOrderHandler` uses it on lines 49, 55, 61 for ERP doc dates).
+
+## Why it matters
+Tests that pass a `FakeTimeProvider` into these handlers to freeze time will find that expiration, lot, and ERP-date fields are controlled, but `CreatedDate`, `StateChangedAt`, and note `CreatedAt` always reflect real wall-clock time. The inconsistency produces silent holes in time-sensitive test assertions — or forces tests to skip those fields entirely — without any hint that the handler has a split dependency.
+
+## Suggested fix
+Replace the five `DateTime.UtcNow` occurrences with `_timeProvider.GetUtcNow().DateTime`:
+
+```csharp
+// CreateManufactureOrderHandler.cs lines 46, 52
+CreatedDate = _timeProvider.GetUtcNow().DateTime,
+StateChangedAt = _timeProvider.GetUtcNow().DateTime,
+
+// DuplicateManufactureOrderHandler.cs lines 47, 52
+CreatedDate = _timeProvider.GetUtcNow().DateTime,
+StateChangedAt = _timeProvider.GetUtcNow().DateTime,
+
+// UpdateManufactureOrderHandler.cs line 145
+CreatedAt = _timeProvider.GetUtcNow().DateTime,
+```
+
+No DI changes needed — `TimeProvider` is already registered and injected in all three handlers.
+
+---
+_Filed by daily arch-review routine on 2026-06-06._

--- a/artifacts/feat-arch-review-manufacture-datetime-utcnow-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-manufacture-datetime-utcnow-/impl/main.r1.md
@@ -1,0 +1,60 @@
+---
+
+# Implementation: Consistent TimeProvider Usage in Manufacture Order Handlers
+
+## What was implemented
+
+Replaced five `DateTime.UtcNow` occurrences across three Manufacture handlers with `_timeProvider.GetUtcNow().DateTime`, making `CreatedDate`, `StateChangedAt`, and note `CreatedAt` fully controllable by `FakeTimeProvider` in tests. Three test classes were updated with frozen-clock `Mock<TimeProvider>` infrastructure and exact-equality assertions.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` — lines 47 and 52: `DateTime.UtcNow` → `_timeProvider.GetUtcNow().DateTime`
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs` — line 145: `DateTime.UtcNow` → `_timeProvider.GetUtcNow().DateTime`
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` — lines 46 and 52: `DateTime.UtcNow` → `_timeProvider.GetUtcNow().DateTime`
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs` — added `CreatedDate` and `StateChangedAt` assertions (mock already in place)
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs` — migrated from `TimeProvider.System` to `Mock<TimeProvider>`, tightened `BeCloseTo` to exact `Be(FixedNow.UtcDateTime)`
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` — migrated from `TimeProvider.System` to `Mock<TimeProvider>`, added `CreatedDate` and `StateChangedAt` assertions
+
+## Tests
+
+- `DuplicateManufactureOrderHandlerTests.cs` — adds frozen-time assertions for `CreatedDate`/`StateChangedAt`; TDD red-green verified
+- `UpdateManufactureOrderHandlerTests.cs` — frozen-time assertion for note `CreatedAt` (11 tests all pass)
+- `CreateManufactureOrderHandlerTests.cs` — frozen-time assertions for `CreatedDate`/`StateChangedAt` (20 tests all pass including `SinglePhaseTests`)
+- Full Manufacture namespace: **534/534 passing**
+
+## How to verify
+
+```bash
+# From worktree root
+grep -n "DateTime\.UtcNow" \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs \
+  || echo "ALL THREE HANDLERS CLEAN"
+
+dotnet build
+dotnet test --no-build --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture"
+```
+
+## Notes
+
+- `CreateManufactureOrderHandlerSinglePhaseTests.cs` was intentionally left unchanged — it uses its own mock setup and doesn't assert on `CreatedDate`/`StateChangedAt`, so it passed without modification.
+- `CreateExistingOrder()` helper in `UpdateManufactureOrderHandlerTests.cs` still calls `DateTime.UtcNow.AddDays(-1)` for test fixture data — this is out of scope per spec and does not affect the frozen-clock assertions.
+- Spec's reference to `Microsoft.Extensions.TimeProvider.Testing` was not used; `Mock<TimeProvider>` from Moq (already the project convention) was used instead, per arch review guidance.
+
+## PR Summary
+
+Replace `DateTime.UtcNow` with `_timeProvider.GetUtcNow().DateTime` in the three Manufacture order handlers (`Create`, `Duplicate`, `Update`) so that `CreatedDate`, `StateChangedAt`, and note `CreatedAt` are fully controllable by `FakeTimeProvider` in tests. Each handler already injected `TimeProvider` and used it for adjacent fields; this change completes the convention for the five remaining fields that had silently reverted to the system clock.
+
+Test classes for `Update` and `Create` handlers were migrated from `TimeProvider.System` to `Mock<TimeProvider>` with a fixed `DateTimeOffset(2026, 6, 8, 10, 0, 0, TimeSpan.Zero)`, and new exact-equality assertions (`Should().Be(FixedNow.UtcDateTime)`) were added for all five previously-uncontrolled fields.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` — replaced 2 `DateTime.UtcNow` calls
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs` — replaced 1 `DateTime.UtcNow` call
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` — replaced 2 `DateTime.UtcNow` calls
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs` — added 2 frozen-time assertions
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs` — migrated to `Mock<TimeProvider>`, tightened note `CreatedAt` assertion
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` — migrated to `Mock<TimeProvider>`, added 2 frozen-time assertions
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-manufacture-datetime-utcnow-/spec.r1.md
+++ b/artifacts/feat-arch-review-manufacture-datetime-utcnow-/spec.r1.md
@@ -1,0 +1,81 @@
+# Specification: Consistent TimeProvider Usage in Manufacture Order Handlers
+
+## Summary
+Three Manufacture handlers inject `TimeProvider` and use it for some timestamp fields while falling back to `DateTime.UtcNow` for others within the same method. This spec defines the surgical replacement of five `DateTime.UtcNow` occurrences with `_timeProvider.GetUtcNow().DateTime` so that all timestamps are controllable by `FakeTimeProvider` in tests.
+
+## Background
+The Manufacture module follows a clean-architecture pattern where handlers depend on `TimeProvider` (already registered in DI) so that time-sensitive logic can be deterministically tested. A daily architecture review on 2026-06-06 flagged that three handlers correctly use `_timeProvider` for some assignments but then call `DateTime.UtcNow` directly for others in the same method body. Tests using `FakeTimeProvider` therefore observe a partially frozen clock: expiration, lot, and ERP-date fields are controlled, but `CreatedDate`, `StateChangedAt`, and note `CreatedAt` reflect real wall-clock time. The inconsistency creates silent holes in time-sensitive assertions without compile-time or runtime warning.
+
+## Functional Requirements
+
+### FR-1: Replace direct UtcNow usage in CreateManufactureOrderHandler
+Replace `DateTime.UtcNow` with `_timeProvider.GetUtcNow().DateTime` at lines 46 (`CreatedDate`) and 52 (`StateChangedAt`) in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`.
+
+**Acceptance criteria:**
+- No occurrence of `DateTime.UtcNow` remains in the handler.
+- `CreatedDate` and `StateChangedAt` on a newly created `ManufactureOrder` equal the value returned by the injected `TimeProvider` at handler execution time.
+- A test using `FakeTimeProvider` with a fixed timestamp observes that timestamp in both fields.
+
+### FR-2: Replace direct UtcNow usage in DuplicateManufactureOrderHandler
+Replace `DateTime.UtcNow` with `_timeProvider.GetUtcNow().DateTime` at lines 47 (`CreatedDate`) and 52 (`StateChangedAt`) in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs`.
+
+**Acceptance criteria:**
+- No occurrence of `DateTime.UtcNow` remains in the handler.
+- `CreatedDate` and `StateChangedAt` on a duplicated `ManufactureOrder` reflect the injected `TimeProvider` value.
+- Test with `FakeTimeProvider` confirms both fields match the frozen time.
+
+### FR-3: Replace direct UtcNow usage in UpdateManufactureOrderHandler
+Replace `DateTime.UtcNow` with `_timeProvider.GetUtcNow().DateTime` at line 145 (note `CreatedAt`) in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs`.
+
+**Acceptance criteria:**
+- No occurrence of `DateTime.UtcNow` remains in the handler.
+- The `CreatedAt` field of a newly appended note reflects the injected `TimeProvider` value.
+- Test with `FakeTimeProvider` confirms note `CreatedAt` matches the frozen time.
+
+### FR-4: Test coverage for time-frozen assertions
+Add or update unit tests that pass a `FakeTimeProvider` with a deterministic timestamp into each of the three handlers and assert that `CreatedDate`, `StateChangedAt`, and note `CreatedAt` equal that timestamp.
+
+**Acceptance criteria:**
+- At least one test per handler asserts the frozen timestamp on each previously-uncontrolled field.
+- Tests fail if a future refactor reintroduces `DateTime.UtcNow` in any of these fields.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. `TimeProvider.GetUtcNow()` is a virtual call already invoked elsewhere in each handler.
+
+### NFR-2: Security
+No security implications. No new dependencies, no new exposed surface.
+
+### NFR-3: Build & Format
+`dotnet build` and `dotnet format` must pass without warnings or formatting changes outside the touched lines.
+
+### NFR-4: Backwards Compatibility
+The change is purely internal to handlers. No DTO, API contract, database schema, or DI registration is modified. Production behavior is identical when the registered `TimeProvider` is `TimeProvider.System` (default).
+
+## Data Model
+No data model changes. The affected entity properties are:
+- `ManufactureOrder.CreatedDate` (DateTime)
+- `ManufactureOrder.StateChangedAt` (DateTime)
+- `ManufactureOrderNote.CreatedAt` (DateTime)
+
+All remain `DateTime` typed; only the *source* of the value changes.
+
+## API / Interface Design
+No public API, DTO, contract, or UI changes. The three MediatR commands (`CreateManufactureOrderCommand`, `DuplicateManufactureOrderCommand`, `UpdateManufactureOrderCommand`) and their response shapes are unchanged.
+
+## Dependencies
+- `Microsoft.Extensions.TimeProvider.Testing` (for `FakeTimeProvider` in tests — already in use elsewhere in the suite).
+- `TimeProvider` registration in DI (already present; no change needed).
+
+## Out of Scope
+- Any audit of other modules (Catalog, Logistics, Purchase, etc.) for similar `DateTime.UtcNow` leaks. A separate sweep should be filed if desired.
+- Refactoring or extracting a helper method around `_timeProvider.GetUtcNow().DateTime`. Direct inline replacement matches existing handler style.
+- Changing the property types from `DateTime` to `DateTimeOffset`.
+- Adding a Roslyn analyzer or test rule to forbid `DateTime.UtcNow` project-wide.
+- Modifying the `ManufactureOrder` or `ManufactureOrderNote` domain entities.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-manufacture-datetime-utcnow-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-manufacture-datetime-utcnow-/task-plan.r1.md
@@ -1,0 +1,11 @@
+Plan saved to `docs/superpowers/plans/2026-06-12-manufacture-timeprovider-consistency.md`.
+
+The plan breaks the work into 4 tasks executing in TDD red-green order:
+
+- **Task 0** — Baseline build + targeted test run to catch preexisting breakage.
+- **Task 1** — Duplicate handler: assertion already has `Mock<TimeProvider>` infrastructure in place; just adds two `Should().Be(FixedNow.UtcDateTime)` assertions, replaces 2 `DateTime.UtcNow` calls, commits.
+- **Task 2** — Update handler: migrates the test class from `TimeProvider.System` → `Mock<TimeProvider>`, tightens the existing `BeCloseTo(DateTime.UtcNow, ...)` assertion at line 223 to exact frozen-time equality, replaces 1 `DateTime.UtcNow` call, commits.
+- **Task 3** — Create handler: migrates the test class from `TimeProvider.System` → `Mock<TimeProvider>`, adds two `CreatedDate`/`StateChangedAt` assertions to the existing `Handle_ShouldCreateOrderWithCorrectBasicProperties` test, replaces 2 `DateTime.UtcNow` calls, commits.
+- **Task 4** — Final sweep: grep-confirm no `DateTime.UtcNow` left, full build, `dotnet format --verify-no-changes`, and full `Anela.Heblo.Tests.Features.Manufacture` namespace test run.
+
+Per pipeline instructions, skipping the execution-choice handoff prompt.

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
@@ -43,13 +43,13 @@ public class CreateManufactureOrderHandler : IRequestHandler<CreateManufactureOr
         var order = new ManufactureOrder
         {
             OrderNumber = orderNumber,
-            CreatedDate = DateTime.UtcNow,
+            CreatedDate = _timeProvider.GetUtcNow().DateTime,
             CreatedByUser = currentUser.Name,
             ResponsiblePerson = request.ResponsiblePerson,
             PlannedDate = request.PlannedDate,
             ManufactureType = request.ManufactureType,
             State = ManufactureOrderState.Draft,
-            StateChangedAt = DateTime.UtcNow,
+            StateChangedAt = _timeProvider.GetUtcNow().DateTime,
             StateChangedByUser = currentUser.Name
         };
 

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs
@@ -44,12 +44,12 @@ public class DuplicateManufactureOrderHandler : IRequestHandler<DuplicateManufac
         var duplicateOrder = new ManufactureOrder
         {
             OrderNumber = orderNumber,
-            CreatedDate = DateTime.UtcNow,
+            CreatedDate = _timeProvider.GetUtcNow().DateTime,
             CreatedByUser = currentUser.GetDisplayName(),
             ResponsiblePerson = sourceOrder.ResponsiblePerson,
             PlannedDate = today,
             State = ManufactureOrderState.Draft,
-            StateChangedAt = DateTime.UtcNow,
+            StateChangedAt = _timeProvider.GetUtcNow().DateTime,
             StateChangedByUser = currentUser.GetDisplayName()
         };
 

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs
@@ -142,7 +142,7 @@ public class UpdateManufactureOrderHandler : IRequestHandler<UpdateManufactureOr
                 order.Notes.Add(new ManufactureOrderNote
                 {
                     Text = request.NewNote.Trim(),
-                    CreatedAt = DateTime.UtcNow,
+                    CreatedAt = _timeProvider.GetUtcNow().DateTime,
                     CreatedByUser = currentUser.GetDisplayName()
                 });
             }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
@@ -17,7 +17,11 @@ public class CreateManufactureOrderHandlerTests
     private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IProductNameFormatter> _productNameFormatterMock;
+    private readonly Mock<TimeProvider> _timeProviderMock;
     private readonly CreateManufactureOrderHandler _handler;
+
+    private static readonly DateTimeOffset FixedNow =
+        new(2026, 6, 8, 10, 0, 0, TimeSpan.Zero);
 
     private const string ValidProductCode = "SEMI001";
     private const string ValidProductName = "Test Semi Product";
@@ -33,6 +37,8 @@ public class CreateManufactureOrderHandlerTests
         _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _productNameFormatterMock = new Mock<IProductNameFormatter>();
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(FixedNow);
 
         _currentUserServiceMock
             .Setup(x => x.GetCurrentUser())
@@ -44,7 +50,7 @@ public class CreateManufactureOrderHandlerTests
             _productNameFormatterMock.Object,
             _catalogRepositoryMock.Object,
             _currentUserServiceMock.Object,
-            TimeProvider.System);
+            _timeProviderMock.Object);
     }
 
     [Fact]
@@ -109,6 +115,8 @@ public class CreateManufactureOrderHandlerTests
         capturedOrder.PlannedDate.Should().Be(request.PlannedDate);
         capturedOrder.State.Should().Be(ManufactureOrderState.Draft);
         capturedOrder.StateChangedByUser.Should().Be("Test User");
+        capturedOrder.CreatedDate.Should().Be(FixedNow.UtcDateTime);
+        capturedOrder.StateChangedAt.Should().Be(FixedNow.UtcDateTime);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
@@ -165,6 +165,8 @@ public class DuplicateManufactureOrderHandlerTests
         captured.StateChangedByUser.Should().Be(DisplayName);
         captured.ResponsiblePerson.Should().Be(ResponsiblePerson);
         captured.PlannedDate.Should().Be(expectedPlannedDate);
+        captured.CreatedDate.Should().Be(FixedNow.UtcDateTime);
+        captured.StateChangedAt.Should().Be(FixedNow.UtcDateTime);
 
         // Assert duplicated semi-product
         captured.SemiProduct.Should().NotBeNull();

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs
@@ -14,8 +14,11 @@ public class UpdateManufactureOrderHandlerTests
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<ILogger<UpdateManufactureOrderHandler>> _loggerMock;
-    private readonly TimeProvider _timeProvider;
+    private readonly Mock<TimeProvider> _timeProviderMock;
     private readonly UpdateManufactureOrderHandler _handler;
+
+    private static readonly DateTimeOffset FixedNow =
+        new(2026, 6, 8, 10, 0, 0, TimeSpan.Zero);
 
     private const int ValidOrderId = 1;
     private const string ValidResponsiblePerson = "Jane Doe";
@@ -27,7 +30,8 @@ public class UpdateManufactureOrderHandlerTests
         _repositoryMock = new Mock<IManufactureOrderRepository>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _loggerMock = new Mock<ILogger<UpdateManufactureOrderHandler>>();
-        _timeProvider = TimeProvider.System;
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(FixedNow);
 
         _currentUserServiceMock
             .Setup(x => x.GetCurrentUser())
@@ -36,7 +40,7 @@ public class UpdateManufactureOrderHandlerTests
         _handler = new UpdateManufactureOrderHandler(
             _repositoryMock.Object,
             _currentUserServiceMock.Object,
-            _timeProvider,
+            _timeProviderMock.Object,
             _loggerMock.Object);
     }
 
@@ -220,7 +224,7 @@ public class UpdateManufactureOrderHandlerTests
         var note = updatedOrder.Notes.First();
         note.Text.Should().Be(ValidNewNote);
         note.CreatedByUser.Should().Be("Test User");
-        note.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        note.CreatedAt.Should().Be(FixedNow.UtcDateTime);
     }
 
     [Fact]

--- a/docs/superpowers/plans/2026-06-12-manufacture-timeprovider-consistency.md
+++ b/docs/superpowers/plans/2026-06-12-manufacture-timeprovider-consistency.md
@@ -1,0 +1,646 @@
+# Consistent TimeProvider Usage in Manufacture Order Handlers — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace five remaining `DateTime.UtcNow` occurrences in three Manufacture handlers with `_timeProvider.GetUtcNow().DateTime` so that `CreatedDate`, `StateChangedAt`, and note `CreatedAt` are deterministically controllable by `FakeTimeProvider` in tests.
+
+**Architecture:** Surgical inline replacement — no new abstractions, no DI changes, no new packages. Each of the three handlers already injects `TimeProvider` and uses it correctly for adjacent fields; this plan completes that convention for the missing fields. Tests use `Mock<TimeProvider>` from Moq (already the dominant project convention) and assert exact equality against `FixedNow.UtcDateTime`.
+
+**Tech Stack:** .NET 8, xUnit, FluentAssertions, Moq. No new NuGet packages.
+
+---
+
+## Background Context (for the implementing engineer)
+
+You do not need to read the spec or arch review documents to execute this plan — the relevant facts are inlined below.
+
+**Three handlers** in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/` mix `_timeProvider` and `DateTime.UtcNow` calls within the same method. Five lines need to change:
+
+| File | Line | Current | Replacement |
+|------|------|---------|-------------|
+| `CreateManufactureOrder/CreateManufactureOrderHandler.cs` | 46 | `CreatedDate = DateTime.UtcNow,` | `CreatedDate = _timeProvider.GetUtcNow().DateTime,` |
+| `CreateManufactureOrder/CreateManufactureOrderHandler.cs` | 52 | `StateChangedAt = DateTime.UtcNow,` | `StateChangedAt = _timeProvider.GetUtcNow().DateTime,` |
+| `DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` | 47 | `CreatedDate = DateTime.UtcNow,` | `CreatedDate = _timeProvider.GetUtcNow().DateTime,` |
+| `DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` | 52 | `StateChangedAt = DateTime.UtcNow,` | `StateChangedAt = _timeProvider.GetUtcNow().DateTime,` |
+| `UpdateManufactureOrder/UpdateManufactureOrderHandler.cs` | 145 | `CreatedAt = DateTime.UtcNow,` | `CreatedAt = _timeProvider.GetUtcNow().DateTime,` |
+
+**Key conventions (don't deviate):**
+- Test double: `Mock<TimeProvider>` from Moq (NOT `Microsoft.Extensions.TimeProvider.Testing` — that package is not in this codebase).
+- Assertion target: `FixedNow.UtcDateTime` (NOT `FixedNow.DateTime` — the property type is `DateTime` and `UtcDateTime` is guaranteed `DateTimeKind.Utc`).
+- Inline replacement: do not cache `_timeProvider.GetUtcNow().DateTime` into a local — the surrounding code already calls it inline at multiple points and the spec keeps that behavior.
+- Mocked `DateTimeOffset`: `new(2026, 6, 8, 10, 0, 0, TimeSpan.Zero)` — matches the existing pattern in `DuplicateManufactureOrderHandlerTests.cs:19-20`. Reuse that value where you introduce a new mock.
+
+**Out of scope (do not touch):** any other handler in the Manufacture module (e.g., `GetManufactureProtocolHandler.cs`, `ResolveManualActionHandler.cs`) even though they also call `DateTime.UtcNow`. Spec is explicit.
+
+---
+
+## File Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/
+  ├── CreateManufactureOrder/CreateManufactureOrderHandler.cs       (2 line edits)
+  ├── DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs (2 line edits)
+  └── UpdateManufactureOrder/UpdateManufactureOrderHandler.cs       (1 line edit)
+
+backend/test/Anela.Heblo.Tests/Features/Manufacture/
+  ├── CreateManufactureOrderHandlerTests.cs       (migrate TimeProvider.System → Mock<TimeProvider>; add frozen-time assertions)
+  ├── DuplicateManufactureOrderHandlerTests.cs    (add frozen-time assertions; mock already in place)
+  └── UpdateManufactureOrderHandlerTests.cs       (migrate TimeProvider.System → Mock<TimeProvider>; fix existing BeCloseTo assertion)
+```
+
+No new files. `CreateManufactureOrderHandlerSinglePhaseTests.cs` already mocks `TimeProvider` and is not modified by this plan — multi-phase test coverage in `CreateManufactureOrderHandlerTests.cs` satisfies FR-1 acceptance criteria for both `CreatedDate` and `StateChangedAt`.
+
+---
+
+## Task 0: Baseline — capture current build and test state
+
+Establish that the unchanged repo builds and the three Manufacture handler test classes pass before any edits. This catches preexisting breakage so it is not misattributed to your changes.
+
+**Files:** none modified
+
+- [ ] **Step 1: Build the backend solution**
+
+Run from repository root:
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded` with 0 errors. Warnings are acceptable.
+
+- [ ] **Step 2: Run the three target Manufacture test classes**
+
+Run from repository root:
+
+```bash
+cd backend && dotnet test --no-build \
+  --filter "FullyQualifiedName~CreateManufactureOrderHandlerTests|FullyQualifiedName~DuplicateManufactureOrderHandlerTests|FullyQualifiedName~UpdateManufactureOrderHandlerTests|FullyQualifiedName~CreateManufactureOrderHandlerSinglePhaseTests"
+```
+
+Expected: `Passed!` with all tests succeeding. If anything fails here, stop and report — do not proceed with changes on a broken baseline.
+
+---
+
+## Task 1: Duplicate handler — frozen-time assertions + handler replacement
+
+The test class already uses `Mock<TimeProvider>` with `FixedNow = new(2026, 6, 8, 10, 0, 0, TimeSpan.Zero)`. You only need to add assertions for `CreatedDate` and `StateChangedAt` to an existing test, then replace the two `DateTime.UtcNow` calls in the handler.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs:160-167` (assertion block in `Handle_DuplicatesAllFields_WhenSourceHasSemiProductAndProducts`)
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs:47` and `:52`
+
+- [ ] **Step 1: Add frozen-time assertions to the existing test**
+
+Open `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs`. Locate the assertion block in `Handle_DuplicatesAllFields_WhenSourceHasSemiProductAndProducts` that currently reads (around lines 160–167):
+
+```csharp
+        // Assert captured order
+        captured.Should().NotBeNull();
+        captured!.OrderNumber.Should().Be(GeneratedOrderNumber);
+        captured.State.Should().Be(ManufactureOrderState.Draft);
+        captured.CreatedByUser.Should().Be(DisplayName);
+        captured.StateChangedByUser.Should().Be(DisplayName);
+        captured.ResponsiblePerson.Should().Be(ResponsiblePerson);
+        captured.PlannedDate.Should().Be(expectedPlannedDate);
+```
+
+Replace that block with the same lines plus two new frozen-time assertions:
+
+```csharp
+        // Assert captured order
+        captured.Should().NotBeNull();
+        captured!.OrderNumber.Should().Be(GeneratedOrderNumber);
+        captured.State.Should().Be(ManufactureOrderState.Draft);
+        captured.CreatedByUser.Should().Be(DisplayName);
+        captured.StateChangedByUser.Should().Be(DisplayName);
+        captured.ResponsiblePerson.Should().Be(ResponsiblePerson);
+        captured.PlannedDate.Should().Be(expectedPlannedDate);
+        captured.CreatedDate.Should().Be(FixedNow.UtcDateTime);
+        captured.StateChangedAt.Should().Be(FixedNow.UtcDateTime);
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS (red)**
+
+```bash
+cd backend && dotnet test --no-build \
+  --filter "FullyQualifiedName~DuplicateManufactureOrderHandlerTests.Handle_DuplicatesAllFields_WhenSourceHasSemiProductAndProducts"
+```
+
+Expected: FAIL. The two new assertions should fail with messages like `Expected captured.CreatedDate to be 2026-06-08T10:00:00.0000000, but found <today's UTC timestamp>.` This confirms the handler still reads from `DateTime.UtcNow`.
+
+If the test passes here, stop — that means the handler may have already been changed or the time-mock setup is not actually being used. Investigate before proceeding.
+
+- [ ] **Step 3: Replace `DateTime.UtcNow` in the handler**
+
+Open `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs`. Edit the order-construction block (around lines 44–54):
+
+Replace:
+
+```csharp
+        // Create the duplicate order
+        var duplicateOrder = new ManufactureOrder
+        {
+            OrderNumber = orderNumber,
+            CreatedDate = DateTime.UtcNow,
+            CreatedByUser = currentUser.GetDisplayName(),
+            ResponsiblePerson = sourceOrder.ResponsiblePerson,
+            PlannedDate = today,
+            State = ManufactureOrderState.Draft,
+            StateChangedAt = DateTime.UtcNow,
+            StateChangedByUser = currentUser.GetDisplayName()
+        };
+```
+
+With:
+
+```csharp
+        // Create the duplicate order
+        var duplicateOrder = new ManufactureOrder
+        {
+            OrderNumber = orderNumber,
+            CreatedDate = _timeProvider.GetUtcNow().DateTime,
+            CreatedByUser = currentUser.GetDisplayName(),
+            ResponsiblePerson = sourceOrder.ResponsiblePerson,
+            PlannedDate = today,
+            State = ManufactureOrderState.Draft,
+            StateChangedAt = _timeProvider.GetUtcNow().DateTime,
+            StateChangedByUser = currentUser.GetDisplayName()
+        };
+```
+
+- [ ] **Step 4: Confirm no remaining `DateTime.UtcNow` in the handler**
+
+```bash
+grep -n "DateTime\.UtcNow" backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs || echo "CLEAN"
+```
+
+Expected: `CLEAN`. If any line is printed, repeat Step 3 for that line.
+
+- [ ] **Step 5: Build and run the test to verify it PASSES (green)**
+
+```bash
+cd backend && dotnet build && dotnet test --no-build \
+  --filter "FullyQualifiedName~DuplicateManufactureOrderHandlerTests"
+```
+
+Expected: `Build succeeded`, then `Passed!` for all DuplicateManufactureOrderHandlerTests.
+
+- [ ] **Step 6: Format**
+
+```bash
+cd backend && dotnet format --include \
+  src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs \
+  test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+```
+
+Expected: no output (or formatter messages only). No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+
+git commit -m "refactor: use TimeProvider for CreatedDate/StateChangedAt in DuplicateManufactureOrderHandler"
+```
+
+---
+
+## Task 2: Update handler — migrate test to mock + fix existing assertion + handler replacement
+
+The test class currently injects `TimeProvider.System` and uses a `BeCloseTo(DateTime.UtcNow, ...)` assertion for the note's `CreatedAt`. You will (a) migrate the constructor field to `Mock<TimeProvider>` with a frozen `FixedNow`, (b) tighten the existing assertion to exact equality against the frozen time, and (c) replace the single `DateTime.UtcNow` in the handler.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs` (constructor + field declarations + one assertion)
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs:145`
+
+- [ ] **Step 1: Replace the field declaration with a mocked TimeProvider**
+
+Open `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs`. Locate the field declarations at lines 14–18:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderHandler>> _loggerMock;
+    private readonly TimeProvider _timeProvider;
+    private readonly UpdateManufactureOrderHandler _handler;
+```
+
+Replace with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderHandler>> _loggerMock;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly UpdateManufactureOrderHandler _handler;
+
+    private static readonly DateTimeOffset FixedNow =
+        new(2026, 6, 8, 10, 0, 0, TimeSpan.Zero);
+```
+
+- [ ] **Step 2: Update the constructor to use the mocked TimeProvider**
+
+Locate the constructor body at lines 25–41:
+
+```csharp
+    public UpdateManufactureOrderHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderHandler>>();
+        _timeProvider = TimeProvider.System;
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
+
+        _handler = new UpdateManufactureOrderHandler(
+            _repositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _timeProvider,
+            _loggerMock.Object);
+    }
+```
+
+Replace with:
+
+```csharp
+    public UpdateManufactureOrderHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderHandler>>();
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(FixedNow);
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
+
+        _handler = new UpdateManufactureOrderHandler(
+            _repositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _timeProviderMock.Object,
+            _loggerMock.Object);
+    }
+```
+
+- [ ] **Step 3: Tighten the existing `BeCloseTo` assertion to exact frozen-time equality**
+
+Still in the same file, locate the assertion in `Handle_WithNewNote_ShouldAddNoteToOrder` at line 223:
+
+```csharp
+        note.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+```
+
+Replace with:
+
+```csharp
+        note.CreatedAt.Should().Be(FixedNow.UtcDateTime);
+```
+
+- [ ] **Step 4: Build, then run the test to verify the note assertion FAILS (red)**
+
+The test infrastructure migration alone (without the assertion change) would still let the handler-side `DateTime.UtcNow` slip through. After Step 3 the assertion is strict, so it should now fail until the handler is fixed.
+
+```bash
+cd backend && dotnet build && dotnet test --no-build \
+  --filter "FullyQualifiedName~UpdateManufactureOrderHandlerTests.Handle_WithNewNote_ShouldAddNoteToOrder"
+```
+
+Expected: FAIL with `Expected note.CreatedAt to be 2026-06-08T10:00:00.0000000, but found <today's UTC timestamp>.`
+
+If the test passes here, the handler may have already been changed; verify and investigate before proceeding.
+
+- [ ] **Step 5: Replace `DateTime.UtcNow` in the handler**
+
+Open `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs`. Locate the note-creation block around lines 141–147:
+
+```csharp
+                var currentUser = _currentUserService.GetCurrentUser();
+                order.Notes.Add(new ManufactureOrderNote
+                {
+                    Text = request.NewNote.Trim(),
+                    CreatedAt = DateTime.UtcNow,
+                    CreatedByUser = currentUser.GetDisplayName()
+                });
+```
+
+Replace with:
+
+```csharp
+                var currentUser = _currentUserService.GetCurrentUser();
+                order.Notes.Add(new ManufactureOrderNote
+                {
+                    Text = request.NewNote.Trim(),
+                    CreatedAt = _timeProvider.GetUtcNow().DateTime,
+                    CreatedByUser = currentUser.GetDisplayName()
+                });
+```
+
+- [ ] **Step 6: Confirm no remaining `DateTime.UtcNow` in the handler**
+
+```bash
+grep -n "DateTime\.UtcNow" backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs || echo "CLEAN"
+```
+
+Expected: `CLEAN`.
+
+- [ ] **Step 7: Build and run all UpdateManufactureOrderHandlerTests (green)**
+
+```bash
+cd backend && dotnet build && dotnet test --no-build \
+  --filter "FullyQualifiedName~UpdateManufactureOrderHandlerTests"
+```
+
+Expected: `Build succeeded`, then `Passed!` for all UpdateManufactureOrderHandlerTests. If any other tests in the class fail (e.g., due to the now-frozen time interacting with `CreateExistingOrder()` which calls `DateTime.UtcNow.AddDays(-1)`), investigate — those assertions only compare against `request` values and `existingOrder` values, not against `_timeProvider`, so they should remain unaffected.
+
+- [ ] **Step 8: Format**
+
+```bash
+cd backend && dotnet format --include \
+  src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs \
+  test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs
+
+git commit -m "refactor: use TimeProvider for note CreatedAt in UpdateManufactureOrderHandler"
+```
+
+---
+
+## Task 3: Create handler — migrate test to mock + frozen-time assertions + handler replacement
+
+The test class currently injects `TimeProvider.System` and never asserts on `CreatedDate` or `StateChangedAt`. You will (a) migrate the constructor field to `Mock<TimeProvider>`, (b) add frozen-time assertions to the existing `Handle_ShouldCreateOrderWithCorrectBasicProperties` test, and (c) replace the two `DateTime.UtcNow` calls in the handler.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` (field declarations + constructor + one assertion block)
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs:46` and `:52`
+
+- [ ] **Step 1: Replace the handler construction in the test constructor with a mocked TimeProvider**
+
+Open `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs`. Locate the field declarations at lines 16–20:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IProductNameFormatter> _productNameFormatterMock;
+    private readonly CreateManufactureOrderHandler _handler;
+```
+
+Replace with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IProductNameFormatter> _productNameFormatterMock;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly CreateManufactureOrderHandler _handler;
+
+    private static readonly DateTimeOffset FixedNow =
+        new(2026, 6, 8, 10, 0, 0, TimeSpan.Zero);
+```
+
+- [ ] **Step 2: Update the constructor body to use the mocked TimeProvider**
+
+Locate the constructor body at lines 30–48:
+
+```csharp
+    public CreateManufactureOrderHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _productNameFormatterMock = new Mock<IProductNameFormatter>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
+
+        _productNameFormatterMock.Setup(s => s.ShortProductName(It.IsAny<string>())).Returns<string>(_ => ValidProductName);
+        _handler = new CreateManufactureOrderHandler(
+            _repositoryMock.Object,
+            _productNameFormatterMock.Object,
+            _catalogRepositoryMock.Object,
+            _currentUserServiceMock.Object,
+            TimeProvider.System);
+    }
+```
+
+Replace with:
+
+```csharp
+    public CreateManufactureOrderHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _productNameFormatterMock = new Mock<IProductNameFormatter>();
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(FixedNow);
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
+
+        _productNameFormatterMock.Setup(s => s.ShortProductName(It.IsAny<string>())).Returns<string>(_ => ValidProductName);
+        _handler = new CreateManufactureOrderHandler(
+            _repositoryMock.Object,
+            _productNameFormatterMock.Object,
+            _catalogRepositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _timeProviderMock.Object);
+    }
+```
+
+- [ ] **Step 3: Add frozen-time assertions to `Handle_ShouldCreateOrderWithCorrectBasicProperties`**
+
+Locate the assertion block at the end of `Handle_ShouldCreateOrderWithCorrectBasicProperties` (lines 105–112):
+
+```csharp
+        capturedOrder.Should().NotBeNull();
+        capturedOrder!.OrderNumber.Should().Be(GeneratedOrderNumber);
+        capturedOrder.CreatedByUser.Should().Be("Test User");
+        capturedOrder.ResponsiblePerson.Should().Be(ValidResponsiblePerson);
+        capturedOrder.PlannedDate.Should().Be(request.PlannedDate);
+        capturedOrder.State.Should().Be(ManufactureOrderState.Draft);
+        capturedOrder.StateChangedByUser.Should().Be("Test User");
+    }
+```
+
+Replace with:
+
+```csharp
+        capturedOrder.Should().NotBeNull();
+        capturedOrder!.OrderNumber.Should().Be(GeneratedOrderNumber);
+        capturedOrder.CreatedByUser.Should().Be("Test User");
+        capturedOrder.ResponsiblePerson.Should().Be(ValidResponsiblePerson);
+        capturedOrder.PlannedDate.Should().Be(request.PlannedDate);
+        capturedOrder.State.Should().Be(ManufactureOrderState.Draft);
+        capturedOrder.StateChangedByUser.Should().Be("Test User");
+        capturedOrder.CreatedDate.Should().Be(FixedNow.UtcDateTime);
+        capturedOrder.StateChangedAt.Should().Be(FixedNow.UtcDateTime);
+    }
+```
+
+- [ ] **Step 4: Build, then run the test to verify it FAILS (red)**
+
+```bash
+cd backend && dotnet build && dotnet test --no-build \
+  --filter "FullyQualifiedName~CreateManufactureOrderHandlerTests.Handle_ShouldCreateOrderWithCorrectBasicProperties"
+```
+
+Expected: FAIL with `Expected capturedOrder.CreatedDate to be 2026-06-08T10:00:00.0000000, but found <today's UTC timestamp>.`
+
+If the test passes here, the handler may already have been changed. Investigate before proceeding.
+
+- [ ] **Step 5: Replace `DateTime.UtcNow` in the handler**
+
+Open `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`. Locate the order-construction block at lines 43–54:
+
+```csharp
+        var order = new ManufactureOrder
+        {
+            OrderNumber = orderNumber,
+            CreatedDate = DateTime.UtcNow,
+            CreatedByUser = currentUser.Name,
+            ResponsiblePerson = request.ResponsiblePerson,
+            PlannedDate = request.PlannedDate,
+            ManufactureType = request.ManufactureType,
+            State = ManufactureOrderState.Draft,
+            StateChangedAt = DateTime.UtcNow,
+            StateChangedByUser = currentUser.Name
+        };
+```
+
+Replace with:
+
+```csharp
+        var order = new ManufactureOrder
+        {
+            OrderNumber = orderNumber,
+            CreatedDate = _timeProvider.GetUtcNow().DateTime,
+            CreatedByUser = currentUser.Name,
+            ResponsiblePerson = request.ResponsiblePerson,
+            PlannedDate = request.PlannedDate,
+            ManufactureType = request.ManufactureType,
+            State = ManufactureOrderState.Draft,
+            StateChangedAt = _timeProvider.GetUtcNow().DateTime,
+            StateChangedByUser = currentUser.Name
+        };
+```
+
+- [ ] **Step 6: Confirm no remaining `DateTime.UtcNow` in the handler**
+
+```bash
+grep -n "DateTime\.UtcNow" backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs || echo "CLEAN"
+```
+
+Expected: `CLEAN`.
+
+- [ ] **Step 7: Build and run all CreateManufactureOrderHandlerTests (green)**
+
+```bash
+cd backend && dotnet build && dotnet test --no-build \
+  --filter "FullyQualifiedName~CreateManufactureOrderHandlerTests|FullyQualifiedName~CreateManufactureOrderHandlerSinglePhaseTests"
+```
+
+Expected: `Build succeeded`, then `Passed!` for both test classes. The `CreateManufactureOrderHandlerSinglePhaseTests` class is included because it constructs the same handler — its preexisting mock setup uses a different `currentTime`, but it does not assert on `CreatedDate` or `StateChangedAt`, so it should continue to pass unchanged.
+
+- [ ] **Step 8: Format**
+
+```bash
+cd backend && dotnet format --include \
+  src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs \
+  test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
+
+git commit -m "refactor: use TimeProvider for CreatedDate/StateChangedAt in CreateManufactureOrderHandler"
+```
+
+---
+
+## Task 4: Final verification — full build, format, and Manufacture test sweep
+
+Confirm the worktree is clean and all Manufacture tests still pass together, not just per-handler.
+
+**Files:** none modified
+
+- [ ] **Step 1: Verify no `DateTime.UtcNow` remains in any of the three handlers**
+
+```bash
+grep -n "DateTime\.UtcNow" \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs \
+  || echo "ALL THREE HANDLERS CLEAN"
+```
+
+Expected: `ALL THREE HANDLERS CLEAN`.
+
+- [ ] **Step 2: Full backend build**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded` with 0 errors. Warning count should not have increased from the baseline in Task 0.
+
+- [ ] **Step 3: Full backend format check**
+
+```bash
+cd backend && dotnet format --verify-no-changes
+```
+
+Expected: no diff and no errors. If `dotnet format` reports changes, run `cd backend && dotnet format` to apply them, then add the formatted files to a follow-up commit.
+
+- [ ] **Step 4: Run the full Manufacture test namespace**
+
+```bash
+cd backend && dotnet test --no-build \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture"
+```
+
+Expected: `Passed!` for every test. If anything fails, locate and fix before declaring done — this catches accidental coupling, e.g. a Manufacture test elsewhere that happens to construct one of these handlers with `TimeProvider.System`.
+
+- [ ] **Step 5: Confirm git working tree is clean**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean`. If there are stray untracked or unstaged files from formatting, commit them with a `chore: dotnet format` message.
+
+---
+
+## Self-Review Notes (for the implementing engineer)
+
+This plan addresses each spec requirement exactly once:
+
+| Requirement | Covered by |
+|-------------|-----------|
+| FR-1 (Create handler — 2 lines) | Task 3, Steps 5–6 |
+| FR-2 (Duplicate handler — 2 lines) | Task 1, Steps 3–4 |
+| FR-3 (Update handler — 1 line)  | Task 2, Steps 5–6 |
+| FR-4 (Test coverage per handler) | Task 1 Step 1 (Duplicate), Task 2 Step 3 (Update), Task 3 Step 3 (Create) |
+| NFR-3 (Build & format clean) | Task 4, Steps 2–3 |
+
+There are no placeholder steps. Each step contains either exact code, exact commands, or both. All `_timeProvider.GetUtcNow().DateTime` references are spelled identically across tasks. The `FixedNow` value is identical to the existing convention in `DuplicateManufactureOrderHandlerTests.cs`.


### PR DESCRIPTION

Replace `DateTime.UtcNow` with `_timeProvider.GetUtcNow().DateTime` in the three Manufacture order handlers (`Create`, `Duplicate`, `Update`) so that `CreatedDate`, `StateChangedAt`, and note `CreatedAt` are fully controllable by `FakeTimeProvider` in tests. Each handler already injected `TimeProvider` and used it for adjacent fields; this change completes the convention for the five remaining fields that had silently reverted to the system clock.

Test classes for `Update` and `Create` handlers were migrated from `TimeProvider.System` to `Mock<TimeProvider>` with a fixed `DateTimeOffset(2026, 6, 8, 10, 0, 0, TimeSpan.Zero)`, and new exact-equality assertions (`Should().Be(FixedNow.UtcDateTime)`) were added for all five previously-uncontrolled fields.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` — replaced 2 `DateTime.UtcNow` calls
- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs` — replaced 1 `DateTime.UtcNow` call
- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` — replaced 2 `DateTime.UtcNow` calls
- `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs` — added 2 frozen-time assertions
- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs` — migrated to `Mock<TimeProvider>`, tightened note `CreatedAt` assertion
- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` — migrated to `Mock<TimeProvider>`, added 2 frozen-time assertions

---

Closes #2676

### Tokens used
12429015
