### PR TITLE
Add cloud environment setup scripts for Claude Code on the web

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,19 @@
   "enabledPlugins": {
     "ralph-loop@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/cloud-session-setup.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/cloud-env-bootstrap.sh
+++ b/scripts/cloud-env-bootstrap.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# cloud-env-bootstrap.sh
+#
+# Repo-INDEPENDENT system installs for Claude Code on the web.
+#
+# Paste the contents of this file into your cloud environment's "Setup script"
+# field (web UI). It runs BEFORE Claude Code launches, before the repo is
+# checked out, so it must NOT reference any repo files — it only installs the
+# system toolchain the base image lacks (.NET 8 SDK, GitHub CLI, SkiaSharp libs).
+#
+# Repo-dependent setup (dotnet restore / npm install) is handled separately by
+# the SessionStart hook scripts/cloud-session-setup.sh, which runs after launch
+# with $CLAUDE_PROJECT_DIR pointing at the checked-out repo.
+#
+# Output is cached by the environment, so these installs persist across new
+# sessions without re-downloading. Idempotent and safe to re-run.
+#
+set -e
+
+DOTNET_CHANNEL="8.0"
+
+# --- SkiaSharp native libs (PDF generation) --------------------------------
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  curl ca-certificates gnupg libfontconfig1 libfreetype6
+
+# --- .NET 8 SDK (not pre-installed) ----------------------------------------
+# Install to /usr/local so `dotnet` is on PATH for the hook, Claude, and shells
+# without sourcing a profile.
+if ! command -v dotnet >/dev/null 2>&1; then
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  bash /tmp/dotnet-install.sh --channel "${DOTNET_CHANNEL}" --install-dir /usr/local/dotnet
+  rm -f /tmp/dotnet-install.sh
+  ln -sf /usr/local/dotnet/dotnet /usr/local/bin/dotnet
+fi
+
+# --- GitHub CLI (not pre-installed) ----------------------------------------
+if ! command -v gh >/dev/null 2>&1; then
+  keyring="/usr/share/keyrings/githubcli-archive-keyring.gpg"
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of="$keyring"
+  chmod go+r "$keyring"
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=$keyring] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list
+  apt-get update -y
+  apt-get install -y gh
+fi
+
+echo "cloud-env-bootstrap: system toolchain ready (dotnet $(dotnet --version), gh $(gh --version | head -1))"

--- a/scripts/cloud-session-setup.sh
+++ b/scripts/cloud-session-setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# cloud-session-setup.sh
+#
+# SessionStart hook entrypoint for Claude Code on the web (cloud sessions).
+#
+# WHY THIS EXISTS:
+#   The cloud environment's "setup script" field runs BEFORE Claude Code
+#   launches, before the repository is reliably checked out at the working
+#   directory. Pointing that field at a repo path (e.g. ./scripts/setup-cloud-env.sh)
+#   fails with "No such file or directory" (exit 127), and a non-zero setup
+#   script makes the whole session fail to start.
+#
+#   Repo-dependent setup therefore belongs in a SessionStart hook, which runs
+#   AFTER launch with the repo checked out and $CLAUDE_PROJECT_DIR pointing at
+#   it. This wrapper is wired up in .claude/settings.json.
+#
+# BEHAVIOUR:
+#   - No-op outside cloud sessions (keeps local SessionStart fast).
+#   - Delegates to the idempotent scripts/setup-cloud-env.sh, resolved via
+#     $CLAUDE_PROJECT_DIR (falls back to this script's own location).
+#   - Skips the heavy Playwright browser download by default; run
+#     ./scripts/setup-cloud-env.sh manually when an E2E session needs it.
+#
+set -euo pipefail
+
+# Cloud-only: CLAUDE_CODE_REMOTE=true is set in Claude Code on the web sessions.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# $CLAUDE_PROJECT_DIR is set when the hook runs; fall back to the repo root
+# inferred from this script's location for manual invocation.
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+SKIP_PLAYWRIGHT="${SKIP_PLAYWRIGHT:-1}" exec "${REPO_ROOT}/scripts/setup-cloud-env.sh"

--- a/scripts/setup-cloud-env.sh
+++ b/scripts/setup-cloud-env.sh
@@ -25,7 +25,10 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 readonly DOTNET_CHANNEL="8.0"
 readonly NODE_MAJOR="20"
-readonly REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Prefer $CLAUDE_PROJECT_DIR (set in Claude Code SessionStart hooks) so the
+# repo-dependent steps resolve correctly even when this script is invoked from
+# outside the repo. Fall back to the script's own location for manual runs.
+readonly REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Use sudo only when not already root (containers usually run as root).
 SUDO=""
@@ -123,6 +126,17 @@ install_gh() {
 # ---------------------------------------------------------------------------
 # 5. Restore project dependencies
 # ---------------------------------------------------------------------------
+require_repo() {
+  if [ ! -f "${REPO_ROOT}/Anela.Heblo.sln" ]; then
+    warn "Repository not found at REPO_ROOT='${REPO_ROOT}' (no Anela.Heblo.sln)."
+    warn "Repo-dependent steps (dotnet restore / npm install) need the checked-out"
+    warn "repo. This script must run from inside the repo or with \$CLAUDE_PROJECT_DIR"
+    warn "set — it cannot run as a cloud 'setup script' field (repo not yet present)."
+    warn "Use the SessionStart hook (scripts/cloud-session-setup.sh) for these steps."
+    exit 1
+  fi
+}
+
 restore_backend() {
   log "Restoring backend NuGet packages..."
   dotnet restore "${REPO_ROOT}/Anela.Heblo.sln"
@@ -158,6 +172,7 @@ main() {
   install_dotnet
   install_node
   install_gh
+  require_repo
   restore_backend
   restore_frontend
   install_playwright


### PR DESCRIPTION
## Summary

Adds two new setup scripts to support Claude Code on the web (cloud sessions) and updates the existing setup script to work correctly in that environment. These changes enable the project to bootstrap system dependencies before the repo is checked out, then perform repo-dependent setup after launch via a SessionStart hook.

## Key changes

- **`scripts/cloud-env-bootstrap.sh`** (new): Repo-independent system bootstrap script for the cloud environment's "setup script" field. Installs .NET 8 SDK, GitHub CLI, and SkiaSharp native libraries before Claude Code launches and before the repo is checked out. Idempotent and safe to re-run.

- **`scripts/cloud-session-setup.sh`** (new): SessionStart hook entrypoint that runs after Claude Code launches with the repo checked out. Delegates to `setup-cloud-env.sh` with `$CLAUDE_PROJECT_DIR` set, skipping Playwright browser download by default (can be run manually when E2E testing is needed).

- **`scripts/setup-cloud-env.sh`** (modified):
  - Updated `REPO_ROOT` resolution to prefer `$CLAUDE_PROJECT_DIR` (set by SessionStart hooks) while falling back to script location for manual runs
  - Added `require_repo()` check to validate the repo is present before attempting repo-dependent steps (dotnet restore / npm install), with clear error messaging directing users to use the SessionStart hook

- **`.claude/settings.json`** (modified): Registered the SessionStart hook to invoke `cloud-session-setup.sh` on startup/resume with a 10-minute timeout.

## Implementation details

The two-phase approach separates concerns:
1. **Phase 1** (cloud setup script): System toolchain installation before repo checkout
2. **Phase 2** (SessionStart hook): Repo-dependent dependency restoration after launch

This avoids the "No such file or directory" failure that occurs when pointing the cloud setup script field at a repo path before checkout. The `require_repo()` guard ensures clear error messages if someone tries to run `setup-cloud-env.sh` outside the repo without `$CLAUDE_PROJECT_DIR` set.

https://claude.ai/code/session_01KEBYoLWVTg8XhqwxiFXEfn