### PR TITLE
feat-3118: Plaud CLI auth-expiry auto-recovery

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/AssemblyAttributes.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/AssemblyAttributes.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Anela.Heblo.Adapters.Plaud.Tests")]

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudAdapterServiceCollectionExtensions.cs
@@ -15,15 +15,18 @@ public static class PlaudAdapterServiceCollectionExtensions
         services.AddSingleton<IPlaudClient, PlaudCliClient>();
         services.AddHostedService<PlaudTokenBootstrapper>();
 
+        // PlaudTokenRefreshClient is stateless (HTTP only) — always register so PlaudCliClient
+        // can auto-refresh on auth expiry regardless of environment.
+        services.AddHttpClient<PlaudTokenRefreshClient>();
+        services.AddTransient<IPlaudTokenRefreshClient>(
+            sp => sp.GetRequiredService<PlaudTokenRefreshClient>());
+
         // Token refresh job requires Key Vault write access.
         // Skip registration in local dev where KeyVault:Uri is unset.
         var keyVaultUri = configuration["KeyVault:Uri"];
         if (!string.IsNullOrWhiteSpace(keyVaultUri))
         {
             services.AddSingleton(new SecretClient(new Uri(keyVaultUri), new DefaultAzureCredential()));
-            services.AddHttpClient<PlaudTokenRefreshClient>();
-            services.AddScoped<IPlaudTokenRefreshClient>(
-                sp => sp.GetRequiredService<PlaudTokenRefreshClient>());
             services.AddScoped<IRecurringJob, PlaudTokenRefreshJob>();
         }
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudCliClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudCliClient.cs
@@ -10,11 +10,21 @@ public sealed class PlaudCliClient : IPlaudClient
 {
     private readonly ILogger<PlaudCliClient> _logger;
     private readonly IOptions<PlaudOptions> _options;
+    private readonly IPlaudTokenRefreshClient _refreshClient;
+    private readonly string _tokensFilePath;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
 
-    public PlaudCliClient(ILogger<PlaudCliClient> logger, IOptions<PlaudOptions> options)
+    public PlaudCliClient(ILogger<PlaudCliClient> logger, IOptions<PlaudOptions> options, IPlaudTokenRefreshClient refreshClient)
+        : this(logger, options, refreshClient,
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".plaud", "tokens.json"))
+    { }
+
+    internal PlaudCliClient(ILogger<PlaudCliClient> logger, IOptions<PlaudOptions> options, IPlaudTokenRefreshClient refreshClient, string tokensFilePath)
     {
         _logger = logger;
         _options = options;
+        _refreshClient = refreshClient;
+        _tokensFilePath = tokensFilePath;
     }
 
     public async Task<List<PlaudRecordingSummary>> ListRecentAsync(int days, CancellationToken ct = default)
@@ -78,6 +88,60 @@ public sealed class PlaudCliClient : IPlaudClient
     }
 
     private async Task<string> RunCliAsync(string[] args, CancellationToken ct)
+    {
+        try
+        {
+            return await RunCliCoreAsync(args, ct);
+        }
+        catch (PlaudAuthExpiredException)
+        {
+            _logger.LogWarning("Plaud auth expired; attempting token refresh and retry.");
+            try
+            {
+                await RefreshTokensAsync(ct);
+                _logger.LogInformation("Plaud token refreshed; retrying CLI call.");
+                return await RunCliCoreAsync(args, ct);
+            }
+            catch (PlaudAuthExpiredException)
+            {
+                _logger.LogError("Plaud auth still expired after token refresh; giving up.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Plaud token refresh failed.");
+                throw new PlaudAuthExpiredException("token refresh failed", ex);
+            }
+        }
+    }
+
+    private async Task RefreshTokensAsync(CancellationToken ct)
+    {
+        await _refreshLock.WaitAsync(ct);
+        try
+        {
+            if (!File.Exists(_tokensFilePath))
+                throw new InvalidOperationException(
+                    $"Plaud tokens file not found at {_tokensFilePath}. Cannot refresh.");
+
+            var diskJson = await File.ReadAllTextAsync(_tokensFilePath, ct);
+            var diskTokens = JsonSerializer.Deserialize<PlaudTokens>(diskJson)
+                ?? throw new InvalidOperationException("Failed to deserialize Plaud tokens from disk.");
+
+            var newTokens = await _refreshClient.RefreshAsync(diskTokens.RefreshToken, ct);
+            var newJson = JsonSerializer.Serialize(newTokens);
+
+            await File.WriteAllTextAsync(_tokensFilePath, newJson, ct);
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(_tokensFilePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private async Task<string> RunCliCoreAsync(string[] args, CancellationToken ct)
     {
         var options = _options.Value;
         var psi = new ProcessStartInfo

--- a/backend/test/Anela.Heblo.Adapters.Plaud.Tests/PlaudCliClientRunTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Plaud.Tests/PlaudCliClientRunTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -6,74 +7,241 @@ namespace Anela.Heblo.Adapters.Plaud.Tests;
 
 public sealed class PlaudCliClientRunTests
 {
-    [SkippableFact]
-    public async Task RunCli_WhenCliExitsWithAuthFailed_ThrowsPlaudAuthExpiredException()
+    // ── Fake refresh client ──────────────────────────────────────────────────
+
+    private sealed class FakeRefreshClient : IPlaudTokenRefreshClient
     {
-        // Skip on platforms that can't run shell scripts
+        private readonly Func<string, Task<PlaudTokens>> _handler;
+
+        public int CallCount { get; private set; }
+        public string? CapturedRefreshToken { get; private set; }
+
+        public FakeRefreshClient(Func<string, Task<PlaudTokens>> handler) => _handler = handler;
+
+        public static FakeRefreshClient Succeeds(PlaudTokens tokens) =>
+            new(_ => Task.FromResult(tokens));
+
+        public static FakeRefreshClient Throws(Exception ex) =>
+            new(_ => Task.FromException<PlaudTokens>(ex));
+
+        public async Task<PlaudTokens> RefreshAsync(string refreshToken, CancellationToken ct = default)
+        {
+            CapturedRefreshToken = refreshToken;
+            CallCount++;
+            return await _handler(refreshToken);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static PlaudOptions OptionsFor(string shimPath) => new()
+    {
+        CliExecutablePath = shimPath,
+        ProcessTimeoutSeconds = 10
+    };
+
+    private static (string dir, string shimPath, string tokensPath) CreateTestDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"plaud_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return (dir, Path.Combine(dir, "plaud.sh"), Path.Combine(dir, "tokens.json"));
+    }
+
+    private static async Task WriteTokensAsync(string path, string accessToken = "old-token",
+        string refreshToken = "refresh-token")
+    {
+        var tokens = new PlaudTokens(accessToken, refreshToken, 9999999999L, "Bearer");
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(tokens));
+    }
+
+    // ── Auth-failed: retry succeeds after refresh ─────────────────────────
+
+    [SkippableFact]
+    public async Task RunCli_WhenAuthFails_RefreshesTokenAndRetries_ReturnsOutput()
+    {
         Skip.If(OperatingSystem.IsWindows(), "Shim script requires bash");
-        if (OperatingSystem.IsWindows()) return; // satisfy CA1416 — unreachable at runtime
+        if (OperatingSystem.IsWindows()) return;
 
-        // Arrange — write a tiny shim that mimics Plaud auth failure
-        var shimPath = Path.Combine(Path.GetTempPath(), $"plaud_shim_{Guid.NewGuid():N}.sh");
-        await File.WriteAllTextAsync(shimPath,
-            "#!/bin/sh\necho '[AUTH_FAILED] Token invalid or expired' >&2\nexit 1\n");
-        File.SetUnixFileMode(shimPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-
+        var (dir, shimPath, tokensPath) = CreateTestDir();
         try
         {
-            var options = Options.Create(new PlaudOptions
-            {
-                CliExecutablePath = shimPath,
-                ProcessTimeoutSeconds = 10
-            });
-            var client = new PlaudCliClient(NullLogger<PlaudCliClient>.Instance, options);
+            // Shim succeeds only after the tokens file contains the refreshed access token.
+            await File.WriteAllTextAsync(shimPath,
+                $"""
+                #!/bin/sh
+                TFILE="{tokensPath}"
+                if grep -q '"refreshed-token"' "$TFILE" 2>/dev/null; then
+                    printf "Recordings in the last 7 days: 0\n"
+                    exit 0
+                else
+                    printf '[AUTH_FAILED] Token invalid or expired\n' >&2
+                    exit 1
+                fi
+                """);
+            File.SetUnixFileMode(shimPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
 
-            // Act
-            Func<Task> act = () => client.ListRecentAsync(7);
+            await WriteTokensAsync(tokensPath);
 
-            // Assert
-            await act.Should()
-                .ThrowAsync<PlaudAuthExpiredException>()
-                .WithMessage("*AUTH_FAILED*");
+            var refreshed = new PlaudTokens("refreshed-token", "new-refresh", 9999999999L, "Bearer");
+            var refreshClient = FakeRefreshClient.Succeeds(refreshed);
+            var client = new PlaudCliClient(
+                NullLogger<PlaudCliClient>.Instance,
+                Options.Create(OptionsFor(shimPath)),
+                refreshClient,
+                tokensPath);
+
+            var result = await client.ListRecentAsync(7);
+
+            result.Should().BeEmpty();
+            refreshClient.CallCount.Should().Be(1);
+            refreshClient.CapturedRefreshToken.Should().Be("refresh-token");
         }
         finally
         {
-            File.Delete(shimPath);
+            Directory.Delete(dir, recursive: true);
         }
     }
+
+    // ── Auth-failed: refresh HTTP call throws ─────────────────────────────
+
+    [SkippableFact]
+    public async Task RunCli_WhenAuthFailsAndRefreshThrows_ThrowsPlaudAuthExpiredException()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Shim script requires bash");
+        if (OperatingSystem.IsWindows()) return;
+
+        var (dir, shimPath, tokensPath) = CreateTestDir();
+        try
+        {
+            await File.WriteAllTextAsync(shimPath,
+                "#!/bin/sh\nprintf '[AUTH_FAILED] Token invalid or expired\\n' >&2\nexit 1\n");
+            File.SetUnixFileMode(shimPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            await WriteTokensAsync(tokensPath);
+
+            var refreshClient = FakeRefreshClient.Throws(
+                new HttpRequestException("Plaud token refresh failed: 401 Unauthorized"));
+            var client = new PlaudCliClient(
+                NullLogger<PlaudCliClient>.Instance,
+                Options.Create(OptionsFor(shimPath)),
+                refreshClient,
+                tokensPath);
+
+            Func<Task> act = () => client.ListRecentAsync(7);
+
+            await act.Should().ThrowAsync<PlaudAuthExpiredException>();
+            refreshClient.CallCount.Should().Be(1);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ── Auth-failed: retry also fails ─────────────────────────────────────
+
+    [SkippableFact]
+    public async Task RunCli_WhenAuthFailsAndRetryAlsoFails_ThrowsPlaudAuthExpiredException()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Shim script requires bash");
+        if (OperatingSystem.IsWindows()) return;
+
+        var (dir, shimPath, tokensPath) = CreateTestDir();
+        try
+        {
+            // Shim always fails with AUTH_FAILED, regardless of tokens.
+            await File.WriteAllTextAsync(shimPath,
+                "#!/bin/sh\nprintf '[AUTH_FAILED] Token invalid or expired\\n' >&2\nexit 1\n");
+            File.SetUnixFileMode(shimPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            await WriteTokensAsync(tokensPath);
+
+            var refreshed = new PlaudTokens("refreshed-token", "new-refresh", 9999999999L, "Bearer");
+            var refreshClient = FakeRefreshClient.Succeeds(refreshed);
+            var client = new PlaudCliClient(
+                NullLogger<PlaudCliClient>.Instance,
+                Options.Create(OptionsFor(shimPath)),
+                refreshClient,
+                tokensPath);
+
+            Func<Task> act = () => client.ListRecentAsync(7);
+
+            await act.Should().ThrowAsync<PlaudAuthExpiredException>();
+            refreshClient.CallCount.Should().Be(1);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ── Auth-failed: tokens file missing ─────────────────────────────────
+
+    [SkippableFact]
+    public async Task RunCli_WhenAuthFailsAndTokensFileMissing_ThrowsPlaudAuthExpiredException()
+    {
+        Skip.If(OperatingSystem.IsWindows(), "Shim script requires bash");
+        if (OperatingSystem.IsWindows()) return;
+
+        var (dir, shimPath, tokensPath) = CreateTestDir();
+        try
+        {
+            await File.WriteAllTextAsync(shimPath,
+                "#!/bin/sh\nprintf '[AUTH_FAILED] Token invalid or expired\\n' >&2\nexit 1\n");
+            File.SetUnixFileMode(shimPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            // Intentionally do NOT write tokens file.
+            var refreshClient = FakeRefreshClient.Succeeds(
+                new PlaudTokens("t", "r", 9999999999L, "Bearer"));
+            var client = new PlaudCliClient(
+                NullLogger<PlaudCliClient>.Instance,
+                Options.Create(OptionsFor(shimPath)),
+                refreshClient,
+                tokensPath);
+
+            Func<Task> act = () => client.ListRecentAsync(7);
+
+            await act.Should().ThrowAsync<PlaudAuthExpiredException>();
+            refreshClient.CallCount.Should().Be(0);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ── Non-zero exit without AUTH_FAILED ────────────────────────────────
 
     [SkippableFact]
     public async Task RunCli_WhenCliExitsNonZeroWithoutAuthFailed_ThrowsInvalidOperationException()
     {
         Skip.If(OperatingSystem.IsWindows(), "Shim script requires bash");
-        if (OperatingSystem.IsWindows()) return; // satisfy CA1416 — unreachable at runtime
+        if (OperatingSystem.IsWindows()) return;
 
-        // Arrange — write a tiny shim that mimics a generic non-zero exit
-        var shimPath = Path.Combine(Path.GetTempPath(), $"plaud_shim_{Guid.NewGuid():N}.sh");
-        await File.WriteAllTextAsync(shimPath,
-            "#!/bin/sh\necho 'some other error' >&2\nexit 1\n");
-        File.SetUnixFileMode(shimPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-
+        var (dir, shimPath, tokensPath) = CreateTestDir();
         try
         {
-            var options = Options.Create(new PlaudOptions
-            {
-                CliExecutablePath = shimPath,
-                ProcessTimeoutSeconds = 10
-            });
-            var client = new PlaudCliClient(NullLogger<PlaudCliClient>.Instance, options);
+            await File.WriteAllTextAsync(shimPath,
+                "#!/bin/sh\nprintf 'some other error\\n' >&2\nexit 1\n");
+            File.SetUnixFileMode(shimPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
 
-            // Act
+            var refreshClient = FakeRefreshClient.Succeeds(
+                new PlaudTokens("t", "r", 9999999999L, "Bearer"));
+            var client = new PlaudCliClient(
+                NullLogger<PlaudCliClient>.Instance,
+                Options.Create(OptionsFor(shimPath)),
+                refreshClient,
+                tokensPath);
+
             Func<Task> act = () => client.ListRecentAsync(7);
 
-            // Assert
             await act.Should()
                 .ThrowAsync<InvalidOperationException>()
                 .WithMessage("*some other error*");
         }
         finally
         {
-            File.Delete(shimPath);
+            Directory.Delete(dir, recursive: true);
         }
     }
 }


### PR DESCRIPTION
## What the issue was

`PlaudCliClient.RunCliAsync` was throwing `PlaudAuthExpiredException` immediately on `AUTH_FAILED` from the CLI, with no attempt to refresh the expired token. This caused 607 exceptions over 7 days after the Plaud access token expired on 2026-06-13. The weekly `PlaudTokenRefreshJob` was disabled by default, leaving the token to expire silently.

## How it was fixed

- **`PlaudCliClient`**: On `PlaudAuthExpiredException`, the client now reads the current token from `~/.plaud/tokens.json`, calls `IPlaudTokenRefreshClient.RefreshAsync`, writes the new tokens back to disk (0600 on Unix), and retries the CLI call once. A `SemaphoreSlim(1,1)` serializes concurrent refresh attempts so multiple callers don't double-refresh.
- **`PlaudAdapterServiceCollectionExtensions`**: `IPlaudTokenRefreshClient` (and its `HttpClient`) is now registered unconditionally, not just when Key Vault is configured. This makes the auto-refresh available in all environments.
- **Tests**: 4 new test cases covering the retry-succeeds, refresh-throws, retry-also-fails, and tokens-file-missing paths. All 21 tests pass.

## Artifacts

Brief, spec, arch-review, design, task-plan, and impl markdown are committed in this branch under `artifacts/feat-3118/`.

Closes #3118

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzfMVBLorM1B8g6gMLWxUH)_