### PR TITLE
#3001: filter benign Azure Blob 409 Conflict telemetry

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
@@ -68,6 +68,7 @@ public static class ApplicationInsightsExtensions
         // Add telemetry processor for filtering
         services.AddApplicationInsightsTelemetryProcessor<CostOptimizedTelemetryProcessor>();
         services.AddApplicationInsightsTelemetryProcessor<HomeAssistantDependencyTelemetryFilter>();
+        services.AddApplicationInsightsTelemetryProcessor<AzureBlobConflictTelemetryFilter>();
 
         // Configure sampling (more aggressive for cost savings)
         services.Configure<TelemetryConfiguration>((config) =>

--- a/backend/src/Anela.Heblo.API/Infrastructure/Telemetry/AzureBlobConflictTelemetryFilter.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Telemetry/AzureBlobConflictTelemetryFilter.cs
@@ -1,0 +1,51 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Anela.Heblo.API.Telemetry;
+
+/// <summary>
+/// Drops the benign HTTP 409 Conflict dependency telemetry emitted when the Azure
+/// Blob SDK provisions a container that already exists.
+///
+/// Both blob code paths (<c>AzureBlobStorageService</c> and <c>AzureBlobPrintQueueSink</c>)
+/// call <c>CreateIfNotExistsAsync</c> on cold start to guarantee the target container
+/// exists. When the container is already present, the storage service answers the
+/// underlying <c>PUT container</c> with 409 Conflict; the SDK treats this as an expected
+/// no-op and returns a null/false result without throwing. The auto-collected dependency
+/// tracking module, however, still records the raw 409 as a <em>failed</em> dependency,
+/// which surfaces as a recurring "Azure blob 409 Conflict" reliability signal even though
+/// no operation actually failed.
+///
+/// This codebase performs no leased or conditional blob writes, so a 409 on the
+/// "Azure blob" dependency type can only originate from this swallowed container-create
+/// conflict. Filtering it removes the false-positive failures without masking any genuine
+/// blob error (uploads use unconditional overwrites and surface their own failures).
+///
+/// Mirrors the established <c>HomeAssistantDependencyTelemetryFilter</c> pattern.
+/// </summary>
+public sealed class AzureBlobConflictTelemetryFilter : ITelemetryProcessor
+{
+    private const string AzureBlobDependencyType = "Azure blob";
+    private const string ConflictResultCode = "409";
+
+    private readonly ITelemetryProcessor _next;
+
+    public AzureBlobConflictTelemetryFilter(ITelemetryProcessor next)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+    }
+
+    public void Process(ITelemetry item)
+    {
+        if (item is DependencyTelemetry dep
+            && string.Equals(dep.Type, AzureBlobDependencyType, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(dep.ResultCode, ConflictResultCode, StringComparison.Ordinal))
+        {
+            // Swallowed-by-SDK container-create conflict — not an application failure.
+            return;
+        }
+
+        _next.Process(item);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/Telemetry/AzureBlobConflictTelemetryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/Telemetry/AzureBlobConflictTelemetryFilterTests.cs
@@ -1,0 +1,90 @@
+using Anela.Heblo.API.Telemetry;
+using FluentAssertions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Moq;
+
+namespace Anela.Heblo.Tests.Infrastructure.Telemetry;
+
+public class AzureBlobConflictTelemetryFilterTests
+{
+    private readonly Mock<ITelemetryProcessor> _next = new();
+    private readonly AzureBlobConflictTelemetryFilter _filter;
+
+    public AzureBlobConflictTelemetryFilterTests()
+    {
+        _filter = new AzureBlobConflictTelemetryFilter(_next.Object);
+    }
+
+    [Fact]
+    public void Process_DropsAzureBlob409Conflict()
+    {
+        var dep = new DependencyTelemetry
+        {
+            Type = "Azure blob",
+            Name = "PUT stheblo",
+            ResultCode = "409",
+            Success = false
+        };
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(It.IsAny<ITelemetry>()), Times.Never);
+    }
+
+    [Fact]
+    public void Process_DropsAzureBlob409_CaseInsensitiveType()
+    {
+        var dep = new DependencyTelemetry
+        {
+            Type = "AZURE BLOB",
+            ResultCode = "409",
+            Success = false
+        };
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(It.IsAny<ITelemetry>()), Times.Never);
+    }
+
+    [Fact]
+    public void Process_ForwardsAzureBlobNonConflictFailures()
+    {
+        var dep = new DependencyTelemetry
+        {
+            Type = "Azure blob",
+            ResultCode = "500",
+            Success = false
+        };
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(dep), Times.Once);
+    }
+
+    [Fact]
+    public void Process_Forwards409FromOtherDependencyTypes()
+    {
+        var dep = new DependencyTelemetry
+        {
+            Type = "Http",
+            ResultCode = "409",
+            Success = false
+        };
+
+        _filter.Process(dep);
+
+        _next.Verify(n => n.Process(dep), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsNonDependencyTelemetry()
+    {
+        var trace = new TraceTelemetry("hello");
+
+        _filter.Process(trace);
+
+        _next.Verify(n => n.Process(trace), Times.Once);
+    }
+}


### PR DESCRIPTION
## What the issue was

App Insights flagged **16 / 231 (6.9%)** Azure Blob dependency calls to
`stheblo.blob.core.windows.net` as failing with HTTP **409 Conflict** (issue #3001).
Direct `BlobClient.Upload` operations showed **0** failures, so the 409s were
coming from a different blob path.

## Root cause

Both blob code paths provision their container on cold start via
`CreateIfNotExistsAsync`:
- `AzureBlobStorageService.GetOrCreateContainerAsync` (FileStorage)
- `AzureBlobPrintQueueSink.EnsureContainerAsync` (ExpeditionList)

When the container already exists, the underlying `PUT container` returns
**409 ContainerAlreadyExists**. The Azure SDK treats this as an expected no-op and
returns without throwing — there is **no application failure** — but the
auto-collected Dependency Tracking module still records the raw 409 as a *failed*
dependency. That is the recurring "Azure blob 409 Conflict" reliability signal.

This matches the telemetry exactly: uploads use unconditional overwrites (never
409); only the once-per-process container-create calls produce the sporadic 409s.

## How it was fixed

Suppress the benign 409 at the telemetry layer, mirroring the existing
`HomeAssistantDependencyTelemetryFilter` precedent — no change to blob behaviour.

- New `AzureBlobConflictTelemetryFilter` (`ITelemetryProcessor`) drops
  `DependencyTelemetry` where `Type == "Azure blob"` and `ResultCode == "409"`.
- Registered in `ApplicationInsightsExtensions` alongside the existing processors.
- 5 unit tests cover the drop case (incl. case-insensitive type) and pass-through
  for non-409 blob failures, 409s from other dependency types, and non-dependency
  telemetry.

This codebase performs no leased or conditional blob writes, so an `Azure blob`
409 can only be the swallowed container-create conflict; genuine blob errors
surface with non-409 codes and are still reported.

## Validation

- `dotnet build` (API): 0 errors
- `dotnet format --verify-no-changes` on changed files: clean
- New filter tests: 5 passed, 0 failed

## Artifacts

- `artifacts/feat-3001/spec.r1.md` (root-cause analysis & decision) is committed
  in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)