### PR TITLE
fix(photobank): register BulkAddPhotoTagRequestValidator and RetagPhotosRequestValidator in DI

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -12,6 +12,8 @@ using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRule;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
 using Anela.Heblo.Application.Features.Photobank.UseCases.RemovePhotoTag;
+using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTag;
+using Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
 using Anela.Heblo.Application.Features.Photobank.Validators;
 using Anela.Heblo.Domain.Features.Configuration;
@@ -67,6 +69,8 @@ public static class PhotobankModule
         services.AddScoped<IValidator<BulkAddPhotoTagByIdsRequest>, BulkAddPhotoTagByIdsRequestValidator>();
         services.AddScoped<IValidator<CreateTagRequest>, CreateTagRequestValidator>();
         services.AddScoped<IValidator<DeleteTagRequest>, DeleteTagRequestValidator>();
+        services.AddScoped<IValidator<BulkAddPhotoTagRequest>, BulkAddPhotoTagRequestValidator>();
+        services.AddScoped<IValidator<RetagPhotosRequest>, RetagPhotosRequestValidator>();
 
         // Register MediatR validation behavior for photobank requests
         services.AddScoped<IPipelineBehavior<AddPhotoTagRequest, AddPhotoTagResponse>, ValidationBehavior<AddPhotoTagRequest, AddPhotoTagResponse>>();
@@ -80,6 +84,8 @@ public static class PhotobankModule
         services.AddScoped<IPipelineBehavior<BulkAddPhotoTagByIdsRequest, BulkAddPhotoTagByIdsResponse>, ValidationBehavior<BulkAddPhotoTagByIdsRequest, BulkAddPhotoTagByIdsResponse>>();
         services.AddScoped<IPipelineBehavior<CreateTagRequest, CreateTagResponse>, ValidationBehavior<CreateTagRequest, CreateTagResponse>>();
         services.AddScoped<IPipelineBehavior<DeleteTagRequest, DeleteTagResponse>, ValidationBehavior<DeleteTagRequest, DeleteTagResponse>>();
+        services.AddScoped<IPipelineBehavior<BulkAddPhotoTagRequest, BulkAddPhotoTagResponse>, ValidationBehavior<BulkAddPhotoTagRequest, BulkAddPhotoTagResponse>>();
+        services.AddScoped<IPipelineBehavior<RetagPhotosRequest, RetagPhotosResponse>, ValidationBehavior<RetagPhotosRequest, RetagPhotosResponse>>();
 
         return services;
     }


### PR DESCRIPTION
## What the issue was

Two FluentValidation validators in the Photobank module were implemented but never registered in `PhotobankModule.cs`, making their rules dead code:

- **`BulkAddPhotoTagRequestValidator`** — enforces the critical "at least one filter (Tags or Search) must be provided" constraint. Without this registration, any API caller could omit all filters and trigger `BulkAddPhotoTagHandler` to count and tag **all photos in the database**. The 5,000-photo hard cap is an insufficient guard since an admin could accidentally tag the entire photo index.
- **`RetagPhotosRequestValidator`** — enforces that `PhotoIds` is non-null, non-empty, and contains ≤ 5,000 IDs. Without registration, callers received no explicit validation error for empty input.

The module correctly registered 11 other request types via this pattern; these two were omitted.

## How it was fixed

Added four missing DI registrations and two missing `using` directives to `PhotobankModule.cs`, exactly following the existing pattern used by the other 11 request types:

- Two `using` directives: `UseCases.BulkAddPhotoTag` and `UseCases.RetagPhotos`
- `IValidator<BulkAddPhotoTagRequest>` → `BulkAddPhotoTagRequestValidator`
- `IValidator<RetagPhotosRequest>` → `RetagPhotosRequestValidator`
- `IPipelineBehavior<BulkAddPhotoTagRequest, BulkAddPhotoTagResponse>` → `ValidationBehavior<...>`
- `IPipelineBehavior<RetagPhotosRequest, RetagPhotosResponse>` → `ValidationBehavior<...>`

No new files, no new packages, no logic changes. Build passes with 0 errors.

Closes #3240