### PR TITLE
#3116: Encapsulate ManufactureOrder state transition rules in the domain entity

### DIFF
--- a/.context/pr.md
+++ b/.context/pr.md
@@ -1,26 +1,33 @@
 # PR Context
 
-- **PR**: #3060 — feat: Harden ShoptetStockClient.ListAsync against transient HTTP failures
-- **URL**: https://github.com/onpaj/Anela.Heblo/pull/3060
-- **Branch**: `feat-telemetry-shoptetstockclient-listasync-8` → `main`
-- **State**: open
+- **PR**: #3204 — #3116: Encapsulate ManufactureOrder state transition rules in the domain entity
+- **URL**: https://github.com/onpaj/Anela.Heblo/pull/3204
+- **Branch**: `feature/3116-arch-review-manufacture-state-transition-rules-liv` → `main`
+- **State**: OPEN
 - **Author**: onpaj
-- **Changes**: +2067 / -18 across 15 files
-- **Absorbed**: backmerged with `main`, all tests passing (4939 passed, 4 skipped), pushed
+- **Changes**: +1437 / -162 across 22 files
+- **Absorbed**: backmerged with `main` (clean, no conflicts), all PR tests passing (693 Manufacture tests). Pre-existing FlexiBee integration-test failures are environment-only (require live FlexiBee config) and exist on `main` too — unrelated to this PR.
 
 ## Description
 
-Hardens `ShoptetStockClient.ListAsync` against transient HTTP failures (~1.1 failures/day).
-Adds Polly retry policy, per-attempt timeout, token redaction in logs, and wraps
-`ProductPairingDqtComparer` stock calls with `ICatalogResilienceService`.
+## What the issue was
+`ManufactureOrder` exposed `State` as an unguarded public setter, and the legal state-transition table lived in `UpdateManufactureOrderStatusHandler.IsValidStateTransition`. Keeping the rule in the Application layer violated *business logic belongs in the domain*: any handler could assign an arbitrary state directly (`order.State = ...`) bypassing validation, and the rule could only be tested through the handler, never against the entity in isolation.
 
-Closes #3000.
+## How it was fixed / handled
+Relocated the transition rules into the `ManufactureOrder` aggregate, following the existing `TransportBox` precedent — no runtime or HTTP-contract change.
 
-## Absorb notes
+### Changes
+- **`ManufactureOrder.cs`** — `State`/`StateChangedAt`/`StateChangedByUser` setters tightened to `internal set`; added `InitializeState(...)` (sanctioned seeding path), `CanTransitionTo(...)` (pure predicate reproducing the existing matrix verbatim, type-agnostic), and a guarded `ChangeState(...)` that throws `ValidationException` on an illegal transition (validate-before-mutate, all three audit fields set atomically).
+- **`UpdateManufactureOrderStatusHandler.cs`** — pre-checks via `order.CanTransitionTo(...)` (identical `InvalidOperation { oldState, newState }` early return preserved — not a thrown-exception path), mutates via `order.ChangeState(...)`; the private `IsValidStateTransition` was deleted. All side effects and response shapes unchanged.
+- **`CreateManufactureOrderHandler.cs` / `DuplicateManufactureOrderHandler.cs`** — seed the initial `Draft` state via `InitializeState` (the latter also assigned `State` in an initializer and had to be redirected to compile under `internal set`).
+- **Tests** — `ManufactureOrderStateTransitionTests` rewritten: removed the three type-aware private mirror helpers and their theories (which never exercised production code and would have silently changed behaviour), replaced with an exhaustive `CanTransitionTo` matrix theory plus legal/illegal `ChangeState` tests against the real entity. Arrange-phase `State = ...` seeding across 8 affected fixtures routed through `InitializeState`; no expected outcomes changed.
 
-- Backmerged `origin/main` (150-file merge, clean — no conflicts)
-- Fixed: `ModuleBoundariesTests` (DataQuality -> Catalog rule) — updated `DataQualityCatalogAllowlist`
-  to cover `ICatalogResilienceService` (new Catalog dep in `ProductPairingDqtComparer`) and
-  replaced stale `<CompareAsync>d__5` EshopStock entry with a parent-type entry covering
-  the new `d__6`/`b__6_1>d` compiler-generated types introduced by the resilience wrapper
-- All CI-relevant tests pass locally (4939 passed, 4 skipped, Category!=Integration filter)
+### Verification
+- `dotnet build` — succeeds (pre-existing warnings only).
+- `dotnet format --verify-no-changes` — clean.
+- `dotnet test --filter "FullyQualifiedName~Manufacture"` — **693 passed, 0 failed, 0 skipped** (includes EF materialization tests confirming `State` still binds under the non-public setter).
+
+## Artifacts
+- Brief, spec, arch review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3116/` in this branch.
+
+Closes #3116

--- a/.context/pr.md
+++ b/.context/pr.md
@@ -5,8 +5,8 @@
 - **Branch**: `feature/3116-arch-review-manufacture-state-transition-rules-liv` → `main`
 - **State**: OPEN
 - **Author**: onpaj
-- **Changes**: +1437 / -162 across 22 files
-- **Absorbed**: backmerged with `main` (clean, no conflicts), all PR tests passing (693 Manufacture tests). Pre-existing FlexiBee integration-test failures are environment-only (require live FlexiBee config) and exist on `main` too — unrelated to this PR.
+- **Changes**: +1461 / -179 across 23 files
+- **Absorbed**: backmerged with `main` (one conflict in `.context/pr.md`, resolved), pushed. All PR tests passing (717 Manufacture tests in `Anela.Heblo.Tests`). The 7 `Anela.Heblo.Adapters.Flexi.Tests` failures are `FlexiIntegrationTestFixture` constructor errors requiring live FlexiBee config — environment-only, present on `main`, unrelated to this PR.
 
 ## Description
 

--- a/artifacts/feat-3116/arch-review.r1.md
+++ b/artifacts/feat-3116/arch-review.r1.md
@@ -1,0 +1,235 @@
+# Architecture Review: Move ManufactureOrder State Transition Rules into the Domain Aggregate
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a textbook Clean Architecture / DDD refactor and it fits the codebase cleanly. The
+project's own guidelines explicitly call this out: `development_guidelines.md` lists "Don't create
+anemic domain models — put behavior in entities" as a common pitfall, and CLAUDE.md states
+"business logic belongs in the domain." Today the legal-transition matrix is a domain invariant
+that lives in an Application handler (`UpdateManufactureOrderStatusHandler.IsValidStateTransition`),
+and `ManufactureOrder.State` is an unguarded `public get; set;`. Moving the rule onto the aggregate
+is squarely aligned with the documented architecture.
+
+The codebase already contains the canonical reference implementation for this exact pattern:
+`TransportBox` (`backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/TransportBox.cs`) keeps
+`State` as `private set`, mutates it only through a private `ChangeState(...)` that delegates to
+`CheckState(...)`, and throws `ValidationException` on an illegal transition. The spec correctly
+nominates this as the precedent to follow. The one meaningful deviation we recommend (below) is
+**not** mirroring `TransportBox`'s `private set` literally, because `ManufactureOrder` is constructed
+and seeded very differently from `TransportBox`.
+
+**Verification of the brief's suggested rule vs. the actual current code:** I read the live handler
+(lines 162–174). The brief's proposed `CanTransitionTo` body is an **exact** transcription of the
+current `IsValidStateTransition(fromState, toState)` switch — same five `from` arms, same `to`
+targets, same `_ => false` default. There is no discrepancy between the brief's fix and production
+behavior. The only "discrepancy" in the area is the stale, type-aware test helpers (see below),
+which never exercised this handler.
+
+## Proposed Architecture
+
+### Component Overview
+
+| Component | Change | Location |
+|-----------|--------|----------|
+| `ManufactureOrder` | Add `CanTransitionTo` (pure predicate) + `ChangeState` (guarded mutator); reduce `State` setter visibility | `backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs` |
+| `UpdateManufactureOrderStatusHandler` | Replace `IsValidStateTransition` call with `order.CanTransitionTo(...)`; route mutation through `ChangeState`; delete private method | `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs` |
+| `ManufactureOrderStateTransitionTests` | Delete stale private mirror helpers; test `CanTransitionTo` / `ChangeState` against the real entity | `backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderStateTransitionTests.cs` |
+| `CreateManufactureOrderHandler` + test fixtures | Adapt only if the setter visibility change breaks object-initializer seeding (see Decision 2) | various |
+
+No new files, no DI changes, no DB migration, no EF configuration file (the entity is
+convention-mapped — there is **no** `ManufactureOrderConfiguration` class; `ManufactureOrders` is a
+plain `DbSet` on `ApplicationDbContext`).
+
+### Key Design Decisions
+
+#### Decision 1: `CanTransitionTo` is a pure predicate that reproduces the handler matrix exactly
+
+**Options considered:**
+- (a) Copy the handler's type-agnostic switch verbatim onto the entity (brief's proposal).
+- (b) Adopt the richer `ManufactureType`-aware rules embodied in the stale test helpers.
+
+**Chosen approach:** (a). Reproduce the current handler matrix one-for-one.
+
+**Rationale:** This is a behavior-preserving refactor (FR-2). The type-aware helpers
+(`ValidateSinglePhaseTransition` / `ValidateMultiPhaseTransition`) in the existing test file are
+private copies that "mirror the private methods in `ManufactureOrderApplicationService`" — a service
+that no longer drives the live path. They never executed production code. Introducing them now would
+be a silent behavioral change (e.g. it would start rejecting `Planned → SemiProductManufactured` for
+single-phase orders, which the live endpoint currently allows). That is explicitly out of scope.
+
+The exact table to reproduce (verbatim from the live handler, lines 165–173):
+
+```csharp
+public bool CanTransitionTo(ManufactureOrderState newState) => State switch
+{
+    ManufactureOrderState.Draft => newState is ManufactureOrderState.Planned or ManufactureOrderState.Cancelled,
+    ManufactureOrderState.Planned => newState is ManufactureOrderState.Draft or ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Completed,
+    ManufactureOrderState.SemiProductManufactured => newState is ManufactureOrderState.Planned or ManufactureOrderState.Completed or ManufactureOrderState.Cancelled,
+    ManufactureOrderState.Completed => newState is ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Planned,
+    ManufactureOrderState.Cancelled => false,
+    _ => false
+};
+```
+
+Note: every arm omits its own state, so all self-transitions return `false` — preserve that.
+
+#### Decision 2: Setter visibility — use `private set`, but expect to touch the seam points
+
+**Options considered:**
+- (a) `private set` (matches `TransportBox`).
+- (b) `internal set`.
+- (c) Leave `public set`, document `ChangeState` as the sanctioned path.
+
+**Chosen approach:** (a) `private set` — but be aware this is **not** a free change here, unlike
+`TransportBox`. `ManufactureOrder` is consistently constructed via C# object initializers that set
+`State` inline. Concretely:
+- Production: `CreateManufactureOrderHandler` (line ~55) does `State = ManufactureOrderState.Draft` inside `new ManufactureOrder { ... }`.
+- Tests: at least 12 sites use `State = ...` in initializers or assign it directly, including
+  `GetManufactureProtocolHandlerTests` (`new ManufactureOrder { ... State = ... }`),
+  `GetManufactureOrdersHandlerTests`, `GetManufactureOrderHandlerTests`,
+  `DuplicateManufactureOrderHandlerTests`, `UpdateManufactureOrderHandlerTests`,
+  `UpdateManufactureOrderStatusHandlerConditionsTests` (`State = state`),
+  `UpdateManufactureOrderStatusHandlerTests` (`State = state`), and
+  `UpdateManufactureOrderScheduleHandlerTests` which does post-construction `existingOrder.State = ...`.
+
+A `private set` breaks every one of these object-initializer assignments at compile time.
+
+**Rationale & mitigation:** Do not let this scare the implementer into option (c); the whole point
+of the task (FR-4) is to make `order.State = x` impossible from outside the Domain assembly. The
+clean resolution is to provide a domain-sanctioned **initial-state** path so seeding does not need
+the setter:
+
+- Give `ManufactureOrder` an explicit way to set the *initial* `Draft` state with audit fields —
+  either a small constructor/factory `ManufactureOrder.CreateDraft(...)` or an `InitializeState(state, at, by)`
+  used only at creation. `CreateManufactureOrderHandler` switches to that.
+- Keep `private set` so EF Core can still materialize via the backing property (EF Core sets
+  private/`init` setters through its property accessor by convention — this works for `TransportBox`
+  today with the same convention-based mapping, so it will work here).
+- Update the test fixtures. Two acceptable tactics: (i) add a test-only builder/factory in the
+  Domain test area that calls the sanctioned construction path, or (ii) where the test only needs an
+  order in a given state for arrange, construct it and call `ChangeState` (with a legal predecessor)
+  or the initializer factory. Prefer a single shared test helper to avoid touching ~12 files
+  individually — but this is a mechanical, in-scope adaptation, not new behavior.
+
+If, and only if, the initial-state factory proves disproportionately invasive across the seed sites,
+fall back to `internal set` (option b): it still forbids `order.State = x` from the Application and
+test assemblies while letting Domain-internal seeding compile. This is the spec's documented
+fallback (Assumption B) and is acceptable. `public set` (option c) is the last resort and should be
+accompanied by a code comment — but it is discouraged because it leaves FR-4 only partially met.
+
+**Recommendation:** Target `private set` + a `CreateDraft`/initializer factory + one shared test
+builder. Treat `internal set` as the pragmatic fallback if the factory churn is large.
+
+#### Decision 3: `ChangeState` mutator with `ValidationException`, handler pre-checks with `CanTransitionTo`
+
+**Options considered:** Throw `ValidationException` (TransportBox precedent) vs.
+`InvalidOperationException`.
+
+**Chosen approach:** `void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)`
+that throws `System.ComponentModel.DataAnnotations.ValidationException` when `!CanTransitionTo(newState)`,
+and otherwise sets `State`, `StateChangedAt`, `StateChangedByUser` together. Mirror `TransportBox`
+shape exactly (it sets state, timestamp, then appends to its log — `ManufactureOrder` has no state
+log, so it just sets the three fields; do **not** add a state-log collection, that's out of scope).
+
+**Rationale:** Consistency with `TransportBox` is the codebase norm. Critically, the handler must
+**keep its `CanTransitionTo` pre-check and early-return** so the HTTP contract is unchanged: an
+illegal transition still returns `ErrorCodes.InvalidOperation` with `{ oldState, newState }`, never
+a thrown exception bubbling to the `catch` (which would wrongly produce `InternalServerError`). The
+`ChangeState` throw is therefore a *defensive* second line, not the primary control flow. The
+ordering in the handler becomes:
+
+```csharp
+var oldState = order.State;
+if (!order.CanTransitionTo(request.NewState))
+    return new UpdateManufactureOrderStatusResponse(ErrorCodes.InvalidOperation,
+        new Dictionary<string, string> { { "oldState", oldState.ToString() }, { "newState", request.NewState.ToString() } });
+
+var currentUserName = _currentUserService.GetCurrentUser().GetDisplayName();
+order.ChangeState(request.NewState, _timeProvider.GetUtcNow().DateTime, currentUserName);
+// ... remaining side effects unchanged (ManualActionRequired, ERP codes, Flexi docs, notes, conditions, inventory)
+```
+
+This preserves the exact ordering of audit-field writes today (lines 69–71) and keeps
+`currentUserName` available for the downstream `WriteDownInventoryAsync` and note creation.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No structural change. Edits land in three existing files (Domain entity, Application handler, Domain
+test) plus mechanical fixture adaptation. No new module, no DI registration, no
+`PersistenceModule`/`ManufactureModule` change.
+
+### Interfaces and Contracts
+
+New public surface on `ManufactureOrder` (Domain assembly):
+- `public bool CanTransitionTo(ManufactureOrderState newState)` — pure, reads `this.State` + arg only.
+- `public void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)` — guarded; throws `ValidationException`; sets the three fields atomically; sets nothing when it throws (validate first, mutate second).
+- A sanctioned initial-state path (e.g. `public static ManufactureOrder CreateDraft(...)` or `public void InitializeState(...)`) so creation does not depend on a public `State` setter.
+- `State { get; private set; }` (or `internal set` fallback).
+
+Removed Application surface:
+- `UpdateManufactureOrderStatusHandler.IsValidStateTransition(...)` — deleted.
+
+HTTP/MediatR contract (`UpdateManufactureOrderStatusRequest` → `UpdateManufactureOrderStatusResponse`)
+is unchanged: same DTOs, same `ErrorCodes.InvalidOperation` / `ResourceNotFound` / `InternalServerError`,
+same success payload (`OldState`, `NewState`, `StateChangedAt`, `StateChangedByUser`).
+
+### Data Flow
+
+1. Controller → MediatR → `UpdateManufactureOrderStatusHandler.Handle`.
+2. Load order; if null → `ResourceNotFound`.
+3. Capture `oldState`. Pre-check `order.CanTransitionTo(request.NewState)`; if false → `InvalidOperation { oldState, newState }`.
+4. Resolve current user via `ICurrentUserService` (per ADR-005, inside the handler — unchanged).
+5. `order.ChangeState(newState, now, user)` sets state + audit fields.
+6. Remaining side effects (ManualActionRequired, ERP order numbers, weight, Flexi doc codes, note,
+   conditions reading at `SemiProductManufactured`/`Completed`, inventory write-down at `Completed`)
+   run exactly as today.
+7. `UpdateOrderAsync` persists; success response returned.
+
+EF read paths (`GetOrdersAsync` filtering on `x.State`, `UpcomingProductionTile`, repository queries)
+are read-only and unaffected by the setter visibility change.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `private set` breaks ~13 object-initializer/assignment sites (`State = ...`) including production `CreateManufactureOrderHandler` | High (compile-break) | Add a sanctioned `CreateDraft`/`InitializeState` path; add one shared test builder; or fall back to `internal set` (spec Assumption B). This is the bulk of the work — plan for it. |
+| EF Core can't materialize `State` with a non-public setter | Low | Convention-based mapping (no config file) materializes through the property accessor; `TransportBox` already uses `private set` with the same convention and works. Verify via existing `ManufactureOrderRepositoryTests`. |
+| Accidentally importing the type-aware rules from the stale test helpers, silently changing behavior | Medium | Decision 1 — reproduce the handler matrix verbatim; delete the `ValidateSinglePhase`/`ValidateMultiPhase`/3-arg helpers entirely. Cross-check every cell against handler lines 165–173. |
+| `ChangeState` exception escaping to the handler `catch` and turning a 400-style `InvalidOperation` into `InternalServerError` | Medium | Keep the `CanTransitionTo` pre-check + early return; `ChangeState` throw is defensive only. Existing `UpdateManufactureOrderStatusHandlerTests` invalid-transition cases must still assert `InvalidOperation`. |
+| `ChangeState` partially mutates when transition is illegal | Low | Validate before assigning any field; unit-test that the entity is unchanged after a thrown `ValidationException`. |
+| `UpdateManufactureOrderScheduleHandlerTests` assigns `existingOrder.State` post-construction (lines 85, 107) | Low | These are arrange-phase setups; route through the test builder / `ChangeState`. Not production writers. |
+
+## Specification Amendments
+
+- **FR-4 / Assumption B (setter visibility):** Strengthen the guidance. Because `ManufactureOrder`
+  (unlike `TransportBox`) is created and seeded via object initializers that set `State` inline, a
+  `private set` is a real, non-trivial change requiring a sanctioned initial-state construction path
+  and test-fixture updates. The spec should explicitly call for adding a `CreateDraft`/`InitializeState`
+  domain method as part of FR-4 rather than presenting `private set` as nearly free. `internal set`
+  remains the acceptable fallback.
+- **Background note:** The spec references an EF "entity type configuration" for `ManufactureOrder`
+  (Dependencies section). There is **no** such configuration class — the entity is convention-mapped
+  via the `ManufactureOrders` `DbSet` on `ApplicationDbContext`. The persistence verification step
+  should target `ManufactureOrderRepositoryTests`, not a config file.
+- **FR-5:** Confirm deletion (not "keep, marked stale") of the three private mirror helpers in
+  `ManufactureOrderStateTransitionTests`. Keeping them — even annotated — invites future confusion
+  about which rules are authoritative. Recommend full removal; if the type-aware intent must be
+  preserved, capture it as a backlog item / Open Question, not as dead test code.
+
+## Prerequisites
+
+None blocking. All inputs verified against live source:
+- Handler matrix (lines 162–174) confirmed; brief's `CanTransitionTo` matches it exactly.
+- `ManufactureOrderState` enum confirmed: `Draft=1, Planned=2, SemiProductManufactured=4, Completed=5, Cancelled=6`.
+- `TransportBox` precedent confirmed (`private set` + `ChangeState` + `CheckState` + `ValidationException`).
+- Direct/initializer `State` writers enumerated (1 production: `CreateManufactureOrderHandler`; 1 production mutator: `UpdateManufactureOrderStatusHandler`; ~12 test fixtures).
+- No EF configuration class; convention-based mapping.
+
+Validation gate before completion: `dotnet build` + `dotnet format`; all touched tests
+(`ManufactureOrderStateTransitionTests`, `UpdateManufactureOrderStatusHandlerTests`,
+`UpdateManufactureOrderStatusHandlerConditionsTests`, `CreateManufactureOrderHandlerTests`,
+`UpdateManufactureOrderScheduleHandlerTests`, `ManufactureOrderRepositoryTests`) green.

--- a/artifacts/feat-3116/brief.md
+++ b/artifacts/feat-3116/brief.md
@@ -1,0 +1,47 @@
+## Module
+Manufacture
+
+## Finding
+`ManufactureOrder` (`backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs`) exposes `State` as a plain public setter with no invariant protection. The allowed state transition table lives in `UpdateManufactureOrderStatusHandler.IsValidStateTransition` (lines 162–174 in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`):
+
+```csharp
+private bool IsValidStateTransition(ManufactureOrderState fromState, ManufactureOrderState toState)
+{
+    return fromState switch
+    {
+        ManufactureOrderState.Draft => toState is ManufactureOrderState.Planned or ManufactureOrderState.Cancelled,
+        ManufactureOrderState.Planned => toState is ManufactureOrderState.Draft or ...,
+        ...
+        ManufactureOrderState.Cancelled => false,
+        _ => false
+    };
+}
+```
+
+Because the entity has no guard, any handler that acquires the aggregate can silently assign any state directly (`order.State = arbitrary;`) without going through this validation.
+
+## Why it matters
+State transition rules are a domain invariant — the aggregate itself should enforce what transitions are legal. Keeping the rule only in the Application handler:
+- Violates _business logic belongs in the domain_ (CLAUDE.md, `development_guidelines.md`)
+- Leaves no protection when other code paths mutate `order.State` directly (e.g. a future handler, or ad-hoc repository update)
+- The check can never be unit-tested against the entity in isolation — only against the handler
+
+## Suggested fix
+Add a method to `ManufactureOrder`:
+
+```csharp
+public bool CanTransitionTo(ManufactureOrderState newState) => State switch
+{
+    ManufactureOrderState.Draft => newState is ManufactureOrderState.Planned or ManufactureOrderState.Cancelled,
+    ManufactureOrderState.Planned => newState is ManufactureOrderState.Draft or ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Completed,
+    ManufactureOrderState.SemiProductManufactured => newState is ManufactureOrderState.Planned or ManufactureOrderState.Completed or ManufactureOrderState.Cancelled,
+    ManufactureOrderState.Completed => newState is ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Planned,
+    ManufactureOrderState.Cancelled => false,
+    _ => false
+};
+```
+
+Then replace `IsValidStateTransition(oldState, request.NewState)` in the handler with `!order.CanTransitionTo(request.NewState)` and delete the private method. The `ManufactureOrderStateTransitionTests` (already present in the test suite) can be moved/extended to test the entity method directly.
+
+---
+_Filed by daily arch-review routine on 2026-06-14._

--- a/artifacts/feat-3116/design.r1.md
+++ b/artifacts/feat-3116/design.r1.md
@@ -1,0 +1,37 @@
+# Design: Encapsulate ManufactureOrder state transition rules in the Domain entity
+
+> **Skip Design: true** — Backend-only pure refactor. No UI/UX work. The architecture
+> review (`arch-review.r1.md`) is authoritative; this document captures only the
+> component/data design that the planner needs.
+
+## Component Design
+
+### Domain layer — `ManufactureOrder` (aggregate root)
+- Add a public, side-effect-free predicate `bool CanTransitionTo(ManufactureOrderState newState)`
+  that encodes the legal state transition table (currently in the Application handler).
+- The transition table reproduced exactly as it exists today:
+  - `Draft` → `Planned`, `Cancelled`
+  - `Planned` → `Draft`, `SemiProductManufactured`, `Cancelled`, `Completed`
+  - `SemiProductManufactured` → `Planned`, `Completed`, `Cancelled`
+  - `Completed` → `SemiProductManufactured`, `Cancelled`, `Planned`
+  - `Cancelled` → (none)
+  - default → false
+- The method reads the entity's own `State` as the "from" state and the argument as the "to" state.
+
+### Application layer — `UpdateManufactureOrderStatusHandler`
+- Replace the call to the private `IsValidStateTransition(oldState, request.NewState)`
+  with `!order.CanTransitionTo(request.NewState)`.
+- Delete the now-unused private `IsValidStateTransition` method.
+- Preserve the existing error response/branching behaviour exactly (same error code,
+  same message, same control flow).
+
+### Constraint on the `State` setter
+Per the architecture review: `ManufactureOrder.State` is currently assigned via object
+initializers in production (`CreateManufactureOrderHandler`) and in ~12 test fixtures.
+Tightening the setter is **out of scope / optional**; the primary deliverable is the
+`CanTransitionTo` predicate plus the handler wiring. Do not break existing initializer
+usage.
+
+## Data Schemas
+No database schema, API contract, DTO, or event payload changes. `ManufactureOrderState`
+enum is unchanged. The public REST behaviour of the update-status endpoint is unchanged.

--- a/artifacts/feat-3116/impl/encapsulate-state-transition.r1.md
+++ b/artifacts/feat-3116/impl/encapsulate-state-transition.r1.md
@@ -1,0 +1,104 @@
+# Implementation: encapsulate-state-transition
+
+## What was implemented
+Relocated the `ManufactureOrder` legal state-transition rules from the Application
+layer into the Domain aggregate, with no change to runtime behavior or the HTTP contract.
+
+- `State` / `StateChangedAt` / `StateChangedByUser` setters tightened to `internal set`
+  so Application/Test assemblies can no longer do `order.State = x`.
+- Added `InitializeState(...)` — sanctioned, unguarded seeding path used at creation time.
+- Added `CanTransitionTo(...)` — pure predicate reproducing the old handler transition
+  matrix verbatim (type-agnostic; all self-transitions and the `Cancelled` row return false).
+- Added `ChangeState(...)` — guarded mutator that throws `ValidationException` on an illegal
+  transition (validate-before-mutate; entity left unchanged on failure) and otherwise sets
+  all three fields atomically.
+- Rewired `UpdateManufactureOrderStatusHandler` to pre-check with `order.CanTransitionTo(...)`
+  (same `InvalidOperation { oldState, newState }` early return) and mutate via
+  `order.ChangeState(...)`; deleted the private `IsValidStateTransition`.
+- Seeded the initial `Draft` state via `InitializeState` in `CreateManufactureOrderHandler`
+  and `DuplicateManufactureOrderHandler` (the latter also assigned `State` in an initializer
+  and would not compile under `internal set`).
+- Rewrote `ManufactureOrderStateTransitionTests` to test the real entity; deleted the three
+  type-aware private mirror helpers and their theories.
+- Redirected arrange-phase `State = ...` seeding in the affected test fixtures through
+  `InitializeState`. Assignments on DTOs/request objects (`ManufactureOrderDto`,
+  `GetManufactureOrdersRequest`) were left untouched.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs` — `internal set`
+  on the three state fields; added `using System.ComponentModel.DataAnnotations;`,
+  `InitializeState`, `CanTransitionTo`, `ChangeState`.
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+  — pre-check via `CanTransitionTo`, mutate via `ChangeState`, deleted `IsValidStateTransition`.
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`
+  — seed initial state via `InitializeState`.
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs`
+  — seed initial state via `InitializeState` (forced by `internal set`).
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderStateTransitionTests.cs`
+  — full rewrite: matrix theory for `CanTransitionTo`, plus legal/illegal `ChangeState` tests.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs`
+  — fixture redirect to `InitializeState`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderScheduleHandlerTests.cs`
+  — fixture + two post-construction seeds redirected to `InitializeState`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs`
+  — `CreateOrderInState` redirected to `InitializeState`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs`
+  — `CreateOrderInState` redirected to `InitializeState`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureProtocolHandlerTests.cs`
+  — inline + `BuildCompletedOrder` redirected to `InitializeState`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrderHandlerTests.cs`
+  — entity fixture redirected (DTO fixture left as-is).
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrdersHandlerTests.cs`
+  — `CreateSampleOrders` rebuilt with locals + `InitializeState` (DTO/request inits left as-is).
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs`
+  — `BuildSourceOrder` redirected to `InitializeState`.
+
+## Tests
+`ManufactureOrderStateTransitionTests` now contains:
+- `CanTransitionTo_ReturnsExpected` — `[Theory]` covering every cell of the matrix (all five
+  rows incl. the terminal `Cancelled` row and all self-transitions).
+- `ChangeState_OnIllegalTransition_ThrowsAndLeavesEntityUnchanged`.
+- `ChangeState_OnLegalTransition_UpdatesAllThreeFields`.
+
+Handler-level tests keep their existing expectations (illegal transition still asserts
+`ErrorCodes.InvalidOperation`, not a thrown exception / `InternalServerError`).
+
+## How to verify
+- `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — succeeds (pre-existing
+  warnings only, no errors).
+- `dotnet format Anela.Heblo.sln --verify-no-changes --include <touched files>` — exit 0.
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Manufacture"`
+  — all green (includes the repository materialization tests that confirm EF still binds `State`
+  through the `internal set`).
+
+## Notes
+- `DuplicateManufactureOrderHandler.cs` was not named in the task context but is a production
+  file that assigned `State` in a `new ManufactureOrder { ... }` initializer; it had to be
+  redirected through `InitializeState` to compile under `internal set`. No behavior change.
+- EF materialization is unaffected: `ApplicationDbContext` exposes `ManufactureOrders` as a plain
+  `DbSet` with no config class, materializing through the property accessor by convention — the
+  same convention `TransportBox` uses with a non-public setter.
+
+## PR Summary
+Moves `ManufactureOrder`'s legal state-transition rules out of the Application handler and into
+the domain aggregate, following the existing `TransportBox` precedent. The transition matrix is
+reproduced verbatim (type-agnostic), so there is no change to runtime behavior or the HTTP
+contract.
+
+### Changes
+- `ManufactureOrder` — `State`/`StateChangedAt`/`StateChangedByUser` are now `internal set`;
+  added `InitializeState` (seeding), `CanTransitionTo` (pure predicate), and `ChangeState`
+  (guarded mutator throwing `ValidationException` on an illegal transition).
+- `UpdateManufactureOrderStatusHandler` — pre-checks with `order.CanTransitionTo(...)` (same
+  `InvalidOperation { oldState, newState }` early return) and mutates via `order.ChangeState(...)`;
+  the private `IsValidStateTransition` was deleted. All side effects and response shapes unchanged.
+- `CreateManufactureOrderHandler` / `DuplicateManufactureOrderHandler` — seed the initial `Draft`
+  state via `InitializeState`.
+- `ManufactureOrderStateTransitionTests` — replaced the three type-aware private mirror helpers
+  and their theories (which never exercised production code) with exhaustive matrix tests against
+  the real `CanTransitionTo`, plus legal/illegal `ChangeState` tests.
+- Test fixtures across the Manufacture suite — arrange-phase `State` seeding routed through
+  `InitializeState`; no expected outcomes changed.
+
+## Status
+DONE

--- a/artifacts/feat-3116/review/encapsulate-state-transition.r1.md
+++ b/artifacts/feat-3116/review/encapsulate-state-transition.r1.md
@@ -1,0 +1,18 @@
+# Code Review: Encapsulate ManufactureOrder state transition rules
+
+## Summary
+The implementation relocates the state-transition rules into the `ManufactureOrder` aggregate exactly as specified: a pure `CanTransitionTo` predicate reproducing the verbatim matrix, a guarded `ChangeState` throwing `ValidationException`, and an `InitializeState` seeding path, with `State`/`StateChangedAt`/`StateChangedByUser` tightened to `internal set`. The handler keeps its `InvalidOperation { oldState, newState }` early return (not a thrown path), `IsValidStateTransition` and the type-aware test mirror helpers are deleted, and tests cover the full matrix plus legal/illegal `ChangeState`.
+
+## Review Result: PASS
+
+### task: encapsulate-state-transition
+**Status:** PASS
+
+## Overall Notes
+- `CanTransitionTo` (ManufactureOrder.cs:76-84) matches the authoritative matrix exactly: Draft→{Planned,Cancelled}; Planned→{Draft,SemiProductManufactured,Cancelled,Completed}; SemiProductManufactured→{Planned,Completed,Cancelled}; Completed→{SemiProductManufactured,Cancelled,Planned}; Cancelled→false; `_ => false`. No arm includes its own state, so all self-transitions return false. Type-agnostic — no `ManufactureType` dependency.
+- `ChangeState` (lines 90-100) validates before mutating; throws `ValidationException` and leaves the entity untouched on failure.
+- Handler (UpdateManufactureOrderStatusHandler.cs:53-69) captures `oldState` before mutation, pre-checks with `CanTransitionTo`, returns the same `InvalidOperation { oldState, newState }` early return (not via exception), and mutates via `ChangeState`. All side effects and response shapes unchanged. `IsValidStateTransition` is deleted.
+- `internal set` applied to all three fields; `InitializeState` added as the sanctioned seeding path. No DB/DTO/error-code changes. Follows the TransportBox precedent (no state-log collection added).
+- `CreateManufactureOrderHandler` seeds via `InitializeState` (line 56); `DuplicateManufactureOrderHandler` also redirected (forced by `internal set`, production file not originally named but correctly handled, no behavior change).
+- Tests (ManufactureOrderStateTransitionTests.cs): full 25-cell matrix theory including the terminal Cancelled row and all self-transitions, plus `ChangeState` legal and illegal-unchanged tests. The three type-aware mirror helpers and their theories are removed (verified absent across the backend).
+- Verified no residual `order.State =` assignments in production or test code; remaining `.State` references are equality comparisons only.

--- a/artifacts/feat-3116/spec.r1.md
+++ b/artifacts/feat-3116/spec.r1.md
@@ -1,0 +1,158 @@
+# Specification: Move ManufactureOrder State Transition Rules into the Domain Aggregate
+
+## Summary
+The `ManufactureOrder` aggregate currently exposes `State` as an unguarded public setter, and the only enforcement of legal state transitions lives in an Application-layer handler (`UpdateManufactureOrderStatusHandler.IsValidStateTransition`). This violates the project's "business logic belongs in the domain" rule and leaves every other code path free to assign arbitrary states. This is a backend-only domain refactoring that relocates the transition rules onto the `ManufactureOrder` entity as a first-class, unit-testable domain invariant, and rewires the handler (and any other writers) to go through it.
+
+## Background
+`ManufactureOrder` (`backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs`) is an EF-mapped aggregate with `public ManufactureOrderState State { get; set; }` plus companion audit fields `StateChangedAt` and `StateChangedByUser`. The legal-transition matrix is encoded in a private method on `UpdateManufactureOrderStatusHandler` (`backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`, lines 162–174).
+
+Problems with the current arrangement:
+- The transition rule is a domain invariant but lives in the Application layer, contradicting `CLAUDE.md` and `docs/architecture/development_guidelines.md` ("Don't create anemic domain models — put behavior in entities").
+- Any handler or ad-hoc repository update can do `order.State = anything;` with no validation.
+- The rule cannot be unit-tested against the entity in isolation; only against the handler.
+
+There is an established sibling pattern in the same codebase: `TransportBox` (`backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/TransportBox.cs`) keeps `State` with a `private set`, mutates it only through a private `ChangeState(...)` that calls `CheckState(...)`, throws `ValidationException` on an illegal transition, and appends to an internal state log. This refactor should align `ManufactureOrder` with that pattern as far as is practical without expanding scope.
+
+### Important pre-existing discrepancy (must be resolved)
+The transition matrix in the handler (`IsValidStateTransition`) is **type-agnostic** — it does not distinguish `ManufactureType.SinglePhase` from `ManufactureType.MultiPhase`. However, the existing test file `backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderStateTransitionTests.cs` tests a **type-aware** rule set (separate `ValidateSinglePhaseTransition` / `ValidateMultiPhaseTransition` helpers, plus an `IsValidStateTransition(current, target, manufactureType)`). These test helpers are private copies that "mirror" a `ManufactureOrderApplicationService` that no longer drives the live path — they do not exercise production code. The brief's suggested `CanTransitionTo` mirrors the **handler** (type-agnostic). This spec adopts the handler's current behavior as the authoritative production rule to preserve existing runtime behavior, and treats the type-aware test as documentation of intended-but-not-implemented richer rules (see FR-2 and Open Questions).
+
+The relevant enums:
+- `ManufactureOrderState` (`ManufactureOrderState.cs`): `Draft = 1, Planned = 2, SemiProductManufactured = 4, Completed = 5, Cancelled = 6`.
+- `ManufactureType` (`ManufactureType.cs`): `MultiPhase = 0` (default), `SinglePhase = 1`.
+
+## Functional Requirements
+
+### FR-1: Add a transition-validation method to the `ManufactureOrder` aggregate
+Add a public, side-effect-free method `bool CanTransitionTo(ManufactureOrderState newState)` to `ManufactureOrder`. It returns `true` iff a transition from the current `State` to `newState` is legal. The rule set must be exactly equivalent to the current handler logic to preserve runtime behavior:
+
+| From | Allowed To |
+|------|-----------|
+| `Draft` | `Planned`, `Cancelled` |
+| `Planned` | `Draft`, `SemiProductManufactured`, `Cancelled`, `Completed` |
+| `SemiProductManufactured` | `Planned`, `Completed`, `Cancelled` |
+| `Completed` | `SemiProductManufactured`, `Cancelled`, `Planned` |
+| `Cancelled` | (none) |
+| any other | (none) |
+
+**Acceptance criteria:**
+- `CanTransitionTo` is defined on `ManufactureOrder` and is `public`.
+- The method is pure: it reads `this.State` and the argument only; it mutates nothing.
+- For every (from, to) pair, the method returns exactly the same boolean as the current `IsValidStateTransition(from, to)`.
+- A self-transition (e.g. `Planned` → `Planned`) returns `false` for every state, matching the current handler matrix (no state lists itself).
+- The method is callable from a unit test that constructs a `ManufactureOrder`, sets `State`, and asserts the result — no handler, repository, or DI required.
+
+### FR-2: Preserve current runtime transition behavior (no behavioral change to the API)
+This is a refactor, not a rules change. The set of transitions the `UpdateManufactureOrderStatus` endpoint accepts/rejects must be identical before and after.
+
+**Acceptance criteria:**
+- The `ManufactureType`-aware rules present only in the old test helpers are NOT introduced into production behavior as part of this task (any such change is out of scope and tracked in Open Questions).
+- An invalid transition still produces `ErrorCodes.InvalidOperation` with the `oldState`/`newState` parameters dictionary, exactly as today (see FR-4).
+- A valid transition still updates `State`, `StateChangedAt`, `StateChangedByUser`, and performs all existing side effects (conditions reading capture, inventory write-down, ERP/Flexi doc fields, notes) unchanged.
+
+### FR-3: Rewire `UpdateManufactureOrderStatusHandler` to use the aggregate method
+Replace the call `IsValidStateTransition(oldState, request.NewState)` with `order.CanTransitionTo(request.NewState)` and delete the private `IsValidStateTransition` method from the handler.
+
+**Acceptance criteria:**
+- The handler no longer declares `IsValidStateTransition`.
+- The guard reads `if (!order.CanTransitionTo(request.NewState)) { return InvalidOperation ... }`, preserving the existing early-return error shape.
+- `oldState` is still captured before mutation for use in the error and success responses.
+- No other behavior in `Handle(...)` changes.
+
+### FR-4: Protect `State` against unguarded external mutation
+Strengthen the invariant so callers cannot bypass the rule by assigning `State` directly. Provide a single mutation entry point on the aggregate that applies the audit fields together with the state change.
+
+Add a method, e.g. `void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)`, that:
+- Throws (e.g. `InvalidOperationException` or `System.ComponentModel.DataAnnotations.ValidationException`, matching the `TransportBox` precedent which uses `ValidationException`) when `!CanTransitionTo(newState)`.
+- On success sets `State`, `StateChangedAt`, and `StateChangedByUser` atomically.
+
+Reduce the visibility of the `State` setter from `public set` toward the most restrictive level that keeps EF Core and existing read paths working. Preferred target is `private set` (matching `TransportBox`). If EF Core materialization or existing serialization/mapping requires it, fall back to `internal set` or `protected set` — but the public mutation path for application code must be `ChangeState`/`CanTransitionTo`, not a raw setter.
+
+**Acceptance criteria:**
+- Application code can no longer perform `order.State = x;` from outside the Domain assembly (compile-time enforced by the reduced setter visibility), OR — if EF constraints force a looser setter — `ChangeState` is the documented and used mutation path and a code-level comment explains the constraint.
+- `ChangeState` throws on an illegal transition and does not modify any field when it throws.
+- The handler at line ~68–71 uses `ChangeState` (or equivalent) so `StateChangedAt`/`StateChangedByUser` are still set from `_timeProvider` and `_currentUserService` as today.
+- All other writers of `order.State` are updated to the new path. Confirmed current direct writers: `UpdateManufactureOrderStatusHandler` (line 69). Test fixtures that set `State` directly (e.g. `UpdateManufactureOrderScheduleHandlerTests`, `CreateManufactureOrderHandlerTests`) are updated to use a domain-appropriate construction path; these are arrange-phase test setups, not production writers.
+- The EF Core mapping for `ManufactureOrder` (`backend/src/Anela.Heblo.Persistence/Manufacture/`) continues to read/write `State` correctly after the visibility change. Verified by the existing persistence/repository tests passing.
+
+### FR-5: Relocate and extend the entity-level transition tests
+Migrate the transition coverage so it exercises the real domain method. The existing `ManufactureOrderStateTransitionTests` uses private copies of removed logic; replace those with tests that call `ManufactureOrder.CanTransitionTo` directly.
+
+**Acceptance criteria:**
+- A test class (may reuse the existing `ManufactureOrderStateTransitionTests` file, located in the Domain test area) drives `CanTransitionTo` via `[Theory]`/`[InlineData]` covering every cell of the FR-1 matrix, including the always-`false` rows for `Cancelled` and self-transitions.
+- The private mirror helpers (`ValidateSinglePhaseTransition`, `ValidateMultiPhaseTransition`, the 3-arg `IsValidStateTransition`) are removed unless a separate decision (Open Questions) keeps them documenting future type-aware rules; if kept, they must be clearly marked as not reflecting current production behavior.
+- A test asserts `ChangeState` throws on an illegal transition and leaves the entity unchanged, and succeeds (updating all three fields) on a legal one.
+- The handler-level test(s) for `UpdateManufactureOrderStatus` (if any) continue to pass without modification to their expected outcomes.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change. `CanTransitionTo` is an O(1) `switch` over an enum; it replaces an equivalent O(1) switch. No new allocations, I/O, or queries.
+
+### NFR-2: Security / Integrity
+The change strengthens an integrity invariant (illegal state transitions become impossible to commit through the application). No authentication/authorization surface changes. No new data is exposed. Error responses retain the existing shape and do not leak additional internal detail.
+
+### NFR-3: Maintainability & Architecture conformance
+- Domain logic moves into the Domain assembly (`Anela.Heblo.Domain`), conforming to Clean Architecture and `development_guidelines.md`.
+- The pattern aligns with the existing `TransportBox` aggregate (private state setter + guarded mutation method).
+- `dotnet build` and `dotnet format` must pass; all touched tests must pass.
+
+### NFR-4: Backward compatibility
+- No database migration is required (the underlying column and mapping are unchanged; only C# property visibility changes).
+- The OpenAPI/HTTP contract of `UpdateManufactureOrderStatus` is unchanged (same request/response DTOs, same error codes).
+
+## Data Model
+Entity affected: `ManufactureOrder` (Domain aggregate, EF-mapped).
+
+Relevant fields (unchanged in shape, only `State` setter visibility changes):
+- `State : ManufactureOrderState` — current lifecycle state.
+- `StateChangedAt : DateTime` — UTC timestamp of last transition.
+- `StateChangedByUser : string` — display name of the user who performed the transition.
+- `ManufactureType : ManufactureType` — `MultiPhase` (default) / `SinglePhase`; relevant only to the deferred type-aware rules discussion, not to FR-1.
+
+Enums (unchanged):
+- `ManufactureOrderState`: `Draft(1)`, `Planned(2)`, `SemiProductManufactured(4)`, `Completed(5)`, `Cancelled(6)`.
+- `ManufactureType`: `MultiPhase(0)`, `SinglePhase(1)`.
+
+No new entities, columns, indexes, or relationships are introduced.
+
+## API / Interface Design
+
+### New domain surface on `ManufactureOrder`
+- `public bool CanTransitionTo(ManufactureOrderState newState)` — pure predicate (FR-1).
+- `public void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)` — guarded mutator; throws on illegal transition, sets state + audit fields atomically (FR-4).
+- `State` setter visibility reduced to `private set` (or the minimum that EF Core permits).
+
+### Removed Application surface
+- `UpdateManufactureOrderStatusHandler.IsValidStateTransition(...)` — deleted (FR-3).
+
+### HTTP endpoint (behavior preserved, not redesigned)
+`UpdateManufactureOrderStatus` (MediatR request `UpdateManufactureOrderStatusRequest` → `UpdateManufactureOrderStatusResponse`):
+- Illegal transition → `UpdateManufactureOrderStatusResponse` with `ErrorCodes.InvalidOperation` and `{ oldState, newState }`.
+- Order not found → `ErrorCodes.ResourceNotFound`.
+- Unexpected exception → `ErrorCodes.InternalServerError`.
+- Success → `{ OldState, NewState, StateChangedAt, StateChangedByUser }` plus all existing side effects.
+
+No new events are emitted.
+
+## Dependencies
+- `Anela.Heblo.Domain` (entity, enums) — primary change site.
+- `Anela.Heblo.Application` — `UpdateManufactureOrderStatusHandler` rewire.
+- `Anela.Heblo.Persistence` — verify EF Core mapping for `ManufactureOrder.State` still binds after setter visibility change (`backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs` and the entity type configuration).
+- `Anela.Heblo.Tests` — relocate/extend transition tests; fix any arrange-phase fixtures that assign `State` directly.
+- No external services, NuGet packages, or migrations.
+
+## Out of Scope
+- Introducing `ManufactureType`-aware (single-phase vs multi-phase) transition rules into production. The current production rule is type-agnostic; changing it is a behavioral change tracked in Open Questions, not part of this refactor.
+- Adding an internal state-change audit log/collection to `ManufactureOrder` analogous to `TransportBox.StateLog` (the order already records `StateChangedAt`/`StateChangedByUser` and a separate `ManufactureOrderNote` trail; a structured log is a larger change).
+- Frontend changes of any kind.
+- Refactoring other aggregates or other Manufacture use cases beyond what is needed to compile and pass tests.
+- Adding new error codes or changing response DTOs.
+
+## Open Questions
+None blocking. Documented assumptions (chosen to keep this a behavior-preserving refactor):
+
+- **Assumption A (rule fidelity):** `CanTransitionTo` mirrors the current handler matrix exactly (type-agnostic), per the brief. The richer type-aware logic embedded in the existing test helpers is treated as not-yet-implemented intent and is explicitly deferred. If the product owner instead wants the type-aware rules to become authoritative, that is a follow-up behavioral change.
+- **Assumption B (setter visibility):** Target `private set` for `State` to match `TransportBox`. If EF Core materialization or existing read/mapping code breaks, fall back to the least-permissive visibility that compiles (`internal`/`protected`), with `ChangeState` remaining the sanctioned mutation path. The final choice is an implementation detail validated by the persistence tests.
+- **Assumption C (exception type):** `ChangeState` throws `ValidationException` to match the `TransportBox` precedent. If the team prefers `InvalidOperationException` for domain invariants, either is acceptable as long as the handler's external error contract (`ErrorCodes.InvalidOperation`) is preserved — the handler should pre-check with `CanTransitionTo` so the exception path is defensive, not the primary control flow.
+
+## Status: COMPLETE

--- a/artifacts/feat-3116/state.json
+++ b/artifacts/feat-3116/state.json
@@ -1,0 +1,36 @@
+{
+  "feature_id": "feat-3116",
+  "issue_number": 3116,
+  "created_at": "2026-06-18T07:03:02.869093Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-18T07:05:18.616459Z"
+    },
+    "architecting": {
+      "status": "completed",
+      "updated_at": "2026-06-18T07:07:55.225485Z"
+    },
+    "designing": {
+      "status": "completed",
+      "updated_at": "2026-06-18T07:08:11.285195Z"
+    },
+    "planning": {
+      "status": "completed",
+      "updated_at": "2026-06-18T07:10:22.485180Z"
+    },
+    "developing": {
+      "status": "completed",
+      "updated_at": "2026-06-18T07:48:55.668982Z"
+    }
+  },
+  "tasks": [
+    {
+      "name": "encapsulate-state-transition",
+      "status": "completed",
+      "revision": 1,
+      "updated_at": "2026-06-18T07:48:55.474707Z"
+    }
+  ]
+}

--- a/artifacts/feat-3116/task-context/encapsulate-state-transition.md
+++ b/artifacts/feat-3116/task-context/encapsulate-state-transition.md
@@ -1,0 +1,317 @@
+### task: encapsulate-state-transition
+
+**Goal**
+
+Relocate the `ManufactureOrder` legal state-transition rules from the Application handler into the
+Domain aggregate, with no change to runtime behavior or the HTTP contract:
+
+1. Add `public bool CanTransitionTo(ManufactureOrderState newState)` to `ManufactureOrder` —
+   a pure predicate reproducing the current handler matrix exactly.
+2. Add `public void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)`
+   — a guarded mutator that throws `ValidationException` on an illegal transition and otherwise sets
+   `State`, `StateChangedAt`, `StateChangedByUser` atomically.
+3. Add a sanctioned initial-state construction path so creation does not depend on a public `State`
+   setter, then reduce the `State` setter visibility (target `internal set`) so Application/Test
+   assembly code can no longer do `order.State = x`.
+4. Rewire `UpdateManufactureOrderStatusHandler` to pre-check with `CanTransitionTo` and mutate via
+   `ChangeState`; delete its private `IsValidStateTransition`.
+5. Redirect `ManufactureOrderStateTransitionTests` to test the real entity methods; adapt the
+   handful of test fixtures that the setter change touches.
+
+**Context** (self-contained — you only read this section)
+
+Today the rule lives in the Application layer and `State` is an unguarded public setter, which
+violates the project rule "business logic belongs in the domain / don't create anemic domain
+models." The canonical precedent in this codebase is `TransportBox`
+(`backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/TransportBox.cs`): `State` has
+`private set`, mutation goes through a guarded `ChangeState(...)` → `CheckState(...)` that throws
+`System.ComponentModel.DataAnnotations.ValidationException` on an illegal transition. Align with that
+pattern but do NOT add a state-log collection (out of scope — the order already records
+`StateChangedAt`/`StateChangedByUser`).
+
+Current entity (`backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs`):
+
+```csharp
+// State management
+public ManufactureOrderState State { get; set; }
+public DateTime StateChangedAt { get; set; }
+public string StateChangedByUser { get; set; } = null!;
+```
+
+Enum `ManufactureOrderState`: `Draft = 1, Planned = 2, SemiProductManufactured = 4, Completed = 5,
+Cancelled = 6`. Enum `ManufactureType`: `MultiPhase = 0` (default), `SinglePhase = 1`.
+
+**Authoritative transition matrix** — reproduce verbatim from the live handler
+(`UpdateManufactureOrderStatusHandler.IsValidStateTransition`, lines 165–173). It is
+**type-agnostic** (does NOT depend on `ManufactureType`):
+
+| From | Allowed To |
+|------|-----------|
+| `Draft` | `Planned`, `Cancelled` |
+| `Planned` | `Draft`, `SemiProductManufactured`, `Cancelled`, `Completed` |
+| `SemiProductManufactured` | `Planned`, `Completed`, `Cancelled` |
+| `Completed` | `SemiProductManufactured`, `Cancelled`, `Planned` |
+| `Cancelled` | (none) |
+| any other | (none) |
+
+Every arm omits its own state, so all self-transitions (e.g. `Planned → Planned`) return `false`.
+Preserve that exactly.
+
+CRITICAL — do NOT introduce the type-aware rules. The existing test file
+`ManufactureOrderStateTransitionTests.cs` contains private helpers
+(`ValidateSinglePhaseTransition`, `ValidateMultiPhaseTransition`, and a 3-arg
+`IsValidStateTransition(current, target, manufactureType)`) that "mirror the private methods in
+`ManufactureOrderApplicationService`" — a service that no longer drives the live path. These never
+executed production code. Adopting them would silently change behavior (e.g. start rejecting
+`Planned → SemiProductManufactured` for single-phase). DELETE these three helpers and their
+`[Theory]` test methods; replace with tests against the real `CanTransitionTo`. Do NOT keep them even
+annotated.
+
+Current handler control flow to preserve (`UpdateManufactureOrderStatusHandler.Handle`):
+- Load order; if `null` → return `ErrorCodes.ResourceNotFound` with `{ id }`.
+- Capture `var oldState = order.State;` BEFORE mutation (used in both error and success responses).
+- If transition illegal → return `ErrorCodes.InvalidOperation` with
+  `{ oldState, newState }` (string-ified). This early-return error shape MUST be preserved — it must
+  NOT come from a thrown exception (which would fall into the `catch` and wrongly produce
+  `InternalServerError`).
+- On success: set state + audit fields, then run all existing side effects unchanged
+  (`ManualActionRequired`, ERP order numbers, weight, Flexi doc codes + dates, `Note`, conditions
+  reading at `SemiProductManufactured`/`Completed`, inventory write-down at `Completed`), call
+  `_repository.UpdateOrderAsync`, and return `{ OldState, NewState, StateChangedAt, StateChangedByUser }`.
+
+Setter-visibility constraint (IMPORTANT): `State` is assigned via object initializers in production
+and in many test fixtures, so the setter must NOT be tightened in a way that breaks those
+initializers without also giving them a working alternative. Confirmed seed/assignment sites:
+- Production: `CreateManufactureOrderHandler` (line ~55) — `State = ManufactureOrderState.Draft`
+  inside `new ManufactureOrder { ... }`.
+- Production mutator: `UpdateManufactureOrderStatusHandler` (line 69) — `order.State = request.NewState;`
+- Tests (9 files under `backend/test/Anela.Heblo.Tests/Features/Manufacture/`):
+  `UpdateManufactureOrderHandlerTests`, `UpdateManufactureOrderScheduleHandlerTests` (post-construction
+  `existingOrder.State = ...`), `UpdateManufactureOrderStatusHandlerConditionsTests`,
+  `UpdateManufactureOrderStatusHandlerTests`, `GetManufactureOrderHandlerTests`,
+  `GetManufactureOrdersHandlerTests`, `GetManufactureProtocolHandlerTests`,
+  `DuplicateManufactureOrderHandlerTests`, `CreateManufactureOrderHandlerTests`.
+
+The arch review's ideal is `private set` + a `CreateDraft`/`InitializeState` factory + a shared test
+builder. The design doc marks setter tightening "optional / do not break initializers." To satisfy
+FR-4 (forbid `order.State = x` from Application & Test assemblies) while keeping the change small and
+the persistence path safe, the **chosen target is `internal set`** (the spec's documented fallback,
+Assumption B). With `internal set`:
+- Domain-assembly code (the new initial-state factory) can still assign `State`.
+- EF Core materializes through the property accessor by convention (no config class exists —
+  `ManufactureOrders` is a plain `DbSet` on `ApplicationDbContext`; `TransportBox` uses the same
+  convention with a non-public setter and works).
+- Application/Test assembly object-initializers that did `State = ...` will no longer compile and
+  MUST be redirected to the new construction path / `ChangeState` (this is the bulk of the
+  mechanical work). `InternalsVisibleTo` is NOT used for the test assembly here, so test fixtures use
+  the public construction path, not the setter.
+
+No DB migration. No DI/module changes. No DTO/error-code changes. No new files.
+
+**Files to create/modify**
+
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`
+- Modify (redirect/extend, do not create new file): `backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderStateTransitionTests.cs`
+- Modify only as forced by the setter change (arrange-phase fixtures): the test files listed above
+  under `backend/test/Anela.Heblo.Tests/Features/Manufacture/`.
+
+**Implementation steps**
+
+1. **Entity — `ManufactureOrder.cs`.** Replace the `State management` block. Tighten the `State`
+   setter to `internal set`, add a sanctioned initial-state factory, `CanTransitionTo`, and
+   `ChangeState`. Add `using System.ComponentModel.DataAnnotations;` at the top of the file.
+
+   ```csharp
+   // State management
+   public ManufactureOrderState State { get; internal set; }
+   public DateTime StateChangedAt { get; internal set; }
+   public string StateChangedByUser { get; internal set; } = null!;
+   ```
+
+   Add these members to the class body:
+
+   ```csharp
+   /// <summary>
+   /// Sanctioned construction path that seeds the initial state and audit fields without
+   /// requiring an externally visible State setter. Use at creation time only.
+   /// </summary>
+   public void InitializeState(ManufactureOrderState initialState, DateTime changedAtUtc, string changedByUser)
+   {
+       State = initialState;
+       StateChangedAt = changedAtUtc;
+       StateChangedByUser = changedByUser;
+   }
+
+   /// <summary>
+   /// Pure predicate: true iff a transition from the current State to <paramref name="newState"/>
+   /// is legal. Reads State and the argument only; mutates nothing.
+   /// </summary>
+   public bool CanTransitionTo(ManufactureOrderState newState) => State switch
+   {
+       ManufactureOrderState.Draft => newState is ManufactureOrderState.Planned or ManufactureOrderState.Cancelled,
+       ManufactureOrderState.Planned => newState is ManufactureOrderState.Draft or ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Completed,
+       ManufactureOrderState.SemiProductManufactured => newState is ManufactureOrderState.Planned or ManufactureOrderState.Completed or ManufactureOrderState.Cancelled,
+       ManufactureOrderState.Completed => newState is ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Planned,
+       ManufactureOrderState.Cancelled => false,
+       _ => false
+   };
+
+   /// <summary>
+   /// Guarded state mutation. Throws when the transition is illegal and leaves the entity
+   /// unchanged; on success sets State + audit fields atomically.
+   /// </summary>
+   public void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)
+   {
+       if (!CanTransitionTo(newState))
+       {
+           throw new ValidationException($"Unable to change state from {State} to {newState}.");
+       }
+
+       State = newState;
+       StateChangedAt = changedAtUtc;
+       StateChangedByUser = changedByUser;
+   }
+   ```
+
+   Validate-before-mutate ordering matters: nothing is assigned when the guard fails.
+
+2. **Production creation — `CreateManufactureOrderHandler.cs`.** Remove `State`, `StateChangedAt`,
+   `StateChangedByUser` from the `new ManufactureOrder { ... }` initializer (lines ~55–57) and seed
+   them via the sanctioned path immediately after construction. Concretely, change:
+
+   ```csharp
+       ManufactureType = request.ManufactureType,
+       State = ManufactureOrderState.Draft,
+       StateChangedAt = now.DateTime,
+       StateChangedByUser = currentUser.Name
+   };
+   ```
+   to:
+   ```csharp
+       ManufactureType = request.ManufactureType
+   };
+   order.InitializeState(ManufactureOrderState.Draft, now.DateTime, currentUser.Name);
+   ```
+   (Adjust the local variable name to whatever the `new ManufactureOrder` is assigned to; verify
+   `now` / `currentUser.Name` are the exact symbols already in scope — they are the current
+   initializer values, so reuse them verbatim.)
+
+3. **Handler rewire — `UpdateManufactureOrderStatusHandler.cs`.**
+   - Keep `var oldState = order.State;` as-is.
+   - Replace the guard call (line 56) `if (!IsValidStateTransition(oldState, request.NewState))` with
+     `if (!order.CanTransitionTo(request.NewState))`. Keep the identical `InvalidOperation` early
+     return with `{ oldState, newState }`.
+   - Replace the three direct assignments (lines 69–71):
+     ```csharp
+     order.State = request.NewState;
+     order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+     order.StateChangedByUser = currentUserName;
+     ```
+     with a single guarded call (keep `currentUserName` resolved on the line above, as today, since
+     it is reused by the note creation and inventory write-down):
+     ```csharp
+     order.ChangeState(request.NewState, _timeProvider.GetUtcNow().DateTime, currentUserName);
+     ```
+   - Delete the entire private `IsValidStateTransition(ManufactureOrderState, ManufactureOrderState)`
+     method (lines 162–174).
+   - Leave everything else in `Handle` (side effects, `CaptureConditionsReadingAsync`,
+     `WriteDownInventoryAsync`) byte-for-byte unchanged. The `CanTransitionTo` pre-check guarantees
+     `ChangeState` never throws on the live path, so the `try/catch` still only catches genuine
+     unexpected failures.
+
+4. **Redirect transition tests — `ManufactureOrderStateTransitionTests.cs`.** Delete the three
+   `[Theory]` methods (`ValidateSinglePhaseTransition_*`, `ValidateMultiPhaseTransition_*`,
+   `IsValidStateTransition_ShouldRespectManufactureType`) AND the three private mirror helpers.
+   Replace with tests that drive the real entity (see "Tests to write"). To set the entity's "from"
+   state in arrange, construct the order and seed via `InitializeState`, then (where a non-initial
+   "from" state is needed) reach it with a legal `ChangeState` chain, OR — since these tests only
+   assert `CanTransitionTo` which reads `State` — add a tiny local builder that uses
+   `InitializeState` to place the order directly into the desired "from" state (legal because
+   `InitializeState` is unguarded and represents seeding). Prefer the `InitializeState`-based builder
+   for the `CanTransitionTo` theory to keep the matrix exhaustive without long chains:
+
+   ```csharp
+   private static ManufactureOrder OrderInState(ManufactureOrderState state)
+   {
+       var order = new ManufactureOrder();
+       order.InitializeState(state, DateTime.UtcNow, "test");
+       return order;
+   }
+   ```
+
+5. **Fix arrange-phase fixtures broken by `internal set`.** Build the test project; every remaining
+   compile error is a test fixture assigning `State`/`StateChangedAt`/`StateChangedByUser` in an
+   initializer or post-construction. For each, replace the `State = X` initializer entry (and any
+   companion `StateChangedAt`/`StateChangedByUser` initializer entries) with a post-construction
+   `order.InitializeState(X, <existing-at-or-DateTime.UtcNow>, <existing-by-or-"test">)`. For
+   `UpdateManufactureOrderScheduleHandlerTests` post-construction `existingOrder.State = ...` (around
+   lines 85/107), replace with `existingOrder.InitializeState(...)` (these are seeds, not transitions).
+   To minimize churn across the 9 files, you MAY add one shared internal test helper (e.g. a static
+   `ManufactureOrderTestBuilder.InState(...)` in the Manufacture test folder) and use it where it
+   reduces edits — but a direct `InitializeState` call per site is equally acceptable. Do NOT change
+   any test's expected assertions or expected outcomes.
+
+**Tests to write** (in `ManufactureOrderStateTransitionTests.cs`, replacing the deleted theories)
+
+1. `CanTransitionTo_ReturnsExpected` — `[Theory]`/`[InlineData]` covering EVERY cell of the matrix,
+   including the always-`false` `Cancelled` row and all self-transitions. Minimum data set (from,
+   to, expected):
+   - Draft→Planned = true; Draft→Cancelled = true; Draft→SemiProductManufactured = false;
+     Draft→Completed = false; Draft→Draft = false.
+   - Planned→Draft = true; Planned→SemiProductManufactured = true; Planned→Cancelled = true;
+     Planned→Completed = true; Planned→Planned = false.
+   - SemiProductManufactured→Planned = true; SemiProductManufactured→Completed = true;
+     SemiProductManufactured→Cancelled = true; SemiProductManufactured→Draft = false;
+     SemiProductManufactured→SemiProductManufactured = false.
+   - Completed→SemiProductManufactured = true; Completed→Cancelled = true; Completed→Planned = true;
+     Completed→Draft = false; Completed→Completed = false.
+   - Cancelled→Draft = false; Cancelled→Planned = false; Cancelled→SemiProductManufactured = false;
+     Cancelled→Completed = false; Cancelled→Cancelled = false.
+   Arrange via `OrderInState(from)`, act `order.CanTransitionTo(to)`, assert equals expected.
+
+2. `ChangeState_OnIllegalTransition_ThrowsAndLeavesEntityUnchanged` — arrange `OrderInState(Cancelled)`
+   with known `StateChangedAt`/`StateChangedByUser`; assert `Assert.Throws<ValidationException>(() =>
+   order.ChangeState(ManufactureOrderState.Planned, DateTime.UtcNow, "user"))`; then assert `State`,
+   `StateChangedAt`, and `StateChangedByUser` are all unchanged from the arranged values.
+
+3. `ChangeState_OnLegalTransition_UpdatesAllThreeFields` — arrange `OrderInState(Draft)`; call
+   `order.ChangeState(ManufactureOrderState.Planned, someUtc, "alice")`; assert
+   `State == Planned`, `StateChangedAt == someUtc`, `StateChangedByUser == "alice"`.
+
+Note: the handler-level tests (`UpdateManufactureOrderStatusHandlerTests`,
+`UpdateManufactureOrderStatusHandlerConditionsTests`) keep their existing expected outcomes — an
+illegal transition must still assert `ErrorCodes.InvalidOperation` (NOT a thrown exception /
+`InternalServerError`). Only their arrange-phase `State = ...` seeding may need the `InitializeState`
+redirect; expectations are unchanged.
+
+**Acceptance criteria**
+
+- `CanTransitionTo` is `public`, pure (reads `State` + arg only, mutates nothing), and returns the
+  exact same boolean as the old `IsValidStateTransition(from, to)` for every (from, to) pair,
+  including `false` for all self-transitions and all `Cancelled` rows.
+- `ChangeState` throws `ValidationException` on an illegal transition and leaves `State`,
+  `StateChangedAt`, `StateChangedByUser` unmodified; on a legal transition it sets all three.
+- `UpdateManufactureOrderStatusHandler` no longer declares `IsValidStateTransition`; it pre-checks
+  with `order.CanTransitionTo(...)` (same `InvalidOperation { oldState, newState }` early return) and
+  mutates via `order.ChangeState(...)`; `oldState` is still captured before mutation; all other
+  side effects and the success/error response shapes are unchanged.
+- The `State` setter is `internal set` (or, if EF materialization unexpectedly fails, fall back to
+  the least-permissive level that compiles and passes the persistence tests, with `ChangeState` /
+  `InitializeState` documented as the sanctioned mutation paths). `order.State = x` no longer
+  compiles from the Application or Test assemblies.
+- `CreateManufactureOrderHandler` seeds the initial `Draft` state via `InitializeState`; no behavior
+  change to the create flow.
+- `ManufactureOrderStateTransitionTests` no longer contains the three private mirror helpers or the
+  type-aware theories; it tests `CanTransitionTo`/`ChangeState` against the real entity.
+- All touched fixtures compile by routing through `InitializeState` (or the shared test builder);
+  no test's expected outcome is changed.
+- `cd backend && dotnet build` succeeds.
+- `cd backend && dotnet format --verify-no-changes` reports no changes (run `dotnet format` to fix
+  if needed).
+- Touched tests pass: `dotnet test backend/test/Anela.Heblo.Tests` filtered to at minimum
+  `ManufactureOrderStateTransitionTests`, `UpdateManufactureOrderStatusHandlerTests`,
+  `UpdateManufactureOrderStatusHandlerConditionsTests`, `CreateManufactureOrderHandlerTests`,
+  `UpdateManufactureOrderScheduleHandlerTests`, and `ManufactureOrderRepositoryTests` (verifies EF
+  materialization still binds `State` after the visibility change). All green.

--- a/artifacts/feat-3116/task-plan.r1.md
+++ b/artifacts/feat-3116/task-plan.r1.md
@@ -1,0 +1,327 @@
+# Task Plan: Encapsulate ManufactureOrder State Transition Rules in the Domain Aggregate (feat-3116)
+
+Backend-only, behavior-preserving DDD refactor (.NET 8). It moves the legal state-transition
+matrix out of `UpdateManufactureOrderStatusHandler` and onto the `ManufactureOrder` aggregate as a
+pure predicate (`CanTransitionTo`) plus a guarded mutator (`ChangeState`), tightens the `State`
+setter so external code can no longer assign arbitrary states, and redirects the existing transition
+tests to exercise the real entity. One cohesive task.
+
+---
+
+### task: encapsulate-state-transition
+
+**Goal**
+
+Relocate the `ManufactureOrder` legal state-transition rules from the Application handler into the
+Domain aggregate, with no change to runtime behavior or the HTTP contract:
+
+1. Add `public bool CanTransitionTo(ManufactureOrderState newState)` to `ManufactureOrder` —
+   a pure predicate reproducing the current handler matrix exactly.
+2. Add `public void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)`
+   — a guarded mutator that throws `ValidationException` on an illegal transition and otherwise sets
+   `State`, `StateChangedAt`, `StateChangedByUser` atomically.
+3. Add a sanctioned initial-state construction path so creation does not depend on a public `State`
+   setter, then reduce the `State` setter visibility (target `internal set`) so Application/Test
+   assembly code can no longer do `order.State = x`.
+4. Rewire `UpdateManufactureOrderStatusHandler` to pre-check with `CanTransitionTo` and mutate via
+   `ChangeState`; delete its private `IsValidStateTransition`.
+5. Redirect `ManufactureOrderStateTransitionTests` to test the real entity methods; adapt the
+   handful of test fixtures that the setter change touches.
+
+**Context** (self-contained — you only read this section)
+
+Today the rule lives in the Application layer and `State` is an unguarded public setter, which
+violates the project rule "business logic belongs in the domain / don't create anemic domain
+models." The canonical precedent in this codebase is `TransportBox`
+(`backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/TransportBox.cs`): `State` has
+`private set`, mutation goes through a guarded `ChangeState(...)` → `CheckState(...)` that throws
+`System.ComponentModel.DataAnnotations.ValidationException` on an illegal transition. Align with that
+pattern but do NOT add a state-log collection (out of scope — the order already records
+`StateChangedAt`/`StateChangedByUser`).
+
+Current entity (`backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs`):
+
+```csharp
+// State management
+public ManufactureOrderState State { get; set; }
+public DateTime StateChangedAt { get; set; }
+public string StateChangedByUser { get; set; } = null!;
+```
+
+Enum `ManufactureOrderState`: `Draft = 1, Planned = 2, SemiProductManufactured = 4, Completed = 5,
+Cancelled = 6`. Enum `ManufactureType`: `MultiPhase = 0` (default), `SinglePhase = 1`.
+
+**Authoritative transition matrix** — reproduce verbatim from the live handler
+(`UpdateManufactureOrderStatusHandler.IsValidStateTransition`, lines 165–173). It is
+**type-agnostic** (does NOT depend on `ManufactureType`):
+
+| From | Allowed To |
+|------|-----------|
+| `Draft` | `Planned`, `Cancelled` |
+| `Planned` | `Draft`, `SemiProductManufactured`, `Cancelled`, `Completed` |
+| `SemiProductManufactured` | `Planned`, `Completed`, `Cancelled` |
+| `Completed` | `SemiProductManufactured`, `Cancelled`, `Planned` |
+| `Cancelled` | (none) |
+| any other | (none) |
+
+Every arm omits its own state, so all self-transitions (e.g. `Planned → Planned`) return `false`.
+Preserve that exactly.
+
+CRITICAL — do NOT introduce the type-aware rules. The existing test file
+`ManufactureOrderStateTransitionTests.cs` contains private helpers
+(`ValidateSinglePhaseTransition`, `ValidateMultiPhaseTransition`, and a 3-arg
+`IsValidStateTransition(current, target, manufactureType)`) that "mirror the private methods in
+`ManufactureOrderApplicationService`" — a service that no longer drives the live path. These never
+executed production code. Adopting them would silently change behavior (e.g. start rejecting
+`Planned → SemiProductManufactured` for single-phase). DELETE these three helpers and their
+`[Theory]` test methods; replace with tests against the real `CanTransitionTo`. Do NOT keep them even
+annotated.
+
+Current handler control flow to preserve (`UpdateManufactureOrderStatusHandler.Handle`):
+- Load order; if `null` → return `ErrorCodes.ResourceNotFound` with `{ id }`.
+- Capture `var oldState = order.State;` BEFORE mutation (used in both error and success responses).
+- If transition illegal → return `ErrorCodes.InvalidOperation` with
+  `{ oldState, newState }` (string-ified). This early-return error shape MUST be preserved — it must
+  NOT come from a thrown exception (which would fall into the `catch` and wrongly produce
+  `InternalServerError`).
+- On success: set state + audit fields, then run all existing side effects unchanged
+  (`ManualActionRequired`, ERP order numbers, weight, Flexi doc codes + dates, `Note`, conditions
+  reading at `SemiProductManufactured`/`Completed`, inventory write-down at `Completed`), call
+  `_repository.UpdateOrderAsync`, and return `{ OldState, NewState, StateChangedAt, StateChangedByUser }`.
+
+Setter-visibility constraint (IMPORTANT): `State` is assigned via object initializers in production
+and in many test fixtures, so the setter must NOT be tightened in a way that breaks those
+initializers without also giving them a working alternative. Confirmed seed/assignment sites:
+- Production: `CreateManufactureOrderHandler` (line ~55) — `State = ManufactureOrderState.Draft`
+  inside `new ManufactureOrder { ... }`.
+- Production mutator: `UpdateManufactureOrderStatusHandler` (line 69) — `order.State = request.NewState;`
+- Tests (9 files under `backend/test/Anela.Heblo.Tests/Features/Manufacture/`):
+  `UpdateManufactureOrderHandlerTests`, `UpdateManufactureOrderScheduleHandlerTests` (post-construction
+  `existingOrder.State = ...`), `UpdateManufactureOrderStatusHandlerConditionsTests`,
+  `UpdateManufactureOrderStatusHandlerTests`, `GetManufactureOrderHandlerTests`,
+  `GetManufactureOrdersHandlerTests`, `GetManufactureProtocolHandlerTests`,
+  `DuplicateManufactureOrderHandlerTests`, `CreateManufactureOrderHandlerTests`.
+
+The arch review's ideal is `private set` + a `CreateDraft`/`InitializeState` factory + a shared test
+builder. The design doc marks setter tightening "optional / do not break initializers." To satisfy
+FR-4 (forbid `order.State = x` from Application & Test assemblies) while keeping the change small and
+the persistence path safe, the **chosen target is `internal set`** (the spec's documented fallback,
+Assumption B). With `internal set`:
+- Domain-assembly code (the new initial-state factory) can still assign `State`.
+- EF Core materializes through the property accessor by convention (no config class exists —
+  `ManufactureOrders` is a plain `DbSet` on `ApplicationDbContext`; `TransportBox` uses the same
+  convention with a non-public setter and works).
+- Application/Test assembly object-initializers that did `State = ...` will no longer compile and
+  MUST be redirected to the new construction path / `ChangeState` (this is the bulk of the
+  mechanical work). `InternalsVisibleTo` is NOT used for the test assembly here, so test fixtures use
+  the public construction path, not the setter.
+
+No DB migration. No DI/module changes. No DTO/error-code changes. No new files.
+
+**Files to create/modify**
+
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`
+- Modify (redirect/extend, do not create new file): `backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderStateTransitionTests.cs`
+- Modify only as forced by the setter change (arrange-phase fixtures): the test files listed above
+  under `backend/test/Anela.Heblo.Tests/Features/Manufacture/`.
+
+**Implementation steps**
+
+1. **Entity — `ManufactureOrder.cs`.** Replace the `State management` block. Tighten the `State`
+   setter to `internal set`, add a sanctioned initial-state factory, `CanTransitionTo`, and
+   `ChangeState`. Add `using System.ComponentModel.DataAnnotations;` at the top of the file.
+
+   ```csharp
+   // State management
+   public ManufactureOrderState State { get; internal set; }
+   public DateTime StateChangedAt { get; internal set; }
+   public string StateChangedByUser { get; internal set; } = null!;
+   ```
+
+   Add these members to the class body:
+
+   ```csharp
+   /// <summary>
+   /// Sanctioned construction path that seeds the initial state and audit fields without
+   /// requiring an externally visible State setter. Use at creation time only.
+   /// </summary>
+   public void InitializeState(ManufactureOrderState initialState, DateTime changedAtUtc, string changedByUser)
+   {
+       State = initialState;
+       StateChangedAt = changedAtUtc;
+       StateChangedByUser = changedByUser;
+   }
+
+   /// <summary>
+   /// Pure predicate: true iff a transition from the current State to <paramref name="newState"/>
+   /// is legal. Reads State and the argument only; mutates nothing.
+   /// </summary>
+   public bool CanTransitionTo(ManufactureOrderState newState) => State switch
+   {
+       ManufactureOrderState.Draft => newState is ManufactureOrderState.Planned or ManufactureOrderState.Cancelled,
+       ManufactureOrderState.Planned => newState is ManufactureOrderState.Draft or ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Completed,
+       ManufactureOrderState.SemiProductManufactured => newState is ManufactureOrderState.Planned or ManufactureOrderState.Completed or ManufactureOrderState.Cancelled,
+       ManufactureOrderState.Completed => newState is ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Planned,
+       ManufactureOrderState.Cancelled => false,
+       _ => false
+   };
+
+   /// <summary>
+   /// Guarded state mutation. Throws when the transition is illegal and leaves the entity
+   /// unchanged; on success sets State + audit fields atomically.
+   /// </summary>
+   public void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)
+   {
+       if (!CanTransitionTo(newState))
+       {
+           throw new ValidationException($"Unable to change state from {State} to {newState}.");
+       }
+
+       State = newState;
+       StateChangedAt = changedAtUtc;
+       StateChangedByUser = changedByUser;
+   }
+   ```
+
+   Validate-before-mutate ordering matters: nothing is assigned when the guard fails.
+
+2. **Production creation — `CreateManufactureOrderHandler.cs`.** Remove `State`, `StateChangedAt`,
+   `StateChangedByUser` from the `new ManufactureOrder { ... }` initializer (lines ~55–57) and seed
+   them via the sanctioned path immediately after construction. Concretely, change:
+
+   ```csharp
+       ManufactureType = request.ManufactureType,
+       State = ManufactureOrderState.Draft,
+       StateChangedAt = now.DateTime,
+       StateChangedByUser = currentUser.Name
+   };
+   ```
+   to:
+   ```csharp
+       ManufactureType = request.ManufactureType
+   };
+   order.InitializeState(ManufactureOrderState.Draft, now.DateTime, currentUser.Name);
+   ```
+   (Adjust the local variable name to whatever the `new ManufactureOrder` is assigned to; verify
+   `now` / `currentUser.Name` are the exact symbols already in scope — they are the current
+   initializer values, so reuse them verbatim.)
+
+3. **Handler rewire — `UpdateManufactureOrderStatusHandler.cs`.**
+   - Keep `var oldState = order.State;` as-is.
+   - Replace the guard call (line 56) `if (!IsValidStateTransition(oldState, request.NewState))` with
+     `if (!order.CanTransitionTo(request.NewState))`. Keep the identical `InvalidOperation` early
+     return with `{ oldState, newState }`.
+   - Replace the three direct assignments (lines 69–71):
+     ```csharp
+     order.State = request.NewState;
+     order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+     order.StateChangedByUser = currentUserName;
+     ```
+     with a single guarded call (keep `currentUserName` resolved on the line above, as today, since
+     it is reused by the note creation and inventory write-down):
+     ```csharp
+     order.ChangeState(request.NewState, _timeProvider.GetUtcNow().DateTime, currentUserName);
+     ```
+   - Delete the entire private `IsValidStateTransition(ManufactureOrderState, ManufactureOrderState)`
+     method (lines 162–174).
+   - Leave everything else in `Handle` (side effects, `CaptureConditionsReadingAsync`,
+     `WriteDownInventoryAsync`) byte-for-byte unchanged. The `CanTransitionTo` pre-check guarantees
+     `ChangeState` never throws on the live path, so the `try/catch` still only catches genuine
+     unexpected failures.
+
+4. **Redirect transition tests — `ManufactureOrderStateTransitionTests.cs`.** Delete the three
+   `[Theory]` methods (`ValidateSinglePhaseTransition_*`, `ValidateMultiPhaseTransition_*`,
+   `IsValidStateTransition_ShouldRespectManufactureType`) AND the three private mirror helpers.
+   Replace with tests that drive the real entity (see "Tests to write"). To set the entity's "from"
+   state in arrange, construct the order and seed via `InitializeState`, then (where a non-initial
+   "from" state is needed) reach it with a legal `ChangeState` chain, OR — since these tests only
+   assert `CanTransitionTo` which reads `State` — add a tiny local builder that uses
+   `InitializeState` to place the order directly into the desired "from" state (legal because
+   `InitializeState` is unguarded and represents seeding). Prefer the `InitializeState`-based builder
+   for the `CanTransitionTo` theory to keep the matrix exhaustive without long chains:
+
+   ```csharp
+   private static ManufactureOrder OrderInState(ManufactureOrderState state)
+   {
+       var order = new ManufactureOrder();
+       order.InitializeState(state, DateTime.UtcNow, "test");
+       return order;
+   }
+   ```
+
+5. **Fix arrange-phase fixtures broken by `internal set`.** Build the test project; every remaining
+   compile error is a test fixture assigning `State`/`StateChangedAt`/`StateChangedByUser` in an
+   initializer or post-construction. For each, replace the `State = X` initializer entry (and any
+   companion `StateChangedAt`/`StateChangedByUser` initializer entries) with a post-construction
+   `order.InitializeState(X, <existing-at-or-DateTime.UtcNow>, <existing-by-or-"test">)`. For
+   `UpdateManufactureOrderScheduleHandlerTests` post-construction `existingOrder.State = ...` (around
+   lines 85/107), replace with `existingOrder.InitializeState(...)` (these are seeds, not transitions).
+   To minimize churn across the 9 files, you MAY add one shared internal test helper (e.g. a static
+   `ManufactureOrderTestBuilder.InState(...)` in the Manufacture test folder) and use it where it
+   reduces edits — but a direct `InitializeState` call per site is equally acceptable. Do NOT change
+   any test's expected assertions or expected outcomes.
+
+**Tests to write** (in `ManufactureOrderStateTransitionTests.cs`, replacing the deleted theories)
+
+1. `CanTransitionTo_ReturnsExpected` — `[Theory]`/`[InlineData]` covering EVERY cell of the matrix,
+   including the always-`false` `Cancelled` row and all self-transitions. Minimum data set (from,
+   to, expected):
+   - Draft→Planned = true; Draft→Cancelled = true; Draft→SemiProductManufactured = false;
+     Draft→Completed = false; Draft→Draft = false.
+   - Planned→Draft = true; Planned→SemiProductManufactured = true; Planned→Cancelled = true;
+     Planned→Completed = true; Planned→Planned = false.
+   - SemiProductManufactured→Planned = true; SemiProductManufactured→Completed = true;
+     SemiProductManufactured→Cancelled = true; SemiProductManufactured→Draft = false;
+     SemiProductManufactured→SemiProductManufactured = false.
+   - Completed→SemiProductManufactured = true; Completed→Cancelled = true; Completed→Planned = true;
+     Completed→Draft = false; Completed→Completed = false.
+   - Cancelled→Draft = false; Cancelled→Planned = false; Cancelled→SemiProductManufactured = false;
+     Cancelled→Completed = false; Cancelled→Cancelled = false.
+   Arrange via `OrderInState(from)`, act `order.CanTransitionTo(to)`, assert equals expected.
+
+2. `ChangeState_OnIllegalTransition_ThrowsAndLeavesEntityUnchanged` — arrange `OrderInState(Cancelled)`
+   with known `StateChangedAt`/`StateChangedByUser`; assert `Assert.Throws<ValidationException>(() =>
+   order.ChangeState(ManufactureOrderState.Planned, DateTime.UtcNow, "user"))`; then assert `State`,
+   `StateChangedAt`, and `StateChangedByUser` are all unchanged from the arranged values.
+
+3. `ChangeState_OnLegalTransition_UpdatesAllThreeFields` — arrange `OrderInState(Draft)`; call
+   `order.ChangeState(ManufactureOrderState.Planned, someUtc, "alice")`; assert
+   `State == Planned`, `StateChangedAt == someUtc`, `StateChangedByUser == "alice"`.
+
+Note: the handler-level tests (`UpdateManufactureOrderStatusHandlerTests`,
+`UpdateManufactureOrderStatusHandlerConditionsTests`) keep their existing expected outcomes — an
+illegal transition must still assert `ErrorCodes.InvalidOperation` (NOT a thrown exception /
+`InternalServerError`). Only their arrange-phase `State = ...` seeding may need the `InitializeState`
+redirect; expectations are unchanged.
+
+**Acceptance criteria**
+
+- `CanTransitionTo` is `public`, pure (reads `State` + arg only, mutates nothing), and returns the
+  exact same boolean as the old `IsValidStateTransition(from, to)` for every (from, to) pair,
+  including `false` for all self-transitions and all `Cancelled` rows.
+- `ChangeState` throws `ValidationException` on an illegal transition and leaves `State`,
+  `StateChangedAt`, `StateChangedByUser` unmodified; on a legal transition it sets all three.
+- `UpdateManufactureOrderStatusHandler` no longer declares `IsValidStateTransition`; it pre-checks
+  with `order.CanTransitionTo(...)` (same `InvalidOperation { oldState, newState }` early return) and
+  mutates via `order.ChangeState(...)`; `oldState` is still captured before mutation; all other
+  side effects and the success/error response shapes are unchanged.
+- The `State` setter is `internal set` (or, if EF materialization unexpectedly fails, fall back to
+  the least-permissive level that compiles and passes the persistence tests, with `ChangeState` /
+  `InitializeState` documented as the sanctioned mutation paths). `order.State = x` no longer
+  compiles from the Application or Test assemblies.
+- `CreateManufactureOrderHandler` seeds the initial `Draft` state via `InitializeState`; no behavior
+  change to the create flow.
+- `ManufactureOrderStateTransitionTests` no longer contains the three private mirror helpers or the
+  type-aware theories; it tests `CanTransitionTo`/`ChangeState` against the real entity.
+- All touched fixtures compile by routing through `InitializeState` (or the shared test builder);
+  no test's expected outcome is changed.
+- `cd backend && dotnet build` succeeds.
+- `cd backend && dotnet format --verify-no-changes` reports no changes (run `dotnet format` to fix
+  if needed).
+- Touched tests pass: `dotnet test backend/test/Anela.Heblo.Tests` filtered to at minimum
+  `ManufactureOrderStateTransitionTests`, `UpdateManufactureOrderStatusHandlerTests`,
+  `UpdateManufactureOrderStatusHandlerConditionsTests`, `CreateManufactureOrderHandlerTests`,
+  `UpdateManufactureOrderScheduleHandlerTests`, and `ManufactureOrderRepositoryTests` (verifies EF
+  materialization still binds `State` after the visibility change). All green.

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
@@ -51,11 +51,9 @@ public class CreateManufactureOrderHandler : IRequestHandler<CreateManufactureOr
             CreatedByUser = currentUser.Name,
             ResponsiblePerson = request.ResponsiblePerson,
             PlannedDate = request.PlannedDate,
-            ManufactureType = request.ManufactureType,
-            State = ManufactureOrderState.Draft,
-            StateChangedAt = now.DateTime,
-            StateChangedByUser = currentUser.Name
+            ManufactureType = request.ManufactureType
         };
+        order.InitializeState(ManufactureOrderState.Draft, now.DateTime, currentUser.Name);
 
         var semiproduct = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
         if (semiproduct == null)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/DuplicateManufactureOrder/DuplicateManufactureOrderHandler.cs
@@ -51,11 +51,9 @@ public class DuplicateManufactureOrderHandler : IRequestHandler<DuplicateManufac
             CreatedDate = now.DateTime,
             CreatedByUser = currentUser.GetDisplayName(),
             ResponsiblePerson = sourceOrder.ResponsiblePerson,
-            PlannedDate = today,
-            State = ManufactureOrderState.Draft,
-            StateChangedAt = now.DateTime,
-            StateChangedByUser = currentUser.GetDisplayName()
+            PlannedDate = today
         };
+        duplicateOrder.InitializeState(ManufactureOrderState.Draft, now.DateTime, currentUser.GetDisplayName());
 
         var expirationDate = sourceOrder.SemiProduct != null
             ? ManufactureOrderExtensions.GetDefaultExpiration(now.DateTime, sourceOrder.SemiProduct.ExpirationMonths)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
@@ -53,7 +53,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
             var oldState = order.State;
 
             // Validate state transition (basic validation - can be extended)
-            if (!IsValidStateTransition(oldState, request.NewState))
+            if (!order.CanTransitionTo(request.NewState))
             {
                 return new UpdateManufactureOrderStatusResponse(Application.Shared.ErrorCodes.InvalidOperation,
                     new Dictionary<string, string>
@@ -66,9 +66,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
             var currentUserName = _currentUserService.GetCurrentUser().GetDisplayName();
 
             // Update state
-            order.State = request.NewState;
-            order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
-            order.StateChangedByUser = currentUserName;
+            order.ChangeState(request.NewState, _timeProvider.GetUtcNow().DateTime, currentUserName);
 
             if (request.ManualActionRequired.HasValue)
                 order.ManualActionRequired = request.ManualActionRequired.Value;
@@ -157,20 +155,6 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
             _logger.LogError(ex, "Error updating manufacture order status for order {OrderId}", request.Id);
             return new UpdateManufactureOrderStatusResponse(ErrorCodes.InternalServerError);
         }
-    }
-
-    private bool IsValidStateTransition(ManufactureOrderState fromState, ManufactureOrderState toState)
-    {
-        // Allow backward and forward state transitions - simplified business rules
-        return fromState switch
-        {
-            ManufactureOrderState.Draft => toState is ManufactureOrderState.Planned or ManufactureOrderState.Cancelled,
-            ManufactureOrderState.Planned => toState is ManufactureOrderState.Draft or ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Completed,
-            ManufactureOrderState.SemiProductManufactured => toState is ManufactureOrderState.Planned or ManufactureOrderState.Completed or ManufactureOrderState.Cancelled,
-            ManufactureOrderState.Completed => toState is ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Planned, // Allow going back from completed
-            ManufactureOrderState.Cancelled => false, // Cannot change from cancelled state
-            _ => false
-        };
     }
 
     private async Task WriteDownInventoryAsync(ManufactureOrder order, string changedByUser, CancellationToken cancellationToken)

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Anela.Heblo.Domain.Features.Manufacture;
 
 public class ManufactureOrder
@@ -15,9 +17,9 @@ public class ManufactureOrder
     public DateOnly PlannedDate { get; set; }
 
     // State management
-    public ManufactureOrderState State { get; set; }
-    public DateTime StateChangedAt { get; set; }
-    public string StateChangedByUser { get; set; } = null!;
+    public ManufactureOrderState State { get; internal set; }
+    public DateTime StateChangedAt { get; internal set; }
+    public string StateChangedByUser { get; internal set; } = null!;
 
     // Collections
     public ManufactureOrderSemiProduct? SemiProduct { get; set; } = null!;
@@ -56,4 +58,44 @@ public class ManufactureOrder
     public bool? WeightWithinTolerance { get; set; }
     public decimal? WeightDifference { get; set; }   // positive = surplus, negative = deficit
 
+    /// <summary>
+    /// Sanctioned construction path that seeds the initial state and audit fields without
+    /// requiring an externally visible State setter. Use at creation time only.
+    /// </summary>
+    public void InitializeState(ManufactureOrderState initialState, DateTime changedAtUtc, string changedByUser)
+    {
+        State = initialState;
+        StateChangedAt = changedAtUtc;
+        StateChangedByUser = changedByUser;
+    }
+
+    /// <summary>
+    /// Pure predicate: true iff a transition from the current State to <paramref name="newState"/>
+    /// is legal. Reads State and the argument only; mutates nothing.
+    /// </summary>
+    public bool CanTransitionTo(ManufactureOrderState newState) => State switch
+    {
+        ManufactureOrderState.Draft => newState is ManufactureOrderState.Planned or ManufactureOrderState.Cancelled,
+        ManufactureOrderState.Planned => newState is ManufactureOrderState.Draft or ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Completed,
+        ManufactureOrderState.SemiProductManufactured => newState is ManufactureOrderState.Planned or ManufactureOrderState.Completed or ManufactureOrderState.Cancelled,
+        ManufactureOrderState.Completed => newState is ManufactureOrderState.SemiProductManufactured or ManufactureOrderState.Cancelled or ManufactureOrderState.Planned,
+        ManufactureOrderState.Cancelled => false,
+        _ => false
+    };
+
+    /// <summary>
+    /// Guarded state mutation. Throws when the transition is illegal and leaves the entity
+    /// unchanged; on success sets State + audit fields atomically.
+    /// </summary>
+    public void ChangeState(ManufactureOrderState newState, DateTime changedAtUtc, string changedByUser)
+    {
+        if (!CanTransitionTo(newState))
+        {
+            throw new ValidationException($"Unable to change state from {State} to {newState}.");
+        }
+
+        State = newState;
+        StateChangedAt = changedAtUtc;
+        StateChangedByUser = changedByUser;
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -235,8 +235,8 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler+<Handle>d__9 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
         "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
         "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler+<Handle>d__4 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
-        "Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus.UpdateManufactureOrderStatusHandler+<>c__DisplayClass10_0 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
-        "Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus.UpdateManufactureOrderStatusHandler+<WriteDownInventoryAsync>d__10 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus.UpdateManufactureOrderStatusHandler+<>c__DisplayClass9_0 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus.UpdateManufactureOrderStatusHandler+<WriteDownInventoryAsync>d__9 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
 
         // Domain enums/types reached via CatalogAggregate properties.
         // Same follow-up as above.

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DuplicateManufactureOrderHandlerTests.cs
@@ -45,11 +45,10 @@ public class DuplicateManufactureOrderHandlerTests
             Id = SourceOrderId,
             OrderNumber = "MO-2025-9999",
             ResponsiblePerson = ResponsiblePerson,
-            State = ManufactureOrderState.Completed,
             PlannedDate = new DateOnly(2025, 1, 1),
             CreatedByUser = "Original Author",
-            StateChangedByUser = "Original Author",
         };
+        order.InitializeState(ManufactureOrderState.Completed, default, "Original Author");
 
         if (includeSemiProduct)
         {

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrderHandlerTests.cs
@@ -174,11 +174,9 @@ public class GetManufactureOrderHandlerTests
             CreatedDate = DateTime.UtcNow.AddDays(-2),
             CreatedByUser = "Test User",
             ResponsiblePerson = "John Doe",
-            PlannedDate = DateOnly.FromDateTime(DateTime.Today.AddDays(7)),
-            State = ManufactureOrderState.Draft,
-            StateChangedAt = DateTime.UtcNow.AddDays(-2),
-            StateChangedByUser = "Test User"
+            PlannedDate = DateOnly.FromDateTime(DateTime.Today.AddDays(7))
         };
+        order.InitializeState(ManufactureOrderState.Draft, DateTime.UtcNow.AddDays(-2), "Test User");
 
         order.SemiProduct = new ManufactureOrderSemiProduct
         {

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrdersHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrdersHandlerTests.cs
@@ -463,31 +463,27 @@ public class GetManufactureOrdersHandlerTests
 
     private static List<ManufactureOrder> CreateSampleOrders()
     {
-        return new List<ManufactureOrder>
+        var first = new ManufactureOrder
         {
-            new ManufactureOrder
-            {
-                Id = 1,
-                OrderNumber = "MO-2024-001",
-                CreatedDate = DateTime.UtcNow.AddDays(-5),
-                CreatedByUser = "User1",
-                ResponsiblePerson = "John Doe",
-                State = ManufactureOrderState.Draft,
-                StateChangedAt = DateTime.UtcNow.AddDays(-5),
-                StateChangedByUser = "User1"
-            },
-            new ManufactureOrder
-            {
-                Id = 2,
-                OrderNumber = "MO-2024-002",
-                CreatedDate = DateTime.UtcNow.AddDays(-3),
-                CreatedByUser = "User2",
-                ResponsiblePerson = "Jane Doe",
-                State = ManufactureOrderState.SemiProductManufactured,
-                StateChangedAt = DateTime.UtcNow.AddDays(-2),
-                StateChangedByUser = "User2"
-            }
+            Id = 1,
+            OrderNumber = "MO-2024-001",
+            CreatedDate = DateTime.UtcNow.AddDays(-5),
+            CreatedByUser = "User1",
+            ResponsiblePerson = "John Doe"
         };
+        first.InitializeState(ManufactureOrderState.Draft, DateTime.UtcNow.AddDays(-5), "User1");
+
+        var second = new ManufactureOrder
+        {
+            Id = 2,
+            OrderNumber = "MO-2024-002",
+            CreatedDate = DateTime.UtcNow.AddDays(-3),
+            CreatedByUser = "User2",
+            ResponsiblePerson = "Jane Doe"
+        };
+        second.InitializeState(ManufactureOrderState.SemiProductManufactured, DateTime.UtcNow.AddDays(-2), "User2");
+
+        return new List<ManufactureOrder> { first, second };
     }
 
     private static List<ManufactureOrderDto> CreateSampleOrderDtos()

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureProtocolHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureProtocolHandlerTests.cs
@@ -27,7 +27,8 @@ public class GetManufactureProtocolHandlerTests
     [Fact]
     public async Task Handle_NonCompletedOrder_Throws()
     {
-        var order = new ManufactureOrder { Id = 1, State = ManufactureOrderState.Planned, OrderNumber = "MO-2026-001" };
+        var order = new ManufactureOrder { Id = 1, OrderNumber = "MO-2026-001" };
+        order.InitializeState(ManufactureOrderState.Planned, DateTime.UtcNow, "test");
         _repositoryMock
             .Setup(r => r.GetOrderByIdAsync(1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(order);
@@ -202,13 +203,11 @@ public class GetManufactureProtocolHandlerTests
 
     private static ManufactureOrder BuildCompletedOrder()
     {
-        return new ManufactureOrder
+        var order = new ManufactureOrder
         {
             Id = 1,
             OrderNumber = "MO-2026-001",
-            State = ManufactureOrderState.Completed,
             CreatedDate = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
-            StateChangedAt = new DateTime(2026, 4, 2, 0, 0, 0, DateTimeKind.Utc),
             ResponsiblePerson = "Jana Nováková",
             ManufactureType = ManufactureType.MultiPhase,
             SemiProduct = new ManufactureOrderSemiProduct
@@ -269,5 +268,7 @@ public class GetManufactureProtocolHandlerTests
                 },
             },
         };
+        order.InitializeState(ManufactureOrderState.Completed, new DateTime(2026, 4, 2, 0, 0, 0, DateTimeKind.Utc), null!);
+        return order;
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderStateTransitionTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderStateTransitionTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Xunit;
 
@@ -6,107 +8,88 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class ManufactureOrderStateTransitionTests
 {
     [Theory]
+    // Draft row
     [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.Planned, true)]
-    [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.SemiProductManufactured, false)] // SinglePhase: Cannot go to SemiProductManufactured
-    [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Completed, false)] // SinglePhase: Never in SemiProductManufactured state
     [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.Cancelled, true)]
-    [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.Cancelled, true)]
-    [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Cancelled, false)] // SinglePhase: Never in SemiProductManufactured state
     [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.SemiProductManufactured, false)]
     [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.Completed, false)]
-    [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.Completed, true)] // Single-phase: Planned → Completed directly
-    [InlineData(ManufactureOrderState.Completed, ManufactureOrderState.SemiProductManufactured, false)]
-    [InlineData(ManufactureOrderState.Cancelled, ManufactureOrderState.Planned, false)]
-    public void ValidateSinglePhaseTransition_ShouldReturnExpectedResult(
-        ManufactureOrderState currentState,
-        ManufactureOrderState targetState,
-        bool expectedValid)
-    {
-        // Act
-        var result = ValidateSinglePhaseTransition(currentState, targetState);
-
-        // Assert
-        Assert.Equal(expectedValid, result);
-    }
-
-    [Theory]
-    [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.Planned, true)]
+    [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.Draft, false)]
+    // Planned row
+    [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.Draft, true)]
     [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.SemiProductManufactured, true)]
-    [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Completed, true)]
-    [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.Cancelled, true)]
     [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.Cancelled, true)]
+    [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.Completed, true)]
+    [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.Planned, false)]
+    // SemiProductManufactured row
+    [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Planned, true)]
+    [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Completed, true)]
     [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Cancelled, true)]
-    [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.SemiProductManufactured, false)]
-    [InlineData(ManufactureOrderState.Draft, ManufactureOrderState.Completed, false)]
-    [InlineData(ManufactureOrderState.Planned, ManufactureOrderState.Completed, false)] // Multi-phase cannot go directly from Planned to Completed
-    [InlineData(ManufactureOrderState.Completed, ManufactureOrderState.SemiProductManufactured, false)]
+    [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Draft, false)]
+    [InlineData(ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.SemiProductManufactured, false)]
+    // Completed row
+    [InlineData(ManufactureOrderState.Completed, ManufactureOrderState.SemiProductManufactured, true)]
+    [InlineData(ManufactureOrderState.Completed, ManufactureOrderState.Cancelled, true)]
+    [InlineData(ManufactureOrderState.Completed, ManufactureOrderState.Planned, true)]
+    [InlineData(ManufactureOrderState.Completed, ManufactureOrderState.Draft, false)]
+    [InlineData(ManufactureOrderState.Completed, ManufactureOrderState.Completed, false)]
+    // Cancelled row (terminal)
+    [InlineData(ManufactureOrderState.Cancelled, ManufactureOrderState.Draft, false)]
     [InlineData(ManufactureOrderState.Cancelled, ManufactureOrderState.Planned, false)]
-    public void ValidateMultiPhaseTransition_ShouldReturnExpectedResult(
-        ManufactureOrderState currentState,
-        ManufactureOrderState targetState,
-        bool expectedValid)
+    [InlineData(ManufactureOrderState.Cancelled, ManufactureOrderState.SemiProductManufactured, false)]
+    [InlineData(ManufactureOrderState.Cancelled, ManufactureOrderState.Completed, false)]
+    [InlineData(ManufactureOrderState.Cancelled, ManufactureOrderState.Cancelled, false)]
+    public void CanTransitionTo_ReturnsExpected(
+        ManufactureOrderState from,
+        ManufactureOrderState to,
+        bool expected)
     {
+        // Arrange
+        var order = OrderInState(from);
+
         // Act
-        var result = ValidateMultiPhaseTransition(currentState, targetState);
+        var result = order.CanTransitionTo(to);
 
         // Assert
-        Assert.Equal(expectedValid, result);
+        Assert.Equal(expected, result);
     }
 
-    [Theory]
-    [InlineData(ManufactureType.SinglePhase, ManufactureOrderState.Planned, ManufactureOrderState.Completed, true)]
-    [InlineData(ManufactureType.SinglePhase, ManufactureOrderState.Planned, ManufactureOrderState.SemiProductManufactured, false)]
-    [InlineData(ManufactureType.MultiPhase, ManufactureOrderState.Planned, ManufactureOrderState.SemiProductManufactured, true)]
-    [InlineData(ManufactureType.MultiPhase, ManufactureOrderState.Planned, ManufactureOrderState.Completed, false)]
-    public void IsValidStateTransition_ShouldRespectManufactureType(
-        ManufactureType manufactureType,
-        ManufactureOrderState currentState,
-        ManufactureOrderState targetState,
-        bool expectedValid)
+    [Fact]
+    public void ChangeState_OnIllegalTransition_ThrowsAndLeavesEntityUnchanged()
     {
+        // Arrange
+        var changedAt = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var order = new ManufactureOrder();
+        order.InitializeState(ManufactureOrderState.Cancelled, changedAt, "seed-user");
+
+        // Act + Assert
+        Assert.Throws<ValidationException>(() =>
+            order.ChangeState(ManufactureOrderState.Planned, DateTime.UtcNow, "user"));
+
+        Assert.Equal(ManufactureOrderState.Cancelled, order.State);
+        Assert.Equal(changedAt, order.StateChangedAt);
+        Assert.Equal("seed-user", order.StateChangedByUser);
+    }
+
+    [Fact]
+    public void ChangeState_OnLegalTransition_UpdatesAllThreeFields()
+    {
+        // Arrange
+        var order = OrderInState(ManufactureOrderState.Draft);
+        var someUtc = new DateTime(2026, 6, 18, 10, 30, 0, DateTimeKind.Utc);
+
         // Act
-        var result = IsValidStateTransition(currentState, targetState, manufactureType);
+        order.ChangeState(ManufactureOrderState.Planned, someUtc, "alice");
 
         // Assert
-        Assert.Equal(expectedValid, result);
+        Assert.Equal(ManufactureOrderState.Planned, order.State);
+        Assert.Equal(someUtc, order.StateChangedAt);
+        Assert.Equal("alice", order.StateChangedByUser);
     }
 
-    // Helper methods that mirror the private methods in ManufactureOrderApplicationService
-    private bool ValidateSinglePhaseTransition(ManufactureOrderState current, ManufactureOrderState target)
+    private static ManufactureOrder OrderInState(ManufactureOrderState state)
     {
-        return (current, target) switch
-        {
-            (ManufactureOrderState.Draft, ManufactureOrderState.Planned) => true,
-            (ManufactureOrderState.Planned, ManufactureOrderState.Completed) => true, // Single-phase: Planned → Completed directly
-            // SinglePhase can be cancelled from Draft and Planned states (not from final states)
-            (ManufactureOrderState.Draft, ManufactureOrderState.Cancelled) => true,
-            (ManufactureOrderState.Planned, ManufactureOrderState.Cancelled) => true,
-            _ => false
-        };
-    }
-
-    private bool ValidateMultiPhaseTransition(ManufactureOrderState current, ManufactureOrderState target)
-    {
-        return (current, target) switch
-        {
-            (ManufactureOrderState.Draft, ManufactureOrderState.Planned) => true,
-            (ManufactureOrderState.Planned, ManufactureOrderState.SemiProductManufactured) => true,
-            (ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Completed) => true,
-            // MultiPhase can be cancelled from Draft, Planned, and SemiProductManufactured states
-            (ManufactureOrderState.Draft, ManufactureOrderState.Cancelled) => true,
-            (ManufactureOrderState.Planned, ManufactureOrderState.Cancelled) => true,
-            (ManufactureOrderState.SemiProductManufactured, ManufactureOrderState.Cancelled) => true,
-            _ => false
-        };
-    }
-
-    private bool IsValidStateTransition(ManufactureOrderState currentState, ManufactureOrderState newState, ManufactureType manufactureType)
-    {
-        return manufactureType switch
-        {
-            ManufactureType.SinglePhase => ValidateSinglePhaseTransition(currentState, newState),
-            ManufactureType.MultiPhase => ValidateMultiPhaseTransition(currentState, newState),
-            _ => false
-        };
+        var order = new ManufactureOrder();
+        order.InitializeState(state, DateTime.UtcNow, "test");
+        return order;
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderHandlerTests.cs
@@ -364,11 +364,9 @@ public class UpdateManufactureOrderHandlerTests
             CreatedDate = DateTime.UtcNow.AddDays(-1),
             CreatedByUser = "Original User",
             ResponsiblePerson = "Original Person",
-            PlannedDate = DateOnly.FromDateTime(DateTime.Today.AddDays(5)),
-            State = ManufactureOrderState.Draft,
-            StateChangedAt = DateTime.UtcNow.AddDays(-1),
-            StateChangedByUser = "Original User"
+            PlannedDate = DateOnly.FromDateTime(DateTime.Today.AddDays(5))
         };
+        order.InitializeState(ManufactureOrderState.Draft, DateTime.UtcNow.AddDays(-1), "Original User");
 
         order.SemiProduct = new ManufactureOrderSemiProduct
         {

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderScheduleHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderScheduleHandlerTests.cs
@@ -82,7 +82,7 @@ public class UpdateManufactureOrderScheduleHandlerTests
         // Arrange
         var request = CreateValidRequest();
         var existingOrder = CreateExistingOrder();
-        existingOrder.State = ManufactureOrderState.Cancelled;
+        existingOrder.InitializeState(ManufactureOrderState.Cancelled, DateTime.UtcNow.AddDays(-1), "Original User");
 
         _repositoryMock
             .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
@@ -104,7 +104,7 @@ public class UpdateManufactureOrderScheduleHandlerTests
         // Arrange
         var request = CreateValidRequest();
         var existingOrder = CreateExistingOrder();
-        existingOrder.State = ManufactureOrderState.Completed;
+        existingOrder.InitializeState(ManufactureOrderState.Completed, DateTime.UtcNow.AddDays(-1), "Original User");
 
         _repositoryMock
             .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
@@ -349,7 +349,7 @@ public class UpdateManufactureOrderScheduleHandlerTests
 
     private static ManufactureOrder CreateExistingOrder()
     {
-        return new ManufactureOrder
+        var order = new ManufactureOrder
         {
             Id = ValidOrderId,
             OrderNumber = "MO-2024-001",
@@ -357,9 +357,6 @@ public class UpdateManufactureOrderScheduleHandlerTests
             CreatedByUser = "Original User",
             ResponsiblePerson = "Test User",
             PlannedDate = DateOnly.FromDateTime(DateTime.Today.AddDays(1)),
-            State = ManufactureOrderState.Draft,
-            StateChangedAt = DateTime.UtcNow.AddDays(-1),
-            StateChangedByUser = "Original User",
             SemiProduct = new ManufactureOrderSemiProduct
             {
                 Id = 1,
@@ -380,5 +377,7 @@ public class UpdateManufactureOrderScheduleHandlerTests
             },
             Notes = new List<ManufactureOrderNote>()
         };
+        order.InitializeState(ManufactureOrderState.Draft, DateTime.UtcNow.AddDays(-1), "Original User");
+        return order;
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
@@ -56,18 +56,19 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
             _inventoryRepositoryMock.Object,
             _catalogRepositoryMock.Object);
 
-    private ManufactureOrder CreateOrderInState(ManufactureOrderState state) =>
-        new ManufactureOrder
+    private ManufactureOrder CreateOrderInState(ManufactureOrderState state)
+    {
+        var order = new ManufactureOrder
         {
             Id = 1,
             OrderNumber = "MO-2026-001",
-            State = state,
-            StateChangedAt = DateTime.UtcNow,
-            StateChangedByUser = "previous-user",
             CreatedByUser = "creator",
             CreatedDate = DateTime.UtcNow.AddDays(-1),
             PlannedDate = DateOnly.FromDateTime(DateTime.Today),
         };
+        order.InitializeState(state, DateTime.UtcNow, "previous-user");
+        return order;
+    }
 
     [Fact]
     public async Task Handle_TransitionToSemiProductManufactured_CapturesConditionsReadingWithLiveSource()

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
@@ -794,17 +794,16 @@ public class UpdateManufactureOrderStatusHandlerTests
 
     private static ManufactureOrder CreateOrderInState(ManufactureOrderState state)
     {
-        return new ManufactureOrder
+        var order = new ManufactureOrder
         {
             Id = ValidOrderId,
             OrderNumber = "MO-2024-001",
             CreatedDate = DateTime.UtcNow.AddDays(-1),
             CreatedByUser = "Original User",
             ResponsiblePerson = "Test Person",
-            PlannedDate = DateOnly.FromDateTime(DateTime.Today.AddDays(7)),
-            State = state,
-            StateChangedAt = DateTime.UtcNow.AddDays(-1),
-            StateChangedByUser = "Original User"
+            PlannedDate = DateOnly.FromDateTime(DateTime.Today.AddDays(7))
         };
+        order.InitializeState(state, DateTime.UtcNow.AddDays(-1), "Original User");
+        return order;
     }
 }


### PR DESCRIPTION
## What the issue was
`ManufactureOrder` exposed `State` as an unguarded public setter, and the legal state-transition table lived in `UpdateManufactureOrderStatusHandler.IsValidStateTransition`. Keeping the rule in the Application layer violated *business logic belongs in the domain*: any handler could assign an arbitrary state directly (`order.State = ...`) bypassing validation, and the rule could only be tested through the handler, never against the entity in isolation.

## How it was fixed / handled
Relocated the transition rules into the `ManufactureOrder` aggregate, following the existing `TransportBox` precedent — no runtime or HTTP-contract change.

### Changes
- **`ManufactureOrder.cs`** — `State`/`StateChangedAt`/`StateChangedByUser` setters tightened to `internal set`; added `InitializeState(...)` (sanctioned seeding path), `CanTransitionTo(...)` (pure predicate reproducing the existing matrix verbatim, type-agnostic), and a guarded `ChangeState(...)` that throws `ValidationException` on an illegal transition (validate-before-mutate, all three audit fields set atomically).
- **`UpdateManufactureOrderStatusHandler.cs`** — pre-checks via `order.CanTransitionTo(...)` (identical `InvalidOperation { oldState, newState }` early return preserved — not a thrown-exception path), mutates via `order.ChangeState(...)`; the private `IsValidStateTransition` was deleted. All side effects and response shapes unchanged.
- **`CreateManufactureOrderHandler.cs` / `DuplicateManufactureOrderHandler.cs`** — seed the initial `Draft` state via `InitializeState` (the latter also assigned `State` in an initializer and had to be redirected to compile under `internal set`).
- **Tests** — `ManufactureOrderStateTransitionTests` rewritten: removed the three type-aware private mirror helpers and their theories (which never exercised production code and would have silently changed behaviour), replaced with an exhaustive `CanTransitionTo` matrix theory plus legal/illegal `ChangeState` tests against the real entity. Arrange-phase `State = ...` seeding across 8 affected fixtures routed through `InitializeState`; no expected outcomes changed.

### Verification
- `dotnet build` — succeeds (pre-existing warnings only).
- `dotnet format --verify-no-changes` — clean.
- `dotnet test --filter "FullyQualifiedName~Manufacture"` — **693 passed, 0 failed, 0 skipped** (includes EF materialization tests confirming `State` still binds under the non-public setter).

## Artifacts
- Brief, spec, arch review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3116/` in this branch.

Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)