### PR TITLE
feat-3079: add unit tests for SubmitManufactureHandler CTS timeout and PersistDocCodesAsync branches

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureHandlerTests.cs
@@ -6,6 +6,7 @@ using Anela.Heblo.Domain.Features.Manufacture;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -249,4 +250,214 @@ public class SubmitManufactureHandlerTests
             new() { ProductCode = "PROD001", Name = "Test Product", Amount = 100 }
         }
     };
+
+    // ── CTS timeout branch ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateLinkedCts_WhenErpTimeoutConfigured_CtsIsArmedWithTimeout()
+    {
+        // Arrange — use 30s timeout so the test does not race with CI wall-clock.
+        CancellationToken capturedCt = default;
+        var handlerWithTimeout = new SubmitManufactureHandler(
+            _clientMock.Object,
+            _repositoryMock.Object,
+            _transformerMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            Options.Create(new ManufactureErpOptions { ErpTimeoutSeconds = 30 }));
+
+        _clientMock
+            .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SubmitManufactureClientRequest, CancellationToken>((_, ct) => capturedCt = ct)
+            .ReturnsAsync(new SubmitManufactureClientResponse { ManufactureId = "MAN-CTS" });
+
+        // Act
+        await handlerWithTimeout.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert — CancelAfter was called so the token can be canceled.
+        capturedCt.CanBeCanceled.Should().BeTrue();
+    }
+
+    // ── PersistDocCodesAsync branches ─────────────────────────────────────────
+
+    [Fact]
+    public async Task PersistDocCodes_WhenOrderIdIsZero_RepositoryIsNotCalled()
+    {
+        // Arrange — BuildRequest() has ManufactureOrderId = 0 by default.
+        _clientMock
+            .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubmitManufactureClientResponse { ManufactureId = "MAN-ZERO" });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _repositoryMock.Verify(
+            r => r.GetOrderByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PersistDocCodes_WhenOrderNotFound_LogsWarningAndDoesNotCallUpdate()
+    {
+        // Arrange
+        var request = BuildRequest();
+        request.ManufactureOrderId = 42;
+
+        _clientMock
+            .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubmitManufactureClientResponse { ManufactureId = "MAN-NOTFOUND" });
+
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder?)null);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("42")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+        _repositoryMock.Verify(
+            r => r.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PersistDocCodes_WhenAllDocCodesPresent_WritesAllSixFieldsWithTimestamp()
+    {
+        // Arrange
+        var fakeTime = new FakeTimeProvider(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+        var expectedNow = fakeTime.GetUtcNow().DateTime;
+
+        var handlerWithFakeTime = new SubmitManufactureHandler(
+            _clientMock.Object,
+            _repositoryMock.Object,
+            _transformerMock.Object,
+            fakeTime,
+            _loggerMock.Object,
+            Options.Create(new ManufactureErpOptions()));
+
+        var request = BuildRequest();
+        request.ManufactureOrderId = 10;
+
+        var order = new ManufactureOrder { Id = 10, OrderNumber = "MO-010", StateChangedByUser = "test" };
+
+        _clientMock
+            .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubmitManufactureClientResponse
+            {
+                ManufactureId = "MAN-ALL",
+                MaterialIssueForSemiProductDocCode = "V-MAT-001",
+                SemiProductReceiptDocCode = "V-POL-001",
+                SemiProductIssueForProductDocCode = "V-POLV-001",
+                MaterialIssueForProductDocCode = "V-MATV-001",
+                ProductReceiptDocCode = "V-PRIJEM-001",
+                DirectSemiProductOutputDocCode = "V-DIRECT-001",
+            });
+
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _repositoryMock
+            .Setup(r => r.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await handlerWithFakeTime.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        order.DocMaterialIssueForSemiProduct.Should().Be("V-MAT-001");
+        order.DocMaterialIssueForSemiProductDate.Should().Be(expectedNow);
+        order.DocSemiProductReceipt.Should().Be("V-POL-001");
+        order.DocSemiProductReceiptDate.Should().Be(expectedNow);
+        order.DocSemiProductIssueForProduct.Should().Be("V-POLV-001");
+        order.DocSemiProductIssueForProductDate.Should().Be(expectedNow);
+        order.DocMaterialIssueForProduct.Should().Be("V-MATV-001");
+        order.DocMaterialIssueForProductDate.Should().Be(expectedNow);
+        order.DocProductReceipt.Should().Be("V-PRIJEM-001");
+        order.DocProductReceiptDate.Should().Be(expectedNow);
+        order.ErpDiscardResidueDocumentNumber.Should().Be("V-DIRECT-001");
+        order.ErpDiscardResidueDocumentNumberDate.Should().Be(expectedNow);
+
+        _repositoryMock.Verify(
+            r => r.UpdateOrderAsync(order, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PersistDocCodes_WhenSomeDocCodesNull_WritesOnlyNonNullFields()
+    {
+        // Arrange — only MaterialIssueForSemiProductDocCode and ProductReceiptDocCode are set.
+        var fakeTime = new FakeTimeProvider(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+        var expectedNow = fakeTime.GetUtcNow().DateTime;
+
+        var handlerWithFakeTime = new SubmitManufactureHandler(
+            _clientMock.Object,
+            _repositoryMock.Object,
+            _transformerMock.Object,
+            fakeTime,
+            _loggerMock.Object,
+            Options.Create(new ManufactureErpOptions()));
+
+        var request = BuildRequest();
+        request.ManufactureOrderId = 20;
+
+        var order = new ManufactureOrder { Id = 20, OrderNumber = "MO-020", StateChangedByUser = "test" };
+
+        _clientMock
+            .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubmitManufactureClientResponse
+            {
+                ManufactureId = "MAN-PARTIAL",
+                MaterialIssueForSemiProductDocCode = "V-MAT-PARTIAL",
+                SemiProductReceiptDocCode = null,
+                SemiProductIssueForProductDocCode = null,
+                MaterialIssueForProductDocCode = null,
+                ProductReceiptDocCode = "V-PRIJEM-PARTIAL",
+                DirectSemiProductOutputDocCode = null,
+            });
+
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _repositoryMock
+            .Setup(r => r.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        // Act
+        var result = await handlerWithFakeTime.Handle(request, CancellationToken.None);
+
+        // Assert — two non-null fields written
+        result.Success.Should().BeTrue();
+        order.DocMaterialIssueForSemiProduct.Should().Be("V-MAT-PARTIAL");
+        order.DocMaterialIssueForSemiProductDate.Should().Be(expectedNow);
+        order.DocProductReceipt.Should().Be("V-PRIJEM-PARTIAL");
+        order.DocProductReceiptDate.Should().Be(expectedNow);
+
+        // Assert — four null fields left untouched
+        order.DocSemiProductReceipt.Should().BeNull();
+        order.DocSemiProductReceiptDate.Should().BeNull();
+        order.DocSemiProductIssueForProduct.Should().BeNull();
+        order.DocSemiProductIssueForProductDate.Should().BeNull();
+        order.DocMaterialIssueForProduct.Should().BeNull();
+        order.DocMaterialIssueForProductDate.Should().BeNull();
+        order.ErpDiscardResidueDocumentNumber.Should().BeNull();
+        order.ErpDiscardResidueDocumentNumberDate.Should().BeNull();
+
+        _repositoryMock.Verify(
+            r => r.UpdateOrderAsync(order, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }


### PR DESCRIPTION
## What the issue was

`SubmitManufactureHandler` had 59.6% line coverage, just below the 60% CI threshold (#3079). Two code paths were completely uncovered:

1. **`CreateLinkedCts` timeout branch** — the `cts.CancelAfter(...)` call guarded by `ErpTimeoutSeconds > 0` was never entered in CI, leaving the ERP timeout mechanism untested. A broken timeout would allow hung ERP calls to block the request pipeline indefinitely.

2. **`PersistDocCodesAsync` branches** — all eight paths were uncovered: the `orderId == 0` early-return, the `order == null` not-found guard, and each of the six independent `if (clientResponse.XxxDocCode != null)` write-branches. Missing doc codes prevent downstream reconciliation in Flexi.

## How it was fixed / handled

Added 5 new `[Fact]` tests to the existing `SubmitManufactureHandlerTests` class — no production code changes:

1. **`CreateLinkedCts_WhenErpTimeoutConfigured_CtsIsArmedWithTimeout`** — constructs handler with `ErpTimeoutSeconds = 30`, captures the `CancellationToken` passed to the client mock via `Callback`, and asserts `ct.CanBeCanceled == true` (proving `CancelAfter` was called). Uses an immediately-resolving mock so the test completes in microseconds.

2. **`PersistDocCodes_WhenOrderIdIsZero_RepositoryIsNotCalled`** — uses the default `BuildRequest()` (which has `ManufactureOrderId = 0`) and verifies `GetOrderByIdAsync` is never called.

3. **`PersistDocCodes_WhenOrderNotFound_LogsWarningAndDoesNotCallUpdate`** — mocks `GetOrderByIdAsync` returning `null` for id=42, verifies a `LogLevel.Warning` containing "42" is emitted and `UpdateOrderAsync` is never called.

4. **`PersistDocCodes_WhenAllDocCodesPresent_WritesAllSixFieldsWithTimestamp`** — uses `FakeTimeProvider` at a pinned UTC timestamp and asserts all 6 doc-code fields plus their date fields are written with exact values.

5. **`PersistDocCodes_WhenSomeDocCodesNull_WritesOnlyNonNullFields`** — provides 2 of 6 doc codes non-null and asserts only those 2 are written; the remaining 4 order fields stay `null`.

All 14 tests pass (9 pre-existing + 5 new). `dotnet build` and `dotnet format` clean.