### PR TITLE
fix(ha): raise RequestTimeoutSeconds 3→10 for Tailscale endpoint

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -82,7 +82,7 @@
     "InnerHumidityEntityId": "sensor.temp17_vytobna_humidity",
     "OuterTemperatureEntityId": "sensor.d32_kurnik_kurnik_venku_teplota",
     "OuterHumidityEntityId": "sensor.d32_kurnik_kurnik_venku_vlhkost",
-    "RequestTimeoutSeconds": 3,
+    "RequestTimeoutSeconds": 10,
     "ConditionsCacheDurationMinutes": 5
   },
   "Comgate": {


### PR DESCRIPTION
## What the issue was

On 2026-06-18, the telemetry routine detected 20 `TaskCanceledException` exceptions from the HomeAssistant integration (issue #3223). HomeAssistant is accessed via a Tailscale VPN endpoint, which adds round-trip latency that causes the existing 3-second per-attempt HTTP timeout to fire prematurely under normal operating conditions. The Polly retry policy retries up to 2 times, then `FetchSensorValueAsync` catches the final exception and logs a `LogWarning`. Because 4 sensors are fetched in parallel per snapshot cycle, 5 affected cycles × 4 sensors = 20 logged exceptions.

## How it was fixed

Single config change: raised `RequestTimeoutSeconds` from `3` to `10` in `backend/src/Anela.Heblo.API/appsettings.json`.

No code changes are required — `HomeAssistantAdapterServiceCollectionExtensions` already reads `settings.RequestTimeoutSeconds` at startup and passes it to Polly's `AddTimeout`. The gate timeout in `ComputeGateTimeout()` auto-adjusts to `10s × 3 + 1s = 31s` because it derives from the same setting.

**Staging** is unaffected (`HomeAssistant.BaseUrl = ""` in `appsettings.Staging.json` causes the adapter to short-circuit). **Production** picks up the new base value automatically on next deployment (no override in `appsettings.Production.json`).

## Artifacts
Brief, spec, architecture review, and task plan generated in pipeline (stored in `artifacts/feat-3223/`, excluded from git by `.gitignore`).

Closes #3223

---
_Generated by [Claude Code](https://claude.ai/code/session_0165b2VS42wF32EyRg3ZTXrS)_