### PR TITLE
feat-3080: add unit tests for DisassembleGiftPackageHandler

### DIFF
--- a/.context/pr.md
+++ b/.context/pr.md
@@ -1,26 +1,22 @@
 # PR Context
 
-- **PR**: #3060 — feat: Harden ShoptetStockClient.ListAsync against transient HTTP failures
-- **URL**: https://github.com/onpaj/Anela.Heblo/pull/3060
-- **Branch**: `feat-telemetry-shoptetstockclient-listasync-8` → `main`
-- **State**: open
+- **PR**: #3199 — feat-3080: add unit tests for DisassembleGiftPackageHandler
+- **URL**: https://github.com/onpaj/Anela.Heblo/pull/3199
+- **Branch**: `feature/feat-3080` → `main`
+- **State**: OPEN
 - **Author**: onpaj
-- **Changes**: +2067 / -18 across 15 files
-- **Absorbed**: backmerged with `main`, all tests passing (4939 passed, 4 skipped), pushed
+- **Changes**: +105 / -0 across 1 file
+- **Absorbed**: no backmerge needed (already up-to-date with main); CI fix pushed
 
 ## Description
 
-Hardens `ShoptetStockClient.ListAsync` against transient HTTP failures (~1.1 failures/day).
-Adds Polly retry policy, per-attempt timeout, token redaction in logs, and wraps
-`ProductPairingDqtComparer` stock calls with `ICatalogResilienceService`.
+`DisassembleGiftPackageHandler` had 10.8% line coverage (threshold: 60%). Both exception-routing catch blocks were completely untested — an `InvalidOperationException` maps to `ErrorCodes.InvalidOperation` and an `ArgumentException` maps to `ErrorCodes.InvalidValue`. Because both catch blocks are structurally identical, a copy-paste regression would be silent without tests.
 
-Closes #3000.
+Closes #3080
 
-## Absorb notes
+## What the routine fixed
 
-- Backmerged `origin/main` (150-file merge, clean — no conflicts)
-- Fixed: `ModuleBoundariesTests` (DataQuality -> Catalog rule) — updated `DataQualityCatalogAllowlist`
-  to cover `ICatalogResilienceService` (new Catalog dep in `ProductPairingDqtComparer`) and
-  replaced stale `<CompareAsync>d__5` EshopStock entry with a parent-type entry covering
-  the new `d__6`/`b__6_1>d` compiler-generated types introduced by the resilience wrapper
-- All CI-relevant tests pass locally (4939 passed, 4 skipped, Category!=Integration filter)
+The only failing CI check was **Claude Code Review**, which was failing with:
+> API Error: 404 — model: claude-sonnet-4-20250514 (not found)
+
+The pinned `claude-code-action` at `de8e0b9c` uses a retired model ID. Fix: added `model: claude-sonnet-4-6` to `.github/workflows/claude-review.yml` to override the default. All functional checks (Backend Tests, Frontend Tests, Docker Build) were already passing.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -65,6 +65,7 @@ jobs:
         uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: claude-sonnet-4-6
           pr_number: ${{ github.event.pull_request.number }}
           direct_prompt: |
             Please review this pull request and provide feedback on:

--- a/backend/test/Anela.Heblo.Tests/Application/GiftPackageManufacture/DisassembleGiftPackageHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/GiftPackageManufacture/DisassembleGiftPackageHandlerTests.cs
@@ -1,0 +1,105 @@
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.UseCases.DisassembleGiftPackage;
+using Anela.Heblo.Application.Shared;
+using FluentAssertions;
+using Moq;
+
+namespace Anela.Heblo.Tests.Application.GiftPackageManufacture;
+
+public class DisassembleGiftPackageHandlerTests
+{
+    private readonly Mock<IGiftPackageManufactureService> _serviceMock = new();
+
+    private DisassembleGiftPackageHandler CreateSut() =>
+        new(_serviceMock.Object);
+
+    [Fact]
+    public async Task Handle_ReturnsSuccessWithDisassembly_WhenServiceSucceeds()
+    {
+        // Arrange
+        var disassembly = new GiftPackageDisassemblyDto
+        {
+            GiftPackageCode = "SET001",
+            QuantityDisassembled = 2,
+            DisassembledAt = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            DisassembledBy = "test-user",
+            ReturnedComponents = new List<GiftPackageDisassemblyItemDto>()
+        };
+
+        _serviceMock
+            .Setup(s => s.DisassembleGiftPackageAsync("SET001", 2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(disassembly);
+
+        var request = new DisassembleGiftPackageRequest
+        {
+            GiftPackageCode = "SET001",
+            Quantity = 2
+        };
+
+        // Act
+        var result = await CreateSut().Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        result.Disassembly.GiftPackageCode.Should().Be("SET001");
+        result.Disassembly.QuantityDisassembled.Should().Be(2);
+
+        _serviceMock.Verify(
+            s => s.DisassembleGiftPackageAsync("SET001", 2, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsInvalidOperation_WhenServiceThrowsInvalidOperationException()
+    {
+        // Arrange
+        _serviceMock
+            .Setup(s => s.DisassembleGiftPackageAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Package SET001 does not exist"));
+
+        var request = new DisassembleGiftPackageRequest
+        {
+            GiftPackageCode = "SET001",
+            Quantity = 2
+        };
+
+        // Act
+        var result = await CreateSut().Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InvalidOperation);
+        result.Params.Should().ContainKey("ErrorMessage")
+            .WhoseValue.Should().Be("Package SET001 does not exist");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsInvalidValue_WhenServiceThrowsArgumentException()
+    {
+        // Arrange
+        // Use single-argument constructor — two-argument ctor appends " (Parameter 'name')" to Message.
+        _serviceMock
+            .Setup(s => s.DisassembleGiftPackageAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("Quantity must be greater than zero"));
+
+        var request = new DisassembleGiftPackageRequest
+        {
+            GiftPackageCode = "SET001",
+            Quantity = -1
+        };
+
+        // Act
+        var result = await CreateSut().Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InvalidValue);
+        result.ErrorCode.Should().NotBe(ErrorCodes.InvalidOperation);
+        result.Params.Should().ContainKey("ErrorMessage")
+            .WhoseValue.Should().Be("Quantity must be greater than zero");
+    }
+}


### PR DESCRIPTION
## What the issue was

`DisassembleGiftPackageHandler` had 10.8% line coverage (threshold: 60%). Both exception-routing catch blocks were completely untested — an `InvalidOperationException` maps to `ErrorCodes.InvalidOperation` and an `ArgumentException` maps to `ErrorCodes.InvalidValue`. Because both catch blocks are structurally identical, a copy-paste regression would be silent without tests.

Closes #3080

## How it was fixed / handled

Added three unit tests to a new file `backend/test/Anela.Heblo.Tests/Application/GiftPackageManufacture/DisassembleGiftPackageHandlerTests.cs`:

1. **Happy path** — mocked service returns a `GiftPackageDisassemblyDto`; asserts `Success == true`, `ErrorCode == null`, `Disassembly` populated, service called exactly once.
2. **`InvalidOperationException`** — asserts `Success == false`, `ErrorCode == ErrorCodes.InvalidOperation`, `Params["ErrorMessage"]` carries the exception message.
3. **`ArgumentException`** — asserts `Success == false`, `ErrorCode == ErrorCodes.InvalidValue`, explicit `NotBe(InvalidOperation)` negative assertion to document the distinction.

All three tests pass. Handler coverage reaches 100%.

## Artifacts
- Brief, spec, arch-review, task plan, and impl markdown are in `artifacts/feat-3080/` (gitignored, available locally).