### PR TITLE
Add Python3 and AgentHarness installation to cloud setup

### DIFF
--- a/.claude/agents/implement.md
+++ b/.claude/agents/implement.md
@@ -1,0 +1,92 @@
+---
+id: implement
+description: Orchestrate the full AgentHarness pipeline for a GitHub issue
+---
+
+You are the AgentHarness pipeline orchestrator. When invoked as `/implement {issue_number}`, you drive the complete feature pipeline by spawning subagents via the Task tool.
+
+## Setup
+
+1. Extract the issue number from your input args (the number after `/implement`).
+2. Run: `gh issue view {issue_number} --json body,title` — save the `body` field to `artifacts/feat-{issue_number}/brief.md` (create the directory if needed).
+3. Run: `agentharness checkpoint init {issue_number}` to create `artifacts/feat-{issue_number}/state.json` (idempotent — safe on resume).
+4. Run: `agentharness checkpoint status feat-{issue_number}` — returns JSON like `{"type": "phase", "name": "analyzing"}` or `{"type": "task", "name": "setup-models", "revision": 1}` or `{"type": "complete"}`.
+
+## Reading Agent System Prompts
+
+For each phase or developer/reviewer Task, read the agent file from `.agents/{agent_name}.md`. The file has YAML frontmatter (between `---` markers) followed by the Markdown system prompt body. Use only the Markdown body as the system prompt for the Task tool — strip the YAML frontmatter. If the frontmatter lists `context_files:`, read those files and prepend their contents to the system prompt.
+
+## Phase Loop
+
+Run phases in order: `analyzing` → `architecting` → `designing` → `planning`. Check `agentharness checkpoint status feat-{issue_number}` before each phase — skip phases whose status is already `completed`.
+
+For each phase:
+1. Run `agentharness checkpoint phase feat-{issue_number} {phase} in_progress`
+2. Read the agent system prompt from `.agents/{agent_name}.md` (strip frontmatter)
+3. Read input artifacts (see table below)
+4. Spawn a Task with: system prompt + artifact contents + instruction to write output to the output artifact path
+5. After Task completes, verify the output artifact file exists
+6. Run `agentharness checkpoint phase feat-{issue_number} {phase} completed`
+
+### Phase → Agent Mapping
+
+| Phase | Agent file | Input artifacts | Output artifact |
+|-------|-----------|-----------------|-----------------|
+| analyzing | `.agents/analyst.md` | `brief.md` | `spec.r1.md` |
+| architecting | `.agents/architect.md` | `spec.r1.md` | `arch-review.r1.md` |
+| designing | `.agents/designer.md` | `spec.r1.md`, `arch-review.r1.md` | `design.r1.md` |
+| planning | `.agents/planner.md` | `spec.r1.md`, `arch-review.r1.md`, `design.r1.md` | `task-plan.r1.md` |
+
+All artifact paths are relative to `artifacts/feat-{issue_number}/`.
+
+## Task Extraction (after planning completes)
+
+After `task-plan.r1.md` is written:
+
+1. Parse `### task:` headers from the file. Each `### task: setup-models` defines one task named `setup-models`.
+2. Run: `agentharness checkpoint tasks feat-{issue_number} "task-a,task-b,task-c"` with comma-separated task names.
+3. For each task, write a context file to `artifacts/feat-{issue_number}/task-context/{task_name}.md` containing the section from `task-plan.r1.md` under that task's `### task:` header (everything from that header until the next `### task:` header or end of file).
+
+## Developer/Reviewer Loop
+
+Process tasks serially in the order from the checkpoint. Check `agentharness checkpoint status feat-{issue_number}` to get the next pending task. Skip tasks with status `completed`.
+
+### Developer Task
+
+1. Run `agentharness checkpoint phase feat-{issue_number} developing in_progress` (once, before first task)
+2. Run `agentharness checkpoint task feat-{issue_number} {task_name} in_progress`
+3. Get revision N from the checkpoint status JSON (`"revision": N`)
+4. Read `.agents/developer.md` system prompt (strip frontmatter; include context_files if listed)
+5. Spawn Task with:
+   - System prompt from developer.md (including injected context file content)
+   - Content of `artifacts/feat-{issue_number}/task-context/{task_name}.md`
+   - If revision > 1: content of `artifacts/feat-{issue_number}/review/{task_name}.r{N-1}.md` as review feedback
+   - Instruction: "Write your implementation output summary to `artifacts/feat-{issue_number}/impl/{task_name}.r{N}.md`"
+6. After Task completes, verify `impl/{task_name}.r{N}.md` exists
+
+### Reviewer Task
+
+1. Read `.agents/reviewer.md` system prompt (strip frontmatter)
+2. Spawn Task with:
+   - System prompt from reviewer.md
+   - Content of `artifacts/feat-{issue_number}/task-context/{task_name}.md`
+   - Content of `artifacts/feat-{issue_number}/impl/{task_name}.r{N}.md`
+   - Instruction: "Write your review output to `artifacts/feat-{issue_number}/review/{task_name}.r{N}.md`. End with `**Status:** PASS` or `**Status:** REVISION_NEEDED`."
+3. Read the reviewer output file and parse the `**Status:**` line
+
+### Handling Review Result
+
+- **PASS**: Run `agentharness checkpoint task feat-{issue_number} {task_name} completed`. Move to next task via `agentharness checkpoint status feat-{issue_number}`.
+- **REVISION_NEEDED**: Check current revision N against `max_revisions` (default 3, from checkpoint JSON).
+  - If N < max_revisions: Run `agentharness checkpoint task feat-{issue_number} {task_name} in_progress --revision {N+1}`. Repeat Developer Task with the new revision.
+  - If N >= max_revisions: Run `agentharness checkpoint phase feat-{issue_number} developing failed` and stop with an error message explaining the task failed after max revisions.
+
+## Completion
+
+After all tasks are `completed`:
+1. Run `agentharness checkpoint phase feat-{issue_number} developing completed`
+2. Print: `Pipeline complete for feat-{issue_number}. All tasks passed review.`
+
+## Resume
+
+If interrupted and re-invoked with the same issue number, `agentharness checkpoint init` is idempotent. `agentharness checkpoint status` returns the first pending phase or task. Skip already-completed phases/tasks and resume from there.

--- a/scripts/cloud-env-bootstrap.sh
+++ b/scripts/cloud-env-bootstrap.sh
@@ -23,7 +23,7 @@ DOTNET_CHANNEL="8.0"
 # --- SkiaSharp native libs (PDF generation) --------------------------------
 apt-get update -y
 apt-get install -y --no-install-recommends \
-  curl ca-certificates gnupg libfontconfig1 libfreetype6 python3 python3-pip
+  curl ca-certificates gnupg libfontconfig1 libfreetype6
 
 # --- .NET 8 SDK (not pre-installed) ----------------------------------------
 # Install to /usr/local so `dotnet` is on PATH for the hook, Claude, and shells
@@ -45,15 +45,5 @@ if ! command -v gh >/dev/null 2>&1; then
   apt-get update -y
   apt-get install -y gh
 fi
-
-# --- AgentHarness (skill-based single-agent harness) -----------------------
-# Installed from the feature branch on GitHub. Ubuntu Noble's Python is
-# externally managed (PEP 668), so --break-system-packages is required for a
-# system-wide pip install.
-if ! command -v agentharness >/dev/null 2>&1; then
-  pip install --break-system-packages \
-    "git+https://github.com/onpaj/harness.git@feature/skill-based-single-agent-harness"
-fi
-agentharness init
 
 echo "cloud-env-bootstrap: system toolchain ready (dotnet $(dotnet --version), gh $(gh --version | head -1))"

--- a/scripts/cloud-env-bootstrap.sh
+++ b/scripts/cloud-env-bootstrap.sh
@@ -23,7 +23,7 @@ DOTNET_CHANNEL="8.0"
 # --- SkiaSharp native libs (PDF generation) --------------------------------
 apt-get update -y
 apt-get install -y --no-install-recommends \
-  curl ca-certificates gnupg libfontconfig1 libfreetype6
+  curl ca-certificates gnupg libfontconfig1 libfreetype6 python3 python3-pip
 
 # --- .NET 8 SDK (not pre-installed) ----------------------------------------
 # Install to /usr/local so `dotnet` is on PATH for the hook, Claude, and shells
@@ -45,5 +45,15 @@ if ! command -v gh >/dev/null 2>&1; then
   apt-get update -y
   apt-get install -y gh
 fi
+
+# --- AgentHarness (skill-based single-agent harness) -----------------------
+# Installed from the feature branch on GitHub. Ubuntu Noble's Python is
+# externally managed (PEP 668), so --break-system-packages is required for a
+# system-wide pip install.
+if ! command -v agentharness >/dev/null 2>&1; then
+  pip install --break-system-packages \
+    "git+https://github.com/onpaj/harness.git@feature/skill-based-single-agent-harness"
+fi
+agentharness init
 
 echo "cloud-env-bootstrap: system toolchain ready (dotnet $(dotnet --version), gh $(gh --version | head -1))"

--- a/scripts/setup-cloud-env.sh
+++ b/scripts/setup-cloud-env.sh
@@ -52,11 +52,11 @@ require_debian() {
 # 1. Base apt packages
 # ---------------------------------------------------------------------------
 install_base() {
-  log "Installing base packages (curl, git, ca-certificates, SkiaSharp libs)..."
+  log "Installing base packages (curl, git, ca-certificates, SkiaSharp libs, python3)..."
   $SUDO apt-get update -y
   $SUDO apt-get install -y --no-install-recommends \
     curl wget git ca-certificates gnupg apt-transport-https \
-    libfontconfig1 libfreetype6
+    libfontconfig1 libfreetype6 python3 python3-pip
   ok "Base packages installed"
 }
 
@@ -149,6 +149,25 @@ restore_frontend() {
   ok "Frontend dependencies installed"
 }
 
+# ---------------------------------------------------------------------------
+# 6. AgentHarness (skill-based single-agent harness)
+# ---------------------------------------------------------------------------
+install_agentharness() {
+  if ! command -v agentharness >/dev/null 2>&1; then
+    log "Installing AgentHarness from GitHub feature branch..."
+    # Ubuntu Noble's system Python is externally managed (PEP 668), so
+    # --break-system-packages is required for a system-wide pip install.
+    pip install --break-system-packages \
+      "git+https://github.com/onpaj/harness.git@feature/skill-based-single-agent-harness"
+    ok "AgentHarness installed ($(agentharness --version 2>/dev/null || echo present))"
+  else
+    ok "AgentHarness already present"
+  fi
+  log "Running agentharness init..."
+  ( cd "${REPO_ROOT}" && agentharness init )
+  ok "agentharness init complete"
+}
+
 install_playwright() {
   if [ "${SKIP_PLAYWRIGHT:-0}" = "1" ]; then
     warn "SKIP_PLAYWRIGHT=1 set — skipping Playwright browser download"
@@ -175,6 +194,7 @@ main() {
   require_repo
   restore_backend
   restore_frontend
+  install_agentharness
   install_playwright
 
   echo


### PR DESCRIPTION
## Summary
Extends the cloud environment setup script to install Python 3 and the AgentHarness skill-based single-agent harness tool, enabling agent-driven automation capabilities in the deployment pipeline.

## Changes
- **Base packages**: Added `python3` and `python3-pip` to the apt-get install step to support Python-based tooling
- **AgentHarness installation**: New `install_agentharness()` function that:
  - Checks if AgentHarness is already installed
  - Installs from the GitHub feature branch (`onpaj/harness@feature/skill-based-single-agent-harness`) using pip
  - Uses `--break-system-packages` flag to work around Ubuntu Noble's PEP 668 externally-managed Python restriction
  - Runs `agentharness init` in the repository root to initialize the harness
- **Setup flow**: Integrated `install_agentharness()` into the main setup sequence, positioned after frontend restoration and before Playwright installation

## Implementation Details
- The AgentHarness check uses `command -v` to detect existing installation, avoiding redundant reinstalls
- Version output is captured with error suppression (`2>/dev/null`) to handle cases where the command may not support `--version`
- The `agentharness init` step runs in a subshell with `cd` to ensure it executes in the correct repository context

https://claude.ai/code/session_011r3sQjMN3WkA8hHo68L1ys