### PR TITLE
#3225: Remove duplicate service registrations in CatalogModule

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -86,10 +86,6 @@ public static class CatalogModule
         services.AddTransient<IMarginCalculationService, MarginCalculationService>();
         services.AddSingleton<ICatalogResilienceService, CatalogResilienceService>();
         services.AddSingleton<ICatalogMergeScheduler, CatalogMergeScheduler>();
-        services.AddSingleton<CatalogCacheStore>();
-        services.AddSingleton<CatalogMergeService>();
-        services.AddTransient<CatalogDataRefreshService>();
-        services.AddHostedService<CatalogMergeCallbackWiring>();
         services.AddTransient<SafeMarginCalculator>();
         services.AddTransient<IProductWeightRecalculationService, ProductWeightRecalculationService>();
         services.AddTransient<IStockUpProcessingService, StockUpProcessingService>();


### PR DESCRIPTION
## What the issue was

`CatalogModule.AddCatalogModule` registered four services twice:
- `CatalogCacheStore` (singleton) — duplicate descriptor visible via `IEnumerable<T>` resolution
- `CatalogMergeService` (singleton) — same issue
- `CatalogDataRefreshService` (transient) — harmless but confusing and increases startup overhead
- `CatalogMergeCallbackWiring` (hosted service) — **most impactful**: `AddHostedService` creates a new descriptor each time, so the host started two instances of this service, each calling `_scheduler.SetMergeCallback(...)` at startup

## How it was fixed / handled

Pure deletion of the four duplicate lines (89–92 in the original file). The first registration block (lines 76–79) is sufficient. Zero behaviour change for correct production paths; removes the latent double-hosted-service bug.

Build: ✅ 0 errors · Tests: ✅ 5148 passed (56 Docker integration tests skipped — pre-existing, environment has no Docker)

Fixes #3225

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo4baK2xWkjRnrV6DE3vsC)_