### PR TITLE
feat: TimeProvider Injection in ProductionActivityAnalyzer

### DIFF
--- a/artifacts/feat-arch-review-manufacture-productionactivi/arch-review.r1.md
+++ b/artifacts/feat-arch-review-manufacture-productionactivi/arch-review.r1.md
@@ -1,0 +1,166 @@
+# Architecture Review: TimeProvider Injection in ProductionActivityAnalyzer
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a pure backend refactor that brings `ProductionActivityAnalyzer` into alignment with an already-established module convention. Verified facts:
+
+- `TimeProvider.System` is registered as a singleton in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:128` — no additional DI wiring is required.
+- 15 handlers/services in `backend/src/Anela.Heblo.Application/Features/Manufacture` already inject `TimeProvider` as a constructor parameter (e.g. `SubmitManufactureHandler.cs:17,25`). The proposed constructor shape `(ILogger<T> logger, TimeProvider timeProvider)` matches the dominant ordering used in the module.
+- `IProductionActivityAnalyzer` is registered scoped in `ManufactureModule.cs:38`; resolution will pick up the singleton `TimeProvider` without code change.
+- The interface in `Anela.Heblo.Domain.Features.Manufacture` is **not** modified — no Domain layer changes, so Clean Architecture boundaries remain intact (Application depends on Domain, Domain has no time concern).
+
+**Main integration point:** `ProductionActivityAnalyzer` is consumed by `ManufactureSeverityCalculator` (and indirectly by stock analysis dashboard handlers). No consumer signature changes — they continue to call interface methods unchanged.
+
+**Architectural verdict:** The change is mechanical, low-risk, conformant. Approve as specified.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.API (composition root)
+   └── AddSingleton(TimeProvider.System)            [unchanged]
+
+Anela.Heblo.Application.Features.Manufacture
+   └── ManufactureModule.AddManufactureModule(...)  [unchanged]
+        └── AddScoped<IProductionActivityAnalyzer, ProductionActivityAnalyzer>
+
+   Services/
+      ProductionActivityAnalyzer  [MODIFIED]
+         ├── ctor(ILogger, TimeProvider)            ← was (ILogger)
+         ├── IsInActiveProduction(...)              ← _timeProvider.GetUtcNow().DateTime
+         ├── GetLastProductionDate(...)             ← unchanged
+         └── CalculateAverageProductionFrequency(...) ← _timeProvider.GetUtcNow().DateTime
+
+Anela.Heblo.Tests.Features.Manufacture.Services
+   └── ProductionActivityAnalyzerTests             [MODIFIED]
+        └── uses fake clock at frozen "now"
+```
+
+No new files. No new interfaces. No DI registration changes.
+
+### Key Design Decisions
+
+#### Decision 1: Constructor ordering — logger first, TimeProvider second
+**Options considered:**
+1. `(ILogger, TimeProvider)` — matches `SubmitManufactureHandler` and most peer handlers.
+2. `(TimeProvider, ILogger)` — places infrastructure dependency first.
+
+**Chosen approach:** Option 1.
+**Rationale:** Module-wide convention places `ILogger<T>` first across the existing 15 TimeProvider-injecting handlers. Consistency wins over abstract ordering preferences.
+
+#### Decision 2: `GetUtcNow().DateTime` rather than `GetUtcNow().UtcDateTime`
+**Options considered:**
+1. `_timeProvider.GetUtcNow().DateTime` — returns the `DateTime` portion as `DateTimeKind.Unspecified`.
+2. `_timeProvider.GetUtcNow().UtcDateTime` — returns `DateTime` with `DateTimeKind.Utc`.
+
+**Chosen approach:** Option 1 (as in spec).
+**Rationale:** Replaces `DateTime.UtcNow` (which produces `Kind=Utc`). However, the existing code compares `m.Date` (a `DateTime` whose `Kind` is whatever the persistence layer hydrates — typically `Unspecified` for PostgreSQL `timestamp without time zone`). Using `.DateTime` matches the comparison semantics already in production and preserves bit-for-bit behavior (FR-6). **Note: see Risk R-1** — if `m.Date` is `Utc`-kinded, neither variant changes comparison correctness (DateTime comparison ignores Kind), so the choice is harmless. Spec wording is correct.
+
+#### Decision 3: Test fake clock — package vs. local subclass
+**Options considered:**
+1. Add `Microsoft.Extensions.TimeProvider.Testing` package to `Anela.Heblo.Tests.csproj` and use `Microsoft.Extensions.Time.Testing.FakeTimeProvider` (as the spec suggests).
+2. Reuse the local `FakeTimeProvider` subclass pattern already used in `backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingDashboardHandlerTests.cs:18` (custom nested subclass).
+3. Define a single shared `FakeTimeProvider` test helper in the test project.
+
+**Chosen approach:** Option 1 — add the Microsoft package.
+**Rationale:** The test project currently has **zero** reference to `Microsoft.Extensions.TimeProvider.Testing` (verified — `Anela.Heblo.Tests.csproj` package list). The packaging-dashboard test rolled its own subclass for a specific reason (`GetLocalNow()` is non-virtual and the test needed a fake local time-zone behavior). The `ProductionActivityAnalyzer` only needs `GetUtcNow()`, which is virtual and trivially overridable — but using the Microsoft-supported `FakeTimeProvider` is the canonical .NET pattern, removes boilerplate, and adds the standard `Advance()` / `SetUtcNow()` ergonomics that future tests in this class will benefit from. The package is part of the official `Microsoft.Extensions.*` family and is the documented testing companion to .NET 8 `TimeProvider`.
+
+**Implication for spec:** the test project must add `<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.x" />` to `Anela.Heblo.Tests.csproj`. The spec already notes this conditionally — make it unconditional.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Modify in place:
+
+| File | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs` | Add `TimeProvider` ctor param + field; replace two `DateTime.UtcNow` references. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs` | Switch to `FakeTimeProvider`; rewrite relative-date seeds to use frozen now; add boundary tests. |
+| `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` | Add `Microsoft.Extensions.TimeProvider.Testing` package reference. |
+
+No changes to `ManufactureModule.cs`, no changes to `IProductionActivityAnalyzer`, no changes to any consumer.
+
+### Interfaces and Contracts
+
+**Unchanged public contract:**
+```csharp
+public interface IProductionActivityAnalyzer
+{
+    bool IsInActiveProduction(IEnumerable<ManufactureHistoryRecord> manufactureHistory, int dayThreshold = 30);
+    DateTime? GetLastProductionDate(IEnumerable<ManufactureHistoryRecord> manufactureHistory);
+    double CalculateAverageProductionFrequency(IEnumerable<ManufactureHistoryRecord> manufactureHistory, int analysisMonths = 12);
+}
+```
+
+**Constructor contract (new):**
+```csharp
+public ProductionActivityAnalyzer(
+    ILogger<ProductionActivityAnalyzer> logger,
+    TimeProvider timeProvider);
+```
+
+**Test fixture contract (recommended):**
+```csharp
+private static readonly DateTime FrozenNowUtc = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(FrozenNowUtc));
+// ctor: _analyzer = new ProductionActivityAnalyzer(_loggerMock.Object, _timeProvider);
+```
+
+### Data Flow
+
+For `IsInActiveProduction`:
+```
+caller → IsInActiveProduction(history, dayThreshold)
+   → cutoffDate = _timeProvider.GetUtcNow().DateTime.AddDays(-dayThreshold)
+   → history.Any(m.Date >= cutoffDate && m.Amount > 0)
+   → bool
+```
+
+For `CalculateAverageProductionFrequency`:
+```
+caller → CalculateAverageProductionFrequency(history, analysisMonths)
+   → analysisStartDate = _timeProvider.GetUtcNow().DateTime.AddMonths(-analysisMonths)
+   → history.Where(Date >= analysisStartDate && Amount > 0).Select(Date).OrderBy
+   → if count < 2: PositiveInfinity
+   → otherwise: average of consecutive intervals (TotalDays)
+```
+
+No call-site changes.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **R-1.** `DateTimeKind` mismatch between `_timeProvider.GetUtcNow().DateTime` (`Unspecified`) and previously `DateTime.UtcNow` (`Utc`) could subtly affect downstream code that inspects `Kind`. | Low | DateTime arithmetic and comparison operators ignore `Kind`. `cutoffDate` and `analysisStartDate` are only used in `>=` comparisons against `m.Date`. Verified: no consumer of the local variables inspects `Kind`. No mitigation needed beyond the existing FR-6 acceptance criterion (observable behavior unchanged). |
+| **R-2.** Boundary semantics in new tests must match production code exactly. Spec FR-5 acceptance leaves "record at exactly `cutoff` included or excluded" as a documented choice. | Low | Production code uses `m.Date >= cutoffDate` — equality is **included**. Tests must encode this explicitly with test names like `IsInActiveProduction_WithRecordExactlyAtCutoff_ReturnsTrue`. Reject any reviewer suggestion to change the comparison operator. |
+| **R-3.** Adding `Microsoft.Extensions.TimeProvider.Testing` may collide with the locally-defined `FakeTimeProvider` in `GetPackingDashboardHandlerTests`. | Very Low | The local subclass is `private sealed` and namespace-scoped to the test class — no collision. If a future refactor unifies them, that's out of scope. |
+| **R-4.** A future writer of additional `ProductionActivityAnalyzer` methods may again reach for `DateTime.UtcNow`. | Low | Convention is now explicit and matches the rest of the module. No structural mitigation required; code review enforces. |
+| **R-5.** Test project version of `Microsoft.Extensions.TimeProvider.Testing` must be compatible with .NET 8. | Low | Use version `8.x` (e.g. `8.0.0` or `8.0.1`); avoid 9.x to match the test SDK targeting `net8.0` (`<TargetFramework>net8.0</TargetFramework>` confirmed in csproj). |
+
+## Specification Amendments
+
+1. **Make the test package reference unconditional.** Spec currently says "Test-only addition (if not already referenced)". Verified: it is **not** referenced. The implementation must add `<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.*" />` to `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`. Pin to the `8.0.x` major to align with the project's `net8.0` target.
+
+2. **Fully qualify the test type to avoid collision.** A `FakeTimeProvider` subclass already exists in the same test assembly (`GetPackingDashboardHandlerTests.FakeTimeProvider`). The new tests should import `Microsoft.Extensions.Time.Testing.FakeTimeProvider` explicitly or use the fully-qualified type name on first reference to keep the reader's intent unambiguous.
+
+3. **Document boundary semantics in test names.** FR-5 leaves the equality case as "chosen behavior must match production code." Pin the choice: `m.Date >= cutoffDate` means the boundary is **inclusive**. Test names should reflect that (e.g. `IsInActiveProduction_RecordExactlyAtCutoff_IsConsideredActive`).
+
+4. **Clarify FR-3 boundary test wording.** Spec says: "a record exactly at `analysisStartDate` is included; a record at `analysisStartDate.AddTicks(-1)` is excluded." This is consistent with `m.Date >= analysisStartDate`. Keep the wording — no change beyond confirming it.
+
+5. **Add an explicit assertion in FR-2 / FR-3 acceptance: log lines must continue to emit the cutoff/analysis date** (currently included in `_logger.LogDebug` calls). FR-6 covers this implicitly; making it explicit prevents accidental log-line removal during refactor.
+
+## Prerequisites
+
+None blocking. All prerequisites are already met in the codebase:
+
+- ✅ `TimeProvider.System` registered as singleton (`ServiceCollectionExtensions.cs:127-128`).
+- ✅ `IProductionActivityAnalyzer` registered scoped (`ManufactureModule.cs:38`).
+- ✅ .NET 8 (provides `System.TimeProvider`).
+- ✅ Convention precedent established across 15 peer files in the Manufacture module.
+
+**One implementation prerequisite** (not infrastructure):
+- Add `Microsoft.Extensions.TimeProvider.Testing` 8.0.x package reference to `Anela.Heblo.Tests.csproj` **before** updating test code, so the test project compiles incrementally.

--- a/artifacts/feat-arch-review-manufacture-productionactivi/brief.md
+++ b/artifacts/feat-arch-review-manufacture-productionactivi/brief.md
@@ -1,0 +1,40 @@
+## Module
+Manufacture
+
+## Finding
+`ProductionActivityAnalyzer` uses `DateTime.UtcNow` directly for two business-logic time cutoffs, with no `TimeProvider` injection:
+
+```
+backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs
+  line 17: var cutoffDate = DateTime.UtcNow.AddDays(-dayThreshold);
+  line 45: var analysisStartDate = DateTime.UtcNow.AddMonths(-analysisMonths);
+```
+
+These cutoffs determine whether a product is classified as "in active production" (`IsInActiveProduction`) and compute average production frequency (`CalculateAverageProductionFrequency`). Both results feed into the severity classifications shown on the stock analysis dashboard, and the service has dedicated tests in `backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs`.
+
+## Why it matters
+The two methods implement time-windowed business logic: "was there a manufacture run in the last N days?" and "what is the average interval over the last M months?". Because the cutoff is hard-wired to wall-clock time, the tests cannot set up deterministic scenarios (e.g. "a run 25 days ago is active with a 30-day threshold but not with a 20-day threshold"). Any test that seeds history records with relative dates is valid only on the day it was written; it will silently drift as time passes. This is inconsistent with every other time-aware handler in the module, which all inject `TimeProvider` for exactly this reason.
+
+## Suggested fix
+1. Add `TimeProvider _timeProvider` to the constructor.
+2. Replace `DateTime.UtcNow` with `_timeProvider.GetUtcNow().DateTime` on lines 17 and 45.
+3. In `ManufactureModule.AddManufactureModule` (already registers `IProductionActivityAnalyzer`), no DI change is needed — `TimeProvider` is registered as a singleton by the framework.
+
+```csharp
+public ProductionActivityAnalyzer(ILogger<ProductionActivityAnalyzer> logger, TimeProvider timeProvider)
+{
+    _logger = logger;
+    _timeProvider = timeProvider;
+}
+
+// line 17
+var cutoffDate = _timeProvider.GetUtcNow().DateTime.AddDays(-dayThreshold);
+
+// line 45
+var analysisStartDate = _timeProvider.GetUtcNow().DateTime.AddMonths(-analysisMonths);
+```
+
+Test fixtures can then pass `FakeTimeProvider` and seed history records relative to the frozen "now".
+
+---
+_Filed by daily arch-review routine on 2026-06-06._

--- a/artifacts/feat-arch-review-manufacture-productionactivi/impl/main.r1.md
+++ b/artifacts/feat-arch-review-manufacture-productionactivi/impl/main.r1.md
@@ -1,0 +1,58 @@
+All 5 tasks complete. Here is the output summary:
+
+---
+
+# Implementation: TimeProvider Injection in ProductionActivityAnalyzer
+
+## What was implemented
+
+Replaced direct `DateTime.UtcNow` usage in `ProductionActivityAnalyzer` with the injected `TimeProvider` abstraction. The constructor now accepts `TimeProvider` alongside the existing `ILogger<T>`, matching the convention already used by 15 peer handlers in the Manufacture module. The test suite was migrated to `FakeTimeProvider` with a frozen UTC instant, making all time-windowed tests fully deterministic, and four new boundary tests were added to pin the inclusive equality semantics (`m.Date >= cutoffDate`).
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs` — added `TimeProvider` field + constructor param; replaced 2× `DateTime.UtcNow` with `_timeProvider.GetUtcNow().DateTime`; `GetLastProductionDate` and all logging unchanged
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs` — fixture switched to `FakeTimeProvider(FrozenNowUtc = 2026-06-01 12:00 UTC)`; all 12 original tests reseeded from `FrozenNowUtc`; 4 new boundary tests added
+- `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — added `Microsoft.Extensions.TimeProvider.Testing 8.1.0` (8.0.1 was not on NuGet; 8.1.0 is the compatible 8.x release)
+
+## Tests
+
+- **ProductionActivityAnalyzerTests** — 16 tests total (12 original + 4 boundary): all pass
+  - `IsInActiveProduction_RecordExactlyAtCutoff_IsConsideredActive` — inclusive boundary
+  - `IsInActiveProduction_RecordOneTickBeforeCutoff_IsNotConsideredActive` — exclusive below
+  - `CalculateAverageProductionFrequency_RecordExactlyAtAnalysisStart_IsIncluded` — inclusive boundary → 15-day interval
+  - `CalculateAverageProductionFrequency_RecordOneTickBeforeAnalysisStart_IsExcluded` — excluded → `PositiveInfinity`
+- **Manufacture slice** — 538 tests, all pass
+
+## How to verify
+
+```bash
+cd backend
+dotnet build Anela.Heblo.sln
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ProductionActivityAnalyzerTests" --no-build
+grep -nH 'DateTime\.UtcNow' \
+  src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs \
+  test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
+```
+All three commands should complete cleanly.
+
+## Notes
+
+- Package version 8.0.1 was unavailable on NuGet; 8.1.0 was used — still targets `net8.0`, fully compatible.
+- `IProductionActivityAnalyzer` interface and all consumers (`ManufactureSeverityCalculator`, etc.) are unchanged.
+- No DI registration changes were required — `TimeProvider.System` was already registered as a singleton in `ServiceCollectionExtensions.cs`.
+
+## PR Summary
+
+Injects `TimeProvider` into `ProductionActivityAnalyzer` so that time-windowed business logic (active-production detection and average production frequency) becomes deterministically testable. This is a pure mechanical refactor — no interface changes, no DI wiring changes, no behavioral changes in production.
+
+The test suite is now anchored to a frozen UTC instant (`2026-06-01 12:00:00`) via `FakeTimeProvider`, eliminating silent date-drift in existing tests and enabling precise boundary assertions. Four new boundary tests pin the inclusive equality semantics (`m.Date >= cutoffDate`) that the production code already implements.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs` — added `TimeProvider` ctor param and field; replaced 2× `DateTime.UtcNow`
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs` — migrated to `FakeTimeProvider`; 4 boundary tests added (16 total)
+- `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — added `Microsoft.Extensions.TimeProvider.Testing 8.1.0`
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-manufacture-productionactivi/spec.r1.md
+++ b/artifacts/feat-arch-review-manufacture-productionactivi/spec.r1.md
@@ -1,0 +1,154 @@
+# Specification: TimeProvider Injection in ProductionActivityAnalyzer
+
+## Summary
+Replace direct `DateTime.UtcNow` usage in `ProductionActivityAnalyzer` with the injected `TimeProvider` abstraction so that time-windowed business logic (active-production detection and average production frequency) becomes deterministically testable. This aligns the service with the rest of the Manufacture module, where every other time-aware handler already injects `TimeProvider`.
+
+## Background
+`ProductionActivityAnalyzer` implements two pieces of time-windowed business logic:
+
+- **`IsInActiveProduction`** — classifies a product as "in active production" if any manufacture history record falls within the last N days.
+- **`CalculateAverageProductionFrequency`** — averages the intervals between production events within the last M months.
+
+Both outputs feed into severity classifications displayed on the stock analysis dashboard. Today both methods read wall-clock time directly via `DateTime.UtcNow` (lines 17 and 45 of `backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs`). The existing test suite in `backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs` works around this by seeding records with `DateTime.UtcNow.AddDays(...)` / `AddMonths(...)` offsets. These tests are correct on the day they were written but drift silently as time passes, and they cannot exercise boundary scenarios (e.g. "a 25-day-old run is active at threshold 30 but inactive at threshold 20") without flakiness.
+
+The Manufacture module already registers `IProductionActivityAnalyzer` in `ManufactureModule.AddManufactureModule`, and `TimeProvider` is registered as a framework singleton — so no DI wiring changes are required beyond constructor injection.
+
+## Functional Requirements
+
+### FR-1: Inject TimeProvider into ProductionActivityAnalyzer
+The `ProductionActivityAnalyzer` constructor must accept `TimeProvider` in addition to its existing `ILogger<ProductionActivityAnalyzer>` dependency, and must store it as a private readonly field.
+
+**Acceptance criteria:**
+- The class exposes a single public constructor with the signature `ProductionActivityAnalyzer(ILogger<ProductionActivityAnalyzer> logger, TimeProvider timeProvider)`.
+- Both parameters are stored as private readonly fields.
+- The class continues to implement `IProductionActivityAnalyzer` without interface changes.
+- The DI container resolves the class without any additional registration changes (TimeProvider is supplied by the framework as a singleton).
+
+### FR-2: Replace DateTime.UtcNow in IsInActiveProduction
+Line 17 must derive `cutoffDate` from the injected `TimeProvider` instead of `DateTime.UtcNow`.
+
+**Acceptance criteria:**
+- `cutoffDate` is computed as `_timeProvider.GetUtcNow().DateTime.AddDays(-dayThreshold)`.
+- The method's observable behavior with a real `TimeProvider.System` is identical to today's behavior (within clock-resolution tolerance).
+- A unit test using `FakeTimeProvider` with a frozen "now" can deterministically verify both sides of the threshold boundary.
+
+### FR-3: Replace DateTime.UtcNow in CalculateAverageProductionFrequency
+Line 45 must derive `analysisStartDate` from the injected `TimeProvider` instead of `DateTime.UtcNow`.
+
+**Acceptance criteria:**
+- `analysisStartDate` is computed as `_timeProvider.GetUtcNow().DateTime.AddMonths(-analysisMonths)`.
+- Filtering, interval calculation, and the "insufficient data" branch are unchanged in logic and signature.
+- A unit test using `FakeTimeProvider` can verify that records exactly on the analysis window boundary are included/excluded correctly and that out-of-window records are filtered.
+
+### FR-4: GetLastProductionDate is unchanged
+`GetLastProductionDate` does not depend on current time and must remain functionally and structurally untouched in this change.
+
+**Acceptance criteria:**
+- The method signature, body, and logging statement are unchanged.
+- Existing tests for `GetLastProductionDate` continue to pass without modification.
+
+### FR-5: Update unit tests to use FakeTimeProvider
+The test class `ProductionActivityAnalyzerTests` must construct the analyzer with a `FakeTimeProvider` (from `Microsoft.Extensions.TimeProvider.Testing`) so that all time-dependent assertions are deterministic.
+
+**Acceptance criteria:**
+- The test fixture instantiates `FakeTimeProvider` with a fixed UTC timestamp ("frozen now") shared across all tests in the class.
+- Tests that previously used `DateTime.UtcNow.AddDays(...)` / `AddMonths(...)` to seed history records now compute dates relative to the frozen now exposed by the fake clock.
+- At least one new boundary test is added per time-windowed method:
+  - `IsInActiveProduction`: a record exactly at `cutoff - 1 day` is excluded; a record at exactly `cutoff` is included (or excluded — chosen behavior must match production code and be documented in the test name).
+  - `CalculateAverageProductionFrequency`: a record exactly at `analysisStartDate` is included; a record at `analysisStartDate.AddTicks(-1)` is excluded.
+- All previously existing assertions still pass.
+- No test reads `DateTime.UtcNow` directly.
+
+### FR-6: Preserve observable behavior in production
+Behavior in production (under `TimeProvider.System`, which the DI container injects by default) must remain bit-for-bit equivalent to today's logic for any input where the wall clock advances negligibly during the call.
+
+**Acceptance criteria:**
+- Logging statements (debug-level cutoff date and frequency log lines) are unchanged in structure and format.
+- Public interface `IProductionActivityAnalyzer` is unchanged.
+- No new configuration keys, options, or feature flags are introduced.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance regression. `TimeProvider.GetUtcNow()` is a single virtual call returning a `DateTimeOffset`; equivalent in cost to `DateTime.UtcNow` at production scale.
+
+**Acceptance criteria:**
+- No additional allocations per call beyond what `GetUtcNow().DateTime` already introduces (one struct copy).
+- Method signatures and call sites in upstream callers (severity classification on the stock analysis dashboard) are unchanged.
+
+### NFR-2: Testability & Determinism
+After this change, tests for `ProductionActivityAnalyzer` must run identically on any wall-clock date and produce identical results.
+
+**Acceptance criteria:**
+- Running the test class on 2026-01-01 vs 2030-01-01 yields the same pass/fail outcome for every test.
+- No test depends on the machine clock.
+
+### NFR-3: Consistency with module conventions
+The change must align with how every other time-aware handler in the Manufacture module accepts time.
+
+**Acceptance criteria:**
+- `TimeProvider` is injected as a constructor parameter, not via a static or service-locator pattern.
+- The injected dependency is used everywhere `DateTime.UtcNow` previously appeared inside the class.
+
+### NFR-4: Backward compatibility
+No external API contract changes. Callers of `IProductionActivityAnalyzer` continue to compile and run unchanged.
+
+**Acceptance criteria:**
+- The interface `IProductionActivityAnalyzer` is unchanged.
+- No call sites outside the class need modification.
+
+## Data Model
+No data model changes. The class continues to consume `IEnumerable<ManufactureHistoryRecord>` (with `Date` and `Amount` fields) and produce primitive results (`bool`, `DateTime?`, `double`).
+
+## API / Interface Design
+
+### Public interface (unchanged)
+```csharp
+public interface IProductionActivityAnalyzer
+{
+    bool IsInActiveProduction(IEnumerable<ManufactureHistoryRecord> manufactureHistory, int dayThreshold = 30);
+    DateTime? GetLastProductionDate(IEnumerable<ManufactureHistoryRecord> manufactureHistory);
+    double CalculateAverageProductionFrequency(IEnumerable<ManufactureHistoryRecord> manufactureHistory, int analysisMonths = 12);
+}
+```
+
+### Constructor (changed)
+```csharp
+public ProductionActivityAnalyzer(
+    ILogger<ProductionActivityAnalyzer> logger,
+    TimeProvider timeProvider)
+{
+    _logger = logger;
+    _timeProvider = timeProvider;
+}
+```
+
+### Method bodies (changed lines)
+```csharp
+// IsInActiveProduction
+var cutoffDate = _timeProvider.GetUtcNow().DateTime.AddDays(-dayThreshold);
+
+// CalculateAverageProductionFrequency
+var analysisStartDate = _timeProvider.GetUtcNow().DateTime.AddMonths(-analysisMonths);
+```
+
+### DI registration
+No change. `IProductionActivityAnalyzer` registration in `ManufactureModule.AddManufactureModule` already resolves the new dependency because `TimeProvider` is registered as a singleton by the framework.
+
+## Dependencies
+- **Existing:** `Microsoft.Extensions.Logging`, `Anela.Heblo.Domain.Features.Manufacture` (for `ManufactureHistoryRecord`).
+- **Existing framework:** `System.TimeProvider` (.NET 8).
+- **Test-only addition (if not already referenced by the test project):** `Microsoft.Extensions.TimeProvider.Testing` for `FakeTimeProvider`.
+
+## Out of Scope
+- Any change to `IProductionActivityAnalyzer` (e.g. adding cancellation tokens, making methods async).
+- Any change to `GetLastProductionDate` body or signature.
+- Refactoring other Manufacture services or analyzers, even if they exhibit similar patterns.
+- Changing severity-classification logic in the stock analysis dashboard or its handlers.
+- Adding new public configuration / options.
+- Renaming files, namespaces, or types.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-manufacture-productionactivi/task-plan.r1.md
+++ b/artifacts/feat-arch-review-manufacture-productionactivi/task-plan.r1.md
@@ -1,0 +1,11 @@
+Plan saved to `artifacts/feat-arch-review-manufacture-productionactivi/plan.r1.md`.
+
+**Summary:** 5 tasks, ~24 steps, all bite-sized with exact paths, complete code blocks, and verifiable command outputs.
+
+- **Task 1** — adds `Microsoft.Extensions.TimeProvider.Testing` 8.0.1 to the test csproj (arch-review amendment #1).
+- **Task 2** — production-code refactor + lockstep test-fixture migration; keeps all 12 existing assertions passing.
+- **Task 3** — two boundary tests for `IsInActiveProduction` pinning inclusive equality (`m.Date >= cutoffDate`).
+- **Task 4** — two boundary tests for `CalculateAverageProductionFrequency` (one record at the boundary is included → 15-day interval; one tick before → `PositiveInfinity`).
+- **Task 5** — `dotnet format` + full backend build + Manufacture test slice + grep gate for any surviving `DateTime.UtcNow`.
+
+Each FR/NFR and arch-review amendment is mapped to a specific task step in the spec-coverage cross-check at the end of the plan.

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs
@@ -6,15 +6,19 @@ namespace Anela.Heblo.Application.Features.Manufacture.Services;
 public class ProductionActivityAnalyzer : IProductionActivityAnalyzer
 {
     private readonly ILogger<ProductionActivityAnalyzer> _logger;
+    private readonly TimeProvider _timeProvider;
 
-    public ProductionActivityAnalyzer(ILogger<ProductionActivityAnalyzer> logger)
+    public ProductionActivityAnalyzer(
+        ILogger<ProductionActivityAnalyzer> logger,
+        TimeProvider timeProvider)
     {
         _logger = logger;
+        _timeProvider = timeProvider;
     }
 
     public bool IsInActiveProduction(IEnumerable<ManufactureHistoryRecord> manufactureHistory, int dayThreshold = 30)
     {
-        var cutoffDate = DateTime.UtcNow.AddDays(-dayThreshold);
+        var cutoffDate = _timeProvider.GetUtcNow().DateTime.AddDays(-dayThreshold);
 
         var recentProduction = manufactureHistory.Any(m =>
             m.Date >= cutoffDate && m.Amount > 0);
@@ -42,7 +46,7 @@ public class ProductionActivityAnalyzer : IProductionActivityAnalyzer
 
     public double CalculateAverageProductionFrequency(IEnumerable<ManufactureHistoryRecord> manufactureHistory, int analysisMonths = 12)
     {
-        var analysisStartDate = DateTime.UtcNow.AddMonths(-analysisMonths);
+        var analysisStartDate = _timeProvider.GetUtcNow().DateTime.AddMonths(-analysisMonths);
 
         var productionDates = manufactureHistory
             .Where(m => m.Date >= analysisStartDate && m.Amount > 0)

--- a/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+++ b/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.1.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.6.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Domain.Features.Manufacture;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -9,13 +10,17 @@ namespace Anela.Heblo.Tests.Features.Manufacture.Services;
 
 public class ProductionActivityAnalyzerTests
 {
+    private static readonly DateTime FrozenNowUtc = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
     private readonly ProductionActivityAnalyzer _analyzer;
     private readonly Mock<ILogger<ProductionActivityAnalyzer>> _loggerMock;
+    private readonly FakeTimeProvider _timeProvider;
 
     public ProductionActivityAnalyzerTests()
     {
         _loggerMock = new Mock<ILogger<ProductionActivityAnalyzer>>();
-        _analyzer = new ProductionActivityAnalyzer(_loggerMock.Object);
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(FrozenNowUtc));
+        _analyzer = new ProductionActivityAnalyzer(_loggerMock.Object, _timeProvider);
     }
 
     [Fact]
@@ -24,8 +29,8 @@ public class ProductionActivityAnalyzerTests
         // Arrange
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
-            new() { Date = DateTime.UtcNow.AddDays(-15), Amount = 10 }, // Within 30 days
-            new() { Date = DateTime.UtcNow.AddDays(-45), Amount = 5 }   // Outside 30 days
+            new() { Date = FrozenNowUtc.AddDays(-15), Amount = 10 }, // Within 30 days
+            new() { Date = FrozenNowUtc.AddDays(-45), Amount = 5 }   // Outside 30 days
         };
 
         // Act
@@ -41,8 +46,8 @@ public class ProductionActivityAnalyzerTests
         // Arrange
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
-            new() { Date = DateTime.UtcNow.AddDays(-45), Amount = 10 }, // Outside 30 days
-            new() { Date = DateTime.UtcNow.AddDays(-60), Amount = 5 }   // Outside 30 days
+            new() { Date = FrozenNowUtc.AddDays(-45), Amount = 10 }, // Outside 30 days
+            new() { Date = FrozenNowUtc.AddDays(-60), Amount = 5 }   // Outside 30 days
         };
 
         // Act
@@ -58,7 +63,7 @@ public class ProductionActivityAnalyzerTests
         // Arrange
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
-            new() { Date = DateTime.UtcNow.AddDays(-15), Amount = 0 } // Recent but zero quantity
+            new() { Date = FrozenNowUtc.AddDays(-15), Amount = 0 } // Recent but zero quantity
         };
 
         // Act
@@ -87,7 +92,7 @@ public class ProductionActivityAnalyzerTests
         // Arrange
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
-            new() { Date = DateTime.UtcNow.AddDays(-8), Amount = 10 } // Within 10 days but outside 5 days
+            new() { Date = FrozenNowUtc.AddDays(-8), Amount = 10 } // Within 10 days but outside 5 days
         };
 
         // Act & Assert
@@ -99,12 +104,12 @@ public class ProductionActivityAnalyzerTests
     public void GetLastProductionDate_WithHistory_ReturnsLatestDate()
     {
         // Arrange
-        var expectedDate = DateTime.UtcNow.AddDays(-10);
+        var expectedDate = FrozenNowUtc.AddDays(-10);
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
-            new() { Date = DateTime.UtcNow.AddDays(-30), Amount = 5 },
+            new() { Date = FrozenNowUtc.AddDays(-30), Amount = 5 },
             new() { Date = expectedDate, Amount = 10 }, // Latest
-            new() { Date = DateTime.UtcNow.AddDays(-20), Amount = 3 }
+            new() { Date = FrozenNowUtc.AddDays(-20), Amount = 3 }
         };
 
         // Act
@@ -133,8 +138,8 @@ public class ProductionActivityAnalyzerTests
         // Arrange
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
-            new() { Date = DateTime.UtcNow.AddDays(-10), Amount = 0 },
-            new() { Date = DateTime.UtcNow.AddDays(-5), Amount = 0 }
+            new() { Date = FrozenNowUtc.AddDays(-10), Amount = 0 },
+            new() { Date = FrozenNowUtc.AddDays(-5), Amount = 0 }
         };
 
         // Act
@@ -149,7 +154,7 @@ public class ProductionActivityAnalyzerTests
     {
         // Arrange
         // Use relative dates to ensure test data falls within the analysis window
-        var baseDate = DateTime.UtcNow.AddMonths(-6); // Well within 12-month window
+        var baseDate = FrozenNowUtc.AddMonths(-6); // Well within 12-month window
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
             new() { Date = baseDate, Amount = 10 },
@@ -172,7 +177,7 @@ public class ProductionActivityAnalyzerTests
         // Arrange
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
-            new() { Date = DateTime.UtcNow.AddDays(-10), Amount = 10 }
+            new() { Date = FrozenNowUtc.AddDays(-10), Amount = 10 }
         };
 
         // Act
@@ -199,8 +204,8 @@ public class ProductionActivityAnalyzerTests
     public void CalculateAverageProductionFrequency_FiltersOldData_ReturnsCorrectResult()
     {
         // Arrange
-        var recentDate = DateTime.UtcNow.AddMonths(-1);
-        var oldDate = DateTime.UtcNow.AddMonths(-24); // Outside 12-month analysis window
+        var recentDate = FrozenNowUtc.AddMonths(-1);
+        var oldDate = FrozenNowUtc.AddMonths(-24); // Outside 12-month analysis window
         var manufactureHistory = new List<ManufactureHistoryRecord>
         {
             new() { Date = oldDate, Amount = 10 },                    // Should be ignored

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
@@ -256,4 +256,45 @@ public class ProductionActivityAnalyzerTests
         // Assert
         result.Should().Be(15.0); // Only one interval: 15 days
     }
+
+    [Fact]
+    public void CalculateAverageProductionFrequency_RecordExactlyAtAnalysisStart_IsIncluded()
+    {
+        // Arrange — first record sits exactly on the analysis-start boundary (inclusive),
+        // second record sits 15 days later (well inside the window). One interval, 15 days.
+        const int analysisMonths = 12;
+        var analysisStartDate = FrozenNowUtc.AddMonths(-analysisMonths);
+        var manufactureHistory = new List<ManufactureHistoryRecord>
+        {
+            new() { Date = analysisStartDate, Amount = 10 },
+            new() { Date = analysisStartDate.AddDays(15), Amount = 5 }
+        };
+
+        // Act
+        var result = _analyzer.CalculateAverageProductionFrequency(manufactureHistory, analysisMonths);
+
+        // Assert
+        result.Should().Be(15.0);
+    }
+
+    [Fact]
+    public void CalculateAverageProductionFrequency_RecordOneTickBeforeAnalysisStart_IsExcluded()
+    {
+        // Arrange — one record one tick before the boundary (must be EXCLUDED) and one
+        // record well inside the window. After filtering only 1 record remains, which is
+        // insufficient for a frequency calculation, so the result is PositiveInfinity.
+        const int analysisMonths = 12;
+        var analysisStartDate = FrozenNowUtc.AddMonths(-analysisMonths);
+        var manufactureHistory = new List<ManufactureHistoryRecord>
+        {
+            new() { Date = analysisStartDate.AddTicks(-1), Amount = 10 },
+            new() { Date = analysisStartDate.AddDays(15), Amount = 5 }
+        };
+
+        // Act
+        var result = _analyzer.CalculateAverageProductionFrequency(manufactureHistory, analysisMonths);
+
+        // Assert
+        result.Should().Be(double.PositiveInfinity);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
@@ -101,6 +101,43 @@ public class ProductionActivityAnalyzerTests
     }
 
     [Fact]
+    public void IsInActiveProduction_RecordExactlyAtCutoff_IsConsideredActive()
+    {
+        // Arrange — record date matches the cutoff exactly. The production code uses
+        // m.Date >= cutoffDate, so equality is INCLUSIVE.
+        const int dayThreshold = 30;
+        var cutoffDate = FrozenNowUtc.AddDays(-dayThreshold);
+        var manufactureHistory = new List<ManufactureHistoryRecord>
+        {
+            new() { Date = cutoffDate, Amount = 10 }
+        };
+
+        // Act
+        var result = _analyzer.IsInActiveProduction(manufactureHistory, dayThreshold);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInActiveProduction_RecordOneTickBeforeCutoff_IsNotConsideredActive()
+    {
+        // Arrange — one tick before the cutoff is OUTSIDE the inclusive window.
+        const int dayThreshold = 30;
+        var cutoffDate = FrozenNowUtc.AddDays(-dayThreshold);
+        var manufactureHistory = new List<ManufactureHistoryRecord>
+        {
+            new() { Date = cutoffDate.AddTicks(-1), Amount = 10 }
+        };
+
+        // Act
+        var result = _analyzer.IsInActiveProduction(manufactureHistory, dayThreshold);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public void GetLastProductionDate_WithHistory_ReturnsLatestDate()
     {
         // Arrange


### PR DESCRIPTION

Injects `TimeProvider` into `ProductionActivityAnalyzer` so that time-windowed business logic (active-production detection and average production frequency) becomes deterministically testable. This is a pure mechanical refactor — no interface changes, no DI wiring changes, no behavioral changes in production.

The test suite is now anchored to a frozen UTC instant (`2026-06-01 12:00:00`) via `FakeTimeProvider`, eliminating silent date-drift in existing tests and enabling precise boundary assertions. Four new boundary tests pin the inclusive equality semantics (`m.Date >= cutoffDate`) that the production code already implements.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ProductionActivityAnalyzer.cs` — added `TimeProvider` ctor param and field; replaced 2× `DateTime.UtcNow`
- `backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs` — migrated to `FakeTimeProvider`; 4 boundary tests added (16 total)
- `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — added `Microsoft.Extensions.TimeProvider.Testing 8.1.0`

---

Closes #2677

### Tokens used
8989199
