### PR TITLE
feat-3181: MetaAds — pass time_range to server-side API filter

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
@@ -43,7 +43,7 @@ public class MetaAdsTransactionSource : IMarketingTransactionSource
         CancellationToken ct)
     {
         var results = new List<MarketingTransaction>();
-        var url = BuildInitialUrl();
+        var url = BuildInitialUrl(from, to);
 
         _logger.LogInformation(
             "MetaAds: fetching transactions for account {AccountId} from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}",
@@ -106,10 +106,11 @@ public class MetaAdsTransactionSource : IMarketingTransactionSource
         }, ct);
     }
 
-    private string BuildInitialUrl() =>
+    private string BuildInitialUrl(DateTime from, DateTime to) =>
         $"https://graph.facebook.com/{_settings.ApiVersion}/{_settings.AccountId}/transactions" +
         $"?fields=id,time,amount,currency,payment_type" +
-        $"&access_token={_settings.AccessToken}";
+        $"&access_token={_settings.AccessToken}" +
+        $"&time_range={{\"since\":\"{from.ToUniversalTime():yyyy-MM-dd}\",\"until\":\"{to.ToUniversalTime():yyyy-MM-dd}\"}}";
 
     private static string RedactToken(string url)
     {

--- a/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
@@ -245,6 +245,54 @@ public class MetaAdsTransactionSourceTests
         transactions.Should().HaveCount(1);
         transactions[0].TransactionId.Should().Be("TX-001");
     }
+
+    [Fact]
+    public async Task GetTransactionsAsync_InitialUrl_ContainsTimeRange()
+    {
+        // Arrange
+        var capturedUrls = new List<string>();
+        var responseBody = """{"data":[],"paging":{"cursors":{"before":"","after":""}}}""";
+        var handler = new CapturingSequentialHandler(
+            capturedUrls,
+            (HttpStatusCode.OK, responseBody));
+
+        var source = CreateSource(handler);
+
+        var from = new DateTime(2024, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2024, 3, 31, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        capturedUrls.Should().HaveCount(1);
+        capturedUrls[0].Should().Contain("""time_range={"since":"2024-03-01","until":"2024-03-31"}""");
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_PaginationUrl_UsedVerbatim()
+    {
+        // Arrange
+        var capturedUrls = new List<string>();
+        var firstPageBody = """{"data":[{"id":"1","time":1709251200,"amount":100,"currency":"CZK","payment_type":"card"}],"paging":{"next":"https://graph.facebook.com/next-page?cursor=abc123"}}""";
+        var secondPageBody = """{"data":[],"paging":{"cursors":{"before":"","after":""}}}""";
+        var handler = new CapturingSequentialHandler(
+            capturedUrls,
+            (HttpStatusCode.OK, firstPageBody),
+            (HttpStatusCode.OK, secondPageBody));
+
+        var source = CreateSource(handler);
+
+        var from = new DateTime(2024, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2024, 3, 31, 0, 0, 0, DateTimeKind.Utc);
+
+        // Act
+        await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        capturedUrls.Should().HaveCount(2);
+        capturedUrls[1].Should().Be("https://graph.facebook.com/next-page?cursor=abc123");
+    }
 }
 
 /// <summary>Always returns the same response.</summary>
@@ -287,6 +335,30 @@ file sealed class SequentialResponseHandler : HttpMessageHandler
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         // Dequeue until the last entry; keep the last for any additional calls.
+        var (status, body) = _responses.Count > 1 ? _responses.Dequeue() : _responses.Peek();
+        var response = new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        return Task.FromResult(response);
+    }
+}
+
+/// <summary>Captures every request URL and returns responses in sequence; repeats the last on exhaustion.</summary>
+file sealed class CapturingSequentialHandler : HttpMessageHandler
+{
+    private readonly List<string> _capturedUrls;
+    private readonly Queue<(HttpStatusCode, string)> _responses;
+
+    public CapturingSequentialHandler(List<string> capturedUrls, params (HttpStatusCode, string)[] responses)
+    {
+        _capturedUrls = capturedUrls;
+        _responses = new Queue<(HttpStatusCode, string)>(responses);
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        _capturedUrls.Add(request.RequestUri?.ToString() ?? string.Empty);
         var (status, body) = _responses.Count > 1 ? _responses.Dequeue() : _responses.Peek();
         var response = new HttpResponseMessage(status)
         {


### PR DESCRIPTION
## What the issue was

`MetaAdsTransactionSource.BuildInitialUrl()` constructed the Meta Graph API URL without any date-range parameter, so every job run fetched the account's **complete billing history** (all pages since account creation) and discarded out-of-range transactions client-side. As the account ages, per-run HTTP cost grows O(account_age) rather than O(7 days of data), putting rate limits and job timeouts on the horizon.

## How it was fixed

`BuildInitialUrl` now accepts `(DateTime from, DateTime to)` and appends `time_range={"since":"yyyy-MM-dd","until":"yyyy-MM-dd"}` after `access_token` in the initial Meta Graph API URL. The call site in `GetTransactionsAsync` was updated from `BuildInitialUrl()` to `BuildInitialUrl(from, to)`. The client-side date guard is retained as a safety net.

## Changes

- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs` — `BuildInitialUrl` gains date parameters and appends `time_range` to the URL
- `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs` — two new tests: `GetTransactionsAsync_InitialUrl_ContainsTimeRange` and `GetTransactionsAsync_PaginationUrl_UsedVerbatim`; new `CapturingSequentialHandler` test helper

All 10 MetaAds unit tests pass.

Closes #3181