### PR TITLE
feat-3119: unit tests for UnspecifiedDateTimeConverter

### DIFF
--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Common/UnspecifiedDateTimeConverterTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Common/UnspecifiedDateTimeConverterTests.cs
@@ -1,0 +1,126 @@
+using Anela.Heblo.Adapters.Flexi.Common;
+using FluentAssertions;
+using Newtonsoft.Json;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Common;
+
+public sealed class UnspecifiedDateTimeConverterTests
+{
+    private static DateTime? Invoke(string json, bool nullable = false, DateParseHandling dateParseHandling = DateParseHandling.None)
+    {
+        using var reader = new JsonTextReader(new StringReader(json));
+        reader.DateParseHandling = dateParseHandling;
+        reader.Read();
+        var converter = new UnspecifiedDateTimeConverter();
+        var targetType = nullable ? typeof(DateTime?) : typeof(DateTime);
+        return (DateTime?)converter.ReadJson(reader, targetType, null, new JsonSerializer());
+    }
+
+    [Fact]
+    public void ReadJson_WithNullToken_AndNullableType_ReturnsNull()
+    {
+        // Act
+        var result = Invoke("null", nullable: true);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadJson_WithNullToken_AndNonNullableType_ThrowsJsonSerializationException()
+    {
+        // Act
+        var act = () => Invoke("null", nullable: false);
+
+        // Assert
+        act.Should().Throw<JsonSerializationException>();
+    }
+
+    [Fact]
+    public void ReadJson_WithValidIsoDateString_ReturnsUtcDateTime()
+    {
+        // Arrange
+        var expectedLocal = new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Unspecified);
+        var expectedUtc = expectedLocal - TimeZoneInfo.Local.GetUtcOffset(expectedLocal);
+
+        // Act
+        var result = Invoke("\"2024-03-15\"");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        result.Value.Should().Be(expectedUtc);
+    }
+
+    [Fact]
+    public void ReadJson_WithValidIsoDateTimeString_ReturnsUtcDateTime()
+    {
+        // Arrange
+        var expectedLocal = new DateTime(2024, 3, 15, 10, 30, 0, DateTimeKind.Unspecified);
+        var expectedUtc = expectedLocal - TimeZoneInfo.Local.GetUtcOffset(expectedLocal);
+
+        // Act
+        var result = Invoke("\"2024-03-15T10:30:00\"");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        result.Value.Should().Be(expectedUtc);
+    }
+
+    [Fact]
+    public void ReadJson_WithEmptyString_ThrowsJsonSerializationException()
+    {
+        // Act
+        var act = () => Invoke("\"\"");
+
+        // Assert
+        act.Should().Throw<JsonSerializationException>();
+    }
+
+    [Fact]
+    public void ReadJson_WithUnparseableString_ThrowsJsonSerializationException()
+    {
+        // Act
+        var act = () => Invoke("\"not-a-date\"");
+
+        // Assert
+        act.Should().Throw<JsonSerializationException>();
+    }
+
+    [Fact]
+    public void ReadJson_WithDateToken_ReturnsUtcDateTime()
+    {
+        // Arrange
+        var expectedLocal = new DateTime(2024, 6, 1, 8, 0, 0, DateTimeKind.Unspecified);
+        var expectedUtc = expectedLocal - TimeZoneInfo.Local.GetUtcOffset(expectedLocal);
+
+        // Act — DateParseHandling.DateTime causes the reader to emit a JsonToken.Date
+        var result = Invoke("\"2024-06-01T08:00:00\"", dateParseHandling: DateParseHandling.DateTime);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        result.Value.Should().Be(expectedUtc);
+    }
+
+    [Fact]
+    public void ReadJson_WithIntegerToken_ThrowsJsonSerializationException()
+    {
+        // Act
+        var act = () => Invoke("42");
+
+        // Assert
+        act.Should().Throw<JsonSerializationException>();
+    }
+
+    [Fact]
+    public void ReadJson_WithBooleanToken_ThrowsJsonSerializationException()
+    {
+        // Act
+        var act = () => Invoke("true");
+
+        // Assert
+        act.Should().Throw<JsonSerializationException>();
+    }
+}


### PR DESCRIPTION
## What the issue was

`UnspecifiedDateTimeConverter` — the Newtonsoft.Json converter that converts every FlexiBee datetime field from local timezone to UTC — had 0% line coverage. All branches of `ReadJson` were completely untested: null handling (nullable vs non-nullable), string token parsing (valid ISO, empty, unparseable), `JsonToken.Date` branch, and unexpected-token guards.

## How it was fixed / handled

Added 9 unit tests in a new `Common/` subdirectory of the existing `Anela.Heblo.Adapters.Flexi.Tests` project:

- **Null + nullable** → returns null
- **Null + non-nullable** → throws `JsonSerializationException`
- **Valid ISO date string** → returns UTC DateTime with `Kind == Utc`
- **Valid ISO datetime string** → returns UTC DateTime with `Kind == Utc`
- **Empty string** → throws `JsonSerializationException`
- **Unparseable string** → throws `JsonSerializationException`
- **`JsonToken.Date` token** (forced via `DateParseHandling.DateTime`) → returns UTC DateTime
- **Integer token** → throws `JsonSerializationException`
- **Boolean token** → throws `JsonSerializationException`

UTC offset assertions use `TimeZoneInfo.Local.GetUtcOffset()` rather than hardcoded values — timezone-agnostic across CI environments. All 9 tests pass.

## Artifacts
Brief, spec, arch-review, design, task plan, and impl markdown are committed in this branch under `artifacts/feat-3119/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eu1aDFWwA3Wx9nvc1PsBq5)_