### PR TITLE
#3120: add unit tests for FlexiStockTakingDomainService

### DIFF
--- a/artifacts/feat-3120/arch-review.r1.md
+++ b/artifacts/feat-3120/arch-review.r1.md
@@ -1,0 +1,197 @@
+# Architecture Review: Unit Tests for FlexiStockTakingDomainService
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This task adds a new test file to an existing, well-established test project. No production code changes. The feature is purely additive and follows the established Adapter-layer unit-test pattern used throughout `Anela.Heblo.Adapters.Flexi.Tests`.
+
+The SUT (`FlexiStockTakingDomainService`) is a straightforward orchestration class with five injectable dependencies and a single public method. All dependencies are interface-typed, which makes them trivially mockable with Moq. The test project already declares references to Moq, FluentAssertions, and xUnit — no new NuGet packages are required.
+
+Key integration points:
+- `IStockTakingClient` (SDK: `Rem.FlexiBeeSDK.Client.Clients.Products.StockTaking`) — `CreateHeaderAsync`, `GetHeaderAsync`, `AddMissingLotsAsync`, `SubmitAsync`
+- `IStockTakingItemsClient` (same SDK namespace) — `AddStockTakingsAsync`, `GetStockTakingsAsync`
+- `IStockTakingRepository` (domain interface) — `AddAsync`, `SaveChangesAsync`
+- `ICurrentUserService` (domain interface) — `GetCurrentUser()` returns `CurrentUser` record
+- `TimeProvider` (.NET 8 abstraction) — use `TimeProvider.System` or a `FakeTimeProvider` stub
+
+`SoftStockTaking` is a **computed property** on `ErpStockTakingRequest` — it returns `true` only when every item in `StockTakingItems` has `SoftStockTaking == true`. To drive the two branches, populate items with `SoftStockTaking = true` (all items) or `SoftStockTaking = false` (at least one item).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Adapters.Flexi.Tests (test project)
+└── Stock/
+    ├── FlexiStockClientTests.cs          (exists — neighbour)
+    └── FlexiStockTakingDomainServiceTests.cs  (NEW — one file, one class)
+
+SUT:
+FlexiStockTakingDomainService
+  ├── Mock<IStockTakingClient>
+  ├── Mock<IStockTakingItemsClient>
+  ├── Mock<IStockTakingRepository>
+  ├── Mock<ICurrentUserService>
+  └── TimeProvider.System  (real, no time assertions needed)
+```
+
+All five tests share a single constructor that wires up the mocks and the SUT. Only the mocks relevant to each scenario need `.Setup(...)` calls — all others default to `MockBehavior.Loose` and do nothing.
+
+### Key Design Decisions
+
+#### Decision 1: MockBehavior for clients
+**Options considered:**
+- `MockBehavior.Loose` (default) — unsetup calls return `default`/`null`
+- `MockBehavior.Strict` — any unexpected call throws
+
+**Chosen approach:** `MockBehavior.Loose` for all mocks.
+
+**Rationale:** The SUT calls several methods in sequence; strict mocks would require exhaustive setup for every call in every test, making the tests brittle and hard to read. The exception-path test already verifies no repository save occurs, which is the critical strict-boundary assertion. Use `Verifiable()` / `.Verify(Times.Never)` selectively where "must not be called" is part of the contract.
+
+#### Decision 2: Returning mock data from IStockTakingItemsClient
+**Options considered:**
+- Return real SDK model instances with properties set
+- Return empty lists
+
+**Chosen approach:** Return minimal but valid `StockTakingItemResult` instances with `AmountFound` and `AmountErp` set to known values so that the `AmountNew` / `AmountOld` assertions on the returned `StockTakingRecord` are deterministic.
+
+**Rationale:** `AmountNew` is `itemsAfter.Sum(s => s.AmountFound)` and `AmountOld` is `itemsBefore.Sum(s => s.AmountErp)`. Tests that only assert on mock-call counts can return empty lists, but any test asserting the record values needs non-zero returns to distinguish zero-because-empty from zero-because-wrong.
+
+#### Decision 3: Repository verification in the exception path
+**Options considered:**
+- Verify `AddAsync` not called
+- Verify `SaveChangesAsync` not called
+- Assert both
+
+**Chosen approach:** Assert both `AddAsync` and `SaveChangesAsync` are never called when an exception is thrown.
+
+**Rationale:** The catch block constructs and returns a `StockTakingRecord` without touching the repository. Asserting only one method leaves a gap. Both assertions together prove the entire persistence side-effect is suppressed, which is the stated risk in the brief.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create exactly one new file:
+
+```
+backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs
+```
+
+Namespace: `Anela.Heblo.Adapters.Flexi.Tests.Stock`
+
+No changes to `.csproj` required — test discovery is automatic.
+
+### Interfaces and Contracts
+
+**SDK types to import:**
+```csharp
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockTaking;  // IStockTakingClient, IStockTakingItemsClient
+using Rem.FlexiBeeSDK.Model.Products.StockTaking;           // StockTakingHeader, StockTakingItemResult
+```
+
+**Domain types:**
+```csharp
+using Anela.Heblo.Adapters.Flexi.Stock;                     // FlexiStockTakingDomainService
+using Anela.Heblo.Domain.Features.Catalog.Stock;            // ErpStockTakingRequest, ErpStockTakingLot, StockTakingRecord
+using Anela.Heblo.Domain.Features.Users;                    // ICurrentUserService, CurrentUser
+```
+
+**Constructor wire-up (shared across all tests):**
+```csharp
+_sut = new FlexiStockTakingDomainService(
+    _mockRepository.Object,
+    _mockStockTakingClient.Object,
+    _mockStockTakingItemsClient.Object,
+    _mockCurrentUser.Object,
+    TimeProvider.System);
+```
+
+`ICurrentUserService.GetCurrentUser()` must be stubbed to return a valid `CurrentUser` record in all tests, e.g.:
+```csharp
+_mockCurrentUser.Setup(x => x.GetCurrentUser())
+    .Returns(new CurrentUser("user-1", "Test User", "test@example.com", true));
+```
+
+### Data Flow
+
+#### Happy path — real stock taking (SoftStockTaking=false, DryRun=false, RemoveMissingLots=false)
+
+```
+test calls SubmitStockTakingAsync(order)
+  → CreateHeaderAsync(headerRequest) → returns StockTakingHeader { Id = 42 }
+  → AddStockTakingsAsync(42, 5, newItems)
+  → GetStockTakingsAsync(42) [itemsBefore]   → returns list with AmountErp
+  → SubmitAsync(42, 60)
+  → GetHeaderAsync(42)                        → returns updated header
+  → GetStockTakingsAsync(42) [itemsAfter]    → returns list with AmountFound
+  → repository.AddAsync(result)
+  → repository.SaveChangesAsync()
+  → returns StockTakingRecord { AmountNew != 0, AmountOld != 0, Error == null }
+```
+
+#### SoftStockTaking=true path
+
+```
+test calls SubmitStockTakingAsync(order where all items.SoftStockTaking=true)
+  → (no ERP calls at all)
+  → repository.AddAsync(result)
+  → repository.SaveChangesAsync()
+  → returns StockTakingRecord { AmountNew == AmountOld == sum(order.StockTakingItems.Amount) }
+```
+
+#### DryRun=true path
+
+Same as happy path except `SubmitAsync` must NOT be called. Assert with `Times.Never`.
+
+#### RemoveMissingLots=true path
+
+An extra `GetStockTakingsAsync` call occurs between `AddStockTakingsAsync` and the `itemsBefore` `GetStockTakingsAsync`, followed by `AddMissingLotsAsync`. The SDK call sequence is:
+1. `CreateHeaderAsync`
+2. `AddStockTakingsAsync`
+3. `GetStockTakingsAsync` (for `RemoveMissingLots` — returns items with `ProductId`)
+4. `AddMissingLotsAsync(headerId, productIds)`
+5. `GetStockTakingsAsync` (itemsBefore)
+6. `SubmitAsync` (if not DryRun)
+7. `GetHeaderAsync`
+8. `GetStockTakingsAsync` (itemsAfter)
+
+Moq's `SetupSequence` is not needed — setting up `GetStockTakingsAsync` to always return the same list is fine for this test.
+
+#### Exception path
+
+```
+CreateHeaderAsync throws new Exception("ERP unavailable")
+  → catch block fires
+  → returns StockTakingRecord { Error = "ERP unavailable", AmountOld = 0 (sum of items = 0 for empty list or known value) }
+  → repository.AddAsync never called
+  → repository.SaveChangesAsync never called
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `GetStockTakingsAsync` is called twice in `RemoveMissingLots=true` path (once for lots, once for itemsBefore); a single loose setup returns the same list both times, potentially masking a bug if the second call was accidentally removed | Low | Accept — the test verifies `AddMissingLotsAsync` was called with correct `productIds`, which is the contract under test; the double-call semantics are an ERP concern, not a domain concern |
+| `SoftStockTaking` is computed from items, not a direct bool field — a test that passes `SoftStockTaking=false` as if it were a direct property will fail to compile | High | Always construct `ErpStockTakingRequest` with `StockTakingItems` containing at least one `ErpStockTakingLot` with `SoftStockTaking = false` to trigger the ERP path |
+| SDK interfaces are not in the test project's namespace — forgetting the correct `using` directives causes compiler errors that look like mock-setup failures | Low | List explicit `using` directives in the test file header as documented above |
+| `AmountOld` in the catch block is set to `order.StockTakingItems.Sum(s => s.Amount)`, NOT `AmountOld = 0` — if the test creates items with non-zero `Amount`, the assertion `AmountOld == expectedAmount` must match | Medium | Use a request with a single item of known `Amount` (e.g. `10m`) in the exception test to make `AmountOld` predictable; assert `result.AmountOld == 10.0` to confirm the catch-block code path ran |
+
+## Specification Amendments
+
+**Amendment 1 — FR-4 clarification (RemoveMissingLots call sequence)**
+The spec says "AddMissingLotsAsync called after adding items". Based on the source, the sequence is: `AddStockTakingsAsync` → `GetStockTakingsAsync` (to obtain `ProductId` list) → `AddMissingLotsAsync`. The test must verify `AddMissingLotsAsync` is called with the `productIds` extracted from the intermediate `GetStockTakingsAsync` result, not just that it is called at all.
+
+**Amendment 2 — Exception test assertion precision**
+The spec says "returned record has Error field set (not null/empty)". Additionally assert `result.Code == order.ProductCode` and `result.Date != default` (both are set in the catch block) to confirm the catch-block record is fully constructed, not a default-initialized `StockTakingRecord`.
+
+**Amendment 3 — SoftStockTaking test: AmountNew == AmountOld assertion**
+The spec is correct. Additionally assert that `AmountNew == (double)order.StockTakingItems.Sum(s => s.Amount)` explicitly, not just that the two fields are equal to each other, to guard against a future bug where both are accidentally set to zero.
+
+## Prerequisites
+
+None. All dependencies exist:
+- Test project `Anela.Heblo.Adapters.Flexi.Tests.csproj` is present with Moq, FluentAssertions, xUnit
+- `InternalsVisibleTo("Anela.Heblo.Adapters.Flexi.Tests")` is declared in the production `.csproj`
+- `Rem.FlexiBeeSDK.Client` v0.1.138 is already referenced in the production project and transitively available to the test project via `ProjectReference`
+- No migrations, config changes, or infrastructure work required

--- a/artifacts/feat-3120/brief.md
+++ b/artifacts/feat-3120/brief.md
@@ -1,0 +1,29 @@
+## Module / File
+backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Stock/FlexiStockTakingDomainService.cs
+
+## Coverage
+Line coverage: 16.7% (filter threshold: 60%)
+
+## What's not tested
+`FlexiStockTakingDomainService.SubmitStockTakingAsync` has four independent decision points, none of which are covered by tests:
+
+1. **`SoftStockTaking` branch**: When `order.SoftStockTaking == true`, the method skips all ERP calls and returns a record where `AmountNew == AmountOld`. The real ERP path (creating a header, adding items, submitting) is also untested.
+2. **`RemoveMissingLots` conditional**: When true, fetches current items and adds missing lots to the ERP document — this external-call sequence is untested.
+3. **`DryRun` conditional**: When true, skips the `SubmitAsync` call, meaning the ERP document is created but not finalized. The dryrun vs. real submit distinction is never asserted.
+4. **Exception path**: When any ERP call throws, the catch block returns a `StockTakingRecord` with an `Error` property set instead of re-throwing. Callers that check only for null (not for `Error != null`) would silently miss the failure.
+
+## Why it matters
+Stock taking is a write operation against a live ERP (FlexiBee). The silent `catch` at line 106 is especially risky: an exception from `CreateHeaderAsync` or `SubmitAsync` currently produces a record indistinguishable from a soft-stock-taking result — `AmountOld` is set to the requested amount and the `Error` field contains the message. If callers don't inspect `Error`, failed stock takes are silently treated as successful soft takes.
+
+## Suggested approach
+Unit tests mocking `IStockTakingClient` / `IStockTakingItemsClient`:
+1. `SoftStockTaking=true` → no ERP calls, returned record has `AmountNew == AmountOld`
+2. `SoftStockTaking=false, DryRun=false` → `SubmitAsync` called once
+3. `SoftStockTaking=false, DryRun=true` → `SubmitAsync` NOT called
+4. `RemoveMissingLots=true` → `AddMissingLotsAsync` called after adding items
+5. ERP throws → returned record has `Error` field set (not null/empty) and no repository save attempt
+
+Effort: ~2–3h.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-15. Based on CI run #27416879267 (3a6b7f99ee715caf82fc0efa17de5a5ede7b46fb)._

--- a/artifacts/feat-3120/impl/write-tests.r1.md
+++ b/artifacts/feat-3120/impl/write-tests.r1.md
@@ -1,0 +1,35 @@
+# write-tests implementation summary
+
+## What was implemented
+
+12 xUnit unit tests for `FlexiStockTakingDomainService.SubmitStockTakingAsync`, covering all five functional requirements identified in the plan:
+
+- **FR-1 SoftStockTaking path** (3 tests): When all items have `SoftStockTaking=true`, no ERP client calls are made; `AmountNew` and `AmountOld` both equal the sum of item amounts; record is saved to the repository.
+- **FR-2 Real ERP path** (2 tests): `CreateHeaderAsync`, `AddStockTakingsAsync`, `GetStockTakingsAsync`, `SubmitAsync`, `GetHeaderAsync` are called in sequence; amounts are taken from ERP `StockTakingItemResult` (`AmountFound`→`AmountNew`, `AmountErp`→`AmountOld`).
+- **FR-3 DryRun flag** (2 tests): `SubmitAsync` is NOT called when `DryRun=true`; repository save still happens.
+- **FR-4 RemoveMissingLots flag** (2 tests): `GetStockTakingsAsync` called at least twice and `AddMissingLotsAsync` called once with the collected product IDs when `RemoveMissingLots=true`; `AddMissingLotsAsync` never called when `RemoveMissingLots=false`.
+- **FR-5 Exception path** (3 tests): When ERP throws, `Error` field is set to the exception message; `AmountNew` equals the submitted item sum; repository `AddAsync` and `SaveChangesAsync` are never called.
+
+## Files created
+
+- `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs` (404 lines)
+
+## Deviations from the plan
+
+One deviation was required after running the tests:
+
+**`SubmitStockTakingAsync_WhenErpThrows_AmountOldEqualsItemAmountSum` — renamed and assertion corrected.**
+
+The planner assumed `AmountOld` would equal the item sum in the error path. The production code's `catch` block only sets `AmountNew` to the item sum; `AmountOld` is left at the default `0.0`. The test was renamed to `_AmountNewEqualsItemAmountSum` and the assertion updated to verify `AmountNew=10.0` and `AmountOld=0.0`, which accurately reflects the production behaviour.
+
+All mock setups use `It.IsAny<CancellationToken>()` because the production code calls ERP and repository methods without explicit CT arguments (relying on `default`).
+
+## Test results
+
+**12 / 12 passed** (the new test class).
+
+Full project run: **230 passed, 72 failed, 5 skipped**. All 72 failures are pre-existing `.Integration.*` tests that require Docker or live API credentials unavailable in this environment; none are related to the new tests.
+
+## Status
+
+DONE

--- a/artifacts/feat-3120/spec.r1.md
+++ b/artifacts/feat-3120/spec.r1.md
@@ -1,0 +1,170 @@
+# Specification: Unit Tests for FlexiStockTakingDomainService
+
+## Summary
+
+`FlexiStockTakingDomainService.SubmitStockTakingAsync` is a write path against the live FlexiBee ERP with four untested decision branches and a silent catch block that swallows exceptions into an `Error` field. This specification defines the unit test suite that brings line coverage above the 60% threshold and validates all behavioral contracts, including the silent-failure risk in the exception path.
+
+## Background
+
+The weekly coverage-gap routine (CI run #27416879267, 2026-06-15) flagged `FlexiStockTakingDomainService` at 16.7% line coverage against a 60% project threshold. The service orchestrates ERP stock-taking documents via `IStockTakingClient` and `IStockTakingItemsClient`. Because it touches a live ERP (no sandbox), correctness of the branching logic must be verified through unit tests with mocked clients rather than integration tests. The most critical risk is the `catch` block (line 106): any ERP exception returns a `StockTakingRecord` whose `AmountOld` equals the submitted amount — structurally identical to a successful soft-stock-taking result — while the failure is recorded only in the nullable `Error` property. Callers that do not inspect `Error` silently treat failed ERP writes as successes.
+
+## Functional Requirements
+
+### FR-1: SoftStockTaking branch — no ERP calls, AmountNew equals AmountOld
+
+When every lot in `order.StockTakingItems` has `SoftStockTaking == true` (which makes `order.SoftStockTaking` return `true`), the method must:
+- Not call `IStockTakingClient.CreateHeaderAsync`
+- Not call `IStockTakingItemsClient.AddStockTakingsAsync`
+- Not call `IStockTakingClient.SubmitAsync`
+- Not call `IStockTakingItemsClient.GetStockTakingsAsync`
+- Return a `StockTakingRecord` where `AmountNew == AmountOld` (both equal the sum of requested amounts)
+- Save the record to the repository (`AddAsync` + `SaveChangesAsync` called once each)
+- Set `Type = StockTakingType.Erp`, `User`, and `Date` on the returned record
+
+**Acceptance criteria:**
+- Test: `SoftStockTaking_NoErpCalls_AmountNewEqualsAmountOld`
+- Given a request with all lots having `SoftStockTaking = true`, when `SubmitStockTakingAsync` is called, then `IStockTakingClient` has zero invocations, `IStockTakingItemsClient` has zero invocations, and the returned record satisfies `AmountNew == AmountOld == (double)sum(lot.Amount)`.
+- `_stockTakingRepository.AddAsync` is called exactly once with the returned record.
+- `_stockTakingRepository.SaveChangesAsync` is called exactly once.
+
+### FR-2: Real ERP path (SoftStockTaking=false, DryRun=false) — full submit
+
+When `SoftStockTaking` is false and `DryRun` is false, the method must:
+- Call `CreateHeaderAsync` exactly once with `WarehouseId = 5`, the current UTC date, the current user name, `Owner = "Heblo"`, and `Type = "Material-{ProductCode}"`
+- Call `AddStockTakingsAsync` exactly once with the header ID and the mapped items
+- Call `SubmitAsync` exactly once with the header ID and document type 60
+- Return a record with `AmountNew` sourced from `itemsAfter.Sum(AmountFound)` and `AmountOld` from `itemsBefore.Sum(AmountErp)`
+- Save the record to the repository
+
+**Acceptance criteria:**
+- Test: `RealErpPath_DryRunFalse_SubmitAsyncCalledOnce`
+- `_stockTakingClient.SubmitAsync` is verified called once with the correct header ID and `60`.
+- Returned record has `AmountNew` and `AmountOld` values sourced from the mock responses (not from the request amounts).
+- Repository `AddAsync` and `SaveChangesAsync` each called once.
+
+### FR-3: DryRun=true — ERP document created but not submitted
+
+When `SoftStockTaking` is false and `DryRun` is true, the method must:
+- Call `CreateHeaderAsync`, `AddStockTakingsAsync`, and the final `GetHeaderAsync` + `GetStockTakingsAsync` pair
+- NOT call `SubmitAsync`
+- Still save the record to the repository
+
+**Acceptance criteria:**
+- Test: `RealErpPath_DryRunTrue_SubmitAsyncNotCalled`
+- `_stockTakingClient.SubmitAsync` is verified with `Times.Never`.
+- All other ERP calls (`CreateHeaderAsync`, `AddStockTakingsAsync`, `GetHeaderAsync`, `GetStockTakingsAsync`) are verified called at least once.
+- Repository `SaveChangesAsync` called once.
+
+### FR-4: RemoveMissingLots=true — missing lots are fetched and added
+
+When `SoftStockTaking` is false and `RemoveMissingLots` is true, after adding items the method must:
+- Call `GetStockTakingsAsync` to fetch current items for the header
+- Call `AddMissingLotsAsync` with the header ID and the list of product IDs from current items
+
+**Acceptance criteria:**
+- Test: `RemoveMissingLots_True_AddMissingLotsAsyncCalled`
+- `_stockTakingItemsClient.GetStockTakingsAsync` is verified called at least once before `_stockTakingClient.AddMissingLotsAsync`.
+- `_stockTakingClient.AddMissingLotsAsync` is verified called exactly once with the header ID from `CreateHeaderAsync` response.
+- Test: `RemoveMissingLots_False_AddMissingLotsAsyncNotCalled`
+- `_stockTakingClient.AddMissingLotsAsync` is verified with `Times.Never`.
+
+### FR-5: Exception path — Error field set, repository not called
+
+When any ERP client call throws an exception, the method must:
+- NOT re-throw the exception
+- Return a `StockTakingRecord` with `Error` set to the exception message (non-null, non-empty)
+- NOT call `_stockTakingRepository.AddAsync`
+- NOT call `_stockTakingRepository.SaveChangesAsync`
+- Set `Code = order.ProductCode` and `Date` on the error record
+
+**Acceptance criteria:**
+- Test: `ErpThrows_ReturnedRecordHasErrorSet_RepositoryNotCalled`
+- `_stockTakingClient.CreateHeaderAsync` throws `Exception("ERP connection failed")`.
+- Returned record: `Error == "ERP connection failed"`, `Code == order.ProductCode`, `Error` is not null or whitespace.
+- `_stockTakingRepository.AddAsync` verified `Times.Never`.
+- `_stockTakingRepository.SaveChangesAsync` verified `Times.Never`.
+- Test variant: `SubmitAsyncThrows_ReturnedRecordHasErrorSet` — `SubmitAsync` throws, same assertions.
+
+### FR-6: Test project placement and naming
+
+All tests live in the existing `Anela.Heblo.Adapters.Flexi.Tests` project (path: `backend/test/Anela.Heblo.Adapters.Flexi.Tests/`) in a new file `Stock/FlexiStockTakingDomainServiceTests.cs`, consistent with the existing `Stock/FlexiStockClientTests.cs` neighbor.
+
+**Acceptance criteria:**
+- New file is at `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs`.
+- Namespace is `Anela.Heblo.Adapters.Flexi.Tests.Stock`.
+- Test class is `FlexiStockTakingDomainServiceTests`.
+- All test methods follow `MethodName_Condition_ExpectedBehavior` naming already used in the project.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+Tests must complete in under 2 seconds total. All dependencies are mocked; no network calls or database I/O.
+
+### NFR-2: Security
+
+No real FlexiBee credentials or ERP endpoints are used. `IStockTakingClient` and `IStockTakingItemsClient` are mocked via Moq.
+
+### NFR-3: Coverage target
+
+After the test suite is added, `dotnet test` with coverlet must report line coverage for `FlexiStockTakingDomainService` at or above 60% (project threshold). The five test scenarios described above cover all executable lines in `SubmitStockTakingAsync`, which constitutes the entirety of the class; coverage should reach approximately 90%+.
+
+### NFR-4: Build compliance
+
+Running `dotnet build` and `dotnet format` must succeed with no warnings introduced by the new test file.
+
+## Data Model
+
+No new persistent entities. The tests exercise the existing domain types:
+
+| Type | Role |
+|---|---|
+| `ErpStockTakingRequest` | Input to `SubmitStockTakingAsync`; has `ProductCode`, `StockTakingItems`, `RemoveMissingLots`, `DryRun`; `SoftStockTaking` is computed from all-lots predicate |
+| `ErpStockTakingLot` | One lot line; has `LotCode`, `Expiration`, `Amount`, `SoftStockTaking` |
+| `StockTakingRecord` | Return value and persisted entity; has `Code`, `AmountNew`, `AmountOld`, `Date`, `User`, `Type`, `Error` |
+| `StockTakingType` | Enum; tests assert `Type == StockTakingType.Erp` on success paths |
+
+## API / Interface Design
+
+No new API surface. The tests interact with the existing interfaces under test:
+
+**`IStockTakingClient` (mocked)**
+- `CreateHeaderAsync(StockTakingHeaderRequest) → StockTakingHeader`
+- `GetHeaderAsync(int headerId) → StockTakingHeader`
+- `AddMissingLotsAsync(int headerId, List<int> productIds) → Task`
+- `SubmitAsync(int headerId, int documentTypeId) → Task`
+
+**`IStockTakingItemsClient` (mocked)**
+- `AddStockTakingsAsync(int headerId, int warehouseId, List<AddStockTakingItemRequest>) → Task`
+- `GetStockTakingsAsync(int headerId) → List<StockTakingItem>`
+
+**`IStockTakingRepository` (mocked)**
+- `AddAsync(StockTakingRecord) → Task`
+- `SaveChangesAsync() → Task`
+
+**`ICurrentUserService` (mocked)**
+- `GetCurrentUser() → User` returning a stub with a `Name` property
+
+**`TimeProvider` (use `TimeProvider.System` or a fixed fake)**
+
+## Dependencies
+
+- `Anela.Heblo.Adapters.Flexi.Tests.csproj` — already references the production `Anela.Heblo.Adapters.Flexi` project and has Moq, FluentAssertions, xUnit
+- `Rem.FlexiBeeSDK.Client` — model types (`StockTakingHeaderRequest`, `StockTakingHeader`, `AddStockTakingItemRequest`, `StockTakingItem`) needed for mock setup; already a transitive dependency
+- `ICurrentUserService` from `Anela.Heblo.Domain.Features.Users` — mock returns a stub user
+- No new NuGet packages required
+
+## Out of Scope
+
+- Integration tests against a live or containerised FlexiBee instance
+- Testing the `IStockTakingRepository` persistence implementation
+- Testing the mapping profile (`FlexiStockMappingProfile`)
+- Testing `FlexiStockClient` (already tested in `FlexiStockClientTests.cs`)
+- Refactoring the silent catch block — this spec covers test coverage only; any decision to change the exception-handling contract is a separate work item
+- The `// TODO Convert to decimal` comments in the source file — out of scope for this task
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3120/state.json
+++ b/artifacts/feat-3120/state.json
@@ -1,0 +1,36 @@
+{
+  "feature_id": "feat-3120",
+  "issue_number": 3120,
+  "created_at": "2026-06-18T09:58:07.014436Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-18T10:00:10.182867Z"
+    },
+    "architecting": {
+      "status": "completed",
+      "updated_at": "2026-06-18T10:04:59.702391Z"
+    },
+    "designing": {
+      "status": "completed",
+      "updated_at": "2026-06-18T10:05:03.849149Z"
+    },
+    "planning": {
+      "status": "completed",
+      "updated_at": "2026-06-18T10:09:37.352151Z"
+    },
+    "developing": {
+      "status": "completed",
+      "updated_at": "2026-06-18T10:16:01.792436Z"
+    }
+  },
+  "tasks": [
+    {
+      "name": "write-tests",
+      "status": "completed",
+      "revision": 1,
+      "updated_at": "2026-06-18T10:16:01.551373Z"
+    }
+  ]
+}

--- a/artifacts/feat-3120/task-context/write-tests.md
+++ b/artifacts/feat-3120/task-context/write-tests.md
@@ -1,0 +1,533 @@
+### task: write-tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs`
+
+- [ ] **Step 1: Create the test file**
+
+Create `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs` with the following content:
+
+```csharp
+using Anela.Heblo.Adapters.Flexi.Stock;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockTaking;
+using Rem.FlexiBeeSDK.Model.Products.StockTaking;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Stock;
+
+public class FlexiStockTakingDomainServiceTests
+{
+    private readonly Mock<IStockTakingRepository> _mockRepository;
+    private readonly Mock<IStockTakingClient> _mockStockTakingClient;
+    private readonly Mock<IStockTakingItemsClient> _mockStockTakingItemsClient;
+    private readonly Mock<ICurrentUserService> _mockCurrentUser;
+    private readonly FlexiStockTakingDomainService _sut;
+
+    public FlexiStockTakingDomainServiceTests()
+    {
+        _mockRepository = new Mock<IStockTakingRepository>(MockBehavior.Loose);
+        _mockStockTakingClient = new Mock<IStockTakingClient>(MockBehavior.Loose);
+        _mockStockTakingItemsClient = new Mock<IStockTakingItemsClient>(MockBehavior.Loose);
+        _mockCurrentUser = new Mock<ICurrentUserService>(MockBehavior.Loose);
+
+        _mockCurrentUser
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", "test@example.com", true));
+
+        _mockRepository
+            .Setup(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockTakingRecord r, CancellationToken _) => r);
+
+        _mockRepository
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _sut = new FlexiStockTakingDomainService(
+            _mockRepository.Object,
+            _mockStockTakingClient.Object,
+            _mockStockTakingItemsClient.Object,
+            _mockCurrentUser.Object,
+            TimeProvider.System);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-1: SoftStockTaking — no ERP calls, AmountNew == AmountOld == sum(items)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_NoErpCallsMade()
+    {
+        // Arrange — SoftStockTaking is a computed property: true when ALL items have SoftStockTaking=true
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — no ERP client should be called at all
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockStockTakingItemsClient.Verify(
+            x => x.AddStockTakingsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_AmountNewEqualsAmountOldEqualsSumOfItems()
+    {
+        // Arrange
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        result.AmountNew.Should().Be(8.0);
+        result.AmountOld.Should().Be(8.0);
+        result.Code.Should().Be("PROD-001");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_RecordSavedToRepository()
+    {
+        // Arrange
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-002",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-2: Real ERP path (SoftStockTaking=false, DryRun=false) — SubmitAsync called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_SubmitAsyncCalledOnce()
+    {
+        // Arrange
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_AmountsComputedFromErpItems()
+    {
+        // Arrange
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — AmountNew from itemsAfter.AmountFound, AmountOld from itemsBefore.AmountErp
+        result.AmountNew.Should().Be(7.5);
+        result.AmountOld.Should().Be(5.0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-3: DryRun=true — document created but SubmitAsync NOT called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_SubmitAsyncNotCalled()
+    {
+        // Arrange
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — document created but never submitted
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_RecordStillSavedToRepository()
+    {
+        // Arrange
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — repo still gets the record
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-4: RemoveMissingLots=true — GetStockTakingsAsync + AddMissingLotsAsync called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsTrue_GetStockTakingsAndAddMissingLotsCalled()
+    {
+        // Arrange — set up the extra GetStockTakingsAsync call for missing lots lookup
+        var headerId = 77;
+        var productIds = new List<int> { 101, 102 };
+
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // First call after AddStockTakingsAsync: returns items with ProductIds for missing lots
+        // Subsequent calls: return itemsBefore and itemsAfter
+        var callCount = 0;
+        _mockStockTakingItemsClient
+            .Setup(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // First call: for missing lots — returns items with ProductId
+                    return new List<StockTakingItemResult>
+                    {
+                        new() { ProductId = 101, AmountErp = 1.0, AmountFound = 1.0 },
+                        new() { ProductId = 102, AmountErp = 2.0, AmountFound = 2.0 },
+                    };
+                }
+                // Second call: itemsBefore
+                return new List<StockTakingItemResult>
+                {
+                    new() { ProductId = 101, AmountErp = 3.0, AmountFound = 4.0 },
+                };
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        // itemsAfter
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()));
+
+        // Re-setup cleanly with a sequence for all three GetStockTakingsAsync calls
+        _mockStockTakingItemsClient.Reset();
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 1: for GetStockTakingsAsync after AddStockTakingsAsync (missing lots lookup)
+                new() { ProductId = 101, AmountErp = 1.0, AmountFound = 1.0 },
+                new() { ProductId = 102, AmountErp = 2.0, AmountFound = 2.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 2: itemsBefore
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 3: itemsAfter
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            });
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-005",
+            DryRun = false,
+            RemoveMissingLots = true,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingItemsClient.Verify(
+            x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(headerId, It.Is<IEnumerable<int>>(ids => ids.Contains(101) && ids.Contains(102)), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsFalse_AddMissingLotsAsyncNotCalled()
+    {
+        // Arrange
+        var headerId = 55;
+        SetupFullErpPath(headerId, amountFound: 1.0, amountErp: 1.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-006",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 1m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(It.IsAny<int>(), It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-5: Exception path — Error field set, repo not called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_ReturnsRecordWithErrorSet()
+    {
+        // Arrange — single item with Amount=10 so AmountOld is predictable from catch block
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP connection failed"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        result.Error.Should().Be("ERP connection failed");
+        result.Code.Should().Be("PROD-ERR");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_AmountOldEqualsItemAmountSum()
+    {
+        // Arrange — catch block sets AmountOld = order.StockTakingItems.Sum(s => s.Amount)
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR2",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — AmountOld in catch = (double)Sum(Amount) = 10.0
+        result.AmountOld.Should().Be(10.0);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_RepositoryNotCalled()
+    {
+        // Arrange
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR3",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — silent catch must NOT persist anything
+        _mockRepository.Verify(
+            x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockRepository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Sets up the standard ERP path (no RemoveMissingLots) with controlled amounts.
+    /// GetStockTakingsAsync is called twice: once for itemsBefore, once for itemsAfter.
+    /// </summary>
+    private void SetupFullErpPath(int headerId, double amountFound, double amountErp)
+    {
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they compile and pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Adapters.Flexi.Tests/ \
+  --filter "FullyQualifiedName~FlexiStockTakingDomainServiceTests" \
+  -v normal 2>&1
+```
+
+Expected: all tests pass (green). If any fail, review the failure message — the most likely issues are:
+- `SetupSequence` not returning enough values: add another `.ReturnsAsync(...)` call in `SetupFullErpPath` for `GetStockTakingsAsync`.
+- Missing `CancellationToken` parameter on a mock setup: all SDK interface methods take an optional `CancellationToken` — ensure `It.IsAny<CancellationToken>()` is used in every `Setup`.
+
+- [ ] **Step 3: Run the full test project to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Adapters.Flexi.Tests/ -v minimal 2>&1
+```
+
+Expected: all previously passing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs
+git commit -m "test: add unit tests for FlexiStockTakingDomainService.SubmitStockTakingAsync
+
+Covers all five behavioral contracts (FR-1 through FR-5):
+- SoftStockTaking path (no ERP calls, AmountNew == AmountOld)
+- Real ERP path (SubmitAsync called, amounts from ERP items)
+- DryRun=true (SubmitAsync skipped, repo still saved)
+- RemoveMissingLots=true (GetStockTakings + AddMissingLots called)
+- Exception path (Error field set, repo not called)"
+```

--- a/artifacts/feat-3120/task-plan.r1.md
+++ b/artifacts/feat-3120/task-plan.r1.md
@@ -1,0 +1,553 @@
+# FlexiStockTakingDomainService Unit Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Write a complete unit test suite for `FlexiStockTakingDomainService.SubmitStockTakingAsync` covering all four decision branches and the exception path to bring line coverage above 60%.
+
+**Architecture:** Single test file added to the existing `Anela.Heblo.Adapters.Flexi.Tests` project. All external collaborators (`IStockTakingRepository`, `IStockTakingClient`, `IStockTakingItemsClient`, `ICurrentUserService`) are mocked with `MockBehavior.Loose`. No new packages or project changes.
+
+**Tech Stack:** xUnit, Moq 4.20, FluentAssertions 6.12, .NET 8
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs` |
+
+---
+
+### task: write-tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs`
+
+- [ ] **Step 1: Create the test file**
+
+Create `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs` with the following content:
+
+```csharp
+using Anela.Heblo.Adapters.Flexi.Stock;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockTaking;
+using Rem.FlexiBeeSDK.Model.Products.StockTaking;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Stock;
+
+public class FlexiStockTakingDomainServiceTests
+{
+    private readonly Mock<IStockTakingRepository> _mockRepository;
+    private readonly Mock<IStockTakingClient> _mockStockTakingClient;
+    private readonly Mock<IStockTakingItemsClient> _mockStockTakingItemsClient;
+    private readonly Mock<ICurrentUserService> _mockCurrentUser;
+    private readonly FlexiStockTakingDomainService _sut;
+
+    public FlexiStockTakingDomainServiceTests()
+    {
+        _mockRepository = new Mock<IStockTakingRepository>(MockBehavior.Loose);
+        _mockStockTakingClient = new Mock<IStockTakingClient>(MockBehavior.Loose);
+        _mockStockTakingItemsClient = new Mock<IStockTakingItemsClient>(MockBehavior.Loose);
+        _mockCurrentUser = new Mock<ICurrentUserService>(MockBehavior.Loose);
+
+        _mockCurrentUser
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", "test@example.com", true));
+
+        _mockRepository
+            .Setup(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockTakingRecord r, CancellationToken _) => r);
+
+        _mockRepository
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _sut = new FlexiStockTakingDomainService(
+            _mockRepository.Object,
+            _mockStockTakingClient.Object,
+            _mockStockTakingItemsClient.Object,
+            _mockCurrentUser.Object,
+            TimeProvider.System);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-1: SoftStockTaking — no ERP calls, AmountNew == AmountOld == sum(items)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_NoErpCallsMade()
+    {
+        // Arrange — SoftStockTaking is a computed property: true when ALL items have SoftStockTaking=true
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — no ERP client should be called at all
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockStockTakingItemsClient.Verify(
+            x => x.AddStockTakingsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_AmountNewEqualsAmountOldEqualsSumOfItems()
+    {
+        // Arrange
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        result.AmountNew.Should().Be(8.0);
+        result.AmountOld.Should().Be(8.0);
+        result.Code.Should().Be("PROD-001");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_RecordSavedToRepository()
+    {
+        // Arrange
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-002",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-2: Real ERP path (SoftStockTaking=false, DryRun=false) — SubmitAsync called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_SubmitAsyncCalledOnce()
+    {
+        // Arrange
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_AmountsComputedFromErpItems()
+    {
+        // Arrange
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — AmountNew from itemsAfter.AmountFound, AmountOld from itemsBefore.AmountErp
+        result.AmountNew.Should().Be(7.5);
+        result.AmountOld.Should().Be(5.0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-3: DryRun=true — document created but SubmitAsync NOT called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_SubmitAsyncNotCalled()
+    {
+        // Arrange
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — document created but never submitted
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_RecordStillSavedToRepository()
+    {
+        // Arrange
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — repo still gets the record
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-4: RemoveMissingLots=true — GetStockTakingsAsync + AddMissingLotsAsync called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsTrue_GetStockTakingsAndAddMissingLotsCalled()
+    {
+        // Arrange — set up the extra GetStockTakingsAsync call for missing lots lookup
+        var headerId = 77;
+        var productIds = new List<int> { 101, 102 };
+
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // First call after AddStockTakingsAsync: returns items with ProductIds for missing lots
+        // Subsequent calls: return itemsBefore and itemsAfter
+        var callCount = 0;
+        _mockStockTakingItemsClient
+            .Setup(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // First call: for missing lots — returns items with ProductId
+                    return new List<StockTakingItemResult>
+                    {
+                        new() { ProductId = 101, AmountErp = 1.0, AmountFound = 1.0 },
+                        new() { ProductId = 102, AmountErp = 2.0, AmountFound = 2.0 },
+                    };
+                }
+                // Second call: itemsBefore
+                return new List<StockTakingItemResult>
+                {
+                    new() { ProductId = 101, AmountErp = 3.0, AmountFound = 4.0 },
+                };
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        // itemsAfter
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()));
+
+        // Re-setup cleanly with a sequence for all three GetStockTakingsAsync calls
+        _mockStockTakingItemsClient.Reset();
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 1: for GetStockTakingsAsync after AddStockTakingsAsync (missing lots lookup)
+                new() { ProductId = 101, AmountErp = 1.0, AmountFound = 1.0 },
+                new() { ProductId = 102, AmountErp = 2.0, AmountFound = 2.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 2: itemsBefore
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 3: itemsAfter
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            });
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-005",
+            DryRun = false,
+            RemoveMissingLots = true,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingItemsClient.Verify(
+            x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(headerId, It.Is<IEnumerable<int>>(ids => ids.Contains(101) && ids.Contains(102)), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsFalse_AddMissingLotsAsyncNotCalled()
+    {
+        // Arrange
+        var headerId = 55;
+        SetupFullErpPath(headerId, amountFound: 1.0, amountErp: 1.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-006",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 1m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(It.IsAny<int>(), It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-5: Exception path — Error field set, repo not called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_ReturnsRecordWithErrorSet()
+    {
+        // Arrange — single item with Amount=10 so AmountOld is predictable from catch block
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP connection failed"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        result.Error.Should().Be("ERP connection failed");
+        result.Code.Should().Be("PROD-ERR");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_AmountOldEqualsItemAmountSum()
+    {
+        // Arrange — catch block sets AmountOld = order.StockTakingItems.Sum(s => s.Amount)
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR2",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — AmountOld in catch = (double)Sum(Amount) = 10.0
+        result.AmountOld.Should().Be(10.0);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_RepositoryNotCalled()
+    {
+        // Arrange
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR3",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — silent catch must NOT persist anything
+        _mockRepository.Verify(
+            x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockRepository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Sets up the standard ERP path (no RemoveMissingLots) with controlled amounts.
+    /// GetStockTakingsAsync is called twice: once for itemsBefore, once for itemsAfter.
+    /// </summary>
+    private void SetupFullErpPath(int headerId, double amountFound, double amountErp)
+    {
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they compile and pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Adapters.Flexi.Tests/ \
+  --filter "FullyQualifiedName~FlexiStockTakingDomainServiceTests" \
+  -v normal 2>&1
+```
+
+Expected: all tests pass (green). If any fail, review the failure message — the most likely issues are:
+- `SetupSequence` not returning enough values: add another `.ReturnsAsync(...)` call in `SetupFullErpPath` for `GetStockTakingsAsync`.
+- Missing `CancellationToken` parameter on a mock setup: all SDK interface methods take an optional `CancellationToken` — ensure `It.IsAny<CancellationToken>()` is used in every `Setup`.
+
+- [ ] **Step 3: Run the full test project to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Adapters.Flexi.Tests/ -v minimal 2>&1
+```
+
+Expected: all previously passing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs
+git commit -m "test: add unit tests for FlexiStockTakingDomainService.SubmitStockTakingAsync
+
+Covers all five behavioral contracts (FR-1 through FR-5):
+- SoftStockTaking path (no ERP calls, AmountNew == AmountOld)
+- Real ERP path (SubmitAsync called, amounts from ERP items)
+- DryRun=true (SubmitAsync skipped, repo still saved)
+- RemoveMissingLots=true (GetStockTakings + AddMissingLots called)
+- Exception path (Error field set, repo not called)"
+```

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs
@@ -1,0 +1,404 @@
+using Anela.Heblo.Adapters.Flexi.Stock;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockTaking;
+using Rem.FlexiBeeSDK.Model.Products.StockTaking;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Stock;
+
+public class FlexiStockTakingDomainServiceTests
+{
+    private readonly Mock<IStockTakingRepository> _mockRepository;
+    private readonly Mock<IStockTakingClient> _mockStockTakingClient;
+    private readonly Mock<IStockTakingItemsClient> _mockStockTakingItemsClient;
+    private readonly Mock<ICurrentUserService> _mockCurrentUser;
+    private readonly FlexiStockTakingDomainService _sut;
+
+    public FlexiStockTakingDomainServiceTests()
+    {
+        _mockRepository = new Mock<IStockTakingRepository>(MockBehavior.Loose);
+        _mockStockTakingClient = new Mock<IStockTakingClient>(MockBehavior.Loose);
+        _mockStockTakingItemsClient = new Mock<IStockTakingItemsClient>(MockBehavior.Loose);
+        _mockCurrentUser = new Mock<ICurrentUserService>(MockBehavior.Loose);
+
+        _mockCurrentUser
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", "test@example.com", true));
+
+        _mockRepository
+            .Setup(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockTakingRecord r, CancellationToken _) => r);
+
+        _mockRepository
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _sut = new FlexiStockTakingDomainService(
+            _mockRepository.Object,
+            _mockStockTakingClient.Object,
+            _mockStockTakingItemsClient.Object,
+            _mockCurrentUser.Object,
+            TimeProvider.System);
+    }
+
+    // FR-1: SoftStockTaking — no ERP calls, AmountNew == AmountOld == sum(items)
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_NoErpCallsMade()
+    {
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockStockTakingItemsClient.Verify(
+            x => x.AddStockTakingsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_AmountNewEqualsAmountOldEqualsSumOfItems()
+    {
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        result.AmountNew.Should().Be(8.0);
+        result.AmountOld.Should().Be(8.0);
+        result.Code.Should().Be("PROD-001");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_RecordSavedToRepository()
+    {
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-002",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = true },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // FR-2: Real ERP path — SubmitAsync called, amounts from ERP items
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_SubmitAsyncCalledOnce()
+    {
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_AmountsComputedFromErpItems()
+    {
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        result.AmountNew.Should().Be(7.5);
+        result.AmountOld.Should().Be(5.0);
+    }
+
+    // FR-3: DryRun=true — SubmitAsync NOT called, repo still saved
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_SubmitAsyncNotCalled()
+    {
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_RecordStillSavedToRepository()
+    {
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // FR-4: RemoveMissingLots=true/false
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsTrue_GetStockTakingsAndAddMissingLotsCalled()
+    {
+        var headerId = 77;
+
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { ProductId = 101, AmountErp = 1.0, AmountFound = 1.0 },
+                new() { ProductId = 102, AmountErp = 2.0, AmountFound = 2.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-005",
+            DryRun = false,
+            RemoveMissingLots = true,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockStockTakingItemsClient.Verify(
+            x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(headerId, It.Is<IEnumerable<int>>(ids => ids.Contains(101) && ids.Contains(102)), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsFalse_AddMissingLotsAsyncNotCalled()
+    {
+        var headerId = 55;
+        SetupFullErpPath(headerId, amountFound: 1.0, amountErp: 1.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-006",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 1m, SoftStockTaking = false },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(It.IsAny<int>(), It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // FR-5: Exception path — Error field set, repo not called
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_ReturnsRecordWithErrorSet()
+    {
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP connection failed"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        result.Error.Should().Be("ERP connection failed");
+        result.Code.Should().Be("PROD-ERR");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_AmountNewEqualsItemAmountSum()
+    {
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR2",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // In the error path the production code sets AmountNew to the submitted sum; AmountOld stays at default 0
+        result.AmountNew.Should().Be(10.0);
+        result.AmountOld.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_RepositoryNotCalled()
+    {
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR3",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        await _sut.SubmitStockTakingAsync(order);
+
+        _mockRepository.Verify(
+            x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockRepository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // Helper
+
+    private void SetupFullErpPath(int headerId, double amountFound, double amountErp)
+    {
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+    }
+}

--- a/docs/superpowers/plans/2026-06-18-flexi-stock-taking-domain-service-tests.md
+++ b/docs/superpowers/plans/2026-06-18-flexi-stock-taking-domain-service-tests.md
@@ -1,0 +1,553 @@
+# FlexiStockTakingDomainService Unit Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Write a complete unit test suite for `FlexiStockTakingDomainService.SubmitStockTakingAsync` covering all four decision branches and the exception path to bring line coverage above 60%.
+
+**Architecture:** Single test file added to the existing `Anela.Heblo.Adapters.Flexi.Tests` project. All external collaborators (`IStockTakingRepository`, `IStockTakingClient`, `IStockTakingItemsClient`, `ICurrentUserService`) are mocked with `MockBehavior.Loose`. No new packages or project changes.
+
+**Tech Stack:** xUnit, Moq 4.20, FluentAssertions 6.12, .NET 8
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs` |
+
+---
+
+### task: write-tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs`
+
+- [ ] **Step 1: Create the test file**
+
+Create `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs` with the following content:
+
+```csharp
+using Anela.Heblo.Adapters.Flexi.Stock;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockTaking;
+using Rem.FlexiBeeSDK.Model.Products.StockTaking;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Stock;
+
+public class FlexiStockTakingDomainServiceTests
+{
+    private readonly Mock<IStockTakingRepository> _mockRepository;
+    private readonly Mock<IStockTakingClient> _mockStockTakingClient;
+    private readonly Mock<IStockTakingItemsClient> _mockStockTakingItemsClient;
+    private readonly Mock<ICurrentUserService> _mockCurrentUser;
+    private readonly FlexiStockTakingDomainService _sut;
+
+    public FlexiStockTakingDomainServiceTests()
+    {
+        _mockRepository = new Mock<IStockTakingRepository>(MockBehavior.Loose);
+        _mockStockTakingClient = new Mock<IStockTakingClient>(MockBehavior.Loose);
+        _mockStockTakingItemsClient = new Mock<IStockTakingItemsClient>(MockBehavior.Loose);
+        _mockCurrentUser = new Mock<ICurrentUserService>(MockBehavior.Loose);
+
+        _mockCurrentUser
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", "test@example.com", true));
+
+        _mockRepository
+            .Setup(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockTakingRecord r, CancellationToken _) => r);
+
+        _mockRepository
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _sut = new FlexiStockTakingDomainService(
+            _mockRepository.Object,
+            _mockStockTakingClient.Object,
+            _mockStockTakingItemsClient.Object,
+            _mockCurrentUser.Object,
+            TimeProvider.System);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-1: SoftStockTaking — no ERP calls, AmountNew == AmountOld == sum(items)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_NoErpCallsMade()
+    {
+        // Arrange — SoftStockTaking is a computed property: true when ALL items have SoftStockTaking=true
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — no ERP client should be called at all
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockStockTakingItemsClient.Verify(
+            x => x.AddStockTakingsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_AmountNewEqualsAmountOldEqualsSumOfItems()
+    {
+        // Arrange
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-001",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 5m, SoftStockTaking = true },
+                new() { Amount = 3m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        result.AmountNew.Should().Be(8.0);
+        result.AmountOld.Should().Be(8.0);
+        result.Code.Should().Be("PROD-001");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenAllItemsAreSoftStockTaking_RecordSavedToRepository()
+    {
+        // Arrange
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-002",
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = true },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-2: Real ERP path (SoftStockTaking=false, DryRun=false) — SubmitAsync called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_SubmitAsyncCalledOnce()
+    {
+        // Arrange
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRealErpAndNotDryRun_AmountsComputedFromErpItems()
+    {
+        // Arrange
+        var headerId = 42;
+        SetupFullErpPath(headerId, amountFound: 7.5, amountErp: 5.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-003",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 4m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — AmountNew from itemsAfter.AmountFound, AmountOld from itemsBefore.AmountErp
+        result.AmountNew.Should().Be(7.5);
+        result.AmountOld.Should().Be(5.0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-3: DryRun=true — document created but SubmitAsync NOT called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_SubmitAsyncNotCalled()
+    {
+        // Arrange
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — document created but never submitted
+        _mockStockTakingClient.Verify(
+            x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockStockTakingClient.Verify(
+            x => x.SubmitAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenDryRun_RecordStillSavedToRepository()
+    {
+        // Arrange
+        var headerId = 99;
+        SetupFullErpPath(headerId, amountFound: 3.0, amountErp: 2.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-004",
+            DryRun = true,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — repo still gets the record
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-4: RemoveMissingLots=true — GetStockTakingsAsync + AddMissingLotsAsync called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsTrue_GetStockTakingsAndAddMissingLotsCalled()
+    {
+        // Arrange — set up the extra GetStockTakingsAsync call for missing lots lookup
+        var headerId = 77;
+        var productIds = new List<int> { 101, 102 };
+
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // First call after AddStockTakingsAsync: returns items with ProductIds for missing lots
+        // Subsequent calls: return itemsBefore and itemsAfter
+        var callCount = 0;
+        _mockStockTakingItemsClient
+            .Setup(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // First call: for missing lots — returns items with ProductId
+                    return new List<StockTakingItemResult>
+                    {
+                        new() { ProductId = 101, AmountErp = 1.0, AmountFound = 1.0 },
+                        new() { ProductId = 102, AmountErp = 2.0, AmountFound = 2.0 },
+                    };
+                }
+                // Second call: itemsBefore
+                return new List<StockTakingItemResult>
+                {
+                    new() { ProductId = 101, AmountErp = 3.0, AmountFound = 4.0 },
+                };
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        // itemsAfter
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()));
+
+        // Re-setup cleanly with a sequence for all three GetStockTakingsAsync calls
+        _mockStockTakingItemsClient.Reset();
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 1: for GetStockTakingsAsync after AddStockTakingsAsync (missing lots lookup)
+                new() { ProductId = 101, AmountErp = 1.0, AmountFound = 1.0 },
+                new() { ProductId = 102, AmountErp = 2.0, AmountFound = 2.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 2: itemsBefore
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                // Call 3: itemsAfter
+                new() { ProductId = 101, AmountErp = 5.0, AmountFound = 6.0 },
+            });
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-005",
+            DryRun = false,
+            RemoveMissingLots = true,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 2m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingItemsClient.Verify(
+            x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(headerId, It.Is<IEnumerable<int>>(ids => ids.Contains(101) && ids.Contains(102)), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenRemoveMissingLotsFalse_AddMissingLotsAsyncNotCalled()
+    {
+        // Arrange
+        var headerId = 55;
+        SetupFullErpPath(headerId, amountFound: 1.0, amountErp: 1.0);
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-006",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 1m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        _mockStockTakingClient.Verify(
+            x => x.AddMissingLotsAsync(It.IsAny<int>(), It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FR-5: Exception path — Error field set, repo not called
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_ReturnsRecordWithErrorSet()
+    {
+        // Arrange — single item with Amount=10 so AmountOld is predictable from catch block
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP connection failed"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert
+        result.Error.Should().Be("ERP connection failed");
+        result.Code.Should().Be("PROD-ERR");
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_AmountOldEqualsItemAmountSum()
+    {
+        // Arrange — catch block sets AmountOld = order.StockTakingItems.Sum(s => s.Amount)
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR2",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        var result = await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — AmountOld in catch = (double)Sum(Amount) = 10.0
+        result.AmountOld.Should().Be(10.0);
+    }
+
+    [Fact]
+    public async Task SubmitStockTakingAsync_WhenErpThrows_RepositoryNotCalled()
+    {
+        // Arrange
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("ERP error"));
+
+        var order = new ErpStockTakingRequest
+        {
+            ProductCode = "PROD-ERR3",
+            DryRun = false,
+            RemoveMissingLots = false,
+            StockTakingItems = new List<ErpStockTakingLot>
+            {
+                new() { Amount = 10m, SoftStockTaking = false },
+            }
+        };
+
+        // Act
+        await _sut.SubmitStockTakingAsync(order);
+
+        // Assert — silent catch must NOT persist anything
+        _mockRepository.Verify(
+            x => x.AddAsync(It.IsAny<StockTakingRecord>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockRepository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Sets up the standard ERP path (no RemoveMissingLots) with controlled amounts.
+    /// GetStockTakingsAsync is called twice: once for itemsBefore, once for itemsAfter.
+    /// </summary>
+    private void SetupFullErpPath(int headerId, double amountFound, double amountErp)
+    {
+        _mockStockTakingClient
+            .Setup(x => x.CreateHeaderAsync(It.IsAny<StockTakingHeaderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+
+        _mockStockTakingItemsClient
+            .Setup(x => x.AddStockTakingsAsync(headerId, 5, It.IsAny<IEnumerable<AddStockTakingItemRequest>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingItemsClient
+            .SetupSequence(x => x.GetStockTakingsAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            })
+            .ReturnsAsync(new List<StockTakingItemResult>
+            {
+                new() { AmountErp = amountErp, AmountFound = amountFound },
+            });
+
+        _mockStockTakingClient
+            .Setup(x => x.SubmitAsync(headerId, 60, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockStockTakingClient
+            .Setup(x => x.GetHeaderAsync(headerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StockTakingHeader { Id = headerId });
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they compile and pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Adapters.Flexi.Tests/ \
+  --filter "FullyQualifiedName~FlexiStockTakingDomainServiceTests" \
+  -v normal 2>&1
+```
+
+Expected: all tests pass (green). If any fail, review the failure message — the most likely issues are:
+- `SetupSequence` not returning enough values: add another `.ReturnsAsync(...)` call in `SetupFullErpPath` for `GetStockTakingsAsync`.
+- Missing `CancellationToken` parameter on a mock setup: all SDK interface methods take an optional `CancellationToken` — ensure `It.IsAny<CancellationToken>()` is used in every `Setup`.
+
+- [ ] **Step 3: Run the full test project to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Adapters.Flexi.Tests/ -v minimal 2>&1
+```
+
+Expected: all previously passing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs
+git commit -m "test: add unit tests for FlexiStockTakingDomainService.SubmitStockTakingAsync
+
+Covers all five behavioral contracts (FR-1 through FR-5):
+- SoftStockTaking path (no ERP calls, AmountNew == AmountOld)
+- Real ERP path (SubmitAsync called, amounts from ERP items)
+- DryRun=true (SubmitAsync skipped, repo still saved)
+- RemoveMissingLots=true (GetStockTakings + AddMissingLots called)
+- Exception path (Error field set, repo not called)"
+```


### PR DESCRIPTION
## What the issue was

`FlexiStockTakingDomainService.SubmitStockTakingAsync` had 16.7% line coverage (threshold: 60%). The method has four independent decision branches — SoftStockTaking, DryRun, RemoveMissingLots, and a silent exception catch — none of which were tested. The catch block is particularly risky: it returns a `StockTakingRecord` with `Error` set but structurally identical to a soft-stock-taking success, so callers that don't inspect `Error` silently treat failed ERP writes as successes.

## How it was fixed / handled

Added 12 unit tests in a new file `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockTakingDomainServiceTests.cs` using Moq and FluentAssertions (already present in the test project). Tests cover all five behavioral contracts:

- **FR-1 SoftStockTaking=true**: zero ERP calls, `AmountNew == AmountOld == sum(items)`, repo saved
- **FR-2 Real ERP path (DryRun=false)**: `SubmitAsync` called once, amounts sourced from ERP item responses
- **FR-3 DryRun=true**: `SubmitAsync` never called, all other ERP calls made, repo still saved
- **FR-4 RemoveMissingLots=true/false**: `AddMissingLotsAsync` called with correct productIds when true, never called when false
- **FR-5 Exception path**: `Error` field set to exception message, `AddAsync`/`SaveChangesAsync` never called

One correction from the plan: the production catch block sets `AmountNew` (not `AmountOld`) to the item sum — tests were updated to match actual behaviour.

All 12 new tests pass. The 72 pre-existing failures are Docker/live-API integration tests, not regressions.

## Artifacts
- Brief, spec, arch-review, task-plan, impl, and plan markdown are committed in this branch under `artifacts/feat-3120/` and `docs/superpowers/plans/`.

Closes #3120