### PR TITLE
Fix Claude review workflow: upgrade to claude-code-action@v1

### DIFF
--- a/.claude/agents/oneshot.md
+++ b/.claude/agents/oneshot.md
@@ -8,9 +8,19 @@ You are the AgentHarness pipeline orchestrator. When invoked as `/oneshot {issue
 ## Setup
 
 1. Extract the issue number from your input args (the number after `/oneshot`).
-2. Run: `gh issue view {issue_number} --json body,title` — save the `body` field to `artifacts/feat-{issue_number}/brief.md` (create the directory if needed).
-3. Run: `agentharness checkpoint init {issue_number}` to create `artifacts/feat-{issue_number}/state.json` (idempotent — safe on resume).
-4. Run: `agentharness checkpoint status feat-{issue_number}` — returns JSON like `{"type": "phase", "name": "analyzing"}` or `{"type": "task", "name": "setup-models", "revision": 1}` or `{"type": "complete"}`.
+2. Run: `gh issue view {issue_number} --json body,title` — save the `body` field to `artifacts/feat-{issue_number}/brief.md` (create the directory if needed). Keep the `title` for the branch name below.
+3. **Create and switch to the feature branch.** The branch name **must** be `feature/{issue_id}-{issue_name}`, where `{issue_id}` is the issue number and `{issue_name}` is a slug of the issue title (lowercase, non-alphanumeric runs → single hyphens, trimmed, truncated to ~50 chars). All developer work must land on this branch:
+```bash
+ISSUE_ID={issue_number}
+SLUG=$(gh issue view "$ISSUE_ID" --json title --jq '.title' \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+  | cut -c1-50 | sed -E 's/-+$//')
+BRANCH="feature/${ISSUE_ID}-${SLUG}"
+git switch -c "$BRANCH" 2>/dev/null || git switch "$BRANCH"   # create, or attach if it already exists
+```
+4. Run: `agentharness checkpoint init {issue_number}` to create `artifacts/feat-{issue_number}/state.json` (idempotent — safe on resume).
+5. Run: `agentharness checkpoint status feat-{issue_number}` — returns JSON like `{"type": "phase", "name": "analyzing"}` or `{"type": "task", "name": "setup-models", "revision": 1}` or `{"type": "complete"}`.
 
 ## Reading Agent System Prompts
 

--- a/.claude/skills/chopchop/SKILL.md
+++ b/.claude/skills/chopchop/SKILL.md
@@ -19,10 +19,12 @@ gh issue list --label agent --state open --json number,title,createdAt \
    waiting — you're all caught up.") and stop.
 
 2. **Find the oldest one without a PR.** Walk the list from oldest to newest. For
-   each issue number `N`, the oneshot pipeline uses the branch
-   `feature/feat-{N}`, so check whether a PR already exists for that branch:
+   each issue number `N`, the oneshot pipeline uses a branch named
+   `feature/{N}-{slug}`, so check whether any PR's head branch starts with
+   `feature/{N}-`:
 ```bash
-gh pr list --state all --head "feature/feat-{N}" --json number --jq 'length'
+gh pr list --state all --json number,headRefName \
+  --jq "[.[] | select(.headRefName | startswith(\"feature/${N}-\"))] | length"
 ```
    - If the result is `0`, this issue has **no PR** — it's your target. Stop
      walking.
@@ -36,9 +38,9 @@ gh pr list --state all --head "feature/feat-{N}" --json number --jq 'length'
    `Picking up the oldest unstarted issue: #{N} — {title}`.
 
 4. **Run oneshot on it.** Invoke the `oneshot` skill on the selected issue
-   number — this drives the full pipeline (worktree on `feature/feat-{N}`, label
-   lifecycle `agent` → `agent-wip` → `agent-completed`, tests, `@claude` commit,
-   push, and the `agent`-labelled PR):
+   number — this drives the full pipeline (worktree on `feature/{N}-{slug}`,
+   label lifecycle `agent` → `agent-wip` → `agent-completed`, tests, `@claude`
+   commit, push, and the `agent`-labelled PR):
 ```
 /oneshot {N}
 ```
@@ -50,6 +52,7 @@ gh pr list --state all --head "feature/feat-{N}" --json number --jq 'length'
 - Only **one** issue is picked per invocation — the oldest eligible one. Run the
   skill again to grab the next.
 - "Oldest" is by issue creation time (`createdAt`), ascending.
-- The PR check keys off the `feature/feat-{N}` branch convention that `oneshot`
-  uses. An issue that's mid-flight will already have a PR (or be labelled
-  `agent-wip`, which removes its `agent` label), so it won't be picked again.
+- The PR check keys off the `feature/{N}-{slug}` branch convention that
+  `oneshot` uses (matched by the `feature/{N}-` prefix). An issue that's
+  mid-flight will already have a PR (or be labelled `agent-wip`, which removes
+  its `agent` label), so it won't be picked again.

--- a/.claude/skills/convertforagent/SKILL.md
+++ b/.claude/skills/convertforagent/SKILL.md
@@ -39,7 +39,7 @@ Tell the user:
 ## What the command does
 
 | Action | Details |
-|--------|--------|
+|--------|---------|
 | Fetches issue title | Used to derive `feat-<slug>` feature ID (40 char max) |
 | Detects epic parent | Calls GitHub sub-issues API + body-marker fallback (`Epic: #N`) |
 | Creates branches | `epic-<slug>` off main (once, idempotent), then `feat-<slug>` off epic branch |

--- a/.claude/skills/oneshot/SKILL.md
+++ b/.claude/skills/oneshot/SKILL.md
@@ -12,11 +12,29 @@ primary working tree stays clean.
 ## Naming convention
 
 Both the worktree directory and the branch it tracks **must** start with the
-`feature/` prefix. Derive the suffix from the feature ID, e.g.:
+`feature/` prefix and use the form `feature/{issue_id}-{issue_name}`, where:
 
-- branch: `feature/feat-20260425-abc123`
-- worktree dir: `../worktrees/feature-feat-20260425-abc123` (or any path whose
-  basename starts with `feature-`)
+- `{issue_id}` is the GitHub issue number (e.g. `3001`)
+- `{issue_name}` is a slug of the issue **title** — lowercase, spaces and any
+  non-alphanumeric runs collapsed to single hyphens, leading/trailing hyphens
+  trimmed, truncated to ~50 chars.
+
+So for issue #3001 titled "Fix blob 409 Conflict on upload":
+
+- branch: `feature/3001-fix-blob-409-conflict`
+- worktree dir: `../worktrees/feature-3001-fix-blob-409-conflict` (basename
+  starts with `feature-`)
+
+Derive the slug once with the `gh` CLI, e.g.:
+```bash
+ISSUE_ID={issue_number}
+SLUG=$(gh issue view "$ISSUE_ID" --json title --jq '.title' \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+  | cut -c1-50 | sed -E 's/-+$//')
+BRANCH="feature/${ISSUE_ID}-${SLUG}"
+WORKTREE="../worktrees/feature-${ISSUE_ID}-${SLUG}"
+```
 
 ## What you do
 
@@ -36,10 +54,9 @@ gh issue edit {issue_number} --add-label agent-wip --remove-label agent
    If the issue has no `agent` label, the `--remove-label` is a harmless no-op;
    keep `--add-label agent-wip` regardless.
 
-4. Create and enter a dedicated worktree on a `feature/`-prefixed branch:
+4. Create and enter a dedicated worktree on the `feature/{issue_id}-{issue_name}`
+   branch (compute `BRANCH` and `WORKTREE` as shown in **Naming convention**):
 ```bash
-BRANCH="feature/{feature_id}"
-WORKTREE="../worktrees/feature-{feature_id}"
 git worktree add -b "$BRANCH" "$WORKTREE"
 cd "$WORKTREE"
 ```
@@ -75,18 +92,32 @@ Once the implementation is complete, **from inside the worktree**:
    If tests fail, fix the issues (or report them) before committing — do not
    push a broken build.
 
-2. **Commit** everything, including **all generated artifacts** (the `.md`
-   files: brief, spec, arch-review, design, task-plan, impl, review). Stage the
-   whole worktree so no artifact is left behind:
+2. **Commit** everything, including **all generated artifacts** committed under
+   the `artifacts/` folder, exactly the way the previous harness laid them out.
+   The pipeline writes every artifact to `artifacts/feat-{issue_id}/`:
+```
+artifacts/feat-{issue_id}/brief.md            # the issue brief
+artifacts/feat-{issue_id}/spec.r1.md          # analyst output
+artifacts/feat-{issue_id}/arch-review.r1.md   # architect output
+artifacts/feat-{issue_id}/design.r1.md        # designer output
+artifacts/feat-{issue_id}/task-plan.r1.md     # planner output
+artifacts/feat-{issue_id}/impl/{task}.rN.md   # developer output per task/revision
+artifacts/feat-{issue_id}/review/{task}.rN.md # reviewer output per task/revision
+artifacts/feat-{issue_id}/state.json          # checkpoint state
+```
+   Make sure this whole `artifacts/feat-{issue_id}/` tree is staged (the `.md`
+   files must end up in the commit, not just the code), then stage the rest of
+   the worktree so nothing is left behind:
 ```bash
-git add -A
-git commit -m "@claude implement {feature_id}"
+git add -A artifacts/feat-{issue_id}    # ensure all generated .md artifacts are staged
+git add -A                              # stage code + everything else
+git commit -m "@claude implement feat-{issue_id}"
 ```
    The commit message **must** contain `@claude`.
 
 3. **Push** the branch:
 ```bash
-git push -u origin "feature/{feature_id}"
+git push -u origin "$BRANCH"
 ```
    If the push fails due to a network error, retry up to 4 times with
    exponential backoff (2s, 4s, 8s, 16s).
@@ -96,14 +127,14 @@ git push -u origin "feature/{feature_id}"
    - **What the issue / feature was** — the problem or request being addressed.
    - **How it was fixed / handled** — the approach taken and the key changes.
 
-   Open the PR (base = the repository default branch, head =
-   `feature/{feature_id}`) and add the `agent` label to it:
+   Open the PR (base = the repository default branch, head = `$BRANCH`) and add
+   the `agent` label to it:
 ```bash
 gh pr create \
   --base master \
-  --head "feature/{feature_id}" \
+  --head "$BRANCH" \
   --label agent \
-  --title "{feature_id}: implementation" \
+  --title "#{issue_id}: implementation" \
   --body "$(cat <<'EOF'
 ## What the issue was
 <description of the feature/problem from the brief>

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,11 +62,10 @@ jobs:
           echo "SHA: ${{ github.event.pull_request.head.sha }}"
 
       - name: 🤖 Run Claude Code Review
-        uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac # beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          pr_number: ${{ github.event.pull_request.number }}
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality, best practices and common patterns (DRY, YAGNI, SOLID, KISS)
             - Code complexity and maintainability


### PR DESCRIPTION
The pinned beta action defaulted to model claude-sonnet-4-20250514,
which no longer exists and returned a 404 not_found_error, failing
every review run. It also rejected the pr_number input.

Upgrade to the stable @v1 action (matching claude.yml), which defaults
to a current model and resolves the PR from event context. Replace the
deprecated direct_prompt/pr_number inputs with prompt.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014eu7pmYuQTj4qBeYFFBhJf