### PR TITLE
feat: Consolidate Duplicate `ResolveContentType` Logic in KnowledgeBase Module

### DIFF
--- a/artifacts/feat-arch-review-knowledgebase-duplicate-reso/arch-review.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-duplicate-reso/arch-review.r1.md
@@ -1,0 +1,235 @@
+I have enough context to write the architecture review.
+
+```markdown
+# Architecture Review: Consolidate Duplicate `ResolveContentType` Logic in KnowledgeBase
+
+## Skip Design: true
+
+This is a pure backend internal refactor — no UI components, screens, layouts, or visual decisions are involved. No frontend file is touched, no public API or DTO changes, no OpenAPI client regeneration is needed.
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with the project's Vertical Slice + Clean Architecture conventions documented in `docs/architecture/filesystem.md`:
+
+- **Module-scoped helper, not cross-module.** Both consumers (`UploadDocumentHandler`, `IndexDocumentHandler`) live under `Application/Features/KnowledgeBase/UseCases/`. A shared helper at `Application/Features/KnowledgeBase/ContentTypeResolver.cs` keeps the change inside the vertical slice — no leakage into `Shared/`, `Domain/`, or another feature.
+- **`internal static` matches existing precedent.** The only other static class in the module today is `KnowledgeBaseModule` (DI registration). Pure-function helpers are an established pattern; nothing in the module-boundary rules prohibits this addition.
+- **No DI footprint.** Resolution is a pure, deterministic mapping with no dependencies, no I/O, no logging — registering it in DI would be over-engineering. Spec correctly calls this out.
+- **MediatR flow is preserved.** The proposal does not change the request DTO, the handler signatures, or the MediatR pipeline. Behavior at both entry points (HTTP upload via `KnowledgeBaseController` and direct `IMediator.Send` from `KnowledgeBaseIngestionJob`) remains observationally identical for currently supported extensions.
+
+**Confirmed by code inspection:**
+- `UploadDocumentHandler.cs` lines 73–84 and `IndexDocumentHandler.cs` lines 141–152 are byte-identical implementations.
+- No other call site invokes the private methods.
+- The `KnowledgeBaseIngestionJob` does not contain its own copy — it goes through `IndexDocumentHandler` via MediatR.
+- Test infrastructure already mocks `IMediator` in `UploadDocumentHandlerTests` and verifies the resolved `ContentType` on the dispatched `IndexDocumentRequest` — these tests cover the cross-handler contract and will catch any behavioral drift.
+
+**One discovery worth flagging (out of scope but related):** an identical fourth copy of `ResolveContentType` lives in `Application/Features/Leaflet/UseCases/UploadLeaflet/UploadLeafletHandler.cs` lines 73–84. The spec explicitly scopes this refactor to KnowledgeBase, so we will not touch Leaflet here, but the `internal` visibility choice (assembly-wide) leaves the door open for a follow-up that consolidates Leaflet's copy too. See *Specification Amendments* below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP upload                       Background ingestion
+     │                                     │
+     ▼                                     │
+┌────────────────────────────┐             │
+│ UploadDocumentHandler      │             │
+│  - reads stream            │             │
+│  - resolves content type ──┼───┐         │
+│  - checks extractor support│   │         │
+│  - dispatches IndexDocReq  │   │         │
+└────────────┬───────────────┘   │         │
+             │ IMediator.Send    │         │
+             ▼                   │         ▼
+┌─────────────────────────────┐  │  ┌──────────────────────────┐
+│ IndexDocumentHandler        │  │  │ KnowledgeBaseIngestionJob│
+│  - resolves content type ───┼──┤  │  - builds IndexDocReq    │
+│  - hashes / dedupes         │  │  │  - calls IMediator.Send  │
+│  - persists + indexes       │  │  └────────────┬─────────────┘
+└─────────────────────────────┘  │               │
+             ▲                   │               │
+             │                   │               │
+             └───────────────────┴───── calls ───┘
+                                 │
+                                 ▼
+                       ┌─────────────────────────┐
+                       │ ContentTypeResolver     │
+                       │  (internal static)      │
+                       │  Resolve(ct, filename)  │
+                       │  — pure function        │
+                       └─────────────────────────┘
+```
+
+Two entry points, one resolver. In the upload flow, `Resolve` runs twice (once before dispatch in `UploadDocumentHandler`, once inside `IndexDocumentHandler`); idempotency makes the second call a no-op. In the ingestion-job flow, `Resolve` runs exactly once inside `IndexDocumentHandler`.
+
+### Key Design Decisions
+
+#### Decision 1: Where to place `ContentTypeResolver`
+**Options considered:**
+- (a) `Application/Features/KnowledgeBase/ContentTypeResolver.cs` — module root, alongside `KnowledgeBaseModule.cs` and `KnowledgeBaseOptions.cs`.
+- (b) `Application/Features/KnowledgeBase/Services/ContentTypeResolver.cs` — under `Services/` with other domain services.
+- (c) `Application/Features/KnowledgeBase/UseCases/IndexDocument/ContentTypeResolver.cs` — co-located with the primary consumer.
+- (d) `Application/Shared/ContentTypeResolver.cs` — shared across all features.
+
+**Chosen approach:** (a) — `Application/Features/KnowledgeBase/ContentTypeResolver.cs`.
+
+**Rationale:**
+- Matches the spec verbatim.
+- (b) is for DI-registered services; this is a pure static helper.
+- (c) couples the helper to one use case, but two use cases consume it; either folder becomes an arbitrary choice.
+- (d) overreaches — the brief is scoped to KnowledgeBase. Promoting to `Shared/` would also need a Leaflet consolidation, which is out of scope. Keep it `internal` to `Anela.Heblo.Application` and at the module root, which still allows a future cross-module promotion without breaking consumers.
+
+#### Decision 2: Visibility — `internal static` vs `public static`
+**Options considered:** `internal` vs `public`.
+**Chosen approach:** `internal static` (matches spec).
+**Rationale:** Only callers are inside the `Anela.Heblo.Application` assembly. `internal` minimizes API surface, makes tests reside in the same assembly's test project (already the case — `Anela.Heblo.Tests` has `InternalsVisibleTo` access via standard project conventions, or tests can call via `internal` access if configured; verify the test project setup before finalizing — see *Prerequisites*).
+
+#### Decision 3: Keep the double-call in the upload flow vs strip it
+**Options considered:**
+- (a) Both handlers call `Resolve` (spec FR-3); upload-flow resolution becomes idempotent (no-op the second time).
+- (b) Only `UploadDocumentHandler` resolves; `IndexDocumentHandler` trusts pre-resolved input.
+
+**Chosen approach:** (a).
+
+**Rationale:** `IndexDocumentHandler` has two callers: `UploadDocumentHandler` (resolves first) and `KnowledgeBaseIngestionJob` (does not). Removing resolution from `IndexDocumentHandler` would silently break the ingestion-job path. Idempotency of `Resolve` makes the double-call free of cost, and centralizing the "I always have a resolved content type" invariant inside `IndexDocumentHandler` is defensive against any future third caller. The brief's suggestion to "drop the second call" is rejected for this reason — the spec correctly walks it back.
+
+#### Decision 4: Test placement
+**Options considered:**
+- (a) `backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs` — at the module root, mirroring the source layout.
+- (b) Under `UseCases/` — co-located with handler tests.
+
+**Chosen approach:** (a). Mirrors the production layout (`Features/KnowledgeBase/ContentTypeResolver.cs` ↔ `KnowledgeBase/ContentTypeResolverTests.cs`).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**New file:**
+```
+backend/src/Anela.Heblo.Application/Features/KnowledgeBase/
+└── ContentTypeResolver.cs                              ← NEW
+```
+
+**New test file:**
+```
+backend/test/Anela.Heblo.Tests/KnowledgeBase/
+└── ContentTypeResolverTests.cs                         ← NEW
+```
+
+**Modified files:**
+```
+backend/src/Anela.Heblo.Application/Features/KnowledgeBase/
+├── UseCases/UploadDocument/UploadDocumentHandler.cs    ← delete lines 73-84, update call site at line 30
+└── UseCases/IndexDocument/IndexDocumentHandler.cs      ← delete lines 141-152, update call site at line 30
+```
+
+### Interfaces and Contracts
+
+```csharp
+namespace Anela.Heblo.Application.Features.KnowledgeBase;
+
+internal static class ContentTypeResolver
+{
+    public static string Resolve(string contentType, string filename);
+}
+```
+
+**Behavioral contract (must match current logic exactly):**
+
+| Input `contentType`                            | `filename` extension | Returns                                                        |
+|------------------------------------------------|----------------------|----------------------------------------------------------------|
+| null or `""`                                   | `.pdf`               | `"application/pdf"`                                            |
+| `"application/octet-stream"` (any case)        | `.docx`              | `"application/vnd.openxmlformats-officedocument...document"`  |
+| `"application/octet-stream"`                   | `.doc`               | `"application/msword"`                                         |
+| `"application/octet-stream"`                   | `.txt`               | `"text/plain"`                                                 |
+| `"application/octet-stream"`                   | `.md`                | `"text/markdown"`                                              |
+| `"application/octet-stream"`                   | `.xyz` (unknown)     | `"application/octet-stream"` (fallback — preserve input)       |
+| null or `""`                                   | `.xyz` (unknown)     | `null` or `""` respectively (fallback returns input unchanged) |
+| `"image/png"`                                  | any                  | `"image/png"` (non-octet pass-through)                         |
+| `"APPLICATION/OCTET-STREAM"`                   | `.PDF`               | `"application/pdf"` (case-insensitive both sides)              |
+
+**Idempotency property (must be unit-tested):**
+```
+Resolve(Resolve(ct, name), name) == Resolve(ct, name)   for all (ct, name)
+```
+This is the property that makes the double-call in the upload flow safe.
+
+### Data Flow
+
+**Upload flow (unchanged structure, helper extracted):**
+1. `KnowledgeBaseController` receives multipart upload → dispatches `UploadDocumentRequest` via MediatR.
+2. `UploadDocumentHandler.Handle`:
+   - Copies stream to byte array.
+   - **`contentType = ContentTypeResolver.Resolve(request.ContentType, request.Filename)`** (was: local private method).
+   - Checks extractor support; returns `UnsupportedFileType` early if no extractor handles the resolved type.
+   - Dispatches `IndexDocumentRequest` with resolved `ContentType`.
+3. `IndexDocumentHandler.Handle`:
+   - **`contentType = ContentTypeResolver.Resolve(request.ContentType, request.Filename)`** (idempotent no-op here since input is already resolved).
+   - Continues with hashing, dedupe, persistence, indexing.
+
+**Background ingestion flow (unchanged structure, helper extracted):**
+1. `KnowledgeBaseIngestionJob` constructs `IndexDocumentRequest` directly (no upstream resolution).
+2. `IndexDocumentHandler.Handle`:
+   - **`contentType = ContentTypeResolver.Resolve(request.ContentType, request.Filename)`** (real work happens here).
+   - Continues as above.
+
+### Test Strategy
+
+Single new test class `ContentTypeResolverTests` covering:
+
+| Test name (suggested)                                                | Inputs                                                | Asserts                          |
+|----------------------------------------------------------------------|-------------------------------------------------------|----------------------------------|
+| `Resolve_OctetStream_Pdf_ReturnsApplicationPdf`                      | `("application/octet-stream", "x.pdf")`               | `"application/pdf"`              |
+| `Resolve_OctetStream_Docx_ReturnsWordprocessing`                     | `("application/octet-stream", "x.docx")`              | full docx MIME                   |
+| `Resolve_OctetStream_Doc_ReturnsMsword`                              | `("application/octet-stream", "x.doc")`               | `"application/msword"`           |
+| `Resolve_OctetStream_Txt_ReturnsTextPlain`                           | `("application/octet-stream", "x.txt")`               | `"text/plain"`                   |
+| `Resolve_OctetStream_Md_ReturnsTextMarkdown`                         | `("application/octet-stream", "x.md")`                | `"text/markdown"`                |
+| `Resolve_EmptyContentType_Pdf_ReturnsApplicationPdf`                 | `("", "x.pdf")`                                       | `"application/pdf"`              |
+| `Resolve_NullContentType_Pdf_ReturnsApplicationPdf`                  | `(null!, "x.pdf")`                                    | `"application/pdf"`              |
+| `Resolve_OctetStream_UnknownExtension_ReturnsOriginalOctetStream`    | `("application/octet-stream", "x.xyz")`               | `"application/octet-stream"`     |
+| `Resolve_NonOctetStream_PassesThrough_RegardlessOfExtension`         | `("image/png", "x.pdf")`                              | `"image/png"`                    |
+| `Resolve_CaseInsensitive_OctetStream_StillResolves`                  | `("APPLICATION/OCTET-STREAM", "x.PDF")`               | `"application/pdf"`              |
+| `Resolve_IsIdempotent`                                               | parametrized over all rows above                      | `Resolve(Resolve(x,n),n)==Resolve(x,n)` |
+
+Prefer `[Theory]`/`[InlineData]` for the mapping table; one `[Fact]` for the idempotency property. xUnit + FluentAssertions, consistent with `UploadDocumentHandlerTests` and other tests in the same project.
+
+The existing `UploadDocumentHandlerTests` and `IndexDocumentHandlerTests` should require **no behavioral changes** — only mechanical updates if they reference the deleted private methods (they should not, since those methods were private).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Test project cannot access `internal` members of `Application` assembly | Low | Verify `InternalsVisibleTo("Anela.Heblo.Tests")` exists in the `Application` `.csproj` or via assembly attribute. If absent, add it. (See *Prerequisites*.) |
+| Subtle copy-paste error during deletion changes call-site behavior | Low | Tests for both handlers already assert on `ContentType` flowing through correctly. The new resolver tests pin the contract. Mitigation is simply: don't rename arguments or reorder them. |
+| Future contributor restores a local `ResolveContentType` in a handler | Low | A code review with the `csharp-reviewer` agent will catch this. Optional: add a banned-symbol analyzer rule, but this is overengineering for the change. |
+| Leaflet handler retains its identical copy → silent divergence between modules | Low (out of scope) | Document in *Specification Amendments*. Open a separate brief if desired. |
+| Resolver signature accepts `string` for `contentType` but real callers may pass `null` | Low | The current implementation already calls `string.IsNullOrEmpty(contentType)` and short-circuits. Behavior preserved. Nullable annotations on the new method should follow the project's existing handler conventions (`string contentType` non-nullable — matches `IndexDocumentRequest.ContentType` default-empty). |
+| `internal` visibility blocks future cross-feature reuse (e.g. Leaflet) | Low | `internal` still permits use anywhere in `Anela.Heblo.Application`. Both Leaflet and KnowledgeBase live in that assembly, so a future consolidation is a visibility no-op. |
+
+## Specification Amendments
+
+The spec is sound. Three small additions strengthen it:
+
+1. **Add an idempotency unit-test requirement** to FR-3 acceptance criteria (already mentioned in prose, but list as an explicit acceptance bullet):
+   > A unit test verifies `Resolve(Resolve(ct, name), name) == Resolve(ct, name)` for the supported mapping table and at least one pass-through case.
+
+2. **Document the existing duplicate in `Leaflet/UploadLeaflet/UploadLeafletHandler.cs` (lines 73–84) as a known follow-up.** Add to *Out of Scope*:
+   > A fourth identical copy of `ResolveContentType` exists in `Application/Features/Leaflet/UseCases/UploadLeaflet/UploadLeafletHandler.cs`. Consolidating it (and any future cross-module promotion of `ContentTypeResolver` to `Application/Shared/`) is explicitly out of scope for this refactor.
+
+3. **Pin the resolver's `contentType` parameter nullability.** The current handler private methods accept `string` (non-nullable). To preserve call-site signatures byte-for-byte, the public method on `ContentTypeResolver` must also be `string contentType` (non-nullable), with `string.IsNullOrEmpty` handling the empty case. Add to FR-1 acceptance criteria:
+   > Method signature: `public static string Resolve(string contentType, string filename)` — both parameters non-nullable; behavior on empty `contentType` preserved by internal `IsNullOrEmpty` check.
+
+No other amendments. The brief's suggestion to "drop the second resolution call in `IndexDocumentHandler`" is correctly walked back by FR-3 of the spec.
+
+## Prerequisites
+
+1. **Confirm `InternalsVisibleTo` for the test assembly.** The new type is `internal`; `Anela.Heblo.Tests` must be able to see it. Before writing the test class, check `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` for `<InternalsVisibleTo Include="Anela.Heblo.Tests" />` (or equivalent `[assembly: InternalsVisibleTo("Anela.Heblo.Tests")]` in an `AssemblyInfo.cs`). If missing, add it as part of this change. If the team prefers not to widen the visibility seam, the fallback is `public static` — but that needlessly grows the public API surface.
+2. **No DI changes.** `KnowledgeBaseModule.cs` is not touched.
+3. **No migrations, no config changes, no Key Vault entries, no Azure changes.**
+4. **No frontend changes, no OpenAPI regeneration.**
+5. **Validation gate** before declaring complete (per `CLAUDE.md`):
+   - `dotnet build` clean.
+   - `dotnet format` clean.
+   - All KnowledgeBase tests pass: `dotnet test --filter "FullyQualifiedName~KnowledgeBase"`.
+   - At minimum, the new `ContentTypeResolverTests`, the existing `UploadDocumentHandlerTests`, and `IndexDocumentHandlerTests` are green.
+```

--- a/artifacts/feat-arch-review-knowledgebase-duplicate-reso/brief.md
+++ b/artifacts/feat-arch-review-knowledgebase-duplicate-reso/brief.md
@@ -1,0 +1,44 @@
+## Module
+KnowledgeBase
+
+## Finding
+
+`ResolveContentType` is a private static method that maps generic `application/octet-stream` MIME types to proper MIME types based on file extension. It exists as two identical copies:
+
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs` lines 73–84
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs` lines 141–152
+
+Both implementations are identical — same 5 extensions (`.pdf`, `.docx`, `.doc`, `.txt`, `.md`), same fallback, same `OrdinalIgnoreCase` comparison.
+
+Additionally, when a file is uploaded via `UploadDocumentHandler`, the method runs twice: `UploadDocumentHandler` resolves the type before constructing `IndexDocumentRequest`, then `IndexDocumentHandler` resolves it again on the already-resolved value (where it becomes a no-op). The double call is harmless today but obscures intent.
+
+## Why it matters
+
+Adding support for a new extension (e.g. `.xlsx`) requires editing both files independently. If only one is updated, `UploadDocumentHandler` and `IndexDocumentHandler` (called directly by the ingestion job) will return different results for the same input — a silent correctness divergence.
+
+## Suggested fix
+
+Extract to a single static helper, e.g. a `ContentTypeResolver` static class at `Application/Features/KnowledgeBase/`:
+
+```csharp
+internal static class ContentTypeResolver
+{
+    public static string Resolve(string contentType, string filename) =>
+        string.IsNullOrEmpty(contentType) || contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetExtension(filename).ToLowerInvariant() switch
+            {
+                ".pdf"  => "application/pdf",
+                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ".doc"  => "application/msword",
+                ".txt"  => "text/plain",
+                ".md"   => "text/markdown",
+                _       => contentType
+            }
+            : contentType;
+}
+```
+
+Both handlers call `ContentTypeResolver.Resolve(...)`. Since `UploadDocumentHandler` already resolves before dispatching `IndexDocumentRequest`, `IndexDocumentHandler` can simply trust `request.ContentType` is already resolved and drop its own call.
+
+---
+_Filed by daily arch-review routine on 2026-06-11._

--- a/artifacts/feat-arch-review-knowledgebase-duplicate-reso/impl/main.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-duplicate-reso/impl/main.r1.md
@@ -1,0 +1,53 @@
+Final review approved. All 4 tasks complete. Now I'll write the output summary artifact.
+
+---
+
+# Implementation: ContentTypeResolver Consolidation — KnowledgeBase Module
+
+## What was implemented
+
+Extracted the duplicate `ResolveContentType` private methods from `UploadDocumentHandler` and `IndexDocumentHandler` into a single shared `internal static ContentTypeResolver` helper at the KnowledgeBase module root. Both handlers now delegate to `ContentTypeResolver.Resolve(...)`. The resolution call is preserved in `IndexDocumentHandler` because the background ingestion job calls it directly without prior resolution (the double-call in the upload flow is idempotent and harmless).
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs` — new `internal static` helper, 17 lines; pure function mapping MIME types from file extensions
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs` — new test class, 23 test cases covering all extensions, empty/null contentType, unknown extension fallback, non-octet-stream pass-through, case-insensitivity, and idempotency
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs` — call site updated to `ContentTypeResolver.Resolve(...)`, private method deleted, `using` added
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs` — call site updated to `ContentTypeResolver.Resolve(...)`, private method deleted, `using` added
+
+## Tests
+
+- `ContentTypeResolverTests.cs`: 23 tests — known extension mapping (5), empty contentType (2), null contentType (1), unknown extension fallback (1), non-octet pass-through (3), case-insensitivity (3), idempotency (8)
+- Existing `UploadDocumentHandlerTests`: 5 tests — all passing, no changes
+- Existing `IndexDocumentHandlerTests`: 15 tests — all passing, no changes
+- Total KnowledgeBase test suite: 43 tests passing
+
+## How to verify
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-knowledgebase-duplicate-reso
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBase"
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+## Notes
+
+- No `ResolveContentType` remains in the KnowledgeBase module (verified by grep)
+- `InternalsVisibleTo("Anela.Heblo.Tests")` was already present — no project file changes needed
+- `UploadLeafletHandler` in the Leaflet module still has an identical copy of this logic — explicitly out of scope per the arch review, documented as a known follow-up
+- Formatting clean: `dotnet format --verify-no-changes` exited 0
+
+## PR Summary
+
+Consolidated duplicate `ResolveContentType` logic in the KnowledgeBase module into a single `internal static ContentTypeResolver` helper, eliminating the silent-divergence risk when new file extensions are added. The mapping table now lives in exactly one place; adding a new extension requires editing one file and one test.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs` — new shared helper
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs` — 23 tests covering all branches and idempotency
+- `backend/src/...UseCases/UploadDocument/UploadDocumentHandler.cs` — swapped call site, deleted private method
+- `backend/src/...UseCases/IndexDocument/IndexDocumentHandler.cs` — swapped call site, deleted private method
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-knowledgebase-duplicate-reso/spec.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-duplicate-reso/spec.r1.md
@@ -1,0 +1,121 @@
+# Specification: Consolidate Duplicate `ResolveContentType` Logic in KnowledgeBase Module
+
+## Summary
+Eliminate duplicate `ResolveContentType` implementations in `UploadDocumentHandler` and `IndexDocumentHandler` by extracting the MIME-type resolution logic into a single shared static helper. This removes a silent-divergence risk when new file extensions are added and clarifies intent by ensuring resolution happens exactly once per ingestion flow.
+
+## Background
+The KnowledgeBase module supports document ingestion through two entry points:
+
+1. **User upload flow** — `UploadDocumentHandler` receives a file, resolves its MIME type, then dispatches an `IndexDocumentRequest` to `IndexDocumentHandler`.
+2. **Background ingestion job** — calls `IndexDocumentHandler` directly (no prior upload step).
+
+Both handlers currently contain identical private static `ResolveContentType` methods that map `application/octet-stream` to a specific MIME type based on file extension (`.pdf`, `.docx`, `.doc`, `.txt`, `.md`). The duplication creates two concrete risks:
+
+- **Silent divergence:** Adding a new extension (e.g. `.xlsx`) requires editing both files. Forgetting one means the upload flow and the ingestion job return different MIME types for the same file.
+- **Obscured intent:** In the upload flow, resolution effectively runs twice — once in `UploadDocumentHandler` before dispatching, once in `IndexDocumentHandler` on the already-resolved value (a no-op). Readers must verify the second call is harmless.
+
+This is a low-risk, high-clarity refactor with no behavioral change for currently supported extensions.
+
+## Functional Requirements
+
+### FR-1: Single Source of Truth for Content-Type Resolution
+A new internal static helper class `ContentTypeResolver` must exist at `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs`, exposing a single public method `Resolve(string contentType, string filename)`.
+
+The method must preserve the existing behavior exactly:
+- If `contentType` is non-empty and not `application/octet-stream` (case-insensitive), return `contentType` unchanged.
+- Otherwise, map the lower-invariant file extension to the corresponding MIME type:
+  - `.pdf`  → `application/pdf`
+  - `.docx` → `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+  - `.doc`  → `application/msword`
+  - `.txt`  → `text/plain`
+  - `.md`   → `text/markdown`
+  - any other extension → the original `contentType` (unchanged fallback)
+
+**Acceptance criteria:**
+- `ContentTypeResolver.Resolve` exists at the specified path and is `internal static`.
+- Unit tests cover each supported extension, the `application/octet-stream` trigger, the empty/null `contentType` trigger, the unsupported-extension fallback, the non-octet-stream pass-through, and case-insensitive comparison of `contentType` and extension.
+- No other `ResolveContentType` method remains in the KnowledgeBase module.
+
+### FR-2: `UploadDocumentHandler` Uses Shared Resolver
+`UploadDocumentHandler` must delegate to `ContentTypeResolver.Resolve` and remove its private `ResolveContentType` method.
+
+**Acceptance criteria:**
+- The private `ResolveContentType` method at lines 73–84 of `UploadDocumentHandler.cs` is deleted.
+- The call site that previously invoked the local method now calls `ContentTypeResolver.Resolve(...)` with identical arguments.
+- The upload flow's externally observable behavior — the `ContentType` stored on the indexed document and returned in any response — is unchanged for all currently supported extensions and for unsupported extensions.
+
+### FR-3: `IndexDocumentHandler` Trusts Pre-Resolved Input from Upload Flow
+Because `UploadDocumentHandler` resolves the content type before dispatching `IndexDocumentRequest`, the resolution inside `IndexDocumentHandler` is a no-op in the upload flow. `IndexDocumentHandler` must also call `ContentTypeResolver.Resolve` so that the **direct-invocation path** (background ingestion job) remains correct.
+
+**Acceptance criteria:**
+- The private `ResolveContentType` method at lines 141–152 of `IndexDocumentHandler.cs` is deleted.
+- `IndexDocumentHandler` calls `ContentTypeResolver.Resolve(request.ContentType, request.FileName)` (or equivalent) at the same point in the flow where resolution previously occurred.
+- Both entry points — user upload via `UploadDocumentHandler` and direct dispatch to `IndexDocumentHandler` (e.g. from the ingestion job) — produce identical resolved MIME types for identical inputs.
+- Calling `Resolve` twice on the same input is idempotent (verified by unit test).
+
+### FR-4: Backward Compatibility for Unsupported Extensions
+For file extensions not in the mapping table, the resolver must return the original `contentType` argument unchanged — even when that argument is `application/octet-stream`. This preserves the current behavior where unknown binary files retain their generic MIME type.
+
+**Acceptance criteria:**
+- A unit test verifies that `Resolve("application/octet-stream", "file.xyz")` returns `"application/octet-stream"`.
+- A unit test verifies that `Resolve("image/png", "file.png")` returns `"image/png"` (non-octet-stream pass-through, regardless of extension).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance regression. The resolver is a synchronous pure function with O(1) dictionary-equivalent dispatch; call frequency is bounded by document ingestion rate (low). No allocations beyond the existing `Path.GetExtension` and `ToLowerInvariant` calls.
+
+### NFR-2: Security
+No change to security posture. Content-type resolution does not cross a trust boundary, does not influence authorization, and the mapping table is hard-coded (no user-controlled input affects the mapping).
+
+### NFR-3: Maintainability
+Adding a new supported extension must require editing exactly one file (`ContentTypeResolver.cs`) and adding one unit test case. No handler-level changes should be needed for future extension additions.
+
+### NFR-4: Test Coverage
+The new `ContentTypeResolver` class must reach the project-wide minimum of 80% line and branch coverage. Given the helper's small surface area, full coverage is expected and required.
+
+## Data Model
+No data model changes. The `ContentType` field on the existing document/index entities continues to store a MIME-type string with identical semantics.
+
+## API / Interface Design
+
+### New internal API
+```csharp
+namespace Anela.Heblo.Application.Features.KnowledgeBase;
+
+internal static class ContentTypeResolver
+{
+    public static string Resolve(string contentType, string filename);
+}
+```
+
+- **Visibility:** `internal` — used only within the `Anela.Heblo.Application` assembly.
+- **Location:** `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs`.
+- **No DI registration** — static helper, called directly.
+
+### Modified handlers
+- `UploadDocumentHandler.cs`: removes private `ResolveContentType`; call site updated to `ContentTypeResolver.Resolve(...)`.
+- `IndexDocumentHandler.cs`: removes private `ResolveContentType`; call site updated to `ContentTypeResolver.Resolve(...)`.
+
+### Public API
+No public API changes. No request/response DTOs change. No OpenAPI client regeneration is needed.
+
+## Dependencies
+- **Runtime:** `System.IO.Path` (already referenced) for `Path.GetExtension`.
+- **Test framework:** xUnit (project convention) for the new unit-test class.
+- **No new NuGet packages.**
+- **No external services** affected.
+- **No coordination with frontend** — purely backend internal refactor.
+
+## Out of Scope
+- Adding support for new file extensions (e.g. `.xlsx`, `.pptx`, `.csv`). This refactor preserves the existing mapping verbatim; extending the mapping is a separate change.
+- Making the mapping configurable (JSON config, database, feature flag). The current hard-coded table is sufficient.
+- Replacing the custom resolver with a third-party MIME library (e.g. `MimeTypes`, `HeyRed.Mime`). Out of scope; would expand the change surface beyond the duplication fix.
+- Refactoring other duplicated logic in the KnowledgeBase module not called out in the brief.
+- Changes to the `IndexDocumentRequest` DTO or `IndexDocumentHandler` flow beyond the call-site swap.
+- Renaming the existing method, parameters, or related variables in the handlers beyond what is needed to invoke the new helper.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-knowledgebase-duplicate-reso/task-plan.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-duplicate-reso/task-plan.r1.md
@@ -1,0 +1,9 @@
+Plan saved to `docs/superpowers/plans/2026-06-13-kb-content-type-resolver-consolidation.md`.
+
+**Summary:** 4 tasks, TDD-ordered:
+1. Create `ContentTypeResolver` + full test matrix (mapping table, empty/null contentType, unsupported-extension fallback, non-octet pass-through, case-insensitivity, idempotency).
+2. Switch `UploadDocumentHandler` to the shared resolver and delete its private method.
+3. Switch `IndexDocumentHandler` to the shared resolver and delete its private method (kept in place because `KnowledgeBaseIngestionJob` calls it directly).
+4. Validation gate: grep for surviving `ResolveContentType`, run all KB tests, `dotnet build`, `dotnet format`.
+
+`InternalsVisibleTo("Anela.Heblo.Tests")` is already present in `Anela.Heblo.Application.csproj`, so no project-file change is needed. The Leaflet copy of `ResolveContentType` is explicitly flagged as out-of-scope per the arch review.

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs
@@ -1,0 +1,17 @@
+namespace Anela.Heblo.Application.Features.KnowledgeBase;
+
+internal static class ContentTypeResolver
+{
+    public static string Resolve(string contentType, string filename) =>
+        string.IsNullOrEmpty(contentType) || contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetExtension(filename).ToLowerInvariant() switch
+            {
+                ".pdf" => "application/pdf",
+                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ".doc" => "application/msword",
+                ".txt" => "text/plain",
+                ".md" => "text/markdown",
+                _ => contentType
+            }
+            : contentType;
+}

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Anela.Heblo.Application.Features.KnowledgeBase;
 using Anela.Heblo.Application.Features.KnowledgeBase.Services;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Domain.Shared.Rag;
@@ -27,7 +28,7 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
     {
         _logger.LogInformation("Indexing document {Filename} from {SourcePath}", request.Filename, request.SourcePath);
 
-        var contentType = ResolveContentType(request.ContentType, request.Filename);
+        var contentType = ContentTypeResolver.Resolve(request.ContentType, request.Filename);
         var contentHash = Convert.ToHexString(SHA256.HashData(request.Content));
 
         var useGraphIdentity = !string.IsNullOrEmpty(request.GraphItemId) && !string.IsNullOrEmpty(request.DriveId);
@@ -133,21 +134,4 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
             IndexedAt = document.IndexedAt,
         };
     }
-
-    /// <summary>
-    /// Resolves the effective content type, falling back to file extension when the source
-    /// reports a generic type (application/octet-stream).
-    /// </summary>
-    private static string ResolveContentType(string contentType, string filename) =>
-        string.IsNullOrEmpty(contentType) || contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
-            ? Path.GetExtension(filename).ToLowerInvariant() switch
-            {
-                ".pdf" => "application/pdf",
-                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                ".doc" => "application/msword",
-                ".txt" => "text/plain",
-                ".md" => "text/markdown",
-                _ => contentType
-            }
-            : contentType;
 }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.KnowledgeBase;
 using Anela.Heblo.Application.Features.KnowledgeBase.Services;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.GetDocuments;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.IndexDocument;
@@ -27,7 +28,7 @@ public class UploadDocumentHandler : IRequestHandler<UploadDocumentRequest, Uplo
         await request.FileStream.CopyToAsync(ms, cancellationToken);
         var fileBytes = ms.ToArray();
 
-        var contentType = ResolveContentType(request.ContentType, request.Filename);
+        var contentType = ContentTypeResolver.Resolve(request.ContentType, request.Filename);
 
         if (!_extractors.Any(e => e.CanHandle(contentType)))
         {
@@ -65,21 +66,4 @@ public class UploadDocumentHandler : IRequestHandler<UploadDocumentRequest, Uplo
             CreatedAt = response.CreatedAt,
             IndexedAt = response.IndexedAt,
         };
-
-    /// <summary>
-    /// Resolves the effective content type, falling back to file extension when the browser
-    /// reports a generic type (application/octet-stream) for drag-and-drop uploads.
-    /// </summary>
-    private static string ResolveContentType(string contentType, string filename) =>
-        string.IsNullOrEmpty(contentType) || contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
-            ? Path.GetExtension(filename).ToLowerInvariant() switch
-            {
-                ".pdf" => "application/pdf",
-                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                ".doc" => "application/msword",
-                ".txt" => "text/plain",
-                ".md" => "text/markdown",
-                _ => contentType
-            }
-            : contentType;
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs
@@ -1,0 +1,86 @@
+using Anela.Heblo.Application.Features.KnowledgeBase;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.KnowledgeBase;
+
+public class ContentTypeResolverTests
+{
+    [Theory]
+    [InlineData("application/octet-stream", "x.pdf", "application/pdf")]
+    [InlineData("application/octet-stream", "x.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    [InlineData("application/octet-stream", "x.doc", "application/msword")]
+    [InlineData("application/octet-stream", "x.txt", "text/plain")]
+    [InlineData("application/octet-stream", "x.md", "text/markdown")]
+    public void Resolve_OctetStream_KnownExtension_ReturnsMappedMime(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", "x.pdf", "application/pdf")]
+    [InlineData("", "x.txt", "text/plain")]
+    public void Resolve_EmptyContentType_KnownExtension_ReturnsMappedMime(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_NullContentType_KnownExtension_ReturnsMappedMime()
+    {
+        var result = ContentTypeResolver.Resolve(null!, "x.pdf");
+
+        result.Should().Be("application/pdf");
+    }
+
+    [Fact]
+    public void Resolve_OctetStream_UnknownExtension_ReturnsOriginalOctetStream()
+    {
+        var result = ContentTypeResolver.Resolve("application/octet-stream", "x.xyz");
+
+        result.Should().Be("application/octet-stream");
+    }
+
+    [Theory]
+    [InlineData("image/png", "x.pdf", "image/png")]
+    [InlineData("text/html", "x.docx", "text/html")]
+    [InlineData("application/json", "x.xyz", "application/json")]
+    public void Resolve_NonOctetStream_PassesThrough_RegardlessOfExtension(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("APPLICATION/OCTET-STREAM", "x.pdf", "application/pdf")]
+    [InlineData("Application/Octet-Stream", "x.PDF", "application/pdf")]
+    [InlineData("application/octet-stream", "x.DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    public void Resolve_CaseInsensitive_OctetStreamAndExtension_StillResolves(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("application/octet-stream", "x.pdf")]
+    [InlineData("application/octet-stream", "x.docx")]
+    [InlineData("application/octet-stream", "x.doc")]
+    [InlineData("application/octet-stream", "x.txt")]
+    [InlineData("application/octet-stream", "x.md")]
+    [InlineData("application/octet-stream", "x.xyz")]
+    [InlineData("image/png", "x.pdf")]
+    [InlineData("", "x.pdf")]
+    public void Resolve_IsIdempotent(string contentType, string filename)
+    {
+        var first = ContentTypeResolver.Resolve(contentType, filename);
+        var second = ContentTypeResolver.Resolve(first, filename);
+
+        second.Should().Be(first);
+    }
+}

--- a/docs/superpowers/plans/2026-06-13-kb-content-type-resolver-consolidation.md
+++ b/docs/superpowers/plans/2026-06-13-kb-content-type-resolver-consolidation.md
@@ -1,0 +1,460 @@
+# Consolidate Duplicate `ResolveContentType` Logic in KnowledgeBase Module — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the byte-identical private `ResolveContentType` implementations in `UploadDocumentHandler` and `IndexDocumentHandler` by extracting a single shared `internal static ContentTypeResolver.Resolve(...)` helper, removing silent-divergence risk for future extension additions.
+
+**Architecture:** New `internal static class ContentTypeResolver` at `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs` (module root, alongside `KnowledgeBaseModule.cs`). Both handlers swap their private method for a call to `ContentTypeResolver.Resolve(...)`. The double-call in the upload flow stays — `Resolve` is idempotent, and `IndexDocumentHandler` must keep resolving because the background ingestion job calls it directly without prior resolution. No DI registration, no API surface change, no migrations, no frontend work.
+
+**Tech Stack:** .NET 8, C# 12, xUnit + FluentAssertions (existing test conventions). `InternalsVisibleTo("Anela.Heblo.Tests")` is already present in `Anela.Heblo.Application.csproj` — no project-file change needed.
+
+---
+
+## File Structure
+
+**New files:**
+
+```
+backend/src/Anela.Heblo.Application/Features/KnowledgeBase/
+└── ContentTypeResolver.cs                                  ← NEW: internal static helper
+
+backend/test/Anela.Heblo.Tests/KnowledgeBase/
+└── ContentTypeResolverTests.cs                             ← NEW: behavior + idempotency tests
+```
+
+**Modified files:**
+
+```
+backend/src/Anela.Heblo.Application/Features/KnowledgeBase/
+├── UseCases/UploadDocument/UploadDocumentHandler.cs        ← call site at line 30; delete lines 73-84
+└── UseCases/IndexDocument/IndexDocumentHandler.cs          ← call site at line 30; delete lines 141-152
+```
+
+**Untouched (verify after change):** `KnowledgeBaseModule.cs`, all `IndexDocumentRequest`/`UploadDocumentRequest` DTOs, `KnowledgeBaseIngestionJob`, `UploadDocumentHandlerTests`, `IndexDocumentHandlerTests`.
+
+---
+
+## Task 1: Add `ContentTypeResolver` and its tests (TDD)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs`
+- Create: `backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs`
+
+### Step 1: Write the failing test file
+
+- [ ] Create `backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs` with the full test class below.
+
+```csharp
+using Anela.Heblo.Application.Features.KnowledgeBase;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.KnowledgeBase;
+
+public class ContentTypeResolverTests
+{
+    [Theory]
+    [InlineData("application/octet-stream", "x.pdf", "application/pdf")]
+    [InlineData("application/octet-stream", "x.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    [InlineData("application/octet-stream", "x.doc", "application/msword")]
+    [InlineData("application/octet-stream", "x.txt", "text/plain")]
+    [InlineData("application/octet-stream", "x.md", "text/markdown")]
+    public void Resolve_OctetStream_KnownExtension_ReturnsMappedMime(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", "x.pdf", "application/pdf")]
+    [InlineData("", "x.txt", "text/plain")]
+    public void Resolve_EmptyContentType_KnownExtension_ReturnsMappedMime(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_NullContentType_KnownExtension_ReturnsMappedMime()
+    {
+        var result = ContentTypeResolver.Resolve(null!, "x.pdf");
+
+        result.Should().Be("application/pdf");
+    }
+
+    [Fact]
+    public void Resolve_OctetStream_UnknownExtension_ReturnsOriginalOctetStream()
+    {
+        var result = ContentTypeResolver.Resolve("application/octet-stream", "x.xyz");
+
+        result.Should().Be("application/octet-stream");
+    }
+
+    [Theory]
+    [InlineData("image/png", "x.pdf", "image/png")]
+    [InlineData("text/html", "x.docx", "text/html")]
+    [InlineData("application/json", "x.xyz", "application/json")]
+    public void Resolve_NonOctetStream_PassesThrough_RegardlessOfExtension(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("APPLICATION/OCTET-STREAM", "x.pdf", "application/pdf")]
+    [InlineData("Application/Octet-Stream", "x.PDF", "application/pdf")]
+    [InlineData("application/octet-stream", "x.DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    public void Resolve_CaseInsensitive_OctetStreamAndExtension_StillResolves(string contentType, string filename, string expected)
+    {
+        var result = ContentTypeResolver.Resolve(contentType, filename);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("application/octet-stream", "x.pdf")]
+    [InlineData("application/octet-stream", "x.docx")]
+    [InlineData("application/octet-stream", "x.doc")]
+    [InlineData("application/octet-stream", "x.txt")]
+    [InlineData("application/octet-stream", "x.md")]
+    [InlineData("application/octet-stream", "x.xyz")]
+    [InlineData("image/png", "x.pdf")]
+    [InlineData("", "x.pdf")]
+    public void Resolve_IsIdempotent(string contentType, string filename)
+    {
+        var first = ContentTypeResolver.Resolve(contentType, filename);
+        var second = ContentTypeResolver.Resolve(first, filename);
+
+        second.Should().Be(first);
+    }
+}
+```
+
+### Step 2: Run the test class to verify it fails
+
+- [ ] Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ContentTypeResolverTests"
+```
+
+Expected: **build failure** — `ContentTypeResolver` does not exist in `Anela.Heblo.Application.Features.KnowledgeBase`. (`CS0103` / `CS0246`.)
+
+### Step 3: Create `ContentTypeResolver.cs`
+
+- [ ] Create `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.KnowledgeBase;
+
+/// <summary>
+/// Resolves the effective content type, falling back to file extension when the source
+/// reports a generic type (application/octet-stream) or no type at all. The mapping is
+/// shared across the KnowledgeBase ingestion entry points so that resolution is performed
+/// in exactly one place.
+/// </summary>
+internal static class ContentTypeResolver
+{
+    public static string Resolve(string contentType, string filename) =>
+        string.IsNullOrEmpty(contentType) || contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetExtension(filename).ToLowerInvariant() switch
+            {
+                ".pdf" => "application/pdf",
+                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ".doc" => "application/msword",
+                ".txt" => "text/plain",
+                ".md" => "text/markdown",
+                _ => contentType
+            }
+            : contentType;
+}
+```
+
+Notes:
+- Method signature mirrors the existing private method byte-for-byte (`string contentType, string filename` — non-nullable parameters; null inputs still work via `string.IsNullOrEmpty` and are exercised by `Resolve_NullContentType_KnownExtension_ReturnsMappedMime`).
+- The `_ => contentType` fallback is what preserves `application/octet-stream` (or any other passed-in value) for unsupported extensions.
+
+### Step 4: Run the tests to verify they pass
+
+- [ ] Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ContentTypeResolverTests"
+```
+
+Expected: **all tests pass** (the matrix above: 5 known-extension + 2 empty-CT + 1 null-CT + 1 unknown-fallback + 3 pass-through + 3 case-insensitive + 8 idempotency rows = 23 passing assertions across the parameterized tests).
+
+### Step 5: Commit
+
+- [ ] Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs \
+        backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs
+git commit -m "refactor: extract ContentTypeResolver for KnowledgeBase ingestion"
+```
+
+---
+
+## Task 2: Switch `UploadDocumentHandler` to the shared resolver
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs` (call site at line 30; delete lines 73–84)
+
+### Step 1: Replace the call site
+
+- [ ] In `UploadDocumentHandler.cs`, replace this single line at line 30:
+
+```csharp
+        var contentType = ResolveContentType(request.ContentType, request.Filename);
+```
+
+with:
+
+```csharp
+        var contentType = ContentTypeResolver.Resolve(request.ContentType, request.Filename);
+```
+
+### Step 2: Delete the private `ResolveContentType` method
+
+- [ ] In the same file, delete lines 73–84 (the entire `ResolveContentType` private static method **and its XML doc comment** on lines 69–72). Specifically, remove this whole block:
+
+```csharp
+    /// <summary>
+    /// Resolves the effective content type, falling back to file extension when the browser
+    /// reports a generic type (application/octet-stream) for drag-and-drop uploads.
+    /// </summary>
+    private static string ResolveContentType(string contentType, string filename) =>
+        string.IsNullOrEmpty(contentType) || contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetExtension(filename).ToLowerInvariant() switch
+            {
+                ".pdf" => "application/pdf",
+                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ".doc" => "application/msword",
+                ".txt" => "text/plain",
+                ".md" => "text/markdown",
+                _ => contentType
+            }
+            : contentType;
+```
+
+After the edit, the class ends at `MapToSummary(...)` on what was line 67. The `using` block at the top of the file already covers `Anela.Heblo.Application.Features.KnowledgeBase` (current namespace via `Features.KnowledgeBase.UseCases.UploadDocument`) — `ContentTypeResolver` lives in `Anela.Heblo.Application.Features.KnowledgeBase`, which is **not** automatically reachable from the nested namespace `...KnowledgeBase.UseCases.UploadDocument` in C#. Add an explicit using if the build fails (see Step 3 expected result).
+
+### Step 3: Build and confirm — add `using` if needed
+
+- [ ] Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: **clean build**. If the compiler emits `CS0103: The name 'ContentTypeResolver' does not exist in the current context`, add at the top of `UploadDocumentHandler.cs` (in alphabetical order with the other `using`s):
+
+```csharp
+using Anela.Heblo.Application.Features.KnowledgeBase;
+```
+
+Re-run `dotnet build` until it succeeds.
+
+### Step 4: Run the existing `UploadDocumentHandler` tests to verify no behavioral change
+
+- [ ] Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UploadDocumentHandlerTests"
+```
+
+Expected: **all existing UploadDocumentHandlerTests pass** — the test fixture already verifies that the resolved `ContentType` flows through to the dispatched `IndexDocumentRequest`, so any drift in `Resolve` semantics would have surfaced there.
+
+### Step 5: Commit
+
+- [ ] Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs
+git commit -m "refactor: use shared ContentTypeResolver in UploadDocumentHandler"
+```
+
+---
+
+## Task 3: Switch `IndexDocumentHandler` to the shared resolver
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs` (call site at line 30; delete lines 141–152)
+
+### Step 1: Replace the call site
+
+- [ ] In `IndexDocumentHandler.cs`, replace this single line at line 30:
+
+```csharp
+        var contentType = ResolveContentType(request.ContentType, request.Filename);
+```
+
+with:
+
+```csharp
+        var contentType = ContentTypeResolver.Resolve(request.ContentType, request.Filename);
+```
+
+This must stay in place — `IndexDocumentHandler` is also called directly by `KnowledgeBaseIngestionJob` with un-resolved input, so the resolution here is real work for that path. In the upload flow the call is an idempotent no-op (the resolver test `Resolve_IsIdempotent` guarantees this).
+
+### Step 2: Delete the private `ResolveContentType` method
+
+- [ ] In the same file, delete lines 141–152 (the entire `ResolveContentType` private static method **and its XML doc comment** on lines 137–140). Specifically, remove this whole block:
+
+```csharp
+    /// <summary>
+    /// Resolves the effective content type, falling back to file extension when the source
+    /// reports a generic type (application/octet-stream).
+    /// </summary>
+    private static string ResolveContentType(string contentType, string filename) =>
+        string.IsNullOrEmpty(contentType) || contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetExtension(filename).ToLowerInvariant() switch
+            {
+                ".pdf" => "application/pdf",
+                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ".doc" => "application/msword",
+                ".txt" => "text/plain",
+                ".md" => "text/markdown",
+                _ => contentType
+            }
+            : contentType;
+```
+
+After the edit, the class ends at the `return new IndexDocumentResponse { ... };` block at line 135.
+
+### Step 3: Build and confirm — add `using` if needed
+
+- [ ] Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: **clean build**. If the compiler emits `CS0103: The name 'ContentTypeResolver' does not exist in the current context`, add at the top of `IndexDocumentHandler.cs` (in alphabetical order with the other `using`s):
+
+```csharp
+using Anela.Heblo.Application.Features.KnowledgeBase;
+```
+
+Re-run `dotnet build` until it succeeds.
+
+### Step 4: Run the existing `IndexDocumentHandler` tests to verify no behavioral change
+
+- [ ] Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~IndexDocumentHandlerTests"
+```
+
+Expected: **all existing IndexDocumentHandlerTests pass** — they exercise the indexing path that includes content-type resolution.
+
+### Step 5: Commit
+
+- [ ] Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs
+git commit -m "refactor: use shared ContentTypeResolver in IndexDocumentHandler"
+```
+
+---
+
+## Task 4: Full validation gate
+
+**Files:** none modified — verification only.
+
+### Step 1: Confirm no other `ResolveContentType` survives in the KnowledgeBase module
+
+- [ ] Run (no `cd`, absolute path):
+
+```bash
+grep -rn "ResolveContentType" backend/src/Anela.Heblo.Application/Features/KnowledgeBase backend/test/Anela.Heblo.Tests/KnowledgeBase
+```
+
+Expected: **no matches**. The private methods are gone; the new helper is named `Resolve`, not `ResolveContentType`. (A match in `Features/Leaflet/UseCases/UploadLeaflet/UploadLeafletHandler.cs` is expected and **explicitly out of scope per arch-review §"Specification Amendments" item 2**. Do not touch Leaflet in this plan.)
+
+### Step 2: Run every KnowledgeBase test
+
+- [ ] Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBase"
+```
+
+Expected: **all KnowledgeBase tests pass** (existing `UploadDocumentHandlerTests`, `IndexDocumentHandlerTests`, any other KB tests, plus the new `ContentTypeResolverTests`).
+
+### Step 3: Full backend build clean
+
+- [ ] Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: **0 errors, 0 new warnings**. (Pre-existing warnings unrelated to KnowledgeBase are acceptable.)
+
+### Step 4: Formatting clean
+
+- [ ] Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: **exit code 0** (no formatting drift introduced).
+
+If it reports formatting changes, run without `--verify-no-changes`, inspect the diff, commit only formatting changes to the three files this plan touched:
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs \
+        backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs \
+        backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs
+git commit -m "chore: dotnet format"
+```
+
+### Step 5: No further commits required
+
+- [ ] Confirm `git status` is clean and three (or four, if formatting was needed) commits exist on the branch:
+
+```bash
+git status
+git log --oneline -5
+```
+
+Expected: clean working tree; the commits introduced by this plan are the three (or four) listed above.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec requirement | Covered by |
+|---|---|
+| FR-1 (single source of truth, exact path, exact method signature, behavior preserved, test cases) | Task 1 — Step 3 creates the file with correct path/signature/visibility; Step 1 enumerates every required test case. |
+| FR-1 acceptance "`Resolve_OctetStream_UnknownExtension_ReturnsOriginalOctetStream`" (unsupported-extension fallback) | Task 1 — `Resolve_OctetStream_UnknownExtension_ReturnsOriginalOctetStream`. |
+| FR-1 acceptance "case-insensitive comparison" | Task 1 — `Resolve_CaseInsensitive_OctetStreamAndExtension_StillResolves` covers both `contentType` case and extension case. |
+| FR-2 (UploadDocumentHandler delegates, private method deleted, behavior unchanged) | Task 2 — Step 1 swaps the call; Step 2 deletes the method; Step 4 verifies via existing tests. |
+| FR-3 (IndexDocumentHandler delegates, private method deleted, both entry points produce identical resolved MIME, idempotency unit-tested) | Task 3 — Step 1 swaps the call; Step 2 deletes the method; idempotency is asserted by `Resolve_IsIdempotent` (Task 1, Step 1); both entry points share one resolver. |
+| FR-4 (backward compatibility for unsupported extensions: `Resolve("application/octet-stream", "file.xyz")` returns `"application/octet-stream"`; non-octet-stream pass-through) | Task 1 — `Resolve_OctetStream_UnknownExtension_ReturnsOriginalOctetStream` and `Resolve_NonOctetStream_PassesThrough_RegardlessOfExtension`. |
+| NFR-1 (performance — pure synchronous helper) | Implementation is identical to existing private methods; no allocations beyond `Path.GetExtension`/`ToLowerInvariant`. |
+| NFR-2 (security unchanged) | Hard-coded mapping, no user input affects mapping; not in any trust boundary. |
+| NFR-3 (one-file change for new extensions) | Future additions edit `ContentTypeResolver.cs` only. |
+| NFR-4 (≥80% line+branch coverage on resolver) | The test matrix exercises every switch arm, both branches of the outer ternary, both halves of the `IsNullOrEmpty || Equals(...)` short-circuit, and the case-insensitive path. Full coverage. |
+| Arch-review amendment 1 (idempotency assertion as explicit FR-3 bullet) | Task 1 — `Resolve_IsIdempotent` covers the full mapping table plus pass-through and empty-CT rows. |
+| Arch-review amendment 2 (Leaflet copy out of scope, do not touch) | Task 4, Step 1 explicitly calls out the expected Leaflet match and forbids touching it. |
+| Arch-review amendment 3 (signature pinned to `string contentType, string filename`, non-nullable) | Task 1, Step 3 — signature is byte-identical to the existing private methods. |
+| Arch-review prerequisite 1 (`InternalsVisibleTo` for tests) | Verified by inspection of `Anela.Heblo.Application.csproj` before writing this plan — the entry `<InternalsVisibleTo Include="Anela.Heblo.Tests" />` is already present. No change required. |
+| Validation gate (`dotnet build`, `dotnet format`, KnowledgeBase tests green) | Task 4 covers all three. |
+
+No gaps.
+
+**2. Placeholder scan:** No "TBD", "implement later", "add appropriate error handling", or similar. Every step gives the exact code, the exact command, and the expected output.
+
+**3. Type consistency:** The helper class is named `ContentTypeResolver` and the method is `Resolve` in every reference (Task 1 declaration, Task 2 call site, Task 3 call site, all test calls). Parameters `string contentType, string filename` are identical at every site. Namespace `Anela.Heblo.Application.Features.KnowledgeBase` is consistent. Test namespace `Anela.Heblo.Tests.KnowledgeBase` matches the existing folder convention (`backend/test/Anela.Heblo.Tests/KnowledgeBase/`).


### PR DESCRIPTION

Consolidated duplicate `ResolveContentType` logic in the KnowledgeBase module into a single `internal static ContentTypeResolver` helper, eliminating the silent-divergence risk when new file extensions are added. The mapping table now lives in exactly one place; adding a new extension requires editing one file and one test.

### Changes
- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ContentTypeResolver.cs` — new shared helper
- `backend/test/Anela.Heblo.Tests/KnowledgeBase/ContentTypeResolverTests.cs` — 23 tests covering all branches and idempotency
- `backend/src/...UseCases/UploadDocument/UploadDocumentHandler.cs` — swapped call site, deleted private method
- `backend/src/...UseCases/IndexDocument/IndexDocumentHandler.cs` — swapped call site, deleted private method

---

Closes #2954

### Tokens used
12868362
