### PR TITLE
feat: Fix UpdateRule Endpoint Body Contract

### DIFF
--- a/artifacts/feat-arch-review-photobank-updaterulerequest-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-photobank-updaterulerequest-/arch-review.r1.md
@@ -1,0 +1,158 @@
+# Architecture Review: Fix UpdateRule Endpoint Body Contract
+
+## Skip Design: true
+
+Backend-only HTTP contract cleanup. No UI components, screens, or visual changes — only the OpenAPI schema and auto-generated TypeScript client *type* shift. No frontend hand-written callers exist (verified: no references to `photobank_UpdateRule` outside `frontend/src/api/generated/api-client.ts`).
+
+## Architectural Fit Assessment
+
+The proposed change is an exact alignment with the Photobank module's established pattern. Verified against the existing codebase:
+
+- **`Anela.Heblo.Application/Features/Photobank/Contracts/`** already contains five `*Body` types (`CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`, plus DTOs). All are plain `class`, all in namespace `Anela.Heblo.Application.Features.Photobank.Contracts`.
+- **`UpdateRuleRequest`** is the only write-endpoint MediatR command that surfaces in a `[FromBody]` slot today (`PhotobankController.cs:301`). Adding `UpdateRuleBody` retires the outlier.
+- **No conflicting validator behavior**: `UpdateRuleRequestValidator` runs against the MediatR command (post-construction in the controller), so it keeps seeing `Id` populated from the route. The `RuleFor(x => x.Id).GreaterThan(0)` rule continues to function identically.
+- **No frontend churn**: a wider grep (`updateRule`, `photobank_UpdateRule`) found no hand-written callers — the regenerated client compiles into nothing but itself.
+
+Integration points: `PhotobankController.UpdateRule` (changed signature only), OpenAPI generator (NSwag/Swashbuckle picks up the new type automatically), TypeScript client regeneration on build.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP PUT /api/photobank/settings/rules/{id}
+        │
+        ▼
+[FromBody] UpdateRuleBody  ◄── NEW: public contract (no Id)
+        │  (controller maps route id + body → command)
+        ▼
+UpdateRuleRequest (MediatR command, unchanged — still has Id)
+        │
+        ▼
+UpdateRuleRequestValidator (unchanged, validates Id > 0 from route)
+        │
+        ▼
+UpdateRuleHandler → UpdateRuleResponse (unchanged)
+```
+
+The dotted boundary between the HTTP contract layer and the MediatR command layer is now consistent across every write endpoint in the module.
+
+### Key Design Decisions
+
+#### Decision 1: Separate HTTP body contract from MediatR command
+**Options considered:**
+- A. Drop `Id` from `UpdateRuleRequest` directly and pass it as a separate `Send` parameter.
+- B. Introduce a dedicated `UpdateRuleBody` and map in the controller (spec's choice).
+- C. Add `[JsonIgnore]` to `UpdateRuleRequest.Id` to hide it from the schema.
+
+**Chosen approach:** B — dedicated `UpdateRuleBody` in `Contracts/`.
+
+**Rationale:** Matches the module's own convention used for every other `POST`/`PUT` endpoint (`AddPhotoTagBody`, `CreateTagBody`, etc.). Option A leaks a route concern into the MediatR command's public shape and breaks any existing internal callers of the command (and the validator). Option C produces a contract that still claims an `Id` field exists in C# while hiding it from JSON — surprising for anyone reading the type. The chosen approach maintains the clean separation: MediatR commands are internal handler inputs; `*Body` types are the public HTTP surface.
+
+#### Decision 2: Keep `Id` on the MediatR command
+**Options considered:**
+- A. Remove `Id` from `UpdateRuleRequest`, thread it as a method parameter or wrapper.
+- B. Keep `UpdateRuleRequest.Id` unchanged (spec's choice).
+
+**Chosen approach:** B.
+
+**Rationale:** The MediatR command is a self-contained, validatable unit of work for the handler. `UpdateRuleRequestValidator.RuleFor(x => x.Id).GreaterThan(0)` depends on `Id` being on the command — removing it would force a validator rewrite or a redundant pre-validator at the controller. The spec correctly scopes this as out-of-scope refactoring.
+
+#### Decision 3: Preserve controller's existing return shape (`HandleResponse`)
+**Observed:** Current controller uses `return HandleResponse(response);` (line 313), not `return Ok(result);` as the spec's sample shows.
+
+**Chosen approach:** Keep `HandleResponse(response)` exactly as it is today.
+
+**Rationale:** `HandleResponse` is the controller's shared response envelope (likely maps `Success`/`Error` to status codes and error contracts consistently across endpoints). Swapping to `Ok(...)` would silently change error status code behavior — outside the spec's "behavior preservation" requirement (FR-5). Treat the spec's sample as illustrative; the actual line to change is **the parameter type and the construction-source for the command's fields**, nothing else.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs`
+
+**Modify:**
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — only lines 299–311 (the `UpdateRule` action).
+
+**Regenerate (build-time, automated):**
+- `frontend/src/api/generated/api-client.ts` — produced by the OpenAPI pipeline on `npm run build` per `docs/development/api-client-generation.md`. Do not hand-edit.
+
+**No changes:**
+- `UseCases/UpdateRule/*` (handler, request, response).
+- `Validators/UpdateRuleRequestValidator.cs`.
+- Any test file under `backend/test/Anela.Heblo.Tests/Features/Photobank/` (no `UpdateRule*Tests.cs` exists today — confirmed by `ls`).
+
+### Interfaces and Contracts
+
+`UpdateRuleBody.cs` (verbatim target — namespace verified against neighboring files):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class UpdateRuleBody
+    {
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public bool IsActive { get; set; }
+        public int SortOrder { get; set; }
+    }
+}
+```
+
+Controller method (only changed lines — keep all attributes, `HandleResponse`, and `_mediator` field name as-is):
+
+```csharp
+public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
+    int id,
+    [FromBody] UpdateRuleBody body,
+    CancellationToken cancellationToken = default)
+{
+    var command = new UpdateRuleRequest
+    {
+        Id = id,
+        PathPattern = body.PathPattern,
+        TagName = body.TagName,
+        IsActive = body.IsActive,
+        SortOrder = body.SortOrder,
+    };
+    var response = await _mediator.Send(command, cancellationToken);
+    return HandleResponse(response);
+}
+```
+
+### Data Flow
+
+1. Client serializes `{ pathPattern, tagName, isActive, sortOrder }` and `PUT /api/photobank/settings/rules/42`.
+2. ASP.NET model-binds the JSON into `UpdateRuleBody`; binds `42` from the route into `int id`.
+3. Controller constructs `UpdateRuleRequest { Id = 42, … body fields }`.
+4. MediatR pipeline runs `UpdateRuleRequestValidator` against the command (Id=42 passes `> 0`).
+5. `UpdateRuleHandler` executes, returns `UpdateRuleResponse`.
+6. `HandleResponse(response)` maps to HTTP — unchanged status code / error envelope behavior.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec sample shows `return Ok(result)`; actual controller uses `HandleResponse(response)`. Following the sample literally would change error status codes. | Medium | Treat the spec sample as illustrative. Implement only the two changes called out in Decision 3 (parameter type + command field source). Diff review must show no change to the return expression. |
+| `AddRule` also binds a MediatR request directly as `[FromBody]` (`PhotobankController.cs:282`) — same anti-pattern, explicitly out of scope here. | Low | Spec marks "Auditing other endpoints" as out of scope. File as a separate item via the daily arch-review routine (don't expand this PR). |
+| Validator file is named `UpdateRuleRequestValidator.cs` and targets the MediatR command — easy to mistake for "needs renaming." | Low | Validators run on commands post-controller construction. Leave name and target type unchanged. |
+| OpenAPI regeneration produces a new TypeScript type `UpdateRuleBody`, removing `UpdateRuleRequest` from the body slot. If any future frontend code imports `UpdateRuleRequest` for the body, it will compile-break. | Low | Verified today no hand-written code references the type. `npm run build` will catch any future regression. |
+| Forgetting to commit the regenerated `api-client.ts` would leave the repo in an inconsistent state. | Medium | Run `npm run build` locally, then `git add frontend/src/api/generated/api-client.ts` explicitly before committing. CI build does not regenerate into the working tree. |
+| Spec says `contracts/` (lowercase), actual folder is `Contracts/` (PascalCase). | Trivial | Use `Contracts/` to match every other file. See **Specification Amendments**. |
+
+## Specification Amendments
+
+1. **Folder casing**: spec refers to `contracts/`; the actual folder and namespace use PascalCase `Contracts`. Create the file at `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs` in namespace `Anela.Heblo.Application.Features.Photobank.Contracts`. No braces vs. file-scoped namespace preference — match neighboring `CreateTagBody.cs` which uses **block-style** namespace (verified).
+2. **Return statement**: spec's example uses `return Ok(result);`. The current controller uses `return HandleResponse(response);`. Keep `HandleResponse(response)` — this is the project's shared error/success envelope. Do not swap to `Ok(...)`.
+3. **Existing tests**: no `UpdateRule*Tests.cs` files exist under `backend/test/Anela.Heblo.Tests/Features/Photobank/` (verified via `ls`). FR-5's "Existing unit/integration tests for UpdateRule pass without modification" is satisfied trivially — there are none to update.
+4. **FR-4 is a no-op**: verified via grep that no hand-written frontend code calls `photobank_UpdateRule`. The change is closed at the C# layer plus a regenerated client file; no `.ts`/`.tsx` edits are needed.
+
+## Prerequisites
+
+None. No migrations, no configuration, no infrastructure. The implementation is:
+
+1. Add `UpdateRuleBody.cs`.
+2. Change two things in `PhotobankController.UpdateRule`: the `[FromBody]` parameter type and the right-hand side of the four field assignments in the `new UpdateRuleRequest { … }` initializer.
+3. `dotnet build` → `dotnet format` → `npm run build` (regenerates `api-client.ts`) → `npm run lint`.
+4. Commit C# changes **plus** the regenerated `frontend/src/api/generated/api-client.ts`.

--- a/artifacts/feat-arch-review-photobank-updaterulerequest-/brief.md
+++ b/artifacts/feat-arch-review-photobank-updaterulerequest-/brief.md
@@ -1,0 +1,56 @@
+## Module
+Photobank
+
+## Finding
+`UpdateRuleRequest` (a MediatR request type) is used directly as the `[FromBody]` parameter in `PhotobankController.UpdateRule`:
+
+```csharp
+// PhotobankController.cs:299-314
+public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
+    int id,
+    [FromBody] UpdateRuleRequest request,   // body type IS the MediatR request
+    CancellationToken cancellationToken = default)
+{
+    var command = new UpdateRuleRequest
+    {
+        Id = id,              // route value wins
+        PathPattern = request.PathPattern,
+        TagName = request.TagName,
+        IsActive = request.IsActive,
+        SortOrder = request.SortOrder,
+    };
+    ...
+```
+
+`UpdateRuleRequest` declares `public int Id { get; set; }` (line 7 in `UpdateRuleRequest.cs`). Because the type is used as the body, the OpenAPI schema for `PUT /api/photobank/settings/rules/{id}` shows an `id` field in the request body. Clients (and the auto-generated TypeScript client) will include `id` in their JSON payload, but the controller overwrites it with the route parameter — the body value is silently discarded.
+
+## Why it matters
+- The auto-generated TypeScript API client will serialize and send `id` in the body, creating a misleading contract.
+- Any future maintainer reading the schema or client type sees an `id` field they can set, but it has no effect — a debugging trap.
+- Violates the module's own pattern: every other write endpoint uses a dedicated `contracts/*Body.cs` type that contains only the fields the client is actually allowed to control.
+
+## Suggested fix
+Introduce `UpdateRuleBody` in `contracts/`:
+```csharp
+// contracts/UpdateRuleBody.cs
+public class UpdateRuleBody
+{
+    public string PathPattern { get; set; } = null!;
+    public string TagName { get; set; } = null!;
+    public bool IsActive { get; set; }
+    public int SortOrder { get; set; }
+}
+```
+Change the controller to:
+```csharp
+public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
+    int id,
+    [FromBody] UpdateRuleBody body,
+    CancellationToken ct)
+{
+    var command = new UpdateRuleRequest { Id = id, PathPattern = body.PathPattern, ... };
+```
+This removes `Id` from the OpenAPI body schema and eliminates the silent override.
+
+---
+_Filed by daily arch-review routine on 2026-06-14._

--- a/artifacts/feat-arch-review-photobank-updaterulerequest-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-photobank-updaterulerequest-/impl/main.r1.md
@@ -1,0 +1,57 @@
+All 5 tasks complete. Writing the implementation artifact.
+
+---
+
+# Implementation: Fix PhotobankController.UpdateRule Body Contract
+
+## What was implemented
+
+Replaced the misleading `[FromBody] UpdateRuleRequest` parameter on `PUT /api/photobank/settings/rules/{id}` with a dedicated `UpdateRuleBody` HTTP contract. The OpenAPI schema and auto-generated TypeScript client no longer advertise an `id` body field. Runtime behavior is identical — `Id` still flows from the route parameter into the MediatR command.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs` — New HTTP body contract: `PathPattern`, `TagName`, `IsActive`, `SortOrder`. No `Id`. Matches neighboring `*Body` class conventions (block namespace, `= null!` initializers, `public class` not record).
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — `UpdateRule` method: `[FromBody] UpdateRuleRequest request` → `[FromBody] UpdateRuleBody body`; four `request.XYZ` assignments → `body.XYZ`. `HandleResponse(response)` and all attributes unchanged.
+- `frontend/src/api/generated/api-client.ts` — Regenerated via NSwag on `npm run build`. `UpdateRuleRequest` (had `id`) replaced by `UpdateRuleBody` (no `id`). `photobank_UpdateRule` parameter renamed `body: UpdateRuleBody`.
+
+## Tests
+
+No new tests added — this is a type-level change with no runtime behavior change. No existing `UpdateRule*Tests.cs` files exist in the project. The verifiable check is the regenerated `api-client.ts` schema (confirmed: `id` absent, 4 correct fields present). 155 existing Photobank tests passed with no regressions.
+
+## How to verify
+
+```bash
+# Backend builds clean
+dotnet build backend/Anela.Heblo.sln
+
+# Frontend builds clean with regenerated client
+cd frontend && npm run build && npm run lint && cd ..
+
+# Confirm id is gone from the body type
+grep -A 15 "class UpdateRuleBody" frontend/src/api/generated/api-client.ts
+
+# Confirm UpdateRuleRequest.Id still exists on the MediatR command
+cat backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/UpdateRule/UpdateRuleRequest.cs
+
+# See the 3 implementation commits on top of the planning artifacts
+git log --oneline main..HEAD
+```
+
+## Notes
+
+- `return HandleResponse(response)` was preserved — the spec sample showed `return Ok(result)` but that would have silently changed error status code behavior (arch-review Risk #1 / Decision #3).
+- `AddRule` (immediate sibling at lines ~280–289, same anti-pattern) was intentionally left untouched per spec Out-of-Scope.
+- 4 pre-existing planning commits (`agent: upload artifacts/...`) on the branch are from the prior arch-review session — not part of this implementation.
+- `dotnet format` made no changes; no formatter commit needed.
+
+## PR Summary
+
+Fixes the `PUT /api/photobank/settings/rules/{id}` endpoint body contract by introducing a dedicated `UpdateRuleBody` class that omits the `id` field. Previously, the endpoint bound `[FromBody] UpdateRuleRequest` directly, causing the OpenAPI schema (and the auto-generated TypeScript client) to advertise an `id` body field that the controller silently ignored in favour of the route value — a debugging trap. The fix aligns `UpdateRule` with every other write endpoint in the Photobank module (`AddPhotoTagBody`, `CreateTagBody`, `BulkAddPhotoTagBody`), which all use dedicated `*Body` contracts. Runtime behaviour is identical.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs` — new HTTP body contract (4 fields, no `id`)
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — `UpdateRule` parameter type changed from `UpdateRuleRequest` to `UpdateRuleBody`
+- `frontend/src/api/generated/api-client.ts` — regenerated; `updateRule` body type now contains only `pathPattern`, `tagName`, `isActive`, `sortOrder`
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-photobank-updaterulerequest-/spec.r1.md
+++ b/artifacts/feat-arch-review-photobank-updaterulerequest-/spec.r1.md
@@ -1,0 +1,175 @@
+# Specification: Fix UpdateRule Endpoint Body Contract
+
+## Summary
+The `PhotobankController.UpdateRule` endpoint exposes a misleading API contract by using the internal MediatR `UpdateRuleRequest` type as its `[FromBody]` parameter, causing an `id` field to appear in the OpenAPI schema and auto-generated TypeScript client even though the controller silently overrides it with the route value. This spec introduces a dedicated `UpdateRuleBody` contract class containing only fields the client is allowed to control, aligning with the rest of the Photobank module's contract pattern.
+
+## Background
+The Photobank module follows a Clean Architecture / Vertical Slice pattern where MediatR request types (commands/queries) are internal handler inputs and `contracts/*Body.cs` types are the public HTTP body contracts. The arch-review on 2026-06-14 found that `PUT /api/photobank/settings/rules/{id}` violates this convention:
+
+- `UpdateRuleRequest` (a MediatR command with `public int Id { get; set; }`) is bound directly as `[FromBody]`.
+- The OpenAPI generator includes `id` in the request body schema.
+- The auto-generated TypeScript client requires (or at minimum allows) callers to set `id` in the JSON payload.
+- The controller manually reconstructs the command, taking `Id` from the route parameter and ignoring the body's `Id`.
+
+The result is a deceptive contract: callers can set body `id` to any value with no effect, creating a debugging trap and a documentation inconsistency. Every other write endpoint in the module already uses a dedicated `contracts/*Body.cs` type, so this is an outlier.
+
+The fix is mechanical and behavior-preserving — the only observable change is that `id` disappears from the request body's OpenAPI schema (and from the regenerated TypeScript client type).
+
+## Functional Requirements
+
+### FR-1: Introduce `UpdateRuleBody` contract
+Create a new class `UpdateRuleBody` under the Photobank module's `contracts/` folder (same folder/namespace convention as other `*Body` types in the module).
+
+The class must contain exactly the fields the client is permitted to control:
+- `PathPattern` (string, required — `null!` initializer matching module convention)
+- `TagName` (string, required — `null!` initializer matching module convention)
+- `IsActive` (bool)
+- `SortOrder` (int)
+
+The class must **not** declare an `Id` field.
+
+The class must be a regular `class`, not a C# `record` (per project DTO rule — `docs/architecture/development_guidelines.md`).
+
+**Acceptance criteria:**
+- File `UpdateRuleBody.cs` exists in the Photobank module's `contracts/` folder.
+- The class is `public`, declares the four properties above with public getters and setters, and contains no other properties.
+- The class is not a `record`.
+- It lives in the same namespace as the other `*Body` types in `contracts/`.
+
+### FR-2: Update `PhotobankController.UpdateRule` to bind `UpdateRuleBody`
+Change the `[FromBody]` parameter type from `UpdateRuleRequest` to `UpdateRuleBody`. Construct the internal `UpdateRuleRequest` MediatR command from the route `id` and the body fields, preserving the existing "route value wins" behavior.
+
+**Acceptance criteria:**
+- `PhotobankController.UpdateRule` signature uses `[FromBody] UpdateRuleBody body` (parameter name may be `body` or equivalent — match local convention).
+- The handler still constructs `new UpdateRuleRequest { Id = id, PathPattern = body.PathPattern, TagName = body.TagName, IsActive = body.IsActive, SortOrder = body.SortOrder }`.
+- The dispatched MediatR command and the returned `ActionResult<UpdateRuleResponse>` are unchanged.
+- No other endpoints, MediatR handlers, validators, or business logic are modified.
+- `UpdateRuleRequest` itself is unchanged — `Id` remains on the MediatR command (it is the handler's input contract).
+
+### FR-3: Regenerate OpenAPI clients
+After the controller change, regenerate the C# and TypeScript OpenAPI clients (per `docs/development/api-client-generation.md`). The regenerated artifacts must reflect the new body schema.
+
+**Acceptance criteria:**
+- The OpenAPI schema for `PUT /api/photobank/settings/rules/{id}` no longer lists `id` as a body property.
+- The regenerated TypeScript client's `updateRule` method body type contains only `pathPattern`, `tagName`, `isActive`, `sortOrder`.
+- Frontend code that previously sent `id` in the body (if any — see FR-4) compiles successfully against the regenerated client.
+
+### FR-4: Frontend caller adjustments
+Search the frontend for callers of the generated `updateRule` client method. If any caller currently passes `id` inside the body payload, remove it (the route parameter is supplied separately). If no callers pass `id` in the body, no frontend change is required.
+
+**Acceptance criteria:**
+- `npm run build` and `npm run lint` pass in `frontend/`.
+- Any updated caller passes the new body shape without an `id` field.
+- No new TypeScript compile errors are introduced by the regenerated client.
+
+### FR-5: Behavior preservation
+The endpoint's runtime behavior must be identical before and after the change for any valid request. The change is a contract cleanup only.
+
+**Acceptance criteria:**
+- Existing unit/integration tests for `UpdateRule` pass without modification (or with only mechanical updates to construct `UpdateRuleBody` instead of `UpdateRuleRequest` in test arrange blocks).
+- A request with the new body shape and a route `id` returns the same `UpdateRuleResponse` as the equivalent pre-change request.
+- Validation messages, status codes, and error envelopes are unchanged.
+
+## Non-Functional Requirements
+
+### NFR-1: Backwards compatibility (wire-level)
+The HTTP wire contract remains backwards-compatible for existing live clients: a JSON body that still includes an extra `id` field will be ignored by ASP.NET model binding (extra properties are not rejected by default), and the route `id` continues to drive the update. The change is therefore non-breaking at the HTTP level; only the *advertised* schema and generated client *types* change.
+
+### NFR-2: Consistency with module conventions
+The change must align `UpdateRule` with the existing `contracts/*Body.cs` pattern used by every other write endpoint in the Photobank module. The new file's namespace, accessibility, property-initializer style (`= null!` for non-nullable references), and folder location must match neighboring `*Body` types.
+
+### NFR-3: Build & format gates
+Before declaring the task done:
+- `dotnet build` succeeds.
+- `dotnet format` reports no changes (or is run and committed).
+- `npm run build` and `npm run lint` succeed in `frontend/`.
+- All touched tests pass.
+
+### NFR-4: No security/authn changes
+The endpoint's existing authentication and authorization attributes (whatever they currently are) are preserved verbatim. This change does not touch the auth surface.
+
+## Data Model
+No database schema changes. The change is purely at the HTTP contract layer.
+
+**New type (HTTP contract):**
+
+| Type | Field | C# type | Notes |
+|---|---|---|---|
+| `UpdateRuleBody` | `PathPattern` | `string` | Required; `= null!` initializer |
+| `UpdateRuleBody` | `TagName` | `string` | Required; `= null!` initializer |
+| `UpdateRuleBody` | `IsActive` | `bool` | |
+| `UpdateRuleBody` | `SortOrder` | `int` | |
+
+**Unchanged internal type:**
+
+`UpdateRuleRequest` (MediatR command) keeps its current shape including `Id`. It is constructed inside the controller from `(routeId, body)`.
+
+## API / Interface Design
+
+**Endpoint:** `PUT /api/photobank/settings/rules/{id}` (unchanged route, method, response shape)
+
+**Before (request body schema, abbreviated):**
+```json
+{
+  "id": 0,
+  "pathPattern": "string",
+  "tagName": "string",
+  "isActive": true,
+  "sortOrder": 0
+}
+```
+
+**After (request body schema, abbreviated):**
+```json
+{
+  "pathPattern": "string",
+  "tagName": "string",
+  "isActive": true,
+  "sortOrder": 0
+}
+```
+
+**Response:** `UpdateRuleResponse` — unchanged.
+
+**Controller (target shape):**
+```csharp
+[HttpPut("settings/rules/{id:int}")]
+public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
+    int id,
+    [FromBody] UpdateRuleBody body,
+    CancellationToken cancellationToken = default)
+{
+    var command = new UpdateRuleRequest
+    {
+        Id = id,
+        PathPattern = body.PathPattern,
+        TagName = body.TagName,
+        IsActive = body.IsActive,
+        SortOrder = body.SortOrder,
+    };
+    var result = await _mediator.Send(command, cancellationToken);
+    return Ok(result);
+}
+```
+(Exact attribute syntax, mediator field name, and return statement should match the current controller — only the parameter type and command construction's field-list source change.)
+
+## Dependencies
+- **OpenAPI client generation pipeline** — the C# and TypeScript clients regenerate on build per `docs/development/api-client-generation.md`. No tooling change required.
+- **Existing `UpdateRuleRequest` MediatR handler** — must continue to receive `Id` populated from the route. No handler-side change.
+- **Frontend TypeScript client consumers** of `updateRule` — may need a mechanical edit if they pass `id` in the body today.
+
+No new external libraries, services, or infrastructure are introduced.
+
+## Out of Scope
+- **Auditing other endpoints** in the Photobank module (or other modules) for the same anti-pattern. If the daily arch-review surfaces more, those will be filed as separate items.
+- **Refactoring `UpdateRuleRequest`** — removing `Id` from the MediatR command is *not* in scope; the command is an internal handler input and other call sites (if any) may depend on its shape.
+- **Validation rule changes** — FluentValidation (or equivalent) rules for `UpdateRuleRequest` are preserved; if validators currently target `UpdateRuleRequest`, they continue to apply after construction in the controller.
+- **Route or HTTP-method changes** to the endpoint.
+- **Response shape changes** to `UpdateRuleResponse`.
+- **Database, persistence, or domain model changes.**
+- **E2E test additions** — the nightly E2E suite already exercises the endpoint via the frontend; no new E2E tests are required for this contract cleanup.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-photobank-updaterulerequest-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-photobank-updaterulerequest-/task-plan.r1.md
@@ -1,0 +1,14 @@
+Plan saved. Summary of what's in it:
+
+**Path:** `docs/superpowers/plans/2026-06-16-fix-photobank-updaterule-body-contract.md`
+
+**Structure:** 5 tasks decomposed into 2–5-minute steps:
+1. Add `UpdateRuleBody.cs` (verbatim contents, block-namespace, `= null!;` style matching neighbours).
+2. Swap `PhotobankController.UpdateRule` parameter type and body→command field source (lines 299–313 only). Explicit warning to keep `HandleResponse(response)` — not the spec sample's `Ok(...)`.
+3. Backend build + `dotnet format` + Photobank tests gate.
+4. Frontend regeneration + `git diff` schema verification + lint + build.
+5. Final cross-cutting check: only the expected files touched, `UpdateRuleRequest.Id` still present, `AddRule` (sibling anti-pattern) untouched.
+
+**Testing strategy:** No new tests — change is type-level only, FR-5 trivially satisfied (no existing UpdateRule tests), and a reflection-style "body has these fields" test would add no value the compiler doesn't already provide. The verifiable check is the regenerated `api-client.ts` schema in Task 4.
+
+**Spec coverage verified:** FR-1 → Task 1, FR-2 → Task 2, FR-3 → Task 4, FR-4 → addressed via no-op verification, FR-5 → Testing Strategy + Task 5. NFRs (build gates, module conventions, no auth changes) covered. All four arch-review amendments respected (PascalCase `Contracts/`, keep `HandleResponse`, no existing tests, FR-4 no-op).

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -298,16 +298,16 @@ namespace Anela.Heblo.API.Controllers
         [FeatureAuthorize(Feature.Marketing_Photobank, AccessLevel.Admin)]
         public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
             int id,
-            [FromBody] UpdateRuleRequest request,
+            [FromBody] UpdateRuleBody body,
             CancellationToken cancellationToken = default)
         {
             var command = new UpdateRuleRequest
             {
                 Id = id,
-                PathPattern = request.PathPattern,
-                TagName = request.TagName,
-                IsActive = request.IsActive,
-                SortOrder = request.SortOrder,
+                PathPattern = body.PathPattern,
+                TagName = body.TagName,
+                IsActive = body.IsActive,
+                SortOrder = body.SortOrder,
             };
             var response = await _mediator.Send(command, cancellationToken);
             return HandleResponse(response);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs
@@ -1,0 +1,10 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class UpdateRuleBody
+    {
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public bool IsActive { get; set; }
+        public int SortOrder { get; set; }
+    }
+}

--- a/docs/superpowers/plans/2026-06-16-fix-photobank-updaterule-body-contract.md
+++ b/docs/superpowers/plans/2026-06-16-fix-photobank-updaterule-body-contract.md
@@ -1,0 +1,322 @@
+# Fix PhotobankController.UpdateRule Body Contract — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the misleading `[FromBody] UpdateRuleRequest` on `PUT /api/photobank/settings/rules/{id}` with a dedicated `UpdateRuleBody` HTTP contract so the OpenAPI schema (and regenerated TypeScript client) no longer advertises an `id` body field that the controller already overrides from the route.
+
+**Architecture:** Pure HTTP-contract cleanup, behavior-preserving. The MediatR command (`UpdateRuleRequest`) and its validator stay unchanged; the controller maps `(route id, body)` → command, exactly the same way as today. The change brings `UpdateRule` in line with every other write endpoint in the Photobank module (`AddPhotoTagBody`, `CreateTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`).
+
+**Tech Stack:** .NET 8 / ASP.NET Core MVC controllers, MediatR, FluentValidation, NSwag-generated TypeScript client (regenerated on `npm run build`).
+
+---
+
+## File Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs` — new public HTTP body contract (4 fields, no `Id`).
+
+**Modify:**
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` (lines 299–313) — change `[FromBody]` parameter type and the right-hand side of the `new UpdateRuleRequest { … }` initializer. Keep all attributes, `HandleResponse(response)`, and the `_mediator` field name as-is.
+
+**Regenerated (build-time, do not hand-edit):**
+- `frontend/src/api/generated/api-client.ts` — NSwag overwrites this on `npm run build`. Must be staged and committed alongside the C# changes.
+
+**No changes:**
+- `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/UpdateRule/UpdateRuleRequest.cs` — MediatR command keeps `Id`.
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs` (or wherever it lives) — validates the post-construction command; route-supplied `Id` still satisfies `GreaterThan(0)`.
+- `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/UpdateRule/UpdateRuleHandler.cs` and `UpdateRuleResponse.cs`.
+- No frontend hand-written caller exists (verified in arch-review). FR-4 is therefore a no-op at the `.ts`/`.tsx` layer.
+
+## Testing Strategy
+
+No new tests are added for this change:
+- No `UpdateRule*Tests.cs` files exist today under `backend/test/Anela.Heblo.Tests/Features/Photobank/` (verified in arch-review).
+- The change is type-level only — it does not alter runtime behavior, validation, response shape, or status codes. Adding a unit test that asserts "body class has these four properties" or "controller maps body fields to command fields" would be reflection-based and brittle, with no value beyond what the compiler already enforces.
+- FR-5 ("existing tests pass without modification") is therefore trivially satisfied — there are none to update.
+- The OpenAPI regeneration step is the verifiable check that the contract change worked: the generated TypeScript `updateRule` body type must no longer contain `id`.
+
+---
+
+## Task 1: Add the `UpdateRuleBody` HTTP contract class
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs`
+
+**Context for the engineer:**
+The `Contracts/` folder under the Photobank module holds public HTTP body DTOs (one per write endpoint). All existing files use:
+- Block-style namespace `Anela.Heblo.Application.Features.Photobank.Contracts`
+- `public class` (never `record` — see CLAUDE.md project rule and `docs/architecture/development_guidelines.md`: OpenAPI generators mishandle record parameter order)
+- `= null!;` initializer for non-nullable required strings (matches `AddPhotoTagBody`, `BulkAddPhotoTagBody`)
+
+This new class mirrors `UpdateRuleRequest` minus the `Id` field. The four properties below come from the MediatR command verbatim (verified in `UpdateRuleRequest.cs:7-11`).
+
+- [ ] **Step 1: Create `UpdateRuleBody.cs` with the exact contents below**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class UpdateRuleBody
+    {
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public bool IsActive { get; set; }
+        public int SortOrder { get; set; }
+    }
+}
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run from repo root:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+Expected: build succeeds with 0 errors. (The class is not yet referenced by anything; this confirms it parses and matches project nullable settings.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs
+git commit -m "feat(photobank): add UpdateRuleBody HTTP contract"
+```
+
+---
+
+## Task 2: Switch `PhotobankController.UpdateRule` to bind `UpdateRuleBody`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs:299-313`
+
+**Context for the engineer:**
+
+`PhotobankController.cs` already has `using Anela.Heblo.Application.Features.Photobank.Contracts;` at the top (line 4), so no new `using` directive is needed.
+
+The current method (verified verbatim from the file, lines 299–313):
+
+```csharp
+public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
+    int id,
+    [FromBody] UpdateRuleRequest request,
+    CancellationToken cancellationToken = default)
+{
+    var command = new UpdateRuleRequest
+    {
+        Id = id,
+        PathPattern = request.PathPattern,
+        TagName = request.TagName,
+        IsActive = request.IsActive,
+        SortOrder = request.SortOrder,
+    };
+    var response = await _mediator.Send(command, cancellationToken);
+    return HandleResponse(response);
+}
+```
+
+Only two things change:
+1. `[FromBody] UpdateRuleRequest request` → `[FromBody] UpdateRuleBody body`
+2. The four `request.XYZ` field reads on the right-hand side become `body.XYZ`.
+
+Everything else — the `[HttpPut]`, the three `[ProducesResponseType]` attributes, `[FeatureAuthorize(Feature.Marketing_Photobank, AccessLevel.Admin)]`, the `_mediator.Send` call, and the `return HandleResponse(response);` line — stays exactly as-is. **Do not change `HandleResponse(response)` to `Ok(...)`** — the spec sample shows `Ok` but the project's shared error/success envelope is `HandleResponse`, and changing it would silently shift error status codes (see arch-review Risk #1 and Decision #3).
+
+- [ ] **Step 1: Replace the method body**
+
+Open `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` and replace lines 299–313 with:
+
+```csharp
+public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
+    int id,
+    [FromBody] UpdateRuleBody body,
+    CancellationToken cancellationToken = default)
+{
+    var command = new UpdateRuleRequest
+    {
+        Id = id,
+        PathPattern = body.PathPattern,
+        TagName = body.TagName,
+        IsActive = body.IsActive,
+        SortOrder = body.SortOrder,
+    };
+    var response = await _mediator.Send(command, cancellationToken);
+    return HandleResponse(response);
+}
+```
+
+Leave lines 291–298 (the XML doc comment and the four attribute lines) and lines after 313 untouched.
+
+- [ ] **Step 2: Confirm `AddRule` immediately above was NOT modified**
+
+Re-open the file and check lines 280–289. They should still show `[FromBody] AddRuleRequest request` (the same anti-pattern, explicitly out of scope for this PR per the spec's "Out of Scope" section and arch-review Risk #2). If `AddRule` was accidentally touched, revert that portion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+git commit -m "refactor(photobank): bind UpdateRule body via UpdateRuleBody contract"
+```
+
+---
+
+## Task 3: Validate the backend (build + format)
+
+**Files:** none modified in this task (validation gate per CLAUDE.md "Validation before completion").
+
+**Context for the engineer:**
+The project requires both `dotnet build` and `dotnet format` to be clean before a backend change is considered done. `dotnet format` may rewrite the new file if its style drifts from the rest of the solution (e.g. trailing newline, brace style). Any rewrites it makes must be committed.
+
+- [ ] **Step 1: Build the full backend solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded.` with 0 Error(s). Warnings are acceptable only if they already existed on `main` for unrelated files — there should be no new warnings traced to `UpdateRuleBody.cs` or `PhotobankController.cs`.
+
+- [ ] **Step 2: Run the formatter**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+Expected: exit code 0. The formatter is silent when nothing changes; if it rewrites either touched file, `git status` will show modifications.
+
+- [ ] **Step 3: Stage and commit any formatter changes (only if `git status` is dirty)**
+
+```bash
+git status
+# If UpdateRuleBody.cs or PhotobankController.cs show as modified:
+git add backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs \
+        backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+git commit -m "style: dotnet format"
+```
+If `git status` is clean, skip the commit — no changes to stage.
+
+- [ ] **Step 4: Run the Photobank test project to confirm nothing regressed**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Photobank" --no-build
+```
+Expected: all tests pass. (No `UpdateRule`-specific tests exist; this gate only catches accidental collateral damage to other Photobank tests.)
+
+---
+
+## Task 4: Regenerate the TypeScript client and verify the new body schema
+
+**Files:**
+- Regenerated: `frontend/src/api/generated/api-client.ts`
+
+**Context for the engineer:**
+The TypeScript client is generated by NSwag during `npm run build` per `docs/development/api-client-generation.md`. The backend Swagger document is consumed and the `.ts` file is overwritten. After the controller change, the generated `updateRule` method's body parameter type must:
+- No longer contain an `id` field
+- Contain exactly `pathPattern: string`, `tagName: string`, `isActive: boolean`, `sortOrder: number`
+
+If a hand-written frontend caller had ever passed `id` in the body, the regenerated client would compile-break it. The arch-review confirmed no hand-written caller exists (a wider grep for `updateRule` and `photobank_UpdateRule` found references only inside `api-client.ts` itself), so no `.ts`/`.tsx` edits should be needed.
+
+- [ ] **Step 1: Run the frontend build (regenerates `api-client.ts`)**
+
+```bash
+cd frontend
+npm run build
+```
+Expected: build succeeds. The build step internally runs the OpenAPI generator before tsc/webpack; `api-client.ts` will be overwritten.
+
+- [ ] **Step 2: Confirm the regenerated client matches the new schema**
+
+```bash
+git diff frontend/src/api/generated/api-client.ts | head -80
+```
+
+The diff must show, in the section defining the `updateRule` body type (search for `UpdateRuleBody` or the inline body interface used by `updateRule`):
+- Removed: a `id: number` or `id?: number` property
+- Added (or already present): exactly the four properties `pathPattern`, `tagName`, `isActive`, `sortOrder`
+
+If `git diff` shows no change to `api-client.ts`, the regeneration step did not run — investigate by checking that the OpenAPI generation script is actually wired into `npm run build` (see `docs/development/api-client-generation.md`). Do not proceed until the diff confirms the schema change.
+
+- [ ] **Step 3: Run the linter**
+
+```bash
+npm run lint
+```
+Expected: clean exit. The regenerated file is generator-managed and typically excluded from lint, but the lint pass also covers any frontend file that imports from `api-client.ts` and might break if the body type changed unexpectedly.
+
+- [ ] **Step 4: Build one more time to confirm tsc is fully green after lint**
+
+```bash
+npm run build
+```
+Expected: succeeds with no TypeScript errors. (This catches the edge case where step 1's build cached a stale tsc state.)
+
+- [ ] **Step 5: Commit the regenerated client**
+
+```bash
+cd ..
+git add frontend/src/api/generated/api-client.ts
+git commit -m "chore(frontend): regenerate api-client for UpdateRuleBody"
+```
+
+If `git status` shows additional frontend files modified, stop and investigate — only `api-client.ts` should change in this task.
+
+---
+
+## Task 5: Final verification before declaring done
+
+**Files:** none modified.
+
+**Context for the engineer:**
+This task is the project's CLAUDE.md "Validation before completion" gate, run end-to-end one final time to catch any cross-cutting issue the per-task gates missed.
+
+- [ ] **Step 1: Verify the full git log shows only the expected commits**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected output (order may differ if Task 3 Step 3 produced a formatter commit, which is optional):
+- `chore(frontend): regenerate api-client for UpdateRuleBody`
+- (optional) `style: dotnet format`
+- `refactor(photobank): bind UpdateRule body via UpdateRuleBody contract`
+- `feat(photobank): add UpdateRuleBody HTTP contract`
+
+If there are extra commits touching anything else (other controllers, other modules, deletion of `Id` from `UpdateRuleRequest`, validator edits, or unrelated frontend files), revert them — the spec explicitly scopes this PR to the four files above.
+
+- [ ] **Step 2: Verify no unintended file changes**
+
+```bash
+git diff --stat main..HEAD
+```
+
+Expected: exactly three files changed (or four if formatter touched anything beyond `UpdateRuleBody.cs`):
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs` (new)
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs`
+- `frontend/src/api/generated/api-client.ts`
+
+If `UpdateRuleRequest.cs`, `UpdateRuleHandler.cs`, `UpdateRuleResponse.cs`, the validator file, or any other controller appears in the diff, revert the unintended change. `UpdateRuleRequest.Id` MUST still exist on the MediatR command (out of scope per spec).
+
+- [ ] **Step 3: Run the full backend build + frontend build one final time**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+cd frontend && npm run build && npm run lint && cd ..
+```
+Expected: all four commands succeed.
+
+- [ ] **Step 4: Verify the OpenAPI generator output the new body schema correctly**
+
+Open `frontend/src/api/generated/api-client.ts` and search for `updateRule`. Inspect the method signature and the body type it accepts. Confirm:
+- The body type contains `pathPattern`, `tagName`, `isActive`, `sortOrder`.
+- The body type does NOT contain `id`.
+- The route `id` is still a separate method parameter (not inside the body).
+
+This is the single most important behavioral check of the entire PR — it is the user-visible artifact of the contract cleanup.
+
+---
+
+## Definition of Done
+
+All boxes above are checked AND:
+
+- [ ] `dotnet build backend/Anela.Heblo.sln` succeeds.
+- [ ] `dotnet format backend/Anela.Heblo.sln` reports no pending changes.
+- [ ] `cd frontend && npm run build && npm run lint` succeeds.
+- [ ] Photobank backend tests pass (`dotnet test … --filter "FullyQualifiedName~Photobank"`).
+- [ ] `git diff main..HEAD` shows only the three (or four with formatter) files listed in Task 5 Step 2.
+- [ ] The regenerated `api-client.ts` no longer advertises an `id` field on the `updateRule` body type.
+- [ ] `UpdateRuleRequest` (MediatR command) is unchanged — `Id` still present.
+- [ ] `AddRule` (the sibling anti-pattern at lines 280–289) is NOT modified — out of scope for this PR.

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -10193,14 +10193,14 @@ export class ApiClient {
         return Promise.resolve<AddRuleResponse>(null as any);
     }
 
-    photobank_UpdateRule(id: number, request: UpdateRuleRequest): Promise<UpdateRuleResponse> {
+    photobank_UpdateRule(id: number, body: UpdateRuleBody): Promise<UpdateRuleResponse> {
         let url_ = this.baseUrl + "/api/photobank/settings/rules/{id}";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
         url_ = url_.replace("{id}", encodeURIComponent("" + id));
         url_ = url_.replace(/[?&]$/, "");
 
-        const content_ = JSON.stringify(request);
+        const content_ = JSON.stringify(body);
 
         let options_: RequestInit = {
             body: content_,
@@ -35393,14 +35393,13 @@ export class UpdateRuleResponse extends BaseResponse implements IUpdateRuleRespo
 export interface IUpdateRuleResponse extends IBaseResponse {
 }
 
-export class UpdateRuleRequest implements IUpdateRuleRequest {
-    id?: number;
+export class UpdateRuleBody implements IUpdateRuleBody {
     pathPattern?: string;
     tagName?: string;
     isActive?: boolean;
     sortOrder?: number;
 
-    constructor(data?: IUpdateRuleRequest) {
+    constructor(data?: IUpdateRuleBody) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -35411,7 +35410,6 @@ export class UpdateRuleRequest implements IUpdateRuleRequest {
 
     init(_data?: any) {
         if (_data) {
-            this.id = _data["id"];
             this.pathPattern = _data["pathPattern"];
             this.tagName = _data["tagName"];
             this.isActive = _data["isActive"];
@@ -35419,16 +35417,15 @@ export class UpdateRuleRequest implements IUpdateRuleRequest {
         }
     }
 
-    static fromJS(data: any): UpdateRuleRequest {
+    static fromJS(data: any): UpdateRuleBody {
         data = typeof data === 'object' ? data : {};
-        let result = new UpdateRuleRequest();
+        let result = new UpdateRuleBody();
         result.init(data);
         return result;
     }
 
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
-        data["id"] = this.id;
         data["pathPattern"] = this.pathPattern;
         data["tagName"] = this.tagName;
         data["isActive"] = this.isActive;
@@ -35437,8 +35434,7 @@ export class UpdateRuleRequest implements IUpdateRuleRequest {
     }
 }
 
-export interface IUpdateRuleRequest {
-    id?: number;
+export interface IUpdateRuleBody {
     pathPattern?: string;
     tagName?: string;
     isActive?: boolean;


### PR DESCRIPTION

Fixes the `PUT /api/photobank/settings/rules/{id}` endpoint body contract by introducing a dedicated `UpdateRuleBody` class that omits the `id` field. Previously, the endpoint bound `[FromBody] UpdateRuleRequest` directly, causing the OpenAPI schema (and the auto-generated TypeScript client) to advertise an `id` body field that the controller silently ignored in favour of the route value — a debugging trap. The fix aligns `UpdateRule` with every other write endpoint in the Photobank module (`AddPhotoTagBody`, `CreateTagBody`, `BulkAddPhotoTagBody`), which all use dedicated `*Body` contracts. Runtime behaviour is identical.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleBody.cs` — new HTTP body contract (4 fields, no `id`)
- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — `UpdateRule` parameter type changed from `UpdateRuleRequest` to `UpdateRuleBody`
- `frontend/src/api/generated/api-client.ts` — regenerated; `updateRule` body type now contains only `pathPattern`, `tagName`, `isActive`, `sortOrder`

---

Closes #3068

### Tokens used
10800545
