### PR TITLE
#3182: Downgrade ProductNotFound McpException to warning telemetry

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
@@ -69,6 +69,7 @@ public static class ApplicationInsightsExtensions
         services.AddApplicationInsightsTelemetryProcessor<CostOptimizedTelemetryProcessor>();
         services.AddApplicationInsightsTelemetryProcessor<HomeAssistantDependencyTelemetryFilter>();
         services.AddApplicationInsightsTelemetryProcessor<AzureBlobConflictTelemetryFilter>();
+        services.AddApplicationInsightsTelemetryProcessor<McpProductNotFoundTelemetryFilter>();
 
         // Configure sampling (more aggressive for cost savings)
         services.Configure<TelemetryConfiguration>((config) =>

--- a/backend/src/Anela.Heblo.API/Infrastructure/Telemetry/McpProductNotFoundTelemetryFilter.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Telemetry/McpProductNotFoundTelemetryFilter.cs
@@ -1,0 +1,54 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Anela.Heblo.API.Telemetry;
+
+/// <summary>
+/// Converts ExceptionTelemetry for McpException[ProductNotFound] from error-level to a
+/// Warning trace, removing it from the exception stream. A product-not-found miss is an
+/// expected MCP protocol response (analogous to a cache miss), not an application error.
+///
+/// Mirrors the established AzureBlobConflictTelemetryFilter pattern.
+/// </summary>
+public sealed class McpProductNotFoundTelemetryFilter : ITelemetryProcessor
+{
+    private const string McpExceptionTypeName = "ModelContextProtocol.McpException";
+    private const string ProductNotFoundMarker = "[ProductNotFound]";
+
+    private readonly ITelemetryProcessor _next;
+
+    public McpProductNotFoundTelemetryFilter(ITelemetryProcessor next)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+    }
+
+    public void Process(ITelemetry item)
+    {
+        if (item is ExceptionTelemetry exc
+            && exc.Message.Contains(ProductNotFoundMarker, StringComparison.Ordinal)
+            && IsMcpException(exc))
+        {
+            var trace = new TraceTelemetry(exc.Message, SeverityLevel.Warning);
+            foreach (var prop in exc.Properties)
+            {
+                trace.Properties[prop.Key] = prop.Value;
+            }
+            _next.Process(trace);
+            return;
+        }
+
+        _next.Process(item);
+    }
+
+    private static bool IsMcpException(ExceptionTelemetry exc)
+    {
+        // When live exceptions are tracked (TrackException or ASP.NET middleware), Exception is set.
+        if (exc.Exception != null)
+            return string.Equals(exc.Exception.GetType().FullName, McpExceptionTypeName, StringComparison.Ordinal);
+
+        // Fallback for telemetry constructed without a live exception object.
+        return exc.ExceptionDetailsInfoList.Count > 0
+            && string.Equals(exc.ExceptionDetailsInfoList[0].TypeName, McpExceptionTypeName, StringComparison.Ordinal);
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/GetCatalogDetail/GetCatalogDetailHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/GetCatalogDetail/GetCatalogDetailHandler.cs
@@ -35,6 +35,7 @@ public class GetCatalogDetailHandler : IRequestHandler<GetCatalogDetailRequest, 
 
         if (catalogItem == null)
         {
+            _logger.LogWarning("Catalog product not found. ProductCode: {ProductCode}", request.ProductCode);
             return new GetCatalogDetailResponse
             {
                 Success = false,

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/GetCatalogDetailHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/GetCatalogDetailHandlerTests.cs
@@ -19,6 +19,7 @@ public class GetCatalogDetailHandlerTests
     private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
     private readonly Mock<IMapper> _mapperMock;
     private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly Mock<ILogger<GetCatalogDetailHandler>> _loggerMock;
     private readonly GetCatalogDetailHandler _handler;
 
     public GetCatalogDetailHandlerTests()
@@ -26,10 +27,8 @@ public class GetCatalogDetailHandlerTests
         _catalogRepositoryMock = new Mock<ICatalogRepository>();
         _mapperMock = new Mock<IMapper>();
         _timeProviderMock = new Mock<TimeProvider>();
-        var loggerMock = new Mock<ILogger<GetCatalogDetailHandler>>();
-        _handler = new GetCatalogDetailHandler(_catalogRepositoryMock.Object, _mapperMock.Object, _timeProviderMock.Object, loggerMock.Object);
-
-        // No longer needed - using pre-calculated margins from CatalogAggregate
+        _loggerMock = new Mock<ILogger<GetCatalogDetailHandler>>();
+        _handler = new GetCatalogDetailHandler(_catalogRepositoryMock.Object, _mapperMock.Object, _timeProviderMock.Object, _loggerMock.Object);
     }
 
     [Fact]
@@ -200,6 +199,31 @@ public class GetCatalogDetailHandlerTests
         response.ErrorCode.Should().Be(ErrorCodes.ProductNotFound);
         response.Params.Should().ContainKey("productCode");
         response.Params!["productCode"].Should().Be("NONEXISTENT");
+    }
+
+    [Fact]
+    public async Task Handle_Should_LogWarning_When_Product_Not_Found()
+    {
+        // Arrange
+        var request = new GetCatalogDetailRequest { ProductCode = "NONEXISTENT" };
+        _catalogRepositoryMock
+            .Setup(r => r.SingleOrDefaultAsync(
+                It.IsAny<System.Linq.Expressions.Expression<System.Func<CatalogAggregate, bool>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CatalogAggregate?)null);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("NONEXISTENT")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/Telemetry/McpProductNotFoundTelemetryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/Telemetry/McpProductNotFoundTelemetryFilterTests.cs
@@ -1,0 +1,91 @@
+using Anela.Heblo.API.Telemetry;
+using FluentAssertions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using ModelContextProtocol;
+using Moq;
+
+namespace Anela.Heblo.Tests.Infrastructure.Telemetry;
+
+public class McpProductNotFoundTelemetryFilterTests
+{
+    private readonly Mock<ITelemetryProcessor> _next = new();
+    private readonly McpProductNotFoundTelemetryFilter _filter;
+
+    public McpProductNotFoundTelemetryFilterTests()
+    {
+        _filter = new McpProductNotFoundTelemetryFilter(_next.Object);
+    }
+
+    private static ExceptionTelemetry BuildMcpExceptionTelemetry(string message)
+    {
+        var exception = new McpException(message);
+        var exc = new ExceptionTelemetry(exception);
+        exc.Message = message;
+        return exc;
+    }
+
+    [Fact]
+    public void Process_ConvertsMatchingMcpExceptionToWarningTrace()
+    {
+        var exc = BuildMcpExceptionTelemetry("[ProductNotFound] ProductNotFound: productCode: SA014");
+
+        _filter.Process(exc);
+
+        _next.Verify(n => n.Process(It.Is<ExceptionTelemetry>(_ => true)), Times.Never);
+        _next.Verify(n => n.Process(It.Is<TraceTelemetry>(t =>
+            t.SeverityLevel == SeverityLevel.Warning &&
+            t.Message.Contains("[ProductNotFound]"))), Times.Once);
+    }
+
+    [Fact]
+    public void Process_CopiesPropertiesFromExceptionToTrace()
+    {
+        var exc = BuildMcpExceptionTelemetry("[ProductNotFound] ProductNotFound: productCode: SA014");
+        exc.Properties["productCode"] = "SA014";
+        exc.Properties["someKey"] = "someValue";
+
+        _filter.Process(exc);
+
+        _next.Verify(n => n.Process(It.Is<TraceTelemetry>(t =>
+            t.Properties.ContainsKey("productCode") &&
+            t.Properties["productCode"] == "SA014" &&
+            t.Properties.ContainsKey("someKey") &&
+            t.Properties["someKey"] == "someValue")), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsOtherMcpExceptionTypes()
+    {
+        var exception = new McpException("[UNKNOWN_ERROR] Something went wrong.");
+        var exc = new ExceptionTelemetry(exception);
+        exc.Message = "[UNKNOWN_ERROR] Something went wrong.";
+
+        _filter.Process(exc);
+
+        _next.Verify(n => n.Process(exc), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsNonMcpExceptions()
+    {
+        var exception = new InvalidOperationException("[ProductNotFound] Something failed.");
+        var exc = new ExceptionTelemetry(exception);
+        exc.Message = "[ProductNotFound] Something failed.";
+
+        _filter.Process(exc);
+
+        _next.Verify(n => n.Process(exc), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsNonExceptionTelemetry()
+    {
+        var trace = new TraceTelemetry("hello world");
+
+        _filter.Process(trace);
+
+        _next.Verify(n => n.Process(trace), Times.Once);
+    }
+}


### PR DESCRIPTION
## What the issue was

`CatalogMcpTools.GetCatalogDetail` was throwing `McpException` for every product code not found in the local catalog — the correct MCP protocol mechanism, but Application Insights was recording each throw as an error-level exception event. Over the P7D window (2026-06-09 to 2026-06-16), this produced 29 exception events (~4/day) and inflated the MCP error rate to ~11.5%, masking genuine failures. Product-not-found is an expected condition (LLM context may reference codes not yet synced from Shoptet/FlexiBee).

## How it was fixed / handled

Two targeted backend-only changes, following the existing `AzureBlobConflictTelemetryFilter` pattern:

1. **Handler warning log** (`GetCatalogDetailHandler.cs`): Added `_logger.LogWarning("Catalog product not found. ProductCode: {ProductCode}", ...)` in the null branch before returning the `ProductNotFound` error response. Product-not-found misses now appear in App Insights Traces with a structured `ProductCode` property, independently of the exception stream.

2. **Telemetry processor** (`McpProductNotFoundTelemetryFilter.cs`): New `ITelemetryProcessor` that intercepts `ExceptionTelemetry` for `McpException[ProductNotFound]`, converts it to a `TraceTelemetry(Warning)` (copying Properties), and forwards it — removing it from the exceptions blade without losing observability. Registered after `AzureBlobConflictTelemetryFilter` in `AddOptimizedApplicationInsights`. MCP protocol behaviour (the `McpException` throw) is unchanged.

## Artifacts
- 5 files changed: handler, filter (new), extensions registration, handler tests, filter tests (new)
- 20 tests passing (handler tests + 5 filter scenarios + existing AzureBlobConflictTelemetryFilter regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXeMTi5hHFBrJ7W9o2eRfi)_