### PR TITLE
fix(dashboard): guard against undefined source in ConditionsTile (#3224)

### DIFF
--- a/frontend/src/components/dashboard/tiles/ConditionsTile.tsx
+++ b/frontend/src/components/dashboard/tiles/ConditionsTile.tsx
@@ -33,7 +33,7 @@ export const ConditionsTile: React.FC<ConditionsTileProps> = ({ data }) => {
   const d = data.data;
   if (!d) return null;
 
-  const src = SOURCE_LABEL[d.source];
+  const src = SOURCE_LABEL[d.source] ?? { label: d.source, cls: 'bg-gray-100 text-gray-700' };
   const recorded = new Date(d.recordedAt);
 
   return (


### PR DESCRIPTION
## What the issue was

App Insights captured a frontend `TypeError: Cannot read properties of undefined (reading 'cls') at vx` on 2026-06-18. The minified symbol `vx` corresponds to the `ConditionsTile` component in the dashboard.

The component uses a `SOURCE_LABEL` lookup table keyed by the `source` field from the API:

```ts
const SOURCE_LABEL: Record<Source, { label: string; cls: string }> = { ... };
const src = SOURCE_LABEL[d.source]; // could be undefined
<span className={`... ${src.cls}`}>  // crashes if src is undefined
```

If the backend returns an unexpected or new `source` value (not one of `'Live' | 'Partial' | 'Unavailable'`), the lookup returns `undefined` and the subsequent `.cls` access throws.

## How it was fixed

Added a nullish-coalescing fallback so that an unknown `source` value renders a neutral grey badge instead of crashing the component:

```ts
const src = SOURCE_LABEL[d.source] ?? { label: d.source, cls: 'bg-gray-100 text-gray-700' };
```

This is a one-line surgical fix. No type changes, no behavioural change for known source values.

## Verification

- `npm run build` passes (exit code 0)
- No lint errors in the changed file
- Fix closes #3224

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMyuHnQ2xktvPXGjdJqKgu)_