### PR TITLE
feat-3151: Move OutlookCalendarSyncService to Anela.Heblo.Adapters.Microsoft365

### DIFF
--- a/Anela.Heblo.sln
+++ b/Anela.Heblo.sln
@@ -81,6 +81,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Persistence.Ana
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.FileSystem", "backend\src\Adapters\Anela.Heblo.Adapters.FileSystem\Anela.Heblo.Adapters.FileSystem.csproj", "{2E2AA044-B62E-49E3-8286-A585EB988086}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Microsoft365", "backend\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj", "{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -463,6 +465,18 @@ Global
 		{2E2AA044-B62E-49E3-8286-A585EB988086}.Release|x64.Build.0 = Release|Any CPU
 		{2E2AA044-B62E-49E3-8286-A585EB988086}.Release|x86.ActiveCfg = Release|Any CPU
 		{2E2AA044-B62E-49E3-8286-A585EB988086}.Release|x86.Build.0 = Release|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Debug|x64.Build.0 = Debug|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Debug|x86.Build.0 = Debug|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|x64.ActiveCfg = Release|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|x64.Build.0 = Release|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|x86.ActiveCfg = Release|Any CPU
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -503,5 +517,6 @@ Global
 		{2F8C5E3A-1B7D-4F9E-A3C8-6D1E5B2F7A4C} = {7D3E9F2B-4A1C-4E6D-8B5F-3C2D7F9E0A1B}
 		{ACA057C0-6F29-408A-A069-E9270E4480CF} = {87237941-D198-446F-919C-467E4968E85F}
 		{2E2AA044-B62E-49E3-8286-A585EB988086} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 	EndGlobalSection
 EndGlobal

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Anela.Heblo.Adapters.Microsoft365.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Anela.Heblo.Adapters.Microsoft365.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Anela.Heblo.Adapters.Microsoft365</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Graph" Version="5.92.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+using Anela.Heblo.Application.Features.Marketing.Services;
+using Anela.Heblo.Domain.Features.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.Microsoft365;
+
+public static class Microsoft365AdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddMicrosoft365Adapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
+        var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
+
+        if (!useMockAuth && !bypassJwt)
+        {
+            services.AddScoped<IOutlookCalendarSync, OutlookCalendarSyncService>();
+        }
+
+        return services;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/OutlookCalendarSyncService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/OutlookCalendarSyncService.cs
@@ -3,13 +3,14 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
+using Anela.Heblo.Application.Features.Marketing.Services;
 using Anela.Heblo.Domain.Features.Marketing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Web;
 
-namespace Anela.Heblo.Application.Features.Marketing.Services
+namespace Anela.Heblo.Adapters.Microsoft365
 {
     // PushEnabled flag is enforced by the caller (handler) before invoking this service.
     // See Task 3 for the guard at the handler level.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/OutlookInternalDtos.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/OutlookInternalDtos.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+using Anela.Heblo.Application.Features.Marketing.Services;
+
+namespace Anela.Heblo.Adapters.Microsoft365
+{
+    internal class GraphEventCollection
+    {
+        [JsonPropertyName("value")]
+        public List<OutlookEventDto> Value { get; set; } = new();
+
+        [JsonPropertyName("@odata.nextLink")]
+        public string? NextLink { get; set; }
+    }
+
+    internal class OutlookEventIdPayload
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+++ b/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
@@ -75,6 +75,7 @@
         <ProjectReference Include="..\Anela.Heblo.Persistence\Anela.Heblo.Persistence.csproj" />
         <ProjectReference Include="..\Anela.Heblo.Xcc\Anela.Heblo.Xcc.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OpenMeteo\Anela.Heblo.Adapters.OpenMeteo.csproj" />
+        <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
     </ItemGroup>
 
     <!-- NSwag tool for OpenAPI client generation -->

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -4,6 +4,7 @@ using Anela.Heblo.Adapters.Anthropic;
 using Anela.Heblo.Adapters.Smartsupp;
 using Anela.Heblo.Adapters.Azure;
 using Anela.Heblo.Adapters.HomeAssistant;
+using Anela.Heblo.Adapters.Microsoft365;
 using Anela.Heblo.Adapters.OpenMeteo;
 using Anela.Heblo.Adapters.Plaud;
 using Anela.Heblo.Adapters.SendGrid;
@@ -115,6 +116,7 @@ public partial class Program
         builder.Services.AddHomeAssistantAdapter(builder.Configuration);
         builder.Services.AddOpenMeteoAdapter(builder.Configuration);
         builder.Services.AddPlaudAdapter(builder.Configuration);
+        builder.Services.AddMicrosoft365Adapter(builder.Configuration);
 
         builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
 

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
@@ -42,7 +42,7 @@ namespace Anela.Heblo.Application.Features.Marketing
             {
                 // Graph HTTP client (safe to register multiple times — IHttpClientFactory deduplicates)
                 services.AddHttpClient("MicrosoftGraph");
-                services.AddScoped<IOutlookCalendarSync, OutlookCalendarSyncService>();
+                // OutlookCalendarSyncService registration moved to Anela.Heblo.Adapters.Microsoft365
             }
             else
             {

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
 using Anela.Heblo.Application.Features.Marketing.Services;
-using Anela.Heblo.Domain.Features.Configuration;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Persistence.Marketing;
 using Microsoft.Extensions.Configuration;
@@ -32,22 +31,11 @@ namespace Anela.Heblo.Application.Features.Marketing
             // The mapper has no Graph dependencies — register in both auth modes.
             services.AddSingleton<IMarketingCategoryMapper, MarketingCategoryMapper>();
 
-            // Outlook calendar sync — use real Graph-backed service only when real Azure AD
-            // authentication is active. Mock auth has no ITokenAcquisition registered, so DI
-            // validation would fail; NoOpOutlookCalendarSync is used in those environments instead.
-            var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-            var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
-
-            if (!useMockAuth && !bypassJwt)
-            {
-                // Graph HTTP client (safe to register multiple times — IHttpClientFactory deduplicates)
-                services.AddHttpClient("MicrosoftGraph");
-                // OutlookCalendarSyncService registration moved to Anela.Heblo.Adapters.Microsoft365
-            }
-            else
-            {
-                services.AddScoped<IOutlookCalendarSync, NoOpOutlookCalendarSync>();
-            }
+            // Graph HTTP client (safe to register multiple times — IHttpClientFactory deduplicates)
+            services.AddHttpClient("MicrosoftGraph");
+            // No-op fallback; AddMicrosoft365Adapter() (called from Program.cs) will override with
+            // the real OutlookCalendarSyncService in production (last registration wins).
+            services.AddScoped<IOutlookCalendarSync, NoOpOutlookCalendarSync>();
 
             // MediatR handlers are auto-registered by assembly scan
             return services;

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Services/OutlookEventDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Services/OutlookEventDto.cs
@@ -51,18 +51,4 @@ namespace Anela.Heblo.Application.Features.Marketing.Services
         public string TimeZone { get; set; } = string.Empty;
     }
 
-    internal class GraphEventCollection
-    {
-        [JsonPropertyName("value")]
-        public List<OutlookEventDto> Value { get; set; } = new();
-
-        [JsonPropertyName("@odata.nextLink")]
-        public string? NextLink { get; set; }
-    }
-
-    internal class OutlookEventIdPayload
-    {
-        [JsonPropertyName("id")]
-        public string Id { get; set; } = string.Empty;
-    }
 }

--- a/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+++ b/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
@@ -51,6 +51,7 @@
     <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.Cups\Anela.Heblo.Adapters.Cups.csproj" />
     <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.FileSystem\Anela.Heblo.Adapters.FileSystem.csproj" />
     <ProjectReference Include="..\..\src\Anela.Heblo.Xcc\Anela.Heblo.Xcc.csproj" />
+    <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/OutlookCalendarSyncServiceTokenTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/OutlookCalendarSyncServiceTokenTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using Anela.Heblo.Adapters.Microsoft365;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
 using Anela.Heblo.Application.Features.Marketing.Services;
 using Anela.Heblo.Domain.Features.Marketing;

--- a/backend/test/Anela.Heblo.Tests/Marketing/OutlookCalendarSyncServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Marketing/OutlookCalendarSyncServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using Anela.Heblo.Adapters.Microsoft365;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
 using Anela.Heblo.Application.Features.Marketing.Services;
 using Anela.Heblo.Domain.Features.Marketing;


### PR DESCRIPTION
## What the issue was

`OutlookCalendarSyncService` was an I/O-bound service making authenticated HTTP calls to Microsoft Graph living in the Application layer (`Anela.Heblo.Application`), violating the project's Adapter pattern rule. This forced `Anela.Heblo.Application.csproj` to carry heavyweight infrastructure package references (`Microsoft.Graph` v5.92.0, `Microsoft.Identity.Web` v3.14.1) that belong in an Adapter project, making the Application layer harder to test and blurring the boundary between business logic and external service calls.

## How it was fixed / handled

Created a new `Anela.Heblo.Adapters.Microsoft365` class library following the same pattern as `Anela.Heblo.Adapters.SendGrid`, `Anela.Heblo.Adapters.OpenAI`, and other adapters:

- **New project** `backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/` — targets net8.0, carries `Microsoft.Graph` and `Microsoft.Identity.Web` package references, references Application.
- **Moved** `OutlookCalendarSyncService.cs` to the adapter; namespace updated to `Anela.Heblo.Adapters.Microsoft365`.
- **Extracted** internal Graph DTOs (`GraphEventCollection`, `OutlookEventIdPayload`) into `OutlookInternalDtos.cs` in the adapter. Public DTOs (`OutlookEventDto`, `GraphEventBody`, `GraphEventDateTime`) remain in Application since 5 handler files reference them.
- **Created** `Microsoft365AdapterServiceCollectionExtensions.AddMicrosoft365Adapter()` — registers `IOutlookCalendarSync → OutlookCalendarSyncService` (scoped) only when real Azure AD auth is active.
- **Simplified** `MarketingModule.cs` — registers `NoOpOutlookCalendarSync` unconditionally; `AddMicrosoft365Adapter` overrides it in production (last-registration-wins).
- **Wired** adapter into `Program.cs`, `Anela.Heblo.API.csproj`, `Anela.Heblo.Tests.csproj`, and `Anela.Heblo.sln`.

Note: `Microsoft.Graph` and `Microsoft.Identity.Web` were **not** removed from `Anela.Heblo.Application.csproj` — other Application-layer services (`UserManagementModule`, `GraphService`, `PhotobankGraphService`, etc.) still depend on them. Removing those is a separate multi-feature refactor.

**Build:** 0 errors. **Tests:** 16 Outlook calendar sync tests pass.

## Artifacts
- Brief, spec, arch-review, task plan, and impl markdown are committed in this branch under `artifacts/feat-3151/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQW1uSWqWQSxHRdqjmYvye)_