### PR TITLE
#3220: stop loading allocations in GetConsumptionHistoryHandler name lookup

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetConsumptionHistory/GetConsumptionHistoryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetConsumptionHistory/GetConsumptionHistoryHandler.cs
@@ -45,7 +45,7 @@ public class GetConsumptionHistoryHandler
         var (records, totalCount) = await _repository.GetConsumptionHistoryAsync(
             filter, skip, pageSize, ascending: !request.SortDescending, cancellationToken);
 
-        var materialNames = (await _repository.GetAllWithAllocationsAsync(cancellationToken))
+        var materialNames = (await _repository.GetAllAsync(cancellationToken))
             .ToDictionary(m => m.Id, m => m.Name);
 
         var items = records.Select(r => MapToDto(r, materialNames)).ToList();


### PR DESCRIPTION
## What the issue was

`GetConsumptionHistoryHandler.Handle` was calling `GetAllWithAllocationsAsync` to build a `Dictionary<int, string>` mapping material IDs to names. That method performs an `Include(pm => pm.Allocations)` eager-load, pulling every allocation row from the database even though only `PackingMaterial.Name` is ever accessed. The allocation data was immediately discarded on every call to the consumption-history endpoint.

## How it was fixed

Replaced the call at line 48 of `GetConsumptionHistoryHandler.cs` with `GetAllAsync`, which is the correct method for a plain entity fetch (no JOIN to `PackingMaterialAllocation`). `GetAllAsync` is already defined on `BaseRepository<PackingMaterial, int>` and is used by other handlers such as `GetPackingMaterialsListHandler`. The `materialNames` dictionary structure and the handler response shape are unchanged.

No interface, repository, mock, or test changes were needed — `MockPackingMaterialRepository.GetAllAsync` was already correctly implemented and all 4 existing handler tests continue to pass.

Closes #3220