### PR TITLE
fix(catalog): replace O(N×S) linear scan in MergeSalesHistory with dictionary pattern

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogMergeService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogMergeService.cs
@@ -110,14 +110,16 @@ public sealed class CatalogMergeService
         var inQuarantineData = _cacheStore.GetInQuarantineData();
         var orderedData = _cacheStore.GetOrderedData();
         var plannedData = _cacheStore.GetPlannedData();
-        var salesData = _cacheStore.GetSalesData();
+        var salesMap = _cacheStore.GetSalesData()
+            .GroupBy(s => s.ProductCode)
+            .ToDictionary(k => k.Key, v => v.ToList());
         var manufactureDifficultyData = _cacheStore.GetManufactureDifficultySettingsData();
 
         // Merge data into each product
         foreach (var product in products)
         {
             MergeErpData(product, erpProductsMap);
-            MergeSalesHistory(product, salesData);
+            MergeSalesHistory(product, salesMap);
             MergeAttributes(product, attributesMap);
             MergeStockData(product, inTransportData, manufacturedData, inReserveData, inQuarantineData, orderedData, plannedData);
             MergeEshopData(product, eshopProductsMap);
@@ -153,9 +155,12 @@ public sealed class CatalogMergeService
         }
     }
 
-    private static void MergeSalesHistory(CatalogAggregate product, IList<CatalogSaleRecord> salesData)
+    private static void MergeSalesHistory(
+        CatalogAggregate product,
+        IDictionary<string, List<CatalogSaleRecord>> salesMap)
     {
-        product.SalesHistory = salesData.Where(w => w.ProductCode == product.ProductCode).ToList();
+        if (salesMap.TryGetValue(product.ProductCode, out var sales))
+            product.SalesHistory = sales.ToList();
     }
 
     private static void MergeAttributes(CatalogAggregate product, IDictionary<string, CatalogAttributes> attributesMap)


### PR DESCRIPTION
## What the issue was

In `CatalogMergeService.Merge()`, sales history was merged using a linear `.Where()` scan over the full sales list for every product — O(P × S) complexity — while all other history data sets (consumed, purchase, manufacture, stock-taking, lots) already used a pre-built `GroupBy/ToDictionary` lookup for O(P + S) performance. Sales records are typically the largest dataset (daily records across all products), making this the dominant bottleneck in every background refresh and priority merge (cache miss).

Closes #3245.

## How it was fixed / handled

Applied the same dictionary pattern used by all other merge helpers to `MergeSalesHistory`:

- **Before the per-product loop**: replaced `var salesData = _cacheStore.GetSalesData()` with a `GroupBy(s => s.ProductCode).ToDictionary(...)` call — O(S) once.
- **Call site**: updated `MergeSalesHistory(product, salesData)` → `MergeSalesHistory(product, salesMap)`.
- **Helper signature and body**: changed parameter from `IList<CatalogSaleRecord>` + `.Where()` to `IDictionary<string, List<CatalogSaleRecord>>` + `TryGetValue`, matching the pattern in `MergeHistoryData`.

Build verified: `dotnet build` — 0 errors.

## Artifacts

Brief, spec, arch-review, design, task plan, and implementation summary are committed under `artifacts/feat-3245/` in this branch.