### PR TITLE
#3226: Remove dead private method ComputeCostsAsync from DirectManufactureCostProvider

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CostProviders/DirectManufactureCostProvider.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CostProviders/DirectManufactureCostProvider.cs
@@ -118,35 +118,6 @@ public class DirectManufactureCostProvider : IDirectManufactureCostProvider
         };
     }
 
-    private async Task<Dictionary<string, List<MonthlyCost>>> ComputeCostsAsync(
-        List<string>? productCodes,
-        DateOnly? dateFrom,
-        DateOnly? dateTo,
-        CancellationToken ct)
-    {
-        await _catalogRepository.WaitForCurrentMergeAsync(ct);
-        var products = await _catalogRepository.GetAllAsync(ct);
-
-        var from = dateFrom ?? DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-_options.Value.ManufactureCostHistoryDays));
-        var to = dateTo ?? DateOnly.FromDateTime(DateTime.UtcNow);
-
-        var productCosts = new Dictionary<string, List<MonthlyCost>>();
-
-        foreach (var product in products)
-        {
-            if (string.IsNullOrEmpty(product.ProductCode))
-                continue;
-
-            if (productCodes != null && !productCodes.Contains(product.ProductCode))
-                continue;
-
-            var monthlyCosts = CalculateDirectManufacturingCosts(product, from, to);
-            productCosts[product.ProductCode] = monthlyCosts;
-        }
-
-        return productCosts;
-    }
-
     private List<MonthlyCost> CalculateDirectManufacturingCosts(CatalogAggregate product, DateOnly dateFrom, DateOnly dateTo)
     {
         // STUB: Returns constant value of 15 (per spec section 2.3)


### PR DESCRIPTION
## What the issue was

`DirectManufactureCostProvider` contained a private method `ComputeCostsAsync` (28 lines) that was never called from anywhere in the codebase. The two active code paths in the class bypassed it entirely:
- `GetCostsAsync` reads from cache directly
- `RefreshAsync` calls `ComputeAllCostsAsync` (a different method)

The dead method appeared to be a leftover from before the cache-first architecture was adopted, duplicating logic that already lives in `ComputeAllCostsAsync`.

## How it was fixed

Deleted lines 121–148 (`ComputeCostsAsync`) from `DirectManufactureCostProvider.cs`. No call sites existed, so the deletion is a pure removal with no behavioural change. Build verified clean (`Build succeeded, 0 Error(s)`).

## Artifacts
Closes #3226