### PR TITLE
feat-3191: Remove dead catch-rethrow block in OrgChartService

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
@@ -64,9 +64,5 @@ public class OrgChartService : IOrgChartService
         {
             throw new InvalidOperationException($"Failed to parse organizational structure: {ex.Message}", ex);
         }
-        catch (Exception)
-        {
-            throw;
-        }
     }
 }


### PR DESCRIPTION
## What the issue was

`OrgChartService.GetOrganizationStructureAsync` contained a dead `catch (Exception) { throw; }` block that caught every exception and immediately re-threw it unmodified — identical behavior to not having the block at all. This misleads readers into thinking there is an intentional handling decision, violating KISS and adding unnecessary cognitive overhead.

## How it was fixed / handled

Removed the 4-line block entirely. The two meaningful catch clauses (`catch (HttpRequestException)` and `catch (JsonException)`) are untouched. Build passes with zero errors. No behavioral change — pure code hygiene.

## Artifacts
- Brief, spec, arch-review, task plan, and impl markdown are committed in this branch.

Closes #3191

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP4cTr1bzLtw9dqzzcmpeg)_