### PR TITLE
fix(telemetry): unique App Insights operation id per route change and packing scan

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@fullcalendar/interaction": "^6.1.20",
         "@fullcalendar/react": "^6.1.20",
         "@headlessui/react": "^2.2.7",
+        "@microsoft/applicationinsights-core-js": "^3.4.1",
         "@microsoft/applicationinsights-react-js": "^18.3.6",
         "@microsoft/applicationinsights-web": "^3.4.1",
         "@openfeature/core": "^1.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@fullcalendar/interaction": "^6.1.20",
     "@fullcalendar/react": "^6.1.20",
     "@headlessui/react": "^2.2.7",
+    "@microsoft/applicationinsights-core-js": "^3.4.1",
     "@microsoft/applicationinsights-react-js": "^18.3.6",
     "@microsoft/applicationinsights-web": "^3.4.1",
     "@openfeature/core": "^1.10.0",

--- a/frontend/src/api/hooks/useScanPackingOrder.ts
+++ b/frontend/src/api/hooks/useScanPackingOrder.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { getAuthenticatedApiClient } from '../client';
+import { startNewTelemetryOperation } from '../../telemetry/appInsights';
 
 interface ApiClientWithInternals {
   baseUrl: string;
@@ -104,4 +105,9 @@ const scanPackingOrder = async ({
 export const useScanPackingOrder = () =>
   useMutation<ScanPackingOrderResult, Error, ScanPackingOrderVariables>({
     mutationFn: scanPackingOrder,
+    onMutate: () => {
+      // Each scan is its own AI operation so repeated scans on the same page do
+      // not collapse into a single end-to-end transaction.
+      startNewTelemetryOperation('packaging-scan');
+    },
   });

--- a/frontend/src/telemetry/AppInsightsProvider.tsx
+++ b/frontend/src/telemetry/AppInsightsProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AppInsightsContext } from '@microsoft/applicationinsights-react-js';
-import { reactPlugin, getAppInsights } from './appInsights';
+import { reactPlugin, getAppInsights, startNewTelemetryOperation } from './appInsights';
 
 interface AppInsightsProviderProps {
   children: React.ReactNode;
@@ -11,6 +11,7 @@ export function AppInsightsProvider({ children }: AppInsightsProviderProps) {
   const location = useLocation();
 
   useEffect(() => {
+    startNewTelemetryOperation(location.pathname);
     getAppInsights()?.trackPageView({ name: location.pathname });
   }, [location.pathname]);
 

--- a/frontend/src/telemetry/__tests__/appInsights.test.ts
+++ b/frontend/src/telemetry/__tests__/appInsights.test.ts
@@ -3,6 +3,7 @@ jest.mock('@microsoft/applicationinsights-web', () => ({
   ApplicationInsights: jest.fn().mockImplementation(() => ({
     loadAppInsights: jest.fn(),
     addTelemetryInitializer: jest.fn(),
+    getTraceCtx: jest.fn(),
   })),
 }));
 
@@ -10,6 +11,11 @@ jest.mock('@microsoft/applicationinsights-react-js', () => ({
   ReactPlugin: jest.fn().mockImplementation(() => ({
     identifier: 'ReactPlugin',
   })),
+}));
+
+// Deterministic id generator so trace/span assertions are stable.
+jest.mock('@microsoft/applicationinsights-core-js', () => ({
+  generateW3CId: jest.fn(() => 'abcdef0123456789abcdef0123456789'),
 }));
 
 describe('appInsights singleton', () => {
@@ -137,5 +143,76 @@ describe('appInsights user identity telemetry initializer', () => {
     getRegisteredInitializer()(envelope);
 
     expect(envelope.data).toEqual({ userName: 'Ada Lovelace' });
+  });
+});
+
+describe('startNewTelemetryOperation', () => {
+  const CONNECTION_STRING =
+    'InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/';
+
+  type TraceCtx = { traceId: string; spanId: string; pageName?: string };
+
+  let initAppInsights: (cs: string) => unknown;
+  let startNewTelemetryOperation: (name?: string) => void;
+  let ApplicationInsightsMock: jest.Mock;
+
+  function mockTraceCtx(ctx: TraceCtx | null): void {
+    const sdkInstance = ApplicationInsightsMock.mock.results[0].value as {
+      getTraceCtx: jest.Mock;
+    };
+    sdkInstance.getTraceCtx.mockReturnValue(ctx);
+  }
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const sdkModule = await import('@microsoft/applicationinsights-web');
+    ApplicationInsightsMock = sdkModule.ApplicationInsights as unknown as jest.Mock;
+    const module = await import('../appInsights');
+    initAppInsights = module.initAppInsights;
+    startNewTelemetryOperation = module.startNewTelemetryOperation;
+  });
+
+  it('assigns a fresh 32-hex traceId and 16-hex spanId on the current context', () => {
+    initAppInsights(CONNECTION_STRING);
+    const ctx: TraceCtx = { traceId: 'old', spanId: 'old' };
+    mockTraceCtx(ctx);
+
+    startNewTelemetryOperation();
+
+    expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(ctx.traceId).not.toBe('old');
+    expect(ctx.spanId).not.toBe('old');
+  });
+
+  it('sets pageName when a name is provided', () => {
+    initAppInsights(CONNECTION_STRING);
+    const ctx: TraceCtx = { traceId: 'old', spanId: 'old' };
+    mockTraceCtx(ctx);
+
+    startNewTelemetryOperation('packaging-scan');
+
+    expect(ctx.pageName).toBe('packaging-scan');
+  });
+
+  it('leaves pageName untouched when no name is provided', () => {
+    initAppInsights(CONNECTION_STRING);
+    const ctx: TraceCtx = { traceId: 'old', spanId: 'old' };
+    mockTraceCtx(ctx);
+
+    startNewTelemetryOperation();
+
+    expect(ctx.pageName).toBeUndefined();
+  });
+
+  it('no-ops when the SDK is not initialized', () => {
+    expect(() => startNewTelemetryOperation('packaging-scan')).not.toThrow();
+  });
+
+  it('no-ops when there is no current trace context', () => {
+    initAppInsights(CONNECTION_STRING);
+    mockTraceCtx(null);
+
+    expect(() => startNewTelemetryOperation('packaging-scan')).not.toThrow();
   });
 });

--- a/frontend/src/telemetry/appInsights.ts
+++ b/frontend/src/telemetry/appInsights.ts
@@ -1,5 +1,6 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import { ReactPlugin } from '@microsoft/applicationinsights-react-js';
+import { generateW3CId } from '@microsoft/applicationinsights-core-js';
 
 export const reactPlugin = new ReactPlugin();
 
@@ -57,4 +58,16 @@ export function initAppInsights(connectionString: string): ApplicationInsights |
 
 export function getAppInsights(): ApplicationInsights | null {
   return instance;
+}
+
+// Starts a fresh AI operation (new W3C trace + span id) so subsequently
+// auto-tracked fetches correlate under a new operation id instead of reusing the
+// one assigned at page load. Without this every request in the SPA session
+// collapses into a single end-to-end transaction.
+export function startNewTelemetryOperation(name?: string): void {
+  const ctx = instance?.getTraceCtx();
+  if (!ctx) return;
+  ctx.traceId = generateW3CId();
+  ctx.spanId = generateW3CId().substring(0, 16);
+  if (name) ctx.pageName = name;
 }


### PR DESCRIPTION
## Problem
In Application Insights "End-to-end transaction details", every packaging API call shared a single Operation ID, so the whole SPA session collapsed into one transaction and individual scan actions couldn't be told apart. Root cause: the App Insights JS SDK assigns one trace/operation id at page load and never resets it, and every auto-tracked `fetch` carries that id to the backend via `traceparent`.

## Change
Adds `startNewTelemetryOperation()` (assigns a fresh W3C trace + span id to the current trace context) and calls it at two boundaries: on each route change in `AppInsightsProvider`, and in `useScanPackingOrder`'s `onMutate` so each packing scan is its own operation. Adds an explicit `@microsoft/applicationinsights-core-js` dependency for `generateW3CId` and 5 unit tests for the new helper.

## Verification
`npm run build` passes, the telemetry test suite passes (14/14), and ESLint is clean on all changed source files. Manual App Insights confirmation still pending as it requires the live app.