### PR TITLE
feat: Unify PhotobankAutoTagJob enable/disable with IRecurringJobStatusChecker

### DIFF
--- a/artifacts/feat-arch-review-photobank-photobankautotagjo/arch-review.r1.md
+++ b/artifacts/feat-arch-review-photobank-photobankautotagjo/arch-review.r1.md
@@ -1,0 +1,165 @@
+Now I have enough context. Let me write the architecture review.
+
+# Architecture Review: Unify PhotobankAutoTagJob enable/disable with IRecurringJobStatusChecker
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+The proposal aligns cleanly with an existing, well-established pattern in the codebase. `IRecurringJobStatusChecker` is the canonical gating mechanism for `IRecurringJob` implementations (used today by `PhotobankIndexJob` and registered globally in `BackgroundJobsModule.cs:21`). The `RecurringJobConfiguration` table is already seeded at startup from `IRecurringJob` metadata via reflection (`AddRecurringJobs()` in `ServiceCollectionExtensions.cs:376`, then `app.SeedRecurringJobConfigurationsAsync()` in `Program.cs:158`), so `PhotobankAutoTagJob` will be discovered, seeded with `IsEnabled = DefaultIsEnabled = false`, and toggleable through the same UseCases (`UpdateRecurringJobStatusHandler`, `UpdateRecurringJobCronHandler`) that already drive `photobank-index`.
+
+Integration points are narrow: the job constructor, the first statement of `ExecuteAsync`, the options class, two `appsettings*.json` entries, and the test fixture. No new contracts, no API changes, no migration, no new DI registration.
+
+There is **one architectural risk that contradicts spec FR-3**, surfaced below in *Risks* and *Specification Amendments*: `RecurringJobStatusChecker.IsJobEnabledAsync` currently fails *open* (returns `true`) when no configuration row exists, instead of falling back to `DefaultIsEnabled`. The spec's "out of scope: refactoring `IRecurringJobStatusChecker`" clause conflicts with FR-3's "first-time resolution falls back to `DefaultIsEnabled` rather than defaulting to true." This must be resolved before implementation.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Hangfire scheduler (cron: 0 4 * * *, Europe/Prague)      │
+└──────────────────────┬───────────────────────────────────┘
+                       ▼
+┌──────────────────────────────────────────────────────────┐
+│ PhotobankAutoTagJob.ExecuteAsync                         │
+│   1. IRecurringJobStatusChecker.IsJobEnabledAsync ───┐   │
+│   2. (if enabled) load tags, page, batch, LLM, stamp │   │
+└──────────────────────────────────────────────────────┼───┘
+                                                       ▼
+┌──────────────────────────────────────────────────────────┐
+│ RecurringJobStatusChecker                                │
+│  → IRecurringJobConfigurationRepository.GetByJobNameAsync│
+└──────────────────────┬───────────────────────────────────┘
+                       ▼
+┌──────────────────────────────────────────────────────────┐
+│ ApplicationDbContext.RecurringJobConfigurations          │
+│ row "photobank-auto-tag" (seeded at startup, default off)│
+└──────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────┐
+│ Operator UI / API                                        │
+│  → UpdateRecurringJobStatusHandler (MediatR)             │
+│    flips IsEnabled, persists via repository              │
+└──────────────────────────────────────────────────────────┘
+
+Parallel ad-hoc path (unchanged, deliberately ungated):
+RetagPhotosHandler → IBackgroundWorker.Enqueue<PhotobankAutoTagJob>
+                  → PhotobankAutoTagJob.ExecuteForPhotosAsync
+```
+
+### Key Design Decisions
+
+#### Decision 1: Single source of truth for "is this job enabled?"
+**Options considered:**
+- (A) Add the status-checker gate *in addition to* `_options.Enabled` (belt-and-braces).
+- (B) Replace `_options.Enabled` with the status-checker gate; remove the option.
+
+**Chosen approach:** B (matches spec FR-1/FR-2).
+**Rationale:** Two flags would let the dashboard report a job as enabled while a stale config silently suppresses it — exactly the "metadata bypass" problem cited in the brief. The status-checker, backed by the `RecurringJobConfiguration` table seeded from `DefaultIsEnabled`, is already the canonical owner of this state across every other recurring job.
+
+#### Decision 2: Where to enforce default-disabled semantics
+**Options considered:**
+- (A) Rely solely on the existing seeding path (`SeedDefaultConfigurationsAsync` → row with `IsEnabled = false`) and accept that `RecurringJobStatusChecker`'s "missing config → return true" fallback remains in place.
+- (B) Tighten `RecurringJobStatusChecker` so a missing row consults `RecurringJobMetadata.DefaultIsEnabled` (requires the checker to know about jobs, or for callers to pass the default).
+- (C) Pass `Metadata.DefaultIsEnabled` from the job to the checker, e.g. `IsJobEnabledAsync(jobName, defaultIfMissing, ct)`.
+
+**Chosen approach:** **A is unsafe; C is the smallest correct change.** Implementers should add an optional `bool defaultIfMissing` parameter (default `true` for backwards-compat with `PhotobankIndexJob`) and pass `Metadata.DefaultIsEnabled` from `PhotobankAutoTagJob`.
+**Rationale:** Option A relies on seeding completing before the cron fires. Seeding is best-effort within the scope of a successful app boot, but if a row is ever absent (manual DB cleanup, a future test scenario, a partial migration), the checker returns `true` and the auto-tag job runs — producing LLM cost and tag writes against the operator's expectation. Option B would require either reading job metadata inside the checker (cross-cutting) or hard-coding defaults. Option C is one new parameter with a backwards-compatible default; `PhotobankIndexJob`'s call site does not need to change.
+
+#### Decision 3: Keep `ExecuteForPhotosAsync` ungated
+**Chosen approach:** Pass `IRecurringJobStatusChecker` to the constructor but do **not** call it from `ExecuteForPhotosAsync` (spec FR-5).
+**Rationale:** The ad-hoc path is operator-initiated through `RetagPhotosHandler` and represents an explicit "yes, run this now" decision. Coupling it to the recurring schedule's toggle would make targeted re-tagging impossible while the recurring run is paused — exactly the scenario the brief calls out as desirable.
+
+#### Decision 4: Treat the obsolete `Photobank:AutoTag:Enabled` key as silent dead config
+**Chosen approach:** Remove `Enabled` from `AutoTagOptions` and from `appsettings.json`. Do not add a deprecation warning. Mention removal in release notes (spec NFR-3).
+**Rationale:** .NET's options binder ignores unmapped properties; emitting a warning would require either a custom validator or a startup probe, both of which add code for a one-time migration. Acceptable for a solo-dev-plus-AI-review project.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Modifications confined to:
+
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs` — add ctor dep, replace gate.
+- `backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs` — remove `Enabled`.
+- `backend/src/Anela.Heblo.API/appsettings.json` — remove the `Photobank:AutoTag:Enabled` key (it is the only `appsettings*.json` carrying it — verified by `grep`).
+- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs` — note the spec's path (`.../Jobs/PhotobankAutoTagJobTests.cs`) is wrong; the file is at `.../Features/Photobank/PhotobankAutoTagJobTests.cs`.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs` and `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobStatusChecker.cs` — per Decision 2, add the optional `defaultIfMissing` parameter (see *Specification Amendments*).
+
+`PhotobankModule.AddPhotobankModule`'s `services.AddScoped<PhotobankAutoTagJob>()` registration stays as-is and is sufficient — the type is *also* auto-discovered by `AddRecurringJobs()` reflection, which is what makes it appear in `GetServices<IRecurringJob>()` for seeding and discovery.
+
+### Interfaces and Contracts
+
+```csharp
+// Domain (Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobStatusChecker.cs)
+public interface IRecurringJobStatusChecker
+{
+    Task<bool> IsJobEnabledAsync(
+        string jobName,
+        bool defaultIfMissing = true,          // ← new, defaults preserve existing callers
+        CancellationToken cancellationToken = default);
+}
+
+// PhotobankAutoTagJob ctor
+public PhotobankAutoTagJob(
+    IPhotobankRepository repo,
+    IChatClient chat,
+    IOptions<AutoTagOptions> options,
+    ILogger<PhotobankAutoTagJob> logger,
+    IPhotobankTagsCache cache,
+    IRecurringJobStatusChecker statusChecker);
+
+// PhotobankAutoTagJob.ExecuteAsync — first statement
+if (!await _statusChecker.IsJobEnabledAsync(
+        Metadata.JobName,
+        Metadata.DefaultIsEnabled,             // ← passes false for auto-tag
+        cancellationToken))
+{
+    _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+    return;
+}
+```
+
+`AutoTagOptions` becomes a pure tuning-knob class with `BatchSize`, `MaxPhotosPerRun`, `Model`, `MaxTagsPerPhoto`, and the `SectionName` constant. Per the project's "DTOs are classes, never records" rule and the existing style of the file, it stays a `sealed class` with `init` setters.
+
+### Data Flow
+
+**Scheduled run (cron fires at 04:00 Europe/Prague):**
+1. Hangfire invokes `PhotobankAutoTagJob.ExecuteAsync`.
+2. The job calls `IRecurringJobStatusChecker.IsJobEnabledAsync("photobank-auto-tag", defaultIfMissing: false, ct)`.
+3. Checker reads `RecurringJobConfigurations` row. Disabled (default) → log and return. Enabled → proceed.
+4. On the proceed path, existing behavior is unchanged: load vocabulary, page pending candidates, LLM call per batch, validate and stamp tags, persist.
+
+**Operator toggle:** `UpdateRecurringJobStatusHandler` flips `IsEnabled` on the row. Next cron firing observes the new value — no restart, no config edit.
+
+**Ad-hoc re-tag (operator-driven):** `RetagPhotosHandler` resolves candidates and enqueues `j => j.ExecuteForPhotosAsync(candidates, ct)` via `IBackgroundWorker`. The status-checker is **not** consulted. Runs even when the cron toggle is off.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `RecurringJobStatusChecker` fails open on missing config row, contradicting spec FR-3 default-disabled guarantee for auto-tag. | **HIGH** | Adopt Decision 2 / Option C: thread `Metadata.DefaultIsEnabled` through the checker. Without this, a startup-seeding failure or absent row would silently enable LLM calls. |
+| Stale `Photobank:AutoTag:Enabled` in environment-specific config (Azure App Service settings, Key Vault) is silently ignored. | LOW | NFR-3 already calls for release-note guidance. Optionally `grep` Key Vault (`az keyvault secret list --vault-name kv-heblo-stg --query "[?contains(name, 'AutoTag')]"`) before deploy. |
+| Tests still passing `Enabled = true/false` in `AutoTagOptions` ctor break the build because the property no longer exists. | MED | Mechanical fix per FR-4; compiler catches every site. Add the explicit `ExecuteForPhotosAsync` ungated test from FR-5. |
+| `PhotobankAutoTagJob` accidentally double-registered as both `IRecurringJob` (via reflection) and `PhotobankAutoTagJob` (explicit) — already true today, not introduced here. | LOW | Leave as-is; not on the critical path of this change. Worth noting in a follow-up cleanup. |
+| Discovery via `Assembly.Load("Anela.Heblo.Application").GetTypes()` would silently miss the job if it were ever moved to a different assembly. | LOW | Not affected by this change; flag for awareness only. |
+
+## Specification Amendments
+
+1. **FR-3 vs. Out-of-Scope conflict — must be resolved.** The spec simultaneously requires "first-time resolution falls back to `DefaultIsEnabled` rather than defaulting to `true`" (FR-3) and forbids "refactoring or generalizing `IRecurringJobStatusChecker`" (Out of Scope). The minimal touch — adding an optional `defaultIfMissing` parameter (default `true`) — is genuinely additive, preserves all existing callers, and is the smallest correct way to satisfy FR-3. Update Out-of-Scope to read: *"Refactoring the persistence schema or read path of `IRecurringJobStatusChecker`; an additive `defaultIfMissing` parameter on the interface is in scope and required by FR-3."*
+
+2. **FR-4 test file path is wrong.** Spec says `PhotobankAutoTagJobTests` lives somewhere implying a `Jobs/` subfolder. Actual location is `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs`. Update the spec accordingly.
+
+3. **FR-5 add concrete test name.** Recommend explicit test `ExecuteForPhotosAsync_RunsEvenWhenStatusCheckerReturnsFalse` to lock in the deliberate ungated behavior.
+
+4. **FR-6 wording slightly misleading.** `PhotobankAutoTagJob` is registered *both* explicitly in `PhotobankModule` (`AddScoped<PhotobankAutoTagJob>()`) *and* implicitly via `AddRecurringJobs()` reflection in `ServiceCollectionExtensions.cs`. The reflection-based registration is what makes it appear in `GetServices<IRecurringJob>()` for seeding and Hangfire discovery. The explicit one supports `IBackgroundWorker.Enqueue<PhotobankAutoTagJob>` from `RetagPhotosHandler`. Note this in FR-6 so it doesn't read as if one registration site is the whole story.
+
+## Prerequisites
+
+None beyond what already exists. Concretely:
+
+- `IRecurringJobStatusChecker` and `IRecurringJobConfigurationRepository` are registered in `BackgroundJobsModule`. ✓
+- `RecurringJobConfigurations` table and EF Core configuration exist (`RecurringJobConfigurationConfiguration.cs`). ✓
+- `SeedDefaultConfigurationsAsync` is wired into the app boot path (`Program.cs:158`) and will pick up `PhotobankAutoTagJob` automatically. ✓
+- No new migration. No new App Service / Key Vault settings.
+
+On deploy, the new `photobank-auto-tag` row will be inserted with `IsEnabled = false` on first start; operators must use the same dashboard/API used for `photobank-index` to enable it.

--- a/artifacts/feat-arch-review-photobank-photobankautotagjo/brief.md
+++ b/artifacts/feat-arch-review-photobank-photobankautotagjo/brief.md
@@ -1,0 +1,64 @@
+## Module
+Photobank
+
+## Finding
+The two recurring jobs in this module use different mechanisms to guard against running when disabled:
+
+**`PhotobankIndexJob.ExecuteAsync`** (line 38–42 in `PhotobankIndexJob.cs`):
+```csharp
+if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken))
+{
+    _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+    return;
+}
+```
+Uses `IRecurringJobStatusChecker` — a runtime-queryable mechanism (presumably backed by a database record), so operators can enable/disable the job without touching config or restarting the app.
+
+**`PhotobankAutoTagJob.ExecuteAsync`** (line 45–50 in `PhotobankAutoTagJob.cs`):
+```csharp
+if (!_options.Enabled)
+{
+    _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+    return;
+}
+```
+Uses `AutoTagOptions.Enabled` — read from `appsettings.json` at startup (`Photobank:AutoTag:Enabled`). Changing this requires editing config and restarting the application.
+
+`PhotobankAutoTagJob.Metadata.DefaultIsEnabled = false`, which means the job is off by default; but if someone ever wants to enable it via a Hangfire dashboard or admin UI (the same way they'd manage `PhotobankIndexJob`), they cannot — the `IRecurringJobStatusChecker` gate is simply absent.
+
+## Why it matters
+- Operational inconsistency: a user who can toggle `photobank-index` at runtime has no equivalent control over `photobank-auto-tag` — they would need a config change and app restart.
+- The `DefaultIsEnabled` on `Metadata` exists precisely so that the job framework can own the enabled/disabled state. Bypassing this with a static config option defeats the purpose.
+- If the auto-tag feature ever needs to be enabled temporarily (e.g., for a bulk re-tag run), the correct procedure is unclear and differs from every other job in the system.
+
+## Suggested fix
+Replace the `_options.Enabled` guard with `IRecurringJobStatusChecker`, exactly as `PhotobankIndexJob` does:
+
+```csharp
+// 1. Add to constructor
+private readonly IRecurringJobStatusChecker _statusChecker;
+
+public PhotobankAutoTagJob(
+    IPhotobankRepository repo,
+    IChatClient chat,
+    IOptions<AutoTagOptions> options,
+    ILogger<PhotobankAutoTagJob> logger,
+    IPhotobankTagsCache cache,
+    IRecurringJobStatusChecker statusChecker)   // add
+{
+    ...
+    _statusChecker = statusChecker;
+}
+
+// 2. In ExecuteAsync, replace the Enabled check:
+if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken))
+{
+    _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+    return;
+}
+```
+
+The `AutoTagOptions.Enabled` field can be removed once the check is unified. `DefaultIsEnabled = false` on the metadata already ensures the job starts disabled.
+
+---
+_Filed by daily arch-review routine on 2026-06-14._

--- a/artifacts/feat-arch-review-photobank-photobankautotagjo/impl/main.r1.md
+++ b/artifacts/feat-arch-review-photobank-photobankautotagjo/impl/main.r1.md
@@ -1,0 +1,14 @@
+Tests: 169 pass, 3 fail — but the 3 failures are Docker/Testcontainers infrastructure (no Docker available), confirmed pre-existing. All relevant Photobank and BackgroundJobs tests pass.
+
+Environment: named branch in a standalone repo, base is `main`.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-photobank-photobankautotagjo/spec.r1.md
+++ b/artifacts/feat-arch-review-photobank-photobankautotagjo/spec.r1.md
@@ -1,0 +1,153 @@
+# Specification: Unify PhotobankAutoTagJob enable/disable with IRecurringJobStatusChecker
+
+## Summary
+Replace the static `AutoTagOptions.Enabled` configuration flag on `PhotobankAutoTagJob` with a runtime check via `IRecurringJobStatusChecker`, mirroring the gating mechanism already used by `PhotobankIndexJob`. This unifies how operators enable and disable recurring jobs across the Photobank module and removes the need for an app restart to toggle auto-tagging.
+
+## Background
+The Photobank module hosts two recurring jobs registered through the `IRecurringJob` abstraction with `RecurringJobMetadata`:
+
+- `PhotobankIndexJob` (`backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs`) — guarded by `IRecurringJobStatusChecker.IsJobEnabledAsync(...)` (runtime, dashboard-toggleable).
+- `PhotobankAutoTagJob` (`backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs`) — guarded by `_options.Enabled` from `AutoTagOptions` (`Photobank:AutoTag:Enabled` in `appsettings.json`, requires restart to change).
+
+This asymmetry has three concrete problems:
+
+1. **Operational inconsistency.** An operator who can toggle `photobank-index` from the Hangfire dashboard or admin UI has no equivalent control over `photobank-auto-tag`. Toggling auto-tag requires a config change and full application restart.
+2. **Metadata bypass.** `RecurringJobMetadata.DefaultIsEnabled` (set to `false` for the auto-tag job) exists so the recurring-job framework owns the enabled/disabled state. Reading a parallel `Enabled` flag from config defeats the metadata contract and risks conflicting state between the two sources of truth.
+3. **Unclear runbook for temporary enabling.** If the team needs to run auto-tag temporarily (e.g., a bulk re-tag run after a vocabulary change), the procedure differs from every other recurring job in the system.
+
+The remaining fields on `AutoTagOptions` (`BatchSize`, `MaxPhotosPerRun`, `Model`, `MaxTagsPerPhoto`) are genuine tuning knobs and stay as options. Only the `Enabled` field is being relocated.
+
+## Functional Requirements
+
+### FR-1: Replace Enabled guard with runtime status check
+`PhotobankAutoTagJob.ExecuteAsync` must consult `IRecurringJobStatusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken)` instead of `_options.Enabled` to determine whether to run.
+
+**Acceptance criteria:**
+- `PhotobankAutoTagJob` accepts `IRecurringJobStatusChecker` as a constructor dependency.
+- The first statement in `ExecuteAsync` is the status-checker gate that logs `"Job {JobName} is disabled. Skipping."` and returns early when the checker returns `false`. The log message and shape mirror `PhotobankIndexJob` exactly.
+- When the checker returns `true`, `ExecuteAsync` proceeds to load tags, page through pending photos, and process batches as it does today.
+- The reference to `_options.Enabled` is removed from `ExecuteAsync`.
+
+### FR-2: Remove the Enabled field from AutoTagOptions
+`AutoTagOptions.Enabled` must be removed from the options class because the job framework — via `IRecurringJobStatusChecker` seeded from `RecurringJobMetadata.DefaultIsEnabled = false` — now owns enabled/disabled state.
+
+**Acceptance criteria:**
+- `Enabled` is removed from `backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs`.
+- The remaining fields (`BatchSize`, `MaxPhotosPerRun`, `Model`, `MaxTagsPerPhoto`) and the `SectionName` constant are unchanged.
+- All `appsettings*.json` files in the repository drop the `Photobank:AutoTag:Enabled` key. Configuration sources outside the repo (e.g., Azure App Service settings, Key Vault) are surveyed; the brief contains no evidence the key was set there, but any stale value would simply be ignored after this change — no migration required.
+- A solution-wide search confirms no remaining references to `AutoTagOptions.Enabled` in production code or tests.
+
+### FR-3: Preserve default-disabled behavior
+The auto-tag job must remain disabled by default after deployment, so existing environments do not silently start running LLM calls.
+
+**Acceptance criteria:**
+- `RecurringJobMetadata.DefaultIsEnabled = false` is retained on `PhotobankAutoTagJob.Metadata` (no change).
+- On a freshly seeded environment, the status checker returns `false` for job name `"photobank-auto-tag"` until an operator explicitly enables it through the same mechanism used for other recurring jobs.
+- Existing environments where the job has not been explicitly toggled in the recurring-job status store also evaluate to disabled (i.e., the seeding logic for previously unknown jobs defers to `DefaultIsEnabled`). If `RecurringJobStatusChecker` does not already seed records from metadata on startup, the implementation must ensure first-time resolution falls back to `DefaultIsEnabled` rather than throwing or defaulting to `true`.
+
+### FR-4: Update unit tests to match the new gating mechanism
+`PhotobankAutoTagJobTests` currently constructs the job with five dependencies and asserts disabled behavior by passing `AutoTagOptions { Enabled = false }`. The tests must be updated for the new constructor signature and gating.
+
+**Acceptance criteria:**
+- The `CreateJob` test helper takes an additional `IRecurringJobStatusChecker` mock (default returns `true` so existing happy-path tests remain meaningful) and passes it to the constructor.
+- `ExecuteAsync_WhenDisabled_DoesNotCallLlmOrRepository` is updated so the status-checker mock returns `false`; it must still assert that neither `IChatClient.GetResponseAsync` nor `IPhotobankRepository.GetTagsWithCountsAsync` is invoked.
+- `AutoTagOptions` instances built in tests omit the `Enabled` field (since it no longer exists) and continue to populate `BatchSize`, `MaxPhotosPerRun`, `Model`, and `MaxTagsPerPhoto` as before.
+- All existing tests in `PhotobankAutoTagJobTests` pass without behavioral regressions; the four scenarios (`WhenDisabled`, `WhenNoPendingPhotos`, `StampsAllPhotosInBatch_EvenWhenLlmReturnsEmptyTags`, `RespectsMaxTagsPerPhoto_Cap`, `AppliesValidTagsAndDropsHallucinations`) all stay green.
+
+### FR-5: Keep ExecuteForPhotosAsync ungated
+`PhotobankAutoTagJob` exposes a secondary entrypoint `ExecuteForPhotosAsync(IReadOnlyList<PhotoAutoTagCandidate>, CancellationToken)` used by ad-hoc/use-case-driven re-tagging flows. This path is intentionally not subject to the recurring-job toggle.
+
+**Acceptance criteria:**
+- `ExecuteForPhotosAsync` does **not** call `IRecurringJobStatusChecker`. It continues to process the supplied candidates unconditionally so that operator-driven bulk re-tag use cases still function while the recurring schedule is paused.
+- This is verified by an explicit unit test: even when the status-checker mock returns `false`, `ExecuteForPhotosAsync` still invokes `IChatClient.GetResponseAsync` and stamps the supplied candidates.
+
+### FR-6: Wire up DI registration
+`PhotobankAutoTagJob` already resolves through DI. The change introduces a new dependency on `IRecurringJobStatusChecker`, which is already registered for `PhotobankIndexJob`.
+
+**Acceptance criteria:**
+- `PhotobankAutoTagJob` continues to be registered in `PhotobankModule.AddPhotobankModule` (`services.AddScoped<PhotobankAutoTagJob>()` line unchanged).
+- No additional registration of `IRecurringJobStatusChecker` is needed in the Photobank module — it is registered globally by the background-jobs infrastructure. A startup smoke test (or `dotnet build` followed by container start) confirms the job resolves with all six dependencies wired.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Runtime status check adds a single call to `IRecurringJobStatusChecker.IsJobEnabledAsync` per scheduled run (once per cron firing, at 04:00 Europe/Prague). This is the same pattern `PhotobankIndexJob` uses and has no measurable impact on job execution time. There is no per-batch overhead.
+
+### NFR-2: Security
+No new attack surface. Disabling the job via the existing recurring-job status mechanism is gated by the same admin/operator controls already used for `PhotobankIndexJob`. No new secrets, endpoints, or external dependencies are introduced.
+
+### NFR-3: Backwards compatibility
+- **Config drift:** Existing deployments may still have `Photobank:AutoTag:Enabled` set in `appsettings.*.json` or environment overrides. After this change the value is silently ignored because the binding target no longer exists. The release notes for this change should explicitly call out that the key can be deleted from environment-specific configuration. No runtime warning is emitted; .NET's options binder ignores unmapped JSON properties.
+- **Operational equivalence:** Operators currently toggling auto-tag via config + restart must learn to toggle it via the same UI/dashboard used for `photobank-index`. Because the job has been default-disabled in production this far, no live runs are interrupted by the cut-over.
+
+### NFR-4: Observability
+The log line emitted on the disabled path keeps the same template and structured property name (`{JobName}`) as `PhotobankIndexJob`, so existing log queries and dashboards keyed on `"Job {JobName} is disabled. Skipping."` continue to work for both jobs.
+
+## Data Model
+No schema changes. The recurring-job status store that backs `IRecurringJobStatusChecker` already supports both jobs:
+
+- The store is keyed by `RecurringJobMetadata.JobName` (`"photobank-auto-tag"`, `"photobank-index"`).
+- On first observation of a job name, the seeding logic must respect `DefaultIsEnabled` from metadata (per FR-3).
+
+The `AutoTagOptions` configuration shape changes by one field — removing `Enabled` — which is a code-level change, not a data change.
+
+## API / Interface Design
+No HTTP API changes. No new MediatR requests/responses. No new endpoints.
+
+The internal interface affected is `PhotobankAutoTagJob`'s constructor:
+
+```csharp
+public PhotobankAutoTagJob(
+    IPhotobankRepository repo,
+    IChatClient chat,
+    IOptions<AutoTagOptions> options,
+    ILogger<PhotobankAutoTagJob> logger,
+    IPhotobankTagsCache cache,
+    IRecurringJobStatusChecker statusChecker); // new
+```
+
+And the body of `ExecuteAsync`:
+
+```csharp
+public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+{
+    if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken))
+    {
+        _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+        return;
+    }
+
+    // existing logic unchanged from here
+}
+```
+
+`AutoTagOptions` becomes:
+
+```csharp
+public sealed class AutoTagOptions
+{
+    public const string SectionName = "Photobank:AutoTag";
+
+    public int BatchSize { get; init; } = 50;
+    public int MaxPhotosPerRun { get; init; } = 5_000;
+    public string Model { get; init; } = "claude-haiku-4-5-20251001";
+    public int MaxTagsPerPhoto { get; init; } = 5;
+}
+```
+
+## Dependencies
+- **Existing:** `IRecurringJobStatusChecker` and its concrete implementation (`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs`) are already in the codebase and DI graph.
+- **Existing:** `RecurringJobMetadata.DefaultIsEnabled` semantics — relied on for seeding new job records as disabled.
+- **No new libraries, NuGet packages, or services.**
+
+## Out of Scope
+- Refactoring or generalizing `RecurringJobMetadata` or `IRecurringJobStatusChecker`. The status-checker abstraction stays as-is; this change only adopts it from a second consumer.
+- Building or modifying the operator UI / Hangfire dashboard control to toggle the job. That mechanism is assumed to already exist for `photobank-index`; making it work for `photobank-auto-tag` is a free consequence of using the same checker.
+- Migrating other recurring jobs outside the Photobank module that may still use config-based enable flags. Those are tracked separately if and when discovered.
+- Changing the cron schedule (`0 4 * * *`), batch size, model, or other tuning knobs on the auto-tag job.
+- Adding a deprecation warning or runtime log when a stale `Photobank:AutoTag:Enabled` key is still present in configuration. The key is simply ignored.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-photobank-photobankautotagjo/task-plan.r1.md
+++ b/artifacts/feat-arch-review-photobank-photobankautotagjo/task-plan.r1.md
@@ -1,0 +1,11 @@
+Plan saved to `docs/superpowers/plans/2026-06-16-photobank-autotag-runtime-status-check.md`.
+
+**Self-review summary:**
+
+- **Spec coverage:** FR-1 (Task 3), FR-2 (Task 5), FR-3 (Tasks 1+2+3 thread `defaultIfMissing: Metadata.DefaultIsEnabled`), FR-4 (Task 3), FR-5 (Task 4), FR-6 (registration unchanged, confirmed in file map).
+- **Arch-review amendments:** all four addressed — the `defaultIfMissing` parameter is in scope (Tasks 1–2), the correct test file path is used throughout, the explicit `ExecuteForPhotosAsync_RunsEvenWhenStatusCheckerReturnsFalse` test name is in Task 4, and the DI-registration nuance is noted in the file map.
+- **Deliberate deviation from arch review:** parameter ordering placed `defaultIfMissing` *after* `cancellationToken` rather than between `jobName` and `cancellationToken`. The arch review's proposed ordering would silently break every existing positional caller (e.g. `IsJobEnabledAsync(name, ct)` would bind `ct` to `bool`). Documented at the top of the plan under "Self-Review Notes".
+- **No placeholders:** every step contains exact code, exact commands, and concrete expected output.
+- **Type consistency:** `IsJobEnabledAsync(string, CancellationToken, bool)` signature and the 6-arg `PhotobankAutoTagJob` constructor match across all tasks.
+
+Per the pipeline note, skipping the execution-handoff prompt.

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -174,7 +174,6 @@
   },
   "Photobank": {
     "AutoTag": {
-      "Enabled": false,
       "BatchSize": 50,
       "MaxPhotosPerRun": 5000,
       "Model": "claude-haiku-4-5-20251001",

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs
@@ -48,9 +48,10 @@ public class RecurringJobStatusChecker : IRecurringJobStatusChecker
         }
         catch (Exception ex)
         {
-            // Safety fallback - on error, use the caller-specified default to avoid blocking critical jobs
-            _logger.LogError(ex, "Error checking job enabled status for job: {JobName}. Returning default: {DefaultIfMissing}.", jobName, defaultIfMissing);
-            return defaultIfMissing;
+            // Safety fallback - on error, always allow job to run to avoid blocking critical jobs.
+            // Intentionally NOT gated by defaultIfMissing: a DB outage should not silently disable jobs.
+            _logger.LogError(ex, "Error checking job enabled status for job: {JobName}. Allowing job to run by default.", jobName);
+            return true;
         }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs
@@ -16,7 +16,10 @@ public class RecurringJobStatusChecker : IRecurringJobStatusChecker
         _logger = logger;
     }
 
-    public async Task<bool> IsJobEnabledAsync(string jobName, CancellationToken cancellationToken = default)
+    public async Task<bool> IsJobEnabledAsync(
+        string jobName,
+        CancellationToken cancellationToken = default,
+        bool defaultIfMissing = true)
     {
         try
         {
@@ -24,9 +27,16 @@ public class RecurringJobStatusChecker : IRecurringJobStatusChecker
 
             if (configuration == null)
             {
-                // Safety fallback - if configuration doesn't exist, allow job to run
-                _logger.LogWarning("Job configuration not found for job: {JobName}. Allowing job to run by default.", jobName);
-                return true;
+                // Return the caller-specified default when no configuration row exists
+                if (defaultIfMissing)
+                {
+                    _logger.LogWarning("Job configuration not found for job: {JobName}. Allowing job to run by default.", jobName);
+                }
+                else
+                {
+                    _logger.LogWarning("Job configuration not found for job: {JobName}. Disabling job by caller request.", jobName);
+                }
+                return defaultIfMissing;
             }
 
             if (!configuration.IsEnabled)
@@ -38,9 +48,9 @@ public class RecurringJobStatusChecker : IRecurringJobStatusChecker
         }
         catch (Exception ex)
         {
-            // Safety fallback - on error, allow job to run to avoid blocking critical jobs
-            _logger.LogError(ex, "Error checking job enabled status for job: {JobName}. Allowing job to run by default.", jobName);
-            return true;
+            // Safety fallback - on error, use the caller-specified default to avoid blocking critical jobs
+            _logger.LogError(ex, "Error checking job enabled status for job: {JobName}. Returning default: {DefaultIfMissing}.", jobName, defaultIfMissing);
+            return defaultIfMissing;
         }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs
@@ -4,7 +4,6 @@ public sealed class AutoTagOptions
 {
     public const string SectionName = "Photobank:AutoTag";
 
-    public bool Enabled { get; init; } = false;
     public int BatchSize { get; init; } = 50;
     public int MaxPhotosPerRun { get; init; } = 5_000;
     public string Model { get; init; } = "claude-haiku-4-5-20251001";

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
@@ -17,6 +17,7 @@ public class PhotobankAutoTagJob : IRecurringJob
     private readonly AutoTagOptions _options;
     private readonly ILogger<PhotobankAutoTagJob> _logger;
     private readonly IPhotobankTagsCache _cache;
+    private readonly IRecurringJobStatusChecker _statusChecker;
 
     public RecurringJobMetadata Metadata { get; } = new()
     {
@@ -32,18 +33,23 @@ public class PhotobankAutoTagJob : IRecurringJob
         IChatClient chat,
         IOptions<AutoTagOptions> options,
         ILogger<PhotobankAutoTagJob> logger,
-        IPhotobankTagsCache cache)
+        IPhotobankTagsCache cache,
+        IRecurringJobStatusChecker statusChecker)
     {
         _repo = repo;
         _chat = chat;
         _options = options.Value;
         _logger = logger;
         _cache = cache;
+        _statusChecker = statusChecker;
     }
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        if (!_options.Enabled)
+        if (!await _statusChecker.IsJobEnabledAsync(
+                Metadata.JobName,
+                cancellationToken,
+                defaultIfMissing: Metadata.DefaultIsEnabled))
         {
             _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
             return;

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
@@ -46,6 +46,7 @@ public class PhotobankAutoTagJob : IRecurringJob
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
+        // defaultIfMissing: false — LLM-cost job must stay off until an operator explicitly enables it in the DB.
         if (!await _statusChecker.IsJobEnabledAsync(
                 Metadata.JobName,
                 cancellationToken,

--- a/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobStatusChecker.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobStatusChecker.cs
@@ -2,5 +2,19 @@ namespace Anela.Heblo.Domain.Features.BackgroundJobs;
 
 public interface IRecurringJobStatusChecker
 {
-    Task<bool> IsJobEnabledAsync(string jobName, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Returns whether the recurring job named <paramref name="jobName"/> is enabled.
+    /// </summary>
+    /// <param name="jobName">Unique job identifier matching <see cref="RecurringJobMetadata.JobName"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="defaultIfMissing">
+    /// Value to return when no configuration row exists for the job.
+    /// Defaults to <c>true</c> to preserve historical fail-open behavior for existing callers.
+    /// Pass <see cref="RecurringJobMetadata.DefaultIsEnabled"/> for jobs that must default disabled
+    /// (e.g. LLM-cost-producing jobs) so an unseeded row does not silently enable them.
+    /// </param>
+    Task<bool> IsJobEnabledAsync(
+        string jobName,
+        CancellationToken cancellationToken = default,
+        bool defaultIfMissing = true);
 }

--- a/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsInvoiceImportJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsInvoiceImportJobTests.cs
@@ -21,7 +21,7 @@ public class GoogleAdsInvoiceImportJobTests
     [Fact]
     public async Task ExecuteAsync_JobDisabled_DoesNotDispatch()
     {
-        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true)).ReturnsAsync(false);
 
         await CreateJob().ExecuteAsync(default);
 
@@ -31,7 +31,7 @@ public class GoogleAdsInvoiceImportJobTests
     [Fact]
     public async Task ExecuteAsync_JobEnabled_DispatchesGoogleAdsRequestWithSevenDayWindow()
     {
-        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true)).ReturnsAsync(true);
         _mockMediator.Setup(m => m.Send(It.IsAny<ImportMarketingInvoicesRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ImportMarketingInvoicesResponse { Platform = "GoogleAds", Imported = 5 });
 
@@ -49,7 +49,7 @@ public class GoogleAdsInvoiceImportJobTests
     [Fact]
     public async Task ExecuteAsync_DispatchThrows_ExceptionIsRethrown()
     {
-        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true)).ReturnsAsync(true);
         _mockMediator.Setup(m => m.Send(It.IsAny<ImportMarketingInvoicesRequest>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Google API down"));
 

--- a/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsInvoiceImportJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsInvoiceImportJobTests.cs
@@ -21,7 +21,7 @@ public class MetaAdsInvoiceImportJobTests
     [Fact]
     public async Task ExecuteAsync_JobDisabled_DoesNotDispatch()
     {
-        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true)).ReturnsAsync(false);
         _mockMediator.Setup(m => m.Send(It.IsAny<ImportMarketingInvoicesRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ImportMarketingInvoicesResponse());
 
@@ -33,7 +33,7 @@ public class MetaAdsInvoiceImportJobTests
     [Fact]
     public async Task ExecuteAsync_JobEnabled_DispatchesMetaAdsRequestWithSevenDayWindow()
     {
-        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true)).ReturnsAsync(true);
         _mockMediator.Setup(m => m.Send(It.IsAny<ImportMarketingInvoicesRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ImportMarketingInvoicesResponse { Platform = "MetaAds", Imported = 3 });
 
@@ -51,7 +51,7 @@ public class MetaAdsInvoiceImportJobTests
     [Fact]
     public async Task ExecuteAsync_DispatchThrows_ExceptionIsRethrown()
     {
-        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _mockStatusChecker.Setup(c => c.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true)).ReturnsAsync(true);
         _mockMediator.Setup(m => m.Send(It.IsAny<ImportMarketingInvoicesRequest>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Meta API down"));
 

--- a/backend/test/Anela.Heblo.Tests/Adapters/Plaud/PlaudTokenRefreshJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/Plaud/PlaudTokenRefreshJobTests.cs
@@ -60,7 +60,7 @@ public sealed class PlaudTokenRefreshJobTests : IDisposable
         Skip.If(OperatingSystem.IsWindows(), "HOME override requires Unix");
 
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
 
         await RunWithTempHome(async () => await CreateJob().ExecuteAsync(default));
@@ -79,7 +79,7 @@ public sealed class PlaudTokenRefreshJobTests : IDisposable
         Skip.If(OperatingSystem.IsWindows(), "HOME override requires Unix");
 
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         // No tokens.json written — the directory exists but the file does not.
@@ -96,7 +96,7 @@ public sealed class PlaudTokenRefreshJobTests : IDisposable
         Skip.If(OperatingSystem.IsWindows(), "HOME override requires Unix");
 
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _refreshClient
             .Setup(r => r.RefreshAsync("old-refresh", It.IsAny<CancellationToken>()))
@@ -125,7 +125,7 @@ public sealed class PlaudTokenRefreshJobTests : IDisposable
         Skip.If(OperatingSystem.IsWindows(), "HOME override requires Unix");
 
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _refreshClient
             .Setup(r => r.RefreshAsync("old-refresh", It.IsAny<CancellationToken>()))
@@ -151,7 +151,7 @@ public sealed class PlaudTokenRefreshJobTests : IDisposable
         Skip.If(OperatingSystem.IsWindows(), "HOME override requires Unix");
 
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _refreshClient
             .Setup(r => r.RefreshAsync("old-refresh", It.IsAny<CancellationToken>()))
@@ -179,7 +179,7 @@ public sealed class PlaudTokenRefreshJobTests : IDisposable
         Skip.If(OperatingSystem.IsWindows(), "HOME override requires Unix");
 
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("plaud-token-refresh", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _refreshClient
             .Setup(r => r.RefreshAsync("old-refresh", It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs
@@ -39,6 +39,28 @@ public class RecurringJobStatusCheckerTests
     }
 
     [Fact]
+    public async Task IsJobEnabledAsync_ReturnsTrue_WhenRowExistsAndEnabled()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync("job-enabled", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RecurringJobConfiguration(
+                jobName: "job-enabled",
+                displayName: "Job Enabled",
+                description: "Test job",
+                cronExpression: "0 * * * *",
+                isEnabled: true,
+                lastModifiedBy: "test"));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync("job-enabled", CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task IsJobEnabledAsync_ReturnsTrue_WhenRowMissing_AndDefaultIfMissingIsTrue()
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs
@@ -1,0 +1,91 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+public class RecurringJobStatusCheckerTests
+{
+    private readonly Mock<IRecurringJobConfigurationRepository> _repo = new();
+
+    private RecurringJobStatusChecker CreateSut() =>
+        new(_repo.Object, NullLogger<RecurringJobStatusChecker>.Instance);
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsConfiguredValue_WhenRowExists()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync("job-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RecurringJobConfiguration(
+                jobName: "job-a",
+                displayName: "Job A",
+                description: "Test job",
+                cronExpression: "0 * * * *",
+                isEnabled: false,
+                lastModifiedBy: "test"));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync("job-a", CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsTrue_WhenRowMissing_AndDefaultIfMissingIsTrue()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RecurringJobConfiguration?)null);
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync("missing-job", CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsFalse_WhenRowMissing_AndDefaultIfMissingIsFalse()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RecurringJobConfiguration?)null);
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync(
+            "missing-job",
+            CancellationToken.None,
+            defaultIfMissing: false);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsTrue_WhenRepositoryThrows()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync("any-job", CancellationToken.None);
+
+        // Assert — error path stays fail-open to avoid blocking critical jobs
+        result.Should().BeTrue();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerIntegrationTests.cs
@@ -36,7 +36,7 @@ public class TriggerRecurringJobHandlerIntegrationTests
         var mockEnqueuerLogger = new Mock<ILogger<HangfireJobEnqueuer>>();
 
         mockStatusChecker
-            .Setup(x => x.IsJobEnabledAsync("test-async-job", It.IsAny<CancellationToken>()))
+            .Setup(x => x.IsJobEnabledAsync("test-async-job", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         var jobs = new List<IRecurringJob>
@@ -70,7 +70,7 @@ public class TriggerRecurringJobHandlerIntegrationTests
 
         // Verify status was checked
         mockStatusChecker.Verify(
-            x => x.IsJobEnabledAsync("test-async-job", It.IsAny<CancellationToken>()),
+            x => x.IsJobEnabledAsync("test-async-job", It.IsAny<CancellationToken>(), true),
             Times.Once);
     }
 
@@ -86,7 +86,7 @@ public class TriggerRecurringJobHandlerIntegrationTests
         var mockEnqueuerLogger = new Mock<ILogger<HangfireJobEnqueuer>>();
 
         mockStatusChecker
-            .Setup(x => x.IsJobEnabledAsync("async-test", It.IsAny<CancellationToken>()))
+            .Setup(x => x.IsJobEnabledAsync("async-test", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         var jobs = new List<IRecurringJob>
@@ -139,7 +139,7 @@ public class TriggerRecurringJobHandlerIntegrationTests
         var mockEnqueuerLogger = new Mock<ILogger<HangfireJobEnqueuer>>();
 
         mockStatusChecker
-            .Setup(x => x.IsJobEnabledAsync("disabled-job", It.IsAny<CancellationToken>()))
+            .Setup(x => x.IsJobEnabledAsync("disabled-job", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
 
         var jobs = new List<IRecurringJob>
@@ -173,7 +173,7 @@ public class TriggerRecurringJobHandlerIntegrationTests
 
         // Verify status check was skipped
         mockStatusChecker.Verify(
-            x => x.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            x => x.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true),
             Times.Never);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
@@ -64,7 +64,7 @@ public class TriggerRecurringJobHandlerTests
         // Arrange
         var statusChecker = new Mock<IRecurringJobStatusChecker>();
         statusChecker
-            .Setup(x => x.IsJobEnabledAsync("disabled-job", It.IsAny<CancellationToken>()))
+            .Setup(x => x.IsJobEnabledAsync("disabled-job", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
 
         var handler = CreateHandler(
@@ -88,7 +88,7 @@ public class TriggerRecurringJobHandlerTests
         // Arrange
         var statusChecker = new Mock<IRecurringJobStatusChecker>();
         statusChecker
-            .Setup(x => x.IsJobEnabledAsync("enabled-job", It.IsAny<CancellationToken>()))
+            .Setup(x => x.IsJobEnabledAsync("enabled-job", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         var enqueuer = new Mock<IHangfireJobEnqueuer>();

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/Infrastructure/Jobs/BankImportJobBaseTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/Infrastructure/Jobs/BankImportJobBaseTests.cs
@@ -25,7 +25,7 @@ public sealed class BankImportJobBaseTests
     {
         // Arrange
         _statusChecker
-            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>()))
+            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
         var job = CreateJob();
 
@@ -44,7 +44,7 @@ public sealed class BankImportJobBaseTests
     {
         // Arrange
         _statusChecker
-            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>()))
+            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         ImportBankStatementRequest? captured = null;
         _mediator
@@ -69,7 +69,7 @@ public sealed class BankImportJobBaseTests
     {
         // Arrange
         _statusChecker
-            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>()))
+            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _mediator
             .Setup(m => m.Send(It.IsAny<ImportBankStatementRequest>(), It.IsAny<CancellationToken>()))
@@ -90,7 +90,7 @@ public sealed class BankImportJobBaseTests
         using var cts = new CancellationTokenSource();
         var token = cts.Token;
         _statusChecker
-            .Setup(c => c.IsJobEnabledAsync(TestJobName, token))
+            .Setup(c => c.IsJobEnabledAsync(TestJobName, token, true))
             .ReturnsAsync(true);
         _mediator
             .Setup(m => m.Send(It.IsAny<ImportBankStatementRequest>(), token))
@@ -101,7 +101,7 @@ public sealed class BankImportJobBaseTests
         await job.ExecuteAsync(token);
 
         // Assert — overload with the exact token must have been called (any other token would not match)
-        _statusChecker.Verify(c => c.IsJobEnabledAsync(TestJobName, token), Times.Once);
+        _statusChecker.Verify(c => c.IsJobEnabledAsync(TestJobName, token, true), Times.Once);
         _mediator.Verify(
             m => m.Send(It.IsAny<ImportBankStatementRequest>(), token),
             Times.Once);
@@ -113,7 +113,7 @@ public sealed class BankImportJobBaseTests
         // Arrange
         var thrown = new InvalidOperationException("simulated handler failure");
         _statusChecker
-            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>()))
+            .Setup(c => c.IsJobEnabledAsync(TestJobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _mediator
             .Setup(m => m.Send(It.IsAny<ImportBankStatementRequest>(), It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/Jobs/ProductExportDownloadJobTests.cs
@@ -63,7 +63,7 @@ public sealed class ProductExportDownloadJobTests
     {
         var mock = new Mock<IRecurringJobStatusChecker>();
         mock
-            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         return mock;
     }
@@ -72,7 +72,7 @@ public sealed class ProductExportDownloadJobTests
     {
         var mock = new Mock<IRecurringJobStatusChecker>();
         mock
-            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
         return mock;
     }

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/InvoiceDqtJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/InvoiceDqtJobTests.cs
@@ -28,7 +28,7 @@ public class InvoiceDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         var calls = new List<string>();
@@ -70,7 +70,7 @@ public class InvoiceDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
 
         // Act
@@ -87,7 +87,7 @@ public class InvoiceDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _repositoryMock
             .Setup(r => r.AddAsync(It.IsAny<DqtRun>(), It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtJobTests.cs
@@ -28,7 +28,7 @@ public class ProductPairingDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         var calls = new List<string>();
@@ -69,7 +69,7 @@ public class ProductPairingDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
 
         // Act
@@ -86,7 +86,7 @@ public class ProductPairingDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _repositoryMock
             .Setup(r => r.AddAsync(It.IsAny<DqtRun>(), It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/StockWriteBackDqtJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/StockWriteBackDqtJobTests.cs
@@ -28,7 +28,7 @@ public class StockWriteBackDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         var calls = new List<string>();
@@ -69,7 +69,7 @@ public class StockWriteBackDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
 
         // Act
@@ -86,7 +86,7 @@ public class StockWriteBackDqtJobTests
     {
         // Arrange
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
         _repositoryMock
             .Setup(r => r.AddAsync(It.IsAny<DqtRun>(), It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
@@ -42,7 +42,7 @@ public class LeafletIngestionJobTests
         opts ??= DefaultLeafletOptions();
 
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("leaflet-ingestion", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("leaflet-ingestion", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         return new LeafletIngestionJob(
@@ -180,7 +180,7 @@ public class LeafletIngestionJobTests
     public async Task Execute_does_nothing_when_job_is_disabled()
     {
         _statusChecker
-            .Setup(s => s.IsJobEnabledAsync("leaflet-ingestion", It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync("leaflet-ingestion", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(false);
 
         var job = new LeafletIngestionJob(

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/FillTrackingNumbersJobTests.cs
@@ -21,7 +21,7 @@ public class FillTrackingNumbersJobTests
         var client = new Mock<IShipmentClient>();
         var statusChecker = new Mock<IRecurringJobStatusChecker>();
         statusChecker
-            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(jobEnabled);
         var logger = NullLogger<FillTrackingNumbersJob>.Instance;
         var sut = new FillTrackingNumbersJob(repo.Object, client.Object, statusChecker.Object, logger);

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
@@ -290,4 +290,65 @@ public class PhotobankAutoTagJobTests
             Times.Never);
         _repo.Verify(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
+
+    [Fact]
+    public async Task ExecuteForPhotosAsync_RunsEvenWhenStatusCheckerReturnsFalse()
+    {
+        // Arrange — recurring-schedule toggle is OFF, but ad-hoc retag must still run.
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(false);
+
+        var candidates = new List<PhotoAutoTagCandidate>
+        {
+            new(Id: 7, FolderPath: "/photos", FileName: "ad-hoc.jpg"),
+        };
+
+        _repo
+            .Setup(r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TagCount> { new(10, "kosmetika", 1) });
+
+        SetupChatResponse("""{"results":[{"id":7,"tags":["kosmetika"]}]}""");
+
+        _repo
+            .Setup(r => r.PhotoTagExistsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _repo
+            .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repo
+            .Setup(r => r.StampAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var job = CreateJob();
+
+        // Act
+        await job.ExecuteForPhotosAsync(candidates, CancellationToken.None);
+
+        // Assert — LLM was invoked and the candidate was stamped, despite the recurring toggle being off.
+        _chat.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repo.Verify(
+            r => r.StampAutoTaggedAtAsync(
+                It.Is<IReadOnlyList<int>>(ids => ids.Count == 1 && ids[0] == 7),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _statusChecker.Verify(
+            s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()),
+            Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Anela.Heblo.Application.Features.Photobank;
 using Anela.Heblo.Application.Features.Photobank.Infrastructure.Jobs;
 using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.Photobank;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
@@ -19,16 +20,29 @@ public class PhotobankAutoTagJobTests
     private readonly Mock<IPhotobankRepository> _repo = new();
     private readonly Mock<IChatClient> _chat = new();
     private readonly Mock<IPhotobankTagsCache> _cache = new();
+    private readonly Mock<IRecurringJobStatusChecker> _statusChecker = new();
+
+    public PhotobankAutoTagJobTests()
+    {
+        // Default: job is enabled. Individual tests override as needed.
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(true);
+    }
 
     private PhotobankAutoTagJob CreateJob(AutoTagOptions? options = null)
     {
-        var opts = options ?? new AutoTagOptions { Enabled = true, BatchSize = 50, MaxPhotosPerRun = 5_000 };
+        var opts = options ?? new AutoTagOptions { BatchSize = 50, MaxPhotosPerRun = 5_000 };
         return new PhotobankAutoTagJob(
             _repo.Object,
             _chat.Object,
             Options.Create(opts),
             NullLogger<PhotobankAutoTagJob>.Instance,
-            _cache.Object);
+            _cache.Object,
+            _statusChecker.Object);
     }
 
     private void SetupEmptyTags() =>
@@ -50,10 +64,16 @@ public class PhotobankAutoTagJobTests
             .ReturnsAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, json)]));
 
     [Fact]
-    public async Task ExecuteAsync_WhenDisabled_DoesNotCallLlmOrRepository()
+    public async Task ExecuteAsync_WhenStatusCheckerReturnsFalse_DoesNotCallLlmOrRepository()
     {
         // Arrange
-        var job = CreateJob(new AutoTagOptions { Enabled = false });
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(false);
+        var job = CreateJob();
 
         // Act
         await job.ExecuteAsync(CancellationToken.None);
@@ -185,9 +205,10 @@ public class PhotobankAutoTagJobTests
         var jobWithCap = new PhotobankAutoTagJob(
             _repo.Object,
             _chat.Object,
-            Options.Create(new AutoTagOptions { Enabled = true, BatchSize = 50, MaxPhotosPerRun = 100, Model = "test-model", MaxTagsPerPhoto = 2 }),
+            Options.Create(new AutoTagOptions { BatchSize = 50, MaxPhotosPerRun = 100, Model = "test-model", MaxTagsPerPhoto = 2 }),
             NullLogger<PhotobankAutoTagJob>.Instance,
-            _cache.Object);
+            _cache.Object,
+            _statusChecker.Object);
 
         // Act
         await jobWithCap.ExecuteAsync(CancellationToken.None);

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankIndexJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankIndexJobTests.cs
@@ -22,7 +22,7 @@ public class PhotobankIndexJobTests
         _statusCheckerMock = new Mock<IRecurringJobStatusChecker>();
 
         _statusCheckerMock
-            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
         _job = new PhotobankIndexJob(

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
@@ -23,7 +23,7 @@ public class KnowledgeBaseIngestionJobTests
 
     private KnowledgeBaseIngestionJob CreateJob(KnowledgeBaseOptions options)
     {
-        _statusChecker.Setup(s => s.IsJobEnabledAsync("knowledge-base-ingestion", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _statusChecker.Setup(s => s.IsJobEnabledAsync("knowledge-base-ingestion", It.IsAny<CancellationToken>(), true)).ReturnsAsync(true);
         return new KnowledgeBaseIngestionJob(
             _oneDrive.Object,
             _mediator.Object,

--- a/docs/superpowers/plans/2026-06-16-photobank-autotag-runtime-status-check.md
+++ b/docs/superpowers/plans/2026-06-16-photobank-autotag-runtime-status-check.md
@@ -1,0 +1,778 @@
+# Unify PhotobankAutoTagJob enable/disable with IRecurringJobStatusChecker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `PhotobankAutoTagJob`'s static `AutoTagOptions.Enabled` flag with a runtime check against `IRecurringJobStatusChecker`, matching the gating mechanism already used by `PhotobankIndexJob`.
+
+**Architecture:** Thread `RecurringJobMetadata.DefaultIsEnabled` through a new optional `defaultIfMissing` parameter on `IRecurringJobStatusChecker.IsJobEnabledAsync` so the auto-tag job stays disabled even if its `RecurringJobConfigurations` row has not yet been seeded. Inject the checker into `PhotobankAutoTagJob`, gate `ExecuteAsync` only (keep `ExecuteForPhotosAsync` ungated for ad-hoc re-tags), and delete the now-redundant `Enabled` field and its `appsettings.json` entry.
+
+**Tech Stack:** .NET 8, xUnit + FluentAssertions + Moq, MediatR + Hangfire, EF Core (PostgreSQL).
+
+---
+
+## Self-Review Notes (decisions baked in)
+
+- **Parameter ordering deviation from arch review.** Arch review proposed `IsJobEnabledAsync(string jobName, bool defaultIfMissing = true, CancellationToken cancellationToken = default)`. That ordering would break every existing positional caller (e.g. `PhotobankIndexJob` calls `IsJobEnabledAsync(Metadata.JobName, cancellationToken)`). To keep all existing callers source-compatible, this plan places `defaultIfMissing` *after* `cancellationToken`. Non-conventional, but the minimal-impact correct choice.
+- **Moq backward compatibility.** Existing `.Setup(s => s.IsJobEnabledAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))` setups remain green because the C# compiler injects the literal `true` default for the new third argument at both setup site and production call site for current consumers; matching is value-based.
+
+---
+
+## File Map
+
+**New files**
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs` — unit tests for the new `defaultIfMissing` behavior of `RecurringJobStatusChecker`.
+
+**Modified files**
+- `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobStatusChecker.cs` — add optional `defaultIfMissing` parameter.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs` — use `defaultIfMissing` for missing-config fallback; keep the on-exception fail-open path returning `true`.
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs` — inject `IRecurringJobStatusChecker`, replace `_options.Enabled` gate with `IsJobEnabledAsync(... , Metadata.DefaultIsEnabled)`.
+- `backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs` — delete `Enabled` property.
+- `backend/src/Anela.Heblo.API/appsettings.json` — delete `Photobank:AutoTag:Enabled` key.
+- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs` — add `Mock<IRecurringJobStatusChecker>` with `true` default, update `CreateJob`, rewrite the disabled-path test to use the checker, drop `Enabled = ...` literals, add `ExecuteForPhotosAsync_RunsEvenWhenStatusCheckerReturnsFalse`.
+
+**Unchanged files (intentional)**
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs` — its existing two-arg call stays valid after the additive interface change.
+- All other `IsJobEnabledAsync` callers — their `(jobName, ct)` or `(jobName)` positional calls remain valid and semantically identical (fail-open on missing config).
+- `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` — registration `services.AddScoped<PhotobankAutoTagJob>()` is sufficient; `IRecurringJobStatusChecker` is already registered globally in `BackgroundJobsModule`.
+
+---
+
+## Task 1: Extend `IRecurringJobStatusChecker` with `defaultIfMissing`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobStatusChecker.cs`
+
+- [ ] **Step 1: Add the optional parameter (additive change)**
+
+Replace the entire file with:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.BackgroundJobs;
+
+public interface IRecurringJobStatusChecker
+{
+    /// <summary>
+    /// Returns whether the recurring job named <paramref name="jobName"/> is enabled.
+    /// </summary>
+    /// <param name="jobName">Unique job identifier matching <see cref="RecurringJobMetadata.JobName"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="defaultIfMissing">
+    /// Value to return when no configuration row exists for the job.
+    /// Defaults to <c>true</c> to preserve historical fail-open behavior for existing callers.
+    /// Pass <see cref="RecurringJobMetadata.DefaultIsEnabled"/> for jobs that must default disabled
+    /// (e.g. LLM-cost-producing jobs) so an unseeded row does not silently enable them.
+    /// </param>
+    Task<bool> IsJobEnabledAsync(
+        string jobName,
+        CancellationToken cancellationToken = default,
+        bool defaultIfMissing = true);
+}
+```
+
+- [ ] **Step 2: Verify the solution still compiles**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: BUILD SUCCEEDED. The additive parameter has a default, so all existing positional callers (`IsJobEnabledAsync(name)`, `IsJobEnabledAsync(name, ct)`) and all Moq setups remain valid.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobStatusChecker.cs
+git commit -m "refactor: add defaultIfMissing parameter to IRecurringJobStatusChecker"
+```
+
+---
+
+## Task 2: Update `RecurringJobStatusChecker` implementation (TDD)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs`
+
+- [ ] **Step 1: Write failing tests for `defaultIfMissing`**
+
+Create `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs` with:
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+public class RecurringJobStatusCheckerTests
+{
+    private readonly Mock<IRecurringJobConfigurationRepository> _repo = new();
+
+    private RecurringJobStatusChecker CreateSut() =>
+        new(_repo.Object, NullLogger<RecurringJobStatusChecker>.Instance);
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsConfiguredValue_WhenRowExists()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync("job-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RecurringJobConfiguration { JobName = "job-a", IsEnabled = false });
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync("job-a", CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsTrue_WhenRowMissing_AndDefaultIfMissingIsTrue()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RecurringJobConfiguration?)null);
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync("missing-job", CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsFalse_WhenRowMissing_AndDefaultIfMissingIsFalse()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((RecurringJobConfiguration?)null);
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync(
+            "missing-job",
+            CancellationToken.None,
+            defaultIfMissing: false);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsJobEnabledAsync_ReturnsTrue_WhenRepositoryThrows()
+    {
+        // Arrange
+        _repo
+            .Setup(r => r.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.IsJobEnabledAsync("any-job", CancellationToken.None);
+
+        // Assert — error path stays fail-open to avoid breaking critical jobs
+        result.Should().BeTrue();
+    }
+}
+```
+
+> **Note:** If the test project does not yet have a `using` for `Anela.Heblo.Domain.Features.BackgroundJobs` for `RecurringJobConfiguration` / `IRecurringJobConfigurationRepository`, verify the exact namespaces with `grep -rn "class RecurringJobConfiguration" backend/src` and `grep -rn "interface IRecurringJobConfigurationRepository" backend/src` and adjust the imports. Both types are expected under `Anela.Heblo.Domain.Features.BackgroundJobs`.
+
+- [ ] **Step 2: Run tests to confirm the third one fails**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecurringJobStatusCheckerTests"`
+Expected: 3 pass, 1 fail. The failure is `IsJobEnabledAsync_ReturnsFalse_WhenRowMissing_AndDefaultIfMissingIsFalse` — current implementation returns hardcoded `true` when the row is missing.
+
+- [ ] **Step 3: Update `RecurringJobStatusChecker` to honor `defaultIfMissing`**
+
+Replace `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs` with:
+
+```csharp
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs;
+
+public class RecurringJobStatusChecker : IRecurringJobStatusChecker
+{
+    private readonly IRecurringJobConfigurationRepository _repository;
+    private readonly ILogger<RecurringJobStatusChecker> _logger;
+
+    public RecurringJobStatusChecker(
+        IRecurringJobConfigurationRepository repository,
+        ILogger<RecurringJobStatusChecker> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<bool> IsJobEnabledAsync(
+        string jobName,
+        CancellationToken cancellationToken = default,
+        bool defaultIfMissing = true)
+    {
+        try
+        {
+            var configuration = await _repository.GetByJobNameAsync(jobName, cancellationToken);
+
+            if (configuration == null)
+            {
+                _logger.LogWarning(
+                    "Job configuration not found for job: {JobName}. Falling back to defaultIfMissing={DefaultIfMissing}.",
+                    jobName,
+                    defaultIfMissing);
+                return defaultIfMissing;
+            }
+
+            if (!configuration.IsEnabled)
+            {
+                _logger.LogInformation("Job {JobName} is disabled. Job will be skipped.", jobName);
+            }
+
+            return configuration.IsEnabled;
+        }
+        catch (Exception ex)
+        {
+            // Safety fallback - on error, allow job to run to avoid blocking critical jobs.
+            // This branch is intentionally NOT gated by defaultIfMissing: a DB outage should
+            // not silently disable jobs that would otherwise run.
+            _logger.LogError(
+                ex,
+                "Error checking job enabled status for job: {JobName}. Allowing job to run by default.",
+                jobName);
+            return true;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Re-run tests, all green**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecurringJobStatusCheckerTests"`
+Expected: 4 passed.
+
+- [ ] **Step 5: Run the broader background-jobs test set to confirm no regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~BackgroundJobs"`
+Expected: all tests pass (existing `TriggerRecurringJobHandlerTests`, `RecurringJobDiscoveryServiceTests`, etc. stay green because their setups still use the two-arg form that resolves to `defaultIfMissing: true`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobStatusChecker.cs \
+        backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs
+git commit -m "feat: honor defaultIfMissing in RecurringJobStatusChecker"
+```
+
+---
+
+## Task 3: Inject `IRecurringJobStatusChecker` into `PhotobankAutoTagJob` and gate `ExecuteAsync`
+
+This task replaces the `_options.Enabled` check with the runtime status check. Updates the production code, the test fixture, and the existing disabled-path test in tandem to keep the suite green at every step.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs`
+
+- [ ] **Step 1: Update the failing test for the disabled path (status-checker driven)**
+
+In `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs`:
+
+a) Add the using directive at the top of the file (after the existing `using Anela.Heblo.Domain.Features.Photobank;`):
+
+```csharp
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+```
+
+b) Add a `Mock<IRecurringJobStatusChecker>` field next to the existing mocks. Replace:
+
+```csharp
+    private readonly Mock<IPhotobankRepository> _repo = new();
+    private readonly Mock<IChatClient> _chat = new();
+    private readonly Mock<IPhotobankTagsCache> _cache = new();
+```
+
+with:
+
+```csharp
+    private readonly Mock<IPhotobankRepository> _repo = new();
+    private readonly Mock<IChatClient> _chat = new();
+    private readonly Mock<IPhotobankTagsCache> _cache = new();
+    private readonly Mock<IRecurringJobStatusChecker> _statusChecker = new();
+
+    public PhotobankAutoTagJobTests()
+    {
+        // Default: job is enabled. Individual tests override as needed.
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(true);
+    }
+```
+
+c) Replace the existing `CreateJob` helper. Replace:
+
+```csharp
+    private PhotobankAutoTagJob CreateJob(AutoTagOptions? options = null)
+    {
+        var opts = options ?? new AutoTagOptions { Enabled = true, BatchSize = 50, MaxPhotosPerRun = 5_000 };
+        return new PhotobankAutoTagJob(
+            _repo.Object,
+            _chat.Object,
+            Options.Create(opts),
+            NullLogger<PhotobankAutoTagJob>.Instance,
+            _cache.Object);
+    }
+```
+
+with:
+
+```csharp
+    private PhotobankAutoTagJob CreateJob(AutoTagOptions? options = null)
+    {
+        var opts = options ?? new AutoTagOptions { BatchSize = 50, MaxPhotosPerRun = 5_000 };
+        return new PhotobankAutoTagJob(
+            _repo.Object,
+            _chat.Object,
+            Options.Create(opts),
+            NullLogger<PhotobankAutoTagJob>.Instance,
+            _cache.Object,
+            _statusChecker.Object);
+    }
+```
+
+d) Rewrite the `ExecuteAsync_WhenDisabled_DoesNotCallLlmOrRepository` test to drive the gate via the status checker. Replace:
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_WhenDisabled_DoesNotCallLlmOrRepository()
+    {
+        // Arrange
+        var job = CreateJob(new AutoTagOptions { Enabled = false });
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        _chat.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _repo.Verify(
+            r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+with:
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_WhenStatusCheckerReturnsFalse_DoesNotCallLlmOrRepository()
+    {
+        // Arrange
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(false);
+        var job = CreateJob();
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        _chat.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _repo.Verify(
+            r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+e) Update the `MaxTagsPerPhoto` test's inline constructor call so it passes the new dependency and drops the obsolete field. Replace:
+
+```csharp
+        // Use job with MaxTagsPerPhoto = 2
+        var jobWithCap = new PhotobankAutoTagJob(
+            _repo.Object,
+            _chat.Object,
+            Options.Create(new AutoTagOptions { Enabled = true, BatchSize = 50, MaxPhotosPerRun = 100, Model = "test-model", MaxTagsPerPhoto = 2 }),
+            NullLogger<PhotobankAutoTagJob>.Instance,
+            _cache.Object);
+```
+
+with:
+
+```csharp
+        // Use job with MaxTagsPerPhoto = 2
+        var jobWithCap = new PhotobankAutoTagJob(
+            _repo.Object,
+            _chat.Object,
+            Options.Create(new AutoTagOptions { BatchSize = 50, MaxPhotosPerRun = 100, Model = "test-model", MaxTagsPerPhoto = 2 }),
+            NullLogger<PhotobankAutoTagJob>.Instance,
+            _cache.Object,
+            _statusChecker.Object);
+```
+
+- [ ] **Step 2: Run the photobank-auto-tag tests; confirm they fail to compile**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: BUILD FAILED. Errors point to `PhotobankAutoTagJob` constructor: "no overload takes 6 arguments" (the production class still has the old 5-arg ctor).
+
+- [ ] **Step 3: Update `PhotobankAutoTagJob` to inject the status checker and use it**
+
+Replace `backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs` lines 13–50 (class declaration through end of disabled-guard block) with the new shape. Concretely:
+
+Replace:
+
+```csharp
+public class PhotobankAutoTagJob : IRecurringJob
+{
+    private readonly IPhotobankRepository _repo;
+    private readonly IChatClient _chat;
+    private readonly AutoTagOptions _options;
+    private readonly ILogger<PhotobankAutoTagJob> _logger;
+    private readonly IPhotobankTagsCache _cache;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "photobank-auto-tag",
+        DisplayName = "Photobank Auto-Tag",
+        Description = "Sends untagged photos to the LLM and stamps validated tags back",
+        CronExpression = "0 4 * * *",
+        DefaultIsEnabled = false,
+    };
+
+    public PhotobankAutoTagJob(
+        IPhotobankRepository repo,
+        IChatClient chat,
+        IOptions<AutoTagOptions> options,
+        ILogger<PhotobankAutoTagJob> logger,
+        IPhotobankTagsCache cache)
+    {
+        _repo = repo;
+        _chat = chat;
+        _options = options.Value;
+        _logger = logger;
+        _cache = cache;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+            return;
+        }
+```
+
+with:
+
+```csharp
+public class PhotobankAutoTagJob : IRecurringJob
+{
+    private readonly IPhotobankRepository _repo;
+    private readonly IChatClient _chat;
+    private readonly AutoTagOptions _options;
+    private readonly ILogger<PhotobankAutoTagJob> _logger;
+    private readonly IPhotobankTagsCache _cache;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "photobank-auto-tag",
+        DisplayName = "Photobank Auto-Tag",
+        Description = "Sends untagged photos to the LLM and stamps validated tags back",
+        CronExpression = "0 4 * * *",
+        DefaultIsEnabled = false,
+    };
+
+    public PhotobankAutoTagJob(
+        IPhotobankRepository repo,
+        IChatClient chat,
+        IOptions<AutoTagOptions> options,
+        ILogger<PhotobankAutoTagJob> logger,
+        IPhotobankTagsCache cache,
+        IRecurringJobStatusChecker statusChecker)
+    {
+        _repo = repo;
+        _chat = chat;
+        _options = options.Value;
+        _logger = logger;
+        _cache = cache;
+        _statusChecker = statusChecker;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(
+                Metadata.JobName,
+                cancellationToken,
+                defaultIfMissing: Metadata.DefaultIsEnabled))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+            return;
+        }
+```
+
+> The `using Anela.Heblo.Domain.Features.BackgroundJobs;` directive is already present at line 5 of the file — no import edit required.
+
+- [ ] **Step 4: Run the full photobank test set; expect green**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Photobank"`
+Expected: all PhotobankAutoTagJobTests and PhotobankIndexJobTests pass (5 in the auto-tag file at this point — the four legacy tests plus the renamed disabled-path test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs \
+        backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
+git commit -m "refactor: gate PhotobankAutoTagJob via IRecurringJobStatusChecker"
+```
+
+---
+
+## Task 4: Add explicit test confirming `ExecuteForPhotosAsync` is ungated
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append the following test at the end of the `PhotobankAutoTagJobTests` class, immediately before its closing brace:
+
+```csharp
+    [Fact]
+    public async Task ExecuteForPhotosAsync_RunsEvenWhenStatusCheckerReturnsFalse()
+    {
+        // Arrange — recurring-schedule toggle is OFF, but ad-hoc retag must still run.
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .ReturnsAsync(false);
+
+        var candidates = new List<PhotoAutoTagCandidate>
+        {
+            new(Id: 7, FolderPath: "/photos", FileName: "ad-hoc.jpg"),
+        };
+
+        _repo
+            .Setup(r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TagCount> { new(10, "kosmetika", 1) });
+
+        SetupChatResponse("""{"results":[{"id":7,"tags":["kosmetika"]}]}""");
+
+        _repo
+            .Setup(r => r.PhotoTagExistsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _repo
+            .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repo
+            .Setup(r => r.StampAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var job = CreateJob();
+
+        // Act
+        await job.ExecuteForPhotosAsync(candidates, CancellationToken.None);
+
+        // Assert — LLM was invoked and the candidate was stamped, despite the recurring toggle being off.
+        _chat.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repo.Verify(
+            r => r.StampAutoTaggedAtAsync(
+                It.Is<IReadOnlyList<int>>(ids => ids.Count == 1 && ids[0] == 7),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _statusChecker.Verify(
+            s => s.IsJobEnabledAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run the test; expect green**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ExecuteForPhotosAsync_RunsEvenWhenStatusCheckerReturnsFalse"`
+Expected: PASS. The production code in `ExecuteForPhotosAsync` (lines 77–87 of `PhotobankAutoTagJob.cs`) was unchanged and does not invoke the checker — this test locks that contract.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
+git commit -m "test: lock ExecuteForPhotosAsync as ungated by IRecurringJobStatusChecker"
+```
+
+---
+
+## Task 5: Remove `Enabled` from `AutoTagOptions`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs`
+
+- [ ] **Step 1: Delete the `Enabled` property**
+
+Replace the entire file with:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank;
+
+public sealed class AutoTagOptions
+{
+    public const string SectionName = "Photobank:AutoTag";
+
+    public int BatchSize { get; init; } = 50;
+    public int MaxPhotosPerRun { get; init; } = 5_000;
+    public string Model { get; init; } = "claude-haiku-4-5-20251001";
+    public int MaxTagsPerPhoto { get; init; } = 5;
+}
+```
+
+- [ ] **Step 2: Verify no production or test code still references `AutoTagOptions.Enabled`**
+
+Run: `grep -rn "AutoTagOptions.*Enabled\|Enabled.*=.*\(true\|false\).*BatchSize" backend/src backend/test --include='*.cs' || echo "no matches"`
+Expected: `no matches`. (If anything appears, it is a leftover from Tasks 3–4; fix and re-run.)
+
+- [ ] **Step 3: Build the solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: BUILD SUCCEEDED. The compiler would catch any remaining `Enabled = ...` initializer or `_options.Enabled` access.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs
+git commit -m "refactor: remove obsolete Enabled flag from AutoTagOptions"
+```
+
+---
+
+## Task 6: Drop the obsolete config key from `appsettings.json`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/appsettings.json` (lines 175–186)
+
+- [ ] **Step 1: Remove the `Enabled` key from the `Photobank:AutoTag` block**
+
+Find the block at lines 175–186:
+
+```json
+  "Photobank": {
+    "AutoTag": {
+      "Enabled": false,
+      "BatchSize": 50,
+      "MaxPhotosPerRun": 5000,
+      "Model": "claude-haiku-4-5-20251001",
+      "MaxTagsPerPhoto": 5
+    },
+    "TagsCache": {
+      "TtlSeconds": 60
+    }
+  },
+```
+
+Replace with:
+
+```json
+  "Photobank": {
+    "AutoTag": {
+      "BatchSize": 50,
+      "MaxPhotosPerRun": 5000,
+      "Model": "claude-haiku-4-5-20251001",
+      "MaxTagsPerPhoto": 5
+    },
+    "TagsCache": {
+      "TtlSeconds": 60
+    }
+  },
+```
+
+- [ ] **Step 2: Confirm no other appsettings file carries the key**
+
+Run: `grep -rn "AutoTag" backend/src/Anela.Heblo.API --include='appsettings*.json'`
+Expected: only the `appsettings.json` `AutoTag` block remains (now without `Enabled`). No matches in `appsettings.Conductor.json`, `appsettings.Development.json`, `appsettings.Production.json`, `appsettings.Staging.json`, or `appsettings.Test.json` — this was already verified during plan authoring; the check guards against drift between then and now.
+
+- [ ] **Step 3: Sanity-build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: BUILD SUCCEEDED. (The JSON change has no compile effect; this confirms nothing in the API project picked up an accidental edit.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/appsettings.json
+git commit -m "chore: drop Photobank:AutoTag:Enabled from appsettings.json"
+```
+
+---
+
+## Task 7: Full validation sweep
+
+- [ ] **Step 1: Run the entire backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: all tests pass. Pay particular attention to:
+- `PhotobankAutoTagJobTests` — 5 tests (4 existing + 1 new ungated test).
+- `RecurringJobStatusCheckerTests` — 4 tests (all new).
+- `PhotobankIndexJobTests`, `TriggerRecurringJobHandlerTests`, `TriggerRecurringJobHandlerIntegrationTests`, and every other job's `*Tests` consuming `IRecurringJobStatusChecker` — must remain green without modification (their setups omit the new param; the compiler-injected `true` default matches production calls that also omit it).
+
+- [ ] **Step 2: Apply formatting**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: no diffs (or only trivial whitespace touch-ups). If diffs appear in files we modified, stage and amend the previous commit for that file; if diffs appear elsewhere, leave them alone and report.
+
+- [ ] **Step 3: Final solution-wide compile**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: BUILD SUCCEEDED with 0 errors and 0 warnings introduced by this change.
+
+- [ ] **Step 4: Spot-check the runtime contract**
+
+Run: `grep -n "_options.Enabled\|AutoTagOptions.*Enabled" backend/src backend/test -r --include='*.cs' || echo "clean"`
+Expected: `clean`. No residual references to the dropped flag.
+
+Run: `grep -n "\"Enabled\"" backend/src/Anela.Heblo.API/appsettings.json | grep -i "AutoTag" || echo "clean"`
+Expected: `clean`. The config key is gone.
+
+- [ ] **Step 5: Commit any formatting fixes (if Step 2 produced edits)**
+
+```bash
+git status            # confirm what changed
+git add -p            # stage formatting hunks only
+git commit -m "chore: dotnet format"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Post-Implementation Notes (release notes hint)
+
+Operators previously toggling auto-tag through `Photobank:AutoTag:Enabled` must now toggle the `photobank-auto-tag` recurring job through the same UI/API used for `photobank-index` (the `UpdateRecurringJobStatusHandler` MediatR endpoint). On first start after deploy, `SeedDefaultConfigurationsAsync` will insert a `RecurringJobConfigurations` row with `IsEnabled = false`, preserving the default-disabled posture. Any stale `Photobank:AutoTag:Enabled` value in Azure App Service settings or Key Vault is silently ignored by the options binder — safe to delete at convenience but not required.


### PR DESCRIPTION
Photobank

## Finding
The two recurring jobs in this module use different mechanisms to guard against running when disabled:

**`PhotobankIndexJob.ExecuteAsync`** (line 38–42 in `PhotobankIndexJob.cs`):
```csharp
if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken))
{
    _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
    return;
}
```
Uses `IRecurringJobStatusChecker` — a runtime-queryable mechanism (presumably backed by a database record), so operators can enable/disable the job without touching config or restarting the app.

**`PhotobankAutoTagJob.ExecuteAsync`** (line 45–50 in `PhotobankAutoTagJob.cs`):
```csharp
if (!_options.Enabled)
{
    _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
    return;
}
```
Uses `AutoTagOptions.Enabled` — read from `appsettings.json` at startup (`Photobank:AutoTag:Enabled`). Changing this requires editing config and restarting the application.

`PhotobankAutoTagJob.Metadata.DefaultIsEnabled = false`, which means the job is off by default; but if someone ever wants to enable it via a Hangfire dashboard or admin UI (the same way they'd manage `PhotobankIndexJob`), they cannot — the `IRecurringJobStatusChecker` gate is simply absent.

## Why it matters
- Operational inconsistency: a user who can toggle `photobank-index` at runtime has no equivalent control over `photobank-auto-tag` — they would need a config change and app restart.
- The `DefaultIsEnabled` on `Metadata` exists precisely so that the job framework can own the enabled/disabled state. Bypassing this with a static config option defeats the purpose.
- If the auto-tag feature ever needs to be enabled temporarily (e.g., for a bulk re-tag run), the correct procedure is unclear and differs from every other job in the system.

## Suggested fix
Replace the `_options.Enabled` guard with `IRecurringJobStatusChecker`, exactly as `PhotobankIndexJob` does:

```csharp
// 1. Add to constructor
private readonly IRecurringJobStatusChecker _statusChecker;

public PhotobankAutoTagJob(
    IPhotobankRepository repo,
    IChatClient chat,
    IOptions<AutoTagOptions> options,
    ILogger<PhotobankAutoTagJob> logger,
    IPhotobankTagsCache cache,
    IRecurringJobStatusChecker statusChecker)   // add
{
    ...
    _statusChecker = statusChecker;
}

// 2. In ExecuteAsync, replace the Enabled check:
if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName, cancellationToken))
{
    _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
    return;
}
```

The `AutoTagOptions.Enabled` field can be removed once the check is unified. `DefaultIsEnabled = false` on the metadata already ensures the job starts disabled.

---
_Filed by daily arch-review routine on 2026-06-14._

---

Closes #3072

### Tokens used
25771528
