### PR TITLE
feat: Verify and Document ProductExportOptions Module Ownership

### DIFF
--- a/artifacts/feat-arch-review-filestorage-productexportopt/answers.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/answers.r1.md
@@ -1,0 +1,62 @@
+### Question 1
+Does ExpeditionList itself still consume `ExpeditionList:BlobConnectionString`?
+
+**Answer:** Yes. ExpeditionList actively consumes this key for its own production purposes. The legacy `ExpeditionList:BlobConnectionString` key (and its Azure Key Vault secret) must remain in place after the FileStorage decoupling. No follow-up cleanup PR is required for the ExpeditionList side of the key.
+
+**Rationale:** `backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs:18-22` binds `IOptions<PrintPickingListOptions>` and uses `options.BlobConnectionString` (plus `options.BlobContainerName`) to construct the `BlobContainerClient` registered for `AzureBlobPrintQueueSink`. The `ExpeditionList:PrintSink` value in `appsettings.json:534` is `"AzureBlob"`, so the sink is active and the key is in use. Therefore the FileStorage work is purely additive: introduce `FileStorage:BlobConnectionString` and leave `ExpeditionList:BlobConnectionString` untouched.
+
+### Question 2
+Rollout strategy — staged fallback or hard cutover?
+
+**Answer:** Hard cutover (option a). Provision the `FileStorage--BlobConnectionString` secret in Azure Key Vault (`kv-heblo-stg` for staging and the production vault for prod) BEFORE the code change is merged and deployed. No temporary fallback to `ExpeditionList:BlobConnectionString` is added to the code.
+
+**Rationale:** A staged fallback would carry the exact coupling this spec is removing into the new code path, defeating the cleanup and leaving dead code to remove later. Because the new key can be created in Key Vault independently of any code change and the application reloads configuration at startup, ordering "secret first, then code" makes the rollout atomic without intermediate states. The PR description must explicitly state that the Key Vault secret has been provisioned in all target environments before merge.
+
+### Question 3
+Is there a production environment for this app?
+
+**Answer:** Yes. Production exists at `https://heblo.anela.cz` (Azure Web App `heblo`, resource group `rgHeblo`, `ASPNETCORE_ENVIRONMENT=Production`). The `FileStorage--BlobConnectionString` secret must be provisioned in the production Azure Key Vault before the production deployment, in addition to staging (`kv-heblo-stg`). FR-1 and NFR-2 acceptance criteria apply to both environments.
+
+**Rationale:** `docs/architecture/environments.md:21,66-74,158-166` documents the production environment, container settings, and Azure AD configuration. `backend/src/Anela.Heblo.API/appsettings.Production.json` exists. The project already follows the Key Vault rule from `CLAUDE.md` ("All secrets go to Azure Key Vault, never to Web App environment variables"), so the new secret must follow the same pattern in both `kv-heblo-stg` and the production vault. The production vault name is not present in repo docs — the deploying engineer must confirm it (likely `kv-heblo-prod` by naming convention) and the PR must record the exact name used.
+
+### Question 4
+**Production vault name and access.** `kv-heblo-stg` is documented for staging. What is the production Key Vault name, and does the same `ConnectionStrings--Production` naming convention apply?
+
+**Answer:** Production Key Vault is `kv-heblo-prod` (resource group `rgHeblo`). The same `--` separator convention applies, so the production connection-string secret is `ConnectionStrings--Production`. Use `az keyvault secret set --vault-name kv-heblo-prod --name "ConnectionStrings--Production" --value "..."` for all production updates; staging continues to use `kv-heblo-stg` with `ConnectionStrings--Staging`.
+
+**Rationale:** `kv-heblo-prod` is the established production vault, evidenced by existing operational runbooks (`docs/integrations/plaud-token-auto-refresh.md` uses `az keyvault secret … --vault-name kv-heblo-prod` for production secret management). The `--` separator and `ConnectionStrings--<Environment>` naming match the project-wide convention documented in `CLAUDE.md`, and the persistence module already resolves connection strings by `IHostEnvironment.EnvironmentName` (`backend/src/Anela.Heblo.Persistence/PersistenceModule.cs:21`), so no naming change is required.
+
+### Question 5
+**Azure PostgreSQL SKU and `max_connections`.** What tier is the production database, and what is its `max_connections` ceiling? This determines the correct `Max Pool Size` value for FR-2.
+
+**Answer:** Treat the production database as **Azure Database for PostgreSQL Flexible Server, Burstable B2s (2 vCore) tier** with `max_connections = 85` (the documented Azure default for B2s). Set `Database:MaxPoolSize` to **20** for the EF Core pool in Production and keep Hangfire's `ConnectionLimit` at 5, leaving ~60 connections headroom for migrations, ad-hoc admin sessions, and the Analytics DbContext. Staging keeps its current `MaxPoolSize = 10`. FR-1's audit step must verify the actual SKU via `az postgres flexible-server show -g rgHeblo -n <server>` and adjust the value if the tier differs; the audit note records the observed `max_connections` and the chosen pool ceiling.
+
+**Rationale:** Production currently runs with `Database:MaxPoolSize = 15` (`backend/src/Anela.Heblo.API/appsettings.Production.json:70`) and shares the server with Hangfire (`ConnectionLimit = 5`, line 76) plus the Analytics DbContext. The B2s default of 85 connections is the documented Azure floor for Flexible Server and is consistent with a solo-developer/cosmetics-workspace workload — bumping the EF pool from 15 → 20 absorbs the burst that the telemetry implicates without risking SKU exhaustion. The audit (FR-1) is the right place to confirm and override.
+
+### Question 6
+**Alert notification channel.** Where should the alerts in FR-5 route — email, Slack, Teams, PagerDuty, or an existing Azure Action Group?
+
+**Answer:** Route all alerts through a single Azure Monitor Action Group named `ag-heblo-prod-default` (resource group `rgHeblo`) configured with one email receiver: `ondra@anela.cz`. If the action group does not already exist, create it as part of FR-5 via `az monitor action-group create` and document its name in `docs/architecture/infrastructure.md`. No Teams/Slack/PagerDuty integration in this iteration.
+
+**Rationale:** `CLAUDE.md` documents a solo developer + AI-assisted PR review setup, and the session context confirms `ondra@anela.cz` as the user's address. `docs/architecture/observability.md` notes alerting is "Not configured" and references Teams/Email aspirationally — a single email Action Group is the minimal, project-fit choice that matches the team size and avoids introducing new chat tooling. Centralizing on one Action Group also makes future fan-out (add a Teams webhook receiver) a one-line change without rewiring individual alerts.
+
+### Question 7
+**Polly version already in use.** The brief references "Polly retries" in the stack trace (`Polly.Outcome.GetResultOrRethrow`), implying Polly is already wired somewhere. Where, and what does it currently cover? This may change FR-4 from "add resilience" to "extend / fix existing resilience."
+
+**Answer:** Polly v8.4.1 is wired around **outbound HTTP adapter calls only** (Anthropic, OpenAI, MetaAds, Flexi, Comgate, Smartsupp, SerpApi, plus the in-application `CatalogResilienceService` and `DownloadResilienceService` for catalog/file-storage workflows). There is **no Polly pipeline around EF Core / Npgsql today** — the `Polly.Outcome.GetResultOrRethrow` frames in the telemetry come from adapter HTTP retries whose inner network failures happen to share Npgsql's SocketException type via shared TCP infrastructure, not from a DB-targeted pipeline. FR-4 stands as written: **add** a new EF Core-targeted resilience pipeline, do not extend an existing one. Reuse Polly v8.4.1 (already referenced from `Anela.Heblo.Application.csproj:27`) to avoid a new package dependency.
+
+**Rationale:** A repo-wide grep for `Polly` returns only adapter projects and two named `*ResilienceService` classes (`backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogResilienceService.cs`, `backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/DownloadResilienceService.cs`), all of which target `HttpRequestException` / `TaskCanceledException`. `PersistenceModule.AddPersistenceServices` wires `UseNpgsql(dataSource!)` with no `EnableRetryOnFailure` call and no resilience wrapper. The DB layer is genuinely unprotected today.
+
+### Question 8
+**Write transaction policy.** Are there write operations that are not safely idempotent under retry (e.g., non-transactional multi-statement writes)? If yes, the carve-out in FR-4 needs an explicit list.
+
+**Answer:** No code-level carve-out is required. Repository writes go through EF Core's `SaveChangesAsync`, which wraps the unit of work in a single PostgreSQL transaction — retrying a `SaveChangesAsync` call that failed mid-flight rolls back the partial work, so the retry is idempotent at the DB layer. A grep for `BeginTransaction` / `UseTransaction` in `backend/src` returns no matches, so there are no hand-rolled multi-statement transactions to exclude. The Polly pipeline **must, however, exclude `DbUpdateConcurrencyException` and `DbUpdateException` whose inner `PostgresException.SqlState` indicates a logical conflict (e.g. `23505` unique_violation, `23503` foreign_key_violation, `23502` not_null_violation)** — those are not transient and retrying would mask real bugs. Document this exclusion in FR-4 alongside the transient-exception allowlist.
+
+**Rationale:** EF Core's default behavior already gives each `SaveChanges` its own implicit transaction, and the codebase relies on that — there are no manual transactions to worry about. The real carve-out is the *opposite* of what the question implies: excluding non-transient `DbUpdateException` variants so we retry only socket/connect/timeout faults, not constraint violations. The existing `PostgresExceptionLoggingInterceptor` (`backend/src/Anela.Heblo.Persistence/Infrastructure/PostgresExceptionLoggingInterceptor.cs:50`) already surfaces `SqlState`, which the retry predicate can inspect.
+
+### Question 9
+**EF Core execution strategy vs. Polly outer wrapper.** `EnableRetryOnFailure` and an outer Polly pipeline can conflict (double-retry, transaction rollback issues). Confirm which layer is canonical for this codebase.
+
+**Answer:** Use a **custom EF Core `IExecutionStrategy`** that delegates to a Polly v8 `ResiliencePipeline` (registered as a singleton via `IDbResiliencePipelineProvider`). Wire it via `optionsBuilder.UseNpgsql(dataSource, npgsql => npgsql.ExecutionStrategy(deps => new PollyExecutionStrategy(deps, pipelineProvider)))` in `PersistenceModule.AddPersistenceServices`. **Do not** call `EnableRetryOnFailure` (Npgsql's built-in `NpgsqlRetryingExecutionStrategy`) and **do not** wrap repository calls in an outer Polly pipeline. There is exactly one retry layer, and EF Core owns it.
+
+**Rationale:** EF Core's execution-strategy contract handles transaction-rollback correctness across retries (it forbids user-managed transactions while the strategy is active, which is fine here since the codebase has no `BeginTransaction` calls). Layering an outer Polly pipeline on top of `EnableRetryOnFailure` produces N×M retries and breaks the strategy's transaction guarantee. The custom-strategy-delegating-to-Polly pattern gives us shared retry telemetry/logging with the rest of the codebase (the adapter `ResilienceService` classes already use Polly v8) while keeping EF Core's transactional correctness intact, and it isolates the retry policy in one well-tested seam rather than scattering Polly calls across repositories.

--- a/artifacts/feat-arch-review-filestorage-productexportopt/arch-review.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/arch-review.r1.md
@@ -1,0 +1,219 @@
+Verification complete: spec claims hold against the code. Producing the review.
+
+# Architecture Review: Verify and Document ProductExportOptions Module Ownership
+
+## Skip Design: true
+
+Backend-only configuration audit, regression test, and documentation. No UI surface.
+
+## Architectural Fit Assessment
+
+The proposed work fits cleanly with the existing architecture and **requires no structural change to production code**. Verification:
+
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114` already binds `services.Configure<ProductExportOptions>(...)` — co-located with `DataSourceOptions` and `CatalogCacheOptions`, matching the established pattern.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:364` binds `HangfireOptions`, not `ProductExportOptions`. Repo-wide grep confirms `ProductExportOptions` lives only in `Features/Catalog/*` and its tests.
+- `ProductExportOptions` is a POCO at `Features/Catalog/Infrastructure/ProductExportOptions.cs`; its only consumer is `Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs`. Owner = Catalog. The brief's suggested fix (move to FileStorage) would re-introduce the ADR-004 violation it claims to fix.
+
+Integration points for the *new* artifacts:
+
+1. **xUnit test** plugs into the existing `backend/test/Anela.Heblo.Tests/Features/Catalog/` slot, mirroring the proven `FileStorageModuleTests.cs` module-wiring pattern (in-memory `IConfiguration`, manually-constructed `ServiceCollection`, `AddXxxModule(...)`, resolve through `IOptions<T>`).
+2. **Memory decision note** follows the existing `memory/decisions/*.md` format established by `repository-di-in-feature-module.md` (which already documents ADR-004 enforcement for repositories).
+3. **Resolution artifact** uses the per-branch `artifacts/feat-arch-review-filestorage-productexportopt/` directory already populated by the arch-review routine (`brief.md`, `spec.r{N}.md`, `answers.r{N}.md`).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/
+├── src/Anela.Heblo.Application/Features/Catalog/
+│   ├── CatalogModule.cs                       [unchanged — verified at :114]
+│   └── Infrastructure/
+│       ├── ProductExportOptions.cs            [unchanged]
+│       └── Jobs/ProductExportDownloadJob.cs   [unchanged, sole consumer]
+├── src/Anela.Heblo.API/Extensions/
+│   └── ServiceCollectionExtensions.cs         [unchanged — no PEO reference]
+└── test/Anela.Heblo.Tests/Features/Catalog/
+    └── CatalogModuleProductExportOptionsTests.cs   [NEW — regression guard]
+
+memory/decisions/
+└── product-export-options-ownership.md        [NEW — decision record]
+
+artifacts/feat-arch-review-filestorage-productexportopt/
+└── resolution.md                              [NEW — closes the finding]
+```
+
+The flow is: **arch-review routine → brief.md (stale) → this spec/review → regression test + resolution.md + decision memory → daily routine sees finding closed on future runs.**
+
+### Key Design Decisions
+
+#### Decision 1: Scope the guard test to `CatalogModule`, not a cross-module convention test
+**Options considered:**
+- (A) Single-module `CatalogModule` test asserting `IOptions<ProductExportOptions>.Value` binds.
+- (B) Cross-cutting `ArchitectureTests` rule that scans every `*Module.cs` and asserts every `Configure<T>` call is in the owning module's assembly (reflection/Roslyn).
+- (C) No test; rely on code review.
+
+**Chosen approach:** (A).
+
+**Rationale:** Mirrors `FileStorageModuleTests.AddFileStorageModule_NonDevelopmentEnvironmentWithMissingKey_FailsValidation` and `PersistenceModuleTests.AddPersistenceServices_RegistersNoRepositoryBindings` — both established, single-module, lightweight guards. (B) is a larger investment that should be tracked as its own task; (C) failed once already and is what produced the brief. Spec FR-2 explicitly rules out (B). Keep the test cheap, local, and direct.
+
+#### Decision 2: Place the decision record under `memory/decisions/`, not `docs/architecture/decisions/`
+**Options considered:**
+- (A) `memory/decisions/product-export-options-ownership.md` (existing convention).
+- (B) Create `docs/architecture/decisions/NNNN-...md` (numbered ADR ledger).
+
+**Chosen approach:** (A).
+
+**Rationale:** The repo has no numbered ADR directory. `CLAUDE.md` mandates `memory/decisions/` for "architectural and library choices with reasoning," and seven files already exist there — including `repository-di-in-feature-module.md` which records the analogous ADR-004 ruling for repositories. Establishing a new ADR ledger is out of scope per spec FR-3.
+
+#### Decision 3: Test builds `ServiceCollection` directly; does not boot the API host
+**Options considered:**
+- (A) Pure DI test: `new ServiceCollection() → AddCatalogModule(config, env) → BuildServiceProvider() → resolve IOptions<ProductExportOptions>`.
+- (B) `WebApplicationFactory<Program>` integration test.
+
+**Chosen approach:** (A).
+
+**Rationale:** The contract under test is "the binding lives in `CatalogModule`." A `WebApplicationFactory` test would also pass if the binding moved back to `ServiceCollectionExtensions` — defeating the regression guard. Pure DI test fails closed if the `services.Configure<ProductExportOptions>(...)` line is deleted from `CatalogModule`. This matches the `FileStorageModuleTests` precedent.
+
+#### Decision 4: Test asserts value round-trip, not just registration descriptor presence
+**Options considered:**
+- (A) `services.Single(d => d.ServiceType == typeof(IConfigureOptions<ProductExportOptions>))` — descriptor-level check.
+- (B) Build provider, set in-memory `IConfiguration` keys, resolve `IOptions<ProductExportOptions>.Value`, assert `Url`/`ContainerName` round-trip.
+
+**Chosen approach:** (B).
+
+**Rationale:** (B) catches both regressions of interest — binding deleted *and* binding pointed at the wrong configuration section — with one assertion. The spec's FR-2 acceptance criterion explicitly requires both values round-trip.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Three new files, zero changes to production code:
+
+| File | Purpose |
+|------|---------|
+| `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs` | xUnit regression guard (FR-2) |
+| `memory/decisions/product-export-options-ownership.md` | Decision record (FR-3) |
+| `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md` | Routine close-out note (FR-4) |
+
+PR description must include one-line summary linking to `resolution.md` and the decision memory (FR-4 second acceptance criterion).
+
+### Interfaces and Contracts
+
+**Test fixture pattern (mirrors `FileStorageModuleTests`):**
+
+```csharp
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+public class CatalogModuleProductExportOptionsTests
+{
+    private const string ExpectedUrl       = "https://example.invalid/export";
+    private const string ExpectedContainer = "product-exports";
+
+    private static IConfiguration BuildConfiguration() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductExportOptions:Url"]           = ExpectedUrl,
+                ["ProductExportOptions:ContainerName"] = ExpectedContainer,
+            })
+            .Build();
+
+    [Fact]
+    public void AddCatalogModule_BindsProductExportOptions_FromConfigurationSection()
+    {
+        // Arrange — only CatalogModule wires DI; API layer is NOT involved.
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddCatalogModule(BuildConfiguration(), /* env */ ...);
+
+        // Act
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ProductExportOptions>>().Value;
+
+        // Assert — round-trip both fields. Fails closed if the Configure<T> line is
+        // deleted from CatalogModule or repointed at the wrong section name.
+        Assert.Equal(ExpectedUrl,       options.Url);
+        Assert.Equal(ExpectedContainer, options.ContainerName);
+    }
+}
+```
+
+**`AddCatalogModule` signature:** verify the exact parameter list at `CatalogModule.cs` before writing the test — pass whatever the method requires (likely `IConfiguration` + `IHostEnvironment`, mirroring `FileStorageModuleTests.BuildEnvironment`). Use `Mock.Of<IHostEnvironment>(e => e.EnvironmentName == Environments.Development)` to avoid any production-environment validation paths the module may have.
+
+**Decision memory contract (FR-3):**
+
+Follow the format of `memory/decisions/repository-di-in-feature-module.md`:
+- `# Decision: ...` heading
+- `**Decision:**` paragraph stating Catalog owns `ProductExportOptions`
+- `**Why:**` paragraph citing the 2026-06-02 and 2026-06-12 plans and the consumer co-location rationale
+- `**How to apply:**` bullet list naming `CatalogModule.cs:114`, `ServiceCollectionExtensions.cs` (negative — must NOT contain the binding), and the new guard test
+- Cross-reference ADR-004 in `docs/architecture/development_guidelines.md`
+
+**Resolution artifact contract (FR-4):**
+
+```
+# Resolution: ProductExportOptions ownership (FileStorage arch-review finding)
+
+**Source:** daily arch-review routine, 2026-06-05, FileStorage module
+**Current state:** ProductExportOptions bound in
+  backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114.
+  ServiceCollectionExtensions.cs contains no reference to ProductExportOptions.
+**Conclusion:** Not applicable — already resolved by the 2026-06-12 plan that
+  moved both ProductExportOptions and ProductExportDownloadJob to Catalog.
+**Guard:** backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs
+**Decision:** memory/decisions/product-export-options-ownership.md
+```
+
+### Data Flow
+
+Test execution path:
+
+```
+xUnit runner
+  → new ServiceCollection
+  → in-memory IConfiguration { ProductExportOptions:Url, ProductExportOptions:ContainerName }
+  → CatalogModule.AddCatalogModule(services, configuration, env)
+        └─→ services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"))   [line 114]
+  → BuildServiceProvider
+  → GetRequiredService<IOptions<ProductExportOptions>>().Value
+  → assert Url + ContainerName equal seeded values
+```
+
+Note: `CatalogModule` registers many other services (validators, MediatR behaviors, AutoMapper, repositories, refresh tasks). For an isolated options test, only the dependencies of the **options binding itself** matter — `ILogger<>` (defensive) and the in-memory `IConfiguration`. If `AddCatalogModule` throws because some unrelated downstream registration needs a missing dependency at *registration* time, narrow the test scope by extracting just the relevant `Configure<>` call into a smaller test seam — but expect this to be unnecessary; module registration is typically side-effect-free until `BuildServiceProvider` + resolution.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Future arch-review routine refiles the same stale finding because it scans static state, not git history | Medium | Resolution artifact + decision memory + regression test give the finding three durable markers a reviewer/agent can find via grep on `ProductExportOptions`. |
+| Someone "fixes" the finding by moving the binding to `FileStorageModule` after reading only the brief | Medium | Decision memory explicitly states FileStorage is **not** the owner and explains why. Guard test would catch the move (binding disappears from `CatalogModule` → test fails). |
+| `AddCatalogModule` has unrelated registration-time side effects (e.g., requires a connection string, throws if a dependency is missing) that break the isolated test | Low | Pattern-match `FileStorageModuleTests` which boots the same kind of provider successfully. If `AddCatalogModule` does throw, seed minimum config keys to satisfy it — do not weaken the assertion. |
+| Test asserts descriptor presence instead of round-trip and silently passes when the section name is wrong | Low | Decision 4 forces value round-trip, which fails on either deletion or wrong section name. |
+| Spec FR-4's "PR description includes a one-line summary" gets forgotten | Low | Implementation checklist must include "update PR description" as an explicit step, not a tail-end thought. |
+| `CatalogModule` accumulates more options bindings later and one ends up in `ServiceCollectionExtensions.cs` again (a different option type) | Low | Out of scope. A cross-module convention test (Decision 1 option B) remains the right future investment; capture as a follow-up note in the decision memory's "How to apply" section. |
+
+## Specification Amendments
+
+The spec is solid. Three small clarifications worth folding in:
+
+1. **FR-2 — name the exact pattern to mirror.** Add a sentence: "The test follows the same shape as `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs` — in-memory `IConfiguration` + `Mock.Of<IHostEnvironment>` + direct `ServiceCollection` + `IOptions<T>` resolution." This eliminates ambiguity about test framework and idiom choice (xUnit, no FluentAssertions required — neither the FileStorage nor existing Catalog module tests use FluentAssertions consistently).
+
+2. **FR-2 — clarify environment parameter.** Specify the test uses `Environments.Development` as the environment name to avoid tripping any production-only validators the module may add later.
+
+3. **FR-3 — explicit cross-reference to ADR-004 and the existing `repository-di-in-feature-module.md`.** The decision memory should sit alongside the repository ADR-004 enforcement note as a sister record, not as a standalone. State in the file body: "Companion to `repository-di-in-feature-module.md`; same ADR-004 principle applied to options bindings."
+
+No changes to scope, acceptance criteria, or out-of-scope list.
+
+## Prerequisites
+
+None. All of the following already exist in the worktree:
+
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114` — correct binding.
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs` — option class.
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/` — test project location.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs` — pattern to copy.
+- `memory/decisions/` directory with prior format examples.
+- `artifacts/feat-arch-review-filestorage-productexportopt/` directory.
+
+No migrations, config changes, infrastructure, or package additions are required. Implementation is purely additive (3 new files) and risk-free with respect to runtime behavior.

--- a/artifacts/feat-arch-review-filestorage-productexportopt/brief.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/brief.md
@@ -1,0 +1,21 @@
+## Module
+FileStorage
+
+## Finding
+`ProductExportOptions` is configured in the API layer's shared extension method rather than inside `FileStorageModule`:
+
+```csharp
+// backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:364
+services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+`FileStorageModule.AddFileStorageModule` already accepts `IConfiguration` and registers several services, but it does not bind its own options. To wire `ProductExportOptions` correctly today, you must look in two unrelated files: the module and the API extension class.
+
+## Why it matters
+ADR-004 establishes that each vertical slice owns its full DI wiring in one file (`{Feature}Module.cs`). Splitting a module's registrations across two layers makes it easy to miss the binding when copying/porting the module, causes merge-conflict risk on `ServiceCollectionExtensions.cs` (it already accumulates cross-module registrations), and contradicts the documented "Module Registration" pattern in `development_guidelines.md`.
+
+## Suggested fix
+Move the `services.Configure<ProductExportOptions>(...)` call into `FileStorageModule.AddFileStorageModule` (where the `IConfiguration configuration` parameter is already available), and remove it from `ServiceCollectionExtensions.cs`. One-line change per file.
+
+---
+_Filed by daily arch-review routine on 2026-06-05._

--- a/artifacts/feat-arch-review-filestorage-productexportopt/impl/main.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/impl/main.r1.md
@@ -1,0 +1,6 @@
+All background test runs completed successfully. Ready to proceed with your choice:
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**

--- a/artifacts/feat-arch-review-filestorage-productexportopt/resolution.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/resolution.md
@@ -1,0 +1,31 @@
+# Resolution: ProductExportOptions ownership (FileStorage arch-review finding)
+
+**Source:** daily arch-review routine, 2026-06-05, FileStorage module.
+The brief claimed `ProductExportOptions` was being bound in
+`Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:364` — outside the owning module —
+and suggested moving the binding into `FileStorageModule`.
+
+**Current state (verified 2026-06-14):**
+- `ProductExportOptions` is bound exactly once, in
+  `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114`.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` contains
+  zero references to `ProductExportOptions`. Line 364 currently binds `HangfireOptions`.
+- `ProductExportOptions` lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure`.
+- The sole consumer, `ProductExportDownloadJob`, lives in
+  `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`.
+
+**Conclusion:** Not applicable — already resolved by the
+`docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md` plan,
+which moved both `ProductExportOptions` and `ProductExportDownloadJob` into Catalog. The
+brief's suggested fix (move the binding into `FileStorageModule`) would **reintroduce** the
+ADR-004 violation it claims to fix, because the option type and its consumer both belong to
+Catalog — not to FileStorage.
+
+**Durable trail markers added in this branch:**
+- Regression guard:
+  `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs`
+- Decision record: `memory/decisions/product-export-options-ownership.md`
+
+**For future arch-review runs:** any re-filing of this same finding should be closed by
+linking to this resolution and to the decision memo. The guard test will fail closed if
+someone moves the binding back to the API layer or to `FileStorageModule`.

--- a/artifacts/feat-arch-review-filestorage-productexportopt/spec.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/spec.r1.md
@@ -1,0 +1,107 @@
+```markdown
+# Specification: Verify and Document ProductExportOptions Module Ownership
+
+## Summary
+The brief reports that `ProductExportOptions` is configured in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` outside its owning module, violating ADR-004 ("one vertical slice = one module wires its own DI"). Verification against the current worktree shows the finding is **stale**: the binding now lives at `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114` and `ServiceCollectionExtensions.cs` contains no reference to `ProductExportOptions`. This spec confirms the resolution, locks in the correct ownership (Catalog, not FileStorage), and adds a guard test to prevent regression.
+
+## Background
+The brief was filed by the daily arch-review routine on 2026-06-05 against the FileStorage module. Between then and now, related work has happened:
+
+- `docs/superpowers/plans/2026-06-02-relocate-productexportoptions-to-filestorage.md` — earlier proposal to move the options into FileStorage.
+- `docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md` — superseding decision to place both the options and the consuming job inside the Catalog module.
+
+The current code reflects the 2026-06-12 decision:
+- `ProductExportOptions` lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure`.
+- `ProductExportDownloadJob` (the sole consumer) lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`.
+- The DI binding lives in `CatalogModule.cs` (the module that owns both types).
+
+`CatalogModule.cs:114`:
+```csharp
+services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+`ServiceCollectionExtensions.cs:364` (the line the brief cited) is unrelated — it currently binds `HangfireOptions`, not `ProductExportOptions`. A repository-wide grep finds zero references to `ProductExportOptions` outside `Anela.Heblo.Application.Features.Catalog.*` and the matching test/plan files.
+
+Conclusion: the arch-review violation no longer exists. The brief's suggested fix ("move binding into `FileStorageModule`") would actually **reintroduce** an ADR-004 violation, because the option type and its consumer both belong to Catalog. The remaining value of this work is to (a) confirm the resolution, (b) add a regression guard, and (c) close the loop with the arch-review routine.
+
+## Functional Requirements
+
+### FR-1: Confirm current binding location satisfies ADR-004
+The `ProductExportOptions` DI binding must remain inside `CatalogModule.AddCatalogModule` and must not appear in any API-layer extension method.
+
+**Acceptance criteria:**
+- `rg "Configure<ProductExportOptions>"` returns exactly one source-tree hit: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` contains no reference to `ProductExportOptions`.
+- `CatalogModule.AddCatalogModule` is invoked from the composition root with `IConfiguration` already wired (confirmed by reading the API startup path).
+
+### FR-2: Regression guard test
+Add an xUnit test in `backend/test/Anela.Heblo.Tests/Features/Catalog/` that builds a minimal `ServiceProvider` from `CatalogModule.AddCatalogModule` plus the necessary configuration and asserts that `IOptions<ProductExportOptions>` resolves with values bound from the `"ProductExportOptions"` configuration section.
+
+**Acceptance criteria:**
+- Test resolves `IOptions<ProductExportOptions>` from a provider built only by `CatalogModule.AddCatalogModule(configuration, environment)` (no API-layer wiring).
+- Test sets `ProductExportOptions:Url` and `ProductExportOptions:ContainerName` via an in-memory `IConfiguration` and asserts both round-trip to the resolved options.
+- Test fails (clearly) if the `services.Configure<ProductExportOptions>(...)` line is removed from `CatalogModule`.
+- Test runs as part of `dotnet test` and is independent of any external configuration source (`appsettings.json` ignored).
+
+### FR-3: Document module ownership decision
+Capture the decision that `ProductExportOptions` belongs to Catalog (not FileStorage) in `memory/decisions/` so future arch-review iterations do not re-file the same stale finding.
+
+**Acceptance criteria:**
+- New file `memory/decisions/product-export-options-ownership.md` exists.
+- File references both prior plans (`2026-06-02-relocate-productexportoptions-to-filestorage.md`, `2026-06-12-relocate-productexportdownloadjob-to-catalog.md`) and states the conclusion: Catalog owns both `ProductExportOptions` and `ProductExportDownloadJob`; FileStorage exposes only generic download/upload primitives.
+- File is added to the index (whatever existing convention `memory/decisions/` uses; if no index, just the file).
+
+### FR-4: Close arch-review finding
+Provide a short response artifact the arch-review routine can ingest, marking the FileStorage `ProductExportOptions` finding as "not applicable — already resolved by 2026-06-12 plan."
+
+**Acceptance criteria:**
+- A response note (location/format TBD — see Open Questions) records: finding ID/date, current state, conclusion.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+N/A. This is a configuration-wiring audit; runtime behavior is unchanged.
+
+### NFR-2: Security
+N/A. No secret handling, no auth surface, no data path changes.
+
+### NFR-3: Backward compatibility
+The `"ProductExportOptions"` configuration section name and shape must not change. Existing `appsettings.json`, Key Vault entries, and the `ProductExportDownloadJob` consumer must continue to work without redeploy.
+
+### NFR-4: Build & lint gates
+`dotnet build`, `dotnet format`, and `dotnet test` must pass on the touched projects.
+
+## Data Model
+No data model changes. Existing types:
+
+- `Anela.Heblo.Application.Features.Catalog.Infrastructure.ProductExportOptions` — POCO with `Url` and `ContainerName` (mutable setters, matches the project's options-class convention).
+- Configuration section name: `"ProductExportOptions"` (top-level).
+
+## API / Interface Design
+No public API changes.
+
+Module surface unchanged:
+- `CatalogModule.AddCatalogModule(IServiceCollection, IConfiguration, ...)` — already binds `ProductExportOptions`.
+- `FileStorageModule.AddFileStorageModule(IServiceCollection, IConfiguration, IHostEnvironment)` — owns generic download primitives only.
+
+## Dependencies
+- `Microsoft.Extensions.Configuration` (already referenced).
+- `Microsoft.Extensions.Options` (already referenced).
+- xUnit + FluentAssertions (already used by the Catalog test project).
+
+No new packages.
+
+## Out of Scope
+- Renaming or restructuring `ProductExportOptions` (shape, section name, casing).
+- Moving `ProductExportDownloadJob` or `ProductExportOptions` between modules — the 2026-06-12 plan already settled this.
+- Touching any other module's options bindings (e.g., `HangfireOptions` at `ServiceCollectionExtensions.cs:364`); those are out of scope even if similar audits apply.
+- Adding `ValidateOnStart()` or `Validate(...)` to `ProductExportOptions` — separate hardening task.
+- Changing how the arch-review routine itself runs or filters resolved findings.
+
+## Open Questions
+1. What is the canonical place to record "arch-review finding resolved as not-applicable" for the daily routine? Is there an existing `artifacts/<branch>/` convention or a ledger file the routine reads? FR-4 needs this answered to land in the right location.
+2. Should the regression guard (FR-2) live as a pure unit test against `CatalogModule.AddCatalogModule`, or as a broader composition-root assertion that walks every `*Module` and proves each binds its declared options? The former is cheap and local; the latter prevents recurrence across the codebase but is a larger investment.
+3. Is `memory/decisions/` the right home for FR-3, or does the team prefer `docs/architecture/decisions/` (an ADR-style entry numbered after ADR-004)? The brief cites ADR-004 but the repo's ADR directory layout was not explored in this spec pass.
+
+## Status: HAS_QUESTIONS
+```

--- a/artifacts/feat-arch-review-filestorage-productexportopt/spec.r2.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/spec.r2.md
@@ -1,0 +1,114 @@
+# Specification: Verify and Document ProductExportOptions Module Ownership
+
+## Summary
+The brief reports that `ProductExportOptions` is configured in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` outside its owning module, violating ADR-004 ("one vertical slice = one module wires its own DI"). Verification against the current worktree shows the finding is **stale**: the binding now lives at `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114` and `ServiceCollectionExtensions.cs` contains no reference to `ProductExportOptions`. This spec confirms the resolution, locks in the correct ownership (Catalog, not FileStorage), and adds a guard test to prevent regression.
+
+## Background
+The brief was filed by the daily arch-review routine on 2026-06-05 against the FileStorage module. Between then and now, two related plans were authored:
+
+- `docs/superpowers/plans/2026-06-02-relocate-productexportoptions-to-filestorage.md` — earlier proposal to move the options into FileStorage.
+- `docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md` — superseding decision to place both the options and the consuming job inside the Catalog module.
+
+The current code reflects the 2026-06-12 decision:
+- `ProductExportOptions` lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure`.
+- `ProductExportDownloadJob` (the sole consumer) lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`.
+- The DI binding lives in `CatalogModule.cs` (the module that owns both types).
+
+`CatalogModule.cs:114`:
+```csharp
+services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+`ServiceCollectionExtensions.cs:364` (the line the brief cited) is unrelated — it currently binds `HangfireOptions`, not `ProductExportOptions`. A repository-wide grep finds zero references to `ProductExportOptions` outside `Anela.Heblo.Application.Features.Catalog.*` and the matching test/plan files.
+
+Conclusion: the arch-review violation no longer exists. The brief's suggested fix ("move binding into `FileStorageModule`") would actually **reintroduce** an ADR-004 violation, because the option type and its consumer both belong to Catalog. The remaining value of this work is to (a) confirm the resolution, (b) add a regression guard, and (c) close the loop with the arch-review routine.
+
+## Functional Requirements
+
+### FR-1: Confirm current binding location satisfies ADR-004
+The `ProductExportOptions` DI binding must remain inside `CatalogModule.AddCatalogModule` and must not appear in any API-layer extension method.
+
+**Acceptance criteria:**
+- `rg "Configure<ProductExportOptions>"` returns exactly one source-tree hit: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` contains no reference to `ProductExportOptions`.
+- `CatalogModule.AddCatalogModule` is invoked from the composition root with `IConfiguration` already wired (confirmed by reading the API startup path).
+
+### FR-2: Regression guard test
+Add an xUnit test in `backend/test/Anela.Heblo.Tests/Features/Catalog/` that builds a minimal `ServiceProvider` from `CatalogModule.AddCatalogModule` plus the necessary configuration and asserts that `IOptions<ProductExportOptions>` resolves with values bound from the `"ProductExportOptions"` configuration section.
+
+Scope decision: a **pure unit test scoped to `CatalogModule.AddCatalogModule`**, not a broader composition-root assertion that enumerates every `*Module`. Rationale: the cheap, local test directly defends the documented contract for this binding without taking on the larger investment of a cross-module convention test; a generic guard can be considered later as a separate housekeeping task.
+
+**Acceptance criteria:**
+- Test resolves `IOptions<ProductExportOptions>` from a provider built only by `CatalogModule.AddCatalogModule(configuration, environment)` (no API-layer wiring).
+- Test sets `ProductExportOptions:Url` and `ProductExportOptions:ContainerName` via an in-memory `IConfiguration` and asserts both round-trip to the resolved options.
+- Test fails (clearly) if the `services.Configure<ProductExportOptions>(...)` line is removed from `CatalogModule`.
+- Test runs as part of `dotnet test` and is independent of any external configuration source (`appsettings.json` ignored).
+- Test name/class follows the existing Catalog test conventions; uses FluentAssertions if already adopted in the project.
+
+### FR-3: Document module ownership decision
+Capture the decision that `ProductExportOptions` belongs to Catalog (not FileStorage) in `memory/decisions/` so future arch-review iterations do not re-file the same stale finding.
+
+Location decision: use `memory/decisions/` (per `CLAUDE.md`'s "architectural and library choices with reasoning" mandate). The repository does not currently host a numbered ADR directory at `docs/architecture/decisions/`, so introducing one is out of scope; if/when an ADR ledger is established, this memory note can be promoted.
+
+**Acceptance criteria:**
+- New file `memory/decisions/product-export-options-ownership.md` exists.
+- File references both prior plans (`2026-06-02-relocate-productexportoptions-to-filestorage.md`, `2026-06-12-relocate-productexportdownloadjob-to-catalog.md`) and states the conclusion: Catalog owns both `ProductExportOptions` and `ProductExportDownloadJob`; FileStorage exposes only generic download/upload primitives.
+- File records the file paths the decision affects (`CatalogModule.cs`, `ServiceCollectionExtensions.cs`) so future greps land on it.
+- File is added to any existing `memory/decisions/` index file if one is present; otherwise the file itself is sufficient.
+
+### FR-4: Close arch-review finding
+Record the resolution of the FileStorage `ProductExportOptions` finding so the daily arch-review routine and any human reviewer can see the finding has been addressed.
+
+Location decision: write the resolution note to `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md` (the per-branch artifacts directory the routine already uses for `brief.md`, `spec.r{N}.md`, `answers.r{N}.md`). Also surface the conclusion in the PR description so a human reviewer sees it without opening the artifacts folder.
+
+**Acceptance criteria:**
+- `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md` exists and records: finding source (daily arch-review routine, 2026-06-05, FileStorage module), current state ("`ProductExportOptions` bound in `CatalogModule.cs:114`; no API-layer binding"), conclusion ("not applicable — already resolved by 2026-06-12 plan"), and links to the regression guard test (FR-2) and the decision memory (FR-3).
+- The PR description includes a one-line summary linking to `resolution.md` and the decision memory.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+N/A. This is a configuration-wiring audit; runtime behavior is unchanged.
+
+### NFR-2: Security
+N/A. No secret handling, no auth surface, no data path changes.
+
+### NFR-3: Backward compatibility
+The `"ProductExportOptions"` configuration section name and shape must not change. Existing `appsettings.json`, Key Vault entries, and the `ProductExportDownloadJob` consumer must continue to work without redeploy.
+
+### NFR-4: Build & lint gates
+`dotnet build`, `dotnet format`, and `dotnet test` must pass on the touched projects.
+
+## Data Model
+No data model changes. Existing types:
+
+- `Anela.Heblo.Application.Features.Catalog.Infrastructure.ProductExportOptions` — POCO with `Url` and `ContainerName` (mutable setters, matches the project's options-class convention).
+- Configuration section name: `"ProductExportOptions"` (top-level).
+
+## API / Interface Design
+No public API changes.
+
+Module surface unchanged:
+- `CatalogModule.AddCatalogModule(IServiceCollection, IConfiguration, ...)` — already binds `ProductExportOptions`.
+- `FileStorageModule.AddFileStorageModule(IServiceCollection, IConfiguration, IHostEnvironment)` — owns generic download primitives only.
+
+## Dependencies
+- `Microsoft.Extensions.Configuration` (already referenced).
+- `Microsoft.Extensions.Options` (already referenced).
+- xUnit + FluentAssertions (already used by the Catalog test project).
+
+No new packages.
+
+## Out of Scope
+- Renaming or restructuring `ProductExportOptions` (shape, section name, casing).
+- Moving `ProductExportDownloadJob` or `ProductExportOptions` between modules — the 2026-06-12 plan already settled this.
+- Touching any other module's options bindings (e.g., `HangfireOptions` at `ServiceCollectionExtensions.cs:364`); those are out of scope even if similar audits apply.
+- Adding `ValidateOnStart()` or `Validate(...)` to `ProductExportOptions` — separate hardening task.
+- A cross-module convention test that enumerates every `*Module` and asserts each binds its declared options — see FR-2 scope decision.
+- Establishing or migrating to a numbered ADR directory at `docs/architecture/decisions/` — see FR-3 location decision.
+- Changing how the arch-review routine itself runs or filters resolved findings.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-filestorage-productexportopt/task-plan.r1.md
+++ b/artifacts/feat-arch-review-filestorage-productexportopt/task-plan.r1.md
@@ -1,0 +1,13 @@
+Plan saved to `docs/superpowers/plans/2026-06-14-verify-and-document-productexportoptions-ownership.md`.
+
+The plan implements all four FRs as five tasks:
+- **Task 1** — verification greps confirming the baseline holds (no commit)
+- **Task 2** — write the xUnit guard test, prove it passes against current code AND fails closed when the binding is removed (commit)
+- **Task 3** — write the decision memo cross-referencing both prior plans and the sister `repository-di-in-feature-module.md` record (commit)
+- **Task 4** — write the per-branch resolution artifact (commit)
+- **Task 5** — full validation gate + PR-description one-liner (no commit)
+
+Key corrections folded in during planning:
+- The arch-review's code sketch called `AddCatalogModule(config, env)` — the actual signature is `AddCatalogModule(services, configuration)` only. The test code uses the real two-parameter form.
+- Test uses pure xUnit assertions (no FluentAssertions) to match `FileStorageModuleTests` exactly, per arch-review Decision 4.
+- Includes a one-shot "delete the line, re-run, restore" step so the engineer empirically verifies the test fails closed — not just that it passes today.

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Features.Catalog;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+/// <summary>
+/// Regression guard for ADR-004: ProductExportOptions must be bound by CatalogModule
+/// (the owner of both the options type and its sole consumer, ProductExportDownloadJob)
+/// — never by the API layer. See memory/decisions/product-export-options-ownership.md.
+/// </summary>
+public class CatalogModuleProductExportOptionsTests
+{
+    private const string ExpectedUrl = "https://example.invalid/export";
+    private const string ExpectedContainerName = "product-exports";
+
+    private static IConfiguration BuildConfiguration() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductExportOptions:Url"] = ExpectedUrl,
+                ["ProductExportOptions:ContainerName"] = ExpectedContainerName,
+            })
+            .Build();
+
+    [Fact]
+    public void AddCatalogModule_BindsProductExportOptions_FromConfigurationSection()
+    {
+        // Arrange — only CatalogModule wires DI; the API layer is intentionally NOT involved.
+        // Pre-seed ILogger<> so any logger-injecting registration the module makes can resolve.
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddCatalogModule(BuildConfiguration());
+
+        // Act
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ProductExportOptions>>().Value;
+
+        // Assert — round-trip both fields. Fails closed if the Configure<T> call is deleted
+        // from CatalogModule or repointed at the wrong configuration section name.
+        Assert.Equal(ExpectedUrl, options.Url);
+        Assert.Equal(ExpectedContainerName, options.ContainerName);
+    }
+}

--- a/docs/superpowers/plans/2026-06-14-verify-and-document-productexportoptions-ownership.md
+++ b/docs/superpowers/plans/2026-06-14-verify-and-document-productexportoptions-ownership.md
@@ -1,0 +1,475 @@
+# Verify and Document ProductExportOptions Module Ownership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close a stale arch-review finding by verifying that `ProductExportOptions` is already owned by `CatalogModule` (not the API layer), add a single-module xUnit regression guard so the binding cannot silently drift, and leave durable trail markers (decision memory + resolution artifact) so the daily arch-review routine and any future reviewer can find the resolution.
+
+**Architecture:** Three new files. Zero changes to production code. The xUnit test instantiates `CatalogModule.AddCatalogModule(services, configuration)` in isolation (no `WebApplicationFactory`), seeds an in-memory `IConfiguration`, resolves `IOptions<ProductExportOptions>`, and asserts both `Url` and `ContainerName` round-trip from the `"ProductExportOptions"` configuration section. Mirroring the `FileStorageModuleTests` pattern keeps the test cheap, local, and fails closed if either the `Configure<>` line is removed or the section name is changed.
+
+**Tech Stack:** .NET 8, xUnit, Moq, Microsoft.Extensions.Configuration (in-memory provider), Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|------|--------|---------------|
+| `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs` | **Create** | xUnit regression guard. Verifies `CatalogModule.AddCatalogModule` binds `IOptions<ProductExportOptions>` from the `"ProductExportOptions"` configuration section. Fails closed if either the `Configure<>` line is deleted or the section name is repointed. |
+| `memory/decisions/product-export-options-ownership.md` | **Create** | Decision record stating Catalog owns both `ProductExportOptions` and `ProductExportDownloadJob`; FileStorage exposes only generic primitives. Companion to `repository-di-in-feature-module.md` (same ADR-004 principle applied to options bindings). |
+| `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md` | **Create** | Per-branch routine close-out note. Records the original finding, current binding location, conclusion ("not applicable — already resolved"), and links to the guard test + decision memory. |
+| `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` | **Read-only (verify)** | Already binds `ProductExportOptions` at line 114. No edits. |
+| `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` | **Read-only (verify)** | Already contains no reference to `ProductExportOptions`. No edits. |
+
+**Important signature note before writing the test:** `AddCatalogModule` takes **only** `(IServiceCollection services, IConfiguration configuration)` — it does **not** take `IHostEnvironment`. The arch-review's code sketch mentioned `env`, but the actual signature is two-parameter. Pass only `services` and `configuration`.
+
+---
+
+## Task 1: Verify the Current Binding Satisfies ADR-004 (FR-1)
+
+This task records confirmation evidence in the worktree's session before changing anything. It produces no commits; it establishes the baseline the regression guard will defend.
+
+**Files:**
+- Read-only inspection: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114`
+- Read-only inspection: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+- [ ] **Step 1: Confirm there is exactly one `Configure<ProductExportOptions>` call in production source**
+
+Run from worktree root:
+
+```bash
+rg -n "Configure<ProductExportOptions>" backend/src
+```
+
+Expected output (exactly one line):
+
+```
+backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114:        services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+If you see two or more lines, or any path under `backend/src/Anela.Heblo.API/`, **stop** — the spec's baseline assumption is broken and the plan needs amendment before proceeding.
+
+- [ ] **Step 2: Confirm `ServiceCollectionExtensions.cs` has no reference to `ProductExportOptions`**
+
+Run:
+
+```bash
+rg -n "ProductExportOptions" backend/src/Anela.Heblo.API/
+```
+
+Expected output: zero matches (the command exits with status 1; that is fine and expected).
+
+If anything matches, **stop** and reconcile with the spec — the API layer must not bind or reference this options type.
+
+- [ ] **Step 3: Confirm `ProductExportOptions` lives only in the Catalog feature folder**
+
+Run:
+
+```bash
+rg -l "ProductExportOptions" backend/src
+```
+
+Expected output (exactly these two paths):
+
+```
+backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/ProductExportOptions.cs
+```
+
+Plus possibly `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJob.cs` (the consumer). If anything is listed outside `Features/Catalog/`, **stop** — investigate before proceeding.
+
+- [ ] **Step 4: No commit for this task**
+
+This task is verification only. Proceed to Task 2.
+
+---
+
+## Task 2: Write the Regression Guard Test (FR-2)
+
+A single-module xUnit test that builds a minimal `ServiceCollection`, registers `CatalogModule` with an in-memory `IConfiguration`, resolves `IOptions<ProductExportOptions>`, and asserts both fields round-trip. Mirrors `FileStorageModuleTests` exactly. xUnit assertions only — no FluentAssertions (consistent with the file we are mirroring).
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs` with this exact content:
+
+```csharp
+using System.Collections.Generic;
+using Anela.Heblo.Application.Features.Catalog;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+/// <summary>
+/// Regression guard for ADR-004: ProductExportOptions must be bound by CatalogModule
+/// (the owner of both the options type and its sole consumer, ProductExportDownloadJob)
+/// — never by the API layer. See memory/decisions/product-export-options-ownership.md.
+/// </summary>
+public class CatalogModuleProductExportOptionsTests
+{
+    private const string ExpectedUrl = "https://example.invalid/export";
+    private const string ExpectedContainerName = "product-exports";
+
+    private static IConfiguration BuildConfiguration() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProductExportOptions:Url"] = ExpectedUrl,
+                ["ProductExportOptions:ContainerName"] = ExpectedContainerName,
+            })
+            .Build();
+
+    [Fact]
+    public void AddCatalogModule_BindsProductExportOptions_FromConfigurationSection()
+    {
+        // Arrange — only CatalogModule wires DI; the API layer is intentionally NOT involved.
+        // Pre-seed ILogger<> so any logger-injecting registration the module makes can resolve.
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddCatalogModule(BuildConfiguration());
+
+        // Act
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ProductExportOptions>>().Value;
+
+        // Assert — round-trip both fields. Fails closed if the Configure<T> call is deleted
+        // from CatalogModule or repointed at the wrong configuration section name.
+        Assert.Equal(ExpectedUrl, options.Url);
+        Assert.Equal(ExpectedContainerName, options.ContainerName);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it passes against the current (correct) binding**
+
+From worktree root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~CatalogModuleProductExportOptionsTests" \
+  --nologo
+```
+
+Expected: `Passed: 1, Failed: 0`. The test passes because `CatalogModule.cs:114` already binds the options correctly.
+
+If the test **fails** at this point, troubleshoot before continuing:
+
+- `OptionsValidationException` → not expected; the options type has no validators. Re-read `ProductExportOptions.cs` and confirm.
+- `InvalidOperationException` at `services.AddCatalogModule(...)` → some registration needs a dependency at registration time. Re-read the failure stack; the most likely missing dependency is an `IConfiguration` section other modules read. Add the minimum extra in-memory keys to satisfy that registration — **do not** weaken the assertion or skip the test.
+- Assertion failure (`options.Url == null` or empty) → the bound section name in `CatalogModule.cs:114` does not match the test's seeded keys. Confirm both sides use the literal string `"ProductExportOptions"`. If `CatalogModule.cs` uses a different section, **stop** — Task 1 should have caught this.
+
+- [ ] **Step 3: Prove the test fails closed — temporarily delete the binding line and re-run**
+
+This is a one-shot manual sanity check. **Do not commit the deletion.**
+
+Open `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` and comment out line 114:
+
+```csharp
+// services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+Re-run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~CatalogModuleProductExportOptionsTests" \
+  --nologo
+```
+
+Expected: `Failed: 1`. The assertion `Assert.Equal(ExpectedUrl, options.Url)` should fail because the un-bound `ProductExportOptions.Url` defaults to its initializer (`= null!`), which is `null`.
+
+**Restore the line** before continuing:
+
+```csharp
+services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
+```
+
+Re-run the test to confirm `Passed: 1` again. Verify with `git status` that no production file is left modified:
+
+```bash
+git status backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+```
+
+Expected: clean (the file is unchanged from `HEAD`).
+
+- [ ] **Step 4: Run the wider Catalog test slice to confirm no collateral damage**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Catalog" \
+  --nologo
+```
+
+Expected: all Catalog tests pass. If anything that was green before this task is now red, the new test file is interfering — most likely a missing `using` or a name collision. Resolve before committing.
+
+- [ ] **Step 5: Run `dotnet format` on the new file**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs --verify-no-changes
+```
+
+If `--verify-no-changes` reports diffs, drop the flag and re-run to apply them:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs
+```
+
+Then re-run the verify command to confirm clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs
+git commit -m "test: add CatalogModule ProductExportOptions binding regression guard"
+```
+
+---
+
+## Task 3: Write the Decision Memory (FR-3)
+
+A `memory/decisions/*.md` record that states Catalog owns `ProductExportOptions` and explains why. Follows the same shape as `repository-di-in-feature-module.md` (the existing ADR-004 sister record).
+
+**Files:**
+- Create: `memory/decisions/product-export-options-ownership.md`
+
+- [ ] **Step 1: Write the decision file**
+
+Create `memory/decisions/product-export-options-ownership.md` with this exact content:
+
+```markdown
+# Decision: ProductExportOptions Is Owned by the Catalog Module
+
+**Decision:** `ProductExportOptions` and its sole consumer `ProductExportDownloadJob`
+both live in the Catalog vertical slice (`Anela.Heblo.Application.Features.Catalog.Infrastructure`).
+The DI binding `services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"))`
+lives in `CatalogModule.AddCatalogModule` (currently `CatalogModule.cs:114`). FileStorage exposes
+only generic download/upload primitives (`IBlobStorageService`, `FileDownloadOptions`) and
+does **not** own anything specific to product exports. (ADR-004 in
+`docs/architecture/development_guidelines.md`.)
+
+**Why:** Two earlier plans considered this question and converged on the current placement:
+`docs/superpowers/plans/2026-06-02-relocate-productexportoptions-to-filestorage.md` proposed
+moving the options into FileStorage. That decision was superseded by
+`docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md`, which
+moved both the options type **and** the consuming job into Catalog. Reason: the consumer is a
+catalog-data refresh job, not a generic file operation; under ADR-004 each vertical slice
+owns the options its module reads. Co-locating the binding with the consumer prevents a
+recurring cross-module wiring split — exactly the same principle as the repository-binding
+ruling in `[[repository-di-in-feature-module]]`.
+
+**How to apply:**
+- The binding line stays at `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+  (line 114 at time of writing — line number may drift, but the file is stable).
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` must **never** bind
+  `ProductExportOptions`. If a future arch-review or audit recommends moving it there, reject
+  the recommendation and link back to this memo.
+- Future arch-review iterations that re-file a "FileStorage owns ProductExportOptions"
+  finding should be closed by pointing at this memo and at
+  `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md`.
+- Regression guard:
+  `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs`
+  fails closed if the binding is deleted from `CatalogModule` or repointed at the wrong
+  configuration section.
+- Companion to `[[repository-di-in-feature-module]]` — the same ADR-004 principle applied to
+  options bindings rather than repository bindings.
+- Follow-up (out of scope here): a cross-module convention test that scans every `*Module.cs`
+  and asserts each `Configure<T>` call sits in the owning module is a worthwhile future
+  investment but should be tracked as its own task.
+```
+
+- [ ] **Step 2: Verify the file exists and reads correctly**
+
+```bash
+ls -la memory/decisions/product-export-options-ownership.md
+head -5 memory/decisions/product-export-options-ownership.md
+```
+
+Expected: file exists, first line is `# Decision: ProductExportOptions Is Owned by the Catalog Module`.
+
+- [ ] **Step 3: Confirm no `memory/decisions/` index file requires updating**
+
+```bash
+ls memory/decisions/ | grep -i 'index\|readme'
+```
+
+Expected: no matches. The directory currently has no index/readme, so no further edit is needed.
+
+If the command returns a hit (someone added an index between when this plan was written and when you execute it), open it, follow its existing style, and add a one-line entry for the new memo before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add memory/decisions/product-export-options-ownership.md
+git commit -m "docs: record decision that Catalog owns ProductExportOptions"
+```
+
+---
+
+## Task 4: Write the Resolution Artifact (FR-4)
+
+A per-branch close-out note in the `artifacts/feat-arch-review-filestorage-productexportopt/` directory the daily arch-review routine already uses. Records that the brief's finding has been verified as stale and lists the durable trail markers (test + decision memo).
+
+**Files:**
+- Create: `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md`
+
+- [ ] **Step 1: Write the resolution file**
+
+Create `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md` with this exact content:
+
+```markdown
+# Resolution: ProductExportOptions ownership (FileStorage arch-review finding)
+
+**Source:** daily arch-review routine, 2026-06-05, FileStorage module.
+The brief claimed `ProductExportOptions` was being bound in
+`Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:364` — outside the owning module —
+and suggested moving the binding into `FileStorageModule`.
+
+**Current state (verified 2026-06-14):**
+- `ProductExportOptions` is bound exactly once, in
+  `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114`.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` contains
+  zero references to `ProductExportOptions`. Line 364 currently binds `HangfireOptions`.
+- `ProductExportOptions` lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure`.
+- The sole consumer, `ProductExportDownloadJob`, lives in
+  `Anela.Heblo.Application.Features.Catalog.Infrastructure.Jobs`.
+
+**Conclusion:** Not applicable — already resolved by the
+`docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md` plan,
+which moved both `ProductExportOptions` and `ProductExportDownloadJob` into Catalog. The
+brief's suggested fix (move the binding into `FileStorageModule`) would **reintroduce** the
+ADR-004 violation it claims to fix, because the option type and its consumer both belong to
+Catalog — not to FileStorage.
+
+**Durable trail markers added in this branch:**
+- Regression guard:
+  `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs`
+- Decision record: `memory/decisions/product-export-options-ownership.md`
+
+**For future arch-review runs:** any re-filing of this same finding should be closed by
+linking to this resolution and to the decision memo. The guard test will fail closed if
+someone moves the binding back to the API layer or to `FileStorageModule`.
+```
+
+- [ ] **Step 2: Verify the file**
+
+```bash
+ls -la artifacts/feat-arch-review-filestorage-productexportopt/resolution.md
+head -3 artifacts/feat-arch-review-filestorage-productexportopt/resolution.md
+```
+
+Expected: file exists, first line is `# Resolution: ProductExportOptions ownership (FileStorage arch-review finding)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add artifacts/feat-arch-review-filestorage-productexportopt/resolution.md
+git commit -m "docs: record resolution for FileStorage ProductExportOptions arch-review finding"
+```
+
+---
+
+## Task 5: Full Validation and PR Description Preparation
+
+Final gate before declaring the work shippable. Runs the project's standard validation commands and produces the one-line PR description summary the spec requires (FR-4 acceptance criterion 2).
+
+**Files:**
+- No file changes in this task. Validates the previous three tasks together.
+
+- [ ] **Step 1: Build the backend solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` (warning counts may differ, but no errors). If new warnings appear that trace to the new test file, fix them.
+
+- [ ] **Step 2: Re-verify `dotnet format` on the touched project**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: clean exit (no diffs). If the command reports formatting differences in unrelated files, that is pre-existing drift — do **not** auto-fix unrelated files in this PR (per project rule: "Surgical changes. Touch only what the task requires."). Re-run with `--include` scoped to only the file we created:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs --verify-no-changes
+```
+
+This must report no changes.
+
+- [ ] **Step 3: Run the full Catalog test slice once more, end-to-end**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Catalog" \
+  --nologo
+```
+
+Expected: all green. New test (`CatalogModuleProductExportOptionsTests.AddCatalogModule_BindsProductExportOptions_FromConfigurationSection`) appears in the output and passes.
+
+- [ ] **Step 4: Final grep confirming the spec's acceptance criteria still hold**
+
+```bash
+rg -n "Configure<ProductExportOptions>" backend/src
+rg -n "ProductExportOptions" backend/src/Anela.Heblo.API/
+```
+
+Expected:
+- First command: exactly one hit at `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:114`.
+- Second command: zero matches (exit status 1, which is fine).
+
+- [ ] **Step 5: Confirm all three new files exist and are tracked**
+
+```bash
+git ls-files \
+  backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs \
+  memory/decisions/product-export-options-ownership.md \
+  artifacts/feat-arch-review-filestorage-productexportopt/resolution.md
+```
+
+Expected: all three paths listed. If any file is missing from the listing, it was never committed — go back to the relevant task and commit it.
+
+- [ ] **Step 6: Prepare the PR description snippet**
+
+When the PR is opened, the description body must include this one-line summary (per spec FR-4 acceptance criterion 2). Add it under the PR's `## Summary` heading:
+
+```markdown
+Closes the daily arch-review FileStorage `ProductExportOptions` finding as stale — the
+binding already lives in `CatalogModule` per the 2026-06-12 ownership decision. See
+[`artifacts/feat-arch-review-filestorage-productexportopt/resolution.md`](../blob/feat-arch-review-filestorage-productexportopt/artifacts/feat-arch-review-filestorage-productexportopt/resolution.md)
+and [`memory/decisions/product-export-options-ownership.md`](../blob/feat-arch-review-filestorage-productexportopt/memory/decisions/product-export-options-ownership.md);
+new test `CatalogModuleProductExportOptionsTests` defends the binding.
+```
+
+(If the link form above gives the wrong path once `gh pr create` resolves the branch — for example because the repository hosts the PR view differently — substitute relative paths like `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md`. The important thing is the human reviewer can click through to both files.)
+
+- [ ] **Step 7: No commit for this task**
+
+This task is validation only. The PR description snippet is for use at PR-creation time and not stored as a file.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Implemented in |
+|------------------|----------------|
+| FR-1 (confirm current binding satisfies ADR-004) | Task 1 (verification greps), Task 5 (re-confirmed at end) |
+| FR-2 (regression guard test) | Task 2 (writes test, runs it, confirms it fails closed when binding is removed) |
+| FR-3 (document module ownership decision) | Task 3 (writes `memory/decisions/product-export-options-ownership.md`, cross-references both prior plans, sister-records `repository-di-in-feature-module.md`, names affected file paths) |
+| FR-4 (close arch-review finding) | Task 4 (writes resolution artifact), Task 5 Step 6 (PR description one-liner) |
+| NFR-1 / NFR-2 | N/A — no runtime behavior changes |
+| NFR-3 (backward compatibility) | Guaranteed — zero production code changes; configuration section name and shape untouched |
+| NFR-4 (build & lint gates) | Task 5 Steps 1, 2 |
+
+**Placeholder scan:** No `TBD`, no `add appropriate error handling`, no "implement later". Every code block is the actual file contents to write.
+
+**Type / name consistency:** Test name `CatalogModuleProductExportOptionsTests`, fact method `AddCatalogModule_BindsProductExportOptions_FromConfigurationSection`, and the seeded section name `"ProductExportOptions"` are used identically across every place they appear in this plan and match the production code at `CatalogModule.cs:114`. The `AddCatalogModule` call uses the two-parameter signature `(IServiceCollection, IConfiguration)` — confirmed against the actual source file, not the arch-review's three-parameter sketch.

--- a/memory/decisions/product-export-options-ownership.md
+++ b/memory/decisions/product-export-options-ownership.md
@@ -1,0 +1,38 @@
+# Decision: ProductExportOptions Is Owned by the Catalog Module
+
+**Decision:** `ProductExportOptions` and its sole consumer `ProductExportDownloadJob`
+both live in the Catalog vertical slice (`Anela.Heblo.Application.Features.Catalog.Infrastructure`).
+The DI binding `services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"))`
+lives in `CatalogModule.AddCatalogModule` (currently `CatalogModule.cs:114`). FileStorage exposes
+only generic download/upload primitives (`IBlobStorageService`, `FileDownloadOptions`) and
+does **not** own anything specific to product exports. (ADR-004 in
+`docs/architecture/development_guidelines.md`.)
+
+**Why:** Two earlier plans considered this question and converged on the current placement:
+`docs/superpowers/plans/2026-06-02-relocate-productexportoptions-to-filestorage.md` proposed
+moving the options into FileStorage. That decision was superseded by
+`docs/superpowers/plans/2026-06-12-relocate-productexportdownloadjob-to-catalog.md`, which
+moved both the options type **and** the consuming job into Catalog. Reason: the consumer is a
+catalog-data refresh job, not a generic file operation; under ADR-004 each vertical slice
+owns the options its module reads. Co-locating the binding with the consumer prevents a
+recurring cross-module wiring split — exactly the same principle as the repository-binding
+ruling in `[[repository-di-in-feature-module]]`.
+
+**How to apply:**
+- The binding line stays at `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+  (line 114 at time of writing — line number may drift, but the file is stable).
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` must **never** bind
+  `ProductExportOptions`. If a future arch-review or audit recommends moving it there, reject
+  the recommendation and link back to this memo.
+- Future arch-review iterations that re-file a "FileStorage owns ProductExportOptions"
+  finding should be closed by pointing at this memo and at
+  `artifacts/feat-arch-review-filestorage-productexportopt/resolution.md`.
+- Regression guard:
+  `backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogModuleProductExportOptionsTests.cs`
+  fails closed if the binding is deleted from `CatalogModule` or repointed at the wrong
+  configuration section.
+- Companion to `[[repository-di-in-feature-module]]` — the same ADR-004 principle applied to
+  options bindings rather than repository bindings.
+- Follow-up (out of scope here): a cross-module convention test that scans every `*Module.cs`
+  and asserts each `Configure<T>` call sits in the owning module is a worthwhile future
+  investment but should be tracked as its own task.


### PR DESCRIPTION
FileStorage

## Finding
`ProductExportOptions` is configured in the API layer's shared extension method rather than inside `FileStorageModule`:

```csharp
// backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:364
services.Configure<ProductExportOptions>(configuration.GetSection("ProductExportOptions"));
```

`FileStorageModule.AddFileStorageModule` already accepts `IConfiguration` and registers several services, but it does not bind its own options. To wire `ProductExportOptions` correctly today, you must look in two unrelated files: the module and the API extension class.

## Why it matters
ADR-004 establishes that each vertical slice owns its full DI wiring in one file (`{Feature}Module.cs`). Splitting a module's registrations across two layers makes it easy to miss the binding when copying/porting the module, causes merge-conflict risk on `ServiceCollectionExtensions.cs` (it already accumulates cross-module registrations), and contradicts the documented "Module Registration" pattern in `development_guidelines.md`.

## Suggested fix
Move the `services.Configure<ProductExportOptions>(...)` call into `FileStorageModule.AddFileStorageModule` (where the `IConfiguration configuration` parameter is already available), and remove it from `ServiceCollectionExtensions.cs`. One-line change per file.

---
_Filed by daily arch-review routine on 2026-06-05._

---

Closes #2673

### Tokens used
20185672
