### PR TITLE
#3195: Introduce IShoptetExpeditionOrderSource — fix concrete dependency in packing/expedition adapters

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/PickingListBatchProcessor.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/PickingListBatchProcessor.cs
@@ -11,7 +11,7 @@ internal sealed class PickingListBatchProcessor
     internal const int CoolingAdditionalFieldIndex = 6;
 
     private readonly ICatalogRepository _catalog;
-    private readonly ShoptetOrderClient _client;
+    private readonly IShoptetExpeditionOrderSource _client;
     private readonly Func<ExpeditionProtocolData, byte[]> _generateDocument;
     // Logger parameter is intentionally typed as the base ILogger (not ILogger<PickingListBatchProcessor>)
     // so the log category remains "ShoptetApiExpeditionListSource". Ops alerting filters on that category;
@@ -20,7 +20,7 @@ internal sealed class PickingListBatchProcessor
 
     public PickingListBatchProcessor(
         ICatalogRepository catalog,
-        ShoptetOrderClient client,
+        IShoptetExpeditionOrderSource client,
         Func<ExpeditionProtocolData, byte[]> generateDocument,
         ILogger logger)
     {

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
@@ -17,7 +17,7 @@ namespace Anela.Heblo.Adapters.ShoptetApi.Expedition;
 
 public class ShoptetApiExpeditionListSource : IPickingListSource
 {
-    private readonly ShoptetOrderClient _client;
+    private readonly IShoptetExpeditionOrderSource _client;
     private readonly TimeProvider _timeProvider;
     private readonly ICatalogRepository _catalog;
     private readonly ICarrierCoolingRepository _carrierCooling;
@@ -26,7 +26,7 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
     private readonly Func<ExpeditionProtocolData, byte[]> _generateDocument;
 
     public ShoptetApiExpeditionListSource(
-        ShoptetOrderClient client,
+        IShoptetExpeditionOrderSource client,
         TimeProvider timeProvider,
         ICatalogRepository catalog,
         ICarrierCoolingRepository carrierCooling,

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/IShoptetExpeditionOrderSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/IShoptetExpeditionOrderSource.cs
@@ -1,0 +1,13 @@
+using Anela.Heblo.Adapters.ShoptetApi.Expedition.Model;
+using Anela.Heblo.Adapters.ShoptetApi.Orders.Model;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.Orders;
+
+public interface IShoptetExpeditionOrderSource
+{
+    Task<OrderListResponse> GetOrdersByStatusAsync(int statusId, int page, CancellationToken ct = default);
+    Task<ExpeditionOrderDetail> GetExpeditionOrderDetailAsync(string code, CancellationToken ct = default);
+    Task<int> GetOrderStatusIdAsync(string orderCode, CancellationToken ct = default);
+    Task UpdateStatusAsync(string orderCode, int statusId, CancellationToken ct = default);
+    Task SetAdditionalFieldAsync(string orderCode, int index, string? text, CancellationToken ct = default);
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
@@ -15,7 +15,7 @@ namespace Anela.Heblo.Adapters.ShoptetApi.Orders;
 /// </summary>
 public class ShoptetApiPackingOrderClient : IPackingOrderClient
 {
-    private readonly ShoptetOrderClient _orderClient;
+    private readonly IShoptetExpeditionOrderSource _orderClient;
     private readonly ICatalogRepository _catalog;
     private readonly ICarrierCoolingRepository _carrierCooling;
     private readonly ILogger<ShoptetApiPackingOrderClient> _logger;
@@ -23,7 +23,7 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
     private readonly ShoptetOrdersSettings _orderSettings;
 
     public ShoptetApiPackingOrderClient(
-        ShoptetOrderClient orderClient,
+        IShoptetExpeditionOrderSource orderClient,
         ICatalogRepository catalog,
         ICarrierCoolingRepository carrierCooling,
         ILogger<ShoptetApiPackingOrderClient> logger,

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Adapters.ShoptetApi.Orders;
 
-public class ShoptetOrderClient : IEshopOrderClient
+public class ShoptetOrderClient : IEshopOrderClient, IShoptetExpeditionOrderSource
 {
     private readonly HttpClient _http;
     private readonly ShoptetOrdersSettings _orderSettings;

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ public static class ShoptetApiAdapterServiceCollectionExtensions
             client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
         });
         services.AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>());
+        services.AddTransient<IShoptetExpeditionOrderSource>(sp => sp.GetRequiredService<ShoptetOrderClient>());
 
         services.AddHttpClient<IEshopStockClient, ShoptetStockClient>((sp, client) =>
         {

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/PickingListBatchProcessorTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/PickingListBatchProcessorTests.cs
@@ -1,16 +1,11 @@
-using System.Net;
-using System.Text;
 using Anela.Heblo.Adapters.ShoptetApi.Expedition;
 using Anela.Heblo.Adapters.ShoptetApi.Orders;
-using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Logistics;
 using Anela.Heblo.Domain.Shared;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace Anela.Heblo.Adapters.Shoptet.Tests.Expedition;
@@ -22,40 +17,30 @@ public class PickingListBatchProcessorTests
     private const string CooledOrderCode = "ORDER-COOL";
     private const string NormalOrderCode = "ORDER-NORMAL";
 
-    private static HttpResponseMessage OkJson(string json) =>
-        new(HttpStatusCode.OK)
-        {
-            Content = new StringContent(json, Encoding.UTF8, "application/json"),
-        };
-
-    private static Mock<HttpMessageHandler> BuildHandler(bool patchShouldThrow = false)
+    private static Mock<IShoptetExpeditionOrderSource> BuildOrderSource(bool setAdditionalFieldShouldThrow = false)
     {
-        var handler = new Mock<HttpMessageHandler>();
+        var mock = new Mock<IShoptetExpeditionOrderSource>();
 
-        if (patchShouldThrow)
+        if (setAdditionalFieldShouldThrow)
         {
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Patch),
-                    ItExpr.IsAny<CancellationToken>())
+            mock.Setup(x => x.SetAdditionalFieldAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException("Simulated Shoptet PATCH failure"));
         }
         else
         {
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Patch),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(OkJson("""{"data":null,"errors":null}"""));
+            mock.Setup(x => x.SetAdditionalFieldAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
         }
 
-        return handler;
-    }
-
-    private static ShoptetOrderClient BuildClient(Mock<HttpMessageHandler> handler)
-    {
-        var http = new HttpClient(handler.Object) { BaseAddress = new Uri("https://test.myshoptet.com") };
-        return new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings()));
+        return mock;
     }
 
     private static Mock<ICatalogRepository> BuildCatalog()
@@ -136,22 +121,22 @@ public class PickingListBatchProcessorTests
     };
 
     private static PickingListBatchProcessor BuildProcessor(
-        Mock<HttpMessageHandler> handler,
+        Mock<IShoptetExpeditionOrderSource> orderSource,
         Mock<ICatalogRepository> catalog,
         ILogger? logger = null,
         Func<ExpeditionProtocolData, byte[]>? generate = null) =>
         new(
             catalog.Object,
-            BuildClient(handler),
+            orderSource.Object,
             generate ?? (_ => new byte[] { 0x25, 0x50, 0x44, 0x46 }),
             logger ?? Mock.Of<ILogger<ShoptetApiExpeditionListSource>>());
 
     [Fact]
     public async Task FlushAsync_InvokesCallbackOnceWithSingleElementList()
     {
-        var handler = BuildHandler();
+        var orderSource = BuildOrderSource();
         var catalog = BuildCatalog();
-        var processor = BuildProcessor(handler, catalog);
+        var processor = BuildProcessor(orderSource, catalog);
 
         var callbackInvocations = new List<IList<string>>();
         Func<IList<string>, Task> callback = paths =>
@@ -175,9 +160,9 @@ public class PickingListBatchProcessorTests
     [Fact]
     public async Task FlushAsync_DoesNotThrow_WhenCallbackIsNull()
     {
-        var handler = BuildHandler();
+        var orderSource = BuildOrderSource();
         var catalog = BuildCatalog();
-        var processor = BuildProcessor(handler, catalog);
+        var processor = BuildProcessor(orderSource, catalog);
 
         var act = async () => await processor.FlushAsync(
             new[] { BuildNormalOrder() },
@@ -194,7 +179,7 @@ public class PickingListBatchProcessorTests
     public async Task FlushAsync_AppliesCatalogEnrichmentToBatchItems()
     {
         ExpeditionProtocolData? captured = null;
-        var handler = BuildHandler();
+        var orderSource = BuildOrderSource();
         var catalog = new Mock<ICatalogRepository>();
         catalog.Setup(x => x.GetByIdAsync(NormalProductCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CatalogAggregate
@@ -206,7 +191,7 @@ public class PickingListBatchProcessorTests
             });
 
         var processor = BuildProcessor(
-            handler,
+            orderSource,
             catalog,
             generate: data =>
             {
@@ -251,9 +236,9 @@ public class PickingListBatchProcessorTests
     [Fact]
     public async Task FlushAsync_PatchesEachCooledOrderOnce_AndSkipsNonCooled()
     {
-        var handler = BuildHandler();
+        var orderSource = BuildOrderSource();
         var catalog = BuildCatalog();
-        var processor = BuildProcessor(handler, catalog);
+        var processor = BuildProcessor(orderSource, catalog);
 
         await processor.FlushAsync(
             new[] { BuildCooledOrder(), BuildNormalOrder() },
@@ -263,30 +248,30 @@ public class PickingListBatchProcessorTests
             onBatchFilesReady: null,
             cancellationToken: CancellationToken.None);
 
-        handler.Protected().Verify(
-            "SendAsync",
-            Times.Once(),
-            ItExpr.Is<HttpRequestMessage>(r =>
-                r.Method == HttpMethod.Patch &&
-                r.RequestUri!.AbsolutePath == $"/api/orders/{CooledOrderCode}/notes"),
-            ItExpr.IsAny<CancellationToken>());
+        orderSource.Verify(
+            x => x.SetAdditionalFieldAsync(
+                CooledOrderCode,
+                PickingListBatchProcessor.CoolingAdditionalFieldIndex,
+                PickingListBatchProcessor.CoolingMarkerValue,
+                It.IsAny<CancellationToken>()),
+            Times.Once());
 
-        handler.Protected().Verify(
-            "SendAsync",
-            Times.Never(),
-            ItExpr.Is<HttpRequestMessage>(r =>
-                r.Method == HttpMethod.Patch &&
-                r.RequestUri!.AbsolutePath == $"/api/orders/{NormalOrderCode}/notes"),
-            ItExpr.IsAny<CancellationToken>());
+        orderSource.Verify(
+            x => x.SetAdditionalFieldAsync(
+                NormalOrderCode,
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never());
     }
 
     [Fact]
     public async Task FlushAsync_PatchFailure_LogsWarning_AndCompletesNormally()
     {
         var logger = new Mock<ILogger<ShoptetApiExpeditionListSource>>();
-        var handler = BuildHandler(patchShouldThrow: true);
+        var orderSource = BuildOrderSource(setAdditionalFieldShouldThrow: true);
         var catalog = BuildCatalog();
-        var processor = BuildProcessor(handler, catalog, logger: logger.Object);
+        var processor = BuildProcessor(orderSource, catalog, logger: logger.Object);
 
         var path = await processor.FlushAsync(
             new[] { BuildCooledOrder() },

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/ShoptetApiExpeditionListSource_CoolingMarkerTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Expedition/ShoptetApiExpeditionListSource_CoolingMarkerTests.cs
@@ -1,18 +1,15 @@
-using System.Net;
-using System.Text;
 using Anela.Heblo.Adapters.ShoptetApi.Expedition;
+using Anela.Heblo.Adapters.ShoptetApi.Expedition.Model;
 using Anela.Heblo.Adapters.ShoptetApi.Orders;
+using Anela.Heblo.Adapters.ShoptetApi.Orders.Model;
+using Anela.Heblo.Application.Features.Logistics.Picking;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Logistics;
 using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
-using Anela.Heblo.Application.Features.Logistics.Picking;
-using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Domain.Shared;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace Anela.Heblo.Adapters.Shoptet.Tests.Expedition;
@@ -25,158 +22,128 @@ public class ShoptetApiExpeditionListSource_CoolingMarkerTests
     private const string CooledProductCode = "PROD-COOL";
     private const string NormalProductCode = "PROD-NORMAL";
 
-    private static HttpResponseMessage OkJson(string json) =>
-        new(HttpStatusCode.OK)
-        {
-            Content = new StringContent(json, Encoding.UTF8, "application/json"),
-        };
-
-    private static readonly string OrderListJson = $$"""
-        {
-          "data": {
-            "orders": [
-              {
-                "code": "{{CooledOrderCode}}",
-                "status": { "id": -2 },
-                "shipping": { "guid": "{{ZasilkovnaDoRukyGuid}}", "name": "Zásilkovna (do ruky)" },
-                "price": { "withVat": "500.00", "currencyCode": "CZK" }
-              },
-              {
-                "code": "{{NormalOrderCode}}",
-                "status": { "id": -2 },
-                "shipping": { "guid": "{{ZasilkovnaDoRukyGuid}}", "name": "Zásilkovna (do ruky)" },
-                "price": { "withVat": "300.00", "currencyCode": "CZK" }
-              }
-            ],
-            "paginator": { "totalCount": 2, "page": 1, "pageCount": 1 }
-          }
-        }
-        """;
-
-    private static readonly string CooledOrderDetailJson = $$"""
-        {
-          "data": {
-            "order": {
-              "code": "{{CooledOrderCode}}",
-              "fullName": "Cooled Customer",
-              "phone": "+420111222333",
-              "billingAddress": {
-                "fullName": "Cooled Customer",
-                "street": "Chladna",
-                "houseNumber": "1",
-                "city": "Praha",
-                "zip": "10000"
-              },
-              "items": [
-                {
-                  "itemType": "product",
-                  "itemId": 1,
-                  "code": "{{CooledProductCode}}",
-                  "name": "Cooled Product",
-                  "amount": 1.000,
-                  "unit": "ks",
-                  "itemPriceWithVat": "100.00"
-                }
-              ],
-              "completion": []
-            }
-          }
-        }
-        """;
-
-    private static readonly string NormalOrderDetailJson = $$"""
-        {
-          "data": {
-            "order": {
-              "code": "{{NormalOrderCode}}",
-              "fullName": "Normal Customer",
-              "phone": "+420444555666",
-              "billingAddress": {
-                "fullName": "Normal Customer",
-                "street": "Normalni",
-                "houseNumber": "2",
-                "city": "Brno",
-                "zip": "60200"
-              },
-              "items": [
-                {
-                  "itemType": "product",
-                  "itemId": 2,
-                  "code": "{{NormalProductCode}}",
-                  "name": "Normal Product",
-                  "amount": 1.000,
-                  "unit": "ks",
-                  "itemPriceWithVat": "80.00"
-                }
-              ],
-              "completion": []
-            }
-          }
-        }
-        """;
-
-    private Mock<HttpMessageHandler> BuildHandler(bool patchShouldThrow = false)
+    private static Mock<IShoptetExpeditionOrderSource> BuildOrderSource(bool patchShouldThrow = false)
     {
-        var handler = new Mock<HttpMessageHandler>();
+        var mock = new Mock<IShoptetExpeditionOrderSource>();
 
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.Is<HttpRequestMessage>(r =>
-                    r.Method == HttpMethod.Get &&
-                    r.RequestUri!.AbsolutePath == "/api/orders" &&
-                    r.RequestUri.Query.Contains("statusId")),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(OkJson(OrderListJson));
+        // GetOrdersByStatusAsync — return two orders on page 1
+        mock.Setup(x => x.GetOrdersByStatusAsync(-2, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrderListResponse
+            {
+                Data = new OrderListData
+                {
+                    Orders =
+                    [
+                        new OrderSummary
+                        {
+                            Code = CooledOrderCode,
+                            Status = new OrderStatusSummary { Id = -2 },
+                            Shipping = new OrderShippingSummary { Guid = ZasilkovnaDoRukyGuid, Name = "Zásilkovna (do ruky)" },
+                            Price = new OrderPriceSummary { WithVat = 500.00m, CurrencyCode = "CZK" },
+                        },
+                        new OrderSummary
+                        {
+                            Code = NormalOrderCode,
+                            Status = new OrderStatusSummary { Id = -2 },
+                            Shipping = new OrderShippingSummary { Guid = ZasilkovnaDoRukyGuid, Name = "Zásilkovna (do ruky)" },
+                            Price = new OrderPriceSummary { WithVat = 300.00m, CurrencyCode = "CZK" },
+                        },
+                    ],
+                    Paginator = new Paginator { TotalCount = 2, Page = 1, PageCount = 1 },
+                },
+            });
 
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.Is<HttpRequestMessage>(r =>
-                    r.Method == HttpMethod.Get &&
-                    r.RequestUri!.AbsolutePath == $"/api/orders/{CooledOrderCode}"),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(OkJson(CooledOrderDetailJson));
+        // GetExpeditionOrderDetailAsync — cooled order
+        mock.Setup(x => x.GetExpeditionOrderDetailAsync(CooledOrderCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExpeditionOrderDetail
+            {
+                Code = CooledOrderCode,
+                FullName = "Cooled Customer",
+                Phone = "+420111222333",
+                BillingAddress = new ExpeditionAddress
+                {
+                    FullName = "Cooled Customer",
+                    Street = "Chladna",
+                    HouseNumber = "1",
+                    City = "Praha",
+                    Zip = "10000",
+                },
+                Items =
+                [
+                    new ExpeditionOrderItemDto
+                    {
+                        ItemType = "product",
+                        ItemId = 1,
+                        Code = CooledProductCode,
+                        Name = "Cooled Product",
+                        Amount = 1m,
+                        Unit = "ks",
+                        ItemPriceWithVat = "100.00",
+                    },
+                ],
+                Completion = [],
+            });
 
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.Is<HttpRequestMessage>(r =>
-                    r.Method == HttpMethod.Get &&
-                    r.RequestUri!.AbsolutePath == $"/api/orders/{NormalOrderCode}"),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(OkJson(NormalOrderDetailJson));
+        // GetExpeditionOrderDetailAsync — normal order
+        mock.Setup(x => x.GetExpeditionOrderDetailAsync(NormalOrderCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExpeditionOrderDetail
+            {
+                Code = NormalOrderCode,
+                FullName = "Normal Customer",
+                Phone = "+420444555666",
+                BillingAddress = new ExpeditionAddress
+                {
+                    FullName = "Normal Customer",
+                    Street = "Normalni",
+                    HouseNumber = "2",
+                    City = "Brno",
+                    Zip = "60200",
+                },
+                Items =
+                [
+                    new ExpeditionOrderItemDto
+                    {
+                        ItemType = "product",
+                        ItemId = 2,
+                        Code = NormalProductCode,
+                        Name = "Normal Product",
+                        Amount = 1m,
+                        Unit = "ks",
+                        ItemPriceWithVat = "80.00",
+                    },
+                ],
+                Completion = [],
+            });
 
+        // SetAdditionalFieldAsync
         if (patchShouldThrow)
         {
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(r =>
-                        r.Method == HttpMethod.Patch &&
-                        r.RequestUri!.AbsolutePath == $"/api/orders/{CooledOrderCode}/notes"),
-                    ItExpr.IsAny<CancellationToken>())
+            mock.Setup(x => x.SetAdditionalFieldAsync(
+                    CooledOrderCode,
+                    It.IsAny<int>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException("Simulated Shoptet PATCH failure"));
         }
         else
         {
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(r =>
-                        r.Method == HttpMethod.Patch &&
-                        r.RequestUri!.AbsolutePath == $"/api/orders/{CooledOrderCode}/notes"),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(OkJson("""{"data":null,"errors":null}"""));
+            mock.Setup(x => x.SetAdditionalFieldAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
         }
 
-        return handler;
+        return mock;
     }
 
-    private ShoptetApiExpeditionListSource BuildSource(
-        Mock<HttpMessageHandler> handler,
+    private static ShoptetApiExpeditionListSource BuildSource(
+        Mock<IShoptetExpeditionOrderSource> orderSource,
         ILogger<ShoptetApiExpeditionListSource>? logger = null,
         string? coolingText = null,
         Action<ExpeditionProtocolData>? captureData = null)
     {
-        var http = new HttpClient(handler.Object) { BaseAddress = new Uri("https://test.myshoptet.com") };
-        var client = new ShoptetOrderClient(http, Options.Create(new ShoptetOrdersSettings()));
-
         var catalog = new Mock<ICatalogRepository>();
         catalog.Setup(x => x.GetByIdAsync(CooledProductCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CatalogAggregate
@@ -205,7 +172,7 @@ public class ShoptetApiExpeditionListSource_CoolingMarkerTests
             .ReturnsAsync(GiftSetting.CreateDefault());
 
         return new ShoptetApiExpeditionListSource(
-            client,
+            orderSource.Object,
             TimeProvider.System,
             catalog.Object,
             carrierCooling.Object,
@@ -229,43 +196,43 @@ public class ShoptetApiExpeditionListSource_CoolingMarkerTests
     [Fact]
     public async Task CreatePickingList_CooledOrder_PatchesShoptetAdditionalField()
     {
-        var handler = BuildHandler();
-        var source = BuildSource(handler);
+        var orderSource = BuildOrderSource();
+        var source = BuildSource(orderSource);
 
         await source.CreatePickingList(BuildRequest(), null, CancellationToken.None);
 
-        handler.Protected().Verify(
-            "SendAsync",
-            Times.Once(),
-            ItExpr.Is<HttpRequestMessage>(r =>
-                r.Method == HttpMethod.Patch &&
-                r.RequestUri!.AbsolutePath == $"/api/orders/{CooledOrderCode}/notes"),
-            ItExpr.IsAny<CancellationToken>());
+        orderSource.Verify(
+            x => x.SetAdditionalFieldAsync(
+                CooledOrderCode,
+                PickingListBatchProcessor.CoolingAdditionalFieldIndex,
+                PickingListBatchProcessor.CoolingMarkerValue,
+                It.IsAny<CancellationToken>()),
+            Times.Once());
     }
 
     [Fact]
     public async Task CreatePickingList_NonCooledOrder_DoesNotPatchAdditionalField()
     {
-        var handler = BuildHandler();
-        var source = BuildSource(handler);
+        var orderSource = BuildOrderSource();
+        var source = BuildSource(orderSource);
 
         await source.CreatePickingList(BuildRequest(), null, CancellationToken.None);
 
-        handler.Protected().Verify(
-            "SendAsync",
-            Times.Never(),
-            ItExpr.Is<HttpRequestMessage>(r =>
-                r.Method == HttpMethod.Patch &&
-                r.RequestUri!.AbsolutePath == $"/api/orders/{NormalOrderCode}/notes"),
-            ItExpr.IsAny<CancellationToken>());
+        orderSource.Verify(
+            x => x.SetAdditionalFieldAsync(
+                NormalOrderCode,
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never());
     }
 
     [Fact]
     public async Task CreatePickingList_PatchFails_PdfStillCompletes()
     {
         var logger = new Mock<ILogger<ShoptetApiExpeditionListSource>>();
-        var handler = BuildHandler(patchShouldThrow: true);
-        var source = BuildSource(handler, logger.Object);
+        var orderSource = BuildOrderSource(patchShouldThrow: true);
+        var source = BuildSource(orderSource, logger.Object);
 
         var result = await source.CreatePickingList(BuildRequest(), null, CancellationToken.None);
 
@@ -285,8 +252,8 @@ public class ShoptetApiExpeditionListSource_CoolingMarkerTests
     public async Task CreatePickingList_CooledOrder_UsesCustomCoolingTextFromSetting()
     {
         ExpeditionProtocolData? captured = null;
-        var handler = BuildHandler();
-        var source = BuildSource(handler, coolingText: "MRAZ", captureData: d => captured = d);
+        var orderSource = BuildOrderSource();
+        var source = BuildSource(orderSource, coolingText: "MRAZ", captureData: d => captured = d);
 
         await source.CreatePickingList(BuildRequest(), null, CancellationToken.None);
 
@@ -295,91 +262,67 @@ public class ShoptetApiExpeditionListSource_CoolingMarkerTests
         cooledOrder.CoolingText.Should().Be("MRAZ");
     }
 
-    private Mock<HttpMessageHandler> BuildTwoBatchHandler()
-    {
-        var handler = new Mock<HttpMessageHandler>();
-
-        // Two orders, 7 items each = 14 total items > MaxItems (13), forcing a mid-loop overflow flush
-        var orderCodes = new[] { "BATCH-ORDER-A", "BATCH-ORDER-B" };
-
-        var twoOrderList = $$"""
-            {
-              "data": {
-                "orders": [
-                  {
-                    "code": "{{orderCodes[0]}}",
-                    "status": { "id": -2 },
-                    "shipping": { "guid": "{{ZasilkovnaDoRukyGuid}}", "name": "Zásilkovna (do ruky)" },
-                    "price": { "withVat": "300.00", "currencyCode": "CZK" }
-                  },
-                  {
-                    "code": "{{orderCodes[1]}}",
-                    "status": { "id": -2 },
-                    "shipping": { "guid": "{{ZasilkovnaDoRukyGuid}}", "name": "Zásilkovna (do ruky)" },
-                    "price": { "withVat": "300.00", "currencyCode": "CZK" }
-                  }
-                ],
-                "paginator": { "totalCount": 2, "page": 1, "pageCount": 1 }
-              }
-            }
-            """;
-
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.Is<HttpRequestMessage>(r =>
-                    r.Method == HttpMethod.Get &&
-                    r.RequestUri!.AbsolutePath == "/api/orders" &&
-                    r.RequestUri.Query.Contains("statusId")),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(OkJson(twoOrderList));
-
-        // 7 items per order JSON builder (inline)
-        foreach (var code in orderCodes)
-        {
-            var items = string.Join(",\n", Enumerable.Range(1, 7).Select(i =>
-                $"{{ \"itemType\": \"product\", \"itemId\": {i}, \"code\": \"{NormalProductCode}\", \"name\": \"Item{i}\", \"amount\": 1, \"unit\": \"ks\", \"itemPriceWithVat\": \"10.00\" }}"));
-
-            var orderJson = $@"{{
-  ""data"": {{
-    ""order"": {{
-      ""code"": ""{code}"",
-      ""fullName"": ""Customer {code}"",
-      ""phone"": ""+420000000000"",
-      ""billingAddress"": {{
-        ""fullName"": ""Customer {code}"",
-        ""street"": ""Test"",
-        ""houseNumber"": ""1"",
-        ""city"": ""Praha"",
-        ""zip"": ""10000""
-      }},
-      ""items"": [
-        {items}
-      ],
-      ""completion"": []
-    }}
-  }}
-}}";
-
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(r =>
-                        r.Method == HttpMethod.Get &&
-                        r.RequestUri!.AbsolutePath == $"/api/orders/{code}"),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(OkJson(orderJson));
-        }
-
-        return handler;
-    }
-
     [Fact]
     public async Task CreatePickingList_MultipleBatches_FilenamesContainSequentialBatchIndex()
     {
-        // Two orders with 7 items each = 14 total items, exceeding MaxItems=13, forcing a mid-loop overflow flush.
-        // This locks in the batchIndex pass-through behavior after the PickingListBatchProcessor refactor.
-        var handler = BuildTwoBatchHandler();
-        var source = BuildSource(handler);
+        // Two orders with 7 items each = 14 total items, exceeding MaxItems=13 for Zásilkovna,
+        // forcing a mid-loop overflow flush. Locks in batchIndex pass-through behavior.
+        var orderSource = new Mock<IShoptetExpeditionOrderSource>();
 
+        var orderCodes = new[] { "BATCH-ORDER-A", "BATCH-ORDER-B" };
+
+        orderSource.Setup(x => x.GetOrdersByStatusAsync(-2, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrderListResponse
+            {
+                Data = new OrderListData
+                {
+                    Orders = orderCodes.Select(code => new OrderSummary
+                    {
+                        Code = code,
+                        Status = new OrderStatusSummary { Id = -2 },
+                        Shipping = new OrderShippingSummary { Guid = ZasilkovnaDoRukyGuid, Name = "Zásilkovna (do ruky)" },
+                        Price = new OrderPriceSummary { WithVat = 300.00m, CurrencyCode = "CZK" },
+                    }).ToList(),
+                    Paginator = new Paginator { TotalCount = 2, Page = 1, PageCount = 1 },
+                },
+            });
+
+        foreach (var code in orderCodes)
+        {
+            var capturedCode = code;
+            orderSource.Setup(x => x.GetExpeditionOrderDetailAsync(capturedCode, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ExpeditionOrderDetail
+                {
+                    Code = capturedCode,
+                    FullName = $"Customer {capturedCode}",
+                    Phone = "+420000000000",
+                    BillingAddress = new ExpeditionAddress
+                    {
+                        FullName = $"Customer {capturedCode}",
+                        Street = "Test",
+                        HouseNumber = "1",
+                        City = "Praha",
+                        Zip = "10000",
+                    },
+                    Items = Enumerable.Range(1, 7).Select(i => new ExpeditionOrderItemDto
+                    {
+                        ItemType = "product",
+                        ItemId = i,
+                        Code = NormalProductCode,
+                        Name = $"Item{i}",
+                        Amount = 1m,
+                        Unit = "ks",
+                        ItemPriceWithVat = "10.00",
+                    }).ToList(),
+                    Completion = [],
+                });
+        }
+
+        orderSource.Setup(x => x.SetAdditionalFieldAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var source = BuildSource(orderSource);
         var result = await source.CreatePickingList(BuildRequest(), null, CancellationToken.None);
 
         result.ExportedFiles.Should().HaveCount(2);


### PR DESCRIPTION
## What the issue was

Three adapter classes (`ShoptetApiPackingOrderClient`, `ShoptetApiExpeditionListSource`, `PickingListBatchProcessor`) depended directly on the concrete `ShoptetOrderClient` class instead of an interface, making unit testing impossible without a live HTTP stack.

## How it was fixed / handled

Introduced a narrow intra-adapter interface `IShoptetExpeditionOrderSource` in the `Anela.Heblo.Adapters.ShoptetApi.Orders` namespace with exactly the five methods needed by these adapters:

- `GetOrdersByStatusAsync`
- `GetExpeditionOrderDetailAsync`
- `GetOrderStatusIdAsync`
- `UpdateStatusAsync`
- `SetAdditionalFieldAsync`

`ShoptetOrderClient` now implements both `IEshopOrderClient` and `IShoptetExpeditionOrderSource`. A factory-delegate DI registration (`sp => sp.GetRequiredService<ShoptetOrderClient>()`) reuses the existing typed `HttpClient` registration for both interfaces.

Both test classes that previously constructed a real `ShoptetOrderClient` over a mock `HttpMessageHandler` were rewritten to use `Mock<IShoptetExpeditionOrderSource>`, removing all JSON-over-HTTP fixture plumbing from the unit test layer.

## Artifacts

Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3195/`.