### PR TITLE
feat: Replace DateTime.Now with caller-supplied year in ManufactureOrderRepository.GenerateOrderNumberAsync

### DIFF
--- a/artifacts/feat-arch-review-manufacture-generateordernum/arch-review.r1.md
+++ b/artifacts/feat-arch-review-manufacture-generateordernum/arch-review.r1.md
@@ -1,0 +1,172 @@
+# Architecture Review: Replace `DateTime.Now` with caller-supplied year in `ManufactureOrderRepository.GenerateOrderNumberAsync`
+
+## Skip Design: true
+
+Backend-only refactor. No UI, screens, layouts, or visual components are added or changed.
+
+## Architectural Fit Assessment
+
+The change aligns perfectly with the codebase's existing temporal-dependency convention: handlers inject `TimeProvider` (see `CreateManufactureOrderHandler.cs:24` and `DuplicateManufactureOrderHandler.cs:17`) and the Persistence layer is intended to remain free of wall-clock reads. The current implementation in `ManufactureOrderRepository.cs:150` is the lone deviation and is a textbook hidden-dependency leak from infrastructure.
+
+Verified integration points:
+- **Interface owner** — `backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs:24` (Domain layer; no other ports referenced from outside).
+- **Implementation** — `backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs:148-170`.
+- **Call sites** — confirmed exactly two: `CreateManufactureOrderHandler.cs:40` and `DuplicateManufactureOrderHandler.cs:38`. No other production caller exists in the solution.
+- **Test impact** — four test files in `backend/test/Anela.Heblo.Tests/Features/Manufacture/` mock `GenerateOrderNumberAsync(It.IsAny<CancellationToken>())`. Each Setup/Verify call must be updated to add the new `year` argument.
+
+The Purchase module already demonstrates the pattern of caller-supplied temporal data: `IPurchaseOrderNumberGenerator.GenerateOrderNumberAsync(DateTime orderDate, …)`. The Manufacture refactor brings this module into line, while keeping its narrower "year-only" surface as specified.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Application Layer (handlers — own TimeProvider)              │
+│  ┌──────────────────────────────────┐                        │
+│  │ CreateManufactureOrderHandler    │  var year =            │
+│  │ DuplicateManufactureOrderHandler │  _timeProvider         │
+│  └────────────────┬─────────────────┘   .GetUtcNow().Year    │
+│                   │                                          │
+│                   │ GenerateOrderNumberAsync(year, ct)       │
+│                   ▼                                          │
+├──────────────────────────────────────────────────────────────┤
+│ Domain Layer (interface — pure contract)                     │
+│  IManufactureOrderRepository                                 │
+│  + GenerateOrderNumberAsync(int year, CancellationToken)     │
+│                   │                                          │
+├──────────────────────────────────────────────────────────────┤
+│ Persistence Layer (NO temporal dependency)                   │
+│  ManufactureOrderRepository                                  │
+│  - Builds prefix from `year` argument                        │
+│  - Runs sequence lookup (existing logic, unchanged)          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Year flows as a primitive `int` parameter, not a `DateTimeOffset`/`DateOnly`
+**Options considered:**
+- (a) Pass `int year` (chosen).
+- (b) Pass `DateTimeOffset` and let the repo extract `.Year`.
+- (c) Inject `TimeProvider` into the repository.
+
+**Chosen approach:** (a) `int year` parameter.
+
+**Rationale:** The repository genuinely needs only the year; a `DateTimeOffset` invites future drift (someone uses `.Month`, reintroducing temporal coupling). Option (c) directly contradicts spec NFR-4 — moving the hidden dependency rather than removing it. Option (a) is the minimum sufficient contract: explicit, unambiguous, trivially testable, and exhausts what the prefix needs.
+
+#### Decision 2: Mirror Purchase module's pattern, not its abstraction
+**Options considered:**
+- (a) Extract `IManufactureOrderNumberGenerator` to mirror `IPurchaseOrderNumberGenerator`.
+- (b) Keep number generation inside `IManufactureOrderRepository` (chosen).
+
+**Chosen approach:** (b) Keep the method on the repository.
+
+**Rationale:** The Purchase generator is stateless (`Task.FromResult(...)` only). The Manufacture generator must query `_context.ManufactureOrders` to find the highest existing sequence — it inherently belongs with the data context. Extracting it would require either passing the DbContext into a separate service (leaks Persistence) or duplicating EF access (worse). Spec explicitly puts new abstractions out of scope; staying on the repository is correct.
+
+#### Decision 3: Update tests in the same PR
+**Chosen approach:** Update all four test files alongside the production change.
+
+**Rationale:** Adding a required parameter to an interface mock signature is a compile break. The tests must change in lockstep — there is no incremental path. Tests should retain `It.IsAny<int>()` for year matching unless the test specifically asserts on year-boundary behavior (FR-3), in which case use the exact `int` value derived from the test's fixed `TimeProvider`.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Edits only:
+
+| File | Change |
+|---|---|
+| `backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs` | Add `int year` to signature. |
+| `backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs` | Replace `DateTime.Now.Year` with parameter; delete the assignment line. |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` | Compute `var year = _timeProvider.GetUtcNow().Year;` once and pass it. Reuse the same instant for `CreatedDate` and `StateChangedAt` for audit consistency (see Risk R-2). |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` | Same pattern. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` | Update all `Setup`/`Verify` calls. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs` | Same. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs` | Same. Add at least one new test per FR-3 acceptance criterion (year-boundary). |
+
+`backend/test/Anela.Heblo.Tests/Features/Purchase/CreatePurchaseOrderHandlerTests.cs` is **not** affected (different interface).
+
+### Interfaces and Contracts
+
+```csharp
+// Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs
+Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default);
+```
+
+```csharp
+// Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
+public async Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default)
+{
+    var prefix = $"MO-{year}-";
+
+    var lastOrderNumber = await _context.ManufactureOrders
+        .Where(x => x.OrderNumber.StartsWith(prefix))
+        .OrderByDescending(x => x.OrderNumber)
+        .Select(x => x.OrderNumber)
+        .FirstOrDefaultAsync(cancellationToken);
+
+    var nextSequence = 1;
+    if (lastOrderNumber != null)
+    {
+        var sequencePart = lastOrderNumber.Substring(prefix.Length);
+        if (int.TryParse(sequencePart, out var lastSequence))
+        {
+            nextSequence = lastSequence + 1;
+        }
+    }
+
+    return $"{prefix}{nextSequence:D3}";
+}
+```
+
+```csharp
+// Both handlers
+var now = _timeProvider.GetUtcNow();
+var orderNumber = await _repository.GenerateOrderNumberAsync(now.Year, cancellationToken);
+// reuse `now` for CreatedDate / StateChangedAt to guarantee row-level audit consistency
+```
+
+### Data Flow
+
+```
+Handler.Handle()
+  └── now = TimeProvider.GetUtcNow()        ◄── single source of time
+  └── orderNumber = repo.GenerateOrderNumberAsync(now.Year, ct)
+        └── prefix := "MO-{year}-"
+        └── EF query: max OrderNumber for prefix → nextSequence
+        └── return "MO-{year}-{nextSequence:D3}"
+  └── order.CreatedDate = now.DateTime
+  └── order.StateChangedAt = now.DateTime
+  └── repo.AddOrderAsync(order, ct)
+```
+
+All temporal values on the same row originate from one `TimeProvider` read.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| **R-1: Hidden third caller exists outside this search.** | Low | Search confirms only two production callers, but compile errors from the breaking interface change will surface any missed call site. Treat compile errors as the safety net; list any new site in the PR description per spec FR-2. |
+| **R-2: Handler reads `_timeProvider.GetUtcNow()` multiple times within one call.** Inspection of `CreateManufactureOrderHandler` shows 4 separate `GetUtcNow()` reads (lines 46, 52, 62, 63). If wall-clock ticks across calls, year and `CreatedDate` could still diverge at the exact stroke of midnight UTC. | Low | Cache `var now = _timeProvider.GetUtcNow();` at the top of `Handle()` and reuse it for **all** stamps in that handler. Same for `DuplicateManufactureOrderHandler`. This is in-scope per spec FR-3 acceptance ("same TimeProvider reading within a single handler invocation"). |
+| **R-3: Year-boundary race on concurrent inserts.** Two requests at 23:59:59.999 UTC on Dec 31 could both compute `year=2026`, then one row commits with `CreatedDate=2027` if processing crosses midnight. | Low | Out of scope per spec; the fix targets static skew, not concurrency. Pre-existing race; not introduced by this change. |
+| **R-4: Existing tests mock `It.IsAny<CancellationToken>()`; the new `int year` parameter shifts argument positions.** | Low | Mechanical update: change Setup to `Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))`. Compile errors will flag any miss. |
+| **R-5: Spec demands "no clock read" inside the repository, but a future maintainer might re-add one for "convenience" defaults.** | Medium | Add a single-line comment at the method head: `// year is supplied by the caller; do not introduce TimeProvider here (see ADR / spec).` This is the one comment that meets the "non-obvious why" bar in the project's coding standards. |
+
+## Specification Amendments
+
+The spec is implementable as written. One **mandatory clarification** that should be added to FR-3 acceptance criteria:
+
+- **FR-3 (clarification):** Both handlers MUST cache the `TimeProvider.GetUtcNow()` result in a local variable at the top of `Handle()` and reuse it for the year argument **and** every `CreatedDate`/`StateChangedAt` assignment on the new row. The current handler code reads `_timeProvider.GetUtcNow()` multiple times; without caching, a millisecond-precision crossing of the year boundary between reads would silently reintroduce the very inconsistency this spec fixes. Add a unit test that uses a fake `TimeProvider` whose successive reads cross midnight, and asserts year + `CreatedDate` agree.
+
+One **optional addition** (low-priority cleanup, not required to satisfy the brief):
+- The Purchase module's `PurchaseOrderNumberGenerator.cs:15-16` reads `DateTime.Now.Hour`/`Minute` — same anti-pattern, different module. Out of scope here but worth filing as a follow-up brief.
+
+## Prerequisites
+
+None. All required infrastructure is already in place:
+- `TimeProvider` is registered in DI and already injected into both handlers.
+- `IManufactureOrderRepository` and its implementation exist.
+- All test projects exist with the right mocking framework (Moq + FluentAssertions + xUnit).
+
+No migrations, no config, no new packages, no new DI registrations.

--- a/artifacts/feat-arch-review-manufacture-generateordernum/brief.md
+++ b/artifacts/feat-arch-review-manufacture-generateordernum/brief.md
@@ -1,0 +1,48 @@
+## Module
+Manufacture
+
+## Finding
+`ManufactureOrderRepository.GenerateOrderNumberAsync` uses `DateTime.Now` (local server time) to derive the year prefix for the order number:
+
+```csharp
+// backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs  line 150
+var currentYear = DateTime.Now.Year;
+var prefix = $"MO-{currentYear}-";
+```
+
+Every other time-stamped value in this module uses either `_timeProvider.GetUtcNow()` (handlers) or `DateTime.UtcNow` (even the handlers that the existing issues #2676–#2679 flag). `DateTime.Now` is the odd one out: it reads the OS local clock, which on most server deployments is UTC — but is not guaranteed, and behaves incorrectly on any host that runs with a non-UTC offset (e.g. CET = UTC+1).
+
+Concrete failure scenario: at 23:30 UTC on 31 December the local time on a CET server is already 00:30 on 1 January. `GenerateOrderNumberAsync` will emit `MO-{next_year}-001` while the handler's `TimeProvider`-controlled timestamps still say the previous year. Conversely, on 31 December CET, an order submitted at 23:30 local time (= 22:30 UTC) carries a `MO-{next_year}` prefix while the order's `CreatedDate` column still says the previous year — creating an inconsistent audit record.
+
+## Why it matters
+- **Correctness**: year-based order numbering diverges from the UTC-based audit timestamps stored on the same row whenever local time ≠ UTC.
+- **Infrastructure encapsulation**: the repository currently self-sources a temporal dependency (`DateTime.Now`) instead of accepting it from the application layer, which owns `TimeProvider`. This makes the function untestable for year-boundary edge cases.
+- **Consistency**: all other date/time dependencies in the module flow through `TimeProvider` or at minimum `DateTime.UtcNow`; this is the only site using local wall-clock time.
+
+## Suggested fix
+Remove the temporal dependency from the repository entirely. Accept the year as a parameter from the caller (the handler already injects `TimeProvider`):
+
+```csharp
+// IManufactureOrderRepository (Domain layer)
+Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default);
+
+// ManufactureOrderRepository (Persistence layer) — line 150
+public async Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default)
+{
+    var prefix = $"MO-{year}-";
+    // ... rest unchanged
+}
+
+// CreateManufactureOrderHandler — after generating the order number
+var year = _timeProvider.GetUtcNow().Year;
+var orderNumber = await _repository.GenerateOrderNumberAsync(year, cancellationToken);
+
+// DuplicateManufactureOrderHandler — same pattern
+var year = _timeProvider.GetUtcNow().Year;
+var orderNumber = await _repository.GenerateOrderNumberAsync(year, cancellationToken);
+```
+
+The interface change is small (adding one `int year` parameter), touches two callers (`CreateManufactureOrderHandler`, `DuplicateManufactureOrderHandler`), and removes a hidden temporal side-effect from the infrastructure layer.
+
+---
+_Filed by daily arch-review routine on 2026-06-06._

--- a/artifacts/feat-arch-review-manufacture-generateordernum/impl/main.r1.md
+++ b/artifacts/feat-arch-review-manufacture-generateordernum/impl/main.r1.md
@@ -1,0 +1,57 @@
+All tasks complete. Here is the implementation summary:
+
+---
+
+# Implementation: Replace DateTime.Now with caller-supplied year in ManufactureOrderRepository.GenerateOrderNumberAsync
+
+## What was implemented
+
+Removed the hidden `DateTime.Now` dependency from `ManufactureOrderRepository.GenerateOrderNumberAsync` by adding an `int year` parameter. Both Manufacture handlers now cache a single `TimeProvider.GetUtcNow()` read and pass `now.Year` to the repository, ensuring the order number's year always agrees with `CreatedDate` on the same row. Six new guard tests lock in the year-boundary and audit-consistency behavior.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs` — added `int year` as first parameter to `GenerateOrderNumberAsync`
+- `backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs` — removed `DateTime.Now.Year`; uses `year` argument to build prefix; added guard comment (FR-1)
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` — caches `var now = _timeProvider.GetUtcNow()` once; passes `now.Year` and reuses `now.DateTime` for all timestamps
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` — same pattern
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` — updated 13 mock signatures; added 3 new guard tests
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs` — updated 2 mock signatures
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs` — updated 3 mock signatures; added 3 new guard tests
+
+## Tests
+
+**Existing tests:** 18 in `CreateManufactureOrderHandlerTests`, 2 in `CreateManufactureOrderHandlerSinglePhaseTests`, 3 in `DuplicateManufactureOrderHandlerTests` — all updated and green.
+
+**New guard tests (6 total):**
+- `Handle_AtYearEndUtc_PassesUtcYearToRepository` — both handlers
+- `Handle_AtYearStartUtc_PassesUtcYearToRepository` — both handlers
+- `Handle_WhenClockCrossesYearBoundaryBetweenReads_KeepsYearAndCreatedDateConsistent` — both handlers (uses `SetupSequence` to detect multiple `GetUtcNow()` reads)
+
+## How to verify
+
+```bash
+cd backend && dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture"
+```
+
+## Notes
+
+- Purchase module untouched (uses a different interface `IPurchaseOrderNumberGenerator`)
+- No database migration required — order number format unchanged
+- Two commits on branch: `8da06e3c` (refactor) and `612103c8` (guard tests)
+
+## PR Summary
+
+Removes the hidden `DateTime.Now` dependency from `ManufactureOrderRepository.GenerateOrderNumberAsync` by threading the year as a caller-supplied `int` parameter. Both handlers now cache a single `TimeProvider.GetUtcNow()` reading at the top of `Handle()` and reuse it for the year argument, `CreatedDate`, `StateChangedAt`, expiration date, and lot number — guaranteeing all temporal stamps on a new order row derive from the same instant and eliminating the year-boundary skew (e.g., CET 00:30 on Jan 1 = UTC Dec 31, which previously produced a `MO-{next_year}` prefix while `CreatedDate` recorded the old year).
+
+### Changes
+- `IManufactureOrderRepository.cs` — added `int year` to `GenerateOrderNumberAsync` signature
+- `ManufactureOrderRepository.cs` — removed `DateTime.Now.Year`; uses supplied year; added FR-1 guard comment
+- `CreateManufactureOrderHandler.cs` — single cached `now` read; passes `now.Year` to repo
+- `DuplicateManufactureOrderHandler.cs` — same pattern
+- `CreateManufactureOrderHandlerTests.cs` — updated 13 mocks + 3 new year-boundary/consistency tests
+- `CreateManufactureOrderHandlerSinglePhaseTests.cs` — updated 2 mocks
+- `DuplicateManufactureOrderHandlerTests.cs` — updated 3 mocks + 3 new year-boundary/consistency tests
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-manufacture-generateordernum/spec.r1.md
+++ b/artifacts/feat-arch-review-manufacture-generateordernum/spec.r1.md
@@ -1,0 +1,118 @@
+# Specification: Replace DateTime.Now with caller-supplied year in ManufactureOrderRepository.GenerateOrderNumberAsync
+
+## Summary
+The `ManufactureOrderRepository.GenerateOrderNumberAsync` method derives the year prefix for manufacture order numbers from `DateTime.Now` (local server time), which is inconsistent with the rest of the Manufacture module that uses `TimeProvider`/`DateTime.UtcNow`. This spec refactors the method to accept the year as a parameter, sourced by handlers from the injected `TimeProvider`, eliminating the hidden temporal dependency and ensuring order numbers align with audit timestamps on the same row.
+
+## Background
+The Manufacture module uses `TimeProvider.GetUtcNow()` everywhere temporal values are stamped — in `CreateManufactureOrderHandler`, `DuplicateManufactureOrderHandler`, and other module handlers. The repository's `GenerateOrderNumberAsync` is the sole site that reads the OS local clock via `DateTime.Now`.
+
+On a server running with a non-UTC offset (e.g. CET = UTC+1), this causes the order number's year prefix to diverge from the order row's `CreatedDate` (which is UTC). The defect window is the year boundary:
+
+- At **23:30 UTC on 31 December**, CET local time is already **00:30 on 1 January**. The repository emits `MO-{next_year}-001` while the handler's `TimeProvider`-driven `CreatedDate` still records the old year.
+- At **23:30 CET on 31 December** (= 22:30 UTC), the repository emits `MO-{next_year}` while `CreatedDate` still records the old year — same inconsistency, opposite direction depending on how the host clock is configured.
+
+The bug:
+- Breaks audit consistency: order number year ≠ creation year.
+- Hides a temporal dependency inside the infrastructure layer, making year-boundary edge cases untestable without manipulating the OS clock.
+- Violates module-wide convention that time flows through `TimeProvider`.
+
+Location: `backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs:150`.
+
+## Functional Requirements
+
+### FR-1: Repository accepts year as a parameter
+`IManufactureOrderRepository.GenerateOrderNumberAsync` must take an `int year` parameter and use it verbatim as the prefix year. The repository must not read any clock (`DateTime.Now`, `DateTime.UtcNow`, `TimeProvider`, etc.) to derive the year.
+
+**Acceptance criteria:**
+- The interface signature is `Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default)`.
+- The implementation builds the prefix as `$"MO-{year}-"` using the supplied `year` argument.
+- A grep for `DateTime.Now`, `DateTime.UtcNow`, and `TimeProvider` inside `ManufactureOrderRepository.GenerateOrderNumberAsync` returns no matches.
+- All sequence-lookup and number-formatting behavior downstream of the prefix calculation is unchanged.
+
+### FR-2: Handlers supply the year from TimeProvider
+Both call sites — `CreateManufactureOrderHandler` and `DuplicateManufactureOrderHandler` — must compute the year from the injected `TimeProvider` (`_timeProvider.GetUtcNow().Year`) and pass it to the repository.
+
+**Acceptance criteria:**
+- `CreateManufactureOrderHandler` calls `_repository.GenerateOrderNumberAsync(_timeProvider.GetUtcNow().Year, cancellationToken)` (or the equivalent via a local variable).
+- `DuplicateManufactureOrderHandler` does the same.
+- No other call site of `GenerateOrderNumberAsync` exists; if one is discovered during implementation, it is updated identically and listed in the PR description.
+
+### FR-3: Generated order numbers reflect the UTC year
+For any order created when the handler's `TimeProvider` UTC instant falls in year Y, the resulting order number prefix is `MO-Y-`.
+
+**Acceptance criteria:**
+- A unit test using a fake/mocked `TimeProvider` set to `2026-12-31T23:30:00Z` produces an order number `MO-2026-…` regardless of the host OS time zone.
+- A unit test using a fake/mocked `TimeProvider` set to `2027-01-01T00:30:00Z` produces an order number `MO-2027-…`.
+- The order's `CreatedDate` (or equivalent UTC timestamp set by the handler) and the year segment of the order number always derive from the same `TimeProvider` reading within a single handler invocation.
+
+### FR-4: Sequence number behavior preserved
+The existing sequence-suffix logic (the `-001`, `-002`, … portion) must continue to function: it counts existing orders for the supplied year and returns the next available suffix.
+
+**Acceptance criteria:**
+- For year Y with no existing orders, the suffix is `001` (or whatever the current implementation produces — the new code must match the existing format and padding).
+- For year Y with N existing orders, the suffix is the next integer formatted identically to today.
+- Suffix lookup uses the supplied `year` argument exclusively; no clock is consulted to determine which year's sequence to query.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance change is expected or acceptable. The refactor removes a clock read and adds an `int` parameter; database query shape and indexing are unchanged.
+
+### NFR-2: Testability
+The refactored method must be unit-testable for year-boundary scenarios without manipulating the system clock or the host time zone. Tests inject a fake `TimeProvider` at the handler level and assert on the year prefix produced.
+
+### NFR-3: Backwards compatibility
+- Order numbers produced before this change remain valid and queryable — no migration of existing data is required.
+- The change is purely additive at the interface level (one new required parameter); no public API surface beyond the repository interface is altered.
+
+### NFR-4: Consistency with module conventions
+After this change, **no** code path in the Manufacture module reads the wall clock to stamp data. All temporal values flow through `TimeProvider`. The repository contains no temporal dependency.
+
+## Data Model
+No changes. The `ManufactureOrder` entity and its `OrderNumber` column are unchanged. The generated string format `MO-{year}-{sequence}` is preserved.
+
+## API / Interface Design
+
+**Interface (Domain layer):**
+```csharp
+// IManufactureOrderRepository
+Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default);
+```
+
+**Implementation (Persistence layer):**
+```csharp
+public async Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default)
+{
+    var prefix = $"MO-{year}-";
+    // existing sequence-lookup logic, parameterized on `prefix` / `year`
+}
+```
+
+**Caller pattern (both handlers):**
+```csharp
+var year = _timeProvider.GetUtcNow().Year;
+var orderNumber = await _repository.GenerateOrderNumberAsync(year, cancellationToken);
+```
+
+No HTTP, MediatR, or contract DTO changes. No frontend changes.
+
+## Dependencies
+- Existing `TimeProvider` registration in DI (already used by Manufacture handlers).
+- `IManufactureOrderRepository` interface (Domain layer).
+- `ManufactureOrderRepository` implementation (Persistence layer).
+- Call sites: `CreateManufactureOrderHandler`, `DuplicateManufactureOrderHandler` (Application layer).
+- Existing unit-test project for the Manufacture module.
+
+No new packages, no new infrastructure, no database migration.
+
+## Out of Scope
+- Issues #2676–#2679 (other temporal-dependency findings in Manufacture handlers). Those handlers correctly use `_timeProvider.GetUtcNow()` after their own fixes; this spec touches only the repository and the two call sites that pass the year in.
+- Changing the order number format (`MO-{year}-{seq}`), sequence padding width, or sequence-rollover rules.
+- Backfilling, renumbering, or auditing historical orders whose number prefix and `CreatedDate` already diverge due to the prior bug.
+- Introducing a clock abstraction at the repository level (e.g. injecting `TimeProvider` into the repository). The agreed approach is to remove temporal dependency from the repository, not to add one.
+- Changing how other Manufacture-module repositories handle time.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-manufacture-generateordernum/task-plan.r1.md
+++ b/artifacts/feat-arch-review-manufacture-generateordernum/task-plan.r1.md
@@ -1,0 +1,7 @@
+Plan saved to `docs/superpowers/plans/2026-06-13-manufacture-generate-order-number-supplied-year.md`.
+
+**Summary:** 8 tasks across two commits.
+- **Commit 1 (refactor, Tasks 1–4):** thread `int year` through the repository interface and implementation, cache `var now = _timeProvider.GetUtcNow()` once in both handlers and pass `now.Year` to the repo, reuse `now.DateTime` for `CreatedDate` / `StateChangedAt` / expiration / lot, and mechanically update the 18 existing mock signatures across three test files. Existing green suite acts as the safety net.
+- **Commit 2 (guards, Tasks 5–8):** six new xUnit tests — year-end and year-start cases for both handlers (FR-3), plus `SetupSequence` audit-consistency tests that fail if the handler reads `TimeProvider` more than once (arch review R-2 mandatory clarification). Closes with full-suite run, `dotnet format`, and a grep guard verifying zero clock reads remain inside `GenerateOrderNumberAsync`.
+
+Spec coverage is mapped requirement-by-requirement in the Self-Review section; no placeholders; signatures and helper names verified against the live code.

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
@@ -36,20 +36,24 @@ public class CreateManufactureOrderHandler : IRequestHandler<CreateManufactureOr
     {
         var currentUser = _currentUserService.GetCurrentUser();
 
-        // Generate unique order number
-        var orderNumber = await _repository.GenerateOrderNumberAsync(cancellationToken);
+        // Cache one TimeProvider reading so the year, CreatedDate, StateChangedAt,
+        // expiration date, and lot number on the new row all derive from the same instant.
+        var now = _timeProvider.GetUtcNow();
+
+        // Generate unique order number using the UTC year — must agree with CreatedDate below.
+        var orderNumber = await _repository.GenerateOrderNumberAsync(now.Year, cancellationToken);
 
         // Create the manufacture order
         var order = new ManufactureOrder
         {
             OrderNumber = orderNumber,
-            CreatedDate = _timeProvider.GetUtcNow().DateTime,
+            CreatedDate = now.DateTime,
             CreatedByUser = currentUser.Name,
             ResponsiblePerson = request.ResponsiblePerson,
             PlannedDate = request.PlannedDate,
             ManufactureType = request.ManufactureType,
             State = ManufactureOrderState.Draft,
-            StateChangedAt = _timeProvider.GetUtcNow().DateTime,
+            StateChangedAt = now.DateTime,
             StateChangedByUser = currentUser.Name
         };
 
@@ -59,8 +63,8 @@ public class CreateManufactureOrderHandler : IRequestHandler<CreateManufactureOr
             return new CreateManufactureOrderResponse(ErrorCodes.ProductNotFound);
         }
 
-        var expirationDate = ManufactureOrderExtensions.GetDefaultExpiration(_timeProvider.GetUtcNow().DateTime, semiproduct.Properties.ExpirationMonths);
-        var lotNumber = ManufactureOrderExtensions.GetDefaultLot(_timeProvider.GetUtcNow().DateTime);
+        var expirationDate = ManufactureOrderExtensions.GetDefaultExpiration(now.DateTime, semiproduct.Properties.ExpirationMonths);
+        var lotNumber = ManufactureOrderExtensions.GetDefaultLot(now.DateTime);
 
         // Create the semi-product entry
         if (request.ManufactureType == ManufactureType.MultiPhase)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs
@@ -34,29 +34,33 @@ public class DuplicateManufactureOrderHandler : IRequestHandler<DuplicateManufac
             return new DuplicateManufactureOrderResponse(ErrorCodes.OrderNotFound);
         }
 
-        // Generate unique order number for the duplicate
-        var orderNumber = await _repository.GenerateOrderNumberAsync(cancellationToken);
+        // Cache one TimeProvider reading so the year, CreatedDate, StateChangedAt,
+        // PlannedDate, expiration date, and lot number on the duplicate row all derive from the same instant.
+        var now = _timeProvider.GetUtcNow();
 
-        // Get the current date for lot number and expiration calculations
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().DateTime);
+        // Generate unique order number for the duplicate using the UTC year.
+        var orderNumber = await _repository.GenerateOrderNumberAsync(now.Year, cancellationToken);
+
+        // Today (UTC) for lot number and expiration calculations
+        var today = DateOnly.FromDateTime(now.DateTime);
 
         // Create the duplicate order
         var duplicateOrder = new ManufactureOrder
         {
             OrderNumber = orderNumber,
-            CreatedDate = _timeProvider.GetUtcNow().DateTime,
+            CreatedDate = now.DateTime,
             CreatedByUser = currentUser.GetDisplayName(),
             ResponsiblePerson = sourceOrder.ResponsiblePerson,
             PlannedDate = today,
             State = ManufactureOrderState.Draft,
-            StateChangedAt = _timeProvider.GetUtcNow().DateTime,
+            StateChangedAt = now.DateTime,
             StateChangedByUser = currentUser.GetDisplayName()
         };
 
         var expirationDate = sourceOrder.SemiProduct != null
-            ? ManufactureOrderExtensions.GetDefaultExpiration(_timeProvider.GetUtcNow().DateTime, sourceOrder.SemiProduct.ExpirationMonths)
+            ? ManufactureOrderExtensions.GetDefaultExpiration(now.DateTime, sourceOrder.SemiProduct.ExpirationMonths)
             : (DateOnly?)null;
-        var lotNumber = ManufactureOrderExtensions.GetDefaultLot(_timeProvider.GetUtcNow().DateTime);
+        var lotNumber = ManufactureOrderExtensions.GetDefaultLot(now.DateTime);
 
         // Duplicate the semi-product with updated lot number and expiration date
         if (sourceOrder.SemiProduct != null)

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs
@@ -21,7 +21,7 @@ public interface IManufactureOrderRepository
     Task<ManufactureOrder> UpdateOrderAsync(ManufactureOrder order, CancellationToken cancellationToken = default);
     Task DeleteOrderAsync(int id, CancellationToken cancellationToken = default);
 
-    Task<string> GenerateOrderNumberAsync(CancellationToken cancellationToken = default);
+    Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default);
     Task<List<ManufactureOrder>> GetOrdersForDateRangeAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default);
 
     Task<Dictionary<string, decimal>> GetPlannedQuantitiesAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
@@ -145,10 +145,10 @@ public class ManufactureOrderRepository : IManufactureOrderRepository
         }
     }
 
-    public async Task<string> GenerateOrderNumberAsync(CancellationToken cancellationToken = default)
+    public async Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default)
     {
-        var currentYear = DateTime.Now.Year;
-        var prefix = $"MO-{currentYear}-";
+        // year is supplied by the caller; do not introduce TimeProvider/DateTime.Now here (see spec FR-1).
+        var prefix = $"MO-{year}-";
 
         var lastOrderNumber = await _context.ManufactureOrders
             .Where(x => x.OrderNumber.StartsWith(prefix))

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs
@@ -64,7 +64,7 @@ public class CreateManufactureOrderHandlerSinglePhaseTests
         var currentTime = new DateTime(2023, 10, 20);
         _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(new DateTimeOffset(currentTime));
 
-        _repositoryMock.Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+        _repositoryMock.Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("MO-2023-001");
 
         var catalogProduct = new CatalogAggregate
@@ -130,7 +130,7 @@ public class CreateManufactureOrderHandlerSinglePhaseTests
         var currentTime = new DateTime(2023, 10, 20);
         _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(new DateTimeOffset(currentTime));
 
-        _repositoryMock.Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+        _repositoryMock.Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("MO-2023-001");
 
         var catalogProduct = new CatalogAggregate

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
@@ -64,7 +64,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -94,7 +94,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -131,7 +131,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -171,7 +171,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -209,7 +209,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -256,7 +256,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -294,7 +294,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -308,7 +308,7 @@ public class CreateManufactureOrderHandlerTests
         await _handler.Handle(request, CancellationToken.None);
 
         _repositoryMock.Verify(
-            x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()),
+            x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -323,7 +323,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -361,7 +361,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -390,7 +390,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock
@@ -414,7 +414,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Order number generation failed"));
 
         var action = async () => await _handler.Handle(request, CancellationToken.None);
@@ -533,7 +533,7 @@ public class CreateManufactureOrderHandlerTests
             .ReturnsAsync(CreateValidCatalogItem());
 
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         _repositoryMock

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
@@ -589,4 +589,115 @@ public class CreateManufactureOrderHandlerTests
             }
         };
     }
+
+    [Fact]
+    public async Task Handle_AtYearEndUtc_PassesUtcYearToRepository()
+    {
+        // Arrange — fake clock at 2026-12-31 23:30 UTC; local time zone is irrelevant.
+        var yearEndUtc = new DateTimeOffset(2026, 12, 31, 23, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearEndUtc);
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            // Capture the year argument passed to the repository
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2026-001");
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = 1; return order; });
+
+        // Act
+        var response = await _handler.Handle(CreateValidRequest(), CancellationToken.None);
+
+        // Assert — year must be 2026, regardless of the host time zone.
+        capturedYear.Should().Be(2026);
+        response.OrderNumber.Should().StartWith("MO-2026-");
+    }
+
+    [Fact]
+    public async Task Handle_AtYearStartUtc_PassesUtcYearToRepository()
+    {
+        // Arrange — fake clock at 2027-01-01 00:30 UTC.
+        var yearStartUtc = new DateTimeOffset(2027, 1, 1, 0, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearStartUtc);
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            // Capture the year argument passed to the repository
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2027-001");
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = 1; return order; });
+
+        // Act
+        var response = await _handler.Handle(CreateValidRequest(), CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2027);
+        response.OrderNumber.Should().StartWith("MO-2027-");
+    }
+
+    [Fact]
+    public async Task Handle_WhenClockCrossesYearBoundaryBetweenReads_KeepsYearAndCreatedDateConsistent()
+    {
+        // Arrange — first read just before midnight UTC on 2026-12-31; any subsequent read jumps to 2027-01-01.
+        var beforeMidnight = new DateTimeOffset(2026, 12, 31, 23, 59, 59, 999, TimeSpan.Zero);
+        var afterMidnight = new DateTimeOffset(2027, 1, 1, 0, 0, 0, 1, TimeSpan.Zero);
+
+        _timeProviderMock
+            .SetupSequence(x => x.GetUtcNow())
+            .Returns(beforeMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight);
+
+        int? capturedYear = null;
+        ManufactureOrder? capturedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            // Capture the year argument passed to the repository
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            // Lambda form: return value reflects the actual year passed so the OrderNumber assertion is meaningful.
+            .ReturnsAsync((int year, CancellationToken _) => $"MO-{year}-001");
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) =>
+            {
+                capturedOrder = order;
+                order.Id = 1;
+                return order;
+            });
+
+        // Act
+        var response = await _handler.Handle(CreateValidRequest(), CancellationToken.None);
+
+        // Assert — year used for the OrderNumber must match the row's CreatedDate year.
+        capturedYear.Should().Be(2026);
+        capturedOrder.Should().NotBeNull();
+        capturedOrder!.CreatedDate.Year.Should().Be(2026);
+        capturedOrder.StateChangedAt.Year.Should().Be(2026);
+        capturedOrder.OrderNumber.Should().StartWith("MO-2026-");
+        response.OrderNumber.Should().StartWith("MO-2026-");
+        response.OrderNumber.Should().Be(capturedOrder!.OrderNumber);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
@@ -252,4 +252,115 @@ public class DuplicateManufactureOrderHandlerTests
             dup.ExpirationDate.Should().BeNull();
         }
     }
+
+    [Fact]
+    public async Task Handle_AtYearEndUtc_PassesUtcYearToRepository()
+    {
+        // Arrange
+        var yearEndUtc = new DateTimeOffset(2026, 12, 31, 23, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearEndUtc);
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildSourceOrder(includeSemiProduct: true));
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            // Capture the year argument passed to the repository
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2026-001");
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = PersistedOrderId; return order; });
+
+        // Act
+        var response = await _handler.Handle(new DuplicateManufactureOrderRequest { SourceOrderId = SourceOrderId }, CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2026);
+        response.OrderNumber.Should().StartWith("MO-2026-");
+    }
+
+    [Fact]
+    public async Task Handle_AtYearStartUtc_PassesUtcYearToRepository()
+    {
+        // Arrange
+        var yearStartUtc = new DateTimeOffset(2027, 1, 1, 0, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearStartUtc);
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildSourceOrder(includeSemiProduct: true));
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            // Capture the year argument passed to the repository
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2027-001");
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = PersistedOrderId; return order; });
+
+        // Act
+        var response = await _handler.Handle(new DuplicateManufactureOrderRequest { SourceOrderId = SourceOrderId }, CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2027);
+        response.OrderNumber.Should().StartWith("MO-2027-");
+    }
+
+    [Fact]
+    public async Task Handle_WhenClockCrossesYearBoundaryBetweenReads_KeepsYearAndCreatedDateConsistent()
+    {
+        // Arrange
+        var beforeMidnight = new DateTimeOffset(2026, 12, 31, 23, 59, 59, 999, TimeSpan.Zero);
+        var afterMidnight = new DateTimeOffset(2027, 1, 1, 0, 0, 0, 1, TimeSpan.Zero);
+
+        _timeProviderMock
+            .SetupSequence(x => x.GetUtcNow())
+            .Returns(beforeMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight);
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildSourceOrder(includeSemiProduct: true));
+
+        int? capturedYear = null;
+        ManufactureOrder? capturedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            // Capture the year argument passed to the repository
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            // Lambda form: return value reflects the actual year passed so the OrderNumber assertion is meaningful.
+            .ReturnsAsync((int year, CancellationToken _) => $"MO-{year}-001");
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) =>
+            {
+                capturedOrder = order;
+                order.Id = PersistedOrderId;
+                return order;
+            });
+
+        // Act
+        var response = await _handler.Handle(new DuplicateManufactureOrderRequest { SourceOrderId = SourceOrderId }, CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2026);
+        capturedOrder.Should().NotBeNull();
+        capturedOrder!.CreatedDate.Year.Should().Be(2026);
+        capturedOrder.StateChangedAt.Year.Should().Be(2026);
+        capturedOrder.OrderNumber.Should().StartWith("MO-2026-");
+        response.OrderNumber.Should().StartWith("MO-2026-");
+        response.OrderNumber.Should().Be(capturedOrder!.OrderNumber);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
@@ -110,7 +110,7 @@ public class DuplicateManufactureOrderHandlerTests
         response.Success.Should().BeFalse();
 
         _repositoryMock.Verify(
-            x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()),
+            x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _repositoryMock.Verify(
             x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()),
@@ -127,7 +127,7 @@ public class DuplicateManufactureOrderHandlerTests
             .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(sourceOrder);
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         ManufactureOrder? captured = null;
@@ -206,7 +206,7 @@ public class DuplicateManufactureOrderHandlerTests
             .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(sourceOrder);
         _repositoryMock
-            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(GeneratedOrderNumber);
 
         ManufactureOrder? captured = null;

--- a/docs/superpowers/plans/2026-06-13-manufacture-generate-order-number-supplied-year.md
+++ b/docs/superpowers/plans/2026-06-13-manufacture-generate-order-number-supplied-year.md
@@ -1,0 +1,686 @@
+# Manufacture `GenerateOrderNumberAsync` — Caller-Supplied Year Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the hidden `DateTime.Now` dependency from `ManufactureOrderRepository.GenerateOrderNumberAsync` by taking the year as an `int` parameter supplied by the caller, and ensure both Manufacture handlers source the year from their injected `TimeProvider` using a single cached reading so the order number's year always agrees with the row's `CreatedDate`.
+
+**Architecture:** Backend-only refactor in the Manufacture vertical slice. Interface change in Domain (`IManufactureOrderRepository`); behavior change in Persistence (`ManufactureOrderRepository`); call-site updates in two Application handlers (`CreateManufactureOrderHandler`, `DuplicateManufactureOrderHandler`). Both handlers cache a single `TimeProvider.GetUtcNow()` reading and reuse it for the year, `CreatedDate`, `StateChangedAt`, and the expiration/lot helpers — guaranteeing all temporal stamps on the new row come from one instant. No HTTP, MediatR, contract, frontend, migration, or DI registration changes.
+
+**Tech Stack:** .NET 8, C#, MediatR, Entity Framework Core, xUnit, Moq, FluentAssertions.
+
+---
+
+## File Structure
+
+**Production code (edit only — no new files):**
+
+| File | Responsibility | Change |
+|---|---|---|
+| `backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs` | Repository port | Add `int year` as first parameter to `GenerateOrderNumberAsync`. |
+| `backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs` | EF Core implementation | Use the `year` parameter to build the prefix; delete the `DateTime.Now.Year` line. Add one short comment guarding against future clock reintroduction. |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` | Create-order handler | Cache `var now = _timeProvider.GetUtcNow();` once at the top of `Handle()`; pass `now.Year` to the repository; reuse `now.DateTime` for `CreatedDate`, `StateChangedAt`, `GetDefaultExpiration`, and `GetDefaultLot`. |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs` | Duplicate-order handler | Same pattern as Create: cache `now` once, pass `now.Year`, reuse for all stamps and helpers. |
+
+**Tests (edit existing — no new files):**
+
+| File | Change |
+|---|---|
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` | Update all 13 `Setup`/`Verify` calls on `GenerateOrderNumberAsync` to add `It.IsAny<int>()`. Add new year-boundary and audit-consistency tests. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs` | Update both `Setup` calls to add `It.IsAny<int>()`. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs` | Update all 3 `Setup`/`Verify` calls to add `It.IsAny<int>()`. Add new year-boundary and audit-consistency tests. |
+
+**Untouched (verified):** `backend/test/Anela.Heblo.Tests/Features/Purchase/CreatePurchaseOrderHandlerTests.cs` uses a different interface (`IPurchaseOrderNumberGenerator`) and must not be modified.
+
+---
+
+## Task 1: Update interface and repository to accept `int year`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs:24`
+- Modify: `backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs:148-170`
+
+Rationale: this single interface change is a compile break that cascades through both handlers and three test files. Doing the interface + implementation here gets the contract locked first; subsequent tasks fix every site the compiler now flags.
+
+- [ ] **Step 1: Update the interface signature**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs`. Find the existing line:
+
+```csharp
+Task<string> GenerateOrderNumberAsync(CancellationToken cancellationToken = default);
+```
+
+Replace with:
+
+```csharp
+Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 2: Update the repository implementation**
+
+Edit `backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs`. Replace the entire `GenerateOrderNumberAsync` method (lines 148-170) with:
+
+```csharp
+public async Task<string> GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default)
+{
+    // year is supplied by the caller; do not introduce TimeProvider/DateTime.Now here (see spec FR-1).
+    var prefix = $"MO-{year}-";
+
+    var lastOrderNumber = await _context.ManufactureOrders
+        .Where(x => x.OrderNumber.StartsWith(prefix))
+        .OrderByDescending(x => x.OrderNumber)
+        .Select(x => x.OrderNumber)
+        .FirstOrDefaultAsync(cancellationToken);
+
+    int nextSequence = 1;
+    if (lastOrderNumber != null)
+    {
+        var sequencePart = lastOrderNumber.Substring(prefix.Length);
+        if (int.TryParse(sequencePart, out int lastSequence))
+        {
+            nextSequence = lastSequence + 1;
+        }
+    }
+
+    return $"{prefix}{nextSequence:D3}"; // Format as 001, 002, etc.
+}
+```
+
+- [ ] **Step 3: Build to surface every broken caller**
+
+Run from the worktree root:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build FAILS with `CS7036` / `CS0117` errors at every site that still calls `GenerateOrderNumberAsync(cancellationToken)` without a year argument. Specifically:
+- `CreateManufactureOrderHandler.cs:40`
+- `DuplicateManufactureOrderHandler.cs:38`
+- Each `Setup`/`Verify` line in the three Manufacture test files listed under File Structure.
+
+These are the expected fix sites for Tasks 2 – 4. Do not commit yet; the build is intentionally broken at the end of this task.
+
+---
+
+## Task 2: Update `CreateManufactureOrderHandler` to cache `now` and pass `now.Year`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs:33-64`
+
+The current handler reads `_timeProvider.GetUtcNow()` four times (lines 46, 52, 62, 63). Per the architecture review (R-2) and the FR-3 clarification, cache the reading once and reuse it so the year, `CreatedDate`, `StateChangedAt`, `GetDefaultExpiration`, and `GetDefaultLot` all come from the same instant.
+
+- [ ] **Step 1: Cache `now`, pass `now.Year`, reuse for all stamps**
+
+Edit the `Handle` method body. Replace the block currently spanning lines 36 – 64 (from the `var currentUser = _currentUserService.GetCurrentUser();` line down to and including the `var lotNumber = ManufactureOrderExtensions.GetDefaultLot(...)` line) with this exact code, preserving the surrounding `Handle` signature, the `if (semiproduct == null)` early return, and everything after the `lotNumber` assignment:
+
+```csharp
+        var currentUser = _currentUserService.GetCurrentUser();
+
+        // Cache one TimeProvider reading so the year, CreatedDate, StateChangedAt,
+        // expiration date, and lot number on the new row all derive from the same instant.
+        var now = _timeProvider.GetUtcNow();
+
+        // Generate unique order number using the UTC year — must agree with CreatedDate below.
+        var orderNumber = await _repository.GenerateOrderNumberAsync(now.Year, cancellationToken);
+
+        // Create the manufacture order
+        var order = new ManufactureOrder
+        {
+            OrderNumber = orderNumber,
+            CreatedDate = now.DateTime,
+            CreatedByUser = currentUser.Name,
+            ResponsiblePerson = request.ResponsiblePerson,
+            PlannedDate = request.PlannedDate,
+            ManufactureType = request.ManufactureType,
+            State = ManufactureOrderState.Draft,
+            StateChangedAt = now.DateTime,
+            StateChangedByUser = currentUser.Name
+        };
+
+        var semiproduct = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
+        if (semiproduct == null)
+        {
+            return new CreateManufactureOrderResponse(ErrorCodes.ProductNotFound);
+        }
+
+        var expirationDate = ManufactureOrderExtensions.GetDefaultExpiration(now.DateTime, semiproduct.Properties.ExpirationMonths);
+        var lotNumber = ManufactureOrderExtensions.GetDefaultLot(now.DateTime);
+```
+
+Leave the rest of the method (semi-product creation, products loop, direct-row creation, save, return) unchanged.
+
+- [ ] **Step 2: Verify no `_timeProvider.GetUtcNow()` survives in this handler**
+
+Run:
+
+```bash
+grep -n "_timeProvider" backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
+```
+
+Expected output: exactly one match on the line `_timeProvider = timeProvider;` inside the constructor, plus the one match inside the cached `var now = _timeProvider.GetUtcNow();` line. No other `_timeProvider` references should remain.
+
+---
+
+## Task 3: Update `DuplicateManufactureOrderHandler` to cache `now` and pass `now.Year`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs:24-59`
+
+The duplicate handler reads `_timeProvider.GetUtcNow()` four times (lines 41, 47, 52, 57, 59). Apply the same single-cached-`now` pattern.
+
+- [ ] **Step 1: Cache `now`, pass `now.Year`, reuse for all stamps**
+
+Edit the `Handle` method body. Replace the block spanning lines 27 – 59 (from `var currentUser = _currentUserService.GetCurrentUser();` down to and including `var lotNumber = ManufactureOrderExtensions.GetDefaultLot(...)`) with this exact code:
+
+```csharp
+        var currentUser = _currentUserService.GetCurrentUser();
+
+        // Get the source order
+        var sourceOrder = await _repository.GetOrderByIdAsync(request.SourceOrderId, cancellationToken);
+        if (sourceOrder == null)
+        {
+            return new DuplicateManufactureOrderResponse(ErrorCodes.OrderNotFound);
+        }
+
+        // Cache one TimeProvider reading so the year, CreatedDate, StateChangedAt,
+        // PlannedDate, expiration date, and lot number on the duplicate row all derive from the same instant.
+        var now = _timeProvider.GetUtcNow();
+
+        // Generate unique order number for the duplicate using the UTC year.
+        var orderNumber = await _repository.GenerateOrderNumberAsync(now.Year, cancellationToken);
+
+        // Today (UTC) for lot number and expiration calculations
+        var today = DateOnly.FromDateTime(now.DateTime);
+
+        // Create the duplicate order
+        var duplicateOrder = new ManufactureOrder
+        {
+            OrderNumber = orderNumber,
+            CreatedDate = now.DateTime,
+            CreatedByUser = currentUser.GetDisplayName(),
+            ResponsiblePerson = sourceOrder.ResponsiblePerson,
+            PlannedDate = today,
+            State = ManufactureOrderState.Draft,
+            StateChangedAt = now.DateTime,
+            StateChangedByUser = currentUser.GetDisplayName()
+        };
+
+        var expirationDate = sourceOrder.SemiProduct != null
+            ? ManufactureOrderExtensions.GetDefaultExpiration(now.DateTime, sourceOrder.SemiProduct.ExpirationMonths)
+            : (DateOnly?)null;
+        var lotNumber = ManufactureOrderExtensions.GetDefaultLot(now.DateTime);
+```
+
+Leave the semi-product duplication, products loop, save, and return unchanged.
+
+- [ ] **Step 2: Verify no extra `_timeProvider.GetUtcNow()` survives in this handler**
+
+Run:
+
+```bash
+grep -n "_timeProvider" backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs
+```
+
+Expected output: exactly two matches — the assignment inside the constructor and the cached `var now = _timeProvider.GetUtcNow();` line.
+
+---
+
+## Task 4: Fix all existing mock signatures in Manufacture tests
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs` (lines 67, 97, 134, 174, 212, 259, 297, 311, 326, 364, 393, 417, 536)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs` (lines 67, 133)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs` (lines 113, 130, 209)
+
+These are mechanical edits that re-establish a green build. Use a single-file find-and-replace for each.
+
+- [ ] **Step 1: Update `CreateManufactureOrderHandlerTests.cs` mocks**
+
+In `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs`, replace every occurrence of:
+
+```csharp
+GenerateOrderNumberAsync(It.IsAny<CancellationToken>())
+```
+
+with:
+
+```csharp
+GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())
+```
+
+(Use `replace_all` — every matching call should be updated.)
+
+- [ ] **Step 2: Update `CreateManufactureOrderHandlerSinglePhaseTests.cs` mocks**
+
+In `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs`, apply the same `replace_all` for the two occurrences.
+
+- [ ] **Step 3: Update `DuplicateManufactureOrderHandlerTests.cs` mocks**
+
+In `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs`, apply the same `replace_all` for the three occurrences.
+
+- [ ] **Step 4: Build the solution — expect a clean compile**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with zero errors. Warnings are acceptable only if pre-existing; new warnings introduced by these edits must be fixed.
+
+- [ ] **Step 5: Run the Manufacture test suite — expect all green**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture" --no-build
+```
+
+Expected: every test in the Manufacture namespace passes. If any test fails, it is a regression introduced by the refactor — fix before continuing.
+
+- [ ] **Step 6: Commit the refactor**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs \
+        backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs \
+        backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+git commit -m "refactor(manufacture): pass year as parameter to GenerateOrderNumberAsync
+
+Removes the DateTime.Now read from ManufactureOrderRepository.GenerateOrderNumberAsync
+and threads the year through the repository contract instead. Both handlers
+(CreateManufactureOrder, DuplicateManufactureOrder) now cache a single
+TimeProvider.GetUtcNow() reading and reuse it for the year, CreatedDate,
+StateChangedAt, expiration date, and lot number — guaranteeing all temporal
+stamps on the new row come from the same instant.
+
+Updates existing test mocks to match the new repository signature. Behavioral
+guard tests for the year boundary and audit consistency are added in a
+follow-up commit."
+```
+
+---
+
+## Task 5: Add year-boundary guard test for `CreateManufactureOrderHandler` (FR-3)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs`
+
+These tests lock in FR-3 behavior: the year the repository receives must come from `TimeProvider.GetUtcNow().Year`, independent of the host clock or time zone.
+
+- [ ] **Step 1: Add a year-end UTC test (verifies year=2026 just before midnight)**
+
+Append the following test method inside the existing `CreateManufactureOrderHandlerTests` class, before the closing brace. If the test class already defines a private `CreateValidRequest()` and a `CreateValidCatalogItem()` helper (used by the existing tests at line 59 / line 64), reuse them. The test asserts that the year the repository receives matches the `TimeProvider`'s UTC year.
+
+```csharp
+    [Fact]
+    public async Task Handle_AtYearEndUtc_PassesUtcYearToRepository()
+    {
+        // Arrange — fake clock at 2026-12-31 23:30 UTC; local time zone is irrelevant.
+        var yearEndUtc = new DateTimeOffset(2026, 12, 31, 23, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearEndUtc);
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2026-001");
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = 1; return order; });
+
+        // Act
+        await _handler.Handle(CreateValidRequest(), CancellationToken.None);
+
+        // Assert — year must be 2026, regardless of the host time zone.
+        capturedYear.Should().Be(2026);
+    }
+```
+
+- [ ] **Step 2: Add a year-start UTC test (verifies year=2027 just after midnight)**
+
+Append directly below the previous test:
+
+```csharp
+    [Fact]
+    public async Task Handle_AtYearStartUtc_PassesUtcYearToRepository()
+    {
+        // Arrange — fake clock at 2027-01-01 00:30 UTC.
+        var yearStartUtc = new DateTimeOffset(2027, 1, 1, 0, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearStartUtc);
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2027-001");
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = 1; return order; });
+
+        // Act
+        await _handler.Handle(CreateValidRequest(), CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2027);
+    }
+```
+
+- [ ] **Step 3: Run the two new tests and confirm they pass**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture.CreateManufactureOrderHandlerTests.Handle_AtYear" \
+  --no-build
+```
+
+Expected: 2 passed, 0 failed.
+
+---
+
+## Task 6: Add year-boundary guard test for `DuplicateManufactureOrderHandler` (FR-3)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs`
+
+- [ ] **Step 1: Add a year-end UTC test**
+
+Append the following test inside `DuplicateManufactureOrderHandlerTests`, before the closing brace. Reuse the existing `BuildSourceOrder(bool)` private helper (visible at line 41 of the file).
+
+```csharp
+    [Fact]
+    public async Task Handle_AtYearEndUtc_PassesUtcYearToRepository()
+    {
+        // Arrange
+        var yearEndUtc = new DateTimeOffset(2026, 12, 31, 23, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearEndUtc);
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildSourceOrder(includeSemiProduct: true));
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2026-001");
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = PersistedOrderId; return order; });
+
+        // Act
+        await _handler.Handle(new DuplicateManufactureOrderRequest { SourceOrderId = SourceOrderId }, CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2026);
+    }
+```
+
+- [ ] **Step 2: Add a year-start UTC test**
+
+Append directly below:
+
+```csharp
+    [Fact]
+    public async Task Handle_AtYearStartUtc_PassesUtcYearToRepository()
+    {
+        // Arrange
+        var yearStartUtc = new DateTimeOffset(2027, 1, 1, 0, 30, 0, TimeSpan.Zero);
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(yearStartUtc);
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildSourceOrder(includeSemiProduct: true));
+
+        int? capturedYear = null;
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync("MO-2027-001");
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) => { order.Id = PersistedOrderId; return order; });
+
+        // Act
+        await _handler.Handle(new DuplicateManufactureOrderRequest { SourceOrderId = SourceOrderId }, CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2027);
+    }
+```
+
+- [ ] **Step 3: Run the new tests and confirm they pass**
+
+```bash
+dotnet test backend/Anela.Heblo.sln \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture.DuplicateManufactureOrderHandlerTests.Handle_AtYear" \
+  --no-build
+```
+
+Expected: 2 passed, 0 failed.
+
+---
+
+## Task 7: Add audit-consistency guard tests (arch review R-2 / FR-3 clarification)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs`
+
+These tests guard the arch review's mandatory clarification: even when the underlying `TimeProvider` would tick across the year boundary between reads, the handler must call `GetUtcNow()` once and reuse that instant — so the year segment of `OrderNumber` always agrees with `CreatedDate.Year` on the same row. We use `SetupSequence` so the second mock read crosses midnight; if the handler reads more than once, the assertion fails.
+
+- [ ] **Step 1: Add the Create-handler audit-consistency test**
+
+Append inside `CreateManufactureOrderHandlerTests`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenClockCrossesYearBoundaryBetweenReads_KeepsYearAndCreatedDateConsistent()
+    {
+        // Arrange — first read just before midnight UTC on 2026-12-31; any subsequent read jumps to 2027-01-01.
+        var beforeMidnight = new DateTimeOffset(2026, 12, 31, 23, 59, 59, 999, TimeSpan.Zero);
+        var afterMidnight  = new DateTimeOffset(2027, 1, 1, 0, 0, 0, 1, TimeSpan.Zero);
+
+        _timeProviderMock
+            .SetupSequence(x => x.GetUtcNow())
+            .Returns(beforeMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight);
+
+        int? capturedYear = null;
+        ManufactureOrder? capturedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync((int year, CancellationToken _) => $"MO-{year}-001");
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) =>
+            {
+                capturedOrder = order;
+                order.Id = 1;
+                return order;
+            });
+
+        // Act
+        await _handler.Handle(CreateValidRequest(), CancellationToken.None);
+
+        // Assert — year used for the OrderNumber must match the row's CreatedDate year.
+        capturedYear.Should().Be(2026);
+        capturedOrder.Should().NotBeNull();
+        capturedOrder!.CreatedDate.Year.Should().Be(2026);
+        capturedOrder.StateChangedAt.Year.Should().Be(2026);
+        capturedOrder.OrderNumber.Should().StartWith("MO-2026-");
+    }
+```
+
+- [ ] **Step 2: Add the Duplicate-handler audit-consistency test**
+
+Append inside `DuplicateManufactureOrderHandlerTests`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenClockCrossesYearBoundaryBetweenReads_KeepsYearAndCreatedDateConsistent()
+    {
+        // Arrange
+        var beforeMidnight = new DateTimeOffset(2026, 12, 31, 23, 59, 59, 999, TimeSpan.Zero);
+        var afterMidnight  = new DateTimeOffset(2027, 1, 1, 0, 0, 0, 1, TimeSpan.Zero);
+
+        _timeProviderMock
+            .SetupSequence(x => x.GetUtcNow())
+            .Returns(beforeMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight)
+            .Returns(afterMidnight);
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(SourceOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildSourceOrder(includeSemiProduct: true));
+
+        int? capturedYear = null;
+        ManufactureOrder? capturedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((year, _) => capturedYear = year)
+            .ReturnsAsync((int year, CancellationToken _) => $"MO-{year}-001");
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken _) =>
+            {
+                capturedOrder = order;
+                order.Id = PersistedOrderId;
+                return order;
+            });
+
+        // Act
+        await _handler.Handle(new DuplicateManufactureOrderRequest { SourceOrderId = SourceOrderId }, CancellationToken.None);
+
+        // Assert
+        capturedYear.Should().Be(2026);
+        capturedOrder.Should().NotBeNull();
+        capturedOrder!.CreatedDate.Year.Should().Be(2026);
+        capturedOrder.StateChangedAt.Year.Should().Be(2026);
+        capturedOrder.OrderNumber.Should().StartWith("MO-2026-");
+    }
+```
+
+- [ ] **Step 3: Run the two new tests and confirm they pass**
+
+```bash
+dotnet test backend/Anela.Heblo.sln \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture&FullyQualifiedName~WhenClockCrossesYearBoundary" \
+  --no-build
+```
+
+Expected: 2 passed, 0 failed.
+
+---
+
+## Task 8: Full Manufacture suite, format, and final commit
+
+- [ ] **Step 1: Run the entire Manufacture suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Manufacture" \
+  --no-build
+```
+
+Expected: all Manufacture tests pass, including the six new behavioral tests from Tasks 5 – 7.
+
+- [ ] **Step 2: Run the whole backend test suite to catch any indirect regression**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all green. The `Purchase` namespace is unaffected by this change — its tests must remain unchanged and passing.
+
+- [ ] **Step 3: Format**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+Expected: no diff, or only trivial whitespace corrections on the files this PR touches.
+
+- [ ] **Step 4: Verify zero clock reads remain in the repository method**
+
+```bash
+grep -nE "DateTime\.Now|DateTime\.UtcNow|TimeProvider" \
+  backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
+```
+
+Expected: zero matches inside `GenerateOrderNumberAsync`. The grep may match other methods on the repository — that is acceptable as long as it does not match anywhere between lines `public async Task<string> GenerateOrderNumberAsync` and its closing brace. Read the file and verify visually if uncertain.
+
+- [ ] **Step 5: Commit the guard tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+git commit -m "test(manufacture): add year-boundary and audit-consistency guards
+
+Adds six xUnit guard tests covering FR-3 and the arch review's clarification:
+
+- Year-end / year-start tests for both Create and Duplicate handlers verifying
+  the year passed to GenerateOrderNumberAsync derives from TimeProvider.GetUtcNow().Year.
+- SetupSequence-based tests that fail if the handler reads TimeProvider more
+  than once per call, guaranteeing the OrderNumber year and CreatedDate year
+  stay consistent even at the stroke of midnight UTC."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Implementing task |
+|---|---|
+| FR-1: interface takes `int year`; repo emits `MO-{year}-` with no clock read | Task 1 (interface), Task 1 (impl with guarding comment), Task 8 Step 4 (grep guard) |
+| FR-2: both handlers compute year from `TimeProvider` and pass it | Task 2 (Create), Task 3 (Duplicate) |
+| FR-3: order numbers reflect UTC year; year + `CreatedDate` derive from same reading | Tasks 5 & 6 (year-end / year-start asserts); Task 7 (SetupSequence audit consistency) |
+| FR-3 clarification (arch review): handlers cache one `GetUtcNow()` reading | Task 2 Step 1 (caches `now`), Task 3 Step 1 (caches `now`); Task 7 SetupSequence test fails if there is more than one read of significance |
+| FR-4: existing sequence-suffix behavior preserved (zero-padding, lookup logic) | Task 1 Step 2 (impl preserved verbatim except for the prefix source); existing tests covering successful path act as the regression net |
+| NFR-2: testability without OS-clock manipulation | Tasks 5 – 7 all rely on `Mock<TimeProvider>` only |
+| NFR-3: backwards compatibility (no migration, no format change) | No DB or DTO changes anywhere in the plan |
+| NFR-4: no Manufacture-module clock reads after change | Task 2 Step 2 grep, Task 3 Step 2 grep, Task 8 Step 4 grep — three independent verifications |
+
+No spec requirement is left without a task.
+
+**Placeholder scan:** zero. Every step has the actual code, exact path, exact command, exact expected output.
+
+**Type consistency:**
+- The repository signature is consistent across the interface (Task 1 Step 1), impl (Task 1 Step 2), the handler call sites (Tasks 2 / 3), and every test mock (Tasks 4 – 7): `GenerateOrderNumberAsync(int year, CancellationToken cancellationToken = default)`.
+- Field names referenced from `ManufactureOrder` (`OrderNumber`, `CreatedDate`, `StateChangedAt`, `PlannedDate`) match the existing entity as observed in the live handler code.
+- Helper names (`ManufactureOrderExtensions.GetDefaultExpiration`, `GetDefaultLot`) match their call sites in the current handlers.
+- The Duplicate-test helper `BuildSourceOrder(bool includeSemiProduct)` and the constants `SourceOrderId`, `PersistedOrderId` referenced in Tasks 6 & 7 exist in the current `DuplicateManufactureOrderHandlerTests.cs`.
+- The Create-test fields `_repositoryMock`, `_catalogRepositoryMock`, `_timeProviderMock`, `_handler`, the constants `ValidProductCode` / `GeneratedOrderNumber`, and the helpers `CreateValidRequest()` / `CreateValidCatalogItem()` exist in the current `CreateManufactureOrderHandlerTests.cs`.


### PR DESCRIPTION

Removes the hidden `DateTime.Now` dependency from `ManufactureOrderRepository.GenerateOrderNumberAsync` by threading the year as a caller-supplied `int` parameter. Both handlers now cache a single `TimeProvider.GetUtcNow()` reading at the top of `Handle()` and reuse it for the year argument, `CreatedDate`, `StateChangedAt`, expiration date, and lot number — guaranteeing all temporal stamps on a new order row derive from the same instant and eliminating the year-boundary skew (e.g., CET 00:30 on Jan 1 = UTC Dec 31, which previously produced a `MO-{next_year}` prefix while `CreatedDate` recorded the old year).

### Changes
- `IManufactureOrderRepository.cs` — added `int year` to `GenerateOrderNumberAsync` signature
- `ManufactureOrderRepository.cs` — removed `DateTime.Now.Year`; uses supplied year; added FR-1 guard comment
- `CreateManufactureOrderHandler.cs` — single cached `now` read; passes `now.Year` to repo
- `DuplicateManufactureOrderHandler.cs` — same pattern
- `CreateManufactureOrderHandlerTests.cs` — updated 13 mocks + 3 new year-boundary/consistency tests
- `CreateManufactureOrderHandlerSinglePhaseTests.cs` — updated 2 mocks
- `DuplicateManufactureOrderHandlerTests.cs` — updated 3 mocks + 3 new year-boundary/consistency tests

---

Closes #2680

### Tokens used
16144757
