### PR TITLE
feat: Decouple Photobank MediatR Requests from HTTP Body DTOs

### DIFF
--- a/artifacts/feat-arch-review-photobank-addrootrequest-add/arch-review.r1.md
+++ b/artifacts/feat-arch-review-photobank-addrootrequest-add/arch-review.r1.md
@@ -1,0 +1,198 @@
+I have enough context. Writing the architecture review now.
+
+# Architecture Review: Decouple Photobank MediatR Requests from HTTP Body DTOs
+
+## Skip Design: true
+
+Backend-only refactor. No UI components, screens, layouts, or visual design decisions. The HTTP wire contract is unchanged, so no frontend UX work is involved beyond the auto-generated client regeneration.
+
+## Architectural Fit Assessment
+
+This work is a **conformance fix**, not a new design. The Photobank module already has the target pattern implemented for 4 of 7 POST endpoints (`AddPhotoTag`, `BulkAddPhotoTag`, `CreateTag`, `BulkAddPhotoTagByIds`), all backed by `*Body` types under `Contracts/`. The three offending endpoints (`AddRoot`, `AddRule`, `RetagPhotos`) are the only outliers in `PhotobankController.cs`. The proposal aligns perfectly with:
+
+- `docs/architecture/development_guidelines.md` — *"DTO objects for API (Request, Response) live in `contracts/` of the specific module."*
+- ADR-005 (User Identity Resolution) — explicitly cites *"Request DTOs must not carry client-settable `UserId` / `ModifiedBy` — these are server-resolved, never trusted from the client (spoofing hole)."* Decoupling `*Body` from `*Request` is the structural enabler for that rule.
+
+The only integration point is the auto-generated OpenAPI TypeScript client. The frontend currently bypasses generated client methods for these endpoints (raw `apiPost` calls with inline JSON in `usePhotobank.ts` and `usePhotobankSettings.ts`), so even the generated type renames have **no runtime impact** on the frontend.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP boundary (API project)               Application module (Photobank feature)
+─────────────────────────────             ─────────────────────────────────────
+PhotobankController.AddRoot                Contracts/                       UseCases/AddRoot/
+  [FromBody] AddRootBody body  ──── maps ──▶ AddRootBody (NEW)              AddRootRequest  ── MediatR ──▶ AddRootHandler
+                                                                              ▲
+PhotobankController.AddRule                Contracts/                       UseCases/AddRule/
+  [FromBody] AddRuleBody body  ──── maps ──▶ AddRuleBody (NEW)              AddRuleRequest  ── MediatR ──▶ AddRuleHandler
+
+PhotobankController.RetagPhotos            Contracts/                       UseCases/RetagPhotos/
+  [FromBody] RetagPhotosBody body ─ maps ──▶ RetagPhotosBody (NEW)          RetagPhotosRequest ── MediatR ▶ RetagPhotosHandler
+```
+
+The three new `*Body` types are pure DTOs (no behavior, no MediatR markers). The existing `*Request` types under `UseCases/` keep their `IRequest<TResponse>` contract — they remain the internal MediatR boundary that handlers depend on. The controller is the single mapping seam.
+
+### Key Design Decisions
+
+#### Decision 1: Folder casing — `Contracts/` (PascalCase), not `contracts/`
+**Options considered:**
+- Use lowercase `contracts/` as the brief and spec text suggest.
+- Use PascalCase `Contracts/` to match the existing directory in this module.
+
+**Chosen approach:** Place new files under the existing `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/` folder (PascalCase) and namespace `Anela.Heblo.Application.Features.Photobank.Contracts`.
+
+**Rationale:** The Photobank module's existing `*Body` DTOs (`AddPhotoTagBody.cs`, `BulkAddPhotoTagBody.cs`, `CreateTagBody.cs`, `BulkAddPhotoTagByIdsBody.cs`) all live under `Contracts/` with PascalCase. The spec's lowercase mention is a citation of the global guideline, not a directive to rename the folder. Consistency with the four well-formed siblings wins.
+
+#### Decision 2: Mapping style — inline object initializer in the controller
+**Options considered:**
+- Inline object initializer in each action method (e.g. `new AddRootRequest { SharePointPath = body.SharePointPath, ... }`).
+- Private mapper method on the controller (`AddRootRequest ToRequest(AddRootBody body)`).
+- AutoMapper / dedicated mapper class in `Contracts/Mappers/`.
+
+**Chosen approach:** Inline object initializer, matching the 4 existing well-formed endpoints in the same controller (e.g. `BulkAddPhotoTag` lines 161–166, `BulkAddPhotoTagByIds` lines 185–189).
+
+**Rationale:** The mappings are 2–3 properties each, no transformations, no conditional logic. Adding a helper method or AutoMapper config for three trivial copies is over-engineering and breaks visual consistency with the existing controller. YAGNI applies.
+
+#### Decision 3: Preserve action-specific response shapes
+**Options considered:**
+- Unify all three updated actions onto `HandleResponse(response)`.
+- Preserve the current per-action response logic (`CreatedAtAction` for AddRoot/AddRule, `Accepted/BadRequest` for RetagPhotos).
+
+**Chosen approach:** Preserve current per-action response logic exactly. Only the input-binding type and the mapping line change.
+
+**Rationale:** The spec (FR-4) explicitly states *"HTTP route, verb, status codes, response type, attribute filters (auth, model validation, etc.), and action name remain unchanged."* `AddRoot` returns 201 via `CreatedAtAction(nameof(GetRoots), ...)`, `AddRule` does the same with `GetRules`, and `RetagPhotos` returns 202 via `Accepted(result)`. These status codes are part of the wire contract and must stay.
+
+#### Decision 4: Do not refactor the MediatR request types
+**Options considered:**
+- Rename `AddRootRequest` → `AddRootCommand` and move them.
+- Leave `UseCases/{X}/{X}Request.cs` intact.
+
+**Chosen approach:** Leave `*Request` classes intact in `UseCases/`. They remain the MediatR internal contract.
+
+**Rationale:** Spec out-of-scope explicitly forbids it. Handlers, validators, and tests already depend on these names; touching them blows up the blast radius for no architectural benefit.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Add three files (no other structural changes):
+
+```
+backend/src/Anela.Heblo.Application/Features/Photobank/
+└── Contracts/
+    ├── AddPhotoTagBody.cs              (existing)
+    ├── BulkAddPhotoTagBody.cs          (existing)
+    ├── BulkAddPhotoTagByIdsBody.cs     (existing)
+    ├── CreateTagBody.cs                (existing)
+    ├── AddRootBody.cs                  ← NEW
+    ├── AddRuleBody.cs                  ← NEW
+    └── RetagPhotosBody.cs              ← NEW
+```
+
+Edit one file:
+
+```
+backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+  - AddRoot      (line 233) — bind AddRootBody, map to AddRootRequest
+  - AddRule      (line 281) — bind AddRuleBody, map to AddRuleRequest
+  - RetagPhotos  (line 203) — bind RetagPhotosBody, map to RetagPhotosRequest
+```
+
+All three new files use namespace `Anela.Heblo.Application.Features.Photobank.Contracts` (matching siblings) and live in the existing `Anela.Heblo.Application` project — no new csproj references needed.
+
+### Interfaces and Contracts
+
+```csharp
+// Contracts/AddRootBody.cs
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddRootBody
+    {
+        public string SharePointPath { get; set; } = null!;
+        public string? DisplayName { get; set; }
+        public string DriveId { get; set; } = null!;
+    }
+}
+
+// Contracts/AddRuleBody.cs
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddRuleBody
+    {
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public int SortOrder { get; set; }
+    }
+}
+
+// Contracts/RetagPhotosBody.cs
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class RetagPhotosBody
+    {
+        public int[] PhotoIds { get; set; } = Array.Empty<int>();
+        public bool ClearExistingAiTags { get; set; }
+    }
+}
+```
+
+Property names, types, nullability, and defaults are an exact 1:1 mirror of the current `*Request` shapes (verified against `AddRootRequest.cs`, `AddRuleRequest.cs`, `RetagPhotosRequest.cs`). This preserves the JSON wire contract bit-for-bit.
+
+Controller body pattern (one example; the other two follow the same shape):
+
+```csharp
+public async Task<ActionResult<AddRootResponse>> AddRoot(
+    [FromBody] AddRootBody body,
+    CancellationToken cancellationToken = default)
+{
+    var request = new AddRootRequest
+    {
+        SharePointPath = body.SharePointPath,
+        DisplayName = body.DisplayName,
+        DriveId = body.DriveId,
+    };
+    var response = await _mediator.Send(request, cancellationToken);
+    if (response.Success)
+        return CreatedAtAction(nameof(GetRoots), response);
+    return HandleResponse(response);
+}
+```
+
+### Data Flow
+
+For each of the three endpoints:
+
+1. HTTP request hits the route (`POST /api/photobank/settings/roots`, etc.).
+2. `[FeatureAuthorize]` runs — unchanged.
+3. ASP.NET model binder deserializes the JSON body into the new `*Body` DTO.
+4. Controller constructs a fresh `*Request` MediatR object from `body` (object initializer, no mutation).
+5. `_mediator.Send(request, ct)` dispatches to the existing handler — unchanged.
+6. Handler returns `*Response` — unchanged.
+7. Controller picks the response status code as it does today (`CreatedAtAction` / `Accepted` / `HandleResponse`).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Wire-shape drift between `*Body` and `*Request` introduced now or later | Medium | The new `*Body` is a 1:1 mirror today; add one controller-level test per endpoint asserting field-by-field copy (spec FR-6 covers this). A property added to `*Request` for server-side use must consciously be omitted from `*Body`. |
+| Generated TypeScript client class rename (`AddRootRequest` → `AddRootBody`) breaks frontend imports | Low | Verified: the frontend never imports `AddRootRequest`, `AddRuleRequest`, or `RetagPhotosRequest` from `generated/api-client.ts`. All three endpoints are called via raw `apiPost` with inline JSON in `usePhotobank.ts` / `usePhotobankSettings.ts`. There is a locally-defined `RetagPhotosRequest` interface in `usePhotobank.ts:221` — it is unrelated to the generated client and unaffected. No frontend changes required. |
+| Schema field renames (camelCase JSON) accidentally change due to NSwag inferring a different name from `*Body` | Low | All Photobank properties use trivial PascalCase that NSwag serializes deterministically to camelCase (`SharePointPath` → `sharePointPath`, etc.). Existing `*Body` siblings already exhibit this. Validate by running `dotnet build` and diffing `generated/api-client.ts` for the three request schemas. |
+| OpenAPI `required` flags change (nullable behavior shift) | Medium | New `*Body` declarations must mirror nullability exactly: `string SharePointPath { get; set; } = null!;` (non-nullable, required), `string? DisplayName` (nullable, optional). Same for `AddRuleBody`, same for `RetagPhotosBody` (`int[] PhotoIds = Array.Empty<int>()` keeps the empty-array default). Diff the regenerated schema for `required: []` arrays. |
+| `UpdateRule` (line 301) has the same coupling issue but is silently fixed or silently skipped | Low | Out of scope per spec. Explicitly do **not** touch `UpdateRule` in this PR. Arch-review routine will file it separately if it is a finding. |
+| The `RetagPhotos` action currently uses `result.Success ? Accepted(result) : BadRequest(result)` — easy to drift to `HandleResponse` by mistake during the refactor | Low | Tester or reviewer to confirm 202/400 status codes survive in controller integration test. |
+
+## Specification Amendments
+
+1. **Folder casing**: The spec's `contracts/` references must be implemented as `Contracts/` (PascalCase) — that is the actual directory in this module, and all existing `*Body` siblings live there. Namespace is `Anela.Heblo.Application.Features.Photobank.Contracts`.
+
+2. **Frontend impact is effectively zero, not "update generated type references"**: FR-5 acceptance criterion "any frontend call site that referenced the old generated type name is updated to use the new generated type name" is vacuously satisfied — the frontend does not reference `AddRootRequest`, `AddRuleRequest`, or `RetagPhotosRequest` from the generated client. The frontend calls these endpoints via raw `apiPost` with inline JSON payloads. The verification step still applies (regenerated client must compile cleanly, `npm run build` and `npm run lint` must pass), but no manual code-site updates are expected.
+
+3. **Preserve `CreatedAtAction` / `Accepted` response semantics**: FR-4 should make explicit that `AddRoot` and `AddRule` keep their `CreatedAtAction(...)` on success / `HandleResponse(response)` on failure shape (current lines 238–240 and 286–288), and `RetagPhotos` keeps its `result.Success ? Accepted(result) : BadRequest(result)` shape (line 208). The spec's sample at "Controller pattern (target)" uses `Ok(result)` which would silently regress these status codes (201 → 200 for the Add* endpoints, 202 → 200 for RetagPhotos) — a wire contract break. The implementation must follow the pattern of the existing endpoints in the file (`CreatedAtAction` / `Accepted` are preserved), not the simplified sample.
+
+4. **Test guidance — handler tests need no change**: FR-6 already implies this, but to be unambiguous: `AddRootHandlerTests`, `RetagPhotosHandlerTests`, etc. construct `*Request` directly and exercise the handler — they remain untouched. Only controller-level integration tests (if added per the per-endpoint mapping coverage requirement) consume the new `*Body` types.
+
+## Prerequisites
+
+None. No migrations, no config changes, no infrastructure work, no new packages, no new Azure Key Vault secrets. The change is purely additive (three new files) plus one controller edit. `dotnet build` regenerates the OpenAPI TypeScript client automatically per existing project configuration. Implementation can start immediately.

--- a/artifacts/feat-arch-review-photobank-addrootrequest-add/brief.md
+++ b/artifacts/feat-arch-review-photobank-addrootrequest-add/brief.md
@@ -1,0 +1,56 @@
+## Module
+Photobank
+
+## Finding
+Three MediatR request types are used directly as `[FromBody]` HTTP body types in `PhotobankController`, bypassing the module's own established `contracts/` pattern:
+
+| Controller action | `[FromBody]` type used | Where it lives |
+|---|---|---|
+| `AddRoot` (line 233) | `AddRootRequest` | `UseCases/AddRoot/AddRootRequest.cs` |
+| `AddRule` (line 281) | `AddRuleRequest` | `UseCases/AddRule/AddRuleRequest.cs` |
+| `RetagPhotos` (line 203) | `RetagPhotosRequest` | `UseCases/RetagPhotos/RetagPhotosRequest.cs` |
+
+The same module already applies the correct pattern for four other endpoints, where a thin `contracts/*Body.cs` type is mapped to the MediatR request in the controller:
+- `AddPhotoTagBody` → `AddPhotoTagRequest`
+- `BulkAddPhotoTagBody` → `BulkAddPhotoTagRequest`
+- `CreateTagBody` → `CreateTagRequest`
+- `BulkAddPhotoTagByIdsBody` → `BulkAddPhotoTagByIdsRequest`
+
+## Why it matters
+`development_guidelines.md` states: *"DTO objects for API (Request, Response) live in `contracts/` of the specific module."* When the MediatR request type is also the HTTP body type, the API contract is coupled to the application contract:
+- Adding an internal server-side field to `AddRootRequest` (e.g. `CreatedByUserId` populated in the handler) immediately exposes it in the OpenAPI schema and the auto-generated TypeScript client — a potential spoofing hole if someone forgets to strip the body value.
+- Changing what the handler needs changes the visible API contract, and vice versa.
+- The three requests all live in `UseCases/` subdirectories, the wrong location per guidelines for API-facing DTOs.
+
+## Suggested fix
+For each affected endpoint, add a slim body DTO to `contracts/`:
+
+```csharp
+// contracts/AddRootBody.cs
+public class AddRootBody
+{
+    public string SharePointPath { get; set; } = null!;
+    public string? DisplayName { get; set; }
+    public string DriveId { get; set; } = null!;
+}
+
+// contracts/AddRuleBody.cs
+public class AddRuleBody
+{
+    public string PathPattern { get; set; } = null!;
+    public string TagName { get; set; } = null!;
+    public int SortOrder { get; set; }
+}
+
+// contracts/RetagPhotosBody.cs
+public class RetagPhotosBody
+{
+    public int[] PhotoIds { get; set; } = Array.Empty<int>();
+    public bool ClearExistingAiTags { get; set; }
+}
+```
+
+Then update the controller actions to map `Body` → `Request`, matching the existing pattern in the same file.
+
+---
+_Filed by daily arch-review routine on 2026-06-14._

--- a/artifacts/feat-arch-review-photobank-addrootrequest-add/impl/main.r1.md
+++ b/artifacts/feat-arch-review-photobank-addrootrequest-add/impl/main.r1.md
@@ -1,72 +1,15 @@
-# Implementation: Decouple Photobank MediatR Requests from HTTP Body DTOs
+All 5 tasks are complete. Here's the summary:
 
-## What was implemented
+---
 
-Three slim `*Body` contract DTOs were added to the Photobank module's `Contracts/` directory, and `PhotobankController` was updated so that `AddRoot`, `AddRule`, and `RetagPhotos` bind `[FromBody]` to the new DTOs and map them to the existing MediatR `*Request` types via inline object initializers — matching the pattern already used by `AddPhotoTag`, `BulkAddPhotoTag`, `CreateTag`, and `BulkAddPhotoTagByIds`. Three controller-level xUnit tests were added to cover the field-by-field `Body → Request` mapping and verify action-specific HTTP status codes. The OpenAPI TypeScript client was regenerated; generated class names for the three endpoints changed from `*Request` to `*Body` but JSON wire shapes are byte-for-byte identical.
+**Implementation complete: Decouple Photobank MediatR Requests from HTTP Body DTOs**
 
-## Files created/modified
+**What was done:**
+- Created 3 new `*Body` DTOs in `Contracts/`: `AddRootBody`, `AddRuleBody`, `RetagPhotosBody`
+- Updated `PhotobankController` actions `AddRoot`, `AddRule`, `RetagPhotos` to bind `[FromBody]` to the new DTOs and map them to the existing MediatR `*Request` types via inline object initializers
+- Added `PhotobankControllerBodyMappingTests.cs` with 3 tests (all pass) — each verifies field-by-field mapping and action-specific HTTP status codes (201 `CreatedAtAction` for Add* endpoints, 202 `Accepted` for RetagPhotos)
+- Regenerated the OpenAPI TypeScript client — generated class names updated (`*Request` → `*Body`) but JSON wire shapes are byte-for-byte identical
 
-- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootBody.cs` — new plain class DTO with `SharePointPath`, `DisplayName`, `DriveId`
-- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleBody.cs` — new plain class DTO with `PathPattern`, `TagName`, `SortOrder`
-- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RetagPhotosBody.cs` — new plain class DTO with `PhotoIds` (default `Array.Empty<int>()`), `ClearExistingAiTags`
-- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — three actions updated: `AddRoot` (lines 233–241), `AddRule` (lines 281–289), `RetagPhotos` (lines 203–209)
-- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs` — new test class with three tests
-- `frontend/src/api/generated/api-client.ts` — regenerated (21 insertions, 21 deletions — class renames only)
+**4 commits on this branch** (`AddRootBody`, `AddRuleBody`, `RetagPhotosBody`, `chore: regenerate client`).
 
-## Tests
-
-`backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs`:
-- `AddRoot_MapsBodyToRequest_AndReturnsCreated` — verifies all 3 fields copied, action returns `CreatedAtActionResult` pointing to `GetRoots`
-- `AddRule_MapsBodyToRequest_AndReturnsCreated` — verifies all 3 fields copied, action returns `CreatedAtActionResult` pointing to `GetRules`
-- `RetagPhotos_MapsBodyToRequest_AndReturnsAccepted` — verifies both fields copied, action returns `AcceptedResult` (202)
-
-All 3 pass. Full Photobank suite: 158 passed, 3 failed (pre-existing Docker/Testcontainers env failures in `PhotobankRepositoryGetTagsSqlShapeTests` — same count on `main`). Full backend suite: 5003 passed, 56 failed (all Docker/Testcontainers, pre-existing).
-
-## How to verify
-
-```bash
-# Run new body-mapping tests
-dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
-  --filter "FullyQualifiedName~PhotobankControllerBodyMappingTests"
-# Expected: 3 passed
-
-# Run full Photobank suite
-dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
-  --filter "FullyQualifiedName~Features.Photobank"
-# Expected: all previously-passing tests still pass
-
-# Verify formatting
-dotnet format backend/Anela.Heblo.sln --verify-no-changes
-# Expected: exit 0
-
-# Verify UpdateRule not touched
-git diff main -- backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs \
-  | grep -E "UpdateRule|UpdateRuleRequest" | head
-# Expected: no output
-```
-
-## Notes
-
-- `npm run lint` returns 161 errors on the frontend — all pre-existing (same count on `main`), located in test utilities, entirely unrelated to the Body DTO changes. `npm run build` compiles cleanly.
-- `AddRoot` and `AddRule` preserve `CreatedAtAction(nameof(GetRoots/GetRules), response)` on success (201). `RetagPhotos` preserves `Accepted(result) : BadRequest(result)` (202/400). None were regressed to `Ok()`.
-- `UpdateRule` (line 299) has the same coupling pattern but is explicitly out of scope per spec; it was not touched.
-- The frontend (`usePhotobank.ts`, `usePhotobankSettings.ts`) calls these endpoints via raw `apiPost` with inline JSON — no call sites reference generated class names, so no frontend code required manual updates.
-
-## PR Summary
-
-Decoupled three `PhotobankController` actions (`AddRoot`, `AddRule`, `RetagPhotos`) from directly binding the MediatR request types by introducing slim `*Body` DTOs in `Contracts/` and mapping them to the existing `*Request` types inside the controller. This closes a latent security exposure (future server-populated fields on `*Request` can't be spoofed from the client), aligns the endpoints with the project's established contract pattern, and matches the four endpoints in the same controller that already follow the convention.
-
-### Changes
-- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootBody.cs` — new DTO mirroring client-supplied fields of `AddRootRequest`
-- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleBody.cs` — new DTO mirroring client-supplied fields of `AddRuleRequest`
-- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RetagPhotosBody.cs` — new DTO mirroring client-supplied fields of `RetagPhotosRequest`
-- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — three actions updated to use Body types with inline object-initializer mapping
-- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs` — new controller-level tests for Body→Request mapping and HTTP status codes
-- `frontend/src/api/generated/api-client.ts` — regenerated; generated class names updated from `*Request` to `*Body`, JSON wire shapes unchanged
-
-## Status
-DONE_WITH_CONCERNS
-
-Concerns:
-1. `npm run lint` returns 161 pre-existing errors (same on `main`). Unrelated to this change, but technically violates the strict reading of FR-5.
-2. 3 Photobank integration tests fail due to Docker/Testcontainers not available in the local environment. Pre-existing, same on `main`. Not caused by this change.
+**Status: DONE_WITH_CONCERNS** — two pre-existing issues that pre-date this branch: 161 frontend lint errors (in test utilities) and 3 Docker/Testcontainers test failures (infrastructure, not code). Neither was introduced by this change.

--- a/artifacts/feat-arch-review-photobank-addrootrequest-add/impl/main.r1.md
+++ b/artifacts/feat-arch-review-photobank-addrootrequest-add/impl/main.r1.md
@@ -1,0 +1,72 @@
+# Implementation: Decouple Photobank MediatR Requests from HTTP Body DTOs
+
+## What was implemented
+
+Three slim `*Body` contract DTOs were added to the Photobank module's `Contracts/` directory, and `PhotobankController` was updated so that `AddRoot`, `AddRule`, and `RetagPhotos` bind `[FromBody]` to the new DTOs and map them to the existing MediatR `*Request` types via inline object initializers — matching the pattern already used by `AddPhotoTag`, `BulkAddPhotoTag`, `CreateTag`, and `BulkAddPhotoTagByIds`. Three controller-level xUnit tests were added to cover the field-by-field `Body → Request` mapping and verify action-specific HTTP status codes. The OpenAPI TypeScript client was regenerated; generated class names for the three endpoints changed from `*Request` to `*Body` but JSON wire shapes are byte-for-byte identical.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootBody.cs` — new plain class DTO with `SharePointPath`, `DisplayName`, `DriveId`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleBody.cs` — new plain class DTO with `PathPattern`, `TagName`, `SortOrder`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RetagPhotosBody.cs` — new plain class DTO with `PhotoIds` (default `Array.Empty<int>()`), `ClearExistingAiTags`
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — three actions updated: `AddRoot` (lines 233–241), `AddRule` (lines 281–289), `RetagPhotos` (lines 203–209)
+- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs` — new test class with three tests
+- `frontend/src/api/generated/api-client.ts` — regenerated (21 insertions, 21 deletions — class renames only)
+
+## Tests
+
+`backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs`:
+- `AddRoot_MapsBodyToRequest_AndReturnsCreated` — verifies all 3 fields copied, action returns `CreatedAtActionResult` pointing to `GetRoots`
+- `AddRule_MapsBodyToRequest_AndReturnsCreated` — verifies all 3 fields copied, action returns `CreatedAtActionResult` pointing to `GetRules`
+- `RetagPhotos_MapsBodyToRequest_AndReturnsAccepted` — verifies both fields copied, action returns `AcceptedResult` (202)
+
+All 3 pass. Full Photobank suite: 158 passed, 3 failed (pre-existing Docker/Testcontainers env failures in `PhotobankRepositoryGetTagsSqlShapeTests` — same count on `main`). Full backend suite: 5003 passed, 56 failed (all Docker/Testcontainers, pre-existing).
+
+## How to verify
+
+```bash
+# Run new body-mapping tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~PhotobankControllerBodyMappingTests"
+# Expected: 3 passed
+
+# Run full Photobank suite
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Features.Photobank"
+# Expected: all previously-passing tests still pass
+
+# Verify formatting
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+# Expected: exit 0
+
+# Verify UpdateRule not touched
+git diff main -- backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs \
+  | grep -E "UpdateRule|UpdateRuleRequest" | head
+# Expected: no output
+```
+
+## Notes
+
+- `npm run lint` returns 161 errors on the frontend — all pre-existing (same count on `main`), located in test utilities, entirely unrelated to the Body DTO changes. `npm run build` compiles cleanly.
+- `AddRoot` and `AddRule` preserve `CreatedAtAction(nameof(GetRoots/GetRules), response)` on success (201). `RetagPhotos` preserves `Accepted(result) : BadRequest(result)` (202/400). None were regressed to `Ok()`.
+- `UpdateRule` (line 299) has the same coupling pattern but is explicitly out of scope per spec; it was not touched.
+- The frontend (`usePhotobank.ts`, `usePhotobankSettings.ts`) calls these endpoints via raw `apiPost` with inline JSON — no call sites reference generated class names, so no frontend code required manual updates.
+
+## PR Summary
+
+Decoupled three `PhotobankController` actions (`AddRoot`, `AddRule`, `RetagPhotos`) from directly binding the MediatR request types by introducing slim `*Body` DTOs in `Contracts/` and mapping them to the existing `*Request` types inside the controller. This closes a latent security exposure (future server-populated fields on `*Request` can't be spoofed from the client), aligns the endpoints with the project's established contract pattern, and matches the four endpoints in the same controller that already follow the convention.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootBody.cs` — new DTO mirroring client-supplied fields of `AddRootRequest`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleBody.cs` — new DTO mirroring client-supplied fields of `AddRuleRequest`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RetagPhotosBody.cs` — new DTO mirroring client-supplied fields of `RetagPhotosRequest`
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — three actions updated to use Body types with inline object-initializer mapping
+- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs` — new controller-level tests for Body→Request mapping and HTTP status codes
+- `frontend/src/api/generated/api-client.ts` — regenerated; generated class names updated from `*Request` to `*Body`, JSON wire shapes unchanged
+
+## Status
+DONE_WITH_CONCERNS
+
+Concerns:
+1. `npm run lint` returns 161 pre-existing errors (same on `main`). Unrelated to this change, but technically violates the strict reading of FR-5.
+2. 3 Photobank integration tests fail due to Docker/Testcontainers not available in the local environment. Pre-existing, same on `main`. Not caused by this change.

--- a/artifacts/feat-arch-review-photobank-addrootrequest-add/spec.r1.md
+++ b/artifacts/feat-arch-review-photobank-addrootrequest-add/spec.r1.md
@@ -1,0 +1,161 @@
+# Specification: Decouple Photobank MediatR Requests from HTTP Body DTOs
+
+## Summary
+Three `PhotobankController` actions (`AddRoot`, `AddRule`, `RetagPhotos`) bind incoming HTTP bodies directly to MediatR request types living under `UseCases/`, breaking the module's established `contracts/` pattern. This work introduces slim `*Body` DTOs in `contracts/` for each endpoint, maps them to the corresponding MediatR requests in the controller, and aligns the three endpoints with the four endpoints in the same controller that already follow the convention.
+
+## Background
+The Photobank module follows the project-wide rule from `docs/architecture/development_guidelines.md`: *"DTO objects for API (Request, Response) live in `contracts/` of the specific module."* The intent is to keep the public HTTP surface decoupled from internal application contracts so that:
+
+- Server-controlled fields (e.g. `CreatedByUserId` populated by the handler) cannot be spoofed from the client because they never appear on the HTTP body DTO.
+- OpenAPI schema and the auto-generated TypeScript client describe only what the API actually accepts.
+- Changes to handler-internal state do not silently reshape the public API contract.
+
+Four endpoints in `PhotobankController` already follow the pattern correctly (`AddPhotoTagBody → AddPhotoTagRequest`, `BulkAddPhotoTagBody → BulkAddPhotoTagRequest`, `CreateTagBody → CreateTagRequest`, `BulkAddPhotoTagByIdsBody → BulkAddPhotoTagByIdsRequest`). The three offending endpoints were filed by the daily arch-review routine on 2026-06-14:
+
+| Controller action | `[FromBody]` type used | Where it lives |
+|---|---|---|
+| `AddRoot` (line 233) | `AddRootRequest` | `UseCases/AddRoot/AddRootRequest.cs` |
+| `AddRule` (line 281) | `AddRuleRequest` | `UseCases/AddRule/AddRuleRequest.cs` |
+| `RetagPhotos` (line 203) | `RetagPhotosRequest` | `UseCases/RetagPhotos/RetagPhotosRequest.cs` |
+
+## Functional Requirements
+
+### FR-1: Introduce `AddRootBody` contract DTO
+Add a class `AddRootBody` under the Photobank module's `contracts/` directory that mirrors only the client-supplied fields of `AddRootRequest`. The class must be a plain C# class (not a record) per the project DTO rule, and properties must match the existing JSON shape consumed by the frontend.
+
+**Acceptance criteria:**
+- File `contracts/AddRootBody.cs` exists in the Photobank module under the same namespace pattern used by existing `*Body` DTOs in the module.
+- `AddRootBody` is a class (not a record).
+- Property names, types, nullability, and default values match the JSON wire shape currently produced by `AddRootRequest` for client-bound fields (`SharePointPath`, `DisplayName`, `DriveId`, plus any other client-facing field present today).
+- No server-populated fields (e.g. user identity, audit metadata) appear on `AddRootBody`.
+- The class compiles and is referenced by the controller (see FR-4).
+
+### FR-2: Introduce `AddRuleBody` contract DTO
+Add a class `AddRuleBody` under `contracts/` mirroring the client-supplied fields of `AddRuleRequest`.
+
+**Acceptance criteria:**
+- File `contracts/AddRuleBody.cs` exists in the Photobank module.
+- `AddRuleBody` is a class (not a record).
+- Property names, types, nullability, and default values match the JSON wire shape currently produced by `AddRuleRequest` for client-bound fields (`PathPattern`, `TagName`, `SortOrder`, plus any other client-facing field present today).
+- No server-populated fields appear on `AddRuleBody`.
+
+### FR-3: Introduce `RetagPhotosBody` contract DTO
+Add a class `RetagPhotosBody` under `contracts/` mirroring the client-supplied fields of `RetagPhotosRequest`.
+
+**Acceptance criteria:**
+- File `contracts/RetagPhotosBody.cs` exists in the Photobank module.
+- `RetagPhotosBody` is a class (not a record).
+- Property names, types, nullability, and default values match the JSON wire shape currently produced by `RetagPhotosRequest` for client-bound fields (`PhotoIds`, `ClearExistingAiTags`, plus any other client-facing field present today).
+- Array/collection defaults preserve the current wire behavior (e.g. `PhotoIds` defaults to an empty array, not null).
+- No server-populated fields appear on `RetagPhotosBody`.
+
+### FR-4: Update `PhotobankController` to map `Body` → `Request`
+Change the three controller actions to bind `[FromBody]` to the new `*Body` types and construct the MediatR `*Request` instance inside the action, matching the established pattern used by `AddPhotoTagBody → AddPhotoTagRequest` in the same file.
+
+**Acceptance criteria:**
+- `AddRoot` action signature uses `[FromBody] AddRootBody body` and sends a `new AddRootRequest { ... }` populated from `body` to `IMediator`.
+- `AddRule` action signature uses `[FromBody] AddRuleBody body` and sends a `new AddRuleRequest { ... }` populated from `body`.
+- `RetagPhotos` action signature uses `[FromBody] RetagPhotosBody body` and sends a `new RetagPhotosRequest { ... }` populated from `body`.
+- The mapping pattern (e.g. object initializer style, helper method, etc.) matches whatever pattern is already used by the four existing well-formed endpoints in the same controller for consistency.
+- No client-facing field on the existing requests is dropped during mapping — the wire contract stays identical.
+- HTTP route, verb, status codes, response type, attribute filters (auth, model validation, etc.), and action name remain unchanged.
+
+### FR-5: Regenerate API clients and verify wire compatibility
+The C# and TypeScript OpenAPI clients must be regenerated and the generated request schemas for the three endpoints must remain wire-compatible with what the frontend currently sends. The generated TypeScript types may legitimately change name (e.g. `AddRootRequest` → `AddRootBody`), but the JSON shape must not.
+
+**Acceptance criteria:**
+- `dotnet build` passes (which triggers the OpenAPI TypeScript client regeneration per project setup).
+- The regenerated OpenAPI schema for `/AddRoot`, `/AddRule`, and `/RetagPhotos` request bodies has the same property names, types, and required flags as before this change.
+- Any frontend call site that referenced the old generated type name is updated to use the new generated type name. No call site changes its payload contents.
+- `npm run build` and `npm run lint` pass in the frontend.
+
+### FR-6: Backend test coverage
+Existing tests covering the three endpoints continue to pass without modification of their input payloads. Where tests directly instantiate `AddRootRequest` / `AddRuleRequest` / `RetagPhotosRequest` to exercise the handler, they may stay unchanged because handlers still accept the same MediatR request types. Where tests exercise the HTTP layer (controller integration tests), they must use the new `*Body` types or raw JSON that matches the unchanged wire shape.
+
+**Acceptance criteria:**
+- All previously passing backend tests in the Photobank module remain green.
+- Controller-level tests for the three endpoints exist or are added so that the `Body → Request` mapping is covered (a single test per endpoint verifying field-by-field copy is sufficient).
+- `dotnet build` and `dotnet format` succeed.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. The change is a thin object-to-object copy in the controller layer. Allocation cost is negligible relative to the MediatR pipeline and downstream I/O. No new async work, no extra DB round-trips, no extra serialization.
+
+### NFR-2: Security
+The change closes a latent over-exposure risk by ensuring that any future server-populated field added to a MediatR request type cannot be set by a malicious client. Specifically:
+
+- No field on `AddRootBody`, `AddRuleBody`, or `RetagPhotosBody` may represent server-controlled state (identity, audit timestamps, derived authorization context, etc.).
+- The mapping in the controller must construct the MediatR request such that server-populated fields are set from the server context, not from the body.
+- No authentication, authorization, or model-validation behavior changes for these endpoints.
+
+### NFR-3: Backward compatibility
+The HTTP wire contract must not break. Existing frontend builds talking to a backend with this change must continue to function until the frontend is rebuilt against the regenerated client. Property names, types, nullability, and required flags in the request JSON schema must remain identical for all three endpoints.
+
+### NFR-4: Maintainability
+The three updated endpoints must visually match the existing well-formed endpoints in `PhotobankController` so the file presents one consistent pattern. Naming convention is `{ActionName}Body` for the contract DTO, matching the existing convention in the module.
+
+## Data Model
+No persistence changes. No database schema changes. No domain entity changes.
+
+New transient API contract types in the Photobank module:
+
+- `AddRootBody` — client-supplied fields for adding a Photobank root.
+- `AddRuleBody` — client-supplied fields for adding a tagging rule.
+- `RetagPhotosBody` — client-supplied fields for triggering a retag operation.
+
+Each is a plain C# class living under the Photobank module's `contracts/` directory, mapped 1:1 to the equivalent client-facing fields of the existing MediatR request under `UseCases/`. Existing MediatR request types (`AddRootRequest`, `AddRuleRequest`, `RetagPhotosRequest`) are retained in `UseCases/` and may freely gain server-populated fields in the future without leaking into the API.
+
+## API / Interface Design
+
+### Endpoints (unchanged routes, unchanged verbs, unchanged status codes)
+
+- `AddRoot` — request body shape unchanged on the wire; bound to `AddRootBody` internally; mapped to `AddRootRequest` before dispatch.
+- `AddRule` — request body shape unchanged on the wire; bound to `AddRuleBody` internally; mapped to `AddRuleRequest` before dispatch.
+- `RetagPhotos` — request body shape unchanged on the wire; bound to `RetagPhotosBody` internally; mapped to `RetagPhotosRequest` before dispatch.
+
+### Controller pattern (target)
+
+```csharp
+public async Task<IActionResult> AddRoot([FromBody] AddRootBody body, CancellationToken ct)
+{
+    var request = new AddRootRequest
+    {
+        SharePointPath = body.SharePointPath,
+        DisplayName = body.DisplayName,
+        DriveId = body.DriveId,
+    };
+    var result = await _mediator.Send(request, ct);
+    return Ok(result);
+}
+```
+
+The exact shape (method signature, return type, attributes) must mirror the existing well-formed endpoints (`AddPhotoTag`, `BulkAddPhotoTag`, `CreateTag`, `BulkAddPhotoTagByIds`) in the same controller.
+
+### Generated TypeScript client
+
+The auto-generated client will expose the new type names (`AddRootBody`, `AddRuleBody`, `RetagPhotosBody`) instead of the old MediatR request names. Frontend call sites that referenced the old names must be updated to the new names; payload contents are identical.
+
+## Dependencies
+
+- MediatR — already in use; no version change.
+- OpenAPI TypeScript client generator — already wired into the build; runs on `dotnet build`.
+- Existing `PhotobankController` and existing handlers for `AddRoot`, `AddRule`, `RetagPhotos` — modified only at the controller boundary; handlers untouched.
+
+No new external services, libraries, NuGet packages, or npm packages are introduced.
+
+## Out of Scope
+
+- Refactoring or renaming the existing MediatR request types under `UseCases/`. They keep their current names and locations.
+- Changing handler logic, validation rules, or business behavior of `AddRoot`, `AddRule`, or `RetagPhotos`.
+- Auditing the rest of the codebase for similar coupling outside the Photobank module. Other modules may have the same issue but are filed separately by the daily arch-review routine.
+- Adding new server-populated fields (e.g. `CreatedByUserId`) to the MediatR requests. This spec only enables that change to be made safely later.
+- Database, persistence, or domain entity changes.
+- UX, design, or layout changes in the frontend.
+- E2E test changes — the wire contract is unchanged, so existing E2E coverage applies as-is.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-photobank-addrootrequest-add/task-plan.r1.md
+++ b/artifacts/feat-arch-review-photobank-addrootrequest-add/task-plan.r1.md
@@ -1,0 +1,3 @@
+Plan saved to `artifacts/feat-arch-review-photobank-addrootrequest-add/plan.r1.md`.
+
+Summary: 5 tasks covering all spec FRs and the three arch-review amendments. Tasks 1–3 are one per endpoint (TDD: failing controller mapping test → new `*Body` DTO → controller rewire → green → commit), Task 4 regenerates and verifies the OpenAPI client + frontend build, Task 5 runs `dotnet format`, the full Photobank test suite, and a sanity check that `UpdateRule` was not touched. Every step shows full code or full commands. Per the pipeline note, skipping the execution handoff prompt.

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -231,9 +231,15 @@ namespace Anela.Heblo.API.Controllers
         [ProducesResponseType(typeof(AddRootResponse), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<ActionResult<AddRootResponse>> AddRoot(
-            [FromBody] AddRootRequest request,
+            [FromBody] AddRootBody body,
             CancellationToken cancellationToken = default)
         {
+            var request = new AddRootRequest
+            {
+                SharePointPath = body.SharePointPath,
+                DisplayName = body.DisplayName,
+                DriveId = body.DriveId,
+            };
             var response = await _mediator.Send(request, cancellationToken);
             if (response.Success)
                 return CreatedAtAction(nameof(GetRoots), response);

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -201,9 +201,14 @@ namespace Anela.Heblo.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<ActionResult<RetagPhotosResponse>> RetagPhotos(
-            [FromBody] RetagPhotosRequest request,
+            [FromBody] RetagPhotosBody body,
             CancellationToken cancellationToken = default)
         {
+            var request = new RetagPhotosRequest
+            {
+                PhotoIds = body.PhotoIds,
+                ClearExistingAiTags = body.ClearExistingAiTags,
+            };
             var result = await _mediator.Send(request, cancellationToken);
             return result.Success ? Accepted(result) : BadRequest(result);
         }

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -285,9 +285,15 @@ namespace Anela.Heblo.API.Controllers
         [ProducesResponseType(typeof(AddRuleResponse), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<ActionResult<AddRuleResponse>> AddRule(
-            [FromBody] AddRuleRequest request,
+            [FromBody] AddRuleBody body,
             CancellationToken cancellationToken = default)
         {
+            var request = new AddRuleRequest
+            {
+                PathPattern = body.PathPattern,
+                TagName = body.TagName,
+                SortOrder = body.SortOrder,
+            };
             var response = await _mediator.Send(request, cancellationToken);
             if (response.Success)
                 return CreatedAtAction(nameof(GetRules), response);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootBody.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddRootBody
+    {
+        public string SharePointPath { get; set; } = null!;
+        public string? DisplayName { get; set; }
+        public string DriveId { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleBody.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddRuleBody
+    {
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public int SortOrder { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RetagPhotosBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RetagPhotosBody.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class RetagPhotosBody
+    {
+        public int[] PhotoIds { get; set; } = Array.Empty<int>();
+        public bool ClearExistingAiTags { get; set; }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.API.Controllers;
 using Anela.Heblo.Application.Features.Photobank.Contracts;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
+using Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
 using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Http;
@@ -101,5 +102,34 @@ public sealed class PhotobankControllerBodyMappingTests
         created.ActionName.Should().Be(nameof(PhotobankController.GetRules));
         var payload = created.Value.Should().BeOfType<AddRuleResponse>().Subject;
         payload.Id.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task RetagPhotos_MapsBodyToRequest_AndReturnsAccepted()
+    {
+        // Arrange
+        var body = new RetagPhotosBody
+        {
+            PhotoIds = new[] { 11, 22, 33 },
+            ClearExistingAiTags = true,
+        };
+
+        RetagPhotosRequest? captured = null;
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<RetagPhotosRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<RetagPhotosResponse>, CancellationToken>((req, _) => captured = (RetagPhotosRequest)req)
+            .ReturnsAsync(new RetagPhotosResponse { JobId = "job-abc", Success = true });
+
+        // Act
+        var result = await _controller.RetagPhotos(body, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.PhotoIds.Should().BeEquivalentTo(body.PhotoIds);
+        captured.ClearExistingAiTags.Should().Be(body.ClearExistingAiTags);
+
+        var accepted = result.Result.Should().BeOfType<AcceptedResult>().Subject;
+        var payload = accepted.Value.Should().BeOfType<RetagPhotosResponse>().Subject;
+        payload.JobId.Should().Be("job-abc");
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs
@@ -1,0 +1,72 @@
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public sealed class PhotobankControllerBodyMappingTests
+{
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly PhotobankController _controller;
+
+    public PhotobankControllerBodyMappingTests()
+    {
+        _controller = new PhotobankController(_mediatorMock.Object);
+        SetupHttpContext();
+    }
+
+    private void SetupHttpContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.NameIdentifier, "test-user") })),
+            RequestServices = services.BuildServiceProvider()
+        };
+
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+    }
+
+    [Fact]
+    public async Task AddRoot_MapsBodyToRequest_AndReturnsCreated()
+    {
+        // Arrange
+        var body = new AddRootBody
+        {
+            SharePointPath = "/sites/marketing/photos",
+            DisplayName = "Marketing photos",
+            DriveId = "drive-abc-123",
+        };
+
+        AddRootRequest? captured = null;
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<AddRootRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<AddRootResponse>, CancellationToken>((req, _) => captured = (AddRootRequest)req)
+            .ReturnsAsync(new AddRootResponse { Id = 42, Success = true });
+
+        // Act
+        var result = await _controller.AddRoot(body, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.SharePointPath.Should().Be(body.SharePointPath);
+        captured.DisplayName.Should().Be(body.DisplayName);
+        captured.DriveId.Should().Be(body.DriveId);
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        created.ActionName.Should().Be(nameof(PhotobankController.GetRoots));
+        var payload = created.Value.Should().BeOfType<AddRootResponse>().Subject;
+        payload.Id.Should().Be(42);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerBodyMappingTests.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.API.Controllers;
 using Anela.Heblo.Application.Features.Photobank.Contracts;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
+using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
 using FluentAssertions;
 using MediatR;
 using Microsoft.AspNetCore.Http;
@@ -68,5 +69,37 @@ public sealed class PhotobankControllerBodyMappingTests
         created.ActionName.Should().Be(nameof(PhotobankController.GetRoots));
         var payload = created.Value.Should().BeOfType<AddRootResponse>().Subject;
         payload.Id.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task AddRule_MapsBodyToRequest_AndReturnsCreated()
+    {
+        // Arrange
+        var body = new AddRuleBody
+        {
+            PathPattern = "/sites/marketing/2026/**",
+            TagName = "marketing-2026",
+            SortOrder = 5,
+        };
+
+        AddRuleRequest? captured = null;
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<AddRuleRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<AddRuleResponse>, CancellationToken>((req, _) => captured = (AddRuleRequest)req)
+            .ReturnsAsync(new AddRuleResponse { Id = 7, Success = true });
+
+        // Act
+        var result = await _controller.AddRule(body, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.PathPattern.Should().Be(body.PathPattern);
+        captured.TagName.Should().Be(body.TagName);
+        captured.SortOrder.Should().Be(body.SortOrder);
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        created.ActionName.Should().Be(nameof(PhotobankController.GetRules));
+        var payload = created.Value.Should().BeOfType<AddRuleResponse>().Subject;
+        payload.Id.Should().Be(7);
     }
 }

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -9918,11 +9918,11 @@ export class ApiClient {
         return Promise.resolve<BulkAddPhotoTagByIdsResponse>(null as any);
     }
 
-    photobank_RetagPhotos(request: RetagPhotosRequest): Promise<RetagPhotosResponse> {
+    photobank_RetagPhotos(body: RetagPhotosBody): Promise<RetagPhotosResponse> {
         let url_ = this.baseUrl + "/api/photobank/photos/auto-tag";
         url_ = url_.replace(/[?&]$/, "");
 
-        const content_ = JSON.stringify(request);
+        const content_ = JSON.stringify(body);
 
         let options_: RequestInit = {
             body: content_,
@@ -10011,11 +10011,11 @@ export class ApiClient {
         return Promise.resolve<GetRootsResponse>(null as any);
     }
 
-    photobank_AddRoot(request: AddRootRequest): Promise<AddRootResponse> {
+    photobank_AddRoot(body: AddRootBody): Promise<AddRootResponse> {
         let url_ = this.baseUrl + "/api/photobank/settings/roots";
         url_ = url_.replace(/[?&]$/, "");
 
-        const content_ = JSON.stringify(request);
+        const content_ = JSON.stringify(body);
 
         let options_: RequestInit = {
             body: content_,
@@ -10148,11 +10148,11 @@ export class ApiClient {
         return Promise.resolve<GetRulesResponse>(null as any);
     }
 
-    photobank_AddRule(request: AddRuleRequest): Promise<AddRuleResponse> {
+    photobank_AddRule(body: AddRuleBody): Promise<AddRuleResponse> {
         let url_ = this.baseUrl + "/api/photobank/settings/rules";
         url_ = url_.replace(/[?&]$/, "");
 
-        const content_ = JSON.stringify(request);
+        const content_ = JSON.stringify(body);
 
         let options_: RequestInit = {
             body: content_,
@@ -34939,11 +34939,11 @@ export interface IRetagPhotosResponse extends IBaseResponse {
     jobId?: string | undefined;
 }
 
-export class RetagPhotosRequest implements IRetagPhotosRequest {
+export class RetagPhotosBody implements IRetagPhotosBody {
     photoIds?: number[];
     clearExistingAiTags?: boolean;
 
-    constructor(data?: IRetagPhotosRequest) {
+    constructor(data?: IRetagPhotosBody) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -34963,9 +34963,9 @@ export class RetagPhotosRequest implements IRetagPhotosRequest {
         }
     }
 
-    static fromJS(data: any): RetagPhotosRequest {
+    static fromJS(data: any): RetagPhotosBody {
         data = typeof data === 'object' ? data : {};
-        let result = new RetagPhotosRequest();
+        let result = new RetagPhotosBody();
         result.init(data);
         return result;
     }
@@ -34982,7 +34982,7 @@ export class RetagPhotosRequest implements IRetagPhotosRequest {
     }
 }
 
-export interface IRetagPhotosRequest {
+export interface IRetagPhotosBody {
     photoIds?: number[];
     clearExistingAiTags?: boolean;
 }
@@ -35125,12 +35125,12 @@ export interface IAddRootResponse extends IBaseResponse {
     id?: number;
 }
 
-export class AddRootRequest implements IAddRootRequest {
+export class AddRootBody implements IAddRootBody {
     sharePointPath?: string;
     displayName?: string | undefined;
     driveId?: string;
 
-    constructor(data?: IAddRootRequest) {
+    constructor(data?: IAddRootBody) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -35147,9 +35147,9 @@ export class AddRootRequest implements IAddRootRequest {
         }
     }
 
-    static fromJS(data: any): AddRootRequest {
+    static fromJS(data: any): AddRootBody {
         data = typeof data === 'object' ? data : {};
-        let result = new AddRootRequest();
+        let result = new AddRootBody();
         result.init(data);
         return result;
     }
@@ -35163,7 +35163,7 @@ export class AddRootRequest implements IAddRootRequest {
     }
 }
 
-export interface IAddRootRequest {
+export interface IAddRootBody {
     sharePointPath?: string;
     displayName?: string | undefined;
     driveId?: string;
@@ -35322,12 +35322,12 @@ export interface IAddRuleResponse extends IBaseResponse {
     id?: number;
 }
 
-export class AddRuleRequest implements IAddRuleRequest {
+export class AddRuleBody implements IAddRuleBody {
     pathPattern?: string;
     tagName?: string;
     sortOrder?: number;
 
-    constructor(data?: IAddRuleRequest) {
+    constructor(data?: IAddRuleBody) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -35344,9 +35344,9 @@ export class AddRuleRequest implements IAddRuleRequest {
         }
     }
 
-    static fromJS(data: any): AddRuleRequest {
+    static fromJS(data: any): AddRuleBody {
         data = typeof data === 'object' ? data : {};
-        let result = new AddRuleRequest();
+        let result = new AddRuleBody();
         result.init(data);
         return result;
     }
@@ -35360,7 +35360,7 @@ export class AddRuleRequest implements IAddRuleRequest {
     }
 }
 
-export interface IAddRuleRequest {
+export interface IAddRuleBody {
     pathPattern?: string;
     tagName?: string;
     sortOrder?: number;


### PR DESCRIPTION
Photobank

## Finding
Three MediatR request types are used directly as `[FromBody]` HTTP body types in `PhotobankController`, bypassing the module's own established `contracts/` pattern:

| Controller action | `[FromBody]` type used | Where it lives |
|---|---|---|
| `AddRoot` (line 233) | `AddRootRequest` | `UseCases/AddRoot/AddRootRequest.cs` |
| `AddRule` (line 281) | `AddRuleRequest` | `UseCases/AddRule/AddRuleRequest.cs` |
| `RetagPhotos` (line 203) | `RetagPhotosRequest` | `UseCases/RetagPhotos/RetagPhotosRequest.cs` |

The same module already applies the correct pattern for four other endpoints, where a thin `contracts/*Body.cs` type is mapped to the MediatR request in the controller:
- `AddPhotoTagBody` → `AddPhotoTagRequest`
- `BulkAddPhotoTagBody` → `BulkAddPhotoTagRequest`
- `CreateTagBody` → `CreateTagRequest`
- `BulkAddPhotoTagByIdsBody` → `BulkAddPhotoTagByIdsRequest`

## Why it matters
`development_guidelines.md` states: *"DTO objects for API (Request, Response) live in `contracts/` of the specific module."* When the MediatR request type is also the HTTP body type, the API contract is coupled to the application contract:
- Adding an internal server-side field to `AddRootRequest` (e.g. `CreatedByUserId` populated in the handler) immediately exposes it in the OpenAPI schema and the auto-generated TypeScript client — a potential spoofing hole if someone forgets to strip the body value.
- Changing what the handler needs changes the visible API contract, and vice versa.
- The three requests all live in `UseCases/` subdirectories, the wrong location per guidelines for API-facing DTOs.

## Suggested fix
For each affected endpoint, add a slim body DTO to `contracts/`:

```csharp
// contracts/AddRootBody.cs
public class AddRootBody
{
    public string SharePointPath { get; set; } = null!;
    public string? DisplayName { get; set; }
    public string DriveId { get; set; } = null!;
}

// contracts/AddRuleBody.cs
public class AddRuleBody
{
    public string PathPattern { get; set; } = null!;
    public string TagName { get; set; } = null!;
    public int SortOrder { get; set; }
}

// contracts/RetagPhotosBody.cs
public class RetagPhotosBody
{
    public int[] PhotoIds { get; set; } = Array.Empty<int>();
    public bool ClearExistingAiTags { get; set; }
}
```

Then update the controller actions to map `Body` → `Request`, matching the existing pattern in the same file.

---
_Filed by daily arch-review routine on 2026-06-14._

---

Closes #3071

### Tokens used
22331854
