### PR TITLE
#3192: Move OrgChartService to Anela.Heblo.Adapters.OrgChart

### DIFF
--- a/Anela.Heblo.sln
+++ b/Anela.Heblo.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.FileSy
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Microsoft365", "backend\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj", "{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.OrgChart", "backend\src\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj", "{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -477,6 +479,18 @@ Global
 		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|x64.Build.0 = Release|Any CPU
 		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|x86.ActiveCfg = Release|Any CPU
 		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}.Release|x86.Build.0 = Release|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Debug|x64.Build.0 = Debug|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Debug|x86.Build.0 = Debug|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Release|x64.ActiveCfg = Release|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Release|x64.Build.0 = Release|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -518,5 +532,6 @@ Global
 		{ACA057C0-6F29-408A-A069-E9270E4480CF} = {87237941-D198-446F-919C-467E4968E85F}
 		{2E2AA044-B62E-49E3-8286-A585EB988086} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 	EndGlobalSection
 EndGlobal

--- a/artifacts/feat-3192/arch-review.r1.md
+++ b/artifacts/feat-3192/arch-review.r1.md
@@ -1,0 +1,206 @@
+# Architecture Review: Move OrgChartService to Dedicated Adapter Project
+
+## Skip Design: false
+
+## Architectural Fit Assessment
+
+This is a pure structural refactor with no functional change. The violation is well-understood and well-scoped: `OrgChartService` is a concrete `HttpClient`-based class that was placed inside `Anela.Heblo.Application/Features/OrgChart/Infrastructure/` — a directory that does not exist as a pattern in any other feature module in the Application project. Every other I/O-bound service in the codebase already lives under `backend/src/Adapters/`, each in its own project with its own `ServiceCollectionExtensions` class. The fix is mechanical: create a new adapter project, move one file, create one extensions class, update three project files (new `.csproj`, `API.csproj`, `Anela.Heblo.sln`), and trim one registration call from `OrgChartModule`.
+
+Verified against the codebase:
+
+- `OrgChartService.cs` uses `HttpClient` directly (constructor-injected typed client). The class namespace is `Anela.Heblo.Application.Features.OrgChart.Infrastructure`.
+- `OrgChartModule.cs` registers both `AddOptions<OrgChartOptions>()` and `AddHttpClient<IOrgChartService, OrgChartService>()`. After this change only the options registration remains.
+- `Anela.Heblo.Application.csproj` does **not** list `Microsoft.Extensions.Http` as an explicit dependency; `HttpClient` compiles today only through transitive resolution. NFR-3 (removing the direct dependency) is satisfied by moving the concrete class — no package removal is needed in the Application csproj because no explicit reference exists.
+- The solution file registers all adapter projects under the `Adapters` solution folder (GUID `{4B6F17C3-0A57-487A-BE8C-1808B40EC604}`) with a `NestedProjects` entry. The new project must follow this same registration pattern.
+- `Program.cs` has a clearly delimited Adapters section (lines 104–119). `AddOrgChartAdapter` belongs immediately after `AddMicrosoft365Adapter` at line 119 to maintain alphabetical-ish grouping.
+- The minimal csproj pattern for a simple typed-HttpClient adapter (no Polly, no domain-specific libraries) is best matched by `Anela.Heblo.Adapters.Cups` — two NuGet packages (`Microsoft.Extensions.Http`, `Microsoft.Extensions.Options.ConfigurationExtensions`) plus a project reference to `Anela.Heblo.Application`.
+
+The spec is correct and complete. No amendments are required.
+
+---
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/src/
+  Adapters/
+    Anela.Heblo.Adapters.OrgChart/               ← NEW project
+      Anela.Heblo.Adapters.OrgChart.csproj       ← NEW
+      OrgChartService.cs                         ← MOVED from Application
+      OrgChartAdapterServiceCollectionExtensions.cs  ← NEW
+
+  Anela.Heblo.Application/
+    Features/OrgChart/
+      Infrastructure/                            ← DELETED (empty after move)
+      OrgChartModule.cs                          ← MODIFIED (remove AddHttpClient call)
+      OrgChartOptions.cs                         ← UNCHANGED
+      Services/IOrgChartService.cs               ← UNCHANGED
+      Contracts/                                 ← UNCHANGED
+      UseCases/                                  ← UNCHANGED
+
+  Anela.Heblo.API/
+    Anela.Heblo.API.csproj                       ← MODIFIED (add project reference)
+    Program.cs                                   ← MODIFIED (add using + AddOrgChartAdapter call)
+
+Anela.Heblo.sln                                  ← MODIFIED (register new project)
+```
+
+### Key Design Decisions
+
+#### Decision 1: No `OrgChartOptions` in the Adapter Project
+
+**Options considered:**
+- Move `OrgChartOptions` into the adapter project alongside `OrgChartService`.
+- Keep `OrgChartOptions` in Application; let the adapter read it via `IOptions<OrgChartOptions>` through the project reference.
+
+**Chosen approach:** Keep `OrgChartOptions` in Application.
+
+**Rationale:** `OrgChartOptions` contains only the `DataSourceUrl` config key — it is a pure configuration shape with a `[Required]` data annotation. The options class carries no `HttpClient` or infrastructure dependency. Keeping it in Application means `GetOrganizationStructureHandler` (which also reads options indirectly via the service) stays co-located with all other handler-level config. More importantly, this is consistent with how `OrgChartOptions.SectionName` is referenced in `OrgChartModule.AddOrgChartServices` — options registration and options class stay together. Every other adapter that owns its own options class (Comgate's `ComgateSettings`, Cups' `CupsOptions`, Anthropic's `AnthropicOptions`) does so because those options are consumed exclusively in the adapter. `OrgChartOptions` is read by `OrgChartService` through the `IOptions<T>` abstraction, which is resolved at runtime across the project boundary; the Application layer never touches it directly at runtime.
+
+#### Decision 2: Typed `HttpClient` Registration (`AddHttpClient<IOrgChartService, OrgChartService>()`)
+
+**Options considered:**
+- Named `HttpClient` via `IHttpClientFactory` (as used by Anthropic and Cups).
+- Typed `HttpClient` where DI injects `HttpClient` directly into the service constructor.
+
+**Chosen approach:** Keep the typed `HttpClient` registration — `services.AddHttpClient<IOrgChartService, OrgChartService>()` — exactly as it exists today in `OrgChartModule`.
+
+**Rationale:** This is the existing registration; changing it would be scope creep and would alter the `HttpClient` lifecycle (typed clients are scoped, named clients are transient from factory). The spec explicitly prohibits behaviour changes. The typed pattern is also appropriate here: `OrgChartService` is the only consumer of this `HttpClient`, and typed clients provide the cleanest injection surface for single-consumer cases.
+
+#### Decision 3: No Polly Packages in the New Project
+
+**Options considered:**
+- Include `Polly` and `Polly.Extensions` in the new csproj to match Comgate and Anthropic adapters.
+- Omit Polly; add it only if resilience is introduced in a follow-up.
+
+**Chosen approach:** Omit Polly.
+
+**Rationale:** The spec explicitly excludes resilience policies. Adding Polly now would be dead weight — unused package references increase build surface. The Cups adapter (the best structural match for this new project) omits Polly. When resilience is added in a follow-up, the package can be added at that time.
+
+#### Decision 4: Solution File Registration
+
+**Options considered:**
+- Rely on directory-based project discovery (if the repo uses that mechanism).
+- Add the project explicitly to `Anela.Heblo.sln`.
+
+**Chosen approach:** Add the project explicitly to `Anela.Heblo.sln` under the existing `Adapters` solution folder.
+
+**Rationale:** Inspection of `Anela.Heblo.sln` confirms the repo uses explicit solution-file registration, not directory-based discovery. All 13 existing adapter projects are listed with individual `Project(...)` entries and `NestedProjects` mappings. A new project that is not in the solution file will not appear in IDE solution views and will not be built by `dotnet build Anela.Heblo.sln`. The new project must be added to the `{4B6F17C3-0A57-487A-BE8C-1808B40EC604}` Adapters folder in the solution.
+
+---
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/
+  Anela.Heblo.Adapters.OrgChart.csproj
+  OrgChartService.cs
+  OrgChartAdapterServiceCollectionExtensions.cs
+```
+
+No subdirectories. The adapter has one service class and one registration class — flat layout matches Comgate and SendGrid adapters at this scale.
+
+### Interfaces and Contracts
+
+Nothing changes externally. For reference, the unchanged contracts:
+
+- **`IOrgChartService`** — `Anela.Heblo.Application.Features.OrgChart.Services` — single method `Task<OrgChartResponse> GetOrganizationStructureAsync(CancellationToken)`.
+- **`OrgChartOptions`** — `Anela.Heblo.Application.Features.OrgChart` — one property: `string DataSourceUrl`.
+- **`OrgChartResponse` / `OrganizationDto` / `PositionDto` / `EmployeeDto`** — `Anela.Heblo.Application.Features.OrgChart.Contracts` — unchanged.
+
+The new extension method signature:
+
+```csharp
+// Anela.Heblo.Adapters.OrgChart.OrgChartAdapterServiceCollectionExtensions
+public static IServiceCollection AddOrgChartAdapter(
+    this IServiceCollection services,
+    IConfiguration configuration)
+```
+
+The `IConfiguration` parameter is required by the spec and matches all peer adapters. For this particular adapter the `configuration` parameter is not read inside `AddOrgChartAdapter` itself (options binding lives in `OrgChartModule`), but it is included for consistency and future use (e.g., if a base URL is ever configured on the `HttpClient` directly).
+
+### Data Flow
+
+No change to runtime data flow. For clarity:
+
+```
+HTTP request → OrgChartController
+  → GetOrganizationStructureRequest (MediatR)
+    → GetOrganizationStructureHandler (Application)
+      → IOrgChartService.GetOrganizationStructureAsync()
+        → OrgChartService (Adapters.OrgChart) — resolved by DI
+          → HttpClient (typed, registered by AddOrgChartAdapter)
+            → external JSON data source (DataSourceUrl from OrgChartOptions)
+```
+
+The only change is which assembly `OrgChartService` is compiled into. DI resolution is identical.
+
+### Step-by-Step Implementation Order
+
+Execute in this order to keep the solution buildable at each step:
+
+1. **Create** `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj`
+   - `TargetFramework=net8.0`, `Nullable=enable`, `ImplicitUsings=enable`, `RootNamespace=Anela.Heblo.Adapters.OrgChart`
+   - NuGet: `Microsoft.Extensions.Http 8.0.0`, `Microsoft.Extensions.Options.ConfigurationExtensions 8.0.0`
+   - Project reference: `..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj`
+
+2. **Move** `OrgChartService.cs` to `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs`
+   - Update namespace: `Anela.Heblo.Adapters.OrgChart`
+   - All `using` statements remain valid through the project reference
+
+3. **Create** `OrgChartAdapterServiceCollectionExtensions.cs` in the new project
+   - Single method: `AddOrgChartAdapter(this IServiceCollection services, IConfiguration configuration)`
+   - Body: `services.AddHttpClient<IOrgChartService, OrgChartService>(); return services;`
+   - Usings: `Anela.Heblo.Application.Features.OrgChart.Services`, `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`
+
+4. **Modify** `OrgChartModule.cs` in Application
+   - Remove: `using Anela.Heblo.Application.Features.OrgChart.Infrastructure;`
+   - Remove: `services.AddHttpClient<IOrgChartService, OrgChartService>();`
+   - Remove: `using Microsoft.Extensions.DependencyInjection;` only if it is no longer needed (check — `IServiceCollection` extension methods are still there, so it stays)
+   - The options registration block is unchanged
+
+5. **Delete** `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/` directory (now empty)
+
+6. **Modify** `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+   - Add: `<ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj" />`
+
+7. **Modify** `backend/src/Anela.Heblo.API/Program.cs`
+   - Add using: `using Anela.Heblo.Adapters.OrgChart;`
+   - Add after line 119 (`AddMicrosoft365Adapter`): `builder.Services.AddOrgChartAdapter(builder.Configuration);`
+
+8. **Modify** `Anela.Heblo.sln`
+   - Add a `Project(...)` block for `Anela.Heblo.Adapters.OrgChart` (generate a fresh GUID)
+   - Add configuration platforms entries for all 6 build configurations
+   - Add a `NestedProjects` entry mapping the new project GUID to the Adapters folder GUID `{4B6F17C3-0A57-487A-BE8C-1808B40EC604}`
+
+9. **Verify**: `dotnet build` at solution root → 0 errors, 0 new warnings. `dotnet format` → no changes.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Forgetting to delete the `Infrastructure/` subdirectory, leaving a dangling empty folder | Low | Step 5 explicitly covers deletion. Verify with `find` after the move. |
+| Compiler resolving `HttpClient` transitively in Application even after the move, masking any residual reference | Low | After the move, `grep -r "HttpClient" backend/src/Anela.Heblo.Application/` should return zero hits (excluding test files). |
+| Solution file GUID collision if generated non-randomly | Low | Use `dotnet new classlib` to create the project so the SDK auto-generates a safe GUID, then move the file to the correct path, or use `Guid.NewGuid()` manually. Do not reuse any existing GUID from the solution file. |
+| `OrgChartModule.cs` still compiles after removing `AddHttpClient` because it no longer references `IOrgChartService` or `OrgChartService` directly at the type level | None (positive) | Confirm the `using Anela.Heblo.Application.Features.OrgChart.Infrastructure;` is removed and no CS8019 unused-using warning surfaces with Nullable enabled. |
+| `AddOrgChartAdapter` parameter `IConfiguration configuration` is unused, triggering a lint warning | Low | Add `// reserved for future base-URL configuration` comment, or suppress with `_ = configuration;` if the linter flags it. Check peer adapters — Comgate and Cups both use their `configuration` parameter, so this is the one structural deviation. Simplest fix: omit the parameter and match the call site to a no-arg overload, but that breaks consistency with every other adapter signature. Keep the parameter; document it. |
+
+---
+
+## Specification Amendments
+
+None. The spec is accurate and complete. One observation for the implementer that is not in the spec:
+
+The `IConfiguration configuration` parameter in `AddOrgChartAdapter` will be accepted but unused in the initial implementation (options binding stays in `OrgChartModule`). This is intentional per FR-3 and FR-4. The parameter is kept for signature consistency with all other adapter extension methods and to avoid a breaking change if base-URL configuration is added to the `HttpClient` registration in a future change.
+
+---
+
+## Prerequisites
+
+None. This is a self-contained structural refactor with no external dependencies, no database changes, no frontend changes, and no configuration changes. The task can be executed immediately on a clean branch from `main`.

--- a/artifacts/feat-3192/brief.md
+++ b/artifacts/feat-3192/brief.md
@@ -1,0 +1,34 @@
+## Module
+OrgChart
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` is a concrete `HttpClient`-based service that fetches data from a remote URL. It is compiled into the `Anela.Heblo.Application` project rather than a dedicated adapter project.
+
+Every other I/O-bound service in this codebase lives under `backend/src/Adapters/`:
+- `Anela.Heblo.Adapters.Flexi` — all Flexi API clients
+- `Anela.Heblo.Adapters.Comgate` — `ComgateBankClient`
+- `Anela.Heblo.Adapters.Cups` — `CupsPrintingService`
+- `Anela.Heblo.Adapters.Azure` — `AzureBlobPrintQueueSink`
+- `Anela.Heblo.Adapters.Anthropic` — `AnthropicChatClient`
+- `Anela.Heblo.Adapters.GoogleAds` — `GoogleAdsTransactionSource`
+
+`filesystem.md` states the rule explicitly: *"Concrete `IPrintQueueSink` implementations and any I/O-bound service live in adapter projects under `backend/src/Adapters/`, not in `Features/{Feature}/Services/`."*
+
+`OrgChartService` is placed in `Features/OrgChart/Infrastructure/` (within the Application project), not in an adapter project. The consequence is that `Anela.Heblo.Application` carries a runtime dependency on `HttpClient` and external network I/O — a violation of the Clean Architecture rule that the Application layer must not depend on infrastructure concerns.
+
+## Why it matters
+- Breaks the dependency rule: Application layer should depend only on abstractions; the concrete `HttpClient`-based implementation belongs in the infrastructure/adapter ring.
+- Inconsistent with every other I/O adapter in the repo, increasing cognitive load when navigating.
+- Prevents the Application project from being tested in complete isolation (without network stubbing at the `HttpClient` level).
+
+## Suggested fix
+Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/` (new project, one file is sufficient):
+
+1. Move `OrgChartService.cs` into `Anela.Heblo.Adapters.OrgChart/`.
+2. Keep `IOrgChartService` in `Application/Features/OrgChart/Services/` (no change).
+3. Move `services.AddHttpClient()` from `OrgChartModule.cs` into `OrgChartAdapterServiceCollectionExtensions` in the new adapter project (same pattern as `FlexiAdapterServiceCollectionExtensions`, `ComgateAdapterServiceCollectionExtensions`, etc.).
+4. Wire the adapter in `Program.cs` alongside the other adapters.
+5. `OrgChartOptions` and `OrgChartModule.AddOrgChartServices` can stay in Application if they only register options and MediatR handlers; otherwise move options to the adapter.
+
+---
+_Filed by daily arch-review routine on 2026-06-17._

--- a/artifacts/feat-3192/design.r1.md
+++ b/artifacts/feat-3192/design.r1.md
@@ -1,0 +1,96 @@
+# Design: Move OrgChartService to a Dedicated Adapter Project
+
+## Component Design
+
+### New project: `Anela.Heblo.Adapters.OrgChart`
+
+**Location:** `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/`
+
+**Responsibility:** Owns the HTTP-based implementation of `IOrgChartService`. Isolates the `HttpClient` dependency from the Application layer, matching the pattern of all other adapter projects (Comgate, Cups, Anthropic, HomeAssistant).
+
+**Project configuration:**
+- Target framework: `net8.0`
+- `Nullable`: `enable`
+- `ImplicitUsings`: `enable`
+- `RootNamespace`: `Anela.Heblo.Adapters.OrgChart`
+- Project reference: `Anela.Heblo.Application`
+- NuGet packages: `Microsoft.Extensions.Http`, `Microsoft.Extensions.Options.ConfigurationExtensions`
+- Registered in solution file alongside the other adapter projects
+
+**Files:**
+
+| File | Description |
+|------|-------------|
+| `Anela.Heblo.Adapters.OrgChart.csproj` | Project file with dependencies above |
+| `OrgChartService.cs` | Moved verbatim from Application; namespace changed to `Anela.Heblo.Adapters.OrgChart` |
+| `OrgChartAdapterServiceCollectionExtensions.cs` | New; provides `AddOrgChartAdapter` extension method |
+
+---
+
+### `OrgChartService.cs`
+
+**Source:** `backend/src/Application/Features/OrgChart/Infrastructure/OrgChartService.cs`  
+**Destination:** `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs`
+
+Only change: namespace declaration updated from whatever it currently is to `Anela.Heblo.Adapters.OrgChart`. Implementation body is untouched.
+
+After the move, `backend/src/Application/Features/OrgChart/Infrastructure/` directory is deleted.
+
+---
+
+### `OrgChartAdapterServiceCollectionExtensions.cs`
+
+**Location:** `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`
+
+**Interface:**
+
+```csharp
+namespace Anela.Heblo.Adapters.OrgChart;
+
+public static class OrgChartAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddOrgChartAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddHttpClient<IOrgChartService, OrgChartService>();
+        return services;
+    }
+}
+```
+
+The `HttpClient` typed-client registration previously in `OrgChartModule` moves here and is removed from `OrgChartModule`.
+
+---
+
+### `OrgChartModule.cs` (Application layer — modified)
+
+**Location:** `backend/src/Application/Features/OrgChart/OrgChartModule.cs` (existing file)
+
+**Change:** Remove the `services.AddHttpClient<IOrgChartService, OrgChartService>()` call (or equivalent typed-client registration). `OrgChartOptions` registration and any other module-level wiring remain untouched.
+
+---
+
+### `Program.cs` (API layer — modified)
+
+**Location:** `backend/src/Api/Program.cs` (existing file)
+
+**Change:** Add `builder.Services.AddOrgChartAdapter(builder.Configuration);` immediately after the existing `AddMicrosoft365Adapter` call.
+
+---
+
+### `Anela.Heblo.Api.csproj` (modified)
+
+**Change:** Add a `<ProjectReference>` to `Anela.Heblo.Adapters.OrgChart.csproj` alongside the other adapter references.
+
+---
+
+### Solution file (modified)
+
+Register the new project in `Anela.Heblo.sln` under the same solution folder as the other adapter projects.
+
+---
+
+## Data Schemas
+
+No new API endpoints, request/response shapes, database schemas, or event payloads are introduced. This is a pure structural refactor — all runtime contracts remain identical.

--- a/artifacts/feat-3192/impl/create-adapter-project.r1.md
+++ b/artifacts/feat-3192/impl/create-adapter-project.r1.md
@@ -1,0 +1,53 @@
+# Implementation: create-adapter-project
+
+## What was implemented
+
+Extracted `OrgChartService` from the Application layer's `Infrastructure` sub-folder into a new dedicated class-library project `Anela.Heblo.Adapters.OrgChart`. The DI registration (`AddHttpClient<IOrgChartService, OrgChartService>`) was moved from `OrgChartModule.cs` (Application layer) into a new extension class `OrgChartAdapterServiceCollectionExtensions` in the adapter project. `Program.cs` now calls `AddOrgChartAdapter` alongside the other adapters. The old `Infrastructure/` directory in the Application layer has been removed.
+
+## Files created/modified
+
+- `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj` — new class-library project targeting net8.0, referencing Microsoft.Extensions.Http, Microsoft.Extensions.Options.ConfigurationExtensions, and the Application project
+- `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs` — moved from Application/Features/OrgChart/Infrastructure/; only the namespace changed to `Anela.Heblo.Adapters.OrgChart`; all logic preserved verbatim
+- `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs` — new DI extension class; registers `IOrgChartService` via `AddHttpClient`
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` — removed Infrastructure using, removed `AddHttpClient` call, kept options registration
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` — DELETED
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/` — DELETED (directory)
+- `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj` — added ProjectReference to new adapter
+- `backend/src/Anela.Heblo.API/Program.cs` — added `using Anela.Heblo.Adapters.OrgChart;` and `AddOrgChartAdapter` call after `AddMicrosoft365Adapter`
+- `Anela.Heblo.sln` — added project block, build configuration entries, and NestedProjects entry for new adapter (GUID `{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}`)
+- `backend/test/Anela.Heblo.Tests/Features/OrgChart/OrgChartServiceTests.cs` — updated using from `Anela.Heblo.Application.Features.OrgChart.Infrastructure` to `Anela.Heblo.Adapters.OrgChart`
+- `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — added ProjectReference to new adapter (required by OrgChartServiceTests)
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Features/OrgChart/OrgChartServiceTests.cs` — existing tests for OrgChartService; updated only the using directive to point at the new namespace. No new tests added — pure structural refactor.
+
+## How to verify
+
+```bash
+cd /home/user/worktrees/feature-3192-orgchart-service-to-adapter
+dotnet build Anela.Heblo.sln     # should succeed with 0 errors
+dotnet format Anela.Heblo.sln --verify-no-changes   # should exit 0
+```
+
+## Notes
+
+- The existing `OrgChartServiceTests.cs` in `Anela.Heblo.Tests` referenced the old `Infrastructure` namespace; it was updated to use `Anela.Heblo.Adapters.OrgChart`. The test project's csproj was also updated with a direct ProjectReference to the new adapter.
+- No runtime behaviour changes: the same `AddHttpClient<IOrgChartService, OrgChartService>()` registration is used; the `OrgChartOptions` binding remains in `OrgChartModule.AddOrgChartServices`.
+
+## PR Summary
+
+Extracts the HttpClient-based `OrgChartService` from the Application layer into a new dedicated `Anela.Heblo.Adapters.OrgChart` project, satisfying Clean Architecture's requirement that the Application layer must not carry infrastructure (HTTP) dependencies. No runtime behaviour change.
+
+### Changes
+
+- `Anela.Heblo.Adapters.OrgChart/` — new adapter project (csproj, OrgChartService.cs, OrgChartAdapterServiceCollectionExtensions.cs)
+- `OrgChartModule.cs` — removed `AddHttpClient` call and `Infrastructure` using
+- `Infrastructure/OrgChartService.cs` — deleted
+- `Program.cs` — registers `AddOrgChartAdapter`
+- `Anela.Heblo.API.csproj` — references new adapter
+- `Anela.Heblo.sln` — includes new project
+- `OrgChartServiceTests.cs` / `Anela.Heblo.Tests.csproj` — updated to new namespace/reference
+
+## Status
+DONE

--- a/artifacts/feat-3192/spec.r1.md
+++ b/artifacts/feat-3192/spec.r1.md
@@ -1,0 +1,125 @@
+# Specification: Move OrgChartService to a Dedicated Adapter Project
+
+## Summary
+
+`OrgChartService`, a concrete `HttpClient`-based implementation, currently resides in `Anela.Heblo.Application/Features/OrgChart/Infrastructure/`, violating the Clean Architecture rule that the Application layer must not carry infrastructure dependencies. This task extracts it into a new `Anela.Heblo.Adapters.OrgChart` project, following the identical pattern already established by every other I/O adapter in the codebase (Comgate, Cups, Anthropic, HomeAssistant, etc.). The change is a pure structural refactor — no runtime behaviour changes.
+
+## Background
+
+The `Anela.Heblo.Application` project is the Application layer: it owns MediatR handlers, domain interfaces, and DTOs. All thirteen existing I/O adapters live under `backend/src/Adapters/` and reference `Anela.Heblo.Application` unidirectionally. `OrgChartService` was placed in `Features/OrgChart/Infrastructure/` (still within the Application project), making `Anela.Heblo.Application.csproj` depend on `Microsoft.Extensions.Http` at runtime and pulling network I/O into a layer that should be infrastructure-free.
+
+The consequence is two-fold: the Application project cannot be compiled or tested in isolation without an `HttpClient` harness, and the pattern inconsistency increases cognitive overhead when navigating the codebase. The fix restores consistency and satisfies the documented architecture rule in `docs/architecture/filesystem.md`.
+
+## Functional Requirements
+
+### FR-1: Create the `Anela.Heblo.Adapters.OrgChart` project
+
+Create a new class library project at `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/` mirroring the structure of peer adapter projects.
+
+**Acceptance criteria:**
+- `Anela.Heblo.Adapters.OrgChart.csproj` exists with `TargetFramework=net8.0`, `Nullable=enable`, `ImplicitUsings=enable`, and `RootNamespace=Anela.Heblo.Adapters.OrgChart`.
+- The project references `Anela.Heblo.Application.csproj` (same as Comgate, Anthropic, etc.).
+- NuGet packages include `Microsoft.Extensions.Http` and `Microsoft.Extensions.Options.ConfigurationExtensions` (minimum required; add `Polly`/`Polly.Extensions` only if resilience is added — see FR-5).
+- The project file is added to the solution (or to the existing directory-based project discovery, whichever mechanism the repo uses).
+
+### FR-2: Move `OrgChartService.cs` into the new adapter project
+
+Move `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` to `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs`.
+
+**Acceptance criteria:**
+- The moved file updates its namespace from `Anela.Heblo.Application.Features.OrgChart.Infrastructure` to `Anela.Heblo.Adapters.OrgChart`.
+- All existing `using` statements that reference types from `Anela.Heblo.Application` (contracts, services, options) remain valid via the project reference established in FR-1.
+- The class implementation is unchanged: constructor signature, `GetOrganizationStructureAsync` logic, logging calls, and exception wrapping are identical.
+- The `Infrastructure/` subdirectory inside the Application project is deleted (it will be empty after the move).
+
+### FR-3: Move `HttpClient` registration from `OrgChartModule` to `OrgChartAdapterServiceCollectionExtensions`
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs` that owns the `AddHttpClient<IOrgChartService, OrgChartService>()` call, following the pattern of `ComgateAdapterServiceCollectionExtensions` and `CupsAdapterServiceCollectionExtensions`.
+
+**Acceptance criteria:**
+- The extension method is named `AddOrgChartAdapter(this IServiceCollection services, IConfiguration configuration)`.
+- It registers `services.AddHttpClient<IOrgChartService, OrgChartService>()` (typed HttpClient, same as the current registration in `OrgChartModule`).
+- It does NOT register `OrgChartOptions` (that stays in Application — see FR-4).
+- `OrgChartModule.cs` in Application is updated: the `services.AddHttpClient<IOrgChartService, OrgChartService>()` call is removed; options registration and the method signature remain.
+
+### FR-4: Keep `OrgChartOptions` and `OrgChartModule` in Application
+
+`OrgChartOptions` and `OrgChartModule.AddOrgChartServices` remain in `Anela.Heblo.Application`. `AddOrgChartServices` continues to register options only (`.AddOptions<OrgChartOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`). MediatR handler discovery is unaffected (scan-based).
+
+**Acceptance criteria:**
+- `OrgChartOptions.cs` namespace and location are unchanged.
+- `OrgChartModule.cs` retains options registration and removes only the `AddHttpClient` call.
+- `ApplicationModule.cs` continues to call `services.AddOrgChartServices(configuration)` without modification.
+
+### FR-5: Wire the new adapter in `Program.cs`
+
+Add `builder.Services.AddOrgChartAdapter(builder.Configuration)` in the Adapters section of `backend/src/Anela.Heblo.API/Program.cs`, alongside the other adapter registrations (after line 119, `AddMicrosoft365Adapter`).
+
+**Acceptance criteria:**
+- `using Anela.Heblo.Adapters.OrgChart;` is added to `Program.cs`.
+- `builder.Services.AddOrgChartAdapter(builder.Configuration);` is present in the Adapters block.
+- `Anela.Heblo.API.csproj` references `Anela.Heblo.Adapters.OrgChart.csproj`.
+
+## Non-Functional Requirements
+
+### NFR-1: Build integrity
+
+The solution must compile cleanly after the refactor with no new warnings.
+
+**Acceptance criteria:**
+- `dotnet build` at solution or backend root produces 0 errors and 0 new warnings.
+- `dotnet format` reports no formatting changes.
+
+### NFR-2: No runtime behaviour change
+
+The refactor is purely structural. The `HttpClient` lifecycle, option validation, and error handling must be identical before and after.
+
+**Acceptance criteria:**
+- The typed `HttpClient` is still registered as `AddHttpClient<IOrgChartService, OrgChartService>()` (same pooling, same scoping).
+- `OrgChartOptions` validation-on-start still fires at application startup.
+- The existing `GET /api/orgchart` endpoint returns the same response for the same upstream data.
+
+### NFR-3: Testability
+
+After this change, the Application project must be compilable and unit-testable without providing a real or stubbed `HttpClient` — only a mock `IOrgChartService` is needed.
+
+**Acceptance criteria:**
+- `Anela.Heblo.Application.csproj` no longer lists `Microsoft.Extensions.Http` as a direct dependency (it may remain as a transitive dep from other packages, but the explicit reference introduced by `OrgChartService` is removed).
+
+### NFR-4: Consistency
+
+The new adapter must follow the same file and naming conventions as existing adapters.
+
+**Acceptance criteria:**
+- Project name: `Anela.Heblo.Adapters.OrgChart`.
+- Root namespace: `Anela.Heblo.Adapters.OrgChart`.
+- Extension method class: `OrgChartAdapterServiceCollectionExtensions`.
+- Extension method name: `AddOrgChartAdapter`.
+
+## Data Model
+
+No data model changes. All contracts (`OrgChartResponse`, `OrganizationDto`, `PositionDto`, `EmployeeDto`) remain in `Anela.Heblo.Application.Features.OrgChart.Contracts`. The interface `IOrgChartService` remains in `Anela.Heblo.Application.Features.OrgChart.Services`.
+
+## API / Interface Design
+
+No API surface changes. The existing `GET /api/orgchart` endpoint, `OrgChartController`, and `GetOrganizationStructureHandler` are untouched. The only interface-level change is the DI wiring: `IOrgChartService` is now implemented by a class in the adapter project rather than in the Application project, but the binding is identical.
+
+## Dependencies
+
+- **Existing**: `Anela.Heblo.Application` (project reference from the new adapter) — already the pattern for all other adapters.
+- **NuGet**: `Microsoft.Extensions.Http` 8.0.0, `Microsoft.Extensions.Options.ConfigurationExtensions` 8.0.0 — both already present in peer adapter projects.
+- **No new external services or libraries** are introduced.
+
+## Out of Scope
+
+- Adding resilience policies (Polly retry, circuit-breaker) to the OrgChart HTTP client. This may be desirable in a follow-up but is explicitly excluded to keep this a pure structural refactor.
+- Caching of the org chart response.
+- Any changes to the frontend or E2E tests (no visible behaviour change).
+- Moving `IOrgChartService` out of the Application layer (the interface belongs there by Clean Architecture convention).
+- Changing the OrgChart configuration section name or key vault path.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3192/state.json
+++ b/artifacts/feat-3192/state.json
@@ -1,0 +1,36 @@
+{
+  "feature_id": "feat-3192",
+  "issue_number": 3192,
+  "created_at": "2026-06-19T16:14:57.164711Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-19T16:17:36.567645Z"
+    },
+    "architecting": {
+      "status": "completed",
+      "updated_at": "2026-06-19T16:20:39.839647Z"
+    },
+    "designing": {
+      "status": "completed",
+      "updated_at": "2026-06-19T16:21:47.967811Z"
+    },
+    "planning": {
+      "status": "completed",
+      "updated_at": "2026-06-19T16:24:08.080211Z"
+    },
+    "developing": {
+      "status": "completed",
+      "updated_at": "2026-06-19T16:34:44.251768Z"
+    }
+  },
+  "tasks": [
+    {
+      "name": "create-adapter-project",
+      "status": "completed",
+      "revision": 1,
+      "updated_at": "2026-06-19T16:34:38.786850Z"
+    }
+  ]
+}

--- a/artifacts/feat-3192/task-context/create-adapter-project.md
+++ b/artifacts/feat-3192/task-context/create-adapter-project.md
@@ -1,0 +1,354 @@
+# Move OrgChartService to Adapter Project Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+
+**Goal:** Extract OrgChartService from the Application layer into a new Anela.Heblo.Adapters.OrgChart project to satisfy Clean Architecture's rule that the Application layer must not carry infrastructure dependencies.
+
+**Architecture:** A new class-library project `Anela.Heblo.Adapters.OrgChart` is added under `backend/src/Adapters/`, mirroring the existing adapter layout (Cups being the closest structural match). OrgChartService.cs is moved there with its namespace updated; the DI registration migrates from OrgChartModule.cs into a new extension class in the adapter project, registered in Program.cs alongside the other adapters.
+
+**Tech Stack:** .NET 8, C#, Microsoft.Extensions.Http, Microsoft.Extensions.Options.ConfigurationExtensions, MSBuild (.csproj + .sln)
+
+---
+
+### task: create-adapter-project
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj`
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs`
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs`
+- Delete: `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs`
+- Delete: `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/` (directory)
+- Modify: `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+- Modify: `backend/src/Anela.Heblo.API/Program.cs`
+- Modify: `Anela.Heblo.sln`
+
+- [ ] Step 1: Create the adapter project directory and csproj.
+
+  ```bash
+  mkdir -p backend/src/Adapters/Anela.Heblo.Adapters.OrgChart
+  ```
+
+  Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj` with this exact content (modelled on Cups):
+
+  ```xml
+  <Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+      <TargetFramework>net8.0</TargetFramework>
+      <Nullable>enable</Nullable>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <RootNamespace>Anela.Heblo.Adapters.OrgChart</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+    </ItemGroup>
+  </Project>
+  ```
+
+- [ ] Step 2: Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs`.
+
+  This is the existing `OrgChartService.cs` with only the namespace changed from `Anela.Heblo.Application.Features.OrgChart.Infrastructure` to `Anela.Heblo.Adapters.OrgChart`. All using directives and logic are preserved verbatim:
+
+  ```csharp
+  using System.Text.Json;
+  using Anela.Heblo.Application.Features.OrgChart.Contracts;
+  using Anela.Heblo.Application.Features.OrgChart.Services;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Options;
+
+  namespace Anela.Heblo.Adapters.OrgChart;
+
+  /// <summary>
+  /// Service for retrieving organizational chart data from external source
+  /// </summary>
+  public class OrgChartService : IOrgChartService
+  {
+      private static readonly JsonSerializerOptions JsonOptions = new()
+      {
+          PropertyNameCaseInsensitive = true
+      };
+
+      private readonly HttpClient _httpClient;
+      private readonly OrgChartOptions _options;
+      private readonly ILogger<OrgChartService> _logger;
+
+      public OrgChartService(
+          HttpClient httpClient,
+          IOptions<OrgChartOptions> options,
+          ILogger<OrgChartService> logger)
+      {
+          _httpClient = httpClient;
+          _options = options.Value;
+          _logger = logger;
+      }
+
+      /// <inheritdoc />
+      public async Task<OrgChartResponse> GetOrganizationStructureAsync(CancellationToken cancellationToken = default)
+      {
+          try
+          {
+              _logger.LogInformation("Fetching organizational structure from {Url}", _options.DataSourceUrl);
+
+              var response = await _httpClient.GetAsync(_options.DataSourceUrl, cancellationToken);
+              response.EnsureSuccessStatusCode();
+
+              var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+              var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions);
+
+              if (orgChart == null)
+              {
+                  throw new InvalidOperationException("Failed to deserialize organizational structure");
+              }
+
+              _logger.LogInformation(
+                  "Successfully loaded organizational structure: {PositionCount} positions, {EmployeeCount} employees",
+                  orgChart.Organization.Positions.Count,
+                  orgChart.Organization.Positions.Sum(p => p.Employees.Count));
+
+              return orgChart;
+          }
+          catch (HttpRequestException ex)
+          {
+              throw new InvalidOperationException($"Failed to fetch organizational structure: {ex.Message}", ex);
+          }
+          catch (JsonException ex)
+          {
+              throw new InvalidOperationException($"Failed to parse organizational structure: {ex.Message}", ex);
+          }
+      }
+  }
+  ```
+
+- [ ] Step 3: Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.OrgChart.Services;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Adapters.OrgChart;
+
+  /// <summary>
+  /// DI registration for the OrgChart adapter
+  /// </summary>
+  public static class OrgChartAdapterServiceCollectionExtensions
+  {
+      /// <summary>
+      /// Registers the OrgChart typed HttpClient adapter
+      /// </summary>
+      public static IServiceCollection AddOrgChartAdapter(
+          this IServiceCollection services,
+          IConfiguration configuration) // reserved for future base-URL configuration
+      {
+          services.AddHttpClient<IOrgChartService, OrgChartService>();
+          return services;
+      }
+  }
+  ```
+
+- [ ] Step 4: Modify `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs`.
+
+  Remove the `AddHttpClient` call and the `using` for the old Infrastructure namespace. The file currently reads:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.OrgChart.Services;
+  using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.OrgChart;
+
+  /// <summary>
+  /// Module for registering OrgChart feature services
+  /// </summary>
+  public static class OrgChartModule
+  {
+      /// <summary>
+      /// Registers OrgChart feature services
+      /// </summary>
+      public static IServiceCollection AddOrgChartServices(this IServiceCollection services, IConfiguration configuration)
+      {
+          // Register configuration options with startup validation
+          services
+              .AddOptions<OrgChartOptions>()
+              .Bind(configuration.GetSection(OrgChartOptions.SectionName))
+              .ValidateDataAnnotations()
+              .ValidateOnStart();
+
+          // Register HTTP client for fetching organization data
+          services.AddHttpClient<IOrgChartService, OrgChartService>();
+
+          // MediatR handlers are automatically registered by AddMediatR scan
+
+          return services;
+      }
+  }
+  ```
+
+  Replace it with:
+
+  ```csharp
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.OrgChart;
+
+  /// <summary>
+  /// Module for registering OrgChart feature services
+  /// </summary>
+  public static class OrgChartModule
+  {
+      /// <summary>
+      /// Registers OrgChart feature services
+      /// </summary>
+      public static IServiceCollection AddOrgChartServices(this IServiceCollection services, IConfiguration configuration)
+      {
+          // Register configuration options with startup validation
+          services
+              .AddOptions<OrgChartOptions>()
+              .Bind(configuration.GetSection(OrgChartOptions.SectionName))
+              .ValidateDataAnnotations()
+              .ValidateOnStart();
+
+          // MediatR handlers are automatically registered by AddMediatR scan
+
+          return services;
+      }
+  }
+  ```
+
+- [ ] Step 5: Delete the now-empty Infrastructure directory:
+
+  ```bash
+  rm backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+  rmdir backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure
+  ```
+
+- [ ] Step 6: Add a ProjectReference to `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`.
+
+  In the `<ItemGroup>` block that contains all adapter ProjectReferences (ends at line 78 with Microsoft365), append after the Microsoft365 line:
+
+  Old (the last two lines of the adapters ItemGroup):
+  ```xml
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OpenMeteo\Anela.Heblo.Adapters.OpenMeteo.csproj" />
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
+      </ItemGroup>
+  ```
+
+  New:
+  ```xml
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OpenMeteo\Anela.Heblo.Adapters.OpenMeteo.csproj" />
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj" />
+      </ItemGroup>
+  ```
+
+- [ ] Step 7: Update `backend/src/Anela.Heblo.API/Program.cs`.
+
+  Add `using Anela.Heblo.Adapters.OrgChart;` in the using block at the top (after `using Anela.Heblo.Adapters.Microsoft365;` on line 7):
+
+  Old:
+  ```csharp
+  using Anela.Heblo.Adapters.Microsoft365;
+  ```
+
+  New:
+  ```csharp
+  using Anela.Heblo.Adapters.Microsoft365;
+  using Anela.Heblo.Adapters.OrgChart;
+  ```
+
+  Then add the adapter call after `AddMicrosoft365Adapter` (line 119):
+
+  Old:
+  ```csharp
+          builder.Services.AddMicrosoft365Adapter(builder.Configuration);
+
+          builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+  ```
+
+  New:
+  ```csharp
+          builder.Services.AddMicrosoft365Adapter(builder.Configuration);
+          builder.Services.AddOrgChartAdapter(builder.Configuration);
+
+          builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+  ```
+
+- [ ] Step 8: Register the new project in `Anela.Heblo.sln`.
+
+  Add the Project entry after the Microsoft365 entry (line 85, before `Global`). The GUID for the new project is `{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}` (new unique GUID as specified in the spec: note spec says `{4B6F17C3-...}` is the Adapters *folder* GUID — the project needs its own GUID; use the one from the spec: actually spec gives GUID for the *folder* already existing, so generate a fresh one).
+
+  Insert after line 85 (`EndProject` for Microsoft365), before line 86 (`Global`):
+
+  Old:
+  ```
+  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Microsoft365", "backend\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj", "{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}"
+  EndProject
+  Global
+  ```
+
+  New:
+  ```
+  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Microsoft365", "backend\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj", "{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}"
+  EndProject
+  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.OrgChart", "backend\src\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj", "{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}"
+  EndProject
+  Global
+  ```
+
+  Also add the NestedProjects entry (to place the project inside the Adapters solution folder). In the `GlobalSection(NestedProjects)` block, after line 520 (`{FB4CF527...} = {4B6F17C3...}`), add:
+
+  Old:
+  ```
+  		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+  	EndGlobalSection
+  ```
+
+  New:
+  ```
+  		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+  		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+  	EndGlobalSection
+  ```
+
+- [ ] Step 9: Verify the build succeeds with zero errors and zero new warnings:
+
+  ```bash
+  cd backend && dotnet build Anela.Heblo.sln
+  ```
+
+  Expected: `Build succeeded.` with 0 Error(s).
+
+- [ ] Step 10: Verify formatting is clean:
+
+  ```bash
+  cd backend && dotnet format Anela.Heblo.sln --verify-no-changes
+  ```
+
+  Expected: exits 0 with no reported changes.
+
+- [ ] Step 11: **Commit**
+
+  ```bash
+  git add \
+    backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj \
+    backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs \
+    backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs \
+    backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs \
+    backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj \
+    backend/src/Anela.Heblo.API/Program.cs \
+    Anela.Heblo.sln
+  git rm backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+  git commit -m "feat: move OrgChartService to Anela.Heblo.Adapters.OrgChart
+
+  Extracts the HttpClient-based OrgChartService from the Application layer
+  into a new dedicated adapter project, satisfying Clean Architecture's
+  requirement that the Application layer must not carry infrastructure
+  dependencies. No runtime behaviour change."
+  ```

--- a/artifacts/feat-3192/task-plan.r1.md
+++ b/artifacts/feat-3192/task-plan.r1.md
@@ -1,0 +1,354 @@
+# Move OrgChartService to Adapter Project Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+
+**Goal:** Extract OrgChartService from the Application layer into a new Anela.Heblo.Adapters.OrgChart project to satisfy Clean Architecture's rule that the Application layer must not carry infrastructure dependencies.
+
+**Architecture:** A new class-library project `Anela.Heblo.Adapters.OrgChart` is added under `backend/src/Adapters/`, mirroring the existing adapter layout (Cups being the closest structural match). OrgChartService.cs is moved there with its namespace updated; the DI registration migrates from OrgChartModule.cs into a new extension class in the adapter project, registered in Program.cs alongside the other adapters.
+
+**Tech Stack:** .NET 8, C#, Microsoft.Extensions.Http, Microsoft.Extensions.Options.ConfigurationExtensions, MSBuild (.csproj + .sln)
+
+---
+
+### task: create-adapter-project
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj`
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs`
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs`
+- Delete: `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs`
+- Delete: `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/` (directory)
+- Modify: `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+- Modify: `backend/src/Anela.Heblo.API/Program.cs`
+- Modify: `Anela.Heblo.sln`
+
+- [ ] Step 1: Create the adapter project directory and csproj.
+
+  ```bash
+  mkdir -p backend/src/Adapters/Anela.Heblo.Adapters.OrgChart
+  ```
+
+  Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj` with this exact content (modelled on Cups):
+
+  ```xml
+  <Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+      <TargetFramework>net8.0</TargetFramework>
+      <Nullable>enable</Nullable>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <RootNamespace>Anela.Heblo.Adapters.OrgChart</RootNamespace>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+    </ItemGroup>
+  </Project>
+  ```
+
+- [ ] Step 2: Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs`.
+
+  This is the existing `OrgChartService.cs` with only the namespace changed from `Anela.Heblo.Application.Features.OrgChart.Infrastructure` to `Anela.Heblo.Adapters.OrgChart`. All using directives and logic are preserved verbatim:
+
+  ```csharp
+  using System.Text.Json;
+  using Anela.Heblo.Application.Features.OrgChart.Contracts;
+  using Anela.Heblo.Application.Features.OrgChart.Services;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Options;
+
+  namespace Anela.Heblo.Adapters.OrgChart;
+
+  /// <summary>
+  /// Service for retrieving organizational chart data from external source
+  /// </summary>
+  public class OrgChartService : IOrgChartService
+  {
+      private static readonly JsonSerializerOptions JsonOptions = new()
+      {
+          PropertyNameCaseInsensitive = true
+      };
+
+      private readonly HttpClient _httpClient;
+      private readonly OrgChartOptions _options;
+      private readonly ILogger<OrgChartService> _logger;
+
+      public OrgChartService(
+          HttpClient httpClient,
+          IOptions<OrgChartOptions> options,
+          ILogger<OrgChartService> logger)
+      {
+          _httpClient = httpClient;
+          _options = options.Value;
+          _logger = logger;
+      }
+
+      /// <inheritdoc />
+      public async Task<OrgChartResponse> GetOrganizationStructureAsync(CancellationToken cancellationToken = default)
+      {
+          try
+          {
+              _logger.LogInformation("Fetching organizational structure from {Url}", _options.DataSourceUrl);
+
+              var response = await _httpClient.GetAsync(_options.DataSourceUrl, cancellationToken);
+              response.EnsureSuccessStatusCode();
+
+              var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+              var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions);
+
+              if (orgChart == null)
+              {
+                  throw new InvalidOperationException("Failed to deserialize organizational structure");
+              }
+
+              _logger.LogInformation(
+                  "Successfully loaded organizational structure: {PositionCount} positions, {EmployeeCount} employees",
+                  orgChart.Organization.Positions.Count,
+                  orgChart.Organization.Positions.Sum(p => p.Employees.Count));
+
+              return orgChart;
+          }
+          catch (HttpRequestException ex)
+          {
+              throw new InvalidOperationException($"Failed to fetch organizational structure: {ex.Message}", ex);
+          }
+          catch (JsonException ex)
+          {
+              throw new InvalidOperationException($"Failed to parse organizational structure: {ex.Message}", ex);
+          }
+      }
+  }
+  ```
+
+- [ ] Step 3: Create `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.OrgChart.Services;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Adapters.OrgChart;
+
+  /// <summary>
+  /// DI registration for the OrgChart adapter
+  /// </summary>
+  public static class OrgChartAdapterServiceCollectionExtensions
+  {
+      /// <summary>
+      /// Registers the OrgChart typed HttpClient adapter
+      /// </summary>
+      public static IServiceCollection AddOrgChartAdapter(
+          this IServiceCollection services,
+          IConfiguration configuration) // reserved for future base-URL configuration
+      {
+          services.AddHttpClient<IOrgChartService, OrgChartService>();
+          return services;
+      }
+  }
+  ```
+
+- [ ] Step 4: Modify `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs`.
+
+  Remove the `AddHttpClient` call and the `using` for the old Infrastructure namespace. The file currently reads:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.OrgChart.Services;
+  using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.OrgChart;
+
+  /// <summary>
+  /// Module for registering OrgChart feature services
+  /// </summary>
+  public static class OrgChartModule
+  {
+      /// <summary>
+      /// Registers OrgChart feature services
+      /// </summary>
+      public static IServiceCollection AddOrgChartServices(this IServiceCollection services, IConfiguration configuration)
+      {
+          // Register configuration options with startup validation
+          services
+              .AddOptions<OrgChartOptions>()
+              .Bind(configuration.GetSection(OrgChartOptions.SectionName))
+              .ValidateDataAnnotations()
+              .ValidateOnStart();
+
+          // Register HTTP client for fetching organization data
+          services.AddHttpClient<IOrgChartService, OrgChartService>();
+
+          // MediatR handlers are automatically registered by AddMediatR scan
+
+          return services;
+      }
+  }
+  ```
+
+  Replace it with:
+
+  ```csharp
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.OrgChart;
+
+  /// <summary>
+  /// Module for registering OrgChart feature services
+  /// </summary>
+  public static class OrgChartModule
+  {
+      /// <summary>
+      /// Registers OrgChart feature services
+      /// </summary>
+      public static IServiceCollection AddOrgChartServices(this IServiceCollection services, IConfiguration configuration)
+      {
+          // Register configuration options with startup validation
+          services
+              .AddOptions<OrgChartOptions>()
+              .Bind(configuration.GetSection(OrgChartOptions.SectionName))
+              .ValidateDataAnnotations()
+              .ValidateOnStart();
+
+          // MediatR handlers are automatically registered by AddMediatR scan
+
+          return services;
+      }
+  }
+  ```
+
+- [ ] Step 5: Delete the now-empty Infrastructure directory:
+
+  ```bash
+  rm backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+  rmdir backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure
+  ```
+
+- [ ] Step 6: Add a ProjectReference to `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`.
+
+  In the `<ItemGroup>` block that contains all adapter ProjectReferences (ends at line 78 with Microsoft365), append after the Microsoft365 line:
+
+  Old (the last two lines of the adapters ItemGroup):
+  ```xml
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OpenMeteo\Anela.Heblo.Adapters.OpenMeteo.csproj" />
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
+      </ItemGroup>
+  ```
+
+  New:
+  ```xml
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OpenMeteo\Anela.Heblo.Adapters.OpenMeteo.csproj" />
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
+          <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj" />
+      </ItemGroup>
+  ```
+
+- [ ] Step 7: Update `backend/src/Anela.Heblo.API/Program.cs`.
+
+  Add `using Anela.Heblo.Adapters.OrgChart;` in the using block at the top (after `using Anela.Heblo.Adapters.Microsoft365;` on line 7):
+
+  Old:
+  ```csharp
+  using Anela.Heblo.Adapters.Microsoft365;
+  ```
+
+  New:
+  ```csharp
+  using Anela.Heblo.Adapters.Microsoft365;
+  using Anela.Heblo.Adapters.OrgChart;
+  ```
+
+  Then add the adapter call after `AddMicrosoft365Adapter` (line 119):
+
+  Old:
+  ```csharp
+          builder.Services.AddMicrosoft365Adapter(builder.Configuration);
+
+          builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+  ```
+
+  New:
+  ```csharp
+          builder.Services.AddMicrosoft365Adapter(builder.Configuration);
+          builder.Services.AddOrgChartAdapter(builder.Configuration);
+
+          builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+  ```
+
+- [ ] Step 8: Register the new project in `Anela.Heblo.sln`.
+
+  Add the Project entry after the Microsoft365 entry (line 85, before `Global`). The GUID for the new project is `{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}` (new unique GUID as specified in the spec: note spec says `{4B6F17C3-...}` is the Adapters *folder* GUID — the project needs its own GUID; use the one from the spec: actually spec gives GUID for the *folder* already existing, so generate a fresh one).
+
+  Insert after line 85 (`EndProject` for Microsoft365), before line 86 (`Global`):
+
+  Old:
+  ```
+  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Microsoft365", "backend\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj", "{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}"
+  EndProject
+  Global
+  ```
+
+  New:
+  ```
+  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Microsoft365", "backend\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj", "{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B}"
+  EndProject
+  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.OrgChart", "backend\src\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj", "{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738}"
+  EndProject
+  Global
+  ```
+
+  Also add the NestedProjects entry (to place the project inside the Adapters solution folder). In the `GlobalSection(NestedProjects)` block, after line 520 (`{FB4CF527...} = {4B6F17C3...}`), add:
+
+  Old:
+  ```
+  		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+  	EndGlobalSection
+  ```
+
+  New:
+  ```
+  		{FB4CF527-5C59-4D5A-9A47-835C6C1AC76B} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+  		{C7A82E5F-3D91-4B06-A2F8-9E0C1D5B4738} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+  	EndGlobalSection
+  ```
+
+- [ ] Step 9: Verify the build succeeds with zero errors and zero new warnings:
+
+  ```bash
+  cd backend && dotnet build Anela.Heblo.sln
+  ```
+
+  Expected: `Build succeeded.` with 0 Error(s).
+
+- [ ] Step 10: Verify formatting is clean:
+
+  ```bash
+  cd backend && dotnet format Anela.Heblo.sln --verify-no-changes
+  ```
+
+  Expected: exits 0 with no reported changes.
+
+- [ ] Step 11: **Commit**
+
+  ```bash
+  git add \
+    backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj \
+    backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs \
+    backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs \
+    backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs \
+    backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj \
+    backend/src/Anela.Heblo.API/Program.cs \
+    Anela.Heblo.sln
+  git rm backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+  git commit -m "feat: move OrgChartService to Anela.Heblo.Adapters.OrgChart
+
+  Extracts the HttpClient-based OrgChartService from the Application layer
+  into a new dedicated adapter project, satisfying Clean Architecture's
+  requirement that the Application layer must not carry infrastructure
+  dependencies. No runtime behaviour change."
+  ```

--- a/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/Anela.Heblo.Adapters.OrgChart.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Anela.Heblo.Adapters.OrgChart</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.OrgChart;
+
+public static class OrgChartAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddOrgChartAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration) // reserved for future base-URL configuration
+    {
+        services.AddHttpClient<IOrgChartService, OrgChartService>();
+        return services;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartService.cs
@@ -1,10 +1,11 @@
 using System.Text.Json;
+using Anela.Heblo.Application.Features.OrgChart;
 using Anela.Heblo.Application.Features.OrgChart.Contracts;
 using Anela.Heblo.Application.Features.OrgChart.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+namespace Anela.Heblo.Adapters.OrgChart;
 
 /// <summary>
 /// Service for retrieving organizational chart data from external source

--- a/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+++ b/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
@@ -76,6 +76,7 @@
         <ProjectReference Include="..\Anela.Heblo.Xcc\Anela.Heblo.Xcc.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OpenMeteo\Anela.Heblo.Adapters.OpenMeteo.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
+        <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj" />
     </ItemGroup>
 
     <!-- NSwag tool for OpenAPI client generation -->

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -5,6 +5,7 @@ using Anela.Heblo.Adapters.Smartsupp;
 using Anela.Heblo.Adapters.Azure;
 using Anela.Heblo.Adapters.HomeAssistant;
 using Anela.Heblo.Adapters.Microsoft365;
+using Anela.Heblo.Adapters.OrgChart;
 using Anela.Heblo.Adapters.OpenMeteo;
 using Anela.Heblo.Adapters.Plaud;
 using Anela.Heblo.Adapters.SendGrid;
@@ -117,6 +118,7 @@ public partial class Program
         builder.Services.AddOpenMeteoAdapter(builder.Configuration);
         builder.Services.AddPlaudAdapter(builder.Configuration);
         builder.Services.AddMicrosoft365Adapter(builder.Configuration);
+        builder.Services.AddOrgChartAdapter(builder.Configuration);
 
         builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
 

--- a/backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
@@ -1,5 +1,3 @@
-using Anela.Heblo.Application.Features.OrgChart.Services;
-using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,9 +19,6 @@ public static class OrgChartModule
             .Bind(configuration.GetSection(OrgChartOptions.SectionName))
             .ValidateDataAnnotations()
             .ValidateOnStart();
-
-        // Register HTTP client for fetching organization data
-        services.AddHttpClient<IOrgChartService, OrgChartService>();
 
         // MediatR handlers are automatically registered by AddMediatR scan
 

--- a/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+++ b/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
@@ -52,6 +52,7 @@
     <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.FileSystem\Anela.Heblo.Adapters.FileSystem.csproj" />
     <ProjectReference Include="..\..\src\Anela.Heblo.Xcc\Anela.Heblo.Xcc.csproj" />
     <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.Microsoft365\Anela.Heblo.Adapters.Microsoft365.csproj" />
+    <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.OrgChart\Anela.Heblo.Adapters.OrgChart.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/test/Anela.Heblo.Tests/Features/OrgChart/OrgChartServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/OrgChart/OrgChartServiceTests.cs
@@ -1,8 +1,8 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Anela.Heblo.Adapters.OrgChart;
 using Anela.Heblo.Application.Features.OrgChart;
-using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
## What the issue was

`OrgChartService` (a concrete `HttpClient`-based implementation) resided in `Anela.Heblo.Application/Features/OrgChart/Infrastructure/`, violating Clean Architecture's rule that the Application layer must not carry infrastructure dependencies. Every other I/O-bound service already lives under `backend/src/Adapters/` — this was the only exception.

## How it was fixed / handled

Extracted `OrgChartService` into a new dedicated class-library project `Anela.Heblo.Adapters.OrgChart`, following the identical pattern established by Comgate, Cups, Anthropic, and all other adapters. The DI registration moved from `OrgChartModule.cs` into a new `OrgChartAdapterServiceCollectionExtensions.AddOrgChartAdapter()` method wired in `Program.cs`. No runtime behaviour change — same typed `HttpClient` registration, same options validation, same endpoint.

### Changes
- `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/` — new adapter project (csproj, OrgChartService.cs, OrgChartAdapterServiceCollectionExtensions.cs)
- `OrgChartModule.cs` — removed `AddHttpClient` call and `Infrastructure` using; options registration unchanged
- `Infrastructure/OrgChartService.cs` — deleted (directory removed)
- `Program.cs` — added `using Anela.Heblo.Adapters.OrgChart;` and `AddOrgChartAdapter` call after `AddMicrosoft365Adapter`
- `Anela.Heblo.API.csproj` — references new adapter project
- `Anela.Heblo.sln` — registers new project under Adapters solution folder
- `OrgChartServiceTests.cs` / `Anela.Heblo.Tests.csproj` — updated namespace/reference to new adapter

## Artifacts
Brief, spec, arch-review, design, task-plan, and impl markdown are committed in this branch under `artifacts/feat-3192/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoKa8YudcVRjvdjJMUbfrE)_