### PR TITLE
fix: weather forecast on expedition settings no longer requires admin permission

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/WeatherForecastController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/WeatherForecastController.cs
@@ -1,11 +1,9 @@
 using Anela.Heblo.Application.Features.WeatherForecast.UseCases.GetWeatherForecast;
-using Anela.Heblo.Domain.Features.Authorization;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Anela.Heblo.API.Controllers;
 
-[FeatureAuthorize(Feature.Admin_Administration)]
 [ApiController]
 [Route("api/weather-forecast")]
 public class WeatherForecastController : BaseApiController

--- a/backend/test/Anela.Heblo.Tests/Authorization/WeatherForecastControllerAuthorizationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/WeatherForecastControllerAuthorizationTests.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Domain.Features.Authorization;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Authorization;
+
+public class WeatherForecastControllerAuthorizationTests
+{
+    [Fact]
+    public void WeatherForecastController_IsNotGatedByFeatureAuthorize()
+    {
+        var attribute = typeof(WeatherForecastController).GetCustomAttribute<FeatureAuthorizeAttribute>();
+
+        attribute.Should().BeNull(
+            "the weather forecast is informational and must be available to every authenticated user; " +
+            "it must not require admin.administration.read on the expedition settings page");
+    }
+}


### PR DESCRIPTION
## Problem
The **Nastavení expedice** page showed *"Přístup zakázán. Chybí oprávnění: admin.administration.read"* errors because the Cooling tab's weather widget calls `GET /api/weather-forecast`, which was gated with `[FeatureAuthorize(Feature.Admin_Administration)]` while the rest of the page only needs expedition permissions.

## Fix
Removed the feature gate from `WeatherForecastController` so the endpoint falls back to the global authenticated-user policy (any logged-in `heblo_user`), matching the convention used by `DashboardController`. Added a regression test asserting the controller is not gated by `FeatureAuthorize`. The endpoint is consumed only by this page (the dashboard weather tile uses a separate mechanism), and 8 other controllers still carry the `Admin_Administration` gate, so `GateConsistencyTests` stays valid.

## Verification
`dotnet build` (0 errors), `dotnet format --verify-no-changes` (clean), and the Authorization test suite (125 passed) all pass.