### PR TITLE
feat: Unit Test Coverage for Invoice Classification Rules

### DIFF
--- a/artifacts/feat-coverage-gap-invoiceclassification-rules/arch-review.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-rules/arch-review.r1.md
@@ -1,0 +1,187 @@
+```markdown
+# Architecture Review: Unit Test Coverage for Invoice Classification Rules
+
+## Skip Design: true
+
+Backend-only test code addition. No UI, no schema, no public APIs, no production code changes. Pure additive coverage of existing domain logic and one application-layer orchestrator.
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with existing conventions:
+
+- **Test project layout** mirrors `src/` already: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/` matches `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/` and `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/`. Adding `Rules/` and `Services/` subfolders extends the mirror, it does not invent a new structure.
+- **Tooling** (xUnit + FluentAssertions + Moq, AAA comments, `MethodName_Scenario_ExpectedOutcome`) is already established in `GetClassificationRuleTypesHandlerTests.cs` — the new tests inherit it without amendment.
+- **Targets are pure functions** with no infrastructure dependencies. `IClassificationRule` is a stateless strategy interface; `RuleEvaluationEngine` takes `IEnumerable<IClassificationRule>` via constructor and a `List<ClassificationRule>` per call. No `DateTime.UtcNow`, no I/O, no statics — fully deterministic and parallel-safe.
+- **Integration points** stay untouched. The existing `ClassifyInvoicesHandlerTests` and `InvoiceClassificationServiceTests` exercise the rules through the full pipeline; the new tests sit *below* them at the unit level. Adding unit coverage does not duplicate or compete with the integration suite — it pinpoints regressions to specific branches the integration tests cannot localize.
+
+Verified facts that constrain the design:
+
+- `ClassificationRule` (line 33–53 of `ClassificationRule.cs`) has a **public constructor** plus a public `SetOrder(int)` method. The spec is correct: the entity can be constructed directly without reflection or test-only factory hacks.
+- `RuleEvaluationEngine.EvaluateRule` (line 27–31) uses `FirstOrDefault` against `Identifier`, returning `false` for unknown identifiers — the no-throw behavior the spec asserts.
+- `AmountClassificationRule` wraps the operator dispatch in a `try { … } catch { return false; }`. The `decimal.TryParse` calls *never throw*, so the `catch` block is effectively unreachable through public inputs. The spec does not require covering it explicitly; documenting this in the architecture review is enough.
+- Each regex rule catches **only `ArgumentException`** from `Regex.IsMatch`. Tests must use a pattern guaranteed to raise `ArgumentException` (unclosed character class `"["` is correct; other malformed regexes raise different exception types and would not exercise the fallback).
+
+No friction. Proceed.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/
+├── Rules/                                          (new — domain-layer unit tests)
+│   ├── AmountClassificationRuleTests.cs            → covers AmountClassificationRule
+│   ├── CompanyNameClassificationRuleTests.cs       → covers CompanyNameClassificationRule
+│   ├── DescriptionClassificationRuleTests.cs       → covers DescriptionClassificationRule
+│   └── ItemDescriptionClassificationRuleTests.cs   → covers ItemDescriptionClassificationRule
+├── Services/                                       (new — application-layer unit tests)
+│   └── RuleEvaluationEngineTests.cs                → covers RuleEvaluationEngine
+└── TestHelpers/                                    (new — shared, test-internal)
+    └── InvoiceClassificationFixtures.cs            → CreateInvoice(...), CreateRule(...), CreateItemizedInvoice(...)
+```
+
+Test-side fixture helpers live in `TestHelpers/` so each test class stays focused on Arrange/Act/Assert rather than object construction. The helpers are `internal static` — not consumed by production code, not exposed beyond the test assembly.
+
+### Key Design Decisions
+
+#### Decision 1: Pure-function tests for rule classes, no mocks
+**Options considered:**
+- (A) Mock `ReceivedInvoice` / `ReceivedInvoiceItem` via Moq.
+- (B) Construct real `ReceivedInvoice` instances directly in tests.
+
+**Chosen approach:** (B). The domain entities are POCOs with public setters; constructing them is one line.
+
+**Rationale:** Mocking POCOs introduces friction without benefit. The rule code reads concrete properties (`invoice.TotalAmount`, `invoice.CompanyName`, `invoice.Items[i].Name`); real instances exercise the same code path and produce more readable Arrange blocks. This mirrors the spec's own NFR-4 (helper methods for readability).
+
+#### Decision 2: Mock `IClassificationRule` strategies in `RuleEvaluationEngineTests`, construct real `ClassificationRule` domain entities
+**Options considered:**
+- (A) Use real `AmountClassificationRule` etc. in `RuleEvaluationEngineTests` and craft patterns that match/don't match.
+- (B) Mock `IClassificationRule` to control match outcomes deterministically; keep `ClassificationRule` (the data record) real.
+
+**Chosen approach:** (B), as the spec already prescribes.
+
+**Rationale:** Engine tests verify **ordering, filtering, short-circuit, and null-on-miss** — not rule semantics. Mocking the strategy decouples engine behavior from any future rule changes. Conversely, `ClassificationRule` is the data carrier the engine sorts and filters; substituting a mock would obscure what the engine actually inspects (`Order`, `IsActive`, `RuleTypeIdentifier`).
+
+#### Decision 3: `[Theory]` + `[InlineData]` for `AmountClassificationRuleTests`, `[Fact]` elsewhere
+**Options considered:**
+- (A) One `[Fact]` per operator boundary, twelve+ methods.
+- (B) `[Theory]` parameterized by `(pattern, amount, expected)` for operator coverage; `[Fact]` for the null/empty/whitespace/parse-failure edges where the scenario name carries semantic meaning.
+
+**Chosen approach:** (B). The spec explicitly endorses this.
+
+**Rationale:** `[Theory]` collapses ~18 nearly identical boundary cases into a single readable matrix. Edge cases (empty pattern, non-numeric body) get their own `[Fact]` because the *name* documents the contract and there is no parameter sweep to perform.
+
+#### Decision 4: Fallback test uses `"["` (unclosed character class)
+**Options considered:**
+- (A) Use a guaranteed-invalid regex like `"["`.
+- (B) Use `"\\"` or another regex with implementation-dependent behavior.
+
+**Chosen approach:** (A).
+
+**Rationale:** `Regex.IsMatch("anything", "[", …)` reliably throws `ArgumentException` on .NET, which is the **only** exception type the production code catches. Other malformed patterns may throw `RegexParseException` (which inherits from `ArgumentException` on .NET 7+; this is a stable contract, but `"["` is the clearest example). Document this in the test fixture's comment so the rationale survives future readers.
+
+#### Decision 5: No new helper for `ClassificationRule` construction beyond `SetOrder`
+**Options considered:**
+- (A) Introduce a test-side builder.
+- (B) Use the public constructor + `SetOrder` directly, optionally behind a small helper method `CreateRule(identifier, pattern, order, isActive)`.
+
+**Chosen approach:** (B).
+
+**Rationale:** The constructor has six parameters but most carry harmless defaults (`name`, `accountingTemplateCode`, `department`, `createdBy`). A 4-line helper in `InvoiceClassificationFixtures.cs` is enough; a fluent builder is overkill at this scale (YAGNI).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create exactly these files. Do not introduce a builder class, a base test class, or shared `[CollectionDefinition]` fixtures — none are warranted.
+
+```
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/
+├── AmountClassificationRuleTests.cs
+├── CompanyNameClassificationRuleTests.cs
+├── DescriptionClassificationRuleTests.cs
+└── ItemDescriptionClassificationRuleTests.cs
+
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/
+└── RuleEvaluationEngineTests.cs
+
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/TestHelpers/
+└── InvoiceClassificationFixtures.cs
+```
+
+Namespaces:
+- `Anela.Heblo.Tests.Features.InvoiceClassification.Rules`
+- `Anela.Heblo.Tests.Features.InvoiceClassification.Services`
+- `Anela.Heblo.Tests.Features.InvoiceClassification.TestHelpers`
+
+### Interfaces and Contracts
+
+The test code consumes existing public APIs only. No new contracts.
+
+**`InvoiceClassificationFixtures.cs` — recommended surface:**
+
+```csharp
+internal static class InvoiceClassificationFixtures
+{
+    internal static ReceivedInvoice CreateInvoice(
+        decimal totalAmount = 0m,
+        string companyName = "",
+        string description = "",
+        params string[] itemNames);
+
+    internal static ClassificationRule CreateRule(
+        string ruleTypeIdentifier,
+        string pattern,
+        int order = 0,
+        bool isActive = true);
+}
+```
+
+`CreateRule` calls `new ClassificationRule(name: "test", ruleTypeIdentifier, pattern, accountingTemplateCode: "TEMPLATE", department: null, createdBy: "test")` then `SetOrder(order)`; if `isActive == false`, it calls `Update(...)` to flip the flag. (Inspect `Update` — it is the only public way to set `IsActive`.)
+
+### Data Flow
+
+**Rule test flow (per test):**
+1. Arrange: instantiate `new <Rule>ClassificationRule()` + `ReceivedInvoice` via fixture.
+2. Act: call `rule.Evaluate(invoice, pattern)`.
+3. Assert: `result.Should().Be(...)`.
+
+No async, no cancellation tokens, no DI container.
+
+**Engine test flow (per test):**
+1. Arrange: build `Mock<IClassificationRule>` strategies (each with a fixed `Identifier` and a stubbed `Evaluate` return value), pass them as `IEnumerable<IClassificationRule>` to `new RuleEvaluationEngine(strategies)`. Build a `List<ClassificationRule>` via the fixture.
+2. Act: call `engine.FindMatchingRule(invoice, rules)`.
+3. Assert: returned `ClassificationRule` reference (or `null`); for short-circuit tests, also assert `Verify(...)` was **not** called on the lower-priority mock to prove early exit.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Test for `Regex.IsMatch` fallback uses a pattern that does not actually throw `ArgumentException`, leaving the fallback branch uncovered while reporting green. | Medium | Standardize on `"["` (unclosed character class) in `CompanyNameClassificationRuleTests`, `DescriptionClassificationRuleTests`, and `ItemDescriptionClassificationRuleTests`. Add a one-line comment in each fallback test explaining why this pattern is used. Optionally, a single sanity `[Fact]` in one of the rule test files can directly call `Regex.IsMatch(..., "[")` and assert it throws — guards against future framework behavior changes. |
+| Cultural decimal-separator drift makes `AmountClassificationRule` tests flake on non-invariant CI hosts. | Low | Use whole-number patterns only (`"100"`, `">=100"`, `"<99"`). The production code calls `decimal.TryParse(string)` without explicit culture; whole numbers parse identically across cultures. The spec's NFR-3 already calls this out — enforce it in code review. |
+| `RuleEvaluationEngine` short-circuit test relies on `OrderBy` being stable; LINQ's `OrderBy` is stable, but the engine sorts on `Order` (an int) where the test must use **distinct** Order values to make the assertion unambiguous. | Low | Use distinct `Order` values (1, 2, 3) across mocks in the short-circuit test. Document the choice in a comment. |
+| `ClassificationRule.SetOrder` mutates `UpdatedAt` via `DateTime.UtcNow`. Tests must avoid asserting on `UpdatedAt` (would couple to wall-clock). | Low | Restrict assertions to `Order`, `IsActive`, `RuleTypeIdentifier`, and the returned reference identity. NFR-3 covers this. |
+| Helper class drift: `InvoiceClassificationFixtures` becomes a dumping ground over time. | Low | Cap its surface at the two methods listed. If another rule type later needs a different shape, add a focused helper next to its test — do not expand the shared fixture. |
+| Future addition of a new operator to `AmountClassificationRule` (e.g. `!=`) leaves the `[Theory]` matrix silently incomplete. | Low | Out of scope for this work, but add a code-review note recommending the operator list be reflected in a test enum or table when the rule changes. No action required now. |
+
+## Specification Amendments
+
+The spec is sound. Minor reinforcements:
+
+1. **FR-2 / FR-3 / FR-4 — fallback test must use `"["` specifically.** Already implied by the spec's `ArgumentException` reference; promote it to an explicit requirement in the acceptance criteria to prevent future authors from picking a pattern that fails differently.
+2. **FR-1 — note that the `AmountClassificationRule` `catch` block is unreachable through public inputs.** The spec lists `">=abc"` as covering "parse failure path"; clarify this exercises `decimal.TryParse` returning `false` (the early-exit path), **not** the `catch`. No test needs to target the unreachable `catch` — call this out so future maintainers do not waste time chasing 100% branch coverage.
+3. **FR-5 — explicit test for "first match short-circuits."** The spec lists this; ensure the implementing developer asserts via `Mock.Verify(r => r.Evaluate(...), Times.Never)` on the **later-ordered** mock, not just by reading the returned reference. This is the only way to *prove* short-circuit behavior.
+4. **FR-6 — add `TestHelpers/InvoiceClassificationFixtures.cs` to the file list.** The spec's file tree omits it; the helpers are not optional given NFR-4.
+5. **NFR-1 — branch coverage of 85% on `AmountClassificationRule.cs` will not include the unreachable `catch`.** Coverage tools count unreachable branches as uncovered. If the CI gate fails on this single file at exactly the 85% threshold, the resolution is either (a) accept the lower-than-target branch coverage with a documented exclusion, or (b) raise it as a separate cleanup item to remove the dead `try/catch` from the production code. Do **not** modify production code as part of *this* task — flag and defer.
+
+## Prerequisites
+
+None. Everything required is already present:
+
+- `Anela.Heblo.Tests.csproj` references xUnit, FluentAssertions, Moq.
+- `IClassificationRule`, the four rule classes, `RuleEvaluationEngine`, `ClassificationRule`, `ReceivedInvoice`, and `ReceivedInvoiceItem` are all public and constructible without DI.
+- Test conventions are demonstrated in `GetClassificationRuleTypesHandlerTests.cs` — use it as the style reference.
+- No migrations, no config, no infrastructure changes, no new packages.
+
+Implementation can begin immediately.
+```

--- a/artifacts/feat-coverage-gap-invoiceclassification-rules/brief.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-rules/brief.md
@@ -1,0 +1,34 @@
+## Module / File
+`backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/Rules/`
+- `AmountClassificationRule.cs` (0%, 27 lines)
+- `CompanyNameClassificationRule.cs` (0%, 12 lines)
+- `DescriptionClassificationRule.cs` (0%, 12 lines)
+- `ItemDescriptionClassificationRule.cs` (0%, 17 lines)
+
+Also related: `RuleEvaluationEngine.cs` (23.5%, 17 lines)
+
+## Coverage
+All four rule files: 0% line coverage. RuleEvaluationEngine: 23.5%. Filter threshold: 60%.
+
+## What's not tested
+**AmountClassificationRule**: evaluates six comparison operators (>=, <=, >, <, =, bare literal) against `TotalAmount`. Branches for each operator are independent and none are covered. Edge: empty pattern returns false.
+
+**CompanyNameClassificationRule** and **DescriptionClassificationRule**: regex match with fallback to plain-text `Contains` when the pattern is an invalid regex. The `ArgumentException` fallback path is never exercised.
+
+**ItemDescriptionClassificationRule**: iterates all invoice items for any match; empty items collection or all-empty item names should return false.
+
+**RuleEvaluationEngine.FindMatchingRule**: ordering by `rule.Order` among active rules, returning the first match — the case where no rule matches (returns null) is untested.
+
+## Why it matters
+These rules are the core of automated invoice classification. A broken operator in AmountClassificationRule silently misclassifies invoices by amount. An invalid-regex fallback that stops working would change match behavior without an error. The `null` return from RuleEvaluationEngine (no match) controls whether an invoice enters manual review — if broken, all invoices skip manual review or are wrongly classified.
+
+## Suggested approach
+Domain-layer unit tests (no mocks needed — pure logic):
+1. AmountClassificationRule: one test per operator (>=, <=, >, <, =, bare), plus boundary values and empty/whitespace pattern
+2. CompanyName/Description rules: valid regex hit, valid regex miss, invalid regex falls back to Contains, null/empty inputs
+3. ItemDescriptionClassificationRule: match on first item, match on second item only, no items match, empty items list
+4. RuleEvaluationEngine: ordered rules where first active match wins; rules ordered by `Order`; no matching rule returns null
+Effort: ~1.5 hours
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-14. Based on CI run #27416879267 (3a6b7f99ee715caf82fc0efa17de5a5ede7b46fb)._

--- a/artifacts/feat-coverage-gap-invoiceclassification-rules/impl/main.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-rules/impl/main.r1.md
@@ -1,0 +1,31 @@
+All tasks complete. Here's the summary:
+
+---
+
+## Implementation Complete
+
+**86 tests passing** (69 new + 17 pre-existing), `dotnet format` clean, build error-free.
+
+### Files created (6 new, 0 modified)
+
+| File | Tests | Coverage target |
+|---|---|---|
+| `TestHelpers/InvoiceClassificationFixtures.cs` | — (helper) | — |
+| `Rules/AmountClassificationRuleTests.cs` | 26 | All 6 operator branches |
+| `Rules/CompanyNameClassificationRuleTests.cs` | 12 | Regex + `"["` fallback |
+| `Rules/DescriptionClassificationRuleTests.cs` | 11 | Regex + `"["` fallback |
+| `Rules/ItemDescriptionClassificationRuleTests.cs` | 12 | Item iteration + per-item fallback |
+| `Services/RuleEvaluationEngineTests.cs` | 7 | Ordering, filter, short-circuit |
+
+### Notable design choices honored
+- `"["` used exclusively for fallback tests (guaranteed `ArgumentException` on all .NET versions); sanity `[Fact]` guards against future framework drift
+- `AmountClassificationRule` `catch` block left uncovered by design — it's unreachable through public inputs (`decimal.TryParse` never throws), documented in test comment
+- Short-circuit test uses `Mock.Verify(..., Times.Never)` on later-ordered strategies — the only way to prove early exit
+
+### Commits
+- `b82792d0` fixtures helper
+- `9834eb4a` Amount tests
+- `e8fb8a49` CompanyName tests
+- `9771bd61` Description tests
+- `4a08f648` ItemDescription tests
+- `eeabcb7b` RuleEvaluationEngine tests

--- a/artifacts/feat-coverage-gap-invoiceclassification-rules/spec.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-rules/spec.r1.md
@@ -1,0 +1,153 @@
+# Specification: Unit Test Coverage for Invoice Classification Rules
+
+## Summary
+Add comprehensive xUnit unit tests for the four invoice classification rule implementations (`AmountClassificationRule`, `CompanyNameClassificationRule`, `DescriptionClassificationRule`, `ItemDescriptionClassificationRule`) and the `RuleEvaluationEngine` that orchestrates them. All five files are currently below the 60% coverage filter threshold; the rule files sit at 0% and the engine at 23.5%. These rules drive automated invoice classification, so silent regressions misclassify invoices or bypass manual review.
+
+## Background
+The invoice classification subsystem matches an incoming `ReceivedInvoice` against an ordered list of `ClassificationRule` records. Each rule is keyed to one of the `IClassificationRule` implementations by `RuleTypeIdentifier`, which evaluates the rule's `Pattern` against the invoice. The `RuleEvaluationEngine.FindMatchingRule` method returns the first matching active rule (ordered by `Order`) or `null` when no rule matches — `null` is the signal that an invoice should enter manual review.
+
+The rule logic is pure domain code with no dependencies: every branch is reachable through deterministic inputs. The coverage gap is therefore cheap to close and high-value, because:
+- `AmountClassificationRule` has six independent operator branches (`>=`, `<=`, `>`, `<`, `=`, bare literal). A regression in any single branch silently misclassifies a subset of invoices.
+- Three rules (`CompanyName`, `Description`, `ItemDescription`) use a regex match with a `Contains` fallback when the pattern is not a valid regex. The fallback path is never exercised, so a change in regex semantics or fallback handling would not be caught.
+- `RuleEvaluationEngine` ordering (`OrderBy(r => r.Order)`) and `IsActive` filtering are critical to predictable rule precedence; the no-match `null` return controls manual review routing.
+
+Existing tests under `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/` use xUnit + FluentAssertions + Moq with AAA structure. New tests must match that style.
+
+## Functional Requirements
+
+### FR-1: AmountClassificationRule — operator coverage
+Add a dedicated test class `AmountClassificationRuleTests` covering each comparison operator branch on `TotalAmount`.
+
+**Acceptance criteria:**
+- Test `>=` operator: returns `true` when amount equals threshold; returns `true` when amount exceeds threshold; returns `false` when amount is below threshold.
+- Test `<=` operator: returns `true` when amount equals threshold; returns `true` when amount is below threshold; returns `false` when amount exceeds threshold.
+- Test `>` operator: returns `true` when amount strictly exceeds threshold; returns `false` when amount equals threshold; returns `false` when amount is below threshold.
+- Test `<` operator: returns `true` when amount strictly below threshold; returns `false` when amount equals threshold; returns `false` when amount exceeds threshold.
+- Test `=` operator: returns `true` when amount equals threshold; returns `false` when amount differs by any amount.
+- Test bare numeric pattern (no operator prefix): returns `true` when amount equals the literal; returns `false` otherwise. The bare-literal branch is semantically equivalent to `=`.
+- Test empty pattern returns `false`.
+- Test whitespace-only pattern (`"   "`) returns `false`.
+- Test pattern with operator but non-numeric body (e.g. `">=abc"`) returns `false` (parse failure path).
+- Test bare non-numeric pattern (e.g. `"abc"`) returns `false`.
+- Each operator boundary test uses unambiguous values (e.g. amount `100m`, threshold `100m` / `99m` / `101m`) to keep equality semantics for `decimal` explicit.
+- `[Theory]` with `[InlineData]` is preferred where the operator and expected outcome are the only varying inputs.
+
+### FR-2: CompanyNameClassificationRule — regex and fallback coverage
+Add `CompanyNameClassificationRuleTests` covering both the regex path and the invalid-regex `Contains` fallback.
+
+**Acceptance criteria:**
+- Returns `true` when the regex pattern matches the company name (e.g. pattern `"ACME"` against `"ACME s.r.o."`).
+- Returns `true` for case-insensitive match (e.g. pattern `"acme"` matches `"ACME s.r.o."`).
+- Returns `false` when a valid regex does not match.
+- Returns `true` when the pattern is an invalid regex but is a substring of the company name (fallback path, e.g. pattern `"["` against `"Company [old]"`).
+- Returns `false` when the pattern is an invalid regex and not a substring (fallback miss).
+- Returns `false` when `invoice.CompanyName` is `null` or empty or whitespace.
+- Returns `false` when `pattern` is `null` or empty or whitespace.
+- The fallback test must use a pattern that genuinely throws `ArgumentException` from `Regex.IsMatch` (e.g. an unclosed character class `"["`).
+
+### FR-3: DescriptionClassificationRule — regex and fallback coverage
+Add `DescriptionClassificationRuleTests` covering the same matrix as FR-2 but against `invoice.Description`.
+
+**Acceptance criteria:**
+- Regex match hit and miss with case-insensitive semantics.
+- Invalid-regex fallback hit and miss against `invoice.Description`.
+- Returns `false` for null/empty/whitespace description.
+- Returns `false` for null/empty/whitespace pattern.
+
+### FR-4: ItemDescriptionClassificationRule — items iteration coverage
+Add `ItemDescriptionClassificationRuleTests` covering iteration over `invoice.Items` and per-item evaluation.
+
+**Acceptance criteria:**
+- Returns `true` when the first item's `Name` matches the pattern.
+- Returns `true` when only a non-first item's `Name` matches (verifies `Any` continues past non-matches).
+- Returns `false` when no item names match.
+- Returns `false` when `invoice.Items` is empty.
+- Returns `false` when all item names are null/empty/whitespace.
+- Returns `false` when pattern is null/empty/whitespace.
+- Case-insensitive regex match works against item names.
+- Invalid-regex fallback evaluates per item with `Contains` (e.g. pattern `"["` matches an item name containing `"["`).
+- A single item with null/empty `Name` does not cause the evaluation to throw; non-matching items are silently skipped.
+
+### FR-5: RuleEvaluationEngine — ordering and no-match coverage
+Add `RuleEvaluationEngineTests` in the application test project covering ordering, active-rule filtering, and the `null` no-match path.
+
+**Acceptance criteria:**
+- Returns the matching rule with the lowest `Order` value when multiple rules match.
+- Skips inactive rules (`IsActive == false`) even when they would otherwise match.
+- Returns `null` when no active rule matches.
+- Returns `null` when the rules list is empty.
+- Returns `null` when the rule references a `RuleTypeIdentifier` that does not correspond to any registered `IClassificationRule` (the engine should not throw on an unknown identifier).
+- Returns the matching rule even when a higher-`Order` rule was inserted into the list first (verifies sort behavior, not list insertion order).
+- The first matching rule (after filtering inactive and sorting by `Order`) short-circuits subsequent evaluations.
+- Tests use `Mock<IClassificationRule>` for the rule strategies registered in the engine so behavior is deterministic and not coupled to the real rule implementations. `ClassificationRule` domain entities are constructed directly (not mocked) using its public constructor and `SetOrder`.
+
+### FR-6: Test organization and conventions
+All new tests follow the existing project's test conventions.
+
+**Acceptance criteria:**
+- Rule tests live under `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/` (new subfolder) — one `<RuleName>Tests.cs` file per rule.
+- `RuleEvaluationEngineTests.cs` lives under `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/` (new subfolder).
+- Namespace mirrors source: `Anela.Heblo.Tests.Features.InvoiceClassification.Rules` and `Anela.Heblo.Tests.Features.InvoiceClassification.Services`.
+- Test framework: xUnit (`[Fact]`, `[Theory]`/`[InlineData]`).
+- Assertions: FluentAssertions.
+- Mocking: Moq (only where mocks are warranted — see FR-5; rule tests need no mocks since the rules are pure functions).
+- AAA structure: each test has explicit `// Arrange`, `// Act`, `// Assert` comments matching `GetClassificationRuleTypesHandlerTests.cs` style.
+- Test method naming: `MethodName_Scenario_ExpectedOutcome` (e.g. `Evaluate_AmountEqualsThreshold_ReturnsTrueForGreaterOrEqual`).
+- No production code is modified for the purpose of testability — all behavior described above is already reachable through public APIs.
+
+## Non-Functional Requirements
+
+### NFR-1: Coverage targets
+- Each of the four rule files reaches ≥ 90% line coverage and ≥ 85% branch coverage.
+- `RuleEvaluationEngine.cs` reaches ≥ 90% line coverage.
+- The five files no longer appear under the 60% coverage filter in the next CI run.
+
+### NFR-2: Test performance
+- The full new test set executes in under 1 second locally (pure in-memory unit tests, no I/O, no shared fixtures required).
+
+### NFR-3: Determinism
+- No reliance on `DateTime.UtcNow`, random values, environment, or culture. Decimal parsing uses the invariant behavior the production code uses; tests document this by using whole-number test values to avoid culture-sensitive separators.
+
+### NFR-4: Maintainability
+- Helper methods (e.g. `CreateInvoice(decimal amount)`, `CreateInvoiceWithItems(params string[] itemNames)`) keep test arrangement readable and avoid copy-paste.
+- No production-code behavior changes are introduced.
+
+## Data Model
+No data model changes. Tests exercise existing domain entities:
+- `ReceivedInvoice` — properties used: `CompanyName`, `Description`, `TotalAmount`, `Items`.
+- `ReceivedInvoiceItem` — property used: `Name`.
+- `ClassificationRule` — properties used: `RuleTypeIdentifier`, `Pattern`, `Order`, `IsActive`. Constructed via public constructor + `SetOrder(int)`.
+- `IClassificationRule` — the rule strategy interface.
+
+## API / Interface Design
+No public API changes. The work is purely additive test code under the test project tree:
+
+```
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/
+├── Rules/
+│   ├── AmountClassificationRuleTests.cs            (new)
+│   ├── CompanyNameClassificationRuleTests.cs       (new)
+│   ├── DescriptionClassificationRuleTests.cs       (new)
+│   └── ItemDescriptionClassificationRuleTests.cs   (new)
+└── Services/
+    └── RuleEvaluationEngineTests.cs                (new)
+```
+
+## Dependencies
+- xUnit (already referenced by `Anela.Heblo.Tests.csproj`).
+- FluentAssertions (already referenced).
+- Moq (already referenced — used for FR-5 only).
+- No new NuGet packages required.
+
+## Out of Scope
+- Modifying production rule code (refactoring, adding new operators, changing fallback behavior).
+- Adding new classification rule types beyond the four already implemented.
+- Adding tests for `VatClassificationRule` (already covered or not flagged by the coverage gap routine).
+- Integration tests covering the full classification pipeline through HTTP/MediatR — those already exist (`ClassifyInvoicesHandlerTests.cs`, `InvoiceClassificationServiceTests.cs`).
+- Mutation testing or property-based testing.
+- Performance benchmarks.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-coverage-gap-invoiceclassification-rules/task-plan.r1.md
+++ b/artifacts/feat-coverage-gap-invoiceclassification-rules/task-plan.r1.md
@@ -1,0 +1,13 @@
+Plan saved to `artifacts/feat-coverage-gap-invoiceclassification-rules/plan.r1.md`.
+
+**Summary:** Seven tasks, all purely additive test code (no production changes):
+
+1. Create `TestHelpers/InvoiceClassificationFixtures.cs` — `CreateInvoice` / `CreateRule` factories
+2. `AmountClassificationRuleTests` — `[Theory]` matrix over all 6 operator branches + edge `[Fact]`s
+3. `CompanyNameClassificationRuleTests` — regex hit/miss + `"["` fallback + null/whitespace guards + sanity check that `Regex.IsMatch("anything", "[")` still throws `ArgumentException`
+4. `DescriptionClassificationRuleTests` — same shape as #3 against `Description`
+5. `ItemDescriptionClassificationRuleTests` — items iteration, per-item fallback, mixed null/match safety
+6. `RuleEvaluationEngineTests` — mock `IClassificationRule` strategies + real `ClassificationRule` data entities; covers ordering, active-filtering, no-match, unknown-identifier, sort-by-Order-not-insertion, and short-circuit via `Mock.Verify(..., Times.Never)` on later strategies
+7. Full-suite validation, `dotnet format --verify-no-changes`, coverage spot-check
+
+Each task is bite-sized (write tests → run → commit). Includes a spec-coverage map at the bottom showing where every FR/NFR/arch-amendment lands.

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/AmountClassificationRuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/AmountClassificationRuleTests.cs
@@ -1,0 +1,107 @@
+using Anela.Heblo.Domain.Features.InvoiceClassification.Rules;
+using Anela.Heblo.Tests.Features.InvoiceClassification.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification.Rules;
+
+public class AmountClassificationRuleTests
+{
+    private readonly AmountClassificationRule _sut = new();
+
+    [Theory]
+    // >=
+    [InlineData(">=100", 100, true)]   // equal to threshold
+    [InlineData(">=100", 101, true)]   // above threshold
+    [InlineData(">=100", 99, false)]   // below threshold
+    // <=
+    [InlineData("<=100", 100, true)]   // equal to threshold
+    [InlineData("<=100", 99, true)]    // below threshold
+    [InlineData("<=100", 101, false)]  // above threshold
+    // >
+    [InlineData(">100", 101, true)]    // strictly above
+    [InlineData(">100", 100, false)]   // equal — must be false
+    [InlineData(">100", 99, false)]    // below
+    // <
+    [InlineData("<100", 99, true)]     // strictly below
+    [InlineData("<100", 100, false)]   // equal — must be false
+    [InlineData("<100", 101, false)]   // above
+    // =
+    [InlineData("=100", 100, true)]    // equal
+    [InlineData("=100", 101, false)]   // above
+    [InlineData("=100", 99, false)]    // below
+    // bare literal (no operator) → equivalent to "="
+    [InlineData("100", 100, true)]
+    [InlineData("100", 99, false)]
+    [InlineData("100", 101, false)]
+    public void Evaluate_OperatorBoundary_ReturnsExpected(string pattern, int amount, bool expected)
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(totalAmount: amount);
+
+        // Act
+        var result = _sut.Evaluate(invoice, pattern);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Evaluate_EmptyPattern_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(totalAmount: 100m);
+
+        // Act
+        var result = _sut.Evaluate(invoice, string.Empty);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_WhitespacePattern_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(totalAmount: 100m);
+
+        // Act
+        var result = _sut.Evaluate(invoice, "   ");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(">=abc")]
+    [InlineData("<=abc")]
+    [InlineData(">abc")]
+    [InlineData("<abc")]
+    [InlineData("=abc")]
+    public void Evaluate_OperatorWithNonNumericBody_ReturnsFalse(string pattern)
+    {
+        // Arrange
+        // decimal.TryParse returns false (does NOT throw) — the early-exit path,
+        // not the unreachable catch block.
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(totalAmount: 100m);
+
+        // Act
+        var result = _sut.Evaluate(invoice, pattern);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_BareNonNumericPattern_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(totalAmount: 100m);
+
+        // Act
+        var result = _sut.Evaluate(invoice, "abc");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/CompanyNameClassificationRuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/CompanyNameClassificationRuleTests.cs
@@ -1,0 +1,123 @@
+using System.Text.RegularExpressions;
+using Anela.Heblo.Domain.Features.InvoiceClassification.Rules;
+using Anela.Heblo.Tests.Features.InvoiceClassification.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification.Rules;
+
+public class CompanyNameClassificationRuleTests
+{
+    private readonly CompanyNameClassificationRule _sut = new();
+
+    [Fact]
+    public void Evaluate_RegexMatchesCompanyName_ReturnsTrue()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(companyName: "ACME s.r.o.");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "ACME");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_RegexMatchesCaseInsensitive_ReturnsTrue()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(companyName: "ACME s.r.o.");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "acme");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_ValidRegexDoesNotMatch_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(companyName: "ACME s.r.o.");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "Globex");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_InvalidRegexThatIsSubstring_FallsBackToContains_ReturnsTrue()
+    {
+        // Arrange
+        // "[" is an unclosed character class — Regex.IsMatch throws ArgumentException,
+        // which is the ONLY exception type the rule catches. The fallback then runs
+        // string.Contains("[", OrdinalIgnoreCase) against the company name.
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(companyName: "Company [old]");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "[");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_InvalidRegexThatIsNotSubstring_FallsBackToContains_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(companyName: "Plain Company");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "[");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Evaluate_NullOrWhitespaceCompanyName_ReturnsFalse(string? companyName)
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(companyName: companyName!);
+
+        // Act
+        var result = _sut.Evaluate(invoice, "ACME");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Evaluate_NullOrWhitespacePattern_ReturnsFalse(string? pattern)
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(companyName: "ACME s.r.o.");
+
+        // Act
+        var result = _sut.Evaluate(invoice, pattern!);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Sanity_UnclosedCharacterClass_ThrowsArgumentException()
+    {
+        // Guard: if a future .NET version changes the exception type thrown by
+        // Regex.IsMatch for "[", the fallback tests above would silently stop
+        // exercising the fallback branch. This sanity check makes that drift loud.
+        var act = () => Regex.IsMatch("anything", "[", RegexOptions.IgnoreCase);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/DescriptionClassificationRuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/DescriptionClassificationRuleTests.cs
@@ -1,0 +1,110 @@
+using Anela.Heblo.Domain.Features.InvoiceClassification.Rules;
+using Anela.Heblo.Tests.Features.InvoiceClassification.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification.Rules;
+
+public class DescriptionClassificationRuleTests
+{
+    private readonly DescriptionClassificationRule _sut = new();
+
+    [Fact]
+    public void Evaluate_RegexMatchesDescription_ReturnsTrue()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(description: "Monthly hosting invoice");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "hosting");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_RegexMatchesCaseInsensitive_ReturnsTrue()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(description: "Monthly HOSTING invoice");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "hosting");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_ValidRegexDoesNotMatch_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(description: "Monthly hosting invoice");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "consulting");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_InvalidRegexThatIsSubstring_FallsBackToContains_ReturnsTrue()
+    {
+        // Arrange
+        // "[" is an unclosed character class — Regex.IsMatch throws ArgumentException,
+        // the only exception type the rule catches, triggering the Contains fallback.
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(description: "Note [archived]");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "[");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_InvalidRegexThatIsNotSubstring_FallsBackToContains_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(description: "Plain description");
+
+        // Act
+        var result = _sut.Evaluate(invoice, "[");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Evaluate_NullOrWhitespaceDescription_ReturnsFalse(string? description)
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(description: description!);
+
+        // Act
+        var result = _sut.Evaluate(invoice, "hosting");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Evaluate_NullOrWhitespacePattern_ReturnsFalse(string? pattern)
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(description: "Monthly hosting invoice");
+
+        // Act
+        var result = _sut.Evaluate(invoice, pattern!);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/ItemDescriptionClassificationRuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Rules/ItemDescriptionClassificationRuleTests.cs
@@ -1,0 +1,167 @@
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Domain.Features.InvoiceClassification.Rules;
+using Anela.Heblo.Tests.Features.InvoiceClassification.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification.Rules;
+
+public class ItemDescriptionClassificationRuleTests
+{
+    private readonly ItemDescriptionClassificationRule _sut = new();
+
+    [Fact]
+    public void Evaluate_FirstItemNameMatches_ReturnsTrue()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(itemNames: new[] { "Widget", "Gizmo" });
+
+        // Act
+        var result = _sut.Evaluate(invoice, "Widget");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_NonFirstItemNameMatches_ReturnsTrue()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(itemNames: new[] { "Widget", "Gizmo", "Doohickey" });
+
+        // Act
+        var result = _sut.Evaluate(invoice, "Doohickey");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_NoItemNameMatches_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(itemNames: new[] { "Widget", "Gizmo" });
+
+        // Act
+        var result = _sut.Evaluate(invoice, "Sprocket");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_EmptyItemsList_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+
+        // Act
+        var result = _sut.Evaluate(invoice, "Widget");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_AllItemNamesNullOrWhitespace_ReturnsFalse()
+    {
+        // Arrange — bypass the fixture (which only accepts string[]) and construct
+        // items with empty/whitespace names directly. ReceivedInvoiceItem.Name
+        // defaults to "" and cannot be set to null via the POCO initializer in C#
+        // nullable-aware mode, so we use empty and whitespace which take the same
+        // guard branch inside EvaluateItemDescription.
+        var invoice = new ReceivedInvoice
+        {
+            Items = new List<ReceivedInvoiceItem>
+            {
+                new() { Name = string.Empty },
+                new() { Name = "   " }
+            }
+        };
+
+        // Act
+        var result = _sut.Evaluate(invoice, "anything");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Evaluate_NullOrWhitespacePattern_ReturnsFalse(string? pattern)
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(itemNames: new[] { "Widget" });
+
+        // Act
+        var result = _sut.Evaluate(invoice, pattern!);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_RegexMatchesItemNameCaseInsensitive_ReturnsTrue()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(itemNames: new[] { "WIDGET" });
+
+        // Act
+        var result = _sut.Evaluate(invoice, "widget");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_InvalidRegexFallsBackToContainsPerItem_ReturnsTrue()
+    {
+        // Arrange
+        // "[" throws ArgumentException from Regex.IsMatch; the per-item helper
+        // falls back to Contains("[", OrdinalIgnoreCase) on each item name.
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(itemNames: new[] { "Plain item", "Bracket [item]" });
+
+        // Act
+        var result = _sut.Evaluate(invoice, "[");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_InvalidRegexFallbackMissesAllItems_ReturnsFalse()
+    {
+        // Arrange
+        var invoice = InvoiceClassificationFixtures.CreateInvoice(itemNames: new[] { "Plain item", "Another plain item" });
+
+        // Act
+        var result = _sut.Evaluate(invoice, "[");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_MixedNullAndMatchingItems_DoesNotThrow_AndReturnsTrue()
+    {
+        // Arrange — an empty-named item between two real items: the empty one
+        // must be silently skipped, the matching one must still be found.
+        var invoice = new ReceivedInvoice
+        {
+            Items = new List<ReceivedInvoiceItem>
+            {
+                new() { Name = string.Empty },
+                new() { Name = "Widget" },
+                new() { Name = "   " }
+            }
+        };
+
+        // Act
+        var result = _sut.Evaluate(invoice, "Widget");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs
@@ -1,0 +1,169 @@
+using Anela.Heblo.Application.Features.InvoiceClassification.Services;
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Tests.Features.InvoiceClassification.TestHelpers;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification.Services;
+
+public class RuleEvaluationEngineTests
+{
+    private static Mock<IClassificationRule> CreateStrategyMock(string identifier, bool evaluateResult)
+    {
+        var mock = new Mock<IClassificationRule>();
+        mock.Setup(r => r.Identifier).Returns(identifier);
+        mock.Setup(r => r.Evaluate(It.IsAny<ReceivedInvoice>(), It.IsAny<string>())).Returns(evaluateResult);
+        return mock;
+    }
+
+    [Fact]
+    public void FindMatchingRule_MultipleMatchingRules_ReturnsLowestOrderMatch()
+    {
+        // Arrange
+        var strategyA = CreateStrategyMock("RULE_A", evaluateResult: true);
+        var strategyB = CreateStrategyMock("RULE_B", evaluateResult: true);
+
+        var sut = new RuleEvaluationEngine(new[] { strategyA.Object, strategyB.Object });
+
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+        var ruleHigherOrder = InvoiceClassificationFixtures.CreateRule("RULE_B", pattern: "p", order: 2);
+        var ruleLowerOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1);
+
+        var rules = new List<ClassificationRule> { ruleHigherOrder, ruleLowerOrder };
+
+        // Act
+        var match = sut.FindMatchingRule(invoice, rules);
+
+        // Assert
+        match.Should().BeSameAs(ruleLowerOrder);
+    }
+
+    [Fact]
+    public void FindMatchingRule_SkipsInactiveRules()
+    {
+        // Arrange
+        var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
+        var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+        var inactiveRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1, isActive: false);
+        var activeRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 2, isActive: true);
+
+        var rules = new List<ClassificationRule> { inactiveRule, activeRule };
+
+        // Act
+        var match = sut.FindMatchingRule(invoice, rules);
+
+        // Assert
+        match.Should().BeSameAs(activeRule);
+    }
+
+    [Fact]
+    public void FindMatchingRule_NoActiveRuleMatches_ReturnsNull()
+    {
+        // Arrange
+        var strategy = CreateStrategyMock("RULE_A", evaluateResult: false);
+        var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+        var rule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1);
+
+        var rules = new List<ClassificationRule> { rule };
+
+        // Act
+        var match = sut.FindMatchingRule(invoice, rules);
+
+        // Assert
+        match.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindMatchingRule_EmptyRulesList_ReturnsNull()
+    {
+        // Arrange
+        var sut = new RuleEvaluationEngine(Enumerable.Empty<IClassificationRule>());
+
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+
+        // Act
+        var match = sut.FindMatchingRule(invoice, new List<ClassificationRule>());
+
+        // Assert
+        match.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindMatchingRule_UnknownRuleTypeIdentifier_DoesNotThrowAndReturnsNull()
+    {
+        // Arrange
+        var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
+        var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+        var unknownIdentifierRule = InvoiceClassificationFixtures.CreateRule("UNKNOWN_RULE", pattern: "p", order: 1);
+
+        var rules = new List<ClassificationRule> { unknownIdentifierRule };
+
+        // Act
+        var act = () => sut.FindMatchingRule(invoice, rules);
+
+        // Assert
+        act.Should().NotThrow();
+        act().Should().BeNull();
+    }
+
+    [Fact]
+    public void FindMatchingRule_SortsByOrder_NotByListInsertionOrder()
+    {
+        // Arrange
+        var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
+        var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+        var insertedFirstHighOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 10);
+        var insertedSecondLowOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1);
+
+        // List insertion order intentionally reversed vs. desired evaluation order.
+        var rules = new List<ClassificationRule> { insertedFirstHighOrder, insertedSecondLowOrder };
+
+        // Act
+        var match = sut.FindMatchingRule(invoice, rules);
+
+        // Assert
+        match.Should().BeSameAs(insertedSecondLowOrder);
+    }
+
+    [Fact]
+    public void FindMatchingRule_FirstMatch_ShortCircuitsSubsequentEvaluations()
+    {
+        // Arrange — distinct Order values (1, 2, 3) make the iteration sequence unambiguous.
+        // Strategies are separate mocks so we can Verify call counts independently.
+        var firstStrategy = CreateStrategyMock("RULE_1", evaluateResult: true);
+        var laterStrategyA = CreateStrategyMock("RULE_2", evaluateResult: true);
+        var laterStrategyB = CreateStrategyMock("RULE_3", evaluateResult: true);
+
+        var sut = new RuleEvaluationEngine(new[]
+        {
+            firstStrategy.Object,
+            laterStrategyA.Object,
+            laterStrategyB.Object
+        });
+
+        var invoice = InvoiceClassificationFixtures.CreateInvoice();
+        var firstRule = InvoiceClassificationFixtures.CreateRule("RULE_1", pattern: "p", order: 1);
+        var secondRule = InvoiceClassificationFixtures.CreateRule("RULE_2", pattern: "p", order: 2);
+        var thirdRule = InvoiceClassificationFixtures.CreateRule("RULE_3", pattern: "p", order: 3);
+
+        var rules = new List<ClassificationRule> { firstRule, secondRule, thirdRule };
+
+        // Act
+        var match = sut.FindMatchingRule(invoice, rules);
+
+        // Assert
+        match.Should().BeSameAs(firstRule);
+        firstStrategy.Verify(s => s.Evaluate(invoice, It.IsAny<string>()), Times.Once);
+        laterStrategyA.Verify(s => s.Evaluate(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()), Times.Never);
+        laterStrategyB.Verify(s => s.Evaluate(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/TestHelpers/InvoiceClassificationFixtures.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/TestHelpers/InvoiceClassificationFixtures.cs
@@ -1,0 +1,54 @@
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification.TestHelpers;
+
+internal static class InvoiceClassificationFixtures
+{
+    internal static ReceivedInvoice CreateInvoice(
+        decimal totalAmount = 0m,
+        string companyName = "",
+        string description = "",
+        params string[] itemNames)
+    {
+        return new ReceivedInvoice
+        {
+            CompanyName = companyName,
+            Description = description,
+            TotalAmount = totalAmount,
+            Items = itemNames
+                .Select(name => new ReceivedInvoiceItem { Name = name })
+                .ToList()
+        };
+    }
+
+    internal static ClassificationRule CreateRule(
+        string ruleTypeIdentifier,
+        string pattern,
+        int order = 0,
+        bool isActive = true)
+    {
+        var rule = new ClassificationRule(
+            name: "test-rule",
+            ruleTypeIdentifier: ruleTypeIdentifier,
+            pattern: pattern,
+            accountingTemplateCode: "TEMPLATE",
+            department: null,
+            createdBy: "test");
+
+        rule.SetOrder(order);
+
+        if (!isActive)
+        {
+            rule.Update(
+                name: "test-rule",
+                ruleTypeIdentifier: ruleTypeIdentifier,
+                pattern: pattern,
+                accountingTemplateCode: "TEMPLATE",
+                department: null,
+                isActive: false,
+                updatedBy: "test");
+        }
+
+        return rule;
+    }
+}


### PR DESCRIPTION
`backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/Rules/`
- `AmountClassificationRule.cs` (0%, 27 lines)
- `CompanyNameClassificationRule.cs` (0%, 12 lines)
- `DescriptionClassificationRule.cs` (0%, 12 lines)
- `ItemDescriptionClassificationRule.cs` (0%, 17 lines)

Also related: `RuleEvaluationEngine.cs` (23.5%, 17 lines)

## Coverage
All four rule files: 0% line coverage. RuleEvaluationEngine: 23.5%. Filter threshold: 60%.

## What's not tested
**AmountClassificationRule**: evaluates six comparison operators (>=, <=, >, <, =, bare literal) against `TotalAmount`. Branches for each operator are independent and none are covered. Edge: empty pattern returns false.

**CompanyNameClassificationRule** and **DescriptionClassificationRule**: regex match with fallback to plain-text `Contains` when the pattern is an invalid regex. The `ArgumentException` fallback path is never exercised.

**ItemDescriptionClassificationRule**: iterates all invoice items for any match; empty items collection or all-empty item names should return false.

**RuleEvaluationEngine.FindMatchingRule**: ordering by `rule.Order` among active rules, returning the first match — the case where no rule matches (returns null) is untested.

## Why it matters
These rules are the core of automated invoice classification. A broken operator in AmountClassificationRule silently misclassifies invoices by amount. An invalid-regex fallback that stops working would change match behavior without an error. The `null` return from RuleEvaluationEngine (no match) controls whether an invoice enters manual review — if broken, all invoices skip manual review or are wrongly classified.

## Suggested approach
Domain-layer unit tests (no mocks needed — pure logic):
1. AmountClassificationRule: one test per operator (>=, <=, >, <, =, bare), plus boundary values and empty/whitespace pattern
2. CompanyName/Description rules: valid regex hit, valid regex miss, invalid regex falls back to Contains, null/empty inputs
3. ItemDescriptionClassificationRule: match on first item, match on second item only, no items match, empty items list
4. RuleEvaluationEngine: ordered rules where first active match wins; rules ordered by `Order`; no matching rule returns null
Effort: ~1.5 hours

---
_Filed by weekly coverage-gap routine on 2026-06-14. Based on CI run #27416879267 (3a6b7f99ee715caf82fc0efa17de5a5ede7b46fb)._

---

Closes #3075

### Tokens used
16780343
