### PR TITLE
fix(telemetry): fix DateTime Kind=Unspecified crash in nightly Hangfire job (#3243)

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Analytics/FlexiAnalyticsSyncOptions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Analytics/FlexiAnalyticsSyncOptions.cs
@@ -11,6 +11,11 @@ public class FlexiAnalyticsSyncOptions
     public string InitialBackfillFrom { get; set; } = "2020-01-01";
     public int RequestTimeoutSeconds { get; set; } = 120;
 
+    // Npgsql 6+ rejects DateTime with Kind != Utc on 'timestamptz' columns.
+    // AssumeLocal produced Kind=Local, which caused ArgumentException in the nightly
+    // Hangfire sync job. AssumeUniversal + ToUniversalTime() guarantees Kind=Utc.
     public DateTime GetInitialBackfillDateTime() =>
-        DateTime.Parse(InitialBackfillFrom, null, System.Globalization.DateTimeStyles.AssumeLocal).Date;
+        DateTime.Parse(InitialBackfillFrom, null, System.Globalization.DateTimeStyles.AssumeUniversal)
+                .Date
+                .ToUniversalTime();
 }

--- a/backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs
@@ -40,7 +40,11 @@ public class GridLayoutRepository : IGridLayoutRepository
 
     public async Task UpsertAsync(string userId, string gridKey, string layoutJson, CancellationToken cancellationToken = default)
     {
-        var lastModified = _timeProvider.GetUtcNow().DateTime;
+        // Npgsql rejects DateTime with Kind != Utc on 'timestamptz' columns (Npgsql 6+).
+        // Although GridLayouts.LastModified maps to 'timestamp' (without time zone),
+        // GetUtcNow().UtcDateTime is used here for semantic correctness and to be safe
+        // if the column type is ever changed to 'timestamptz'.
+        var lastModified = _timeProvider.GetUtcNow().UtcDateTime;
 
         try
         {

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Analytics/FlexiAnalyticsSyncOptionsTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Analytics/FlexiAnalyticsSyncOptionsTests.cs
@@ -1,0 +1,14 @@
+using Anela.Heblo.Adapters.Flexi.Analytics;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Analytics;
+
+public class FlexiAnalyticsSyncOptionsTests
+{
+    [Fact]
+    public void GetInitialBackfillDateTime_ReturnsUtcKind()
+    {
+        var options = new FlexiAnalyticsSyncOptions { InitialBackfillFrom = "2024-01-01" };
+        var result = options.GetInitialBackfillDateTime();
+        Assert.Equal(DateTimeKind.Utc, result.Kind);
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Analytics/LedgerSyncServiceTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Analytics/LedgerSyncServiceTests.cs
@@ -80,7 +80,7 @@ public class LedgerSyncServiceTests
 
         // Assert — lastUpdateFrom should equal InitialBackfillFrom when no watermark
         client.Verify(c => c.GetChangedSinceAsync(
-            new DateTime(2024, 1, 1), 10, 0, It.IsAny<CancellationToken>()), Times.Once);
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), 10, 0, It.IsAny<CancellationToken>()), Times.Once);
         result.IsSuccess.Should().BeTrue();
         result.RowsFetched.Should().Be(1);
     }


### PR DESCRIPTION
## What the issue was

A nightly Hangfire job (running ~02:00 UTC) failed 11 times on 2026-06-19 with `ArgumentException: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone'`. The job exhausted Hangfire's exponential-backoff retries by 06:37 UTC.

The root cause: `FlexiAnalyticsSyncOptions.GetInitialBackfillDateTime()` used `DateTimeStyles.AssumeLocal`, producing a `DateTime` with `Kind=Local`. Npgsql 6+ rejects any `DateTime` with `Kind != Utc` on `timestamptz` columns, raising `ArgumentException` inside `NpgsqlParameterCollection.ProcessParameters` on each retry.

A latent second defect was also present: `GridLayoutRepository.UpsertAsync` called `_timeProvider.GetUtcNow().DateTime`, which strips the UTC annotation and produces `Kind=Unspecified`. The `GridLayouts.LastModified` column currently maps to `timestamp` (not `timestamptz`), so this did not crash — but it would silently break if the column type were ever changed.

## How it was fixed

**`FlexiAnalyticsSyncOptions.cs` (live crash — FR-3):**
- Changed `DateTimeStyles.AssumeLocal` → `DateTimeStyles.AssumeUniversal` + `.ToUniversalTime()`
- Result: `GetInitialBackfillDateTime()` now returns `DateTime(Kind=Utc)` — accepted by Npgsql on `timestamptz` columns

**`GridLayoutRepository.cs` (latent defect — FR-2):**
- Changed `_timeProvider.GetUtcNow().DateTime` → `_timeProvider.GetUtcNow().UtcDateTime`
- Result: the raw SQL `LastModified` parameter always carries `Kind=Utc`

**Tests:**
- `LedgerSyncServiceTests.SyncAsync_WhenNoWatermark_FetchesFromInitialBackfillDate`: updated assertion from `new DateTime(2024, 1, 1)` (Kind=Unspecified) to `new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)` to match the corrected return value
- `FlexiAnalyticsSyncOptionsTests.GetInitialBackfillDateTime_ReturnsUtcKind` (new): directly asserts `result.Kind == DateTimeKind.Utc`

Closes #3243

---
_Generated by [Claude Code](https://claude.ai/code/session_01VViWauUwUs8FDtQA8KbPos)_