### PR TITLE
fix: PhotoTags PK_PhotoTags 23505 — add idempotency guard to PhotobankIndexJob

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs
@@ -133,7 +133,7 @@ public class PhotobankIndexJob : IRecurringJob
         photo.DriveId = driveId;
 
         if (pathChanged)
-            photo!.LastAutoTaggedAt = null;
+            photo.LastAutoTaggedAt = null;
 
         await _repo.SaveChangesAsync(ct);
 
@@ -145,6 +145,7 @@ public class PhotobankIndexJob : IRecurringJob
         foreach (var tagName in matchingTagNames)
         {
             var tag = await _repo.GetOrCreateTagAsync(tagName, ct);
+            if (await _repo.PhotoTagExistsAsync(photo.Id, tag!.Id, ct)) continue;
 
             await _repo.AddPhotoTagAsync(new PhotoTag
             {

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankIndexJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankIndexJobTests.cs
@@ -97,6 +97,10 @@ public class PhotobankIndexJobTests
             .Setup(r => r.GetOrCreateTagAsync("produkty", It.IsAny<CancellationToken>()))
             .ReturnsAsync(tag);
 
+        _repoMock
+            .Setup(r => r.PhotoTagExistsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
         PhotoTag? capturedPhotoTag = null;
         _repoMock
             .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
@@ -132,6 +136,92 @@ public class PhotobankIndexJobTests
 
         _repoMock.Verify(r => r.AddPhotoAsync(It.IsAny<Photo>(), It.IsAny<CancellationToken>()), Times.Once);
         _repoMock.Verify(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpsertPhoto_WhenTagAlreadyExists_SkipsInsert()
+    {
+        // Arrange
+        var root = new PhotobankIndexRoot
+        {
+            Id = 1,
+            SharePointPath = "/sites/test/photos",
+            DriveId = "drive-1",
+            RootItemId = "root-item-1",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        var tagRule = new TagRule
+        {
+            PathPattern = "Fotky/Produkty",
+            TagName = "produkty",
+            IsActive = true,
+            SortOrder = 0,
+        };
+
+        var photoItem = new GraphPhotoItem
+        {
+            ItemId = "file-abc-123",
+            Name = "photo.jpg",
+            FolderPath = "Fotky/Produkty",
+            WebUrl = "https://sharepoint.example.com/photo.jpg",
+            FileSizeBytes = 1024,
+            LastModifiedAt = DateTime.UtcNow,
+            DriveId = "drive-1",
+            IsDeleted = false,
+        };
+
+        _repoMock
+            .Setup(r => r.GetActiveRootsWithDriveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([root]);
+
+        _repoMock
+            .Setup(r => r.GetActiveTagRulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([tagRule]);
+
+        _repoMock
+            .Setup(r => r.GetPhotoBySharePointFileIdAsync("file-abc-123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Photo?)null);
+
+        _repoMock
+            .Setup(r => r.AddPhotoAsync(It.IsAny<Photo>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repoMock
+            .Setup(r => r.GetPhotoTagsByPhotoAndSourceAsync(It.IsAny<int>(), PhotoTagSource.Rule, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _repoMock
+            .Setup(r => r.RemovePhotoTagsAsync(It.IsAny<IEnumerable<PhotoTag>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var tag = new Tag { Id = 42, Name = "produkty" };
+        _repoMock
+            .Setup(r => r.GetOrCreateTagAsync("produkty", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repoMock
+            .Setup(r => r.PhotoTagExistsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _repoMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _graphServiceMock
+            .Setup(g => g.GetDeltaAsync("drive-1", "root-item-1", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GraphDeltaResult
+            {
+                Items = [photoItem],
+                NewDeltaLink = "https://graph.microsoft.com/v1.0/drives/drive-1/items/root-item-1/delta?token=abc",
+            });
+
+        // Act
+        await _job.ExecuteAsync();
+
+        // Assert
+        _repoMock.Verify(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## What the issue was

`PhotobankIndexJob` (Hangfire cron `0 3 * * *`, 01:00 UTC) inserts `PhotoTag` rows via EF Core `SaveChangesAsync` without checking whether a `(PhotoId, TagId)` row already exists. On every nightly run after the first, the same pairs are re-inserted, violating the composite primary key `PK_PhotoTags` and producing bursts of 4 × `23505` exceptions (confirmed by App Insights at 2026-06-15T01:00:59 UTC).

## How it was fixed

Added a single existence-check guard inside `PhotobankIndexJob.UpsertPhotoAsync`, mirroring the identical guard already present in `PhotobankAutoTagJob.ApplyTagsForPhotoAsync`:

```csharp
if (await _repo.PhotoTagExistsAsync(photo.Id, tag!.Id, ct)) continue;
```

Also removed a redundant null-forgiving `!` on `photo.LastAutoTaggedAt` (the variable is always non-null in that branch).

No interface changes, no migration, no new repository methods — `IPhotobankRepository.PhotoTagExistsAsync` was already declared and implemented.

## Test coverage

- Updated `ExecuteAsync_InsertsNewPhoto_WithRuleTagsApplied` to explicitly mock `PhotoTagExistsAsync → false` (previously relied on Moq default).
- Added `UpsertPhoto_WhenTagAlreadyExists_SkipsInsert`: mocks `PhotoTagExistsAsync → true` and asserts `AddPhotoTagAsync` is called `Times.Never`.

All 4 tests in `PhotobankIndexJobTests` pass.

## Files changed

- `backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs` — added guard, removed `!`
- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankIndexJobTests.cs` — updated existing test + new test

Closes #3154