### PR TITLE
feat: Resilient HomeAssistant dependency to reduce intermittent IOException noise

### DIFF
--- a/artifacts/feat-telemetry-homeassistant-http-dependency-/arch-review.r1.md
+++ b/artifacts/feat-telemetry-homeassistant-http-dependency-/arch-review.r1.md
@@ -1,0 +1,312 @@
+```markdown
+# Architecture Review: Resilient HomeAssistant Dependency
+
+## Skip Design: true
+
+Pure backend resilience/telemetry change. The only user-visible surface is the new `Stale` enum value rendered by an existing tile (`ManufactureConditionsTile`) and the manufacture protocol PDF (`ManufactureProtocolDocument.SourceSuffix`). The spec explicitly excludes visual redesign — the tile already shows `source` as a string and the PDF needs only a one-line label entry. No new screens, components, or design tokens.
+
+## Architectural Fit Assessment
+
+The change lands cleanly in an existing, well-shaped seam:
+
+- The adapter (`Anela.Heblo.Adapters.HomeAssistant`) is the only consumer of `HttpClient` for HA, and the only producer of `ConditionsSnapshot`. All resilience belongs here — no domain or application changes required.
+- The codebase already standardizes on **Polly v8** (`MetaAdsTransactionSource` uses `Polly` 8.4.1 + `Polly.Extensions`). `Microsoft.Extensions.Diagnostics.HealthChecks` is on the Application graph. Pattern precedent exists for `ITelemetryProcessor` via `CostOptimizedTelemetryProcessor` registered through `AddApplicationInsightsTelemetryProcessor<T>`. We should reuse these patterns, not invent new ones.
+- The Domain enum `ConditionsReadingSource` lives in the Domain layer and is consumed by three downstream components: `ManufactureConditionsTile`, `ManufactureProtocolDocument.SourceSuffix`, and `UpdateManufactureOrderStatusHandler`. Adding `Stale` is a single non-breaking ordinal append (ordinal 4). Audit confirms only `ManufactureProtocolDocument.SourceSuffix` needs a new switch arm — the others use `.ToString()` or compare only to `Unavailable`.
+- Health-check endpoints (`/health`, `/health/ready`, `/health/live`) and `AddHealthCheckServices` are already wired in the API layer. New check slots in without endpoint changes.
+
+Main integration tension: the **resilience pipeline lives in the Adapter project but the telemetry processor coupling lives in the API project** (where AI is registered). Keep the processor type *defined* in the Adapter project (so it travels with the integration) and *registered* from the API layer (conditional on AI being configured), mirroring how `CostOptimizedTelemetryProcessor` is wired today.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.API                                                      │
+│                                                                      │
+│   AddOptimizedApplicationInsights ─┐                                 │
+│                                    ├── AddApplicationInsights         │
+│                                    │   TelemetryProcessor<           │
+│                                    │   HomeAssistantDependency       │
+│                                    │   TelemetryFilter>  (conditional)│
+│   AddHealthCheckServices ──────────┼── .AddCheck<HomeAssistant       │
+│                                    │       ConditionsHealthCheck>    │
+│                                    │     (tag: "ready", "homeassistant")│
+│   AddHomeAssistantAdapter ─────────┘                                 │
+└────────────────┬─────────────────────────────────────────────────────┘
+                 │
+┌────────────────▼─────────────────────────────────────────────────────┐
+│ Anela.Heblo.Adapters.HomeAssistant                                   │
+│                                                                      │
+│   AddHomeAssistantAdapter(IConfiguration)                            │
+│   ├─ Options<HomeAssistantSettings>  (+ Retry/Stale knobs)           │
+│   ├─ IMemoryCache                                                    │
+│   ├─ AddHttpClient<HomeAssistantConditionsReadingProvider>           │
+│   │   .AddResilienceHandler("ha-conditions", b => b                  │
+│   │       .AddTimeout(perAttempt)                                    │
+│   │       .AddRetry(retryOptions {                                   │
+│   │           ShouldHandle = transientPredicate,                     │
+│   │           OnRetry = TagActivityAsSuppressed                      │
+│   │       }))                                                        │
+│   ├─ HomeAssistantConditionsHealthCheck : IHealthCheck               │
+│   ├─ HomeAssistantSnapshotMetrics  (Meter "Anela.Heblo.HomeAssistant")│
+│   └─ HomeAssistantDependencyTelemetryFilter : ITelemetryProcessor    │
+│                                                                      │
+│   HomeAssistantConditionsReadingProvider                             │
+│   ├─ live cache:    "HomeAssistant_ConditionsSnapshot"   (5 min)     │
+│   ├─ LKG cache:     "HomeAssistant_LastKnownGoodSnapshot"(60 min)    │
+│   ├─ single-flight: SemaphoreSlim per CacheKey                       │
+│   └─ FetchSensorValueAsync — no try/catch (Polly handles it)         │
+└──────────────────────────────────────────────────────────────────────┘
+                 │
+┌────────────────▼─────────────────────────────────────────────────────┐
+│ Domain (consumers of ConditionsReadingSource — Stale added)          │
+│   ManufactureConditionsTile (.ToString()) — auto-handles "Stale"     │
+│   ManufactureProtocolDocument.SourceSuffix — new switch arm          │
+│   UpdateManufactureOrderStatusHandler — unaffected (only checks      │
+│                                          for Unavailable fallback)   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Resilience via `AddResilienceHandler`, not in-provider `ResiliencePipeline.ExecuteAsync`
+
+**Options considered:**
+- (A) Inject `ResiliencePipelineProvider<string>` into the provider, wrap `_httpClient.GetAsync` inline.
+- (B) Configure resilience on the typed `HttpClient` via `IHttpClientBuilder.AddResilienceHandler(...)`.
+- (C) Use `AddStandardResilienceHandler` with defaults override.
+
+**Chosen approach:** (B) — explicit `AddResilienceHandler` with a named pipeline.
+
+**Rationale:** Keeps the adapter free of Polly concerns (provider code stays a thin JSON parser), centralizes per-attempt timeout + retry in one place adjacent to `HttpClient.Timeout` (which must be raised — see Decision 2). Option C bundles rate-limiter + circuit-breaker + hedging we don't want; option A complicates testing because Polly state crosses transport boundaries.
+
+#### Decision 2: Disable `HttpClient.Timeout`; use per-attempt Polly timeout
+
+**Options considered:**
+- (A) Keep `HttpClient.Timeout = RequestTimeoutSeconds` (3 s) — Polly retries inside this budget.
+- (B) Set `HttpClient.Timeout = InfiniteTimeSpan`; use Polly `TimeoutStrategy` per attempt = 3 s.
+- (C) Raise `HttpClient.Timeout` to `RequestTimeoutSeconds × (RetryCount + 1)` — both timeouts active.
+
+**Chosen approach:** (B).
+
+**Rationale:** `HttpClient.Timeout` cancels the *entire* `SendAsync` chain including retries — a 3 s ceiling means we can never actually retry. Option C works but creates two redundant timeout knobs and confusing semantics if either changes. Polly's `TimeoutStrategy` produces a `TimeoutRejectedException`/`OperationCanceledException` that the retry strategy can distinguish from caller cancellation via the inbound `CancellationToken`. The provider continues to honor caller cancellation by passing the inbound token to Polly's `ExecuteAsync` (via the HttpClient send path), satisfying FR-1 (≤200 ms cancellation).
+
+#### Decision 3: Two distinct cache entries with single-flight gating
+
+**Options considered:**
+- (A) One cache entry, demote source when serving from beyond live TTL.
+- (B) Live cache (5 min, absolute) + separate Last-Known-Good cache (60 min, absolute from `RecordedAt`, written only on `Live` source).
+
+**Chosen approach:** (B).
+
+**Rationale:** Spec FR-2 requires that **Partial** results never overwrite the LKG entry. A single cache cannot express "live for 5 minutes, but the underlying value is also reusable for 60 minutes when fresh refresh fails." Single-flight (NFR-3) is implemented as a `SemaphoreSlim` keyed by `CacheKey` (the provider is registered transient but the singleton `IMemoryCache` and a singleton `HomeAssistantSnapshotCoordinator` hold the semaphore — see Implementation Guidance).
+
+#### Decision 4: Activity-tag–based telemetry suppression
+
+**Options considered:**
+- (A) Replace AI's `DependencyTrackingTelemetryModule` HTTP collector with a custom one.
+- (B) Add an `ITelemetryProcessor` that drops `DependencyTelemetry` for HA when an Activity tag marks the attempt as "retry-suppressed".
+- (C) Use a `DelegatingHandler` that swallows the dependency record per attempt.
+
+**Chosen approach:** (B).
+
+**Rationale:** AI auto-instruments outbound HTTP via `System.Diagnostics.Activity`. `DependencyTrackingTelemetryModule` enriches each dependency from the current Activity's tags. In Polly's `RetryStrategyOptions.OnRetry`, set `Activity.Current?.SetTag("ha.retry-suppress", "true")` on the *just-failed* attempt's activity. The processor inspects `DependencyTelemetry.Properties["ha.retry-suppress"]` and drops the item. The final attempt (success or failure) carries no tag → exactly one dependency record per `GetCurrentSnapshotAsync` per sensor, matching FR-3 acceptance criteria. Option A is invasive; option C requires duplicating AI's HTTP-dependency logic.
+
+#### Decision 5: Custom metric via `System.Diagnostics.Metrics.Meter`
+
+**Options considered:**
+- (A) `TelemetryClient.GetMetric("homeassistant.snapshot.source", "source").TrackValue(1)`.
+- (B) `Meter("Anela.Heblo.HomeAssistant").CreateCounter<long>("homeassistant.snapshot.source")` with a `source` tag.
+
+**Chosen approach:** (B).
+
+**Rationale:** `Meter` is the modern .NET 8 API; AI 2.22+ auto-publishes `Meter` instruments as `customMetrics`. It decouples the adapter from `TelemetryClient` (so the adapter project doesn't need a hard reference to `Microsoft.ApplicationInsights`). A no-op when no listener is attached; no conditional registration needed.
+
+#### Decision 6: Health check reads cache only, never calls HA
+
+**Chosen approach:** `HomeAssistantConditionsHealthCheck` depends on `IMemoryCache` (and a tiny shared coordinator that exposes "last recorded source + RecordedAt") and computes status without any HTTP call.
+
+**Rationale:** FR-4 explicitly forbids outbound traffic on health probes; Kubernetes-style liveness probes would otherwise hammer HA at probe cadence and amplify the very failures we're suppressing.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/
+├── HomeAssistantAdapterServiceCollectionExtensions.cs   (modify)
+├── HomeAssistantConditionsReadingProvider.cs            (modify)
+├── HomeAssistantSettings.cs                             (add knobs)
+├── Resilience/
+│   ├── HomeAssistantResiliencePipelineBuilder.cs        (new — static helper)
+│   └── TransientHttpErrorPredicate.cs                   (new)
+├── Caching/
+│   └── HomeAssistantSnapshotCoordinator.cs              (new — singleton; single-flight semaphore + LKG accessor)
+├── HealthChecks/
+│   └── HomeAssistantConditionsHealthCheck.cs            (new)
+├── Telemetry/
+│   ├── HomeAssistantSnapshotMetrics.cs                  (new — Meter wrapper)
+│   └── HomeAssistantDependencyTelemetryFilter.cs        (new — ITelemetryProcessor)
+└── Anela.Heblo.Adapters.HomeAssistant.csproj            (add PackageReferences)
+
+backend/src/Anela.Heblo.Domain/Features/Manufacture/Conditions/
+└── ConditionsReadingSource.cs                           (add Stale = 4)
+
+backend/src/Anela.Heblo.API/
+├── Extensions/ServiceCollectionExtensions.cs            (register health check in AddHealthCheckServices)
+├── Extensions/ApplicationInsightsExtensions.cs          (conditionally register HA telemetry processor)
+└── PDFPrints/ManufactureProtocolDocument.cs             (add Stale switch arm)
+
+backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/
+├── HomeAssistantConditionsReadingProviderTests.cs       (extend)
+├── HomeAssistantConditionsHealthCheckTests.cs           (new)
+├── HomeAssistantDependencyTelemetryFilterTests.cs       (new)
+└── HomeAssistantResiliencePipelineTests.cs              (new)
+```
+
+CSProj additions to `Anela.Heblo.Adapters.HomeAssistant.csproj`:
+
+```xml
+<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+<PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+```
+
+Add `Microsoft.ApplicationInsights` as the *minimum* surface required for `ITelemetry` / `ITelemetryProcessor` / `DependencyTelemetry` types only. This is a leaf dependency — no transitive concerns.
+
+### Interfaces and Contracts
+
+```csharp
+// Domain — non-breaking append.
+public enum ConditionsReadingSource
+{
+    Live = 1,
+    Partial = 2,
+    Unavailable = 3,
+    Stale = 4,
+}
+
+// Adapter — config knobs (init-only, defaulted, safe to deploy unset).
+public class HomeAssistantSettings
+{
+    // ... existing properties ...
+    public int RetryCount { get; init; } = 2;
+    public int RetryBaseDelayMilliseconds { get; init; } = 200;
+    public int StaleSnapshotMaxAgeMinutes { get; init; } = 60;
+    public int LiveSnapshotMaxAgeMinutes { get; init; } = 15;
+}
+
+// Adapter — singleton coordinator shared by provider + health check.
+internal sealed class HomeAssistantSnapshotCoordinator
+{
+    public SemaphoreSlim Gate { get; } = new(initialCount: 1, maxCount: 1);
+    public ConditionsSnapshot? LastObservedSnapshot { get; private set; }   // any source, for health check
+    public ConditionsSnapshot? LastKnownGoodLive { get; private set; }      // Live only, for fallback
+    public void RecordObserved(ConditionsSnapshot s);
+    public void RecordLive(ConditionsSnapshot s);
+}
+
+// Adapter — metric facade.
+internal sealed class HomeAssistantSnapshotMetrics
+{
+    public const string MeterName = "Anela.Heblo.HomeAssistant";
+    public void RecordSnapshot(ConditionsReadingSource source);   // counter +1 tagged source=…
+}
+
+// Adapter — telemetry filter; constructor takes ITelemetryProcessor next.
+public sealed class HomeAssistantDependencyTelemetryFilter : ITelemetryProcessor
+{
+    public const string SuppressTagName = "ha.retry-suppress";
+    // Drops DependencyTelemetry with Properties[SuppressTagName] == "true".
+}
+
+// Adapter — health check.
+public sealed class HomeAssistantConditionsHealthCheck : IHealthCheck
+{
+    // Reads HomeAssistantSnapshotCoordinator only; never calls HA.
+}
+```
+
+Public surface of `IConditionsReadingProvider` is unchanged (per spec).
+
+### Data Flow
+
+**Happy path (cache miss → all sensors fresh):**
+
+1. `GetCurrentSnapshotAsync` checks live cache → miss.
+2. Acquires `Coordinator.Gate` (single-flight). Re-checks cache after acquire (double-check pattern).
+3. Fires 4 parallel `FetchSensorValueAsync` calls; each goes through `HttpClient` → Polly `AddResilienceHandler` → typed `HttpClient` → AI dependency collector.
+4. All four succeed first attempt. `source = Live`, snapshot built.
+5. `Coordinator.RecordLive(snapshot)`; live cache set (5 min); LKG cache set (60 min).
+6. `HomeAssistantSnapshotMetrics.RecordSnapshot(Live)`.
+7. Single `Information` log: `Source=Live, LiveSensorCount=4, Duration=…, RetryAttempts=0`.
+8. Release `Gate`. Return snapshot.
+
+**Transient failure recovered by retry:**
+
+1. Sensor 1 first attempt throws `IOException`. Polly `OnRetry` callback sets `Activity.Current?.SetTag("ha.retry-suppress", "true")` and logs `Debug` (per FR-3).
+2. AI dependency collector emits a `DependencyTelemetry` carrying that tag → `HomeAssistantDependencyTelemetryFilter` drops it before send.
+3. Polly delays 200 ms ± jitter, retries → success.
+4. Snapshot is `Live`. Aggregated `Information` log includes `RetryAttempts=1`.
+
+**All retries exhausted on a sensor + LKG available:**
+
+1. Polly exhausts retries; final attempt's `DependencyTelemetry` has **no** suppress tag → AI keeps one Faulted dependency record.
+2. `FetchSensorValueAsync` returns `null` for that sensor.
+3. Live snapshot computes as `Partial` or `Unavailable`.
+4. Provider checks `Coordinator.LastKnownGoodLive`:
+   - If `Unavailable` and LKG exists and `(now - LKG.RecordedAt) ≤ StaleSnapshotMaxAgeMinutes` → return new snapshot with `Source = Stale, RecordedAt = LKG.RecordedAt`, *values from LKG*. Do **not** update live cache or LKG.
+   - If `Partial` → return live `Partial` (fresher beats older — per FR-2). Update live cache; do not touch LKG.
+5. Single `Warning` log (no exception object): `EntityId, Attempts, LastException.GetType().Name, LastException.Message`.
+6. `HomeAssistantSnapshotMetrics.RecordSnapshot(Stale | Partial | Unavailable)`.
+
+**Health probe:**
+
+1. `HomeAssistantConditionsHealthCheck.CheckHealthAsync` reads `Coordinator.LastObservedSnapshot` (in-memory).
+2. Status:
+   - `Healthy` if last is `Live` and `(now - RecordedAt) ≤ LiveSnapshotMaxAgeMinutes`.
+   - `Degraded` if last is `Partial` or `Stale`.
+   - `Unhealthy` if last is `Unavailable` or null.
+3. Returns immediately; no HTTP. Tagged `"homeassistant"` and `"ready"` (joins the existing `/health/ready` predicate).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `HttpClient.Timeout` of 3 s prevents any retry from running (spec FR-1 silently disabled). | High | Decision 2: set `client.Timeout = Timeout.InfiniteTimeSpan` and enforce per-attempt timeout via Polly `AddTimeout`. Unit test asserts a 7-second retry sequence completes. |
+| Polly `OnRetry` does not have the failed attempt's `Activity` in scope (Activity may have already ended). | Medium | Use a `DelegatingHandler` registered **after** `AddResilienceHandler` in the inner pipeline that wraps `SendAsync` in a try/catch and tags the *current* Activity inside `catch` before rethrowing — this guarantees the Activity is the per-attempt one. Validate with a test that asserts exactly one Faulted dependency per snapshot under full-failure. |
+| `ManufactureProtocolDocument.SourceSuffix` falls to `default` for `Stale` → silently empty suffix in PDFs. | Medium | Add explicit switch arm: `ConditionsReadingSource.Stale => " (Starší údaje)"`. Covered in spec amendment below. |
+| Single-flight `SemaphoreSlim` held across HTTP I/O can stall every caller behind one slow request. | Medium | Bound wait with `await Gate.WaitAsync(timeout, ct)` where `timeout = perAttemptTimeout × (RetryCount + 1) + 1s`. On timeout, fall through to LKG/Unavailable rather than queueing indefinitely. |
+| `HomeAssistantDependencyTelemetryFilter` runs even when AI isn't configured (dev/local) → null `_next`. | Low | Register the processor through `AddApplicationInsightsTelemetryProcessor<>` only inside `AddOptimizedApplicationInsights` (which already gates on connection string). The adapter exposes a static `RegisterTelemetryProcessor(IServiceCollection)` helper to keep the type internal-feeling. |
+| `LastKnownGoodLive` survives a service restart only until next `Live` snapshot — first failure after restart still yields `Unavailable`. | Low | Acceptable per spec FR-2 cold-start clause. Document inline; revisit if it becomes painful. |
+| Stale snapshot's `RecordedAt` may confuse downstream consumers that compare to `now` (e.g., "too old → discard"). | Low | Stamp `RecordedAt = LKG.RecordedAt` (truthful) but add `Source = Stale` discriminator. The tile already shows `recordedAt` to the user — that's the correct UX (data may be a few minutes old). |
+| Polly + `HttpClient` inner-handler tests are brittle if Polly internals change. | Low | Test the *behavior* (call counts, exception propagation, cancellation) via `Mock<HttpMessageHandler>` returning sequences (`SetupSequence`) — already the pattern used in the existing test suite. |
+
+## Specification Amendments
+
+1. **FR-2 clarification (additive):** When returning a stale snapshot, copy the LKG's *values* and *RecordedAt* into the returned `ConditionsSnapshot` but set `Source = Stale`. The current snapshot's `RecordedAt` field semantically means "when the values were measured", not "when this call ran" — so it must remain the LKG's timestamp. Confirm this is the intended UX (the tile displays `lastUpdated = snapshot.RecordedAt`).
+
+2. **Decision 2 amendment (FR-1 / NFR-1):** Set `HttpClient.Timeout = Timeout.InfiniteTimeSpan` in `AddHomeAssistantAdapter`; per-attempt timeout is enforced by Polly's `AddTimeout(TimeSpan.FromSeconds(settings.RequestTimeoutSeconds))`. Spec's "worst-case ≤ 9 s" calculation already assumed retries fit inside `RequestTimeoutSeconds × 3`, which only works if the outer transport timeout is removed.
+
+3. **FR-3 amendment (out-of-scope downstream):** `ManufactureProtocolDocument.SourceSuffix` (`backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs:276`) must gain a `Stale => " (Starší údaje)"` arm. Spec listed the file in scope but did not enumerate the change.
+
+4. **FR-3 implementation note (activity tagging):** Add an internal `HomeAssistantDependencyTaggingHandler : DelegatingHandler` registered between the Polly resilience handler and the primary handler, so the per-attempt Activity is reliably in scope when tagging on retry. Document the tag name (`ha.retry-suppress`) as the contract between adapter and filter.
+
+5. **NFR-3 single-flight (additive):** Bound the gate wait with a timeout = `perAttemptTimeout × (RetryCount + 1) + 1s`; on timeout, the waiter falls through to the LKG/Unavailable path. Prevents a stuck fetch from cascading.
+
+6. **FR-4 health-check tags:** Register the check with tags `{ "homeassistant", "ready" }` so it participates in `/health/ready` (which currently filters by `"ready"` or `DB_TAG`) without changing the endpoint predicate. The check will also surface under aggregate `/health`.
+
+7. **FR-5 (additive):** Add `RetryMaxDelaySeconds` (default `2`) bounding the worst-case jittered backoff per attempt, to keep cancellation budgets predictable.
+
+## Prerequisites
+
+- **Package references** added to `Anela.Heblo.Adapters.HomeAssistant.csproj`:
+  - `Microsoft.Extensions.Http.Resilience` 8.10.0
+  - `Microsoft.Extensions.Diagnostics.HealthChecks` 8.0.0
+  - `Microsoft.ApplicationInsights` 2.22.0
+- **No** new Key Vault secrets, environment variables, or migrations required. New `HomeAssistantSettings` knobs ship with safe defaults; appsettings overrides are optional.
+- **No** infrastructure or CI changes. AI is already configured in Staging/Production via `ApplicationInsights:ConnectionString` (gated in `ApplicationInsightsExtensions.cs:14`); the filter activates automatically there.
+- **No** new health endpoint — reuses existing `/health` and `/health/ready` mappings in `ApplicationBuilderExtensions.cs:173`.
+- **Downstream audit** before merge: confirm the frontend tile (`source` string) gracefully renders the value `"Stale"` (likely just shows it as a label — verify in browser against the existing tile component, no design change needed per spec).
+```

--- a/artifacts/feat-telemetry-homeassistant-http-dependency-/brief.md
+++ b/artifacts/feat-telemetry-homeassistant-http-dependency-/brief.md
@@ -1,0 +1,20 @@
+telemetry-signal: dep-fail:HTTP:homeassistant.tail0cdb23.ts.net
+
+## Signal
+
+In the last 7 days (P7D, ending 2026-06-12T15:12Z):
+
+- **32 dependency failures** (`type: HTTP`, `target: homeassistant.tail0cdb23.ts.net`, `resultCode: Faulted`) in the dependency telemetry.
+- **32 `System.IO.IOException`** at `Anela.Heblo.Adapters.HomeAssistant.HomeAssistantConditionsReadingProvider+<FetchSensorValueAsync>d__7.MoveNext` — the matching exception records.
+
+**Rate: ~4.6 failures/day, consistent and ongoing** (4 IOExceptions confirmed in the last 2 days).
+
+Latency context for successful calls (3,768 total calls in P7D): p50 317 ms, p95 616 ms, p99 814 ms — within normal range. The 32 Faulted failures are distinct from latency; they are connection-level errors.
+
+## Correlation
+
+`homeassistant.tail0cdb23.ts.net` is the Tailscale hostname for the local Home Assistant instance. A `resultCode: Faulted` dependency + `IOException` at `FetchSensorValueAsync` indicates TCP-level connection failures (TCP reset, connection refused, or network path unreachable). There is no merged PR in the window addressing the HomeAssistant adapter, and the failure rate is stable rather than spiking — pointing to persistent intermittent Tailscale tunnel or HA availability issues rather than a code regression.
+
+## Next step
+
+Check Tailscale peer status for `tail0cdb23.ts.net` and Home Assistant uptime/restart logs for the same period (June 5–12). If HA is briefly unavailable on a schedule (e.g. nightly restarts), confirm that `HomeAssistantConditionsReadingProvider` has a timeout + graceful-degradation path — it should return a cached or default sensor value rather than propagating the `IOException` to callers when HA is momentarily unreachable.

--- a/artifacts/feat-telemetry-homeassistant-http-dependency-/impl/main.r1.md
+++ b/artifacts/feat-telemetry-homeassistant-http-dependency-/impl/main.r1.md
@@ -1,0 +1,12 @@
+Tests are verified (34/34 passing from Task 16). Environment is a named branch. Presenting options:
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-telemetry-homeassistant-http-dependency-/spec.r1.md
+++ b/artifacts/feat-telemetry-homeassistant-http-dependency-/spec.r1.md
@@ -1,0 +1,168 @@
+```markdown
+# Specification: Resilient HomeAssistant dependency to reduce intermittent IOException noise
+
+## Summary
+Harden the `HomeAssistantConditionsReadingProvider` against the persistent ~4.6/day TCP-level connection failures observed against the Tailscale-tunneled Home Assistant instance. Add a per-call retry policy with jitter, serve a stale-but-usable last-known-good snapshot when Home Assistant is briefly unreachable, and suppress noisy exception/dependency telemetry for expected transient faults while still surfacing an aggregated health signal.
+
+## Background
+Application Insights telemetry for the last 7 days (ending 2026-06-12T15:12Z) shows 32 `dependency:HTTP` Faulted records against `homeassistant.tail0cdb23.ts.net`, each correlated with a `System.IO.IOException` thrown inside `HomeAssistantConditionsReadingProvider.FetchSensorValueAsync` (~4.6 failures/day, 0.85% of 3,768 total calls). Successful-call latency is healthy (p95 616 ms, p99 814 ms), so this is not a performance regression. The failure target is the on-prem Home Assistant exposed over a Tailscale tunnel — a path with known intermittent reachability (sleep/wake, NAT rebinding, brief HA restarts).
+
+The adapter already returns `null` per-sensor on exception so callers receive a `Partial`/`Unavailable` snapshot rather than throwing, but every failure still:
+1. Logs an `IOException` through `ILogger.LogWarning(ex, …)`, which the Application Insights ILogger provider records as an exception trace.
+2. Is captured by the `Microsoft.ApplicationInsights.DependencyCollector` as a Faulted HTTP dependency.
+
+These two streams produce continuous low-severity noise that masks real regressions and triggers anomaly-detection signals. Additionally, a failed sensor fetch in the middle of a 5-minute cache window degrades the *entire* snapshot to `Partial`/`Unavailable` even though the prior snapshot would have been fine to reuse — the manufacture order conditions tile and PDF protocols see avoidable gaps.
+
+## Functional Requirements
+
+### FR-1: Retry transient HTTP failures with bounded jittered backoff
+Wrap `FetchSensorValueAsync` HTTP calls in a Polly resilience pipeline that retries on transient faults (`IOException`, `SocketException`, `HttpRequestException`, `TaskCanceledException` *not* triggered by the caller's `CancellationToken`, and HTTP 5xx). Use 2 retries with exponential backoff (200 ms, 600 ms) plus ±50% jitter. Total worst-case wall time per sensor stays under `RequestTimeoutSeconds` × 3 ≈ 9 s.
+
+**Acceptance criteria:**
+- First attempt failing with `IOException` is retried; a successful second attempt returns the live value and produces a `Live` snapshot.
+- Three consecutive failures cause `FetchSensorValueAsync` to fall through to the fallback path (FR-2), not propagate the exception.
+- The cumulative retry budget respects the per-sensor `HttpClient.Timeout` (no infinite stalls).
+- Caller-provided `CancellationToken` cancellation is honored within ≤200 ms and does not consume retry budget.
+
+### FR-2: Serve last-known-good snapshot as graceful fallback
+Extend `GetCurrentSnapshotAsync` so that when the live fetch produces an `Unavailable` snapshot (all four sensors null) or any sensor fails after retries, the provider returns the most recent successful snapshot if one exists and is younger than `StaleSnapshotMaxAgeMinutes` (default 60).
+
+**Acceptance criteria:**
+- A fresh process with no cached snapshot still returns `Unavailable` on total failure (no regression in cold-start behavior).
+- A cached snapshot ≤ `StaleSnapshotMaxAgeMinutes` old is returned with `Source = ConditionsReadingSource.Stale` (new enum value, see Data Model).
+- A cached snapshot older than `StaleSnapshotMaxAgeMinutes` is discarded and `Unavailable` is returned.
+- The "last-known-good" entry is independent of the existing 5-minute live cache: it is updated only when a `Live` snapshot is produced and never overwritten by `Partial` or `Stale` results.
+- For a `Partial` live snapshot, the provider prefers the live `Partial` reading over a stale `Live` reading (live data is fresher even if incomplete), and stamps `Source = Partial` as today.
+
+### FR-3: Suppress noisy telemetry for expected transient faults
+Reduce log/telemetry severity for connection-level Home Assistant failures so a single brief outage no longer floods Application Insights:
+- Demote `IOException` / `SocketException` / `HttpRequestException` thrown by `FetchSensorValueAsync` from `LogWarning(ex, …)` to `LogDebug` when the retry pipeline ultimately recovers.
+- When all retries are exhausted for a sensor, log a single `LogWarning` *without* the exception object so AI ILogger does not record it as an exception trace; include structured properties `EntityId`, `Attempts`, `LastException.GetType().Name`, `LastException.Message`.
+- Suppress the Application Insights dependency telemetry record for the retried calls by attaching a `DependencyTelemetryInitializer` (or equivalent) that filters successful-after-retry attempts. Failed-after-retry attempts MUST still produce exactly one Faulted dependency record per snapshot fetch (not one per retry).
+
+**Acceptance criteria:**
+- A 7-day window matching the original signal would produce ≤ ~1 Faulted dependency per actual outage instead of one per call (target reduction: ≥80%).
+- No `IOException` exception traces appear in AI for recoverable transients.
+- Final-failure telemetry is still queryable via `customDimensions.EntityId` and structured fields for alerting.
+
+### FR-4: Emit a stable health metric and Application Insights custom metric
+Expose two signals so on-call operators can monitor the integration without grepping logs:
+1. An ASP.NET Core health check `homeassistant-conditions` registered with the standard health-checks pipeline (probe path unchanged; HA check is part of the existing readiness/liveness setup if any, otherwise added under `/health`).
+2. A custom metric `homeassistant.snapshot.source` (counter, one increment per `GetCurrentSnapshotAsync` call) tagged with the resulting `Source` value (`Live` / `Partial` / `Stale` / `Unavailable`).
+
+**Acceptance criteria:**
+- Health check returns `Healthy` when the most recent snapshot is `Live` and ≤ `LiveSnapshotMaxAgeMinutes` (default 15) old, `Degraded` when `Partial` or `Stale`, `Unhealthy` when `Unavailable` or no snapshot exists.
+- Health check does NOT trigger an additional outbound HTTP call to Home Assistant on each probe (must read cached state only).
+- The custom metric is visible in AI via `customMetrics | where name == "homeassistant.snapshot.source"` and supports filtering by `source` dimension.
+
+### FR-5: Configurability of new behavior
+All new knobs ship as bound options on `HomeAssistantSettings` with safe defaults so the change is configuration-free.
+
+**Acceptance criteria:**
+- `RetryCount` (default `2`), `RetryBaseDelayMilliseconds` (default `200`), `StaleSnapshotMaxAgeMinutes` (default `60`), `LiveSnapshotMaxAgeMinutes` (default `15`) are settable via `appsettings*.json` / Key Vault.
+- Setting `RetryCount = 0` disables retry (legacy behavior) without disabling stale fallback.
+- Setting `StaleSnapshotMaxAgeMinutes = 0` disables the stale fallback (legacy behavior).
+- Defaults are documented inline via `<summary>` XML doc comments on the option properties.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Happy-path latency for `GetCurrentSnapshotAsync` must not regress: p95 ≤ 700 ms (currently ~616 ms).
+- Worst-case latency for a fully-failing snapshot fetch (all 4 sensors fail all retries) must be ≤ 12 s with default settings (4 sensors run in parallel; each capped at `RequestTimeoutSeconds` × `(RetryCount + 1)` ≈ 9 s).
+- Stale-fallback path must add ≤ 5 ms vs. a cache hit (in-memory lookup only).
+
+### NFR-2: Security
+- No new credentials introduced; all HTTP auth continues to flow through the existing `Bearer` token sourced from `HomeAssistantSettings.AccessToken` (Key Vault).
+- Logging must continue to avoid emitting `AccessToken` or the bearer header (verify in unit test).
+- The Polly retry pipeline must not leak HTTP request/response bodies into logs.
+
+### NFR-3: Reliability and resilience
+- Single-flight protection on `GetCurrentSnapshotAsync`: concurrent callers during cache miss must not produce more than one outbound burst of 4 sensor calls. Use the existing `IMemoryCache` semantics plus an `AsyncLock` keyed by `CacheKey`, or `MemoryCacheEntryOptions` with a factory pattern.
+- Retry pipeline must be per-call (not per-process) so unrelated callers don't share state.
+
+### NFR-4: Observability
+- Every snapshot fetch emits exactly one structured log event at `Information` summarizing `Source`, `LiveSensorCount`, `Duration`, `RetryAttempts`.
+- The single warning emitted on full failure includes correlation properties (`EntityId`, `Attempts`).
+
+### NFR-5: Testability
+- Unit tests cover: happy path, single transient failure recovered by retry, full failure with stale fallback, full failure without stale fallback, stale snapshot expiry, cold start with no cache, cancellation during retry, partial live snapshot does not overwrite last-known-good, telemetry suppression behavior.
+- Coverage target ≥ 80% on the adapter project (existing target).
+- Tests use `Moq` `HttpMessageHandler` patterns already established in `HomeAssistantConditionsReadingProviderTests.cs`.
+
+## Data Model
+
+### Updated enum `ConditionsReadingSource`
+Add a new value while preserving existing ordinals:
+```
+public enum ConditionsReadingSource
+{
+    Live = 1,
+    Partial = 2,
+    Unavailable = 3,
+    Stale = 4,   // new — served from last-known-good cache
+}
+```
+Downstream consumers (`ManufactureConditionsTile`, `ManufactureProtocolData`, `ManufactureProtocolDocument`, `UpdateManufactureOrderStatusHandler`) MUST be audited to confirm they handle `Stale` sensibly (display the value, optionally annotate "data may be stale"). No DB migration required (enum is in-memory only).
+
+### Internal "last-known-good" cache entry
+New cache key `HomeAssistant_LastKnownGoodSnapshot` storing the most recent `Live` `ConditionsSnapshot`. Lifetime = `StaleSnapshotMaxAgeMinutes` (sliding expiration disabled — absolute expiry from `RecordedAt`).
+
+### `HomeAssistantSettings` additions
+```
+public int RetryCount { get; init; } = 2;
+public int RetryBaseDelayMilliseconds { get; init; } = 200;
+public int StaleSnapshotMaxAgeMinutes { get; init; } = 60;
+public int LiveSnapshotMaxAgeMinutes { get; init; } = 15;
+```
+
+## API / Interface Design
+
+### Provider public surface — unchanged
+`IConditionsReadingProvider.GetCurrentSnapshotAsync(CancellationToken)` keeps its signature. Behavior changes are described in FR-2 and FR-3.
+
+### DI registration changes
+`HomeAssistantAdapterServiceCollectionExtensions.AddHomeAssistantAdapter` is extended to:
+1. Configure a Polly resilience pipeline on the typed `HttpClient` via `AddStandardResilienceHandler` or an inline `AddResilienceHandler` (preferred: explicit configuration for the retry strategy described in FR-1).
+2. Register a `HomeAssistantConditionsHealthCheck : IHealthCheck` against the existing `IHealthChecksBuilder`. If the project does not yet wire health checks for outbound dependencies, add `services.AddHealthChecks().AddCheck<HomeAssistantConditionsHealthCheck>("homeassistant-conditions")`.
+3. Register the dependency-telemetry filter (`ITelemetryProcessor` or `ITelemetryInitializer`) only when `services.AddApplicationInsightsTelemetry(...)` is in use — detect via `IConfiguration` check on `ApplicationInsights:ConnectionString` to avoid coupling the adapter to AI when AI isn't configured.
+
+### Health endpoint
+No new HTTP route; existing health endpoint (if present) gains the `homeassistant-conditions` check. If no health endpoint exists, this spec adds one under `GET /health` returning standard ASP.NET Core health-check JSON payload, gated behind the `Production` and `Staging` environments only (same env policy as today's other diagnostic endpoints).
+
+### Configuration shape (`appsettings.json` / Key Vault)
+```
+"HomeAssistant": {
+  "BaseUrl": "https://homeassistant.tail0cdb23.ts.net",
+  "AccessToken": "<from KV>",
+  "InnerTemperatureEntityId": "…",
+  …
+  "RequestTimeoutSeconds": 3,
+  "ConditionsCacheDurationMinutes": 5,
+  "RetryCount": 2,
+  "RetryBaseDelayMilliseconds": 200,
+  "StaleSnapshotMaxAgeMinutes": 60,
+  "LiveSnapshotMaxAgeMinutes": 15
+}
+```
+Existing Key Vault secrets (`HomeAssistant--BaseUrl`, `HomeAssistant--AccessToken`, etc.) are unchanged. New options have safe defaults and need no KV entry to function.
+
+## Dependencies
+- **Polly v8** (`Microsoft.Extensions.Http.Resilience` package) — already a transitive dependency via .NET 8 templates; confirm it is referenced directly in `Anela.Heblo.Adapters.HomeAssistant.csproj`, add if missing.
+- **Microsoft.Extensions.Diagnostics.HealthChecks** — verify presence; pull in if not already referenced by the API project graph.
+- **Microsoft.ApplicationInsights** dependency-tracking telemetry initializer hook — already in use by the host; the adapter will only register an `ITelemetryProcessor` if AI is configured in DI.
+- Domain enum change is consumed by `ManufactureConditionsTile`, `ManufactureProtocolData`, `ManufactureProtocolDocument`, `UpdateManufactureOrderStatusHandler` — those four files require touch-up.
+
+## Out of Scope
+- Investigating or remediating the underlying Tailscale tunnel instability or Home Assistant uptime (operational, not application).
+- Switching transport away from the Tailscale tunnel (e.g., direct VPN, public reverse proxy).
+- Adding push/webhook-based sensor updates from Home Assistant instead of polling.
+- Surfacing per-sensor history or trend charts in the frontend.
+- Changing the manufacture-order conditions UX (tile/PDF) — only enum-handling correctness, not visual redesign.
+- Alerting rules / Application Insights workbook updates (handled separately by ops).
+- Front-end changes to display the new `Stale` source visually beyond confirming the existing "data may be unavailable" affordance still renders correctly.
+
+## Open Questions
+None.
+
+## Status: COMPLETE
+```

--- a/artifacts/feat-telemetry-homeassistant-http-dependency-/task-plan.r1.md
+++ b/artifacts/feat-telemetry-homeassistant-http-dependency-/task-plan.r1.md
@@ -1,0 +1,22 @@
+Plan saved to `docs/superpowers/plans/2026-06-13-resilient-homeassistant-dependency.md`.
+
+**Summary of the 16-task plan:**
+
+1. **Domain enum** — append `Stale = 4` to `ConditionsReadingSource`.
+2. **PDF consumer** — add `Stale => " (Starší údaje)"` switch arm in `ManufactureProtocolDocument`.
+3. **Settings knobs** — `RetryCount`, `RetryBaseDelayMilliseconds`, `RetryMaxDelaySeconds`, `StaleSnapshotMaxAgeMinutes`, `LiveSnapshotMaxAgeMinutes`.
+4. **NuGet packages** — `Microsoft.Extensions.Http.Resilience` 8.10.0, `Microsoft.Extensions.Diagnostics.HealthChecks` 8.0.0, `Microsoft.ApplicationInsights` 2.22.0.
+5. **`HomeAssistantSnapshotCoordinator`** (TDD) — singleton with single-flight gate, last-observed, last-known-good `Live`.
+6. **`HomeAssistantSnapshotMetrics`** — `Meter`-backed `homeassistant.snapshot.source` counter.
+7. **Transient-error predicate** — centralizes "what counts as retryable".
+8. **Retry-activity tagging `DelegatingHandler`** — tags `Activity.Current` with `ha.retry-suppress` on transient send failures.
+9. **`HomeAssistantDependencyTelemetryFilter`** (TDD) — `ITelemetryProcessor` that drops tagged dependencies.
+10. **`HomeAssistantConditionsHealthCheck`** (TDD) — coordinator-only, never calls HA.
+11. **Provider rewrite** (TDD) — single-flight, stale fallback, structured `Information` summary, demoted final-failure warning without exception object.
+12. **DI wiring** — `AddResilienceHandler` + `HttpClient.Timeout = Infinite` + tagging handler + singletons.
+13. **End-to-end retry pipeline tests** — recovery from one transient, exhausted retries → `Unavailable`.
+14. **API health check registration** — tags `{ "homeassistant", "ready" }`.
+15. **Conditional AI processor registration** — alongside existing `CostOptimizedTelemetryProcessor`.
+16. **Final build / format / test sweep**.
+
+Self-review confirms full FR/NFR coverage, type consistency across tasks (`Coordinator.Gate`, `SuppressTagName`, predicate shape, provider ctor), and no placeholders.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj
@@ -9,8 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Caching/HomeAssistantSnapshotCoordinator.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Caching/HomeAssistantSnapshotCoordinator.cs
@@ -1,0 +1,23 @@
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Caching;
+
+public sealed class HomeAssistantSnapshotCoordinator
+{
+    public SemaphoreSlim Gate { get; } = new(initialCount: 1, maxCount: 1);
+
+    public ConditionsSnapshot? LastObservedSnapshot { get; private set; }
+
+    public ConditionsSnapshot? LastKnownGoodLive { get; private set; }
+
+    public void RecordObserved(ConditionsSnapshot snapshot)
+    {
+        LastObservedSnapshot = snapshot;
+    }
+
+    public void RecordLive(ConditionsSnapshot snapshot)
+    {
+        LastObservedSnapshot = snapshot;
+        LastKnownGoodLive = snapshot;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HealthChecks/HomeAssistantConditionsHealthCheck.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HealthChecks/HomeAssistantConditionsHealthCheck.cs
@@ -1,0 +1,57 @@
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
+
+public sealed class HomeAssistantConditionsHealthCheck : IHealthCheck
+{
+    private readonly HomeAssistantSnapshotCoordinator _coordinator;
+    private readonly HomeAssistantSettings _settings;
+    private readonly TimeProvider _timeProvider;
+
+    public HomeAssistantConditionsHealthCheck(
+        HomeAssistantSnapshotCoordinator coordinator,
+        IOptions<HomeAssistantSettings> options,
+        TimeProvider timeProvider)
+    {
+        _coordinator = coordinator;
+        _settings = options.Value;
+        _timeProvider = timeProvider;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var observed = _coordinator.LastObservedSnapshot;
+
+        if (observed is null)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                "No HomeAssistant snapshot has been observed yet."));
+        }
+
+        var age = _timeProvider.GetUtcNow().UtcDateTime - observed.RecordedAt;
+        var data = new Dictionary<string, object>
+        {
+            ["source"] = observed.Source.ToString(),
+            ["recordedAt"] = observed.RecordedAt,
+            ["ageSeconds"] = age.TotalSeconds,
+        };
+
+        return Task.FromResult(observed.Source switch
+        {
+            ConditionsReadingSource.Live when age <= TimeSpan.FromMinutes(_settings.LiveSnapshotMaxAgeMinutes)
+                => HealthCheckResult.Healthy("HomeAssistant snapshot is Live and fresh.", data),
+            ConditionsReadingSource.Live
+                => HealthCheckResult.Degraded("Last Live snapshot is older than LiveSnapshotMaxAgeMinutes.", data: data),
+            ConditionsReadingSource.Partial or ConditionsReadingSource.Stale
+                => HealthCheckResult.Degraded($"HomeAssistant snapshot is {observed.Source}.", data: data),
+            ConditionsReadingSource.Unavailable
+                => HealthCheckResult.Unhealthy("HomeAssistant snapshot is Unavailable.", data: data),
+            _ => HealthCheckResult.Unhealthy("Unknown snapshot source.", data: data),
+        });
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantAdapterServiceCollectionExtensions.cs
@@ -1,7 +1,13 @@
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
+using Anela.Heblo.Adapters.HomeAssistant.Resilience;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
+using Polly;
 
 namespace Anela.Heblo.Adapters.HomeAssistant;
 
@@ -16,24 +22,54 @@ public static class HomeAssistantAdapterServiceCollectionExtensions
 
         services.AddMemoryCache();
 
-        services.AddHttpClient<HomeAssistantConditionsReadingProvider>((sp, client) =>
+        services.AddSingleton<HomeAssistantSnapshotCoordinator>();
+        services.AddSingleton<HomeAssistantSnapshotMetrics>();
+        services.AddSingleton<TimeProvider>(_ => TimeProvider.System);
+        services.AddTransient<HomeAssistantRetryActivityTaggingHandler>();
+
+        var haClientBuilder = services.AddHttpClient<HomeAssistantConditionsReadingProvider>((sp, client) =>
         {
             var settings = sp.GetRequiredService<IOptions<HomeAssistantSettings>>().Value;
 
             if (string.IsNullOrWhiteSpace(settings.BaseUrl)
                 || !Uri.TryCreate(settings.BaseUrl, UriKind.Absolute, out var baseUri))
             {
-                // HomeAssistant is not configured for this environment.
-                // HTTP calls in HomeAssistantConditionsReadingProvider will fail per-sensor and
-                // return null, which bubbles up as ConditionsReadingSource.Unavailable — no exception.
+                // HomeAssistant not configured — HTTP calls will fail per-sensor and
+                // surface as ConditionsReadingSource.Unavailable.
                 return;
             }
 
             client.BaseAddress = baseUri;
-            client.Timeout = TimeSpan.FromSeconds(settings.RequestTimeoutSeconds);
+            // Per-attempt timeout is enforced by Polly AddTimeout below.
+            // Setting HttpClient.Timeout would cancel the entire retry chain.
+            client.Timeout = Timeout.InfiniteTimeSpan;
             client.DefaultRequestHeaders.Authorization =
                 new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", settings.AccessToken);
         });
+
+        // Outer: resilience (retry + per-attempt timeout)
+        haClientBuilder.AddResilienceHandler("ha-conditions", (builder, context) =>
+        {
+            var settings = context.ServiceProvider.GetRequiredService<IOptions<HomeAssistantSettings>>().Value;
+
+            builder
+                .AddRetry(new HttpRetryStrategyOptions
+                {
+                    MaxRetryAttempts = settings.RetryCount,
+                    Delay = TimeSpan.FromMilliseconds(settings.RetryBaseDelayMilliseconds),
+                    BackoffType = DelayBackoffType.Exponential,
+                    UseJitter = true,
+                    MaxDelay = TimeSpan.FromSeconds(settings.RetryMaxDelaySeconds),
+                    ShouldHandle = args => ValueTask.FromResult(
+                        HomeAssistantTransientErrorPredicate.IsTransient(
+                            args.Outcome.Exception,
+                            args.Outcome.Result)),
+                })
+                .AddTimeout(TimeSpan.FromSeconds(settings.RequestTimeoutSeconds));
+        });
+
+        // Inner: activity tagging runs inside the retry loop so each per-attempt Activity is tagged.
+        haClientBuilder.AddHttpMessageHandler<HomeAssistantRetryActivityTaggingHandler>();
 
         services.AddTransient<IConditionsReadingProvider>(
             sp => sp.GetRequiredService<HomeAssistantConditionsReadingProvider>());

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantConditionsReadingProvider.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantConditionsReadingProvider.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -14,17 +17,23 @@ public class HomeAssistantConditionsReadingProvider : IConditionsReadingProvider
     private readonly HttpClient _httpClient;
     private readonly HomeAssistantSettings _settings;
     private readonly IMemoryCache _cache;
+    private readonly HomeAssistantSnapshotCoordinator _coordinator;
+    private readonly HomeAssistantSnapshotMetrics _metrics;
     private readonly ILogger<HomeAssistantConditionsReadingProvider> _logger;
 
     public HomeAssistantConditionsReadingProvider(
         HttpClient httpClient,
         IOptions<HomeAssistantSettings> options,
         IMemoryCache cache,
+        HomeAssistantSnapshotCoordinator coordinator,
+        HomeAssistantSnapshotMetrics metrics,
         ILogger<HomeAssistantConditionsReadingProvider> logger)
     {
         _httpClient = httpClient;
         _settings = options.Value;
         _cache = cache;
+        _coordinator = coordinator;
+        _metrics = metrics;
         _logger = logger;
     }
 
@@ -32,37 +41,126 @@ public class HomeAssistantConditionsReadingProvider : IConditionsReadingProvider
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (TryGetCachedLive(out var cached))
+            return cached!;
+
+        var gateTimeout = ComputeGateTimeout();
+        if (!await _coordinator.Gate.WaitAsync(gateTimeout, cancellationToken))
+        {
+            return ServeStaleOrUnavailable(duration: TimeSpan.Zero, gateTimedOut: true);
+        }
+
+        try
+        {
+            if (TryGetCachedLive(out var cachedAfterGate))
+                return cachedAfterGate!;
+
+            var stopwatch = Stopwatch.StartNew();
+
+            var innerTempTask = FetchSensorValueAsync(_settings.InnerTemperatureEntityId, cancellationToken);
+            var innerHumidityTask = FetchSensorValueAsync(_settings.InnerHumidityEntityId, cancellationToken);
+            var outerTempTask = FetchSensorValueAsync(_settings.OuterTemperatureEntityId, cancellationToken);
+            var outerHumidityTask = FetchSensorValueAsync(_settings.OuterHumidityEntityId, cancellationToken);
+
+            await Task.WhenAll(innerTempTask, innerHumidityTask, outerTempTask, outerHumidityTask);
+
+            stopwatch.Stop();
+
+            var innerTemp = innerTempTask.Result;
+            var innerHumidity = innerHumidityTask.Result;
+            var outerTemp = outerTempTask.Result;
+            var outerHumidity = outerHumidityTask.Result;
+
+            var nonNullCount = new[] { innerTemp, innerHumidity, outerTemp, outerHumidity }.Count(v => v.HasValue);
+            var source = nonNullCount == 4 ? ConditionsReadingSource.Live
+                : nonNullCount == 0 ? ConditionsReadingSource.Unavailable
+                : ConditionsReadingSource.Partial;
+
+            if (source == ConditionsReadingSource.Unavailable)
+            {
+                return ServeStaleOrUnavailable(duration: stopwatch.Elapsed, gateTimedOut: false);
+            }
+
+            var snapshot = new ConditionsSnapshot(
+                InnerTemperature: innerTemp,
+                InnerHumidity: innerHumidity,
+                OuterTemperature: outerTemp,
+                OuterHumidity: outerHumidity,
+                RecordedAt: DateTime.UtcNow,
+                Source: source);
+
+            _cache.Set(CacheKey, snapshot, TimeSpan.FromMinutes(_settings.ConditionsCacheDurationMinutes));
+
+            if (source == ConditionsReadingSource.Live)
+                _coordinator.RecordLive(snapshot);
+            else
+                _coordinator.RecordObserved(snapshot);
+
+            _metrics.RecordSnapshot(source);
+            LogSummary(source, nonNullCount, stopwatch.Elapsed);
+
+            return snapshot;
+        }
+        finally
+        {
+            _coordinator.Gate.Release();
+        }
+    }
+
+    private bool TryGetCachedLive(out ConditionsSnapshot? snapshot)
+    {
         if (_cache.TryGetValue(CacheKey, out ConditionsSnapshot? cached) && cached is not null)
-            return cached;
+        {
+            snapshot = cached;
+            return true;
+        }
+        snapshot = null;
+        return false;
+    }
 
-        var innerTempTask = FetchSensorValueAsync(_settings.InnerTemperatureEntityId, cancellationToken);
-        var innerHumidityTask = FetchSensorValueAsync(_settings.InnerHumidityEntityId, cancellationToken);
-        var outerTempTask = FetchSensorValueAsync(_settings.OuterTemperatureEntityId, cancellationToken);
-        var outerHumidityTask = FetchSensorValueAsync(_settings.OuterHumidityEntityId, cancellationToken);
+    private ConditionsSnapshot ServeStaleOrUnavailable(TimeSpan duration, bool gateTimedOut)
+    {
+        var lkg = _coordinator.LastKnownGoodLive;
+        var staleMaxAge = TimeSpan.FromMinutes(_settings.StaleSnapshotMaxAgeMinutes);
 
-        await Task.WhenAll(innerTempTask, innerHumidityTask, outerTempTask, outerHumidityTask);
+        if (lkg is not null
+            && _settings.StaleSnapshotMaxAgeMinutes > 0
+            && (DateTime.UtcNow - lkg.RecordedAt) <= staleMaxAge)
+        {
+            var stale = lkg with { Source = ConditionsReadingSource.Stale };
+            _coordinator.RecordObserved(stale);
+            _metrics.RecordSnapshot(ConditionsReadingSource.Stale);
+            LogSummary(ConditionsReadingSource.Stale, liveSensorCount: 0, duration);
+            return stale;
+        }
 
-        var innerTemp = innerTempTask.Result;
-        var innerHumidity = innerHumidityTask.Result;
-        var outerTemp = outerTempTask.Result;
-        var outerHumidity = outerHumidityTask.Result;
+        var unavailable = new ConditionsSnapshot(null, null, null, null, DateTime.UtcNow, ConditionsReadingSource.Unavailable);
+        _coordinator.RecordObserved(unavailable);
+        _metrics.RecordSnapshot(ConditionsReadingSource.Unavailable);
 
-        var nonNullCount = new[] { innerTemp, innerHumidity, outerTemp, outerHumidity }.Count(v => v.HasValue);
-        var source = nonNullCount == 4 ? ConditionsReadingSource.Live
-            : nonNullCount == 0 ? ConditionsReadingSource.Unavailable
-            : ConditionsReadingSource.Partial;
+        if (gateTimedOut)
+        {
+            _logger.LogWarning(
+                "HomeAssistant snapshot fetch timed out waiting for single-flight gate ({GateTimeoutSeconds}s)",
+                ComputeGateTimeout().TotalSeconds);
+        }
 
-        var snapshot = new ConditionsSnapshot(
-            InnerTemperature: innerTemp,
-            InnerHumidity: innerHumidity,
-            OuterTemperature: outerTemp,
-            OuterHumidity: outerHumidity,
-            RecordedAt: DateTime.UtcNow,
-            Source: source);
+        LogSummary(ConditionsReadingSource.Unavailable, liveSensorCount: 0, duration);
+        return unavailable;
+    }
 
-        _cache.Set(CacheKey, snapshot, TimeSpan.FromMinutes(_settings.ConditionsCacheDurationMinutes));
+    private void LogSummary(ConditionsReadingSource source, int liveSensorCount, TimeSpan duration)
+    {
+        _logger.LogInformation(
+            "HomeAssistant snapshot {Source}, sensors={LiveSensorCount}, durationMs={DurationMs}",
+            source, liveSensorCount, duration.TotalMilliseconds);
+    }
 
-        return snapshot;
+    private TimeSpan ComputeGateTimeout()
+    {
+        var perAttempt = TimeSpan.FromSeconds(_settings.RequestTimeoutSeconds);
+        var attempts = Math.Max(1, _settings.RetryCount + 1);
+        return perAttempt * attempts + TimeSpan.FromSeconds(1);
     }
 
     private async Task<decimal?> FetchSensorValueAsync(string entityId, CancellationToken cancellationToken)
@@ -105,13 +203,16 @@ public class HomeAssistantConditionsReadingProvider : IConditionsReadingProvider
 
             return value;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to fetch HomeAssistant entity {EntityId}", entityId);
+            // Exception object NOT passed to LogWarning to avoid AI ILogger recording an exception trace.
+            _logger.LogWarning(
+                "HomeAssistant fetch exhausted retries for {EntityId} after {Attempts} attempts: {ExceptionType} {ExceptionMessage}",
+                entityId, _settings.RetryCount + 1, ex.GetType().Name, ex.Message);
             return null;
         }
     }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantSettings.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantSettings.cs
@@ -12,4 +12,19 @@ public class HomeAssistantSettings
     public string OuterHumidityEntityId { get; init; } = null!;
     public int RequestTimeoutSeconds { get; init; } = 3;
     public int ConditionsCacheDurationMinutes { get; init; } = 5;
+
+    /// <summary>Polly retry attempts on transient HTTP failures. 0 disables retry.</summary>
+    public int RetryCount { get; init; } = 2;
+
+    /// <summary>Base delay (ms) for exponential backoff between retry attempts.</summary>
+    public int RetryBaseDelayMilliseconds { get; init; } = 200;
+
+    /// <summary>Upper bound (seconds) on the jittered backoff between retry attempts.</summary>
+    public int RetryMaxDelaySeconds { get; init; } = 2;
+
+    /// <summary>Last-known-good snapshot is reused for up to this many minutes. 0 disables stale fallback.</summary>
+    public int StaleSnapshotMaxAgeMinutes { get; init; } = 60;
+
+    /// <summary>Health check reports Healthy only if the last Live snapshot is younger than this.</summary>
+    public int LiveSnapshotMaxAgeMinutes { get; init; } = 15;
 }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantRetryActivityTaggingHandler.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantRetryActivityTaggingHandler.cs
@@ -7,7 +7,7 @@ namespace Anela.Heblo.Adapters.HomeAssistant.Resilience;
 /// Application Insights dependency processor can drop transient retries
 /// before they reach the AI ingestion endpoint.
 /// </summary>
-internal sealed class HomeAssistantRetryActivityTaggingHandler : DelegatingHandler
+public sealed class HomeAssistantRetryActivityTaggingHandler : DelegatingHandler
 {
     public const string SuppressTagName = "ha.retry-suppress";
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantRetryActivityTaggingHandler.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantRetryActivityTaggingHandler.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Resilience;
+
+/// <summary>
+/// Tags the per-attempt Activity when the HTTP send throws, so the
+/// Application Insights dependency processor can drop transient retries
+/// before they reach the AI ingestion endpoint.
+/// </summary>
+internal sealed class HomeAssistantRetryActivityTaggingHandler : DelegatingHandler
+{
+    public const string SuppressTagName = "ha.retry-suppress";
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            if (HomeAssistantTransientErrorPredicate.IsTransient(exception: null, result: response))
+            {
+                Activity.Current?.SetTag(SuppressTagName, "true");
+            }
+            return response;
+        }
+        catch (Exception ex) when (HomeAssistantTransientErrorPredicate.IsTransient(ex, result: null))
+        {
+            Activity.Current?.SetTag(SuppressTagName, "true");
+            throw;
+        }
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantTransientErrorPredicate.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantTransientErrorPredicate.cs
@@ -1,0 +1,38 @@
+using System.Net.Sockets;
+using Polly.Retry;
+using Polly.Timeout;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Resilience;
+
+/// <summary>
+/// Transient error predicate for HomeAssistant HTTP resilience policies.
+/// Determines which failures should be retried and which should fail fast.
+/// Caller cancellation is always respected — never retried when caller requests cancellation.
+/// </summary>
+internal static class HomeAssistantTransientErrorPredicate
+{
+    /// <summary>
+    /// Determines whether an exception or result is transient and should trigger a retry.
+    /// Used in retry strategy ShouldHandle predicates.
+    /// </summary>
+    public static bool IsTransient(Exception? exception, object? result)
+    {
+        if (exception is null && result is HttpResponseMessage response)
+        {
+            return (int)response.StatusCode >= 500;
+        }
+
+        return exception switch
+        {
+            IOException => true,
+            SocketException => true,
+            HttpRequestException => true,
+            TimeoutException => true,
+            // Polly's TimeoutStrategy raises this on a per-attempt timeout.
+            TimeoutRejectedException => true,
+            // Per-attempt cancellation triggered by Polly's timeout strategy is internal — retry.
+            OperationCanceledException oce when oce.CancellationToken == default => true,
+            _ => false,
+        };
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantDependencyTelemetryFilter.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantDependencyTelemetryFilter.cs
@@ -1,0 +1,28 @@
+using Anela.Heblo.Adapters.HomeAssistant.Resilience;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+
+public sealed class HomeAssistantDependencyTelemetryFilter : ITelemetryProcessor
+{
+    private readonly ITelemetryProcessor _next;
+
+    public HomeAssistantDependencyTelemetryFilter(ITelemetryProcessor next)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+    }
+
+    public void Process(ITelemetry item)
+    {
+        if (item is DependencyTelemetry dep
+            && dep.Properties.TryGetValue(HomeAssistantRetryActivityTaggingHandler.SuppressTagName, out var value)
+            && string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _next.Process(item);
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantSnapshotMetrics.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantSnapshotMetrics.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.Metrics;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+
+public sealed class HomeAssistantSnapshotMetrics : IDisposable
+{
+    public const string MeterName = "Anela.Heblo.HomeAssistant";
+    public const string SnapshotCounterName = "homeassistant.snapshot.source";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _snapshotCounter;
+
+    public HomeAssistantSnapshotMetrics()
+    {
+        _meter = new Meter(MeterName);
+        _snapshotCounter = _meter.CreateCounter<long>(SnapshotCounterName);
+    }
+
+    public void RecordSnapshot(ConditionsReadingSource source)
+    {
+        _snapshotCounter.Add(1, new KeyValuePair<string, object?>("source", source.ToString()));
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
 using Anela.Heblo.API.Telemetry;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
 
 namespace Anela.Heblo.API.Extensions;
 
@@ -59,6 +60,7 @@ public static class ApplicationInsightsExtensions
 
         // Add telemetry processor for filtering
         services.AddApplicationInsightsTelemetryProcessor<CostOptimizedTelemetryProcessor>();
+        services.AddApplicationInsightsTelemetryProcessor<HomeAssistantDependencyTelemetryFilter>();
 
         // Configure sampling (more aggressive for cost savings)
         services.Configure<TelemetryConfiguration>((config) =>

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ using Anela.Heblo.API.Features.ExpeditionList;
 using Anela.Heblo.Application.Shared.Printing;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetSemiproductRecipePdf;
+using Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
 
 namespace Anela.Heblo.API.Extensions;
 
@@ -104,7 +105,11 @@ public static class ServiceCollectionExtensions
             .AddCheck<DataQualitySchemaHealthCheck>(
                 name: "data-quality-schema",
                 failureStatus: HealthStatus.Unhealthy,
-                tags: new[] { "ready", "db", "schema" });
+                tags: new[] { "ready", "db", "schema" })
+            .AddCheck<HomeAssistantConditionsHealthCheck>(
+                name: "homeassistant-conditions",
+                failureStatus: HealthStatus.Degraded,
+                tags: new[] { "ready", "homeassistant" });
 
         // Add database health check via the shared NpgsqlDataSource so the probe
         // reuses the application connection pool instead of opening a fresh connection

--- a/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
+++ b/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
@@ -278,6 +278,7 @@ public class ManufactureProtocolDocument : IDocument
         ConditionsReadingSource.Live => string.Empty,
         ConditionsReadingSource.Partial => " (Částečné)",
         ConditionsReadingSource.Unavailable => " (HA nedostupný)",
+        ConditionsReadingSource.Stale => " (Starší údaje)",
         _ => string.Empty,
     };
 

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/Conditions/ConditionsReadingSource.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/Conditions/ConditionsReadingSource.cs
@@ -5,4 +5,5 @@ public enum ConditionsReadingSource
     Live = 1,
     Partial = 2,
     Unavailable = 3,
+    Stale = 4,
 }

--- a/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj
+++ b/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj
@@ -11,12 +11,14 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 

--- a/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsHealthCheckTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsHealthCheckTests.cs
@@ -1,0 +1,81 @@
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using FluentAssertions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantConditionsHealthCheckTests
+{
+    private readonly HomeAssistantSettings _settings = new()
+    {
+        BaseUrl = "http://ha.test",
+        AccessToken = "tok",
+        InnerTemperatureEntityId = "i_t",
+        InnerHumidityEntityId = "i_h",
+        OuterTemperatureEntityId = "o_t",
+        OuterHumidityEntityId = "o_h",
+        LiveSnapshotMaxAgeMinutes = 15,
+    };
+
+    private HomeAssistantConditionsHealthCheck CreateCheck(HomeAssistantSnapshotCoordinator coordinator) =>
+        new(coordinator, Options.Create(_settings), TimeProvider.System);
+
+    private static ConditionsSnapshot Snap(ConditionsReadingSource source, DateTime recordedAt) =>
+        new(21m, 55m, 18m, 72m, recordedAt, source);
+
+    [Fact]
+    public async Task CheckHealthAsync_NoSnapshot_ReturnsUnhealthy()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_FreshLive_ReturnsHealthy()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordLive(Snap(ConditionsReadingSource.Live, DateTime.UtcNow));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_OldLive_ReturnsDegraded()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordLive(Snap(ConditionsReadingSource.Live, DateTime.UtcNow.AddMinutes(-30)));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_LastObservedPartial_ReturnsDegraded()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordObserved(Snap(ConditionsReadingSource.Partial, DateTime.UtcNow));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_LastObservedStale_ReturnsDegraded()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordObserved(Snap(ConditionsReadingSource.Stale, DateTime.UtcNow.AddMinutes(-3)));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_LastObservedUnavailable_ReturnsUnhealthy()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordObserved(Snap(ConditionsReadingSource.Unavailable, DateTime.UtcNow));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsReadingProviderTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsReadingProviderTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Text.Json;
 using Anela.Heblo.Adapters.HomeAssistant;
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using FluentAssertions;
 using Microsoft.Extensions.Caching.Memory;
@@ -29,10 +31,14 @@ public class HomeAssistantConditionsReadingProviderTests
             OuterHumidityEntityId = "sensor.outer_humidity",
             RequestTimeoutSeconds = 5,
             ConditionsCacheDurationMinutes = 5,
+            StaleSnapshotMaxAgeMinutes = 60,
         };
     }
 
-    private HomeAssistantConditionsReadingProvider CreateProvider(IMemoryCache? cache = null)
+    private HomeAssistantConditionsReadingProvider CreateProvider(
+        IMemoryCache? cache = null,
+        HomeAssistantSnapshotCoordinator? coordinator = null,
+        HomeAssistantSnapshotMetrics? metrics = null)
     {
         var httpClient = new HttpClient(_handlerMock.Object)
         {
@@ -41,7 +47,11 @@ public class HomeAssistantConditionsReadingProviderTests
         };
         var options = Options.Create(_settings);
         cache ??= new MemoryCache(new MemoryCacheOptions());
-        return new HomeAssistantConditionsReadingProvider(httpClient, options, cache, NullLogger<HomeAssistantConditionsReadingProvider>.Instance);
+        coordinator ??= new HomeAssistantSnapshotCoordinator();
+        metrics ??= new HomeAssistantSnapshotMetrics();
+        return new HomeAssistantConditionsReadingProvider(
+            httpClient, options, cache, coordinator, metrics,
+            NullLogger<HomeAssistantConditionsReadingProvider>.Instance);
     }
 
     private void SetupSensorResponse(string entityId, string stateValue, HttpStatusCode status = HttpStatusCode.OK)
@@ -277,5 +287,163 @@ public class HomeAssistantConditionsReadingProviderTests
             Times.Exactly(8),
             ItExpr.IsAny<HttpRequestMessage>(),
             ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_UnavailableLive_WithFreshLkg_ReturnsStaleFromLkg()
+    {
+        // Arrange — first call succeeds (populates LKG), second call all fail.
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(cache, coordinator);
+
+        var live = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+        live.Source.Should().Be(ConditionsReadingSource.Live);
+
+        // Invalidate live cache and reconfigure all to fail.
+        cache.Remove(HomeAssistantConditionsReadingProvider.CacheKey);
+        _handlerMock.Reset();
+        SetupSensorFailure("sensor.inner_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.inner_humidity", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_humidity", HttpStatusCode.InternalServerError);
+
+        // Act
+        var stale = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // Assert
+        stale.Source.Should().Be(ConditionsReadingSource.Stale);
+        stale.InnerTemperature.Should().Be(21.5m);
+        stale.RecordedAt.Should().Be(live.RecordedAt, "stale snapshot carries the LKG timestamp");
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_UnavailableLive_WithExpiredLkg_ReturnsUnavailable()
+    {
+        // Arrange — populate LKG manually with an old snapshot.
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        coordinator.RecordLive(new ConditionsSnapshot(
+            21m, 55m, 18m, 72m,
+            DateTime.UtcNow.AddMinutes(-_settings.StaleSnapshotMaxAgeMinutes - 1),
+            ConditionsReadingSource.Live));
+
+        SetupSensorFailure("sensor.inner_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.inner_humidity", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_humidity", HttpStatusCode.InternalServerError);
+
+        var provider = CreateProvider(coordinator: coordinator);
+
+        // Act
+        var result = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // Assert
+        result.Source.Should().Be(ConditionsReadingSource.Unavailable);
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_ColdStart_NoCache_AllFail_ReturnsUnavailable()
+    {
+        SetupSensorFailure("sensor.inner_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.inner_humidity", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_humidity", HttpStatusCode.InternalServerError);
+
+        var provider = CreateProvider();
+
+        var result = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        result.Source.Should().Be(ConditionsReadingSource.Unavailable);
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_PartialLive_DoesNotOverwriteLkg()
+    {
+        // Arrange — first call all live to populate LKG.
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(cache, coordinator);
+
+        var live = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+        coordinator.LastKnownGoodLive.Should().NotBeNull();
+
+        // Invalidate cache, make one sensor fail (partial result).
+        cache.Remove(HomeAssistantConditionsReadingProvider.CacheKey);
+        _handlerMock.Reset();
+        SetupSensorResponse("sensor.inner_temp", "22.0");
+        SetupSensorResponse("sensor.inner_humidity", "56.0");
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorResponse("sensor.outer_humidity", "73.0");
+
+        // Act
+        var partial = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // Assert
+        partial.Source.Should().Be(ConditionsReadingSource.Partial);
+        coordinator.LastKnownGoodLive.Should().Be(live, "Partial result must not overwrite LKG");
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_RecordsLastObservedOnCoordinator()
+    {
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(coordinator: coordinator);
+
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        coordinator.LastObservedSnapshot.Should().Be(snapshot);
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_ConcurrentCallers_ProduceOnlyOneBurstOfHttpCalls()
+    {
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(cache, coordinator);
+
+        // Act
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => provider.GetCurrentSnapshotAsync(CancellationToken.None))
+            .ToArray();
+        await Task.WhenAll(tasks);
+
+        // Assert — only 4 outbound HTTP calls, not 40.
+        _handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(4),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_PreCancelledToken_ThrowsBeforeAcquiringGate()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var provider = CreateProvider();
+
+        var act = async () => await provider.GetCurrentSnapshotAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantDependencyTelemetryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantDependencyTelemetryFilterTests.cs
@@ -1,0 +1,52 @@
+using Anela.Heblo.Adapters.HomeAssistant.Resilience;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+using FluentAssertions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Moq;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantDependencyTelemetryFilterTests
+{
+    private readonly Mock<ITelemetryProcessor> _next = new();
+    private readonly HomeAssistantDependencyTelemetryFilter _filter;
+
+    public HomeAssistantDependencyTelemetryFilterTests()
+    {
+        _filter = new HomeAssistantDependencyTelemetryFilter(_next.Object);
+    }
+
+    [Fact]
+    public void Process_DropsDependencyTelemetryTaggedSuppress()
+    {
+        var dep = new DependencyTelemetry { Name = "GET /api/states/sensor.x" };
+        dep.Properties[HomeAssistantRetryActivityTaggingHandler.SuppressTagName] = "true";
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(It.IsAny<ITelemetry>()), Times.Never);
+    }
+
+    [Fact]
+    public void Process_ForwardsDependencyTelemetryWithoutSuppressTag()
+    {
+        var dep = new DependencyTelemetry { Name = "GET /api/states/sensor.x" };
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(dep), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsNonDependencyTelemetryEvenIfTaggedSomehow()
+    {
+        var trace = new TraceTelemetry("hello");
+        trace.Properties[HomeAssistantRetryActivityTaggingHandler.SuppressTagName] = "true";
+
+        _filter.Process(trace);
+
+        _next.Verify(n => n.Process(trace), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantRetryPipelineTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantRetryPipelineTests.cs
@@ -46,6 +46,36 @@ public class HomeAssistantRetryPipelineTests
         };
 
     [Fact]
+    public async Task Resilience_RecoversOneTransientIoException_ProducesLiveSnapshot()
+    {
+        // Each sensor fails on its FIRST attempt, succeeds on retry — verified via per-entity call count.
+        var perEntityCalls = new System.Collections.Concurrent.ConcurrentDictionary<string, int>();
+        var handler = new StatefulHandler(request =>
+        {
+            var entityId = request.RequestUri!.Segments.Last();
+            var count = perEntityCalls.AddOrUpdate(entityId, 1, (_, v) => v + 1);
+            if (count == 1)
+                throw new IOException("boom on first attempt");
+            return Json(entityId switch
+            {
+                "sensor.inner_temp" => "21.5",
+                "sensor.inner_humidity" => "55.0",
+                "sensor.outer_temp" => "18.2",
+                "sensor.outer_humidity" => "72.3",
+                _ => "0",
+            });
+        });
+
+        using var sp = (ServiceProvider)BuildProvider(handler);
+        var provider = sp.GetRequiredService<HomeAssistantConditionsReadingProvider>();
+
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        snapshot.Source.Should().Be(ConditionsReadingSource.Live);
+        handler.CallCount.Should().Be(8, "each of 4 sensors fails once and retries once");
+    }
+
+    [Fact]
     public async Task Resilience_AllSucceed_ProducesLiveSnapshot()
     {
         HttpResponseMessage Handler(HttpRequestMessage request)
@@ -127,6 +157,27 @@ public class HomeAssistantRetryPipelineTests
         // With 4 sensors and up to 3 attempts each, we expect up to 12 calls,
         // but we only fail the first 2, so we should use slightly more than 4 calls
         handler.CallCount.Should().BeGreaterThan(4, "retry policy should make additional attempts");
+    }
+
+    private sealed class SequencedHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> _responses;
+        public int CallCount { get; private set; }
+
+        public SequencedHandler(params Func<HttpResponseMessage>[] responses)
+        {
+            _responses = new Queue<Func<HttpResponseMessage>>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            if (_responses.Count == 0)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            var factory = _responses.Dequeue();
+            try { return Task.FromResult(factory()); }
+            catch (Exception ex) { return Task.FromException<HttpResponseMessage>(ex); }
+        }
     }
 
     private sealed class StatefulHandler : HttpMessageHandler

--- a/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantRetryPipelineTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantRetryPipelineTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Text.Json;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantRetryPipelineTests
+{
+    private static IServiceProvider BuildProvider(HttpMessageHandler handler)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["HomeAssistant:BaseUrl"] = "http://ha.test:8123",
+                ["HomeAssistant:AccessToken"] = "tok",
+                ["HomeAssistant:InnerTemperatureEntityId"] = "sensor.inner_temp",
+                ["HomeAssistant:InnerHumidityEntityId"] = "sensor.inner_humidity",
+                ["HomeAssistant:OuterTemperatureEntityId"] = "sensor.outer_temp",
+                ["HomeAssistant:OuterHumidityEntityId"] = "sensor.outer_humidity",
+                ["HomeAssistant:RequestTimeoutSeconds"] = "5",
+                ["HomeAssistant:RetryCount"] = "2",
+                ["HomeAssistant:RetryBaseDelayMilliseconds"] = "10",
+                ["HomeAssistant:RetryMaxDelaySeconds"] = "1",
+                ["HomeAssistant:StaleSnapshotMaxAgeMinutes"] = "60",
+                ["HomeAssistant:LiveSnapshotMaxAgeMinutes"] = "15",
+                ["HomeAssistant:ConditionsCacheDurationMinutes"] = "5",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHomeAssistantAdapter(config);
+        services.ConfigureHttpClientDefaults(b =>
+            b.ConfigurePrimaryHttpMessageHandler(() => handler));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static HttpResponseMessage Json(string state) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(new { state, entity_id = "x" })),
+        };
+
+    [Fact]
+    public async Task Resilience_AllSucceed_ProducesLiveSnapshot()
+    {
+        HttpResponseMessage Handler(HttpRequestMessage request)
+        {
+            var entityId = request.RequestUri?.LocalPath.Split('/').Last() ?? "unknown";
+            return Json(entityId switch
+            {
+                "sensor.inner_temp" => "21.5",
+                "sensor.inner_humidity" => "55.0",
+                "sensor.outer_temp" => "18.2",
+                "sensor.outer_humidity" => "72.3",
+                _ => "0"
+            });
+        }
+
+        var handler = new StatefulHandler(Handler);
+
+        using var sp = (ServiceProvider)BuildProvider((HttpMessageHandler)handler);
+        var provider = sp.GetRequiredService<HomeAssistantConditionsReadingProvider>();
+
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        snapshot.Source.Should().Be(ConditionsReadingSource.Live);
+        snapshot.InnerTemperature.Should().Be(21.5m);
+        snapshot.InnerHumidity.Should().Be(55.0m);
+        snapshot.OuterTemperature.Should().Be(18.2m);
+        snapshot.OuterHumidity.Should().Be(72.3m);
+        handler.CallCount.Should().Be(4, "each of 4 sensors succeeds on first attempt");
+    }
+
+    [Fact]
+    public async Task Resilience_RetryPolicyIsActive_AllowsMoreAttempts()
+    {
+        // Verify Polly retry is active: fail first 2 attempts globally, succeed after
+        int callCount = 0;
+        var lockObj = new object();
+
+        HttpResponseMessage Handler(HttpRequestMessage request)
+        {
+            lock (lockObj)
+            {
+                callCount++;
+                // First 2 calls globally fail, then all succeed
+                if (callCount <= 2)
+                    throw new IOException($"transient attempt #{callCount}");
+            }
+
+            var path = request.RequestUri?.LocalPath ?? "/unknown";
+            var sensorName = path.Contains("inner_temp") ? "inner_temp"
+                : path.Contains("inner_humidity") ? "inner_humidity"
+                : path.Contains("outer_temp") ? "outer_temp"
+                : path.Contains("outer_humidity") ? "outer_humidity"
+                : "unknown";
+
+            return Json(sensorName switch
+            {
+                "inner_temp" => "21.5",
+                "inner_humidity" => "55.0",
+                "outer_temp" => "18.2",
+                "outer_humidity" => "72.3",
+                _ => "0"
+            });
+        }
+
+        var handler = new StatefulHandler(Handler);
+
+        using var sp = (ServiceProvider)BuildProvider((HttpMessageHandler)handler);
+        var provider = sp.GetRequiredService<HomeAssistantConditionsReadingProvider>();
+
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // With RetryCount=2 (meaning up to 3 total attempts per sensor),
+        // we expect to eventually succeed if only the first 2 global calls fail
+        snapshot.Source.Should().Be(ConditionsReadingSource.Live);
+        snapshot.InnerTemperature.Should().Be(21.5m);
+        snapshot.InnerHumidity.Should().Be(55.0m);
+        snapshot.OuterTemperature.Should().Be(18.2m);
+        snapshot.OuterHumidity.Should().Be(72.3m);
+        // With 4 sensors and up to 3 attempts each, we expect up to 12 calls,
+        // but we only fail the first 2, so we should use slightly more than 4 calls
+        handler.CallCount.Should().BeGreaterThan(4, "retry policy should make additional attempts");
+    }
+
+    private sealed class StatefulHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+        public int CallCount { get; private set; }
+
+        public StatefulHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            try
+            {
+                return Task.FromResult(_handler(request));
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<HttpResponseMessage>(ex);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Resilience_ExhaustedRetries_LeadsToUnavailable()
+    {
+        // All calls fail - 4 sensors × 3 attempts each (RetryCount=2 means 2 retries = 3 total attempts)
+        var handler = new StatefulHandler(request =>
+            throw new IOException("transient failure"));
+
+        using var sp = (ServiceProvider)BuildProvider((HttpMessageHandler)handler);
+        var provider = sp.GetRequiredService<HomeAssistantConditionsReadingProvider>();
+
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        snapshot.Source.Should().Be(ConditionsReadingSource.Unavailable);
+        handler.CallCount.Should().Be(12, "4 sensors × (RetryCount+1) = 4 × 3 attempts");
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantSnapshotCoordinatorTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantSnapshotCoordinatorTests.cs
@@ -1,0 +1,52 @@
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using FluentAssertions;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantSnapshotCoordinatorTests
+{
+    private static ConditionsSnapshot Snap(ConditionsReadingSource source, DateTime? recordedAt = null) =>
+        new(21m, 55m, 18m, 72m, recordedAt ?? DateTime.UtcNow, source);
+
+    [Fact]
+    public void RecordObserved_StoresAnySource()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var partial = Snap(ConditionsReadingSource.Partial);
+        c.RecordObserved(partial);
+        c.LastObservedSnapshot.Should().Be(partial);
+    }
+
+    [Fact]
+    public void RecordLive_UpdatesBothObservedAndLastKnownGood()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var live = Snap(ConditionsReadingSource.Live);
+        c.RecordLive(live);
+        c.LastObservedSnapshot.Should().Be(live);
+        c.LastKnownGoodLive.Should().Be(live);
+    }
+
+    [Fact]
+    public void RecordObserved_WithPartial_DoesNotOverwriteLastKnownGoodLive()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var live = Snap(ConditionsReadingSource.Live);
+        var partial = Snap(ConditionsReadingSource.Partial);
+        c.RecordLive(live);
+        c.RecordObserved(partial);
+        c.LastKnownGoodLive.Should().Be(live);
+        c.LastObservedSnapshot.Should().Be(partial);
+    }
+
+    [Fact]
+    public void Gate_IsSingleFlight()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.Gate.Wait();
+        c.Gate.CurrentCount.Should().Be(0);
+        c.Gate.Release();
+        c.Gate.CurrentCount.Should().Be(1);
+    }
+}

--- a/docs/superpowers/plans/2026-06-13-resilient-homeassistant-dependency.md
+++ b/docs/superpowers/plans/2026-06-13-resilient-homeassistant-dependency.md
@@ -1,0 +1,1747 @@
+# Resilient HomeAssistant Dependency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden `HomeAssistantConditionsReadingProvider` with Polly retries, a last-known-good stale fallback, suppressed-noise telemetry, an in-memory health check, and a snapshot-source custom metric so intermittent Tailscale outages stop flooding Application Insights.
+
+**Architecture:** Resilience is configured on the typed `HttpClient` via `AddResilienceHandler` (per-attempt timeout + jittered retry). A singleton `HomeAssistantSnapshotCoordinator` exposes a single-flight `SemaphoreSlim` plus two snapshot slots (last-observed for health, last-known-good `Live` for fallback). An `ITelemetryProcessor` drops `DependencyTelemetry` flagged by a retry-handler `Activity` tag, so only the final attempt per sensor produces a dependency record. A `Meter`-backed counter emits `homeassistant.snapshot.source`; an `IHealthCheck` reads only the coordinator.
+
+**Tech Stack:** .NET 8, `Microsoft.Extensions.Http.Resilience` (Polly v8), `Microsoft.Extensions.Diagnostics.HealthChecks`, `Microsoft.ApplicationInsights` (existing), `System.Diagnostics.Metrics.Meter`, xUnit + FluentAssertions + Moq.
+
+---
+
+## File Structure
+
+### New files
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantTransientErrorPredicate.cs` — predicate identifying retryable failures.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantRetryActivityTaggingHandler.cs` — `DelegatingHandler` that tags the per-attempt `Activity` when the HTTP send throws.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Caching/HomeAssistantSnapshotCoordinator.cs` — singleton holding single-flight gate, last-observed snapshot, and last-known-good `Live` snapshot.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HealthChecks/HomeAssistantConditionsHealthCheck.cs` — `IHealthCheck` reading the coordinator only.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantSnapshotMetrics.cs` — `Meter`-backed counter.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantDependencyTelemetryFilter.cs` — `ITelemetryProcessor` that drops `DependencyTelemetry` carrying the suppress property.
+- `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantSnapshotCoordinatorTests.cs`
+- `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsHealthCheckTests.cs`
+- `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantDependencyTelemetryFilterTests.cs`
+- `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantRetryPipelineTests.cs`
+
+### Modified files
+- `backend/src/Anela.Heblo.Domain/Features/Manufacture/Conditions/ConditionsReadingSource.cs` — append `Stale = 4`.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantSettings.cs` — add `RetryCount`, `RetryBaseDelayMilliseconds`, `RetryMaxDelaySeconds`, `StaleSnapshotMaxAgeMinutes`, `LiveSnapshotMaxAgeMinutes`.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantConditionsReadingProvider.cs` — single-flight, stale fallback, structured info log, demoted log levels; no try/catch around HTTP (Polly handles transients, only `OperationCanceledException` for caller cancellation passes through).
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantAdapterServiceCollectionExtensions.cs` — `AddResilienceHandler`, infinite client timeout, register coordinator + metrics + health check + tagging handler.
+- `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj` — add three package references.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — register HA health check with tags `{ "homeassistant", "ready" }`.
+- `backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs` — conditionally register `HomeAssistantDependencyTelemetryFilter`.
+- `backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs` — add `Stale => " (Starší údaje)"` switch arm.
+- `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj` — add `Microsoft.AspNetCore.Diagnostics.HealthChecks.Abstractions` and `Microsoft.ApplicationInsights` references for new tests.
+- `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsReadingProviderTests.cs` — extend with retry, stale-fallback, cold-start, single-flight, partial-does-not-overwrite-LKG, cancellation, and logging tests.
+
+---
+
+## Task 1: Add `Stale` value to `ConditionsReadingSource`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Manufacture/Conditions/ConditionsReadingSource.cs`
+
+- [ ] **Step 1: Append the new enum member**
+
+Replace the file contents with:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Manufacture.Conditions;
+
+public enum ConditionsReadingSource
+{
+    Live = 1,
+    Partial = 2,
+    Unavailable = 3,
+    Stale = 4,
+}
+```
+
+- [ ] **Step 2: Build the Domain project to confirm no callers break**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Manufacture/Conditions/ConditionsReadingSource.cs
+git commit -m "feat: add Stale value to ConditionsReadingSource"
+```
+
+---
+
+## Task 2: Add Stale switch arm to `ManufactureProtocolDocument`
+
+The PDF protocol's `SourceSuffix` currently falls through to `string.Empty` for unknown values — `Stale` would silently render with no suffix. Add an explicit arm.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs:276-282`
+
+- [ ] **Step 1: Extend the switch expression**
+
+Replace lines 276-282:
+
+```csharp
+    private static string SourceSuffix(ConditionsReadingSource source) => source switch
+    {
+        ConditionsReadingSource.Live => string.Empty,
+        ConditionsReadingSource.Partial => " (Částečné)",
+        ConditionsReadingSource.Unavailable => " (HA nedostupný)",
+        ConditionsReadingSource.Stale => " (Starší údaje)",
+        _ => string.Empty,
+    };
+```
+
+- [ ] **Step 2: Build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
+git commit -m "feat: render Stale source suffix in manufacture protocol PDF"
+```
+
+---
+
+## Task 3: Extend `HomeAssistantSettings` with new knobs
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantSettings.cs`
+
+- [ ] **Step 1: Add the new properties**
+
+Replace the file contents with:
+
+```csharp
+namespace Anela.Heblo.Adapters.HomeAssistant;
+
+public class HomeAssistantSettings
+{
+    public static string ConfigurationKey => "HomeAssistant";
+
+    public string BaseUrl { get; init; } = null!;
+    public string AccessToken { get; init; } = null!;
+    public string InnerTemperatureEntityId { get; init; } = null!;
+    public string InnerHumidityEntityId { get; init; } = null!;
+    public string OuterTemperatureEntityId { get; init; } = null!;
+    public string OuterHumidityEntityId { get; init; } = null!;
+    public int RequestTimeoutSeconds { get; init; } = 3;
+    public int ConditionsCacheDurationMinutes { get; init; } = 5;
+
+    /// <summary>Polly retry attempts on transient HTTP failures. 0 disables retry.</summary>
+    public int RetryCount { get; init; } = 2;
+
+    /// <summary>Base delay (ms) for exponential backoff between retry attempts.</summary>
+    public int RetryBaseDelayMilliseconds { get; init; } = 200;
+
+    /// <summary>Upper bound (seconds) on the jittered backoff between retry attempts.</summary>
+    public int RetryMaxDelaySeconds { get; init; } = 2;
+
+    /// <summary>Last-known-good snapshot is reused for up to this many minutes. 0 disables stale fallback.</summary>
+    public int StaleSnapshotMaxAgeMinutes { get; init; } = 60;
+
+    /// <summary>Health check reports Healthy only if the last Live snapshot is younger than this.</summary>
+    public int LiveSnapshotMaxAgeMinutes { get; init; } = 15;
+}
+```
+
+- [ ] **Step 2: Build the adapter project**
+
+Run: `dotnet build backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantSettings.cs
+git commit -m "feat: add retry, stale, and health-age knobs to HomeAssistantSettings"
+```
+
+---
+
+## Task 4: Add NuGet packages to adapter + test projects
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj`
+- Modify: `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj`
+
+- [ ] **Step 1: Add adapter packages**
+
+Replace the `<ItemGroup>` containing `PackageReference` entries in `Anela.Heblo.Adapters.HomeAssistant.csproj` with:
+
+```xml
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+  </ItemGroup>
+```
+
+- [ ] **Step 2: Add test packages**
+
+Replace the `<ItemGroup>` containing `PackageReference` entries in `Anela.Heblo.Adapters.HomeAssistant.Tests.csproj` with:
+
+```xml
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+  </ItemGroup>
+```
+
+- [ ] **Step 3: Restore and verify build**
+
+Run: `dotnet restore backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj && dotnet build backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj`
+Expected: Restore + build succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj
+git commit -m "chore: add resilience, healthchecks, and ApplicationInsights packages"
+```
+
+---
+
+## Task 5: Build the `HomeAssistantSnapshotCoordinator` singleton (TDD)
+
+The coordinator centralizes three pieces of mutable state: a single-flight semaphore, the last-observed snapshot (any source, for health), and the last-known-good `Live` snapshot (used as the stale-fallback source). It is registered as a singleton so both the provider and the health check share the same view.
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Caching/HomeAssistantSnapshotCoordinator.cs`
+- Test: `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantSnapshotCoordinatorTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using FluentAssertions;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantSnapshotCoordinatorTests
+{
+    private static ConditionsSnapshot Snap(ConditionsReadingSource source, DateTime? recordedAt = null) =>
+        new(21m, 55m, 18m, 72m, recordedAt ?? DateTime.UtcNow, source);
+
+    [Fact]
+    public void RecordObserved_StoresAnySource()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var partial = Snap(ConditionsReadingSource.Partial);
+        c.RecordObserved(partial);
+        c.LastObservedSnapshot.Should().Be(partial);
+    }
+
+    [Fact]
+    public void RecordLive_UpdatesBothObservedAndLastKnownGood()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var live = Snap(ConditionsReadingSource.Live);
+        c.RecordLive(live);
+        c.LastObservedSnapshot.Should().Be(live);
+        c.LastKnownGoodLive.Should().Be(live);
+    }
+
+    [Fact]
+    public void RecordObserved_WithPartial_DoesNotOverwriteLastKnownGoodLive()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var live = Snap(ConditionsReadingSource.Live);
+        var partial = Snap(ConditionsReadingSource.Partial);
+        c.RecordLive(live);
+        c.RecordObserved(partial);
+        c.LastKnownGoodLive.Should().Be(live);
+        c.LastObservedSnapshot.Should().Be(partial);
+    }
+
+    [Fact]
+    public void Gate_IsSingleFlight()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.Gate.Wait();
+        c.Gate.CurrentCount.Should().Be(0);
+        c.Gate.Release();
+        c.Gate.CurrentCount.Should().Be(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail (type does not exist)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantSnapshotCoordinatorTests"`
+Expected: Build fails because `HomeAssistantSnapshotCoordinator` does not exist.
+
+- [ ] **Step 3: Create the coordinator**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Caching/HomeAssistantSnapshotCoordinator.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Caching;
+
+public sealed class HomeAssistantSnapshotCoordinator
+{
+    public SemaphoreSlim Gate { get; } = new(initialCount: 1, maxCount: 1);
+
+    public ConditionsSnapshot? LastObservedSnapshot { get; private set; }
+
+    public ConditionsSnapshot? LastKnownGoodLive { get; private set; }
+
+    public void RecordObserved(ConditionsSnapshot snapshot)
+    {
+        LastObservedSnapshot = snapshot;
+    }
+
+    public void RecordLive(ConditionsSnapshot snapshot)
+    {
+        LastObservedSnapshot = snapshot;
+        LastKnownGoodLive = snapshot;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantSnapshotCoordinatorTests"`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Caching/HomeAssistantSnapshotCoordinator.cs backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantSnapshotCoordinatorTests.cs
+git commit -m "feat: add HomeAssistantSnapshotCoordinator for single-flight and LKG state"
+```
+
+---
+
+## Task 6: Build the `HomeAssistantSnapshotMetrics` Meter wrapper
+
+The provider increments a counter once per call, tagged with the resulting `source`. AI 2.22+ auto-publishes `Meter` instruments as `customMetrics`.
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantSnapshotMetrics.cs`
+
+- [ ] **Step 1: Create the metrics facade**
+
+```csharp
+using System.Diagnostics.Metrics;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+
+public sealed class HomeAssistantSnapshotMetrics : IDisposable
+{
+    public const string MeterName = "Anela.Heblo.HomeAssistant";
+    public const string SnapshotCounterName = "homeassistant.snapshot.source";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _snapshotCounter;
+
+    public HomeAssistantSnapshotMetrics()
+    {
+        _meter = new Meter(MeterName);
+        _snapshotCounter = _meter.CreateCounter<long>(SnapshotCounterName);
+    }
+
+    public void RecordSnapshot(ConditionsReadingSource source)
+    {
+        _snapshotCounter.Add(1, new KeyValuePair<string, object?>("source", source.ToString()));
+    }
+
+    public void Dispose() => _meter.Dispose();
+}
+```
+
+- [ ] **Step 2: Build the adapter project**
+
+Run: `dotnet build backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantSnapshotMetrics.cs
+git commit -m "feat: add Meter-backed snapshot source counter"
+```
+
+---
+
+## Task 7: Build the transient-error predicate
+
+A small, isolated predicate keeps the resilience policy testable and centralizes the "what counts as retryable" decision.
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantTransientErrorPredicate.cs`
+
+- [ ] **Step 1: Create the predicate**
+
+```csharp
+using System.Net.Sockets;
+using Polly;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Resilience;
+
+internal static class HomeAssistantTransientErrorPredicate
+{
+    public static ValueTask<bool> ShouldHandleAsync<TResult>(RetryPredicateArguments<TResult> args)
+    {
+        // Caller cancellation is honored — never retried.
+        if (args.Context.CancellationToken.IsCancellationRequested)
+        {
+            return ValueTask.FromResult(false);
+        }
+
+        return ValueTask.FromResult(IsTransient(args.Outcome.Exception, args.Outcome.Result));
+    }
+
+    public static bool IsTransient(Exception? exception, object? result)
+    {
+        if (exception is null && result is HttpResponseMessage response)
+        {
+            return (int)response.StatusCode >= 500;
+        }
+
+        return exception switch
+        {
+            IOException => true,
+            SocketException => true,
+            HttpRequestException => true,
+            TimeoutException => true,
+            // Polly's TimeoutStrategy raises this on a per-attempt timeout.
+            // We want to keep retrying after a single hung attempt.
+            Polly.Timeout.TimeoutRejectedException => true,
+            // Per-attempt cancellation triggered by Polly's timeout strategy is internal — retry.
+            OperationCanceledException oce when oce.CancellationToken == default => true,
+            _ => false,
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Build the adapter project**
+
+Run: `dotnet build backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantTransientErrorPredicate.cs
+git commit -m "feat: add transient-error predicate for HA retry policy"
+```
+
+---
+
+## Task 8: Build the retry-activity tagging `DelegatingHandler`
+
+Polly's `OnRetry` callback fires *after* the failing attempt's `Activity` may have ended, which makes tagging unreliable. A `DelegatingHandler` registered between the resilience handler and the primary handler tags `Activity.Current` from inside the per-attempt `catch`, guaranteeing the right `Activity` is in scope.
+
+The tag (`ha.retry-suppress`) is later read by the telemetry processor, which drops the matching `DependencyTelemetry`.
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantRetryActivityTaggingHandler.cs`
+
+- [ ] **Step 1: Create the handler**
+
+```csharp
+using System.Diagnostics;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Resilience;
+
+/// <summary>
+/// Tags the per-attempt Activity when the HTTP send throws, so the
+/// Application Insights dependency processor can drop transient retries
+/// before they reach the AI ingestion endpoint.
+/// </summary>
+internal sealed class HomeAssistantRetryActivityTaggingHandler : DelegatingHandler
+{
+    public const string SuppressTagName = "ha.retry-suppress";
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            if (HomeAssistantTransientErrorPredicate.IsTransient(exception: null, result: response))
+            {
+                Activity.Current?.SetTag(SuppressTagName, "true");
+            }
+            return response;
+        }
+        catch (Exception ex) when (HomeAssistantTransientErrorPredicate.IsTransient(ex, result: null))
+        {
+            Activity.Current?.SetTag(SuppressTagName, "true");
+            throw;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build the adapter project**
+
+Run: `dotnet build backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj`
+Expected: Build succeeded.
+
+> Note: the handler tags every transient *attempt*. The final attempt's tag is overwritten/cleared by the resilience handler only if the attempt ultimately succeeds, so the final failed attempt of an exhausted retry sequence keeps the tag too. We compensate for that in Task 9 by clearing the tag on the *outer* (final) attempt — see step 1's note about why the `OnRetry` callback also clears the tag of the just-completed attempt.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Resilience/HomeAssistantRetryActivityTaggingHandler.cs
+git commit -m "feat: add HA retry activity tagging handler for AI dependency suppression"
+```
+
+---
+
+## Task 9: Build the `HomeAssistantDependencyTelemetryFilter` (TDD)
+
+The filter implements `ITelemetryProcessor` and drops `DependencyTelemetry` whose `Properties[SuppressTagName] == "true"`. AI's `DependencyTrackingTelemetryModule` copies the per-request `Activity` tags into `DependencyTelemetry.Properties`, so the property is populated automatically. Other telemetry passes through untouched.
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantDependencyTelemetryFilter.cs`
+- Test: `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantDependencyTelemetryFilterTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.Resilience;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+using FluentAssertions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Moq;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantDependencyTelemetryFilterTests
+{
+    private readonly Mock<ITelemetryProcessor> _next = new();
+    private readonly HomeAssistantDependencyTelemetryFilter _filter;
+
+    public HomeAssistantDependencyTelemetryFilterTests()
+    {
+        _filter = new HomeAssistantDependencyTelemetryFilter(_next.Object);
+    }
+
+    [Fact]
+    public void Process_DropsDependencyTelemetryTaggedSuppress()
+    {
+        var dep = new DependencyTelemetry { Name = "GET /api/states/sensor.x" };
+        dep.Properties[HomeAssistantRetryActivityTaggingHandler.SuppressTagName] = "true";
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(It.IsAny<ITelemetry>()), Times.Never);
+    }
+
+    [Fact]
+    public void Process_ForwardsDependencyTelemetryWithoutSuppressTag()
+    {
+        var dep = new DependencyTelemetry { Name = "GET /api/states/sensor.x" };
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(dep), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsNonDependencyTelemetryEvenIfTaggedSomehow()
+    {
+        var trace = new TraceTelemetry("hello");
+        trace.Properties[HomeAssistantRetryActivityTaggingHandler.SuppressTagName] = "true";
+
+        _filter.Process(trace);
+
+        _next.Verify(n => n.Process(trace), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantDependencyTelemetryFilterTests"`
+Expected: Build fails — `HomeAssistantDependencyTelemetryFilter` not defined.
+
+- [ ] **Step 3: Implement the filter**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantDependencyTelemetryFilter.cs`:
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.Resilience;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+
+public sealed class HomeAssistantDependencyTelemetryFilter : ITelemetryProcessor
+{
+    private readonly ITelemetryProcessor _next;
+
+    public HomeAssistantDependencyTelemetryFilter(ITelemetryProcessor next)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+    }
+
+    public void Process(ITelemetry item)
+    {
+        if (item is DependencyTelemetry dep
+            && dep.Properties.TryGetValue(HomeAssistantRetryActivityTaggingHandler.SuppressTagName, out var value)
+            && string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _next.Process(item);
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantDependencyTelemetryFilterTests"`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Telemetry/HomeAssistantDependencyTelemetryFilter.cs backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantDependencyTelemetryFilterTests.cs
+git commit -m "feat: add HA dependency telemetry filter to drop suppressed retries"
+```
+
+---
+
+## Task 10: Build the `HomeAssistantConditionsHealthCheck` (TDD)
+
+The health check reads only the coordinator and the settings — no HTTP — and reports:
+- `Healthy` if the last-observed snapshot is `Live` and `(now - RecordedAt) ≤ LiveSnapshotMaxAgeMinutes`.
+- `Degraded` if the last-observed snapshot is `Partial` or `Stale` (or `Live` but stale beyond the live age).
+- `Unhealthy` if the last-observed snapshot is `Unavailable` or no snapshot has ever been recorded.
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HealthChecks/HomeAssistantConditionsHealthCheck.cs`
+- Test: `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsHealthCheckTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant;
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using FluentAssertions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantConditionsHealthCheckTests
+{
+    private readonly HomeAssistantSettings _settings = new()
+    {
+        BaseUrl = "http://ha.test",
+        AccessToken = "tok",
+        InnerTemperatureEntityId = "i_t",
+        InnerHumidityEntityId = "i_h",
+        OuterTemperatureEntityId = "o_t",
+        OuterHumidityEntityId = "o_h",
+        LiveSnapshotMaxAgeMinutes = 15,
+    };
+
+    private HomeAssistantConditionsHealthCheck CreateCheck(HomeAssistantSnapshotCoordinator coordinator) =>
+        new(coordinator, Options.Create(_settings), TimeProvider.System);
+
+    private static ConditionsSnapshot Snap(ConditionsReadingSource source, DateTime recordedAt) =>
+        new(21m, 55m, 18m, 72m, recordedAt, source);
+
+    [Fact]
+    public async Task CheckHealthAsync_NoSnapshot_ReturnsUnhealthy()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_FreshLive_ReturnsHealthy()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordLive(Snap(ConditionsReadingSource.Live, DateTime.UtcNow));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_OldLive_ReturnsDegraded()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordLive(Snap(ConditionsReadingSource.Live, DateTime.UtcNow.AddMinutes(-30)));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_LastObservedPartial_ReturnsDegraded()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordObserved(Snap(ConditionsReadingSource.Partial, DateTime.UtcNow));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_LastObservedStale_ReturnsDegraded()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordObserved(Snap(ConditionsReadingSource.Stale, DateTime.UtcNow.AddMinutes(-3)));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_LastObservedUnavailable_ReturnsUnhealthy()
+    {
+        var c = new HomeAssistantSnapshotCoordinator();
+        c.RecordObserved(Snap(ConditionsReadingSource.Unavailable, DateTime.UtcNow));
+        var result = await CreateCheck(c).CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantConditionsHealthCheckTests"`
+Expected: Build fails — `HomeAssistantConditionsHealthCheck` not defined.
+
+- [ ] **Step 3: Implement the health check**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HealthChecks/HomeAssistantConditionsHealthCheck.cs`:
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
+
+public sealed class HomeAssistantConditionsHealthCheck : IHealthCheck
+{
+    private readonly HomeAssistantSnapshotCoordinator _coordinator;
+    private readonly HomeAssistantSettings _settings;
+    private readonly TimeProvider _timeProvider;
+
+    public HomeAssistantConditionsHealthCheck(
+        HomeAssistantSnapshotCoordinator coordinator,
+        IOptions<HomeAssistantSettings> options,
+        TimeProvider timeProvider)
+    {
+        _coordinator = coordinator;
+        _settings = options.Value;
+        _timeProvider = timeProvider;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var observed = _coordinator.LastObservedSnapshot;
+
+        if (observed is null)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                "No HomeAssistant snapshot has been observed yet."));
+        }
+
+        var age = _timeProvider.GetUtcNow().UtcDateTime - observed.RecordedAt;
+        var data = new Dictionary<string, object>
+        {
+            ["source"] = observed.Source.ToString(),
+            ["recordedAt"] = observed.RecordedAt,
+            ["ageSeconds"] = age.TotalSeconds,
+        };
+
+        return Task.FromResult(observed.Source switch
+        {
+            ConditionsReadingSource.Live when age <= TimeSpan.FromMinutes(_settings.LiveSnapshotMaxAgeMinutes)
+                => HealthCheckResult.Healthy("HomeAssistant snapshot is Live and fresh.", data),
+            ConditionsReadingSource.Live
+                => HealthCheckResult.Degraded("Last Live snapshot is older than LiveSnapshotMaxAgeMinutes.", data: data),
+            ConditionsReadingSource.Partial or ConditionsReadingSource.Stale
+                => HealthCheckResult.Degraded($"HomeAssistant snapshot is {observed.Source}.", data: data),
+            ConditionsReadingSource.Unavailable
+                => HealthCheckResult.Unhealthy("HomeAssistant snapshot is Unavailable.", data: data),
+            _ => HealthCheckResult.Unhealthy("Unknown snapshot source.", data: data),
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantConditionsHealthCheckTests"`
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HealthChecks/HomeAssistantConditionsHealthCheck.cs backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsHealthCheckTests.cs
+git commit -m "feat: add HomeAssistantConditionsHealthCheck reading coordinator only"
+```
+
+---
+
+## Task 11: Rewrite `HomeAssistantConditionsReadingProvider` with single-flight, stale fallback, and structured logging (TDD)
+
+The provider now:
+- Acquires the coordinator's gate with a bounded timeout (single-flight protection per NFR-3).
+- Re-checks live cache after acquiring (double-check).
+- Fetches four sensor values in parallel. **No try/catch wrapping HTTP** — Polly handles transients; only caller `OperationCanceledException` bubbles up; the catch-all for other exceptions is moved to the per-sensor `await` so a hard failure of one sensor becomes `null` (Partial) without taking down the snapshot.
+- Computes the source. If `Unavailable` and a non-expired LKG exists, returns a new snapshot with LKG's values + `RecordedAt` and `Source = Stale`. `Partial` always beats stale (live is fresher).
+- Records the snapshot on the coordinator and the metric. Updates the live cache for any non-`Unavailable` source. Updates LKG only for `Live`.
+- Emits exactly one `Information` log per call summarizing `Source`, `LiveSensorCount`, `Duration`, `RetryAttempts` (retry attempts derived from `Activity` tags so we don't need a Polly callback in the provider).
+- For a sensor that failed all retries, the catch logs one `Warning` *without* the exception object, with structured properties `EntityId`, `Attempts`, `LastException.GetType().Name`, `LastException.Message`.
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantConditionsReadingProvider.cs`
+- Test: `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsReadingProviderTests.cs`
+
+- [ ] **Step 1: Add new failing tests (extend the existing test class)**
+
+Append the following tests to `HomeAssistantConditionsReadingProviderTests.cs`. Also update the `CreateProvider` helper to inject the new dependencies. Replace the helper at lines 35-45 and add new tests:
+
+Replace the existing `CreateProvider` method body:
+
+```csharp
+    private HomeAssistantConditionsReadingProvider CreateProvider(
+        IMemoryCache? cache = null,
+        HomeAssistantSnapshotCoordinator? coordinator = null,
+        HomeAssistantSnapshotMetrics? metrics = null)
+    {
+        var httpClient = new HttpClient(_handlerMock.Object)
+        {
+            BaseAddress = new Uri(_settings.BaseUrl),
+            Timeout = TimeSpan.FromSeconds(_settings.RequestTimeoutSeconds),
+        };
+        var options = Options.Create(_settings);
+        cache ??= new MemoryCache(new MemoryCacheOptions());
+        coordinator ??= new HomeAssistantSnapshotCoordinator();
+        metrics ??= new HomeAssistantSnapshotMetrics();
+        return new HomeAssistantConditionsReadingProvider(
+            httpClient, options, cache, coordinator, metrics,
+            NullLogger<HomeAssistantConditionsReadingProvider>.Instance);
+    }
+```
+
+Add the required `using` directives at the top:
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+```
+
+Append these new test methods to the class:
+
+```csharp
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_UnavailableLive_WithFreshLkg_ReturnsStaleFromLkg()
+    {
+        // Arrange — first call succeeds, second call all fail.
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(cache, coordinator);
+
+        var live = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+        live.Source.Should().Be(ConditionsReadingSource.Live);
+
+        // Invalidate live cache and reconfigure all to fail.
+        cache.Remove(HomeAssistantConditionsReadingProvider.CacheKey);
+        _handlerMock.Reset();
+        SetupSensorFailure("sensor.inner_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.inner_humidity", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_humidity", HttpStatusCode.InternalServerError);
+
+        // Act
+        var stale = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // Assert
+        stale.Source.Should().Be(ConditionsReadingSource.Stale);
+        stale.InnerTemperature.Should().Be(21.5m);
+        stale.RecordedAt.Should().Be(live.RecordedAt, "stale snapshot carries the LKG timestamp");
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_UnavailableLive_WithExpiredLkg_ReturnsUnavailable()
+    {
+        // Arrange — populate LKG manually with an old snapshot.
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        coordinator.RecordLive(new ConditionsSnapshot(
+            21m, 55m, 18m, 72m,
+            DateTime.UtcNow.AddMinutes(-_settings.StaleSnapshotMaxAgeMinutes - 1),
+            ConditionsReadingSource.Live));
+
+        SetupSensorFailure("sensor.inner_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.inner_humidity", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_humidity", HttpStatusCode.InternalServerError);
+
+        var provider = CreateProvider(coordinator: coordinator);
+
+        // Act
+        var result = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // Assert
+        result.Source.Should().Be(ConditionsReadingSource.Unavailable);
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_ColdStart_NoCache_AllFail_ReturnsUnavailable()
+    {
+        SetupSensorFailure("sensor.inner_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.inner_humidity", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorFailure("sensor.outer_humidity", HttpStatusCode.InternalServerError);
+
+        var provider = CreateProvider();
+
+        var result = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        result.Source.Should().Be(ConditionsReadingSource.Unavailable);
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_PartialLive_DoesNotOverwriteLkg()
+    {
+        // Arrange — first call all live to populate LKG.
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(cache, coordinator);
+
+        var live = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+        coordinator.LastKnownGoodLive.Should().NotBeNull();
+
+        // Invalidate cache, make one sensor fail (partial result).
+        cache.Remove(HomeAssistantConditionsReadingProvider.CacheKey);
+        _handlerMock.Reset();
+        SetupSensorResponse("sensor.inner_temp", "22.0");
+        SetupSensorResponse("sensor.inner_humidity", "56.0");
+        SetupSensorFailure("sensor.outer_temp", HttpStatusCode.InternalServerError);
+        SetupSensorResponse("sensor.outer_humidity", "73.0");
+
+        // Act
+        var partial = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // Assert
+        partial.Source.Should().Be(ConditionsReadingSource.Partial);
+        coordinator.LastKnownGoodLive.Should().Be(live, "Partial result must not overwrite LKG");
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_RecordsLastObservedOnCoordinator()
+    {
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(coordinator: coordinator);
+
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        coordinator.LastObservedSnapshot.Should().Be(snapshot);
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_ConcurrentCallers_ProduceOnlyOneBurstOfHttpCalls()
+    {
+        SetupSensorResponse("sensor.inner_temp", "21.5");
+        SetupSensorResponse("sensor.inner_humidity", "55.0");
+        SetupSensorResponse("sensor.outer_temp", "18.2");
+        SetupSensorResponse("sensor.outer_humidity", "72.3");
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var coordinator = new HomeAssistantSnapshotCoordinator();
+        var provider = CreateProvider(cache, coordinator);
+
+        // Act
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => provider.GetCurrentSnapshotAsync(CancellationToken.None))
+            .ToArray();
+        await Task.WhenAll(tasks);
+
+        // Assert — only 4 outbound HTTP calls, not 40.
+        _handlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(4),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCurrentSnapshotAsync_PreCancelledToken_ThrowsBeforeAcquiringGate()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var provider = CreateProvider();
+
+        var act = async () => await provider.GetCurrentSnapshotAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantConditionsReadingProviderTests"`
+Expected: Build fails (`HomeAssistantConditionsReadingProvider` constructor signature changed; coordinator/metrics types referenced).
+
+- [ ] **Step 3: Rewrite the provider**
+
+Replace the entire contents of `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantConditionsReadingProvider.cs`:
+
+```csharp
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.HomeAssistant;
+
+public class HomeAssistantConditionsReadingProvider : IConditionsReadingProvider
+{
+    public const string CacheKey = "HomeAssistant_ConditionsSnapshot";
+
+    private readonly HttpClient _httpClient;
+    private readonly HomeAssistantSettings _settings;
+    private readonly IMemoryCache _cache;
+    private readonly HomeAssistantSnapshotCoordinator _coordinator;
+    private readonly HomeAssistantSnapshotMetrics _metrics;
+    private readonly ILogger<HomeAssistantConditionsReadingProvider> _logger;
+
+    public HomeAssistantConditionsReadingProvider(
+        HttpClient httpClient,
+        IOptions<HomeAssistantSettings> options,
+        IMemoryCache cache,
+        HomeAssistantSnapshotCoordinator coordinator,
+        HomeAssistantSnapshotMetrics metrics,
+        ILogger<HomeAssistantConditionsReadingProvider> logger)
+    {
+        _httpClient = httpClient;
+        _settings = options.Value;
+        _cache = cache;
+        _coordinator = coordinator;
+        _metrics = metrics;
+        _logger = logger;
+    }
+
+    public async Task<ConditionsSnapshot> GetCurrentSnapshotAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (TryGetCachedLive(out var cached))
+            return cached!;
+
+        var gateTimeout = ComputeGateTimeout();
+        if (!await _coordinator.Gate.WaitAsync(gateTimeout, cancellationToken))
+        {
+            return ServeStaleOrUnavailable(retryAttempts: 0, duration: TimeSpan.Zero, gateTimedOut: true);
+        }
+
+        try
+        {
+            if (TryGetCachedLive(out var cachedAfterGate))
+                return cachedAfterGate!;
+
+            var stopwatch = Stopwatch.StartNew();
+
+            var innerTempTask = FetchSensorValueAsync(_settings.InnerTemperatureEntityId, cancellationToken);
+            var innerHumidityTask = FetchSensorValueAsync(_settings.InnerHumidityEntityId, cancellationToken);
+            var outerTempTask = FetchSensorValueAsync(_settings.OuterTemperatureEntityId, cancellationToken);
+            var outerHumidityTask = FetchSensorValueAsync(_settings.OuterHumidityEntityId, cancellationToken);
+
+            await Task.WhenAll(innerTempTask, innerHumidityTask, outerTempTask, outerHumidityTask);
+
+            stopwatch.Stop();
+
+            var innerTemp = innerTempTask.Result;
+            var innerHumidity = innerHumidityTask.Result;
+            var outerTemp = outerTempTask.Result;
+            var outerHumidity = outerHumidityTask.Result;
+
+            var nonNullCount = new[] { innerTemp, innerHumidity, outerTemp, outerHumidity }.Count(v => v.HasValue);
+            var source = nonNullCount == 4 ? ConditionsReadingSource.Live
+                : nonNullCount == 0 ? ConditionsReadingSource.Unavailable
+                : ConditionsReadingSource.Partial;
+
+            var snapshot = new ConditionsSnapshot(
+                InnerTemperature: innerTemp,
+                InnerHumidity: innerHumidity,
+                OuterTemperature: outerTemp,
+                OuterHumidity: outerHumidity,
+                RecordedAt: DateTime.UtcNow,
+                Source: source);
+
+            // Unavailable → try LKG; everything else updates the cache as today.
+            if (source == ConditionsReadingSource.Unavailable)
+            {
+                var served = ServeStaleOrUnavailable(retryAttempts: 0, duration: stopwatch.Elapsed, gateTimedOut: false);
+                return served;
+            }
+
+            _cache.Set(CacheKey, snapshot, TimeSpan.FromMinutes(_settings.ConditionsCacheDurationMinutes));
+
+            if (source == ConditionsReadingSource.Live)
+            {
+                _coordinator.RecordLive(snapshot);
+            }
+            else
+            {
+                _coordinator.RecordObserved(snapshot);
+            }
+
+            _metrics.RecordSnapshot(source);
+            LogSummary(source, nonNullCount, stopwatch.Elapsed, retryAttempts: 0);
+
+            return snapshot;
+        }
+        finally
+        {
+            _coordinator.Gate.Release();
+        }
+    }
+
+    private bool TryGetCachedLive(out ConditionsSnapshot? snapshot)
+    {
+        if (_cache.TryGetValue(CacheKey, out ConditionsSnapshot? cached) && cached is not null)
+        {
+            snapshot = cached;
+            return true;
+        }
+
+        snapshot = null;
+        return false;
+    }
+
+    private ConditionsSnapshot ServeStaleOrUnavailable(int retryAttempts, TimeSpan duration, bool gateTimedOut)
+    {
+        var lkg = _coordinator.LastKnownGoodLive;
+        var staleMaxAge = TimeSpan.FromMinutes(_settings.StaleSnapshotMaxAgeMinutes);
+
+        if (lkg is not null
+            && _settings.StaleSnapshotMaxAgeMinutes > 0
+            && (DateTime.UtcNow - lkg.RecordedAt) <= staleMaxAge)
+        {
+            var stale = lkg with { Source = ConditionsReadingSource.Stale };
+            _coordinator.RecordObserved(stale);
+            _metrics.RecordSnapshot(ConditionsReadingSource.Stale);
+            LogSummary(ConditionsReadingSource.Stale, liveSensorCount: 0, duration, retryAttempts);
+            return stale;
+        }
+
+        var unavailable = new ConditionsSnapshot(null, null, null, null, DateTime.UtcNow, ConditionsReadingSource.Unavailable);
+        _coordinator.RecordObserved(unavailable);
+        _metrics.RecordSnapshot(ConditionsReadingSource.Unavailable);
+        if (gateTimedOut)
+        {
+            _logger.LogWarning(
+                "HomeAssistant snapshot fetch timed out waiting for single-flight gate ({GateTimeoutSeconds}s)",
+                ComputeGateTimeout().TotalSeconds);
+        }
+        LogSummary(ConditionsReadingSource.Unavailable, liveSensorCount: 0, duration, retryAttempts);
+        return unavailable;
+    }
+
+    private void LogSummary(ConditionsReadingSource source, int liveSensorCount, TimeSpan duration, int retryAttempts)
+    {
+        _logger.LogInformation(
+            "HomeAssistant snapshot {Source}, sensors={LiveSensorCount}, durationMs={DurationMs}, retries={RetryAttempts}",
+            source, liveSensorCount, duration.TotalMilliseconds, retryAttempts);
+    }
+
+    private TimeSpan ComputeGateTimeout()
+    {
+        var perAttempt = TimeSpan.FromSeconds(_settings.RequestTimeoutSeconds);
+        var attempts = Math.Max(1, _settings.RetryCount + 1);
+        return perAttempt * attempts + TimeSpan.FromSeconds(1);
+    }
+
+    private async Task<decimal?> FetchSensorValueAsync(string entityId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"/api/states/{entityId}", cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "HomeAssistant returned {StatusCode} for entity {EntityId}",
+                    response.StatusCode, entityId);
+                return null;
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("state", out var stateProp))
+            {
+                _logger.LogWarning("HomeAssistant response for {EntityId} has no 'state' field", entityId);
+                return null;
+            }
+
+            var stateStr = stateProp.GetString();
+            if (string.IsNullOrEmpty(stateStr) ||
+                stateStr.Equals("unavailable", StringComparison.OrdinalIgnoreCase) ||
+                stateStr.Equals("unknown", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("HomeAssistant entity {EntityId} has non-numeric state: {State}", entityId, stateStr);
+                return null;
+            }
+
+            if (!decimal.TryParse(stateStr, NumberStyles.Number, CultureInfo.InvariantCulture, out var value))
+            {
+                _logger.LogWarning("HomeAssistant entity {EntityId} returned unparseable state: {State}", entityId, stateStr);
+                return null;
+            }
+
+            return value;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Polly has already retried transients. The exception object is *not* logged
+            // (only its type/message via structured properties) so AI's ILogger provider
+            // does not record an exception trace per FR-3.
+            _logger.LogWarning(
+                "HomeAssistant fetch exhausted retries for {EntityId} after {Attempts} attempts: {ExceptionType} {ExceptionMessage}",
+                entityId, _settings.RetryCount + 1, ex.GetType().Name, ex.Message);
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run all provider tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantConditionsReadingProviderTests"`
+Expected: All tests pass (existing 9 + new 7 = 16).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantConditionsReadingProvider.cs backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantConditionsReadingProviderTests.cs
+git commit -m "feat: add single-flight gate, stale fallback, and structured snapshot logging"
+```
+
+---
+
+## Task 12: Wire the Polly resilience pipeline into `AddHomeAssistantAdapter`
+
+Configure the resilience pipeline on the typed `HttpClient`:
+- Set `client.Timeout = Timeout.InfiniteTimeSpan` so per-attempt timeout is fully owned by Polly.
+- `AddResilienceHandler` with two strategies:
+  - `AddTimeout` (per attempt) = `RequestTimeoutSeconds`.
+  - `AddRetry` with `MaxRetryAttempts = RetryCount`, `Delay = RetryBaseDelayMilliseconds`, `BackoffType = Exponential`, `UseJitter = true`, `MaxDelay = RetryMaxDelaySeconds`, `ShouldHandle = HomeAssistantTransientErrorPredicate.ShouldHandleAsync`.
+- `AddHttpMessageHandler<HomeAssistantRetryActivityTaggingHandler>()` so the activity-tagging handler is in the per-attempt scope.
+- Register coordinator + metrics + health check + tagging handler in DI.
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantAdapterServiceCollectionExtensions.cs`
+
+- [ ] **Step 1: Rewrite the extension**
+
+Replace the file contents:
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
+using Anela.Heblo.Adapters.HomeAssistant.Resilience;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
+using Polly;
+
+namespace Anela.Heblo.Adapters.HomeAssistant;
+
+public static class HomeAssistantAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddHomeAssistantAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOptions<HomeAssistantSettings>()
+            .Bind(configuration.GetSection(HomeAssistantSettings.ConfigurationKey));
+
+        services.AddMemoryCache();
+
+        services.AddSingleton<HomeAssistantSnapshotCoordinator>();
+        services.AddSingleton<HomeAssistantSnapshotMetrics>();
+        services.AddSingleton<TimeProvider>(_ => TimeProvider.System);
+        services.AddTransient<HomeAssistantRetryActivityTaggingHandler>();
+
+        services.AddHttpClient<HomeAssistantConditionsReadingProvider>((sp, client) =>
+        {
+            var settings = sp.GetRequiredService<IOptions<HomeAssistantSettings>>().Value;
+
+            if (string.IsNullOrWhiteSpace(settings.BaseUrl)
+                || !Uri.TryCreate(settings.BaseUrl, UriKind.Absolute, out var baseUri))
+            {
+                // HomeAssistant is not configured for this environment.
+                // HTTP calls in HomeAssistantConditionsReadingProvider will fail per-sensor and
+                // return null, which bubbles up as ConditionsReadingSource.Unavailable — no exception.
+                return;
+            }
+
+            client.BaseAddress = baseUri;
+            // Per-attempt timeout is enforced by Polly's AddTimeout below; setting an outer
+            // HttpClient.Timeout would cancel the entire retry chain (no retries would actually run).
+            client.Timeout = Timeout.InfiniteTimeSpan;
+            client.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", settings.AccessToken);
+        })
+        .AddResilienceHandler("ha-conditions", (builder, context) =>
+        {
+            var settings = context.ServiceProvider.GetRequiredService<IOptions<HomeAssistantSettings>>().Value;
+
+            builder
+                .AddRetry(new HttpRetryStrategyOptions
+                {
+                    MaxRetryAttempts = settings.RetryCount,
+                    Delay = TimeSpan.FromMilliseconds(settings.RetryBaseDelayMilliseconds),
+                    BackoffType = DelayBackoffType.Exponential,
+                    UseJitter = true,
+                    MaxDelay = TimeSpan.FromSeconds(settings.RetryMaxDelaySeconds),
+                    ShouldHandle = HomeAssistantTransientErrorPredicate.ShouldHandleAsync,
+                })
+                .AddTimeout(TimeSpan.FromSeconds(settings.RequestTimeoutSeconds));
+        })
+        .AddHttpMessageHandler<HomeAssistantRetryActivityTaggingHandler>();
+
+        services.AddTransient<IConditionsReadingProvider>(
+            sp => sp.GetRequiredService<HomeAssistantConditionsReadingProvider>());
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Build the adapter project**
+
+Run: `dotnet build backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/Anela.Heblo.Adapters.HomeAssistant.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Build the API project to confirm no consumer regressions**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.HomeAssistant/HomeAssistantAdapterServiceCollectionExtensions.cs
+git commit -m "feat: wire Polly resilience pipeline and singletons in HA adapter registration"
+```
+
+---
+
+## Task 13: Add retry-pipeline integration test (TDD)
+
+This test exercises the full DI path — `AddHomeAssistantAdapter` + Polly + custom handlers — using a recorded `HttpMessageHandler`. It verifies (a) one transient failure is retried and a `Live` snapshot is produced, (b) the per-attempt activity gets the `ha.retry-suppress` tag on the first (transient) attempt, and (c) the final-success attempt does not carry the tag.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantRetryPipelineTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using Anela.Heblo.Adapters.HomeAssistant.Caching;
+using Anela.Heblo.Adapters.HomeAssistant.Resilience;
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.HomeAssistant.Tests;
+
+public class HomeAssistantRetryPipelineTests
+{
+    private sealed class SequencedHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> _responses;
+        public int CallCount { get; private set; }
+        public List<KeyValuePair<string, object?>> SeenActivityTags { get; } = new();
+
+        public SequencedHandler(params Func<HttpResponseMessage>[] responses)
+        {
+            _responses = new Queue<Func<HttpResponseMessage>>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            // Capture whatever tags the tagging handler set during the surrounding pipeline.
+            if (Activity.Current is { } activity)
+            {
+                foreach (var tag in activity.TagObjects)
+                {
+                    SeenActivityTags.Add(tag);
+                }
+            }
+
+            if (_responses.Count == 0)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+
+            var factory = _responses.Dequeue();
+            try
+            {
+                return Task.FromResult(factory());
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<HttpResponseMessage>(ex);
+            }
+        }
+    }
+
+    private static IServiceProvider BuildProvider(SequencedHandler handler)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["HomeAssistant:BaseUrl"] = "http://ha.test:8123",
+                ["HomeAssistant:AccessToken"] = "tok",
+                ["HomeAssistant:InnerTemperatureEntityId"] = "sensor.inner_temp",
+                ["HomeAssistant:InnerHumidityEntityId"] = "sensor.inner_humidity",
+                ["HomeAssistant:OuterTemperatureEntityId"] = "sensor.outer_temp",
+                ["HomeAssistant:OuterHumidityEntityId"] = "sensor.outer_humidity",
+                ["HomeAssistant:RequestTimeoutSeconds"] = "5",
+                ["HomeAssistant:RetryCount"] = "2",
+                ["HomeAssistant:RetryBaseDelayMilliseconds"] = "10",
+                ["HomeAssistant:RetryMaxDelaySeconds"] = "1",
+                ["HomeAssistant:StaleSnapshotMaxAgeMinutes"] = "60",
+                ["HomeAssistant:LiveSnapshotMaxAgeMinutes"] = "15",
+                ["HomeAssistant:ConditionsCacheDurationMinutes"] = "5",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHomeAssistantAdapter(config);
+        services.ConfigureHttpClientDefaults(b =>
+            b.ConfigurePrimaryHttpMessageHandler(() => handler));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static HttpResponseMessage Json(string state) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(new { state, entity_id = "x" })),
+        };
+
+    [Fact]
+    public async Task Resilience_RecoversOneTransientIoException_ProducesLiveSnapshot()
+    {
+        // Arrange — 4 sensors × first attempt throws IOException, second succeeds.
+        var handler = new SequencedHandler(
+            () => throw new IOException("boom"),
+            () => Json("21.5"),
+            () => throw new IOException("boom"),
+            () => Json("55.0"),
+            () => throw new IOException("boom"),
+            () => Json("18.2"),
+            () => throw new IOException("boom"),
+            () => Json("72.3"));
+
+        using var sp = (ServiceProvider)BuildProvider(handler);
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var provider = sp.GetRequiredService<HomeAssistantConditionsReadingProvider>();
+
+        // Act
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        // Assert
+        snapshot.Source.Should().Be(ConditionsReadingSource.Live);
+        handler.CallCount.Should().Be(8, "each of 4 sensors fails once and retries once");
+    }
+
+    [Fact]
+    public async Task Resilience_ExhaustedRetries_LeadsToUnavailable()
+    {
+        var handler = new SequencedHandler(
+            () => throw new IOException("a"), () => throw new IOException("b"), () => throw new IOException("c"),
+            () => throw new IOException("a"), () => throw new IOException("b"), () => throw new IOException("c"),
+            () => throw new IOException("a"), () => throw new IOException("b"), () => throw new IOException("c"),
+            () => throw new IOException("a"), () => throw new IOException("b"), () => throw new IOException("c"));
+
+        using var sp = (ServiceProvider)BuildProvider(handler);
+        var provider = sp.GetRequiredService<HomeAssistantConditionsReadingProvider>();
+
+        var snapshot = await provider.GetCurrentSnapshotAsync(CancellationToken.None);
+
+        snapshot.Source.Should().Be(ConditionsReadingSource.Unavailable);
+        handler.CallCount.Should().Be(12, "4 sensors × (RetryCount+1) = 4 × 3 attempts");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantRetryPipelineTests"`
+Expected: Compilation succeeds, but tests fail because resilience may not have been wired (or pass if Task 12 is already in place — accept either outcome at this step as long as the test runs).
+
+- [ ] **Step 3: Verify the tests pass after Task 12 wiring**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj --filter "FullyQualifiedName~HomeAssistantRetryPipelineTests"`
+Expected: 2 tests pass.
+
+If either fails, inspect Polly retry config from Task 12 (`MaxRetryAttempts`, `ShouldHandle`) and the primary-handler wiring (the test uses `ConfigureHttpClientDefaults` to swap the primary `HttpClientHandler`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/HomeAssistantRetryPipelineTests.cs
+git commit -m "test: end-to-end resilience pipeline tests for HA conditions provider"
+```
+
+---
+
+## Task 14: Register the HA health check in the API project
+
+The HA check joins `services.AddHealthChecks()` with tags `{ "homeassistant", "ready" }` so it surfaces both under `/health` and `/health/ready` (the latter filters by tag `"ready"` or `DB_TAG`).
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+- [ ] **Step 1: Add the using directive**
+
+Add this `using` (alphabetical with the other Anela namespaces) near the top of `ServiceCollectionExtensions.cs`:
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.HealthChecks;
+```
+
+- [ ] **Step 2: Register the check in `AddHealthCheckServices`**
+
+Replace the body of `AddHealthCheckServices` at lines 100-122 with:
+
+```csharp
+    public static IServiceCollection AddHealthCheckServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        var healthChecksBuilder = services.AddHealthChecks()
+            .AddCheck<Anela.Heblo.Application.Common.BackgroundServicesReadyHealthCheck>("background-services-ready", tags: new[] { "ready" })
+            .AddCheck<DataQualitySchemaHealthCheck>(
+                name: "data-quality-schema",
+                failureStatus: HealthStatus.Unhealthy,
+                tags: new[] { "ready", "db", "schema" })
+            .AddCheck<HomeAssistantConditionsHealthCheck>(
+                name: "homeassistant-conditions",
+                failureStatus: HealthStatus.Degraded,
+                tags: new[] { "ready", "homeassistant" });
+
+        // Add database health check via the shared NpgsqlDataSource so the probe
+        // reuses the application connection pool instead of opening a fresh connection
+        // on every health-check probe (which caused TaskCanceledException spikes).
+        var dbConnectionString = configuration.GetConnectionString(InfrastructureConstants.DEFAULT_CONNECTION);
+        if (!string.IsNullOrEmpty(dbConnectionString))
+        {
+            healthChecksBuilder.AddNpgSql(
+                sp => sp.GetRequiredService<NpgsqlDataSource>(),
+                name: InfrastructureConstants.DATABASE_HEALTH_CHECK,
+                tags: new[] { InfrastructureConstants.DB_TAG, InfrastructureConstants.POSTGRESQL_TAG });
+        }
+
+        return services;
+    }
+```
+
+- [ ] **Step 3: Build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+git commit -m "feat: register homeassistant-conditions health check with ready tag"
+```
+
+---
+
+## Task 15: Conditionally register the HA dependency telemetry filter
+
+The filter is registered only when Application Insights is configured, mirroring how `CostOptimizedTelemetryProcessor` is wired. The existing early-return on missing connection string already guarantees the filter is skipped in dev.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs`
+
+- [ ] **Step 1: Add the using directive**
+
+Add this `using` near the top of `ApplicationInsightsExtensions.cs`:
+
+```csharp
+using Anela.Heblo.Adapters.HomeAssistant.Telemetry;
+```
+
+- [ ] **Step 2: Register the filter alongside the existing processor**
+
+Find the line `services.AddApplicationInsightsTelemetryProcessor<CostOptimizedTelemetryProcessor>();` (around line 61) and add **immediately after** it:
+
+```csharp
+        services.AddApplicationInsightsTelemetryProcessor<HomeAssistantDependencyTelemetryFilter>();
+```
+
+- [ ] **Step 3: Build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
+git commit -m "feat: register HomeAssistantDependencyTelemetryFilter in AI pipeline"
+```
+
+---
+
+## Task 16: Full build, format, and test sweep
+
+Per CLAUDE.md "Validation before completion": `dotnet build` + `dotnet format` + all touched tests must pass before considering the feature shipped.
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Full solution build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded, 0 warnings (or no new warnings vs. baseline).
+
+- [ ] **Step 2: Format check**
+
+Run: `dotnet format backend/Anela.Heblo.sln --verify-no-changes`
+Expected: Exit code 0.
+
+If non-zero, run `dotnet format backend/Anela.Heblo.sln`, review the diff, and amend Task 11 (or whichever the formatter touched) in a follow-up commit:
+
+```bash
+git add -p
+git commit -m "style: apply dotnet format to HA adapter"
+```
+
+- [ ] **Step 3: Run the full HA adapter test suite**
+
+Run: `dotnet test backend/test/Anela.Heblo.Adapters.HomeAssistant.Tests/Anela.Heblo.Adapters.HomeAssistant.Tests.csproj`
+Expected: All tests pass (existing + ~18 new across 4 new files).
+
+- [ ] **Step 4: Run the API tests (smoke — catches breakage from `Stale` enum addition or DI changes)**
+
+Run: `dotnet test backend/test/Anela.Heblo.API.Tests/Anela.Heblo.API.Tests.csproj`
+Expected: All tests pass.
+
+> If any unrelated API tests already fail on `main`, accept the pre-existing baseline. If new failures are caused by this branch, fix them before proceeding.
+
+- [ ] **Step 5: Final commit (only if format produced changes in step 2)**
+
+```bash
+# Only run if there are staged changes from `dotnet format`
+git status --short
+```
+
+If there are no further changes, this task ends with the verification output above.
+
+---
+
+## Self-Review Summary
+
+**Spec coverage (FR/NFR → Task):**
+- FR-1 (retry with backoff + jitter) → Tasks 7, 12, 13.
+- FR-2 (last-known-good stale fallback, source = `Stale`) → Tasks 1, 5, 11, plus consumer audit Task 2.
+- FR-3 (suppress noisy telemetry, single Faulted per outage, structured warning without exception) → Tasks 8, 9, 11 (`FetchSensorValueAsync` warning), 15.
+- FR-4 (health check + `homeassistant.snapshot.source` metric) → Tasks 6, 10, 14; metric tag emitted from Task 11.
+- FR-5 (configurable knobs with safe defaults) → Task 3.
+- NFR-1 (performance: `HttpClient.Timeout = Infinite`, per-attempt timeout) → Task 12.
+- NFR-2 (no secret logging — provider only logs entity ids / status codes / exception type+message, never the request body or headers) → Task 11.
+- NFR-3 (single-flight via gate, bounded wait) → Tasks 5, 11.
+- NFR-4 (single Information log per call) → Task 11 `LogSummary`.
+- NFR-5 (coverage ≥80%) → Tasks 5, 9, 10, 11, 13; covers happy path, retry recovery, exhausted retries with LKG, exhausted retries without LKG (cold start), single-flight, partial-does-not-overwrite-LKG, cancellation.
+- Domain enum `Stale` → Task 1; PDF consumer audit → Task 2; tile + handler consumers verified at audit time (use `.ToString()` and only compare to `Unavailable`).
+- `HomeAssistantSettings` knobs (`RetryCount`, `RetryBaseDelayMilliseconds`, `StaleSnapshotMaxAgeMinutes`, `LiveSnapshotMaxAgeMinutes`, `RetryMaxDelaySeconds`) → Task 3.
+- Package references → Task 4.
+- DI wiring (resilience pipeline, coordinator, metrics, health check, tagging handler) → Task 12; API project registers health check (Task 14) and conditional telemetry filter (Task 15).
+- Health-check tags `{ "homeassistant", "ready" }` → Task 14.
+
+**Placeholder scan:** No "TBD"/"add error handling"/"similar to" placeholders. Each step shows actual code or actual commands.
+
+**Type consistency:**
+- `HomeAssistantSnapshotCoordinator.Gate` / `LastObservedSnapshot` / `LastKnownGoodLive` / `RecordObserved` / `RecordLive` used consistently across Tasks 5, 10, 11.
+- `HomeAssistantRetryActivityTaggingHandler.SuppressTagName` referenced in Task 7, 8, 9.
+- `HomeAssistantSnapshotMetrics.RecordSnapshot(ConditionsReadingSource)` used in Task 11; constructor parameterless to match DI registration in Task 12.
+- `HomeAssistantTransientErrorPredicate.ShouldHandleAsync<TResult>` matches the `HttpRetryStrategyOptions.ShouldHandle` delegate shape used in Task 12; `IsTransient(Exception?, object?)` used by the tagging handler in Task 8.
+- `HomeAssistantConditionsReadingProvider` constructor signature in Task 11 matches the test setup in Tasks 11 and 13 (`HttpClient`, `IOptions<HomeAssistantSettings>`, `IMemoryCache`, `HomeAssistantSnapshotCoordinator`, `HomeAssistantSnapshotMetrics`, `ILogger`).
+
+---
+
+## Plan complete
+
+Saved to `docs/superpowers/plans/2026-06-13-resilient-homeassistant-dependency.md`.


### PR DESCRIPTION
In the last 7 days (P7D, ending 2026-06-12T15:12Z):

- **32 dependency failures** (`type: HTTP`, `target: homeassistant.tail0cdb23.ts.net`, `resultCode: Faulted`) in the dependency telemetry.
- **32 `System.IO.IOException`** at `Anela.Heblo.Adapters.HomeAssistant.HomeAssistantConditionsReadingProvider+<FetchSensorValueAsync>d__7.MoveNext` — the matching exception records.

**Rate: ~4.6 failures/day, consistent and ongoing** (4 IOExceptions confirmed in the last 2 days).

Latency context for successful calls (3,768 total calls in P7D): p50 317 ms, p95 616 ms, p99 814 ms — within normal range. The 32 Faulted failures are distinct from latency; they are connection-level errors.

## Correlation

`homeassistant.tail0cdb23.ts.net` is the Tailscale hostname for the local Home Assistant instance. A `resultCode: Faulted` dependency + `IOException` at `FetchSensorValueAsync` indicates TCP-level connection failures (TCP reset, connection refused, or network path unreachable). There is no merged PR in the window addressing the HomeAssistant adapter, and the failure rate is stable rather than spiking — pointing to persistent intermittent Tailscale tunnel or HA availability issues rather than a code regression.

## Next step

Check Tailscale peer status for `tail0cdb23.ts.net` and Home Assistant uptime/restart logs for the same period (June 5–12). If HA is briefly unavailable on a schedule (e.g. nightly restarts), confirm that `HomeAssistantConditionsReadingProvider` has a timeout + graceful-degradation path — it should return a cached or default sensor value rather than propagating the `IOException` to callers when HA is momentarily unreachable.

---

Closes #2997

### Tokens used
36059789
