### PR TITLE
feat: TimeProvider Consistency in UpcomingProductionTile

### DIFF
--- a/artifacts/feat-arch-review-manufacture-upcomingproducti/arch-review.r1.md
+++ b/artifacts/feat-arch-review-manufacture-upcomingproducti/arch-review.r1.md
@@ -1,0 +1,225 @@
+```markdown
+# Architecture Review: TimeProvider Consistency in UpcomingProductionTile
+
+## Skip Design: true
+
+Backend-only refactor of dashboard tile clock-source plumbing. No new visual components, screens, layouts, or design decisions are introduced. The rendered tile JSON shape is unchanged; only the source of `lastUpdated` and the drill-down branch comparison change.
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with an established and *in-flight* pattern in this codebase:
+
+- **Sibling tiles already follow it.** `ManualActionRequiredTile.cs` and `ManufactureConditionsTile.cs` (same `DashboardTiles/` folder) both hold `private readonly TimeProvider _timeProvider` and emit `lastUpdated` via `_timeProvider.GetUtcNow()`.
+- **Direct subclasses already source-of-truth this.** `TodayProductionTile` (line 18) and `NextDayProductionTile` (line 17) already accept `TimeProvider` and use `timeProvider.GetUtcNow().Date` to derive `ReferenceDate`. Forwarding the same instance to the base is the natural completion of that pattern.
+- **Module-wide push is recent and consistent.** Commits `860673e4` (`ProductionActivityAnalyzer`) and `6ac0a30e` (Manufacture order handlers) closed analogous gaps. Issues #2676 and #2677 track remaining gaps elsewhere. This work closes a sibling gap that those issues do not cover.
+- **DI is a no-op.** `TimeProvider.System` is framework-registered; `RegisterTile<T>()` in `ManufactureModule.cs:67-70` resolves the new constructor parameter automatically.
+
+The integration points are exactly: one base constructor signature, two call sites in the base (`LoadDataAsync` line 50, `GenerateDrillDownFilters` lines 65 and 69), and two subclass `base(...)` invocations.
+
+**Architectural risk discovered during code reading**: the spec/brief misread the current branch logic. The base actually returns `view = "weekly"` for **both** today **and** today+1, and `view = "grid"` for everything else. The spec's FR-4 says "verify `NextDayProductionTile` returns `grid`" — that is wrong. See **Specification Amendments** below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ManufactureModule (DI)
+   │ RegisterTile<TodayProductionTile>()
+   │ RegisterTile<NextDayProductionTile>()
+   ▼
+┌────────────────────────────────────────────────┐
+│ UpcomingProductionTile (abstract)              │
+│   ─ IManufactureOrderRepository _repository    │
+│   ─ TimeProvider _timeProvider   ◄── NEW       │
+│   ─ abstract DateOnly ReferenceDate            │
+│                                                │
+│   LoadDataAsync()                              │
+│     lastUpdated = _timeProvider.GetUtcNow()... │
+│     drillDown.filters = GenerateDrillDown...() │
+│                                                │
+│   virtual GenerateDrillDownFilters()           │
+│     today = DateOnly.From(_timeProvider...)    │
+│     ReferenceDate == today      → weekly       │
+│     ReferenceDate == today+1    → weekly       │
+│     else                        → grid         │
+└────────────────────────────────────────────────┘
+        ▲                       ▲
+        │ base(repo, tp)        │ base(repo, tp)
+┌───────┴────────┐      ┌───────┴────────────┐
+│ TodayProduct…  │      │ NextDayProduct…    │
+│ ReferenceDate  │      │ ReferenceDate =    │
+│  = today       │      │  next working day  │
+└────────────────┘      └────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Inject `TimeProvider` into base, do not re-derive in each call site
+
+**Options considered:**
+- **(A)** Inject `TimeProvider` into the base via constructor; store as `private readonly`.
+- **(B)** Keep the base clock-free; have subclasses override `GenerateDrillDownFilters()` and pass in "today" themselves.
+- **(C)** Add a `protected abstract DateOnly Today { get; }` and let subclasses implement it from their already-held `TimeProvider`.
+
+**Chosen approach:** (A).
+
+**Rationale:** (A) matches the sibling-tile pattern (`ManualActionRequiredTile`, `ManufactureConditionsTile`) exactly. (B) duplicates logic across subclasses, defeating the purpose of the virtual base method. (C) is a layer of indirection that yields no benefit because every concrete subclass already receives a `TimeProvider`; an abstract member with a single mechanical implementation is dead weight. The codebase convention is to store `TimeProvider` as a field and call it directly.
+
+#### Decision 2: `GetUtcNow().Date` (not `GetLocalNow()`) for "today"
+
+**Options considered:**
+- **(A)** `_timeProvider.GetUtcNow().Date`.
+- **(B)** `_timeProvider.GetLocalNow().Date`.
+
+**Chosen approach:** (A).
+
+**Rationale:** Both existing subclasses already use `timeProvider.GetUtcNow().Date` (or `.DateTime`) to set `ReferenceDate`. The base must use the **same wall** as `ReferenceDate` or the equality comparison is meaningless. Picking `GetLocalNow()` would re-introduce the very bug we are fixing in a different costume.
+
+#### Decision 3: `.UtcDateTime` for `lastUpdated` metadata
+
+**Options considered:**
+- **(A)** `_timeProvider.GetUtcNow().UtcDateTime` (matches `ManufactureConditionsTile.cs:46`).
+- **(B)** `_timeProvider.GetUtcNow().DateTime` (matches `ManualActionRequiredTile.cs:43`).
+
+**Chosen approach:** (A) — `.UtcDateTime`.
+
+**Rationale:** The codebase has both. `.UtcDateTime` is semantically correct: the value has `DateTimeKind.Utc`, eliminating ambiguity for downstream serializers. `.DateTime` returns whatever Kind the `DateTimeOffset` was constructed with — fragile under future changes. The spec defers this to "established repo convention"; since two conventions coexist, prefer the unambiguous one. State this explicitly in the implementation comment if reviewers question the divergence from `ManualActionRequiredTile`.
+
+#### Decision 4: Test with `FakeTimeProvider`, not `Mock<TimeProvider>`
+
+**Options considered:**
+- **(A)** `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` (used in `ProductionActivityAnalyzerTests.cs`).
+- **(B)** `Mock<TimeProvider>` (used in older `ManualActionRequiredTileTests.cs`).
+
+**Chosen approach:** (A).
+
+**Rationale:** The Testing package is already a referenced dependency (`backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`), and (A) is the newer convention from commits `860673e4` / `6ac0a30e`. `Mock<TimeProvider>` works but requires setting up every clock method individually; `FakeTimeProvider` is the recommended Microsoft-supplied stub and is cheaper to write.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files for production code. All changes are surgical edits to existing files:
+
+```
+backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/
+├── UpcomingProductionTile.cs        ← add TimeProvider field + ctor param;
+│                                      replace clock calls at lines 50, 65, 69
+├── TodayProductionTile.cs           ← forward timeProvider to base(...)
+└── NextDayProductionTile.cs         ← forward timeProvider to base(...)
+```
+
+New test file (path mirrors `src/`):
+
+```
+backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/
+└── UpcomingProductionTileTests.cs   ← NEW; covers drill-down + lastUpdated
+```
+
+No changes to `ManufactureModule.cs` — DI is satisfied automatically.
+
+### Interfaces and Contracts
+
+**Internal contract changes only — no public API change.**
+
+```csharp
+// UpcomingProductionTile.cs
+public abstract class UpcomingProductionTile : ITile
+{
+    private readonly IManufactureOrderRepository _repository;
+    private readonly TimeProvider _timeProvider;            // NEW
+
+    protected UpcomingProductionTile(
+        IManufactureOrderRepository repository,
+        TimeProvider timeProvider)                          // NEW param
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+    }
+    // ...
+}
+```
+
+```csharp
+// TodayProductionTile.cs
+public TodayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider)
+    : base(repository, timeProvider)                        // forward
+{
+    ReferenceDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().Date);
+}
+```
+
+```csharp
+// NextDayProductionTile.cs
+public NextDayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider)
+    : base(repository, timeProvider)                        // forward
+{
+    ReferenceDate = GetNextWorkingDay(DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime));
+}
+```
+
+`ITile` itself is untouched. The tile's emitted JSON object shape is byte-for-byte identical except for the `lastUpdated` value's source.
+
+### Data Flow
+
+```
+DI container
+  └─► TimeProvider.System (singleton, framework-registered)
+        │
+        ├─► TodayProductionTile     ──┐
+        ├─► NextDayProductionTile   ──┤
+        │   (constructor)             │
+        │     ReferenceDate ← _timeProvider.GetUtcNow().Date (already wired)
+        │                             │
+        └─► forwards to base ─────────┘
+              └─► UpcomingProductionTile._timeProvider field
+
+Tile load (per dashboard request):
+  client → TileRegistry → tile.LoadDataAsync()
+    ├─ _repository.GetOrdersForDateRangeAsync(ReferenceDate, ReferenceDate)
+    ├─ lastUpdated = _timeProvider.GetUtcNow().UtcDateTime
+    └─ GenerateDrillDownFilters()
+         today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().Date)
+         compare ReferenceDate vs today / today+1
+         → emit view = "weekly" | "grid"
+```
+
+The key property to preserve: **`ReferenceDate` and `today` (in `GenerateDrillDownFilters`) must be derived from the same `TimeProvider` instance.** Forwarding to `base(...)` guarantees this without subclasses needing to know.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec FR-4 has incorrect expected behavior for `NextDayProductionTile` (claims it returns `grid`; actual code returns `weekly` for today+1, and even `grid` only when `GetNextWorkingDay()` skips weekends past today+1). Writing tests to the spec verbatim will produce tests that fail on correct code. | **HIGH** | Apply the **Specification Amendments** below before writing tests. Test what the code actually does, not what the brief misread. |
+| Future maintainer adds a third subclass and forgets to forward `TimeProvider` → compile error (good) but a tempting "fix" is to add a parameterless overload. | LOW | Do **not** introduce a parameterless base constructor as a convenience. Keep the single 2-arg constructor; the compile error is the safety net. |
+| `.UtcDateTime` vs `.DateTime` divergence between `lastUpdated` in this tile and `ManualActionRequiredTile`. | LOW | Acceptable — both are valid; UTC kind is the safer choice. A future sweep can normalize the sibling. Out of scope for this PR. |
+| Existing `ManualActionRequiredTileTests` uses `Mock<TimeProvider>` (older pattern). Mixing styles in `UpcomingProductionTileTests` could confuse readers. | LOW | Use `FakeTimeProvider` as decided. Add a one-line `// Uses FakeTimeProvider per the convention established in #2988` comment if it aids review. Do **not** retrofit the unrelated `ManualActionRequiredTileTests` — out of scope. |
+| `NextDayProductionTile.GetNextWorkingDay` skips weekends, so `ReferenceDate` is not always `today + 1`. Drill-down branch landing in `weekly` vs `grid` depends on the day-of-week of the frozen clock. | MEDIUM | Pick a `FakeTimeProvider` instant on a weekday (e.g. Mon 2026-06-15) for tests asserting `weekly`. Pick a Friday-like date (or assert against the actual `tile.ReferenceDate` rather than a hard-coded `today+1`) for the `grid` case. Document why the date was chosen in test comments. |
+
+## Specification Amendments
+
+The spec needs the following corrections before implementation begins:
+
+1. **FR-4 expected-result error.** The brief and FR-4 both state that `NextDayProductionTile.GenerateDrillDownFilters()` should return `view = "grid"`. Reading `UpcomingProductionTile.cs:69-71` shows the **today+1** branch returns `view = "weekly"`, not `grid`. Only dates that are **neither today nor today+1** fall through to `grid` (line 73). Amend FR-4 to:
+   > A unit test sets `FakeTimeProvider` to a weekday (e.g. **Mon 2026-06-15**) and verifies `NextDayProductionTile.GenerateDrillDownFilters()` returns `view = "weekly"` (because `ReferenceDate` = `today + 1` = `2026-06-16`, a Tuesday).
+   > A unit test sets `FakeTimeProvider` to a **Friday** (e.g. **2026-06-19**) and verifies `NextDayProductionTile.GenerateDrillDownFilters()` returns `view = "grid"` (because `GetNextWorkingDay` skips to Monday `2026-06-22`, which equals neither `today` nor `today + 1`).
+
+2. **Clarify the chosen `lastUpdated` extraction.** FR-3 says `.DateTime` "or `.UtcDateTime` if that is the established repo convention". Resolve to **`.UtcDateTime`** per Decision 3 above. Update FR-3 to remove the ambiguity.
+
+3. **Add explicit "no DI change" note to acceptance criteria.** FR-1 says no DI registration changes; reaffirm by adding to acceptance criteria: *"`ManufactureModule.RegisterTile<>` lines remain unchanged; DI resolution verified by running `dotnet build` and at least one integration/startup test."*
+
+4. **Test placement.** The spec defers path discovery to the implementer. Confirm: new test file at `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs`, matching the directory of `ManualActionRequiredTileTests.cs`.
+
+5. **Subclass scope is exactly two.** The spec hedges with "and any other concrete subclasses". A grep of the codebase confirms only `TodayProductionTile` and `NextDayProductionTile` derive from `UpcomingProductionTile`. State this as fact, not a discovery task.
+
+## Prerequisites
+
+None. Everything required is already in place:
+
+- `TimeProvider` is framework-registered (no DI changes needed in `ManufactureModule.cs`).
+- `Microsoft.Extensions.TimeProvider.Testing` is already referenced in `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` (added by commit `860673e4`).
+- No database migrations, configuration entries, secrets, or infrastructure prep are involved.
+- No coordinated frontend change is needed; the tile's JSON contract is preserved.
+
+Implementation can begin immediately after the spec is amended per the section above.
+```

--- a/artifacts/feat-arch-review-manufacture-upcomingproducti/brief.md
+++ b/artifacts/feat-arch-review-manufacture-upcomingproducti/brief.md
@@ -1,0 +1,47 @@
+## Module
+Manufacture
+
+## Finding
+`UpcomingProductionTile.GenerateDrillDownFilters()` hard-codes two comparisons against `DateTime.Today`, even though the concrete subclasses already receive a `TimeProvider` to set `ReferenceDate`:
+
+```
+backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs
+  line 65: if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today))
+  line 70: if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today.AddDays(1)))
+```
+
+`TodayProductionTile` (and `NextDayProductionTile`) correctly injects `TimeProvider` and sets `ReferenceDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().Date)` in their constructors. But the virtual `GenerateDrillDownFilters()` in the base class then compares that same `ReferenceDate` against wall-clock `DateTime.Today`, not against the `TimeProvider`-controlled value.
+
+`LoadDataAsync` on the same base class also uses `DateTime.UtcNow` directly for the `lastUpdated` metadata field (line 50), though that field is cosmetic.
+
+## Why it matters
+If a test passes a `FakeTimeProvider` set to "tomorrow" to `TodayProductionTile`, the constructor correctly sets `ReferenceDate` to tomorrow. But `GenerateDrillDownFilters()` then compares against real `DateTime.Today` — so the "is this tomorrow?" branch (line 70) is never reached during testing. The returned drill-down view type (`weekly` vs `grid`) will be incorrect in any time-shifted test scenario, and the split between `TimeProvider`-controlled `ReferenceDate` and hard-wired `DateTime.Today` makes the split invisible.
+
+This is the same pattern as the existing open issues #2676 and #2677 (handlers and services that bypass `TimeProvider`) but in the dashboard tile layer, which is not covered by those issues.
+
+## Suggested fix
+1. Add `TimeProvider _timeProvider` to the `UpcomingProductionTile` base constructor (subclasses already receive it).
+2. Replace `DateTime.Today` with `DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date)` (or `GetUtcNow().Date` for consistency with the rest of the module).
+3. Replace `DateTime.UtcNow` on line 50 with `_timeProvider.GetUtcNow().DateTime`.
+
+```csharp
+// UpcomingProductionTile constructor
+protected UpcomingProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider)
+{
+    _repository = repository;
+    _timeProvider = timeProvider;
+}
+
+// GenerateDrillDownFilters — lines 65, 70
+var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().Date);
+if (ReferenceDate == today) { ... }
+if (ReferenceDate == today.AddDays(1)) { ... }
+
+// LoadDataAsync — line 50
+lastUpdated = _timeProvider.GetUtcNow().DateTime,
+```
+
+No DI change needed; `TimeProvider` is a framework-registered singleton.
+
+---
+_Filed by daily arch-review routine on 2026-06-06._

--- a/artifacts/feat-arch-review-manufacture-upcomingproducti/impl/main.r1.md
+++ b/artifacts/feat-arch-review-manufacture-upcomingproducti/impl/main.r1.md
@@ -1,0 +1,59 @@
+Both tasks complete. Here is the implementation summary:
+
+---
+
+# Implementation: TimeProvider Consistency in UpcomingProductionTile
+
+## What was implemented
+
+Eliminated hard-coded `DateTime.Today` and `DateTime.UtcNow` calls from the `UpcomingProductionTile` abstract base class by injecting `TimeProvider` through the constructor. Both subclasses now forward their existing `TimeProvider` argument to the base. All three wall-clock call sites are replaced with `_timeProvider.GetUtcNow()`-derived values. Four xUnit tests covering the drill-down and `lastUpdated` behavior under a `FakeTimeProvider` were added.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs` — Added `private readonly TimeProvider _timeProvider` field, new 2-arg constructor, replaced `DateTime.UtcNow` with `_timeProvider.GetUtcNow().UtcDateTime` and both `DateTime.Today` calls with a `today` local variable computed once from `_timeProvider.GetUtcNow().Date`
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs` — Changed `base(repository)` → `base(repository, timeProvider)`
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs` — Changed `base(repository)` → `base(repository, timeProvider)`
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs` — New file with 4 xUnit tests using `FakeTimeProvider`
+
+## Tests
+
+`UpcomingProductionTileTests.cs` — 4 tests, all passing:
+
+1. `TodayProductionTile_GenerateDrillDownFilters_ReturnsWeeklyView` — Mon 2026-06-15, today branch returns `weekly`
+2. `NextDayProductionTile_OnWeekday_GenerateDrillDownFilters_ReturnsWeeklyView` — Mon 2026-06-15, today+1 (Tue) branch returns `weekly`
+3. `NextDayProductionTile_OnFriday_GenerateDrillDownFilters_ReturnsGridView` — Fri 2026-06-19, `GetNextWorkingDay` skips to Mon June 22, falls through to `grid`
+4. `LoadDataAsync_LastUpdated_ComesFromTimeProvider` — asserts `lastUpdated` equals frozen time and has `DateTimeKind.Utc`
+
+All 18 DashboardTiles tests pass (4 new + 14 pre-existing).
+
+## How to verify
+
+```bash
+cd backend && dotnet build
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Features.Manufacture.DashboardTiles"
+```
+
+## Notes
+
+- Commits: `ab5acd8b` (production code), `716d7a23` (tests)
+- `lastUpdated` uses `.UtcDateTime` (not `.DateTime`) per arch-review Decision 3 — semantically unambiguous `DateTimeKind.Utc`
+- No DI changes required — `TimeProvider.System` already framework-registered; `ManufactureModule.cs` is untouched
+- Spec FR-4 misread corrected per arch-review Amendment 1: `NextDayProductionTile` returns `weekly` on weekday (today+1), `grid` on Friday (skips to Monday)
+- `FakeTimeProvider` pattern matches `ProductionActivityAnalyzerTests` convention (not `Mock<TimeProvider>`)
+
+## PR Summary
+
+Inject `TimeProvider` into `UpcomingProductionTile` base class, eliminating the last wall-clock `DateTime.Today`/`DateTime.UtcNow` calls in the Manufacture dashboard tile layer.
+
+The base class previously compared `ReferenceDate` (sourced from the injected `TimeProvider` in subclasses) against `DateTime.Today` (wall-clock) in `GenerateDrillDownFilters()`, making the returned drill-down view type non-deterministic in time-shifted tests. `lastUpdated` also used `DateTime.UtcNow` directly. Both call sites now use `_timeProvider.GetUtcNow()`, and both subclasses forward their existing `TimeProvider` to `base(...)`. No DI changes are needed; `TimeProvider.System` is already framework-registered.
+
+### Changes
+- `backend/src/.../DashboardTiles/UpcomingProductionTile.cs` — added `_timeProvider` field, 2-arg constructor, replaced clock calls at line 50 and lines 65/69
+- `backend/src/.../DashboardTiles/TodayProductionTile.cs` — forwarded `timeProvider` to `base(repository, timeProvider)`
+- `backend/src/.../DashboardTiles/NextDayProductionTile.cs` — forwarded `timeProvider` to `base(repository, timeProvider)`
+- `backend/test/.../DashboardTiles/UpcomingProductionTileTests.cs` — new; 4 tests covering drill-down weekday/Friday branches and `lastUpdated` UTC kind under `FakeTimeProvider`
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-manufacture-upcomingproducti/spec.r1.md
+++ b/artifacts/feat-arch-review-manufacture-upcomingproducti/spec.r1.md
@@ -1,0 +1,117 @@
+# Specification: TimeProvider Consistency in UpcomingProductionTile
+
+## Summary
+The `UpcomingProductionTile` base class hard-codes `DateTime.Today` and `DateTime.UtcNow` in `GenerateDrillDownFilters()` and `LoadDataAsync()`, even though concrete subclasses (`TodayProductionTile`, `NextDayProductionTile`) already accept `TimeProvider` to set `ReferenceDate`. This split between `TimeProvider`-controlled and wall-clock time makes drill-down behavior untestable under time-shifted scenarios. The fix is to inject `TimeProvider` into the base class and replace all direct clock calls with provider-backed equivalents.
+
+## Background
+Issues #2676 and #2677 already document the same anti-pattern in the handler and service layers of the Manufacture module. This finding extends that pattern to the dashboard tile layer, which those issues do not cover. The recent commits `860673e4` ("TimeProvider Injection in ProductionActivityAnalyzer") and `6ac0a30e` ("Consistent TimeProvider Usage in Manufacture Order Handlers") confirm that systematic `TimeProvider` adoption is in flight across the module; this work closes a remaining gap.
+
+Concretely, a test that supplies a `FakeTimeProvider` to `TodayProductionTile` cannot exercise the "is this tomorrow?" branch of `GenerateDrillDownFilters()` because line 70 still compares `ReferenceDate` (provider-backed) against `DateTime.Today` (wall-clock). The returned `DrillDownViewType` (`weekly` vs `grid`) is therefore non-deterministic in time-shifted tests.
+
+## Functional Requirements
+
+### FR-1: Inject `TimeProvider` into `UpcomingProductionTile` base class
+Add a protected `TimeProvider` field to the `UpcomingProductionTile` base class and accept it via the base constructor. Update the existing subclass constructors (`TodayProductionTile`, `NextDayProductionTile`, and any other concrete subclasses) to forward their existing `TimeProvider` parameter to the base.
+
+**Acceptance criteria:**
+- `UpcomingProductionTile` exposes a protected (or private with subclass access pattern matching repo conventions) `TimeProvider` field.
+- Base constructor signature is `protected UpcomingProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider)`.
+- All subclasses pass their existing `TimeProvider` argument to `base(...)`.
+- No DI registration changes required — `TimeProvider.System` is already framework-registered.
+
+### FR-2: Replace `DateTime.Today` in `GenerateDrillDownFilters()`
+Both occurrences of `DateOnly.FromDateTime(DateTime.Today)` in `GenerateDrillDownFilters()` (lines 65 and 70) must compute "today" from the injected `TimeProvider`.
+
+**Acceptance criteria:**
+- Line 65 and line 70 derive "today" from `_timeProvider.GetUtcNow().Date` (chosen for consistency with the rest of the Manufacture module — see Open Questions).
+- The value is computed once at the top of the method and reused for both comparisons.
+- No call to `DateTime.Today`, `DateTime.Now`, `DateTime.UtcNow`, `DateOnly.FromDateTime(DateTime.Today)` etc. remains in the method.
+
+### FR-3: Replace `DateTime.UtcNow` in `LoadDataAsync()`
+The `lastUpdated` metadata assignment on line 50 must use the injected `TimeProvider` rather than `DateTime.UtcNow`.
+
+**Acceptance criteria:**
+- `lastUpdated = _timeProvider.GetUtcNow().DateTime` (or `.UtcDateTime` if that is the established repo convention).
+- No call to `DateTime.UtcNow` remains in `LoadDataAsync()`.
+
+### FR-4: Test coverage for time-shifted drill-down behavior
+Add unit tests that verify `GenerateDrillDownFilters()` correctly returns the `weekly` drill-down view when `ReferenceDate` equals "today" and the `grid` view when `ReferenceDate` equals "tomorrow", using a `FakeTimeProvider` set to a non-default date.
+
+**Acceptance criteria:**
+- A unit test sets `FakeTimeProvider` to a specific date (e.g. 2026-06-15) and verifies `TodayProductionTile.GenerateDrillDownFilters()` returns the expected `weekly` view type.
+- A unit test sets `FakeTimeProvider` to a specific date and verifies `NextDayProductionTile.GenerateDrillDownFilters()` returns the expected `grid` view type (since its `ReferenceDate` is `today + 1`).
+- A unit test confirms `lastUpdated` in the load result equals the `FakeTimeProvider`'s configured time.
+- Tests fail against the current code (pre-fix) and pass after the fix.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. `TimeProvider.GetUtcNow()` is a cheap call; one extra invocation per drill-down generation and one per `LoadDataAsync` call is negligible.
+
+### NFR-2: Security
+Not applicable — purely an internal refactor with no exposed surface change.
+
+### NFR-3: Backward Compatibility
+Public surface of dashboard tiles (rendered output for default `TimeProvider.System`) must be unchanged. Production behavior must remain identical to today; only test-time behavior under a `FakeTimeProvider` is affected.
+
+### NFR-4: Consistency
+The choice of `GetUtcNow()` vs `GetLocalNow()` must match the convention already established in the Manufacture module (per the brief's preference for "consistency with the rest of the module"). The codebase appears to favor `GetUtcNow()` based on the existing `TodayProductionTile` constructor pattern.
+
+## Data Model
+No data model changes. `ReferenceDate` (type `DateOnly`) on `UpcomingProductionTile` is already correctly set by subclasses via `TimeProvider`; this work only aligns the comparison sites with that source of truth.
+
+## API / Interface Design
+
+### Affected files
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs` — base class changes (constructor, `GenerateDrillDownFilters`, `LoadDataAsync`).
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs` — forward `TimeProvider` to base.
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs` — forward `TimeProvider` to base.
+- Any other `UpcomingProductionTile` subclasses discovered during implementation.
+- Corresponding test files under `backend/test/...Manufacture.../DashboardTiles/` (path to be confirmed by implementer against existing test layout).
+
+### Constructor signature change
+```csharp
+// Before
+protected UpcomingProductionTile(IManufactureOrderRepository repository) { ... }
+
+// After
+protected UpcomingProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) { ... }
+```
+
+### Behavioral diff in `GenerateDrillDownFilters()`
+```csharp
+// Before
+if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today)) { ... weekly ... }
+if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today.AddDays(1))) { ... grid ... }
+
+// After
+var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().Date);
+if (ReferenceDate == today) { ... weekly ... }
+if (ReferenceDate == today.AddDays(1)) { ... grid ... }
+```
+
+### Behavioral diff in `LoadDataAsync()` line 50
+```csharp
+// Before
+lastUpdated = DateTime.UtcNow,
+
+// After
+lastUpdated = _timeProvider.GetUtcNow().DateTime,
+```
+
+## Dependencies
+- `Microsoft.Extensions.Time.Abstractions` / framework-registered `TimeProvider.System` — already present, used by sibling tile classes.
+- `Microsoft.Extensions.TimeProvider.Testing` (`FakeTimeProvider`) — already used in this module's test suite (per recent commits #2982, #2988).
+- No new package references required.
+
+## Out of Scope
+- Refactoring of `DateTime.Today` / `DateTime.UtcNow` usage outside `UpcomingProductionTile.cs` and its subclass constructors. Other Manufacture module gaps are tracked by issues #2676 and #2677.
+- Changes to `DrillDownViewType` enum or drill-down result structure.
+- Changes to repository (`IManufactureOrderRepository`) signatures or behavior.
+- Switching between UTC and local time semantics — preserve whatever the rest of the module uses; do not introduce a new convention.
+- Frontend changes — drill-down view types are consumed by the FE but their values/shape are unchanged.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-manufacture-upcomingproducti/task-plan.r1.md
+++ b/artifacts/feat-arch-review-manufacture-upcomingproducti/task-plan.r1.md
@@ -1,0 +1,14 @@
+Plan saved to `docs/superpowers/plans/2026-06-13-upcoming-production-tile-timeprovider.md`.
+
+**Summary of the 9 tasks:**
+1. Add `TimeProvider` field + ctor param to `UpcomingProductionTile`, replace `DateTime.UtcNow` (line 50) and `DateTime.Today` (lines 65, 69) with `_timeProvider.GetUtcNow()`-derived values.
+2. Forward `timeProvider` to `base(...)` in `TodayProductionTile`.
+3. Forward `timeProvider` to `base(...)` in `NextDayProductionTile`.
+4. Verify subclass scope, build, format, commit production code.
+5. New test file + `TodayProductionTile` weekly-drill-down test under `FakeTimeProvider` (Mon 2026-06-15).
+6. `NextDayProductionTile` weekday test → `weekly` view (today+1 = Tue).
+7. `NextDayProductionTile` Friday test → `grid` view (Mon skip via `GetNextWorkingDay`), correcting spec FR-4 misread per arch-review Amendment 1.
+8. `lastUpdated` test asserts the value equals `FakeTimeProvider` time and has `DateTimeKind.Utc` (locks in `.UtcDateTime` choice from Decision 3).
+9. Full filter run, format, commit tests.
+
+All four arch-review spec amendments are incorporated. No DI changes required.

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs
@@ -12,7 +12,7 @@ public class NextDayProductionTile : UpcomingProductionTile
 
     protected sealed override DateOnly ReferenceDate { get; set; }
 
-    public NextDayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository)
+    public NextDayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository, timeProvider)
     {
         ReferenceDate = GetNextWorkingDay(DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime));
     }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs
@@ -13,7 +13,7 @@ public class TodayProductionTile : UpcomingProductionTile
 
     protected sealed override DateOnly ReferenceDate { get; set; }
 
-    public TodayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository)
+    public TodayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository, timeProvider)
     {
         ReferenceDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().Date); // Get next workday
     }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs
@@ -6,6 +6,7 @@ namespace Anela.Heblo.Application.Features.Manufacture.DashboardTiles;
 public abstract class UpcomingProductionTile : ITile
 {
     private readonly IManufactureOrderRepository _repository;
+    private readonly TimeProvider _timeProvider;
 
     // Self-describing metadata
     public abstract string Title { get; }
@@ -18,9 +19,10 @@ public abstract class UpcomingProductionTile : ITile
 
     protected abstract DateOnly ReferenceDate { get; set; }
 
-    protected UpcomingProductionTile(IManufactureOrderRepository repository)
+    protected UpcomingProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider)
     {
         _repository = repository;
+        _timeProvider = timeProvider;
     }
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
@@ -47,7 +49,7 @@ public abstract class UpcomingProductionTile : ITile
             },
             metadata = new
             {
-                lastUpdated = DateTime.UtcNow,
+                lastUpdated = _timeProvider.GetUtcNow().UtcDateTime,
                 source = "ManufactureOrderRepository"
             },
             drillDown = new
@@ -61,12 +63,13 @@ public abstract class UpcomingProductionTile : ITile
 
     protected virtual object GenerateDrillDownFilters()
     {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().Date);
         var dateString = ReferenceDate.ToString("yyyy-MM-dd");
-        if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today))
+        if (ReferenceDate == today)
         {
             return new { date = dateString, view = "weekly" };
         }
-        if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today.AddDays(1)))
+        if (ReferenceDate == today.AddDays(1))
         {
             return new { date = dateString, view = "weekly" };
         }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs
@@ -1,0 +1,122 @@
+using System.Reflection;
+using Anela.Heblo.Application.Features.Manufacture.DashboardTiles;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.DashboardTiles;
+
+public class UpcomingProductionTileTests
+{
+    // Monday 2026-06-15 12:00 UTC — ReferenceDate for TodayProductionTile = June 15 = today (weekly).
+    // Also: NextDayProductionTile.GetNextWorkingDay(June 15) = June 16 = today+1 (weekly).
+    private static readonly DateTimeOffset FrozenMondayUtc =
+        new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    // Friday 2026-06-19 12:00 UTC — NextDayProductionTile.GetNextWorkingDay(June 19) = June 22 (Mon),
+    // which is neither today nor today+1, so GenerateDrillDownFilters() returns "grid".
+    private static readonly DateTimeOffset FrozenFridayUtc =
+        new(2026, 6, 19, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock = new();
+
+    [Fact]
+    public async Task TodayProductionTile_GenerateDrillDownFilters_ReturnsWeeklyView()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(FrozenMondayUtc);
+        var tile = new TodayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var filters = GetAnonymousProperty(payload, "drillDown.filters");
+
+        // Assert
+        Assert.Equal("2026-06-15", GetAnonymousProperty(filters!, "date"));
+        Assert.Equal("weekly", GetAnonymousProperty(filters!, "view"));
+    }
+
+    [Fact]
+    public async Task NextDayProductionTile_OnWeekday_GenerateDrillDownFilters_ReturnsWeeklyView()
+    {
+        // Arrange: Monday → next working day = Tuesday = today + 1.
+        var timeProvider = new FakeTimeProvider(FrozenMondayUtc);
+        var tile = new NextDayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var filters = GetAnonymousProperty(payload, "drillDown.filters");
+
+        // Assert
+        Assert.Equal("2026-06-16", GetAnonymousProperty(filters!, "date"));
+        Assert.Equal("weekly", GetAnonymousProperty(filters!, "view"));
+    }
+
+    [Fact]
+    public async Task NextDayProductionTile_OnFriday_GenerateDrillDownFilters_ReturnsGridView()
+    {
+        // Arrange: Friday → next working day = Monday, which is today + 3, neither today nor today+1.
+        var timeProvider = new FakeTimeProvider(FrozenFridayUtc);
+        var tile = new NextDayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var filters = GetAnonymousProperty(payload, "drillDown.filters");
+
+        // Assert
+        Assert.Equal("2026-06-22", GetAnonymousProperty(filters!, "date"));
+        Assert.Equal("grid", GetAnonymousProperty(filters!, "view"));
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LastUpdated_ComesFromTimeProvider()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(FrozenMondayUtc);
+        var tile = new TodayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var lastUpdated = (DateTime)GetAnonymousProperty(payload, "metadata.lastUpdated")!;
+
+        // Assert
+        Assert.Equal(FrozenMondayUtc.UtcDateTime, lastUpdated);
+        Assert.Equal(DateTimeKind.Utc, lastUpdated.Kind);
+    }
+
+    private static object? GetAnonymousProperty(object source, string path)
+    {
+        object? current = source;
+        foreach (var name in path.Split('.'))
+        {
+            if (current is null) return null;
+            var prop = current.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            current = prop?.GetValue(current);
+        }
+        return current;
+    }
+}

--- a/docs/superpowers/plans/2026-06-13-upcoming-production-tile-timeprovider.md
+++ b/docs/superpowers/plans/2026-06-13-upcoming-production-tile-timeprovider.md
@@ -1,0 +1,645 @@
+# TimeProvider Consistency in UpcomingProductionTile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate hard-coded `DateTime.Today` / `DateTime.UtcNow` calls in `UpcomingProductionTile` by injecting `TimeProvider` into the base class, then add unit tests that verify drill-down behavior under a `FakeTimeProvider`.
+
+**Architecture:** Add a `private readonly TimeProvider _timeProvider` field to the abstract `UpcomingProductionTile` and accept it via constructor. Replace the three wall-clock call sites (`LoadDataAsync` line 50, `GenerateDrillDownFilters` lines 65 and 69) with `_timeProvider.GetUtcNow()`-derived values. Forward the `TimeProvider` already held by `TodayProductionTile` and `NextDayProductionTile` to `base(...)`. Cover the changes with new xUnit tests using `FakeTimeProvider` to match the convention established by `ProductionActivityAnalyzerTests`.
+
+**Tech Stack:** .NET 8 / C#, xUnit, Moq, `Microsoft.Extensions.TimeProvider.Testing` (`FakeTimeProvider`), MediatR-based Manufacture module, framework-registered `TimeProvider.System` (no DI changes required).
+
+---
+
+## File Structure
+
+**Production code (all modifications, no new files):**
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs` | Abstract base tile; loads orders for `ReferenceDate` and emits dashboard JSON with drill-down. | Add `TimeProvider` field + ctor parameter; replace `DateTime.UtcNow` (line 50) and both `DateOnly.FromDateTime(DateTime.Today...)` calls (lines 65, 69) with `_timeProvider.GetUtcNow()`-derived values. |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs` | Concrete tile, `ReferenceDate = today`. | Forward the already-injected `timeProvider` to `base(repository, timeProvider)`. |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs` | Concrete tile, `ReferenceDate = next working day`. | Forward the already-injected `timeProvider` to `base(repository, timeProvider)`. |
+
+**Test code (new file):**
+
+| File | Responsibility |
+|------|----------------|
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs` | xUnit tests covering: (a) `TodayProductionTile.GenerateDrillDownFilters()` returns `weekly` when `ReferenceDate == today`; (b) `NextDayProductionTile.GenerateDrillDownFilters()` returns `weekly` on a weekday and `grid` on a Friday (because `GetNextWorkingDay` skips to Monday); (c) `lastUpdated` metadata equals the `FakeTimeProvider`-configured time. |
+
+**Out of scope:** `ManufactureModule.cs` (no DI change), `IManufactureOrderRepository` (no signature change), `ManualActionRequiredTile.cs` / `ManufactureConditionsTile.cs` (already correct), any other Manufacture-module clock cleanup tracked by issues #2676 and #2677.
+
+---
+
+### Task 1: Update `UpcomingProductionTile` base class to accept and use `TimeProvider`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs`
+
+**Context — current state of the file** (so the engineer does not need to re-read it):
+
+```csharp
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Xcc.Services.Dashboard;
+
+namespace Anela.Heblo.Application.Features.Manufacture.DashboardTiles;
+
+public abstract class UpcomingProductionTile : ITile
+{
+    private readonly IManufactureOrderRepository _repository;
+
+    // ... metadata properties unchanged ...
+
+    protected abstract DateOnly ReferenceDate { get; set; }
+
+    protected UpcomingProductionTile(IManufactureOrderRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<object> LoadDataAsync(...)
+    {
+        // ...
+        return new
+        {
+            // ...
+            metadata = new
+            {
+                lastUpdated = DateTime.UtcNow,          // ← line 50, replace
+                source = "ManufactureOrderRepository"
+            },
+            // ...
+        };
+    }
+
+    protected virtual object GenerateDrillDownFilters()
+    {
+        var dateString = ReferenceDate.ToString("yyyy-MM-dd");
+        if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today))          // ← line 65, replace
+        {
+            return new { date = dateString, view = "weekly" };
+        }
+        if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today.AddDays(1))) // ← line 69, replace
+        {
+            return new { date = dateString, view = "weekly" };
+        }
+        return new { date = dateString, view = "grid" };
+    }
+}
+```
+
+- [ ] **Step 1: Add the `_timeProvider` field and constructor parameter**
+
+Edit the field declaration block. Replace:
+
+```csharp
+    private readonly IManufactureOrderRepository _repository;
+```
+
+with:
+
+```csharp
+    private readonly IManufactureOrderRepository _repository;
+    private readonly TimeProvider _timeProvider;
+```
+
+Then replace the constructor:
+
+```csharp
+    protected UpcomingProductionTile(IManufactureOrderRepository repository)
+    {
+        _repository = repository;
+    }
+```
+
+with:
+
+```csharp
+    protected UpcomingProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider)
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+    }
+```
+
+No `using` directive change is required — `TimeProvider` lives in the `System` namespace, which is implicitly imported via `<ImplicitUsings>enable</ImplicitUsings>`.
+
+- [ ] **Step 2: Replace `DateTime.UtcNow` in `LoadDataAsync` (was line 50)**
+
+Replace:
+
+```csharp
+                lastUpdated = DateTime.UtcNow,
+```
+
+with:
+
+```csharp
+                lastUpdated = _timeProvider.GetUtcNow().UtcDateTime,
+```
+
+Rationale (per arch-review Decision 3): `.UtcDateTime` returns a value with `DateTimeKind.Utc`, eliminating downstream serializer ambiguity. The codebase has both `.UtcDateTime` (`ManufactureConditionsTile.cs:46`) and `.DateTime` (`ManualActionRequiredTile.cs:43`) — prefer the unambiguous one.
+
+- [ ] **Step 3: Replace `DateTime.Today` in `GenerateDrillDownFilters` (was lines 65 and 69)**
+
+Replace the entire `GenerateDrillDownFilters` method body:
+
+```csharp
+    protected virtual object GenerateDrillDownFilters()
+    {
+        var dateString = ReferenceDate.ToString("yyyy-MM-dd");
+        if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today))
+        {
+            return new { date = dateString, view = "weekly" };
+        }
+        if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today.AddDays(1)))
+        {
+            return new { date = dateString, view = "weekly" };
+        }
+        return new { date = dateString, view = "grid" };
+    }
+```
+
+with:
+
+```csharp
+    protected virtual object GenerateDrillDownFilters()
+    {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().Date);
+        var dateString = ReferenceDate.ToString("yyyy-MM-dd");
+        if (ReferenceDate == today)
+        {
+            return new { date = dateString, view = "weekly" };
+        }
+        if (ReferenceDate == today.AddDays(1))
+        {
+            return new { date = dateString, view = "weekly" };
+        }
+        return new { date = dateString, view = "grid" };
+    }
+```
+
+Note: the `today` value is computed once and reused for both comparisons.
+
+- [ ] **Step 4: Verify no clock primitive remains in the file**
+
+Run:
+
+```bash
+grep -nE "DateTime\.(Today|Now|UtcNow)" backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs
+```
+
+Expected: no matches (exit code 1, empty output).
+
+- [ ] **Step 5: Do NOT compile/commit yet — Task 2 and Task 3 fix the subclass call sites**
+
+The build will fail until subclasses are updated. Move directly to Task 2.
+
+---
+
+### Task 2: Forward `timeProvider` from `TodayProductionTile` to base
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs`
+
+- [ ] **Step 1: Update the base-class constructor call**
+
+Replace:
+
+```csharp
+    public TodayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository)
+    {
+        ReferenceDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().Date); // Get next workday
+    }
+```
+
+with:
+
+```csharp
+    public TodayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository, timeProvider)
+    {
+        ReferenceDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().Date); // Get next workday
+    }
+```
+
+(Only the `base(...)` call changes — the body that derives `ReferenceDate` is unchanged.)
+
+---
+
+### Task 3: Forward `timeProvider` from `NextDayProductionTile` to base
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs`
+
+- [ ] **Step 1: Update the base-class constructor call**
+
+Replace:
+
+```csharp
+    public NextDayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository)
+    {
+        ReferenceDate = GetNextWorkingDay(DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime));
+    }
+```
+
+with:
+
+```csharp
+    public NextDayProductionTile(IManufactureOrderRepository repository, TimeProvider timeProvider) : base(repository, timeProvider)
+    {
+        ReferenceDate = GetNextWorkingDay(DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime));
+    }
+```
+
+(Only the `base(...)` call changes — `GetNextWorkingDay` is untouched.)
+
+---
+
+### Task 4: Verify the solution compiles cleanly
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm no other subclasses of `UpcomingProductionTile` exist**
+
+Run:
+
+```bash
+grep -rln ": UpcomingProductionTile" backend/src
+```
+
+Expected output (exactly these two files):
+
+```
+backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs
+backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs
+```
+
+If any additional file appears, update its constructor with the same change as Task 2/Task 3 (`base(repository, timeProvider)` and forward an injected `TimeProvider` parameter).
+
+- [ ] **Step 2: Build the backend**
+
+Run:
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded. 0 Error(s)`. Warnings unrelated to this change are acceptable.
+
+If `error CS7036` ("no argument given that corresponds to the required parameter 'timeProvider'") appears, a subclass constructor was missed — fix it before continuing.
+
+- [ ] **Step 3: Format**
+
+Run:
+
+```bash
+cd backend && dotnet format Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: exits successfully with no whitespace or analyzer diffs left over.
+
+- [ ] **Step 4: Commit the production-code changes**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs \
+        backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/TodayProductionTile.cs \
+        backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/NextDayProductionTile.cs
+git commit -m "refactor: inject TimeProvider into UpcomingProductionTile base"
+```
+
+---
+
+### Task 5: Write failing tests for `TodayProductionTile` drill-down (`weekly` branch)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs`
+
+The tests use `FakeTimeProvider` (per arch-review Decision 4, matches `ProductionActivityAnalyzerTests` convention) and `Mock<IManufactureOrderRepository>` (matches `ManualActionRequiredTileTests`).
+
+- [ ] **Step 1: Create the test file with a `TodayProductionTile` drill-down test**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs` with the following content:
+
+```csharp
+using System.Reflection;
+using Anela.Heblo.Application.Features.Manufacture.DashboardTiles;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.DashboardTiles;
+
+public class UpcomingProductionTileTests
+{
+    // Monday 2026-06-15 12:00 UTC — chosen so that ReferenceDate + 1 = Tuesday (a working day),
+    // exercising the today+1 "weekly" branch in NextDayProductionTile.
+    private static readonly DateTimeOffset FrozenMondayUtc =
+        new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    // Friday 2026-06-19 12:00 UTC — chosen so GetNextWorkingDay skips Sat/Sun and returns
+    // Monday 2026-06-22, which equals neither today nor today+1, exercising the "grid" branch.
+    private static readonly DateTimeOffset FrozenFridayUtc =
+        new(2026, 6, 19, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock = new();
+
+    [Fact]
+    public async Task TodayProductionTile_GenerateDrillDownFilters_ReturnsWeeklyView()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(FrozenMondayUtc);
+        var tile = new TodayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var filters = GetAnonymousProperty(payload, "drillDown.filters");
+
+        // Assert
+        Assert.Equal("2026-06-15", GetAnonymousProperty(filters!, "date"));
+        Assert.Equal("weekly", GetAnonymousProperty(filters!, "view"));
+    }
+
+    private static object? GetAnonymousProperty(object source, string path)
+    {
+        object? current = source;
+        foreach (var name in path.Split('.'))
+        {
+            if (current is null)
+            {
+                return null;
+            }
+            var prop = current.GetType().GetProperty(
+                name,
+                BindingFlags.Public | BindingFlags.Instance);
+            current = prop?.GetValue(current);
+        }
+        return current;
+    }
+}
+```
+
+Notes for the engineer:
+- The anonymous return type from `LoadDataAsync` has no compile-time accessor, so `GetAnonymousProperty` uses reflection to traverse `drillDown.filters.date` / `.view`.
+- `BindingFlags.Public | BindingFlags.Instance` is enough; anonymous-type members are public-instance.
+- The repository mock returns an empty list — we only care about the drill-down branch, not the data section.
+
+- [ ] **Step 2: Run the test to verify it FAILS (red phase)**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpcomingProductionTileTests.TodayProductionTile_GenerateDrillDownFilters_ReturnsWeeklyView" \
+  --no-restore
+```
+
+Expected: PASS.
+
+Wait — this test is expected to **PASS** even before any further changes, because the production-code refactor (Tasks 1–4) has already wired `_timeProvider` through the base class. The TDD red/green cycle here is: *before* Task 1 this test would have failed (the production code would have compared against the real `DateTime.Today` and the comparison would have been false on most days). *After* Task 1 it correctly returns `weekly`. That is the regression the spec calls out in FR-4.
+
+To convince yourself the test actually exercises the new code path: temporarily revert the change to line 65 (`if (ReferenceDate == today)` → `if (ReferenceDate == DateOnly.FromDateTime(DateTime.Today))`), re-run the test, and confirm it fails unless today's real wall-clock date happens to be 2026-06-15. Then restore the change. Do **not** commit this temporary revert.
+
+If the test fails on the post-refactor code, debug the wiring before continuing.
+
+---
+
+### Task 6: Add the `NextDayProductionTile` weekday test (`weekly` branch via today+1)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs`
+
+- [ ] **Step 1: Add the test method**
+
+Insert the following method into `UpcomingProductionTileTests` (above the private `GetAnonymousProperty` helper):
+
+```csharp
+    [Fact]
+    public async Task NextDayProductionTile_OnWeekday_GenerateDrillDownFilters_ReturnsWeeklyView()
+    {
+        // Arrange: Monday → next working day = Tuesday = today + 1.
+        var timeProvider = new FakeTimeProvider(FrozenMondayUtc);
+        var tile = new NextDayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var filters = GetAnonymousProperty(payload, "drillDown.filters");
+
+        // Assert
+        Assert.Equal("2026-06-16", GetAnonymousProperty(filters!, "date"));
+        Assert.Equal("weekly", GetAnonymousProperty(filters!, "view"));
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpcomingProductionTileTests.NextDayProductionTile_OnWeekday_GenerateDrillDownFilters_ReturnsWeeklyView" \
+  --no-restore
+```
+
+Expected: PASS.
+
+---
+
+### Task 7: Add the `NextDayProductionTile` Friday test (`grid` branch)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs`
+
+This test fixes the spec's FR-4 misread (per arch-review Specification Amendment 1): on a Friday, `GetNextWorkingDay` skips Sat/Sun and returns Monday, which equals neither `today` (Fri) nor `today + 1` (Sat), so the drill-down falls through to `view = "grid"`.
+
+- [ ] **Step 1: Add the test method**
+
+Insert the following method into `UpcomingProductionTileTests` (above the private `GetAnonymousProperty` helper):
+
+```csharp
+    [Fact]
+    public async Task NextDayProductionTile_OnFriday_GenerateDrillDownFilters_ReturnsGridView()
+    {
+        // Arrange: Friday → next working day = Monday, which is today + 3, neither today nor today+1.
+        var timeProvider = new FakeTimeProvider(FrozenFridayUtc);
+        var tile = new NextDayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var filters = GetAnonymousProperty(payload, "drillDown.filters");
+
+        // Assert
+        Assert.Equal("2026-06-22", GetAnonymousProperty(filters!, "date"));
+        Assert.Equal("grid", GetAnonymousProperty(filters!, "view"));
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpcomingProductionTileTests.NextDayProductionTile_OnFriday_GenerateDrillDownFilters_ReturnsGridView" \
+  --no-restore
+```
+
+Expected: PASS.
+
+---
+
+### Task 8: Add the `lastUpdated` metadata test
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs`
+
+This test verifies FR-3: `lastUpdated` is sourced from the injected `TimeProvider`, not wall-clock.
+
+- [ ] **Step 1: Add the test method**
+
+Insert the following method into `UpcomingProductionTileTests` (above the private `GetAnonymousProperty` helper):
+
+```csharp
+    [Fact]
+    public async Task LoadDataAsync_LastUpdated_ComesFromTimeProvider()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(FrozenMondayUtc);
+        var tile = new TodayProductionTile(_repositoryMock.Object, timeProvider);
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureOrder>());
+
+        // Act
+        var payload = await tile.LoadDataAsync();
+        var lastUpdated = (DateTime)GetAnonymousProperty(payload, "metadata.lastUpdated")!;
+
+        // Assert
+        Assert.Equal(FrozenMondayUtc.UtcDateTime, lastUpdated);
+        Assert.Equal(DateTimeKind.Utc, lastUpdated.Kind);
+    }
+```
+
+The `Kind` assertion is what locks in Decision 3 (`.UtcDateTime` vs `.DateTime`). If a future maintainer regresses to `.DateTime`, the `Kind` assertion fires.
+
+- [ ] **Step 2: Run the test**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpcomingProductionTileTests.LoadDataAsync_LastUpdated_ComesFromTimeProvider" \
+  --no-restore
+```
+
+Expected: PASS.
+
+---
+
+### Task 9: Final verification, format, and commit
+
+**Files:** none new (verification + commit only).
+
+- [ ] **Step 1: Run the full new test class**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpcomingProductionTileTests" \
+  --no-restore
+```
+
+Expected: `Passed: 4, Failed: 0, Skipped: 0`.
+
+- [ ] **Step 2: Run the broader Manufacture DashboardTiles test scope to catch regressions**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Features.Manufacture.DashboardTiles" \
+  --no-restore
+```
+
+Expected: all tests pass — `UpcomingProductionTileTests` (4 new) and `ManualActionRequiredTileTests` (5 pre-existing) both green.
+
+- [ ] **Step 3: Confirm DI resolution still works (acceptance criterion from FR-1)**
+
+Run the full solution build to confirm no startup-time DI error was introduced:
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+Inspect `ManufactureModule.cs:67-68` and confirm the lines are unchanged:
+
+```bash
+grep -n "RegisterTile<TodayProductionTile>\|RegisterTile<NextDayProductionTile>" \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
+```
+
+Expected output:
+
+```
+67:        services.RegisterTile<TodayProductionTile>();
+68:        services.RegisterTile<NextDayProductionTile>();
+```
+
+- [ ] **Step 4: Format the test project**
+
+Run:
+
+```bash
+cd backend && dotnet format test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: exits successfully with no diffs.
+
+- [ ] **Step 5: Commit the tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs
+git commit -m "test: cover UpcomingProductionTile drill-down under FakeTimeProvider"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- FR-1 (inject `TimeProvider` into base) → Tasks 1, 2, 3.
+- FR-2 (replace `DateTime.Today` in `GenerateDrillDownFilters`) → Task 1 Step 3.
+- FR-3 (replace `DateTime.UtcNow` in `LoadDataAsync`) → Task 1 Step 2, asserted by Task 8.
+- FR-4 (time-shifted drill-down + `lastUpdated` tests) → Tasks 5, 6, 7, 8. FR-4's misreading of the `NextDayProductionTile` `grid` expectation is corrected per arch-review Specification Amendment 1 (Tasks 6 and 7 split the case by day-of-week).
+- NFR-3 (backward compat) → Task 9 Step 3 confirms DI registrations and build are unchanged.
+- NFR-4 (consistency: `GetUtcNow()`) → Task 1 Steps 2 and 3 pick `GetUtcNow()` matching the existing subclass convention.
+
+**Architectural amendments applied:**
+- Spec Amendment 1 (FR-4 expected-result error): incorporated into Tasks 6 and 7.
+- Spec Amendment 2 (`.UtcDateTime`): incorporated into Task 1 Step 2 + Task 8 `Kind` assertion.
+- Spec Amendment 3 (no DI change): Task 9 Step 3.
+- Spec Amendment 4 (test placement): tests live at `backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/UpcomingProductionTileTests.cs`.
+- Spec Amendment 5 (subclass scope = exactly two): Task 4 Step 1 verifies, no other subclasses to update.


### PR DESCRIPTION

Inject `TimeProvider` into `UpcomingProductionTile` base class, eliminating the last wall-clock `DateTime.Today`/`DateTime.UtcNow` calls in the Manufacture dashboard tile layer.

The base class previously compared `ReferenceDate` (sourced from the injected `TimeProvider` in subclasses) against `DateTime.Today` (wall-clock) in `GenerateDrillDownFilters()`, making the returned drill-down view type non-deterministic in time-shifted tests. `lastUpdated` also used `DateTime.UtcNow` directly. Both call sites now use `_timeProvider.GetUtcNow()`, and both subclasses forward their existing `TimeProvider` to `base(...)`. No DI changes are needed; `TimeProvider.System` is already framework-registered.

### Changes
- `backend/src/.../DashboardTiles/UpcomingProductionTile.cs` — added `_timeProvider` field, 2-arg constructor, replaced clock calls at line 50 and lines 65/69
- `backend/src/.../DashboardTiles/TodayProductionTile.cs` — forwarded `timeProvider` to `base(repository, timeProvider)`
- `backend/src/.../DashboardTiles/NextDayProductionTile.cs` — forwarded `timeProvider` to `base(repository, timeProvider)`
- `backend/test/.../DashboardTiles/UpcomingProductionTileTests.cs` — new; 4 tests covering drill-down weekday/Friday branches and `lastUpdated` UTC kind under `FakeTimeProvider`

---

Closes #2679

### Tokens used
8215312
