### PR TITLE
Marketing: batch Outlook import into a single SaveChanges (#3153)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/ImportFromOutlookHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/ImportFromOutlookHandler.cs
@@ -59,6 +59,13 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook
             var response = new ImportFromOutlookResponse();
             var unmappedAccumulator = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            // Persistence is deferred until the loop completes so that a single
+            // SaveChangesAsync covers the whole import. Saving per-event used to
+            // leave the shared DbContext dirty after a failed save, poisoning
+            // every subsequent event in the run (and costing N round-trips).
+            var pendingCreates = new List<(MarketingAction action, OutlookEventDto evt)>();
+            var pendingUpdates = new List<(MarketingAction action, OutlookEventDto evt)>();
+
             foreach (var evt in events)
             {
                 try
@@ -92,16 +99,7 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook
                         if (!request.DryRun)
                         {
                             await _repository.UpdateAsync(existing, cancellationToken);
-                            await _repository.SaveChangesAsync(cancellationToken);
-
-                            response.Updated++;
-                            response.Items.Add(new ImportedItemDto
-                            {
-                                OutlookEventId = evt.Id,
-                                Subject = evt.Subject,
-                                Status = ImportStatus.Updated,
-                                CreatedActionId = existing.Id,
-                            });
+                            pendingUpdates.Add((existing, evt));
                         }
                         else
                         {
@@ -120,17 +118,8 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook
 
                         if (!request.DryRun)
                         {
-                            var created = await _repository.AddAsync(action, cancellationToken);
-                            await _repository.SaveChangesAsync(cancellationToken);
-
-                            response.Created++;
-                            response.Items.Add(new ImportedItemDto
-                            {
-                                OutlookEventId = evt.Id,
-                                Subject = evt.Subject,
-                                Status = ImportStatus.Created,
-                                CreatedActionId = created.Id,
-                            });
+                            await _repository.AddAsync(action, cancellationToken);
+                            pendingCreates.Add((action, evt));
                         }
                         else
                         {
@@ -160,6 +149,62 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook
                         Error = ex.Message,
                     });
                 }
+            }
+
+            if (!request.DryRun && (pendingCreates.Count > 0 || pendingUpdates.Count > 0))
+            {
+                try
+                {
+                    await _repository.SaveChangesAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    // The batch is atomic: if the single save fails, none of the
+                    // staged creates/updates were persisted. Report them all as
+                    // failed instead of claiming success for unwritten rows.
+                    _logger.LogError(ex,
+                        "Failed to persist Outlook import batch of {Count} action(s); no changes were saved",
+                        pendingCreates.Count + pendingUpdates.Count);
+
+                    foreach (var (_, evt) in pendingCreates.Concat(pendingUpdates))
+                    {
+                        response.Failed++;
+                        response.Items.Add(new ImportedItemDto
+                        {
+                            OutlookEventId = evt.Id,
+                            Subject = evt.Subject,
+                            Status = ImportStatus.Failed,
+                            Error = ex.Message,
+                        });
+                    }
+
+                    pendingCreates.Clear();
+                    pendingUpdates.Clear();
+                }
+            }
+
+            foreach (var (action, evt) in pendingCreates)
+            {
+                response.Created++;
+                response.Items.Add(new ImportedItemDto
+                {
+                    OutlookEventId = evt.Id,
+                    Subject = evt.Subject,
+                    Status = ImportStatus.Created,
+                    CreatedActionId = action.Id,
+                });
+            }
+
+            foreach (var (action, evt) in pendingUpdates)
+            {
+                response.Updated++;
+                response.Items.Add(new ImportedItemDto
+                {
+                    OutlookEventId = evt.Id,
+                    Subject = evt.Subject,
+                    Status = ImportStatus.Updated,
+                    CreatedActionId = action.Id,
+                });
             }
 
             response.UnmappedCategories = unmappedAccumulator.ToList();

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
@@ -738,4 +738,68 @@ public class ImportFromOutlookHandlerTests
         result.Updated.Should().Be(1);
         existingAction.Title.Should().Be("New Title");
     }
+
+    [Fact]
+    public async Task Handle_WhenMultipleNewEvents_PersistsBatchWithSingleSaveChanges()
+    {
+        // Regression for the per-event SaveChangesAsync (issue #3153): the whole
+        // import must be persisted in one round-trip, not one save per event.
+        var events = new List<OutlookEventDto>
+        {
+            BuildEvent(id: "evt-a", subject: "Event A"),
+            BuildEvent(id: "evt-b", subject: "Event B"),
+            BuildEvent(id: "evt-c", subject: "Event C"),
+        };
+
+        _outlookSyncMock
+            .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events);
+
+        var nextId = 0;
+        _repositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MarketingAction a, CancellationToken _) => { a.Id = ++nextId; return a; });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Created.Should().Be(3);
+        result.Items.Should().OnlyContain(i => i.Status == ImportStatus.Created && i.CreatedActionId != null);
+        _repositoryMock.Verify(x => x.AddAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+        _repositoryMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenBatchSaveFails_ReportsAllStagedEventsAsFailed()
+    {
+        // The single batch save is atomic: if it throws (e.g. a DB constraint
+        // violation), none of the staged rows were written, so every staged
+        // event must be reported as Failed rather than Created.
+        var events = new List<OutlookEventDto>
+        {
+            BuildEvent(id: "evt-a", subject: "Event A"),
+            BuildEvent(id: "evt-b", subject: "Event B"),
+        };
+
+        _outlookSyncMock
+            .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events);
+
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Simulated batch DB failure"));
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Created.Should().Be(0);
+        result.Failed.Should().Be(2);
+        result.Items.Should().HaveCount(2);
+        result.Items.Should().OnlyContain(i => i.Status == ImportStatus.Failed && i.Error == "Simulated batch DB failure");
+        // The batch is saved exactly once — failure is not retried per-event.
+        _repositoryMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
 }


### PR DESCRIPTION
## What the issue was
`ImportFromOutlookHandler.Handle` called `_repository.SaveChangesAsync` **inside** the per-event `foreach` loop (issue #3153). When a save threw (e.g. a unique-constraint or column-size violation) for one event, EF Core's `DbContext` kept tracking that failed entity. The next iteration added another entity to the **same** context and called `SaveChangesAsync` again — re-attempting the already-failed write and cascading the failure to every remaining event. The reported `Failed: 1` could really mean `Failed: N`. It also issued N DB round-trips for N events.

## How it was fixed / handled
Implemented **Option A** from the issue (batch and save once), which is the architecturally clean fit here because `IRepository` does not expose the EF `ChangeTracker`, so Option B (detach failed entity) would have meant leaking Infrastructure into the Application layer.

- The loop now stages each create/update (`AddAsync`/`UpdateAsync`) into pending lists instead of saving per event.
- A single `SaveChangesAsync` runs after the loop — one round-trip, no cross-event context poisoning.
- The batch is **atomic**: if the save throws, every staged event is reported as `Failed` (with the exception message) rather than falsely counted as `Created`/`Updated`.
- Per-event mapping/build errors still continue the loop and are reported individually, preserving the existing partial-success contract.
- `DryRun` behaviour is unchanged (never persists).

## Tests
- All 22 `ImportFromOutlookHandlerTests` pass, including the existing partial-failure test.
- Added `Handle_WhenMultipleNewEvents_PersistsBatchWithSingleSaveChanges` — verifies `SaveChangesAsync` is called exactly once for a 3-event batch.
- Added `Handle_WhenBatchSaveFails_ReportsAllStagedEventsAsFailed` — verifies a thrown batch save marks all staged events Failed with no false Created.

`dotnet build` and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2oL5xiR9XDLAeExD5VVYS