### PR TITLE
feat-3069: fix Smartsupp webhook 500 — widen varchar(500) conversation columns

### DIFF
--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260617203913_WidenSmartsuppConversationUrlAndSubjectColumns.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260617203913_WidenSmartsuppConversationUrlAndSubjectColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617203913_WidenSmartsuppConversationUrlAndSubjectColumns")]
+    partial class WidenSmartsuppConversationUrlAndSubjectColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260617203913_WidenSmartsuppConversationUrlAndSubjectColumns.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260617203913_WidenSmartsuppConversationUrlAndSubjectColumns.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenSmartsuppConversationUrlAndSubjectColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Subject",
+                schema: "public",
+                table: "SmartsuppConversations",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Referer",
+                schema: "public",
+                table: "SmartsuppConversations",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ContactAvatarUrl",
+                schema: "public",
+                table: "SmartsuppConversations",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Subject",
+                schema: "public",
+                table: "SmartsuppConversations",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Referer",
+                schema: "public",
+                table: "SmartsuppConversations",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ContactAvatarUrl",
+                schema: "public",
+                table: "SmartsuppConversations",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Smartsupp/SmartsuppConversationConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Smartsupp/SmartsuppConversationConfiguration.cs
@@ -12,14 +12,14 @@ public sealed class SmartsuppConversationConfiguration : IEntityTypeConfiguratio
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id).HasMaxLength(100);
         builder.Property(e => e.ExtId).HasMaxLength(100);
-        builder.Property(e => e.Subject).HasMaxLength(500);
+        builder.Property(e => e.Subject).HasColumnType("text");
         builder.Property(e => e.ContactId).HasMaxLength(100);
         builder.Property(e => e.ContactName).HasMaxLength(200);
         builder.Property(e => e.ContactEmail).HasMaxLength(200);
-        builder.Property(e => e.ContactAvatarUrl).HasMaxLength(500);
+        builder.Property(e => e.ContactAvatarUrl).HasColumnType("text");
         builder.Property(e => e.VisitorId).HasMaxLength(100);
         builder.Property(e => e.Domain).HasMaxLength(200);
-        builder.Property(e => e.Referer).HasMaxLength(500);
+        builder.Property(e => e.Referer).HasColumnType("text");
         builder.Property(e => e.LocationCountry).HasMaxLength(100);
         builder.Property(e => e.LocationCity).HasMaxLength(100);
         builder.Property(e => e.LocationIp).HasMaxLength(50);

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppConversationSchemaTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppConversationSchemaTests.cs
@@ -1,0 +1,38 @@
+using Anela.Heblo.Domain.Features.Smartsupp;
+using Anela.Heblo.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Smartsupp;
+
+// Regression guard for issue #3069: a Smartsupp webhook payload with a long
+// referer URL / subject / avatar URL overflowed the varchar(500) columns and
+// produced a 500 (Npgsql 22001). These free-text/URL fields carry arbitrary
+// external content and must remain unbounded (text).
+public class SmartsuppConversationSchemaTests
+{
+    private static ApplicationDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    [Theory]
+    [InlineData(nameof(SmartsuppConversation.Subject))]
+    [InlineData(nameof(SmartsuppConversation.Referer))]
+    [InlineData(nameof(SmartsuppConversation.ContactAvatarUrl))]
+    public void Conversation_FreeTextAndUrlColumns_AreUnbounded(string propertyName)
+    {
+        using var db = NewContext();
+
+        var property = db.Model
+            .FindEntityType(typeof(SmartsuppConversation))!
+            .FindProperty(propertyName)!;
+
+        property.GetMaxLength().Should().BeNull(
+            $"{propertyName} carries arbitrary external content and must not be capped");
+    }
+}


### PR DESCRIPTION
Closes #3069

## What the issue was
`POST SmartsuppWebhook/Receive` returned HTTP 500 in a burst on 2026-06-13. Root cause was a Postgres `22001: value too long for type character varying(500)` thrown from `SmartsuppRepository.SaveChangesAsync`. A live Smartsupp webhook payload contained a string field that exceeded a `varchar(500)` column on `SmartsuppConversations`. Smartsupp then retried the delivery, producing the burst.

## Root cause analysis
`SmartsuppPayloadMapper.MapConversation` maps three unbounded external strings straight into `varchar(500)` columns **without truncation**:

- `Subject`
- `Referer` (a referer URL with query string easily exceeds 500 chars — the most likely culprit)
- `ContactAvatarUrl`

`LastMessagePreview` is also `varchar(500)` but the mapper already truncates it to 200 chars, so it was never at risk.

## How it was fixed
Took the issue's recommended option (a) — increase column size, no silent data loss — by converting the three free-text/URL columns to `text` (unbounded), matching how `Content`, `PageUrl`, and `AttachmentsJson` are already stored.

- **EF config**: `SmartsuppConversationConfiguration` — `Subject`, `Referer`, `ContactAvatarUrl` now `HasColumnType("text")`.
- **Migration**: `WidenSmartsuppConversationUrlAndSubjectColumns` (+ updated model snapshot). `varchar(500)` → `text` is a metadata-only change in Postgres.
- **Regression test**: `SmartsuppConversationSchemaTests` asserts these columns are unbounded in the EF model.

> Note: migrations are applied manually in this project — this migration must be run against staging/production after merge.

## Validation
- `dotnet build` (Persistence) ✅
- `dotnet format --verify-no-changes` ✅
- Smartsupp tests: 184 passed, 0 failed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)