### PR TITLE
3117: Remove dead DiscardRedisueDocumentCode property from UpdateManufactureOrderStatusRequest

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflow.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflow.cs
@@ -285,7 +285,6 @@ public class ConfirmProductCompletionWorkflow : IConfirmProductCompletionWorkflo
             Note = combined,
             SemiProductOrderCode = null,
             ProductOrderCode = submitResult.ManufactureId,
-            DiscardRedisueDocumentCode = null,
             ManualActionRequired = manualActionRequired,
             WeightWithinTolerance = distribution.IsWithinAllowedThreshold,
             WeightDifference = distribution.Difference,

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmSemiProductManufactureWorkflow.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmSemiProductManufactureWorkflow.cs
@@ -174,7 +174,6 @@ public class ConfirmSemiProductManufactureWorkflow : IConfirmSemiProductManufact
                 : submitResult.UserMessage ?? submitResult.FullError(),
             SemiProductOrderCode = submitResult.ManufactureId,
             ProductOrderCode = null,
-            DiscardRedisueDocumentCode = null,
             ManualActionRequired = !submitResult.Success,
             WeightWithinTolerance = null,
             WeightDifference = null,

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusRequest.cs
@@ -17,7 +17,6 @@ public class UpdateManufactureOrderStatusRequest : IRequest<UpdateManufactureOrd
     public bool? ManualActionRequired { get; set; }
     public string? SemiProductOrderCode { get; set; }
     public string? ProductOrderCode { get; set; }
-    public string? DiscardRedisueDocumentCode { get; set; }
     public bool? WeightWithinTolerance { get; set; }
     public decimal? WeightDifference { get; set; }
     public string? FlexiDocMaterialIssueForSemiProduct { get; set; }


### PR DESCRIPTION
## What the issue was

`UpdateManufactureOrderStatusRequest` declared a property `DiscardRedisueDocumentCode` (typo: `Redisue` instead of `Residue`) that was never read by the handler. Both callers in `ConfirmSemiProductManufactureWorkflow` and `ConfirmProductCompletionWorkflow` always passed `null`, making the property a dead no-op. It also surfaced in the generated OpenAPI TypeScript client, misleading frontend consumers with a callable parameter that had no effect.

## How it was fixed / handled

- Removed `DiscardRedisueDocumentCode` from `UpdateManufactureOrderStatusRequest`
- Removed `DiscardRedisueDocumentCode = null` from `ConfirmSemiProductManufactureWorkflow.UpdateStatusAsync`
- Removed `DiscardRedisueDocumentCode = null` from `ConfirmProductCompletionWorkflow.TransitionToCompletedAsync`

The handler never wired this property to `order.ErpDiscardResidueDocumentNumber` — that field is populated via `SubmitManufactureHandler` / `UpdateManufactureOrderHandler`. If the status-update endpoint ever needs to set the discard-residue document number, a correctly-named `DiscardResidueDocumentCode` can be added and wired at that time.

Build: `dotnet build` — 0 errors. Format: `dotnet format --verify-no-changes` — clean.

Closes #3117

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjFj4r3ebJ9MQBnxKUN9hb)_