### PR TITLE
feat: Unit Test Coverage for ManufactureBasedMaterialCostProvider

### DIFF
--- a/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/arch-review.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/arch-review.r1.md
@@ -1,0 +1,175 @@
+Exploration complete. Writing the architecture review now.
+
+# Architecture Review: Unit Test Coverage for ManufactureBasedMaterialCostProvider
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a **test-only feature** that fits cleanly into an established pattern. The codebase already has a direct sibling — `SalesCostProviderTests.cs` (`backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/`) — built on the same xUnit + FluentAssertions + Moq stack, with the same `[Collection]` serialization strategy required because both providers share a `static SemaphoreSlim _refreshLock` lifecycle. No production code changes are needed; no new abstractions; no new dependencies. The architectural decision is essentially "duplicate the SalesCostProviderTests shape and adapt to the manufacture-history domain."
+
+Three integration points were verified against the live source (commit on `feat-coverage-gap-catalog-manufacturebasedmat`):
+
+1. **`ManufactureBasedMaterialCostProvider`** (`backend/src/Anela.Heblo.Application/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProvider.cs`) — constructor takes `IMaterialCostCache`, `ICatalogRepository`, `ILogger<...>`, and `IOptions<DataSourceOptions>`. All four are mockable.
+2. **`CatalogAggregate`** — `PurchasePriceWithVat` is a **computed read-only property** sourced from `ErpPrice?.PurchasePriceWithVat`. Tests cannot set it directly; they must set `ErpPrice = new ProductPriceErp { PurchasePriceWithVat = ... }` (or leave `ErpPrice = null` for the "null" case).
+3. **`ManufactureHistory`** — the property is typed `IReadOnlyList<ManufactureHistoryRecord>` (from `Anela.Heblo.Domain.Features.Manufacture`), **not** `CatalogManufactureRecord` as the spec states.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ ManufactureBasedMaterialCostProviderTests                                │
+│ [Collection("ManufactureBasedMaterialCostProviderTests")]                │
+│                                                                          │
+│   Helpers                                                                │
+│   ├── BuildManufacturedProduct(code, type, history, purchasePrice?)      │
+│   ├── BuildNonManufacturedProduct(code, type, purchasePrice?)            │
+│   ├── BuildHydratedCacheData(productCodes)                               │
+│   ├── CreateProvider(cacheMock?, repoMock?, loggerMock?, historyDays?)   │
+│   └── VerifyLog(loggerMock, level, messageContains, times?)              │
+│                                                                          │
+│   Test methods (one per FR; some Theory-backed)                          │
+└────────────────────────┬─────────────────────────────────────────────────┘
+                         │ instantiates with mocks
+                         ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│ ManufactureBasedMaterialCostProvider (SUT)                               │
+│  - GetCostsAsync   → IMaterialCostCache.GetCachedDataAsync               │
+│  - RefreshAsync    → ICatalogRepository.WaitForCurrentMergeAsync         │
+│                    → ICatalogRepository.GetAllAsync                      │
+│                    → IMaterialCostCache.SetCachedDataAsync               │
+└──────────────────────────────────────────────────────────────────────────┘
+                         ▲
+                         │ doubles supplied by tests
+┌────────────────────────┴─────────────────────────────────────────────────┐
+│  Mock<IMaterialCostCache>   Mock<ICatalogRepository>                     │
+│  Mock<ILogger<...>>         Options.Create(new DataSourceOptions { ... })│
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Drive behavior through `RefreshAsync`, not internal methods
+**Options considered:** (a) expose `CalculateMaterialCosts` via `InternalsVisibleTo` and call it directly with controlled `dateFrom`/`dateTo`; (b) drive everything through `RefreshAsync` and capture the `CostCacheData` written to `SetCachedDataAsync`.
+**Chosen approach:** Option (b).
+**Rationale:** Option (a) would require modifying production code (an `InternalsVisibleTo` attribute or visibility change), violating the "no production behavior changes" out-of-scope rule. `SalesCostProviderTests` already proves the capture-via-mock pattern works for asserting per-month cost values. The provider always uses **all months between `now - ManufactureCostHistoryDays` and `now`**, so by injecting a `ManufactureCostHistoryDays` large enough to cover any synthetic date the test seeds (e.g. 4000 days = ~11 years), the test can place `ManufactureHistoryRecord`s at arbitrary fixed dates in the recent past and the `CalculateFromManufactureHistory` algorithm will visit them deterministically.
+
+#### Decision 2: Use fixed-anchor dates relative to `DateTime.UtcNow` for in-window placement
+**Options considered:** (a) build test dates from absolute literals like `new DateTime(2026, 1, 1)`; (b) anchor every test date to the start of "this month" / "last month" via `DateTime.UtcNow`.
+**Chosen approach:** Option (b), mirroring `SalesCostProviderTests` line 99–100.
+**Rationale:** The provider's window is `[utcNow - historyDays, utcNow]`. Absolute dates risk falling outside the window when the clock advances. Anchoring relative to `DateTime.UtcNow` (e.g. `new DateTime(now.Year, now.Month, 1).AddMonths(-3)` for "M1") keeps tests stable indefinitely, matches the existing test-suite style, and lets each FR control gap/carry-forward/backfill semantics by spacing manufacture records months apart from a known anchor.
+
+#### Decision 3: Test the divide-by-zero behavior (FR-8) by asserting the actual runtime outcome
+**Options considered:** (a) pin `Assert.Throws<DivideByZeroException>`; (b) inspect the produced `MonthlyCost.Cost` for a degenerate value.
+**Chosen approach:** Option (a) — assert `DivideByZeroException` is raised.
+**Rationale:** The provider uses `decimal` arithmetic (`g.Sum(m => m.PricePerPiece * (decimal)m.Amount) / (decimal)g.Sum(m => m.Amount)`). `decimal / 0m` throws `DivideByZeroException` (it does not produce `NaN` — that's a `double`-only behavior). The exception will propagate out of `ComputeAllCostsAsync` → `RefreshAsync`, which already logs at Error and rethrows. The test must therefore `await Assert.ThrowsAsync<DivideByZeroException>(() => provider.RefreshAsync())` — **not** `Assert.Throws`. This pins observed behavior; any future guard added in production code will deliberately break this test and force a spec amendment.
+
+#### Decision 4: Set `PurchasePriceWithVat` via `ErpPrice`, not direct assignment
+**Options considered:** none — the property is read-only.
+**Chosen approach:** All product builders must set `ErpPrice = new ProductPriceErp { PurchasePriceWithVat = value }` to drive the purchase-price path. The "`PurchasePriceWithVat == null`" scenario from FR-6 is realised by leaving `ErpPrice = null`.
+**Rationale:** The spec's "`PurchasePriceWithVat = null`" / "`= 0m`" / "`= -1m`" phrasing implies a setter that does not exist. The test helpers must encapsulate this so individual tests stay readable.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Single new file:
+
+```
+backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/
+    └── ManufactureBasedMaterialCostProviderTests.cs   (NEW)
+```
+
+No changes to other files. No new test project, no new `[Collection]` definition file (xUnit auto-discovers collections from `[Collection("name")]` attributes when the collection has no fixture).
+
+### Interfaces and Contracts
+
+Helpers must use these signatures so each FR test stays a one-liner setup:
+
+```csharp
+private static CatalogAggregate BuildManufacturedProduct(
+    string productCode,
+    ProductType type,
+    IEnumerable<(DateTime date, decimal pricePerPiece, double amount)>? history = null,
+    decimal? purchasePriceWithVat = null);
+// - history == null  → ManufactureHistory left at default empty list
+// - history.Empty()  → ManufactureHistory assigned new empty list
+// - purchasePriceWithVat == null → ErpPrice left null
+// - purchasePriceWithVat != null → ErpPrice = new ProductPriceErp { PurchasePriceWithVat = value.Value }
+
+private static CatalogAggregate BuildNonManufacturedProduct(
+    string productCode,
+    ProductType type,
+    decimal? purchasePriceWithVat);
+// Same ErpPrice semantics; ManufactureHistory irrelevant (untouched).
+
+private static ManufactureBasedMaterialCostProvider CreateProvider(
+    Mock<IMaterialCostCache>? cacheMock = null,
+    Mock<ICatalogRepository>? repoMock = null,
+    Mock<ILogger<ManufactureBasedMaterialCostProvider>>? loggerMock = null,
+    int manufactureCostHistoryDays = DefaultHistoryDays);
+
+private static CostCacheData BuildHydratedCacheData(IEnumerable<string> productCodes);
+
+private static void VerifyLog(
+    Mock<ILogger<ManufactureBasedMaterialCostProvider>> logger,
+    LogLevel level,
+    string messageContains,
+    Times? times = null);
+```
+
+The `VerifyLog` body must use the same lambda shape as `SalesCostProviderTests.VerifyLog` (lines 61–75) so the `ILogger` extension-method indirection is intercepted correctly.
+
+`DefaultHistoryDays` should be set to a value that comfortably covers all test scenarios (e.g. **`4000`** ≈ 11 years). This lets tests place manufacture records 1–6 months back without worrying about month-window boundary effects, and it eliminates flakiness when CI runs near a month boundary.
+
+### Data Flow
+
+For an FR-3 carry-forward test, the data flow is:
+
+1. Build `CatalogAggregate` with `Type = Product`, `ManufactureHistory = [{ Date: M1, PricePerPiece: 100m, Amount: 1.0 }, { Date: M3, PricePerPiece: 200m, Amount: 1.0 }]` (M1, M3 are first-of-month anchors derived from `DateTime.UtcNow`).
+2. `repoMock.GetAllAsync` returns `[product]`; `repoMock.WaitForCurrentMergeAsync` returns `Task.CompletedTask`.
+3. `cacheMock.SetCachedDataAsync` callback captures the `CostCacheData` into a local variable.
+4. Call `await provider.RefreshAsync()`.
+5. Assert: `captured.ProductCosts["PROD-A"]` contains a `MonthlyCost` for every month in the SUT's window. Filter to `[M1, M2, M3, M4]` by month-anchor equality, then assert `[100m, 100m, 200m, 200m]`.
+
+For FR-9..FR-11, the flow goes through `GetCostsAsync` instead — `cacheMock.GetCachedDataAsync` returns a pre-built `CostCacheData` (or throws), and `repoMock`/repository methods must never be invoked (assert with `repoMock.VerifyNoOtherCalls()` per the FR-10 baseline in `SalesCostProviderTests` line 306).
+
+For FR-12 concurrent-lock, use the exact `TaskCompletionSource<...>` gating pattern from `SalesCostProviderTests` lines 378–432: gate one of the dependencies (here, `GetAllAsync`), spin-wait until the gated invocation registers, then issue the second `RefreshAsync` and assert the "already in progress" log + zero `SetCachedDataAsync` calls before releasing the gate.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `static SemaphoreSlim _refreshLock` leaks between tests when xUnit parallelises | High | `[Collection("ManufactureBasedMaterialCostProviderTests")]` (distinct from the Sales collection) serialises tests within this class. Every lock-touching test must release via the production `finally` block — verified by an explicit "subsequent refresh succeeds" assertion in FR-12 exception-path tests. |
+| Test seeds `ManufactureHistoryRecord`s outside the SUT's `[now - historyDays, now]` window, silently producing different cost series | High | Use `DefaultHistoryDays = 4000` and anchor every record to `new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1).AddMonths(-N)`. Never use absolute date literals. |
+| Spec uses `CatalogManufactureRecord`, but production type is `ManufactureHistoryRecord` | Medium | Spec amendment listed below. Test code must use `ManufactureHistoryRecord` from `Anela.Heblo.Domain.Features.Manufacture`. |
+| FR-6 "`PurchasePriceWithVat = null`" implies a settable property that doesn't exist | Medium | Helpers encapsulate the `ErpPrice` setup; null = leave `ErpPrice` unset. Documented above under Decision 4. |
+| FR-8 — spec says "DivideByZeroException **or** NaN for `double`"; reality is decimal-only | Medium | Decision 3 above — pin `DivideByZeroException` only. Remove the NaN branch from the test. |
+| FR-12 concurrent-lock test races on `Invocations` inspection | Medium | Re-use `SalesCostProviderTests` line 404–407 pattern: spin on `ledgerMock.Invocations.Any(...)` with `await Task.Yield()`. Here, spin on `repoMock.Invocations` looking for `GetAllAsync`. |
+| Coverage tooling (Coverlet) excludes private methods in some configs | Low | Driving everything through public `RefreshAsync`/`GetCostsAsync` keeps every private branch covered. No exclusion attributes needed. |
+
+## Specification Amendments
+
+The following corrections to `spec.r1.md` must be applied before or during implementation. None alter intent — they reconcile spec wording with the actual codebase.
+
+1. **§ Data Model** — replace `CatalogManufactureRecord` with `ManufactureHistoryRecord` (namespace `Anela.Heblo.Domain.Features.Manufacture`). Its fields are `Date` (`DateTime`), `Amount` (`double`), `PricePerPiece` (`decimal`).
+2. **FR-1, FR-5, FR-6** — clarify that `PurchasePriceWithVat` is **read-only** on `CatalogAggregate`. Set it via `ErpPrice = new ProductPriceErp { PurchasePriceWithVat = value }`. The "`null`" case is realised by leaving `ErpPrice = null` (not by assigning `null` to `PurchasePriceWithVat`).
+3. **FR-8** — drop "(or NaN for `double`)". The SUT uses `decimal` arithmetic, so the only possible outcome is `DivideByZeroException`. Test must use `Assert.ThrowsAsync<DivideByZeroException>` (routed through `RefreshAsync`, since the exception propagates).
+4. **FR-10** — substring to verify is "`MaterialCostCache not hydrated`" (the production log emits `"MaterialCostCache not hydrated yet"`). Any substring of that string works; "not hydrated" is fine but pin it to "MaterialCostCache not hydrated" for safety against unrelated provider naming changes.
+5. **FR-11** — error log substring is "`Error getting material costs`".
+6. **FR-12** — concurrent-skip log substring is "`refresh already in progress`". Repository-throws log substring is "`Failed to refresh MaterialCostCache`".
+7. **NFR-3** — note that `DefaultHistoryDays` for the test helper should be **~4000** (not 365 as in the spec's outline), to guarantee any synthetic month-anchored record falls inside the SUT's window regardless of when CI runs.
+8. **§ API / Interface Design test outline** — change `DefaultHistoryDays` from `365` to `4000`; remove `ILedgerService` (not a dependency of `ManufactureBasedMaterialCostProvider`); add the `BuildHydratedCacheData` helper that already exists in `SalesCostProviderTests`.
+
+## Prerequisites
+
+None. All NuGet packages, project references, and test infrastructure already exist:
+
+- `Anela.Heblo.Tests` already references `Anela.Heblo.Application` (where the SUT lives), xUnit, FluentAssertions, Moq, and `Microsoft.Extensions.*`.
+- `Features/Catalog/CostProviders/` directory already exists in the test project (it contains `SalesCostProviderTests.cs`).
+- No CI configuration change required — Coverlet picks up the new file automatically.
+- No documentation update required (no new pattern introduced; matches `docs/architecture/testing-strategy.md`).
+
+Implementation can begin immediately upon spec amendments §1–§8 being acknowledged.

--- a/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/brief.md
+++ b/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/brief.md
@@ -1,0 +1,29 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProvider.cs`
+
+## Coverage
+Line coverage: 25% (filter threshold: 60%)
+
+## What's not tested
+`CalculateMaterialCosts` routes by product type and `CalculateFromManufactureHistory` implements a temporal carry-forward algorithm. Untested paths:
+- **Product-type routing**: Set/Product/SemiProduct use manufacture history; all other types fall back to purchase price with VAT — the branch guard is unchecked
+- **Carry-forward (no gap months)**: when a month has no manufacture entry, the last-known price is carried forward; verifying the sequence is never asserted
+- **Future-manufacture backfill**: months before the first manufacture record use the earliest future price — the `futureManufacture != default` branch is uncovered
+- **No-history fallback**: products with empty `ManufactureHistory` fall back to purchase-price path — untested
+- **Zero/null purchase price guard**: `CalculateFromPurchasePriceWithVat` returns empty list when price is null or ≤ 0 — never exercised
+- **Weighted average calculation**: `Sum(PricePerPiece * Amount) / Sum(Amount)` across grouped month records — any overflow or divide-by-zero is uncaught
+
+## Why it matters
+This is the M0 cost source feeding product margin calculations. The carry-forward logic silently propagates stale prices across months. A wrong branch (e.g., type check widened or carry-forward skipped) would corrupt historical cost data for all manufactured products without raising an exception.
+
+## Suggested approach
+Unit tests with mocked `ICatalogRepository`:
+1. Manufactured product with gaps → verify carry-forward fills missing months with last-known price
+2. Manufactured product with future manufacture only → verify backfill from first future record
+3. Non-manufactured product (type = Material) → verify purchase-price path is used
+4. Manufactured product with no history → verify falls back to purchase-price path
+5. Purchase price null → verify empty list returned
+Effort: ~2–3 hours
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-14. Based on CI run #27416879267 (3a6b7f99ee715caf82fc0efa17de5a5ede7b46fb)._

--- a/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/impl/main.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/impl/main.r1.md
@@ -1,0 +1,12 @@
+27 tests pass. This is a standalone clone (`.git` is a directory, `GIT_DIR == GIT_COMMON`), so presenting the standard 4 options:
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/spec.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/spec.r1.md
@@ -1,0 +1,223 @@
+# Specification: Unit Test Coverage for ManufactureBasedMaterialCostProvider
+
+## Summary
+Add comprehensive xUnit unit tests for `ManufactureBasedMaterialCostProvider` to raise line coverage from 25% to ≥ 80%, exercising product-type routing, the temporal carry-forward algorithm, future-manufacture backfill, weighted-average aggregation, and purchase-price fallback paths. The tests must mock `ICatalogRepository` and `IMaterialCostCache` and follow the test layout established by `SalesCostProviderTests` (commit `1ac55964`).
+
+## Background
+`ManufactureBasedMaterialCostProvider` is the M0 cost source feeding product margin calculations. Its `CalculateMaterialCosts` method routes by `ProductType`, and `CalculateFromManufactureHistory` implements a temporal carry-forward algorithm that silently propagates the last-known weighted-average price across months that have no manufacture record. The current 25% line coverage means a regression in routing, carry-forward, or backfill logic would corrupt historical cost data across all manufactured products without raising an exception — making the file a high-risk hole in the M0 pipeline.
+
+This work mirrors the recently-completed `SalesCostProvider` test harness (PR #3103) and uses the same Moq + xUnit + FluentAssertions stack, the same `[Collection]` strategy to serialize tests that interact with the provider's `static SemaphoreSlim _refreshLock`, and the same `BuildProduct` / `CreateProvider` helper conventions.
+
+## Functional Requirements
+
+### FR-1: Manufactured product types are routed to manufacture-history path
+`CalculateMaterialCosts` must route products whose `Type` is `Set`, `Product`, or `SemiProduct` to `CalculateFromManufactureHistory`, returning weighted-average monthly costs derived from `ManufactureHistory`.
+
+**Acceptance criteria:**
+- A product with `Type = Product` and a single manufacture record at price `100m` produces a `MonthlyCost` series whose `Cost` values equal `100m`.
+- The same assertion holds with `Type = Set` and `Type = SemiProduct`.
+- The product's `PurchasePriceWithVat` is **not** used when manufacture history is present (verified by setting `PurchasePriceWithVat = 999m` and asserting the series does not contain `999m`).
+
+### FR-2: Non-manufactured product types fall back to purchase-price path
+Products whose `Type` is `Goods`, `Material`, or `UNDEFINED` must be routed to `CalculateFromPurchasePriceWithVat`, returning a constant `PurchasePriceWithVat` for every month in `[dateFrom, dateTo]`, regardless of any `ManufactureHistory` content.
+
+**Acceptance criteria:**
+- A product with `Type = Material`, `PurchasePriceWithVat = 50m`, and a populated `ManufactureHistory` produces a series of `MonthlyCost` entries each with `Cost == 50m`.
+- The same assertion holds for `Type = Goods` and `Type = UNDEFINED`.
+- The returned series count equals the number of whole months in `[dateFrom, dateTo]` inclusive on both endpoints' first-of-month.
+
+### FR-3: Carry-forward fills gap months with last-known price
+For manufactured products, months that contain no manufacture record but follow at least one month that does must carry forward the most recent weighted-average price.
+
+**Acceptance criteria:**
+- Given manufacture records only in month `M1` at price `120m`, and a range spanning `M1..M4`, the returned series for `M2`, `M3`, `M4` each has `Cost == 120m`.
+- Given manufacture records in `M1 = 100m` and `M3 = 200m`, the series produces `M1 = 100m`, `M2 = 100m` (carry-forward), `M3 = 200m`, `M4 = 200m` (carry-forward).
+- The carry-forward never skips a month — the returned series has exactly one entry per month in `[dateFrom, dateTo]` after the first known price is set.
+
+### FR-4: Future-manufacture backfill for months preceding any record
+For manufactured products, months in `[dateFrom, dateTo]` that precede the earliest manufacture record must be backfilled using the price of that earliest record.
+
+**Acceptance criteria:**
+- Given the only manufacture record sits in `M3` at price `300m`, and the range spans `M1..M4`, the series produces `M1 = 300m`, `M2 = 300m`, `M3 = 300m`, `M4 = 300m`.
+- Given manufacture records at `M3 = 300m` and `M5 = 500m` with range `M1..M5`, the series produces `M1 = 300m`, `M2 = 300m` (backfill from first future), `M3 = 300m`, `M4 = 300m` (carry-forward), `M5 = 500m`.
+- Backfill uses the **earliest** future price, not the latest (verified with two future records of different prices).
+
+### FR-5: Empty manufacture history falls back to purchase price
+For a manufactured-type product (`Set`/`Product`/`SemiProduct`) whose `ManufactureHistory` is `null` or empty, `CalculateFromManufactureHistory` must delegate to `CalculateFromPurchasePriceWithVat`, producing the same constant-price series.
+
+**Acceptance criteria:**
+- A `Product`-type product with `ManufactureHistory = null` and `PurchasePriceWithVat = 75m` returns a series where every `Cost == 75m`.
+- The same product with `ManufactureHistory = new List<...>()` (empty list) returns the same series.
+- The series length equals the month count of the date range.
+
+### FR-6: Missing or non-positive purchase price returns empty list
+`CalculateFromPurchasePriceWithVat` must return an empty `List<MonthlyCost>` when `PurchasePriceWithVat` is `null`, `0m`, or negative. This applies to both the direct non-manufactured path (FR-2) and the fallback path (FR-5).
+
+**Acceptance criteria:**
+- `Type = Material`, `PurchasePriceWithVat = null` → returns an empty list.
+- `Type = Material`, `PurchasePriceWithVat = 0m` → returns an empty list.
+- `Type = Material`, `PurchasePriceWithVat = -1m` → returns an empty list.
+- `Type = Product` with empty `ManufactureHistory` and `PurchasePriceWithVat = null` → returns an empty list (fallback path produces empty).
+
+### FR-7: Weighted-average price is computed per month across grouped records
+When multiple manufacture records exist within the same calendar month, the monthly price must equal `Σ(PricePerPiece × Amount) / Σ(Amount)`.
+
+**Acceptance criteria:**
+- Two records in month `M1`: `(PricePerPiece=100, Amount=10)` and `(PricePerPiece=200, Amount=30)` → `M1` cost equals `(100*10 + 200*30) / (10 + 30) = 175m`.
+- A single record in a month behaves identically (degenerate case) — `PricePerPiece × Amount / Amount == PricePerPiece`.
+- Records in different months are not blended — each month's weighted average is independent.
+
+### FR-8: Months with zero total amount are excluded from manufacture aggregation
+If a month's manufacture records sum to a total `Amount` of `0`, the weighted-average formula would divide by zero. Test must document and pin the current behavior: the provider currently does not guard against this — confirm whether the test exposes a divide-by-zero or whether the aggregation step never receives such input under realistic conditions.
+
+**Acceptance criteria:**
+- A test inputs two records in the same month, both with `Amount = 0`, and asserts the observed behavior. If a `DivideByZeroException` (or NaN for `double`) is raised, the test must `Assert.Throws<DivideByZeroException>` so that future code changes — for example adding a guard — surface a deliberate failure that prompts spec update. (See Open Questions.)
+
+### FR-9: `GetCostsAsync` returns cached data filtered by product codes when cache is hydrated
+When the injected `IMaterialCostCache` returns `IsHydrated = true`, `GetCostsAsync` must return the cached `ProductCosts` filtered by the `productCodes` argument; passing `null` or empty `productCodes` returns the full cache.
+
+**Acceptance criteria:**
+- Cache hydrated with three product codes; calling `GetCostsAsync(productCodes: ["A"])` returns a dictionary containing only key `"A"`.
+- Cache hydrated; calling `GetCostsAsync(productCodes: null)` returns a dictionary with all three keys.
+- Cache hydrated; calling `GetCostsAsync(productCodes: [])` returns all entries (matches `SalesCostProvider` semantics).
+- Cache hydrated; calling `GetCostsAsync(productCodes: ["MISSING"])` returns an empty dictionary.
+
+### FR-10: `GetCostsAsync` returns empty dictionary and logs a warning when cache is not hydrated
+When `IMaterialCostCache.GetCachedDataAsync` returns `IsHydrated = false`, `GetCostsAsync` must return an empty dictionary and emit a `LogLevel.Warning` log containing "not hydrated".
+
+**Acceptance criteria:**
+- Cache mock returns `CostCacheData { IsHydrated = false }`; `GetCostsAsync()` returns an empty dictionary.
+- Logger verifies exactly one warning entry whose message contains "not hydrated".
+
+### FR-11: `GetCostsAsync` rethrows underlying cache exceptions after logging an error
+If `IMaterialCostCache.GetCachedDataAsync` throws, `GetCostsAsync` must log the exception at `LogLevel.Error` and rethrow.
+
+**Acceptance criteria:**
+- Cache mock throws `InvalidOperationException("boom")`; `await GetCostsAsync()` re-throws `InvalidOperationException` with the same message.
+- Logger verifies one `LogLevel.Error` entry referencing the exception.
+
+### FR-12: `RefreshAsync` computes costs, writes cache, and respects single-flight lock
+`RefreshAsync` must call `_catalogRepository.WaitForCurrentMergeAsync`, then `GetAllAsync`, compute per-product costs for all non-empty product codes, and finally write a populated `CostCacheData` via `IMaterialCostCache.SetCachedDataAsync`. A concurrent second call entering while the first holds the lock must short-circuit without invoking `SetCachedDataAsync` a second time.
+
+**Acceptance criteria:**
+- A single `RefreshAsync` call results in exactly one `SetCachedDataAsync` invocation, where the supplied `CostCacheData` has `IsHydrated == true`, `ProductCosts.Count` equals the number of products with non-empty `ProductCode`, and `DataFrom`/`DataTo` lie within the configured `ManufactureCostHistoryDays` window.
+- Products with `ProductCode == ""` or `null` are excluded from `ProductCosts`.
+- When two `RefreshAsync` tasks are awaited concurrently (with the cache write artificially delayed), the second call logs an information entry containing "already in progress" and does **not** invoke `SetCachedDataAsync`.
+- If `_catalogRepository.GetAllAsync` throws, `RefreshAsync` logs at `LogLevel.Error`, rethrows the exception, **and** still releases the lock so a subsequent call succeeds.
+
+### FR-13: Test file naming, location, and execution serialization
+The test file must follow the project's testing conventions and not interfere with other test classes that share the provider's `static SemaphoreSlim _refreshLock`.
+
+**Acceptance criteria:**
+- New file path: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`.
+- Class is decorated with `[Collection("ManufactureBasedMaterialCostProviderTests")]` (mirroring `SalesCostProviderTests`).
+- Uses xUnit `[Fact]`/`[Theory]`, FluentAssertions for assertions, and Moq for `IMaterialCostCache`, `ICatalogRepository`, and `ILogger<ManufactureBasedMaterialCostProvider>` doubles.
+- Each FR maps to one or more test methods named in the `Method_ExpectedBehavior_WhenCondition` form used elsewhere in the suite.
+- `dotnet test --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests"` passes locally and in CI.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Whole suite added by this change must complete in under 5 seconds locally; no test may sleep, hit the filesystem, or open a real database.
+- Concurrent-refresh test in FR-12 may use a `TaskCompletionSource` to gate the first refresh — no `Thread.Sleep`.
+
+### NFR-2: Security
+- No secrets, no real connection strings, no network calls. Test inputs use synthetic product codes and prices.
+- No code under test or test code may log or expose PII.
+
+### NFR-3: Determinism
+- Tests must not depend on `DateTime.UtcNow` ambient state. Where the provider uses `DateTime.UtcNow` (in `ComputeAllCostsAsync` / `ComputeCostsAsync`), tests must drive behavior through `RefreshAsync` only when verifying the `DataFrom`/`DataTo` window — and assertions must use tolerant ranges (e.g., "within configured `ManufactureCostHistoryDays` ± 1 day of now") rather than equality on exact dates.
+- All other tests must invoke `CalculateMaterialCosts` indirectly through `RefreshAsync` with controlled date ranges, or — if the implementation exposes no seam — must pass a date range driven by fixed-clock inputs constructed inside the test.
+
+### NFR-4: Coverage
+- Line coverage for `ManufactureBasedMaterialCostProvider.cs` must rise to ≥ 80% after the new tests land, measured by the same Coverlet configuration used by the existing CI report.
+- All branches inside `CalculateMaterialCosts`, `CalculateFromManufactureHistory`, and `CalculateFromPurchasePriceWithVat` must be exercised by at least one test.
+
+## Data Model
+
+The tests construct in-memory `CatalogAggregate` instances; no schema changes.
+
+Key value objects used:
+- `CatalogAggregate` — fields exercised: `ProductCode`, `Type` (`ProductType`), `ManufactureHistory` (`IReadOnlyList<CatalogManufactureRecord>` or equivalent — confirm exact property type during implementation), `PurchasePriceWithVat` (`decimal?`).
+- `CatalogManufactureRecord` — fields exercised: `Date` (`DateTime`), `PricePerPiece` (`decimal`), `Amount` (`double`).
+- `MonthlyCost` — read-only record with `Month` (`DateTime`, always day 1) and `Cost` (`decimal`).
+- `ProductType` enum — values used: `Product`, `Set`, `SemiProduct`, `Material`, `Goods`, `UNDEFINED`.
+- `CostCacheData` — fields exercised: `ProductCosts` (`Dictionary<string, List<MonthlyCost>>`), `IsHydrated`, `LastUpdated`, `DataFrom`, `DataTo`.
+- `DataSourceOptions` — field exercised: `ManufactureCostHistoryDays`.
+
+## API / Interface Design
+
+No production API changes. Test class outline:
+
+```csharp
+[Collection("ManufactureBasedMaterialCostProviderTests")]
+public sealed class ManufactureBasedMaterialCostProviderTests
+{
+    private const int DefaultHistoryDays = 365;
+
+    private static CatalogAggregate BuildManufacturedProduct(
+        string productCode,
+        ProductType type,
+        IEnumerable<(DateTime date, decimal pricePerPiece, double amount)> history,
+        decimal? purchasePriceWithVat = null) { ... }
+
+    private static CatalogAggregate BuildNonManufacturedProduct(
+        string productCode,
+        ProductType type,
+        decimal? purchasePriceWithVat) { ... }
+
+    private static ManufactureBasedMaterialCostProvider CreateProvider(
+        Mock<IMaterialCostCache>? cacheMock = null,
+        Mock<ICatalogRepository>? repoMock = null,
+        Mock<ILogger<ManufactureBasedMaterialCostProvider>>? loggerMock = null,
+        int manufactureCostHistoryDays = DefaultHistoryDays) { ... }
+
+    private static void VerifyLog(
+        Mock<ILogger<ManufactureBasedMaterialCostProvider>> logger,
+        LogLevel level,
+        string messageContains,
+        Times? times = null) { ... }
+
+    // FR-1 .. FR-12 test methods
+}
+```
+
+Each FR maps to ≥ 1 test method:
+
+| FR    | Example test method                                                                                     |
+|-------|---------------------------------------------------------------------------------------------------------|
+| FR-1  | `RefreshAsync_UsesManufactureHistory_WhenProductTypeIsManufactured(ProductType type)` (Theory)          |
+| FR-2  | `RefreshAsync_UsesPurchasePrice_WhenProductTypeIsNonManufactured(ProductType type)` (Theory)            |
+| FR-3  | `RefreshAsync_CarriesForwardLastKnownPrice_WhenMonthHasNoManufacture`                                   |
+| FR-4  | `RefreshAsync_BackfillsFromEarliestFuturePrice_WhenNoPriorManufactureExists`                            |
+| FR-5  | `RefreshAsync_FallsBackToPurchasePrice_WhenManufactureHistoryIsEmpty`                                   |
+| FR-6  | `RefreshAsync_ReturnsEmptyCostList_WhenPurchasePriceIsNullOrNonPositive(decimal? price)` (Theory)       |
+| FR-7  | `RefreshAsync_AggregatesWithWeightedAverage_WhenMonthHasMultipleManufactureRecords`                     |
+| FR-8  | `RefreshAsync_Behavior_WhenMonthlyAmountSumIsZero` (pins observed behavior — see Open Questions)        |
+| FR-9  | `GetCostsAsync_ReturnsFilteredCache_WhenHydrated(string[] requestedCodes, string[] expectedKeys)`       |
+| FR-10 | `GetCostsAsync_ReturnsEmptyAndLogsWarning_WhenCacheNotHydrated`                                         |
+| FR-11 | `GetCostsAsync_LogsAndRethrows_WhenCacheThrows`                                                         |
+| FR-12 | `RefreshAsync_PopulatesCache_OnSuccess` + `RefreshAsync_SkipsConcurrentCall_WhenLockHeld` + `RefreshAsync_ReleasesLock_WhenRepositoryThrows` |
+
+## Dependencies
+
+- xUnit (already referenced by `Anela.Heblo.Tests`)
+- FluentAssertions (already referenced)
+- Moq (already referenced)
+- `Microsoft.Extensions.Options` / `Microsoft.Extensions.Logging` (already referenced)
+- No new NuGet packages required.
+
+## Out of Scope
+
+- Modifying the production behavior of `ManufactureBasedMaterialCostProvider` (including adding a divide-by-zero guard) — those changes belong in a separate task; FR-8 pins existing behavior only.
+- Tests for `IMaterialCostCache` implementations themselves.
+- Tests for `CatalogAggregate` construction or `ProductType` enum mapping.
+- Integration tests against a real `ICatalogRepository`.
+- Updating `docs/architecture/testing-strategy.md` (no new pattern introduced).
+- Raising coverage in other files under `Features/Catalog/CostProviders`.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/task-plan.r1.md
+++ b/artifacts/feat-coverage-gap-catalog-manufacturebasedmat/task-plan.r1.md
@@ -1,0 +1,7 @@
+Plan saved to `docs/superpowers/plans/2026-06-15-manufacturebased-material-cost-provider-tests.md`. Self-review pass:
+
+- **Spec coverage:** all FRs and NFRs mapped to tasks (table at the end of the plan).
+- **No placeholders:** every step shows the actual code or command an engineer would run.
+- **Type consistency:** uses `ManufactureHistoryRecord` (not the spec's stale `CatalogManufactureRecord`), `ErpPrice = new ProductPriceErp { … }` everywhere `PurchasePriceWithVat` is needed, and `DefaultHistoryDays = 4000` consistently across all date-anchored tests.
+
+16 tasks, one new file. The plan is self-contained; the engineer can execute it task-by-task without referring back to the spec.

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
@@ -578,4 +578,268 @@ public class ManufactureBasedMaterialCostProviderTests
             c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    // ===== FR-9: GetCostsAsync filters by product codes when cache hydrated =====
+
+    [Fact]
+    internal async Task GetCostsAsync_ReturnsFullDictionary_WhenProductCodesAreNull()
+    {
+        var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+        var provider = CreateProvider(cacheMock: cacheMock);
+
+        var result = await provider.GetCostsAsync(null);
+
+        result.Should().HaveCount(3);
+        result.Keys.Should().BeEquivalentTo("A", "B", "C");
+    }
+
+    [Fact]
+    internal async Task GetCostsAsync_ReturnsFullDictionary_WhenProductCodesAreEmpty()
+    {
+        var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+        var provider = CreateProvider(cacheMock: cacheMock);
+
+        var result = await provider.GetCostsAsync(new List<string>());
+
+        result.Should().HaveCount(3);
+        result.Keys.Should().BeEquivalentTo("A", "B", "C");
+    }
+
+    [Fact]
+    internal async Task GetCostsAsync_ReturnsSubset_WhenProductCodesProvided()
+    {
+        var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+        var provider = CreateProvider(cacheMock: cacheMock);
+
+        var result = await provider.GetCostsAsync(new List<string> { "A", "C", "MISSING" });
+
+        result.Should().HaveCount(2);
+        result.Keys.Should().BeEquivalentTo("A", "C");
+    }
+
+    [Fact]
+    internal async Task GetCostsAsync_ReturnsEmptyDictionary_WhenRequestedProductCodeNotInCache()
+    {
+        var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+        var provider = CreateProvider(cacheMock: cacheMock);
+
+        var result = await provider.GetCostsAsync(new List<string> { "MISSING" });
+
+        result.Should().BeEmpty();
+    }
+
+    // ===== FR-10: GetCostsAsync returns empty + warning when cache not hydrated =====
+
+    [Fact]
+    internal async Task GetCostsAsync_ReturnsEmptyAndLogsWarning_WhenCacheNotHydrated()
+    {
+        // Arrange
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CostCacheData.Empty());
+
+        var repoMock = new Mock<ICatalogRepository>();
+        var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+        // Act
+        var result = await provider.GetCostsAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+
+        VerifyLog(loggerMock, LogLevel.Warning, "MaterialCostCache not hydrated");
+
+        // Cache hydration miss must not trigger any repository work.
+        repoMock.VerifyNoOtherCalls();
+    }
+
+    // ===== FR-11: GetCostsAsync logs error and rethrows when cache throws =====
+
+    [Fact]
+    internal async Task GetCostsAsync_LogsErrorAndRethrows_WhenCacheReadFails()
+    {
+        // Arrange
+        var boom = new InvalidOperationException("boom");
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ThrowsAsync(boom);
+
+        var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+        var provider = CreateProvider(cacheMock: cacheMock, loggerMock: loggerMock);
+
+        // Act
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetCostsAsync());
+
+        // Assert
+        thrown.Should().BeSameAs(boom);
+        VerifyLog(loggerMock, LogLevel.Error, "Error getting material costs");
+    }
+
+    // ===== FR-12a: RefreshAsync populates cache on success =====
+
+    [Fact]
+    internal async Task RefreshAsync_PopulatesCache_OnSuccess_AndExcludesEmptyProductCodes()
+    {
+        // Arrange — three real products + two skip cases (empty + null code).
+        var products = new List<CatalogAggregate>
+        {
+            BuildNonManufacturedProduct("MAT-A", ProductType.Material, 10m),
+            BuildNonManufacturedProduct("MAT-B", ProductType.Material, 20m),
+            BuildNonManufacturedProduct("MAT-C", ProductType.Material, 30m),
+            BuildNonManufacturedProduct(string.Empty, ProductType.Material, 99m), // skipped
+            BuildNonManufacturedProduct(null!, ProductType.Material, 99m),         // skipped
+        };
+
+        var callOrder = new List<string>();
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("WaitForCurrentMergeAsync"))
+            .Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("GetAllAsync"))
+            .ReturnsAsync(products);
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, manufactureCostHistoryDays: 90);
+
+        var nowBefore = DateTime.UtcNow;
+
+        // Act
+        await provider.RefreshAsync();
+
+        var nowAfter = DateTime.UtcNow;
+
+        // Assert — cache populated with exactly the three non-empty product codes.
+        captured.Should().NotBeNull();
+        captured!.IsHydrated.Should().BeTrue();
+        captured.ProductCosts.Keys.Should().BeEquivalentTo("MAT-A", "MAT-B", "MAT-C");
+
+        // DataFrom/DataTo within tolerant window around UtcNow.
+        var expectedFromLower = DateOnly.FromDateTime(nowBefore.AddDays(-90));
+        var expectedFromUpper = DateOnly.FromDateTime(nowAfter.AddDays(-90));
+        captured.DataFrom.Should().BeOnOrAfter(expectedFromLower);
+        captured.DataFrom.Should().BeOnOrBefore(expectedFromUpper);
+
+        captured.DataTo.Should().BeOnOrAfter(DateOnly.FromDateTime(nowBefore));
+        captured.DataTo.Should().BeOnOrBefore(DateOnly.FromDateTime(nowAfter));
+
+        // Call order
+        callOrder.Should().Equal("WaitForCurrentMergeAsync", "GetAllAsync");
+    }
+
+    // ===== FR-12b: RefreshAsync skips concurrent second call =====
+
+    [Fact]
+    internal async Task RefreshAsync_SkipsSecondInvocation_WhenFirstStillRunning()
+    {
+        // Arrange — gate `GetAllAsync` with a TaskCompletionSource so the first refresh blocks
+        // inside ComputeAllCostsAsync, holding the static _refreshLock. The second refresh must
+        // detect WaitAsync(0) failure, log "refresh already in progress", and return.
+        var gate = new TaskCompletionSource<IEnumerable<CatalogAggregate>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).Returns(gate.Task);
+
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+        // Act 1 — first refresh; blocks on gate after acquiring the lock.
+        var firstRefresh = provider.RefreshAsync();
+
+        while (!repoMock.Invocations.Any(i => i.Method.Name == nameof(ICatalogRepository.GetAllAsync)))
+        {
+            await Task.Yield();
+        }
+
+        // Act 2 — second refresh; sees lock held, short-circuits.
+        await provider.RefreshAsync();
+
+        // Assert intermediate
+        VerifyLog(loggerMock, LogLevel.Information, "refresh already in progress");
+        cacheMock.Verify(
+            c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Release gate, let first refresh finish.
+        gate.SetResult((IEnumerable<CatalogAggregate>)new List<CatalogAggregate>());
+        await firstRefresh;
+
+        cacheMock.Verify(
+            c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Act 3 — fresh refresh after lock released must proceed.
+        await provider.RefreshAsync();
+
+        cacheMock.Verify(
+            c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ===== FR-12c: RefreshAsync releases lock when repository throws =====
+
+    [Fact]
+    internal async Task RefreshAsync_ReleasesLockOnRepositoryException_AndAllowsSubsequentRefresh()
+    {
+        // Arrange — first GetAllAsync throws, second succeeds. Lock must be released by the SUT's
+        // `finally` block so the second call proceeds rather than logging "refresh already in progress".
+        var boom = new InvalidOperationException("repo offline");
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.SetupSequence(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(boom)
+            .ReturnsAsync(new List<CatalogAggregate>());
+
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+        // Act 1 — first call throws and logs.
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.RefreshAsync());
+        thrown.Should().BeSameAs(boom);
+        VerifyLog(loggerMock, LogLevel.Error, "Failed to refresh MaterialCostCache");
+        cacheMock.Verify(
+            c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Act 2 — second call must proceed (lock released by finally).
+        await provider.RefreshAsync();
+
+        // Positive proof: the second call entered the normal execution path, never the "skip" branch.
+        VerifyLog(loggerMock, LogLevel.Information, "refresh already in progress", Times.Never());
+        VerifyLog(loggerMock, LogLevel.Information, "Starting MaterialCostCache refresh", Times.Exactly(2));
+        cacheMock.Verify(
+            c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
@@ -1,0 +1,169 @@
+using Anela.Heblo.Application.Common;
+using Anela.Heblo.Application.Features.Catalog.CostProviders;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Cache;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+using Anela.Heblo.Domain.Features.Catalog.ValueObjects;
+using Anela.Heblo.Domain.Features.Manufacture;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.CostProviders;
+
+/// <summary>
+/// Tests for ManufactureBasedMaterialCostProvider.
+/// Uses Collection attribute to ensure sequential execution due to static _refreshLock in the provider.
+/// </summary>
+[Collection("ManufactureBasedMaterialCostProviderTests")]
+public class ManufactureBasedMaterialCostProviderTests
+{
+    /// <summary>
+    /// 4000 days (~11 years) — comfortably covers any synthetic month anchored to UtcNow,
+    /// so the SUT's [now - historyDays, now] window always contains seeded records.
+    /// </summary>
+    private const int DefaultHistoryDays = 4000;
+
+    // ===== Helpers =====
+
+    private static DateTime CurrentMonthStartUtc() =>
+        new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+
+    private static DateTime MonthOffsetFromNow(int monthsOffset) =>
+        CurrentMonthStartUtc().AddMonths(monthsOffset);
+
+    private static CatalogAggregate BuildManufacturedProduct(
+        string productCode,
+        ProductType type,
+        IEnumerable<(DateTime date, decimal pricePerPiece, double amount)>? history = null,
+        decimal? purchasePriceWithVat = null)
+    {
+        var agg = new CatalogAggregate
+        {
+            ProductCode = productCode,
+            ProductName = productCode,
+            Type = type,
+        };
+
+        if (history != null)
+        {
+            agg.ManufactureHistory = history
+                .Select(h => new ManufactureHistoryRecord
+                {
+                    Date = h.date,
+                    PricePerPiece = h.pricePerPiece,
+                    Amount = h.amount,
+                    PriceTotal = h.pricePerPiece * (decimal)h.amount,
+                    ProductCode = productCode,
+                    DocumentNumber = "TEST-DOC",
+                })
+                .ToList();
+        }
+
+        if (purchasePriceWithVat.HasValue)
+        {
+            agg.ErpPrice = new ProductPriceErp { PurchasePriceWithVat = purchasePriceWithVat.Value };
+        }
+
+        return agg;
+    }
+
+    private static CatalogAggregate BuildNonManufacturedProduct(
+        string productCode,
+        ProductType type,
+        decimal? purchasePriceWithVat)
+    {
+        var agg = new CatalogAggregate
+        {
+            ProductCode = productCode,
+            ProductName = productCode,
+            Type = type,
+        };
+
+        if (purchasePriceWithVat.HasValue)
+        {
+            agg.ErpPrice = new ProductPriceErp { PurchasePriceWithVat = purchasePriceWithVat.Value };
+        }
+
+        return agg;
+    }
+
+    private static CostCacheData BuildHydratedCacheData(IEnumerable<string> productCodes)
+    {
+        var month = new DateTime(2026, 1, 1);
+        var dict = productCodes.ToDictionary(
+            code => code,
+            code => new List<MonthlyCost> { new(month, 1m) });
+        return new CostCacheData
+        {
+            ProductCosts = dict,
+            LastUpdated = DateTime.UtcNow,
+            DataFrom = DateOnly.FromDateTime(month),
+            DataTo = DateOnly.FromDateTime(month.AddMonths(1).AddDays(-1)),
+            IsHydrated = true,
+        };
+    }
+
+    private static ManufactureBasedMaterialCostProvider CreateProvider(
+        Mock<IMaterialCostCache>? cacheMock = null,
+        Mock<ICatalogRepository>? repoMock = null,
+        Mock<ILogger<ManufactureBasedMaterialCostProvider>>? loggerMock = null,
+        int manufactureCostHistoryDays = DefaultHistoryDays)
+    {
+        return new ManufactureBasedMaterialCostProvider(
+            (cacheMock ?? new Mock<IMaterialCostCache>()).Object,
+            (repoMock ?? new Mock<ICatalogRepository>()).Object,
+            (loggerMock ?? new Mock<ILogger<ManufactureBasedMaterialCostProvider>>()).Object,
+            Options.Create(new DataSourceOptions { ManufactureCostHistoryDays = manufactureCostHistoryDays }));
+    }
+
+    private static void VerifyLog(
+        Mock<ILogger<ManufactureBasedMaterialCostProvider>> logger,
+        LogLevel level,
+        string messageContains,
+        Times? times = null)
+    {
+        logger.Verify(
+            x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains(messageContains)),
+                It.IsAny<Exception?>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+            times ?? Times.AtLeastOnce());
+    }
+
+    /// <summary>
+    /// Captures the CostCacheData written to the cache by RefreshAsync and returns
+    /// the configured cache mock. Tests can read the captured value via the out parameter.
+    /// </summary>
+    private static Mock<IMaterialCostCache> BuildCaptureCacheMock(out Action<Action<CostCacheData>> onCaptured)
+    {
+        var cacheMock = new Mock<IMaterialCostCache>();
+        Action<CostCacheData>? subscriber = null;
+        onCaptured = handler => subscriber = handler;
+
+        cacheMock
+            .Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+            .Callback<CostCacheData, CancellationToken>((d, _) => subscriber?.Invoke(d))
+            .Returns(Task.CompletedTask);
+
+        return cacheMock;
+    }
+
+    private static int ExpectedMonthCount(DateOnly from, DateOnly to)
+    {
+        return ((to.Year - from.Year) * 12) + (to.Month - from.Month) + 1;
+    }
+
+    // ===== Tests =====
+
+    [Fact]
+    internal void Scaffold_Compiles_AndCanCreateProvider()
+    {
+        var provider = CreateProvider();
+        provider.Should().NotBeNull();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
@@ -166,4 +166,416 @@ public class ManufactureBasedMaterialCostProviderTests
         var provider = CreateProvider();
         provider.Should().NotBeNull();
     }
+
+    // ===== FR-1: Manufactured product types route to manufacture-history =====
+
+    [Theory]
+    [InlineData(ProductType.Product)]
+    [InlineData(ProductType.Set)]
+    [InlineData(ProductType.SemiProduct)]
+    internal async Task RefreshAsync_UsesManufactureHistory_WhenProductTypeIsManufactured(ProductType type)
+    {
+        // Arrange — a single manufacture record at price 100m; PurchasePriceWithVat is a sentinel
+        // that MUST NOT appear anywhere in the resulting cost series.
+        var manufactureMonth = MonthOffsetFromNow(-2).AddDays(10);
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-A",
+            type: type,
+            history: new[] { (manufactureMonth, 100m, 5.0) },
+            purchasePriceWithVat: 999m);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.ProductCosts.Should().ContainKey("PROD-A");
+        var series = captured.ProductCosts["PROD-A"];
+        series.Should().NotBeEmpty();
+        series.Should().AllSatisfy(mc => mc.Cost.Should().Be(100m));
+        series.Select(mc => mc.Cost).Should().NotContain(999m);
+    }
+
+    // ===== FR-2: Non-manufactured types fall back to purchase-price =====
+
+    [Theory]
+    [InlineData(ProductType.Material)]
+    [InlineData(ProductType.Goods)]
+    [InlineData(ProductType.UNDEFINED)]
+    internal async Task RefreshAsync_UsesPurchasePrice_WhenProductTypeIsNonManufactured(ProductType type)
+    {
+        // Arrange — populated ManufactureHistory MUST be ignored for non-manufactured types.
+        var manufactureMonth = MonthOffsetFromNow(-2).AddDays(10);
+        var product = BuildManufacturedProduct(
+            productCode: "MAT-1",
+            type: type,
+            history: new[] { (manufactureMonth, 100m, 5.0) },
+            purchasePriceWithVat: 50m);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        var series = captured!.ProductCosts["MAT-1"];
+        series.Should().NotBeEmpty();
+        series.Should().AllSatisfy(mc => mc.Cost.Should().Be(50m));
+
+        // Series spans the SUT window [now - DefaultHistoryDays, now] aligned to first-of-month.
+        var expectedMonthCount = ExpectedMonthCount(captured.DataFrom, captured.DataTo);
+        series.Should().HaveCount(expectedMonthCount);
+    }
+
+    // ===== FR-3: Carry-forward fills gap months =====
+
+    [Fact]
+    internal async Task RefreshAsync_CarriesForwardLastKnownPrice_WhenMonthHasNoManufacture()
+    {
+        // Arrange — anchors: M1 = 4 months ago, M2 = 3 months ago, M3 = 2 months ago, M4 = 1 month ago.
+        // Records exist at M1 (100m) and M3 (200m). Expect carry-forward in M2 (=100m) and M4 (=200m).
+        var m1 = MonthOffsetFromNow(-4);
+        var m2 = MonthOffsetFromNow(-3);
+        var m3 = MonthOffsetFromNow(-2);
+        var m4 = MonthOffsetFromNow(-1);
+
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-CF",
+            type: ProductType.Product,
+            history: new[]
+            {
+                (m1.AddDays(5), 100m, 1.0),
+                (m3.AddDays(5), 200m, 1.0),
+            });
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        var series = captured!.ProductCosts["PROD-CF"];
+
+        series.Single(mc => mc.Month == m1).Cost.Should().Be(100m);
+        series.Single(mc => mc.Month == m2).Cost.Should().Be(100m); // carry-forward
+        series.Single(mc => mc.Month == m3).Cost.Should().Be(200m);
+        series.Single(mc => mc.Month == m4).Cost.Should().Be(200m); // carry-forward
+
+        // No gaps between m1 and m4 — every month present.
+        var inRange = series.Where(mc => mc.Month >= m1 && mc.Month <= m4).OrderBy(mc => mc.Month).ToList();
+        inRange.Should().HaveCount(4);
+        inRange.Select(mc => mc.Month).Should().Equal(m1, m2, m3, m4);
+    }
+
+    // ===== FR-4: Future-manufacture backfill =====
+
+    [Fact]
+    internal async Task RefreshAsync_BackfillsFromEarliestFuturePrice_WhenNoPriorManufactureExists()
+    {
+        // Arrange — only manufacture record sits 2 months ago at 300m. Months 4 and 3 months ago
+        // precede the record and must be backfilled with 300m.
+        var earliest = MonthOffsetFromNow(-2);
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-BF",
+            type: ProductType.Product,
+            history: new[] { (earliest.AddDays(5), 300m, 1.0) });
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert — every month in the SUT's window contains 300m (backfill + record + carry-forward).
+        captured.Should().NotBeNull();
+        var series = captured!.ProductCosts["PROD-BF"];
+        series.Should().NotBeEmpty();
+        series.Should().AllSatisfy(mc => mc.Cost.Should().Be(300m));
+    }
+
+    [Fact]
+    internal async Task RefreshAsync_BackfillsUsingEarliestFuturePrice_WhenMultipleFutureRecordsExist()
+    {
+        // Arrange — records at M3 (=300m) and M5 (=500m), backfill must pick 300m (earliest),
+        // not 500m (latest). Earlier months M1, M2 must read 300m. M4 carries forward 300m.
+        var m1 = MonthOffsetFromNow(-5);
+        var m2 = MonthOffsetFromNow(-4);
+        var m3 = MonthOffsetFromNow(-3);
+        var m4 = MonthOffsetFromNow(-2);
+        var m5 = MonthOffsetFromNow(-1);
+
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-BF2",
+            type: ProductType.Product,
+            history: new[]
+            {
+                (m3.AddDays(5), 300m, 1.0),
+                (m5.AddDays(5), 500m, 1.0),
+            });
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        var series = captured!.ProductCosts["PROD-BF2"];
+
+        series.Single(mc => mc.Month == m1).Cost.Should().Be(300m); // backfill
+        series.Single(mc => mc.Month == m2).Cost.Should().Be(300m); // backfill
+        series.Single(mc => mc.Month == m3).Cost.Should().Be(300m);
+        series.Single(mc => mc.Month == m4).Cost.Should().Be(300m); // carry-forward
+        series.Single(mc => mc.Month == m5).Cost.Should().Be(500m);
+    }
+
+    // ===== FR-5: Empty/null manufacture history falls back to purchase price =====
+
+    [Fact]
+    internal async Task RefreshAsync_FallsBackToPurchasePrice_WhenManufactureHistoryIsEmptyList()
+    {
+        // Arrange — manufactured-type product with explicitly empty history.
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-EMPTY",
+            type: ProductType.Product,
+            history: Array.Empty<(DateTime, decimal, double)>(),
+            purchasePriceWithVat: 75m);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        var series = captured!.ProductCosts["PROD-EMPTY"];
+        series.Should().NotBeEmpty();
+        series.Should().AllSatisfy(mc => mc.Cost.Should().Be(75m));
+        series.Should().HaveCount(ExpectedMonthCount(captured.DataFrom, captured.DataTo));
+    }
+
+    [Fact]
+    internal async Task RefreshAsync_FallsBackToPurchasePrice_WhenManufactureHistoryDefaultsToEmpty()
+    {
+        // Arrange — manufactured-type product, do not touch ManufactureHistory (default empty list).
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-DEFAULT",
+            type: ProductType.Product,
+            history: null,
+            purchasePriceWithVat: 75m);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        var series = captured!.ProductCosts["PROD-DEFAULT"];
+        series.Should().NotBeEmpty();
+        series.Should().AllSatisfy(mc => mc.Cost.Should().Be(75m));
+    }
+
+    // ===== FR-6: Missing/non-positive purchase price returns empty list =====
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    internal async Task RefreshAsync_ReturnsEmptyCostList_WhenPurchasePriceIsNullOrNonPositive(double? priceOrNull)
+    {
+        // Arrange — non-manufactured product so we hit the purchase-price path directly.
+        decimal? price = priceOrNull.HasValue ? (decimal?)priceOrNull.Value : null;
+        var product = BuildNonManufacturedProduct(
+            productCode: "MAT-EMPTY",
+            type: ProductType.Material,
+            purchasePriceWithVat: price);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.ProductCosts.Should().ContainKey("MAT-EMPTY");
+        captured.ProductCosts["MAT-EMPTY"].Should().BeEmpty();
+    }
+
+    [Fact]
+    internal async Task RefreshAsync_ReturnsEmptyCostList_WhenManufacturedTypeFallbackHasNoPurchasePrice()
+    {
+        // Arrange — manufactured type with empty history and no ErpPrice → fallback returns empty.
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-NO-PRICE",
+            type: ProductType.Product,
+            history: Array.Empty<(DateTime, decimal, double)>(),
+            purchasePriceWithVat: null);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.ProductCosts.Should().ContainKey("PROD-NO-PRICE");
+        captured.ProductCosts["PROD-NO-PRICE"].Should().BeEmpty();
+    }
+
+    // ===== FR-7: Weighted-average per month aggregation =====
+
+    [Fact]
+    internal async Task RefreshAsync_AggregatesWithWeightedAverage_WhenMonthHasMultipleManufactureRecords()
+    {
+        // Arrange — two records in the same month: (100, 10) and (200, 30) → weighted avg = 175m.
+        // A second month has a single record (300, 5) which must remain 300m (independent month).
+        var monthA = MonthOffsetFromNow(-3);
+        var monthB = MonthOffsetFromNow(-2);
+
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-WA",
+            type: ProductType.Product,
+            history: new[]
+            {
+                (monthA.AddDays(2),  100m, 10.0),
+                (monthA.AddDays(20), 200m, 30.0),
+                (monthB.AddDays(5),  300m,  5.0),
+            });
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = BuildCaptureCacheMock(out var subscribe);
+        CostCacheData? captured = null;
+        subscribe(d => captured = d);
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+        // Act
+        await provider.RefreshAsync();
+
+        // Assert
+        captured.Should().NotBeNull();
+        var series = captured!.ProductCosts["PROD-WA"];
+        series.Single(mc => mc.Month == monthA).Cost.Should().Be(175m);
+        series.Single(mc => mc.Month == monthB).Cost.Should().Be(300m);
+    }
+
+    // ===== FR-8: Zero total amount throws DivideByZeroException =====
+
+    [Fact]
+    internal async Task RefreshAsync_ThrowsDivideByZero_WhenMonthlyAmountSumIsZero()
+    {
+        // Arrange — two records in the same month both with Amount = 0; weighted-average denominator is 0.
+        // The SUT uses `decimal` arithmetic, so `decimal / 0m` raises DivideByZeroException
+        // (decimal does NOT produce NaN — that's a double-only behavior).
+        // The exception is logged at Error and rethrown by RefreshAsync; this test pins that contract.
+        var month = MonthOffsetFromNow(-2);
+        var product = BuildManufacturedProduct(
+            productCode: "PROD-DBZ",
+            type: ProductType.Product,
+            history: new[]
+            {
+                (month.AddDays(2), 100m, 0.0),
+                (month.AddDays(3), 200m, 0.0),
+            });
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var cacheMock = new Mock<IMaterialCostCache>();
+        cacheMock.Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+        var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+        // Act + Assert
+        await Assert.ThrowsAsync<DivideByZeroException>(() => provider.RefreshAsync());
+
+        // The exception path logs at Error and never writes the cache.
+        VerifyLog(loggerMock, LogLevel.Error, "Failed to refresh MaterialCostCache");
+        cacheMock.Verify(
+            c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/docs/superpowers/plans/2026-06-15-manufacturebased-material-cost-provider-tests.md
+++ b/docs/superpowers/plans/2026-06-15-manufacturebased-material-cost-provider-tests.md
@@ -1,0 +1,1285 @@
+# ManufactureBasedMaterialCostProvider Unit Test Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add xUnit + Moq + FluentAssertions unit tests for `ManufactureBasedMaterialCostProvider` to raise its line coverage from 25 % to ≥ 80 %, exercising product-type routing, the temporal carry-forward algorithm, future-manufacture backfill, weighted-average aggregation, purchase-price fallback paths, and the `RefreshAsync` / `GetCostsAsync` cache surface.
+
+**Architecture:** Single new test class `ManufactureBasedMaterialCostProviderTests` placed beside its sibling `SalesCostProviderTests`. Behavior is driven entirely through the public `RefreshAsync` and `GetCostsAsync` surface — no production-code changes, no new `InternalsVisibleTo` attributes. The class is decorated with `[Collection("ManufactureBasedMaterialCostProviderTests")]` so xUnit serializes tests within it (the SUT holds a `static SemaphoreSlim _refreshLock` whose lifecycle must not race across tests).
+
+**Tech Stack:** xUnit, FluentAssertions, Moq, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Logging` — all already referenced by the `Anela.Heblo.Tests` project. No new NuGet packages.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs` (NEW) | All tests, helpers, and the `[Collection]` declaration for this SUT. |
+
+No other files are created or modified.
+
+**Key types referenced (already in the codebase — do not create):**
+
+| Type | Location | Notes |
+|------|----------|-------|
+| `ManufactureBasedMaterialCostProvider` (SUT) | `Anela.Heblo.Application.Features.Catalog.CostProviders` | Public constructor takes `IMaterialCostCache`, `ICatalogRepository`, `ILogger<…>`, `IOptions<DataSourceOptions>`. |
+| `CatalogAggregate` | `Anela.Heblo.Domain.Features.Catalog` | `PurchasePriceWithVat` is a **read-only** computed property sourced from `ErpPrice?.PurchasePriceWithVat`. Set via `ErpPrice = new ProductPriceErp { PurchasePriceWithVat = … }`. `ManufactureHistory` is `IReadOnlyList<ManufactureHistoryRecord>` (default `new List<ManufactureHistoryRecord>()`). |
+| `ManufactureHistoryRecord` | `Anela.Heblo.Domain.Features.Manufacture` | Mutable class with `Date` (`DateTime`), `Amount` (`double`), `PricePerPiece` (`decimal`), `PriceTotal` (`decimal`), `ProductCode` (`string`), `DocumentNumber` (`string`). |
+| `ProductPriceErp` | `Anela.Heblo.Domain.Features.Catalog.Price` | Mutable class — set `PurchasePriceWithVat` to drive the fallback path. |
+| `ProductType` | `Anela.Heblo.Domain.Features.Catalog` | Enum values: `Product`, `Set`, `SemiProduct`, `Material`, `Goods`, `UNDEFINED`. |
+| `MonthlyCost` | `Anela.Heblo.Domain.Features.Catalog.ValueObjects` | Class with `Month` (`DateTime`) + `Cost` (`decimal`); constructor `(month, cost)`. |
+| `CostCacheData` | `Anela.Heblo.Domain.Features.Catalog.Cache` | Class with `ProductCosts`, `IsHydrated`, `LastUpdated`, `DataFrom` (`DateOnly`), `DataTo` (`DateOnly`). `Empty()` factory returns `IsHydrated = false`. |
+| `IMaterialCostCache` | `Anela.Heblo.Domain.Features.Catalog.Cache` | Extends `ICostCache` → `GetCachedDataAsync(ct)` + `SetCachedDataAsync(data, ct)`. |
+| `ICatalogRepository` | `Anela.Heblo.Domain.Features.Catalog` | Tests use `WaitForCurrentMergeAsync(ct)` and `GetAllAsync(ct)`. |
+| `DataSourceOptions` | `Anela.Heblo.Application.Common` | Field exercised: `ManufactureCostHistoryDays`. Default `400`; tests inject `4000` to keep synthetic dates inside the SUT window. |
+
+---
+
+## Task 1: Scaffold the test file with helpers
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Create the test file with usings, namespace, `[Collection]`, helpers, and a single sanity `[Fact]`**
+
+```csharp
+using Anela.Heblo.Application.Common;
+using Anela.Heblo.Application.Features.Catalog.CostProviders;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Cache;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+using Anela.Heblo.Domain.Features.Catalog.ValueObjects;
+using Anela.Heblo.Domain.Features.Manufacture;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.CostProviders;
+
+/// <summary>
+/// Tests for ManufactureBasedMaterialCostProvider.
+/// Uses Collection attribute to ensure sequential execution due to static _refreshLock in the provider.
+/// </summary>
+[Collection("ManufactureBasedMaterialCostProviderTests")]
+public class ManufactureBasedMaterialCostProviderTests
+{
+    /// <summary>
+    /// 4000 days (~11 years) — comfortably covers any synthetic month anchored to UtcNow,
+    /// so the SUT's [now - historyDays, now] window always contains seeded records.
+    /// </summary>
+    private const int DefaultHistoryDays = 4000;
+
+    // ===== Helpers =====
+
+    private static DateTime CurrentMonthStartUtc() =>
+        new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+
+    private static DateTime MonthOffsetFromNow(int monthsOffset) =>
+        CurrentMonthStartUtc().AddMonths(monthsOffset);
+
+    private static CatalogAggregate BuildManufacturedProduct(
+        string productCode,
+        ProductType type,
+        IEnumerable<(DateTime date, decimal pricePerPiece, double amount)>? history = null,
+        decimal? purchasePriceWithVat = null)
+    {
+        var agg = new CatalogAggregate
+        {
+            ProductCode = productCode,
+            ProductName = productCode,
+            Type = type,
+        };
+
+        if (history != null)
+        {
+            agg.ManufactureHistory = history
+                .Select(h => new ManufactureHistoryRecord
+                {
+                    Date = h.date,
+                    PricePerPiece = h.pricePerPiece,
+                    Amount = h.amount,
+                    PriceTotal = h.pricePerPiece * (decimal)h.amount,
+                    ProductCode = productCode,
+                    DocumentNumber = "TEST-DOC",
+                })
+                .ToList();
+        }
+
+        if (purchasePriceWithVat.HasValue)
+        {
+            agg.ErpPrice = new ProductPriceErp { PurchasePriceWithVat = purchasePriceWithVat.Value };
+        }
+
+        return agg;
+    }
+
+    private static CatalogAggregate BuildNonManufacturedProduct(
+        string productCode,
+        ProductType type,
+        decimal? purchasePriceWithVat)
+    {
+        var agg = new CatalogAggregate
+        {
+            ProductCode = productCode,
+            ProductName = productCode,
+            Type = type,
+        };
+
+        if (purchasePriceWithVat.HasValue)
+        {
+            agg.ErpPrice = new ProductPriceErp { PurchasePriceWithVat = purchasePriceWithVat.Value };
+        }
+
+        return agg;
+    }
+
+    private static CostCacheData BuildHydratedCacheData(IEnumerable<string> productCodes)
+    {
+        var month = new DateTime(2026, 1, 1);
+        var dict = productCodes.ToDictionary(
+            code => code,
+            code => new List<MonthlyCost> { new(month, 1m) });
+        return new CostCacheData
+        {
+            ProductCosts = dict,
+            LastUpdated = DateTime.UtcNow,
+            DataFrom = DateOnly.FromDateTime(month),
+            DataTo = DateOnly.FromDateTime(month.AddMonths(1).AddDays(-1)),
+            IsHydrated = true,
+        };
+    }
+
+    private static ManufactureBasedMaterialCostProvider CreateProvider(
+        Mock<IMaterialCostCache>? cacheMock = null,
+        Mock<ICatalogRepository>? repoMock = null,
+        Mock<ILogger<ManufactureBasedMaterialCostProvider>>? loggerMock = null,
+        int manufactureCostHistoryDays = DefaultHistoryDays)
+    {
+        return new ManufactureBasedMaterialCostProvider(
+            (cacheMock ?? new Mock<IMaterialCostCache>()).Object,
+            (repoMock ?? new Mock<ICatalogRepository>()).Object,
+            (loggerMock ?? new Mock<ILogger<ManufactureBasedMaterialCostProvider>>()).Object,
+            Options.Create(new DataSourceOptions { ManufactureCostHistoryDays = manufactureCostHistoryDays }));
+    }
+
+    private static void VerifyLog(
+        Mock<ILogger<ManufactureBasedMaterialCostProvider>> logger,
+        LogLevel level,
+        string messageContains,
+        Times? times = null)
+    {
+        logger.Verify(
+            x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains(messageContains)),
+                It.IsAny<Exception?>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+            times ?? Times.AtLeastOnce());
+    }
+
+    /// <summary>
+    /// Captures the CostCacheData written to the cache by RefreshAsync and returns
+    /// the configured cache mock. Tests can read the captured value via the out parameter.
+    /// </summary>
+    private static Mock<IMaterialCostCache> BuildCaptureCacheMock(out Action<Action<CostCacheData>> onCaptured)
+    {
+        var cacheMock = new Mock<IMaterialCostCache>();
+        Action<CostCacheData>? subscriber = null;
+        onCaptured = handler => subscriber = handler;
+
+        cacheMock
+            .Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+            .Callback<CostCacheData, CancellationToken>((d, _) => subscriber?.Invoke(d))
+            .Returns(Task.CompletedTask);
+
+        return cacheMock;
+    }
+
+    // ===== Tests =====
+
+    [Fact]
+    internal void Scaffold_Compiles_AndCanCreateProvider()
+    {
+        var provider = CreateProvider();
+        provider.Should().NotBeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Build the test project to verify the scaffold compiles**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: Build succeeds, 0 errors, 0 new warnings attributable to this file.
+
+- [ ] **Step 3: Run the scaffold test to confirm xUnit discovers the class**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: scaffold ManufactureBasedMaterialCostProviderTests with helpers"
+```
+
+---
+
+## Task 2: FR-1 — manufactured product types route to manufacture-history path
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-1 theory test inside `ManufactureBasedMaterialCostProviderTests`**
+
+```csharp
+[Theory]
+[InlineData(ProductType.Product)]
+[InlineData(ProductType.Set)]
+[InlineData(ProductType.SemiProduct)]
+internal async Task RefreshAsync_UsesManufactureHistory_WhenProductTypeIsManufactured(ProductType type)
+{
+    // Arrange — a single manufacture record at price 100m; PurchasePriceWithVat is a sentinel
+    // that MUST NOT appear anywhere in the resulting cost series.
+    var manufactureMonth = MonthOffsetFromNow(-2).AddDays(10);
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-A",
+        type: type,
+        history: new[] { (manufactureMonth, 100m, 5.0) },
+        purchasePriceWithVat: 999m);
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    captured!.ProductCosts.Should().ContainKey("PROD-A");
+    var series = captured.ProductCosts["PROD-A"];
+    series.Should().NotBeEmpty();
+    series.Should().AllSatisfy(mc => mc.Cost.Should().Be(100m));
+    series.Select(mc => mc.Cost).Should().NotContain(999m);
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_UsesManufactureHistory_WhenProductTypeIsManufactured"`
+Expected: 3 passed (one per `InlineData`), 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-1 routing for manufactured types"
+```
+
+---
+
+## Task 3: FR-2 — non-manufactured product types fall back to purchase-price path
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-2 theory test**
+
+```csharp
+[Theory]
+[InlineData(ProductType.Material)]
+[InlineData(ProductType.Goods)]
+[InlineData(ProductType.UNDEFINED)]
+internal async Task RefreshAsync_UsesPurchasePrice_WhenProductTypeIsNonManufactured(ProductType type)
+{
+    // Arrange — populated ManufactureHistory MUST be ignored for non-manufactured types.
+    var manufactureMonth = MonthOffsetFromNow(-2).AddDays(10);
+    var product = BuildManufacturedProduct(
+        productCode: "MAT-1",
+        type: type,
+        history: new[] { (manufactureMonth, 100m, 5.0) },
+        purchasePriceWithVat: 50m);
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    var series = captured!.ProductCosts["MAT-1"];
+    series.Should().NotBeEmpty();
+    series.Should().AllSatisfy(mc => mc.Cost.Should().Be(50m));
+
+    // Series spans the SUT window [now - DefaultHistoryDays, now] aligned to first-of-month.
+    var expectedMonthCount = ExpectedMonthCount(captured.DataFrom, captured.DataTo);
+    series.Should().HaveCount(expectedMonthCount);
+}
+
+private static int ExpectedMonthCount(DateOnly from, DateOnly to)
+{
+    return ((to.Year - from.Year) * 12) + (to.Month - from.Month) + 1;
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_UsesPurchasePrice_WhenProductTypeIsNonManufactured"`
+Expected: 3 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-2 routing for non-manufactured types"
+```
+
+---
+
+## Task 4: FR-3 — carry-forward fills gap months with last-known price
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-3 test**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_CarriesForwardLastKnownPrice_WhenMonthHasNoManufacture()
+{
+    // Arrange — anchors: M1 = 4 months ago, M2 = 3 months ago, M3 = 2 months ago, M4 = 1 month ago.
+    // Records exist at M1 (100m) and M3 (200m). Expect carry-forward in M2 (=100m) and M4 (=200m).
+    var m1 = MonthOffsetFromNow(-4);
+    var m2 = MonthOffsetFromNow(-3);
+    var m3 = MonthOffsetFromNow(-2);
+    var m4 = MonthOffsetFromNow(-1);
+
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-CF",
+        type: ProductType.Product,
+        history: new[]
+        {
+            (m1.AddDays(5), 100m, 1.0),
+            (m3.AddDays(5), 200m, 1.0),
+        });
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    var series = captured!.ProductCosts["PROD-CF"];
+
+    series.Single(mc => mc.Month == m1).Cost.Should().Be(100m);
+    series.Single(mc => mc.Month == m2).Cost.Should().Be(100m); // carry-forward
+    series.Single(mc => mc.Month == m3).Cost.Should().Be(200m);
+    series.Single(mc => mc.Month == m4).Cost.Should().Be(200m); // carry-forward
+
+    // No gaps between m1 and m4 — every month present.
+    var inRange = series.Where(mc => mc.Month >= m1 && mc.Month <= m4).OrderBy(mc => mc.Month).ToList();
+    inRange.Should().HaveCount(4);
+    inRange.Select(mc => mc.Month).Should().Equal(m1, m2, m3, m4);
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_CarriesForwardLastKnownPrice_WhenMonthHasNoManufacture"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-3 carry-forward gap months"
+```
+
+---
+
+## Task 5: FR-4 — future-manufacture backfill for months preceding any record
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-4 test**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_BackfillsFromEarliestFuturePrice_WhenNoPriorManufactureExists()
+{
+    // Arrange — only manufacture record sits 2 months ago at 300m. Months 4 and 3 months ago
+    // precede the record and must be backfilled with 300m.
+    var earliest = MonthOffsetFromNow(-2);
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-BF",
+        type: ProductType.Product,
+        history: new[] { (earliest.AddDays(5), 300m, 1.0) });
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert — every month in the SUT's window contains 300m (backfill + record + carry-forward).
+    captured.Should().NotBeNull();
+    var series = captured!.ProductCosts["PROD-BF"];
+    series.Should().NotBeEmpty();
+    series.Should().AllSatisfy(mc => mc.Cost.Should().Be(300m));
+}
+
+[Fact]
+internal async Task RefreshAsync_BackfillsUsingEarliestFuturePrice_WhenMultipleFutureRecordsExist()
+{
+    // Arrange — records at M3 (=300m) and M5 (=500m), backfill must pick 300m (earliest),
+    // not 500m (latest). Earlier months M1, M2 must read 300m. M4 carries forward 300m.
+    var m1 = MonthOffsetFromNow(-5);
+    var m2 = MonthOffsetFromNow(-4);
+    var m3 = MonthOffsetFromNow(-3);
+    var m4 = MonthOffsetFromNow(-2);
+    var m5 = MonthOffsetFromNow(-1);
+
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-BF2",
+        type: ProductType.Product,
+        history: new[]
+        {
+            (m3.AddDays(5), 300m, 1.0),
+            (m5.AddDays(5), 500m, 1.0),
+        });
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    var series = captured!.ProductCosts["PROD-BF2"];
+
+    series.Single(mc => mc.Month == m1).Cost.Should().Be(300m); // backfill
+    series.Single(mc => mc.Month == m2).Cost.Should().Be(300m); // backfill
+    series.Single(mc => mc.Month == m3).Cost.Should().Be(300m);
+    series.Single(mc => mc.Month == m4).Cost.Should().Be(300m); // carry-forward
+    series.Single(mc => mc.Month == m5).Cost.Should().Be(500m);
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_Backfills"`
+Expected: 2 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-4 future-manufacture backfill"
+```
+
+---
+
+## Task 6: FR-5 — empty / null manufacture history falls back to purchase price
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-5 tests**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_FallsBackToPurchasePrice_WhenManufactureHistoryIsEmptyList()
+{
+    // Arrange — manufactured-type product with explicitly empty history.
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-EMPTY",
+        type: ProductType.Product,
+        history: Array.Empty<(DateTime, decimal, double)>(),
+        purchasePriceWithVat: 75m);
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    var series = captured!.ProductCosts["PROD-EMPTY"];
+    series.Should().NotBeEmpty();
+    series.Should().AllSatisfy(mc => mc.Cost.Should().Be(75m));
+    series.Should().HaveCount(ExpectedMonthCount(captured.DataFrom, captured.DataTo));
+}
+
+[Fact]
+internal async Task RefreshAsync_FallsBackToPurchasePrice_WhenManufactureHistoryDefaultsToEmpty()
+{
+    // Arrange — manufactured-type product, do not touch ManufactureHistory (default empty list).
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-DEFAULT",
+        type: ProductType.Product,
+        history: null,
+        purchasePriceWithVat: 75m);
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    var series = captured!.ProductCosts["PROD-DEFAULT"];
+    series.Should().NotBeEmpty();
+    series.Should().AllSatisfy(mc => mc.Cost.Should().Be(75m));
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_FallsBackToPurchasePrice"`
+Expected: 2 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-5 fallback to purchase price when history empty"
+```
+
+---
+
+## Task 7: FR-6 — missing / non-positive purchase price returns empty list
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-6 tests**
+
+```csharp
+[Theory]
+[InlineData(null)]
+[InlineData(0.0)]
+[InlineData(-1.0)]
+internal async Task RefreshAsync_ReturnsEmptyCostList_WhenPurchasePriceIsNullOrNonPositive(double? priceOrNull)
+{
+    // Arrange — non-manufactured product so we hit the purchase-price path directly.
+    decimal? price = priceOrNull.HasValue ? (decimal?)priceOrNull.Value : null;
+    var product = BuildNonManufacturedProduct(
+        productCode: "MAT-EMPTY",
+        type: ProductType.Material,
+        purchasePriceWithVat: price);
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    captured!.ProductCosts.Should().ContainKey("MAT-EMPTY");
+    captured.ProductCosts["MAT-EMPTY"].Should().BeEmpty();
+}
+
+[Fact]
+internal async Task RefreshAsync_ReturnsEmptyCostList_WhenManufacturedTypeFallbackHasNoPurchasePrice()
+{
+    // Arrange — manufactured type with empty history and no ErpPrice → fallback returns empty.
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-NO-PRICE",
+        type: ProductType.Product,
+        history: Array.Empty<(DateTime, decimal, double)>(),
+        purchasePriceWithVat: null);
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    captured!.ProductCosts.Should().ContainKey("PROD-NO-PRICE");
+    captured.ProductCosts["PROD-NO-PRICE"].Should().BeEmpty();
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_ReturnsEmptyCostList"`
+Expected: 4 passed (3 from theory + 1 fact), 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-6 empty list when purchase price absent"
+```
+
+---
+
+## Task 8: FR-7 — weighted-average per month aggregation
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-7 test**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_AggregatesWithWeightedAverage_WhenMonthHasMultipleManufactureRecords()
+{
+    // Arrange — two records in the same month: (100, 10) and (200, 30) → weighted avg = 175m.
+    // A second month has a single record (300, 5) which must remain 300m (independent month).
+    var monthA = MonthOffsetFromNow(-3);
+    var monthB = MonthOffsetFromNow(-2);
+
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-WA",
+        type: ProductType.Product,
+        history: new[]
+        {
+            (monthA.AddDays(2),  100m, 10.0),
+            (monthA.AddDays(20), 200m, 30.0),
+            (monthB.AddDays(5),  300m,  5.0),
+        });
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock);
+
+    // Act
+    await provider.RefreshAsync();
+
+    // Assert
+    captured.Should().NotBeNull();
+    var series = captured!.ProductCosts["PROD-WA"];
+    series.Single(mc => mc.Month == monthA).Cost.Should().Be(175m);
+    series.Single(mc => mc.Month == monthB).Cost.Should().Be(300m);
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_AggregatesWithWeightedAverage"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-7 weighted-average per month"
+```
+
+---
+
+## Task 9: FR-8 — zero total amount throws DivideByZeroException
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-8 test**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_ThrowsDivideByZero_WhenMonthlyAmountSumIsZero()
+{
+    // Arrange — two records in the same month both with Amount = 0; weighted-average denominator is 0.
+    // The SUT uses `decimal` arithmetic, so `decimal / 0m` raises DivideByZeroException
+    // (decimal does NOT produce NaN — that's a double-only behavior).
+    // The exception is logged at Error and rethrown by RefreshAsync; this test pins that contract.
+    var month = MonthOffsetFromNow(-2);
+    var product = BuildManufacturedProduct(
+        productCode: "PROD-DBZ",
+        type: ProductType.Product,
+        history: new[]
+        {
+            (month.AddDays(2), 100m, 0.0),
+            (month.AddDays(3), 200m, 0.0),
+        });
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<CatalogAggregate> { product });
+
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+        .Returns(Task.CompletedTask);
+
+    var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+    // Act + Assert
+    await Assert.ThrowsAsync<DivideByZeroException>(() => provider.RefreshAsync());
+
+    // The exception path logs at Error and never writes the cache.
+    VerifyLog(loggerMock, LogLevel.Error, "Failed to refresh MaterialCostCache");
+    cacheMock.Verify(
+        c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_ThrowsDivideByZero"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: pin ManufactureBasedMaterialCostProvider FR-8 divide-by-zero behavior"
+```
+
+---
+
+## Task 10: FR-9 — GetCostsAsync filters by product codes when cache hydrated
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-9 tests**
+
+```csharp
+[Fact]
+internal async Task GetCostsAsync_ReturnsFullDictionary_WhenProductCodesAreNull()
+{
+    var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+    var provider = CreateProvider(cacheMock: cacheMock);
+
+    var result = await provider.GetCostsAsync(null);
+
+    result.Should().HaveCount(3);
+    result.Keys.Should().BeEquivalentTo("A", "B", "C");
+}
+
+[Fact]
+internal async Task GetCostsAsync_ReturnsFullDictionary_WhenProductCodesAreEmpty()
+{
+    var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+    var provider = CreateProvider(cacheMock: cacheMock);
+
+    var result = await provider.GetCostsAsync(new List<string>());
+
+    result.Should().HaveCount(3);
+    result.Keys.Should().BeEquivalentTo("A", "B", "C");
+}
+
+[Fact]
+internal async Task GetCostsAsync_ReturnsSubset_WhenProductCodesProvided()
+{
+    var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+    var provider = CreateProvider(cacheMock: cacheMock);
+
+    var result = await provider.GetCostsAsync(new List<string> { "A", "C", "MISSING" });
+
+    result.Should().HaveCount(2);
+    result.Keys.Should().BeEquivalentTo("A", "C");
+}
+
+[Fact]
+internal async Task GetCostsAsync_ReturnsEmptyDictionary_WhenRequestedProductCodeNotInCache()
+{
+    var hydrated = BuildHydratedCacheData(new[] { "A", "B", "C" });
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(hydrated);
+
+    var provider = CreateProvider(cacheMock: cacheMock);
+
+    var result = await provider.GetCostsAsync(new List<string> { "MISSING" });
+
+    result.Should().BeEmpty();
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.GetCostsAsync_Returns"`
+Expected: 4 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-9 GetCostsAsync filtering"
+```
+
+---
+
+## Task 11: FR-10 — GetCostsAsync returns empty + warns when cache not hydrated
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-10 test**
+
+```csharp
+[Fact]
+internal async Task GetCostsAsync_ReturnsEmptyAndLogsWarning_WhenCacheNotHydrated()
+{
+    // Arrange
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>()))
+        .ReturnsAsync(CostCacheData.Empty());
+
+    var repoMock = new Mock<ICatalogRepository>();
+    var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+    // Act
+    var result = await provider.GetCostsAsync();
+
+    // Assert
+    result.Should().NotBeNull();
+    result.Should().BeEmpty();
+
+    VerifyLog(loggerMock, LogLevel.Warning, "MaterialCostCache not hydrated");
+
+    // Cache hydration miss must not trigger any repository work.
+    repoMock.VerifyNoOtherCalls();
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.GetCostsAsync_ReturnsEmptyAndLogsWarning"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-10 GetCostsAsync warning when cache not hydrated"
+```
+
+---
+
+## Task 12: FR-11 — GetCostsAsync logs error and rethrows when cache throws
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-11 test**
+
+```csharp
+[Fact]
+internal async Task GetCostsAsync_LogsErrorAndRethrows_WhenCacheReadFails()
+{
+    // Arrange
+    var boom = new InvalidOperationException("boom");
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.GetCachedDataAsync(It.IsAny<CancellationToken>())).ThrowsAsync(boom);
+
+    var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+    var provider = CreateProvider(cacheMock: cacheMock, loggerMock: loggerMock);
+
+    // Act
+    var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetCostsAsync());
+
+    // Assert
+    thrown.Should().BeSameAs(boom);
+    VerifyLog(loggerMock, LogLevel.Error, "Error getting material costs");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.GetCostsAsync_LogsErrorAndRethrows"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-11 error log + rethrow on cache failure"
+```
+
+---
+
+## Task 13: FR-12a — RefreshAsync populates cache on success
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-12a test**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_PopulatesCache_OnSuccess_AndExcludesEmptyProductCodes()
+{
+    // Arrange — three real products + two skip cases (empty + null code).
+    var products = new List<CatalogAggregate>
+    {
+        BuildNonManufacturedProduct("MAT-A", ProductType.Material, 10m),
+        BuildNonManufacturedProduct("MAT-B", ProductType.Material, 20m),
+        BuildNonManufacturedProduct("MAT-C", ProductType.Material, 30m),
+        BuildNonManufacturedProduct(string.Empty, ProductType.Material, 99m), // skipped
+        BuildNonManufacturedProduct(null!, ProductType.Material, 99m),         // skipped
+    };
+
+    var callOrder = new List<string>();
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>()))
+        .Callback(() => callOrder.Add("WaitForCurrentMergeAsync"))
+        .Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+        .Callback(() => callOrder.Add("GetAllAsync"))
+        .ReturnsAsync(products);
+
+    var cacheMock = BuildCaptureCacheMock(out var subscribe);
+    CostCacheData? captured = null;
+    subscribe(d => captured = d);
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, manufactureCostHistoryDays: 90);
+
+    var nowBefore = DateTime.UtcNow;
+
+    // Act
+    await provider.RefreshAsync();
+
+    var nowAfter = DateTime.UtcNow;
+
+    // Assert — cache populated with exactly the three non-empty product codes.
+    captured.Should().NotBeNull();
+    captured!.IsHydrated.Should().BeTrue();
+    captured.ProductCosts.Keys.Should().BeEquivalentTo("MAT-A", "MAT-B", "MAT-C");
+
+    // DataFrom/DataTo within tolerant window around UtcNow.
+    var expectedFromLower = DateOnly.FromDateTime(nowBefore.AddDays(-90));
+    var expectedFromUpper = DateOnly.FromDateTime(nowAfter.AddDays(-90));
+    captured.DataFrom.Should().BeOnOrAfter(expectedFromLower);
+    captured.DataFrom.Should().BeOnOrBefore(expectedFromUpper);
+
+    captured.DataTo.Should().BeOnOrAfter(DateOnly.FromDateTime(nowBefore));
+    captured.DataTo.Should().BeOnOrBefore(DateOnly.FromDateTime(nowAfter));
+
+    // Call order
+    callOrder.Should().Equal("WaitForCurrentMergeAsync", "GetAllAsync");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_PopulatesCache_OnSuccess"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-12a RefreshAsync success path"
+```
+
+---
+
+## Task 14: FR-12b — RefreshAsync skips concurrent second call
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-12b test**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_SkipsSecondInvocation_WhenFirstStillRunning()
+{
+    // Arrange — gate `GetAllAsync` with a TaskCompletionSource so the first refresh blocks
+    // inside ComputeAllCostsAsync, holding the static _refreshLock. The second refresh must
+    // detect WaitAsync(0) failure, log "refresh already in progress", and return.
+    var gate = new TaskCompletionSource<List<CatalogAggregate>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).Returns(gate.Task);
+
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+        .Returns(Task.CompletedTask);
+
+    var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+    // Act 1 — first refresh; blocks on gate after acquiring the lock.
+    var firstRefresh = provider.RefreshAsync();
+
+    while (!repoMock.Invocations.Any(i => i.Method.Name == nameof(ICatalogRepository.GetAllAsync)))
+    {
+        await Task.Yield();
+    }
+
+    // Act 2 — second refresh; sees lock held, short-circuits.
+    await provider.RefreshAsync();
+
+    // Assert intermediate
+    VerifyLog(loggerMock, LogLevel.Information, "refresh already in progress");
+    cacheMock.Verify(
+        c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+
+    // Release gate, let first refresh finish.
+    gate.SetResult(new List<CatalogAggregate>());
+    await firstRefresh;
+
+    cacheMock.Verify(
+        c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+
+    // Act 3 — fresh refresh after lock released must proceed.
+    await provider.RefreshAsync();
+
+    cacheMock.Verify(
+        c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+        Times.Exactly(2));
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_SkipsSecondInvocation"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-12b concurrent refresh skipped"
+```
+
+---
+
+## Task 15: FR-12c — RefreshAsync releases lock when repository throws
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs`
+
+- [ ] **Step 1: Append the FR-12c test**
+
+```csharp
+[Fact]
+internal async Task RefreshAsync_ReleasesLockOnRepositoryException_AndAllowsSubsequentRefresh()
+{
+    // Arrange — first GetAllAsync throws, second succeeds. Lock must be released by the SUT's
+    // `finally` block so the second call proceeds rather than logging "refresh already in progress".
+    var boom = new InvalidOperationException("repo offline");
+
+    var repoMock = new Mock<ICatalogRepository>();
+    repoMock.Setup(r => r.WaitForCurrentMergeAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    repoMock.SetupSequence(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+        .ThrowsAsync(boom)
+        .ReturnsAsync(new List<CatalogAggregate>());
+
+    var cacheMock = new Mock<IMaterialCostCache>();
+    cacheMock.Setup(c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()))
+        .Returns(Task.CompletedTask);
+
+    var loggerMock = new Mock<ILogger<ManufactureBasedMaterialCostProvider>>();
+
+    var provider = CreateProvider(cacheMock: cacheMock, repoMock: repoMock, loggerMock: loggerMock);
+
+    // Act 1 — first call throws and logs.
+    var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.RefreshAsync());
+    thrown.Should().BeSameAs(boom);
+    VerifyLog(loggerMock, LogLevel.Error, "Failed to refresh MaterialCostCache");
+    cacheMock.Verify(
+        c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+
+    // Act 2 — second call must proceed (lock released by finally).
+    await provider.RefreshAsync();
+
+    // Positive proof: the second call entered the normal execution path, never the "skip" branch.
+    VerifyLog(loggerMock, LogLevel.Information, "refresh already in progress", Times.Never());
+    VerifyLog(loggerMock, LogLevel.Information, "Starting MaterialCostCache refresh", Times.Exactly(2));
+    cacheMock.Verify(
+        c => c.SetCachedDataAsync(It.IsAny<CostCacheData>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests.RefreshAsync_ReleasesLockOnRepositoryException"`
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "test: cover ManufactureBasedMaterialCostProvider FR-12c lock release on repo exception"
+```
+
+---
+
+## Task 16: Coverage verification
+
+**Files:**
+- (none modified — verification only)
+
+- [ ] **Step 1: Run the full suite to confirm nothing else broke**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests"`
+Expected: All tests in the new class pass (≈ 20 tests including theory variants).
+
+- [ ] **Step 2: Run the wider test project to confirm no cross-collection regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: 0 failed.
+
+- [ ] **Step 3: Collect coverage for the SUT file**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ManufactureBasedMaterialCostProviderTests" \
+  --collect:"XPlat Code Coverage" \
+  --results-directory backend/test/Anela.Heblo.Tests/TestResults/coverage-mbmcp \
+  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+```
+
+Then inspect the produced `coverage.cobertura.xml` for the SUT (search the file for `Anela.Heblo.Application/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProvider`) and confirm `line-rate >= 0.80`.
+
+Expected: line-rate on `ManufactureBasedMaterialCostProvider.cs` ≥ 0.80. If lower, identify the uncovered branch(es) by reading the XML and add a targeted test to the appropriate FR's task before completing.
+
+- [ ] **Step 4: Final validation gate**
+
+Run:
+- `dotnet build backend/backend.sln` → expected: build succeeds.
+- `dotnet format backend/backend.sln --verify-no-changes --include backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs` → expected: no formatting changes required (run `dotnet format ... --include <file>` without `--verify-no-changes` to auto-fix if it fails, then re-verify).
+
+Expected: both commands succeed.
+
+- [ ] **Step 5: Commit any formatting touch-ups (if any)**
+
+If `dotnet format` produced changes, commit them:
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProviderTests.cs
+git commit -m "chore: apply dotnet format to ManufactureBasedMaterialCostProviderTests"
+```
+
+If no changes, skip this step.
+
+---
+
+## Spec Coverage Verification
+
+| FR / NFR | Task |
+|----------|------|
+| FR-1 — Manufactured types route to manufacture-history | Task 2 |
+| FR-2 — Non-manufactured types route to purchase-price | Task 3 |
+| FR-3 — Carry-forward gap months | Task 4 |
+| FR-4 — Backfill from earliest future record | Task 5 |
+| FR-5 — Empty/null history → purchase-price fallback | Task 6 |
+| FR-6 — Null/zero/negative price → empty list | Task 7 |
+| FR-7 — Weighted-average per month | Task 8 |
+| FR-8 — Zero-amount divide-by-zero behavior | Task 9 |
+| FR-9 — GetCostsAsync filtered cache when hydrated | Task 10 |
+| FR-10 — GetCostsAsync empty + warning when not hydrated | Task 11 |
+| FR-11 — GetCostsAsync error log + rethrow | Task 12 |
+| FR-12 — RefreshAsync success / concurrent / lock release | Tasks 13, 14, 15 |
+| FR-13 — File naming, location, `[Collection]`, conventions | Task 1 (scaffold) + reinforced by every subsequent task |
+| NFR-1 — Performance (no sleeps, no I/O) | All tasks use in-memory mocks + `TaskCompletionSource` gating |
+| NFR-2 — Security (no secrets, no PII) | All tasks use synthetic codes/prices |
+| NFR-3 — Determinism (anchor dates relative to UtcNow + `DefaultHistoryDays = 4000`) | All date-driven tasks (Tasks 2–9, 13) |
+| NFR-4 — Coverage ≥ 80 % | Task 16 |
+
+## Architecture-Review Amendments Applied
+
+- Spec said `CatalogManufactureRecord` → plan uses **`ManufactureHistoryRecord`** (`Anela.Heblo.Domain.Features.Manufacture`).
+- Spec said "set `PurchasePriceWithVat`" → plan sets `ErpPrice = new ProductPriceErp { PurchasePriceWithVat = … }` because the property is read-only.
+- Spec said "null / 0 / negative `PurchasePriceWithVat`" → plan realises null by leaving `ErpPrice = null` (Task 7).
+- Spec said "DivideByZeroException or NaN" → plan asserts only **`DivideByZeroException`** (decimal arithmetic).
+- Spec said `DefaultHistoryDays = 365` → plan uses **4000** to keep synthetic month anchors inside the SUT window.
+- Log substrings updated to match production text: `"MaterialCostCache not hydrated"`, `"Error getting material costs"`, `"refresh already in progress"`, `"Failed to refresh MaterialCostCache"`, `"Starting MaterialCostCache refresh"`.


### PR DESCRIPTION
`backend/src/Anela.Heblo.Application/Features/Catalog/CostProviders/ManufactureBasedMaterialCostProvider.cs`

## Coverage
Line coverage: 25% (filter threshold: 60%)

## What's not tested
`CalculateMaterialCosts` routes by product type and `CalculateFromManufactureHistory` implements a temporal carry-forward algorithm. Untested paths:
- **Product-type routing**: Set/Product/SemiProduct use manufacture history; all other types fall back to purchase price with VAT — the branch guard is unchecked
- **Carry-forward (no gap months)**: when a month has no manufacture entry, the last-known price is carried forward; verifying the sequence is never asserted
- **Future-manufacture backfill**: months before the first manufacture record use the earliest future price — the `futureManufacture != default` branch is uncovered
- **No-history fallback**: products with empty `ManufactureHistory` fall back to purchase-price path — untested
- **Zero/null purchase price guard**: `CalculateFromPurchasePriceWithVat` returns empty list when price is null or ≤ 0 — never exercised
- **Weighted average calculation**: `Sum(PricePerPiece * Amount) / Sum(Amount)` across grouped month records — any overflow or divide-by-zero is uncaught

## Why it matters
This is the M0 cost source feeding product margin calculations. The carry-forward logic silently propagates stale prices across months. A wrong branch (e.g., type check widened or carry-forward skipped) would corrupt historical cost data for all manufactured products without raising an exception.

## Suggested approach
Unit tests with mocked `ICatalogRepository`:
1. Manufactured product with gaps → verify carry-forward fills missing months with last-known price
2. Manufactured product with future manufacture only → verify backfill from first future record
3. Non-manufactured product (type = Material) → verify purchase-price path is used
4. Manufactured product with no history → verify falls back to purchase-price path
5. Purchase price null → verify empty list returned
Effort: ~2–3 hours

---
_Filed by weekly coverage-gap routine on 2026-06-14. Based on CI run #27416879267 (3a6b7f99ee715caf82fc0efa17de5a5ede7b46fb)._

---

Closes #3074

### Tokens used
27002213
