### PR TITLE
Encapsulate MarketingAction soft-delete and Outlook-sync fields

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -43,25 +43,25 @@ namespace Anela.Heblo.Domain.Features.Marketing
         [MaxLength(100)]
         public string? ModifiedByUsername { get; private set; }
 
-        public bool IsDeleted { get; set; }
-        public DateTime? DeletedAt { get; set; }
+        public bool IsDeleted { get; internal set; }
+        public DateTime? DeletedAt { get; internal set; }
 
         [MaxLength(100)]
-        public string? DeletedByUserId { get; set; }
+        public string? DeletedByUserId { get; internal set; }
 
         [MaxLength(100)]
-        public string? DeletedByUsername { get; set; }
+        public string? DeletedByUsername { get; internal set; }
 
         // Outlook sync fields
         [MaxLength(500)]
-        public string? OutlookEventId { get; set; }
+        public string? OutlookEventId { get; internal set; }
 
-        public DateTime? OutlookLastAttemptAt { get; set; }
+        public DateTime? OutlookLastAttemptAt { get; internal set; }
 
-        public MarketingSyncStatus OutlookSyncStatus { get; set; } = MarketingSyncStatus.NotSynced;
+        public MarketingSyncStatus OutlookSyncStatus { get; internal set; } = MarketingSyncStatus.NotSynced;
 
         [MaxLength(1000)]
-        public string? OutlookSyncError { get; set; }
+        public string? OutlookSyncError { get; internal set; }
 
         // Navigation properties
         public virtual ICollection<MarketingActionProduct> ProductAssociations { get; set; } = new List<MarketingActionProduct>();

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionSyncTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionSyncTests.cs
@@ -37,7 +37,8 @@ namespace Anela.Heblo.Tests.Domain.Marketing
         {
             // Arrange
             var action = CreateAction();
-            action.OutlookSyncError = "previous error";
+            action.MarkOutlookSynced("seed-event", new DateTime(2026, 4, 27, 9, 0, 0, DateTimeKind.Utc));
+            action.OutlookSyncError = "previous error"; // internal set: no domain method seeds an error value
             var utcNow = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc);
 
             // Act
@@ -52,10 +53,8 @@ namespace Anela.Heblo.Tests.Domain.Marketing
         {
             // Arrange
             var action = CreateAction();
-            action.OutlookEventId = "some-event-id";
-            action.OutlookLastAttemptAt = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc);
-            action.OutlookSyncStatus = MarketingSyncStatus.Synced;
-            action.OutlookSyncError = "some error";
+            action.MarkOutlookSynced("some-event-id", new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc));
+            action.OutlookSyncError = "some error"; // internal set: seed an error to prove ClearOutlookLink resets it
 
             // Act
             action.ClearOutlookLink();

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs
@@ -47,8 +47,11 @@ namespace Anela.Heblo.Tests.Domain.Marketing
 
         public MarketingAction Build()
         {
-            // Construct via the public ctor (FR-1). Then layer modified-audit
-            // and Id/Outlook fields on top — the latter still expose public setters.
+            // Construct via the public ctor. Then layer modified-audit, Id, and
+            // Outlook fields on top. Id has a public setter; the Outlook fields use
+            // internal set and are assignable here via the InternalsVisibleTo grant
+            // to Anela.Heblo.Tests — this lets the builder express an arbitrary
+            // OutlookEventId with NotSynced status, a state no domain method produces.
             var action = new MarketingAction(
                 title: _title,
                 description: _description,


### PR DESCRIPTION
## Summary

Closes #3152.

`MarketingAction` exposed `public set` on eight invariant-bearing fields, letting any handler or repository bypass the domain methods that are supposed to mutate them atomically (e.g. setting `IsDeleted = true` without stamping `DeletedAt` / `DeletedByUserId` / `ModifiedAt`). This narrows those setters so the aggregate's invariants can only change through its domain contract.

### Changes
- `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` — narrowed eight setters from `public set` to `internal set`: `IsDeleted`, `DeletedAt`, `DeletedByUserId`, `DeletedByUsername`, `OutlookEventId`, `OutlookLastAttemptAt`, `OutlookSyncStatus`, `OutlookSyncError`. The `= MarketingSyncStatus.NotSynced` initializer is preserved. `Id` and navigation collections are unchanged.
- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionSyncTests.cs` — arrange Outlook state via `MarkOutlookSynced()` where the domain method expresses it; keep `internal set` only for seeding an error value no domain method produces.
- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs` — refreshed a stale comment to reflect the new `internal set` accessibility.

### Why `internal set` instead of `private set`

The brief suggested `private set`, but the domain assembly already declares `InternalsVisibleTo("Anela.Heblo.Tests")` (and `Anela.Heblo.Persistence`). Using `internal set`:
- Blocks the real bypass risk — the Application/API handlers can no longer mutate these fields directly (they already route through `SoftDelete()` / `MarkOutlookSynced()` / `ClearOutlookLink()`).
- Lets the test assembly arrange states no domain method can express (e.g. an arbitrary `OutlookEventId` with `NotSynced` status), avoiding reflection hacks.
- Matches the codebase's existing `internal` + `InternalsVisibleTo` test-seam convention.

### Persistence

No EF Core configuration change and no migration. EF Core 8 materializes the `internal set` properties through the existing private parameterless constructor; column mappings, the `!IsDeleted` query filter, and indexes are unchanged.

## Verification
- `dotnet build Anela.Heblo.sln` — succeeds, 0 errors.
- `dotnet format --verify-no-changes` — clean.
- `dotnet test --filter "FullyQualifiedName~Domain.Marketing"` — 54/54 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDjzuxxsSdrmgTBmwQvt2v

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDjzuxxsSdrmgTBmwQvt2v)_