### PR TITLE
#3254: Fix UpdatedBy always set to CreatedBy in PurchaseOrder line-mutation methods

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs
@@ -89,7 +89,8 @@ public class CreatePurchaseOrderHandler : IRequestHandler<CreatePurchaseOrderReq
                     materialName,
                     lineRequest.Quantity,
                     lineRequest.UnitPrice,
-                    lineRequest.Notes);
+                    lineRequest.Notes,
+                    createdBy);
             }
         }
 

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs
@@ -68,7 +68,7 @@ public class UpdatePurchaseOrderHandler : IRequestHandler<UpdatePurchaseOrderReq
             var linesToRemove = existingLineIds.Except(requestLineIds).ToList();
             foreach (var lineId in linesToRemove)
             {
-                purchaseOrder.RemoveLine(lineId);
+                purchaseOrder.RemoveLine(lineId, updatedBy);
             }
 
             // Batch-fetch every material referenced by the incoming request lines.
@@ -95,7 +95,8 @@ public class UpdatePurchaseOrderHandler : IRequestHandler<UpdatePurchaseOrderReq
                         materialName,
                         lineRequest.Quantity,
                         lineRequest.UnitPrice,
-                        lineRequest.Notes);
+                        lineRequest.Notes,
+                        updatedBy);
                 }
                 else
                 {
@@ -104,7 +105,8 @@ public class UpdatePurchaseOrderHandler : IRequestHandler<UpdatePurchaseOrderReq
                         materialName,
                         lineRequest.Quantity,
                         lineRequest.UnitPrice,
-                        lineRequest.Notes);
+                        lineRequest.Notes,
+                        updatedBy);
                 }
             }
 

--- a/backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
@@ -58,7 +58,7 @@ public class PurchaseOrder : IEntity<int>
         AddHistoryEntry($"Order created", null, Status.ToString(), createdBy);
     }
 
-    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes, string updatedBy)
     {
         if (!IsEditable)
         {
@@ -68,11 +68,11 @@ public class PurchaseOrder : IEntity<int>
         var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
         _lines.Add(line);
 
-        UpdatedBy = CreatedBy;
+        UpdatedBy = updatedBy;
         UpdatedAt = DateTime.UtcNow;
     }
 
-    public void RemoveLine(int lineId)
+    public void RemoveLine(int lineId, string updatedBy)
     {
         if (!IsEditable)
         {
@@ -83,12 +83,12 @@ public class PurchaseOrder : IEntity<int>
         if (line != null)
         {
             _lines.Remove(line);
-            UpdatedBy = CreatedBy;
+            UpdatedBy = updatedBy;
             UpdatedAt = DateTime.UtcNow;
         }
     }
 
-    public void UpdateLine(int lineId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    public void UpdateLine(int lineId, string materialName, decimal quantity, decimal unitPrice, string? notes, string updatedBy)
     {
         if (!IsEditable)
         {
@@ -99,12 +99,12 @@ public class PurchaseOrder : IEntity<int>
         if (line != null)
         {
             line.Update(materialName, quantity, unitPrice, notes);
-            UpdatedBy = CreatedBy;
+            UpdatedBy = updatedBy;
             UpdatedAt = DateTime.UtcNow;
         }
     }
 
-    public void ClearAllLines()
+    public void ClearAllLines(string updatedBy)
     {
         if (!IsEditable)
         {
@@ -112,7 +112,7 @@ public class PurchaseOrder : IEntity<int>
         }
 
         _lines.Clear();
-        UpdatedBy = CreatedBy;
+        UpdatedBy = updatedBy;
         UpdatedAt = DateTime.UtcNow;
     }
 

--- a/backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs
@@ -89,7 +89,7 @@ public class PurchaseOrderTests
         const decimal unitPrice = 25.50m;
         const string notes = "Test line item";
 
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, quantity, unitPrice, notes);
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, quantity, unitPrice, notes, ValidCreatedBy);
 
         purchaseOrder.Lines.Should().HaveCount(1);
         var line = purchaseOrder.Lines.First();
@@ -112,7 +112,7 @@ public class PurchaseOrderTests
         const decimal unitPrice = 25.50m;
         const string notes = "Test line item";
 
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, quantity, unitPrice, notes);
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, quantity, unitPrice, notes, ValidCreatedBy);
 
         purchaseOrder.Lines.Should().HaveCount(1);
         var line = purchaseOrder.Lines.First();
@@ -132,7 +132,7 @@ public class PurchaseOrderTests
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Received, ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Completed, ValidCreatedBy);
 
-        var action = () => purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes");
+        var action = () => purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes", ValidCreatedBy);
 
         action.Should().Throw<InvalidOperationException>()
             .WithMessage("Cannot add lines to completed orders");
@@ -142,10 +142,10 @@ public class PurchaseOrderTests
     public void RemoveLine_FromDraftOrder_ShouldRemoveLineAndUpdateTotals()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes", ValidCreatedBy);
         var lineId = purchaseOrder.Lines.First().Id;
 
-        purchaseOrder.RemoveLine(lineId);
+        purchaseOrder.RemoveLine(lineId, ValidCreatedBy);
 
         purchaseOrder.Lines.Should().BeEmpty();
         purchaseOrder.TotalAmount.Should().Be(0);
@@ -155,11 +155,11 @@ public class PurchaseOrderTests
     public void RemoveLine_FromInTransitOrder_ShouldRemoveLineSuccessfully()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes", ValidCreatedBy);
         var lineId = purchaseOrder.Lines.First().Id;
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.InTransit, ValidCreatedBy);
 
-        purchaseOrder.RemoveLine(lineId);
+        purchaseOrder.RemoveLine(lineId, ValidCreatedBy);
 
         purchaseOrder.Lines.Should().BeEmpty();
         purchaseOrder.TotalAmount.Should().Be(0);
@@ -169,13 +169,13 @@ public class PurchaseOrderTests
     public void RemoveLine_FromCompletedOrder_ShouldThrowInvalidOperationException()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes", ValidCreatedBy);
         var lineId = purchaseOrder.Lines.First().Id;
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.InTransit, ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Received, ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Completed, ValidCreatedBy);
 
-        var action = () => purchaseOrder.RemoveLine(lineId);
+        var action = () => purchaseOrder.RemoveLine(lineId, ValidCreatedBy);
 
         action.Should().Throw<InvalidOperationException>()
             .WithMessage("Cannot remove lines from completed orders");
@@ -185,10 +185,10 @@ public class PurchaseOrderTests
     public void UpdateLine_InDraftOrder_ShouldUpdateLineAndRecalculateTotals()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "old notes");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "old notes", ValidCreatedBy);
         var lineId = purchaseOrder.Lines.First().Id;
 
-        purchaseOrder.UpdateLine(lineId, "Updated Material Name", 20, 30.00m, "new notes");
+        purchaseOrder.UpdateLine(lineId, "Updated Material Name", 20, 30.00m, "new notes", ValidCreatedBy);
 
         var line = purchaseOrder.Lines.First();
         line.Quantity.Should().Be(20);
@@ -202,11 +202,11 @@ public class PurchaseOrderTests
     public void UpdateLine_InInTransitOrder_ShouldUpdateLineSuccessfully()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "old notes");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "old notes", ValidCreatedBy);
         var lineId = purchaseOrder.Lines.First().Id;
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.InTransit, ValidCreatedBy);
 
-        purchaseOrder.UpdateLine(lineId, "Updated Material Name", 20, 30.00m, "new notes");
+        purchaseOrder.UpdateLine(lineId, "Updated Material Name", 20, 30.00m, "new notes", ValidCreatedBy);
 
         var line = purchaseOrder.Lines.First();
         line.Quantity.Should().Be(20);
@@ -220,13 +220,13 @@ public class PurchaseOrderTests
     public void UpdateLine_InCompletedOrder_ShouldThrowInvalidOperationException()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "notes", ValidCreatedBy);
         var lineId = purchaseOrder.Lines.First().Id;
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.InTransit, ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Received, ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Completed, ValidCreatedBy);
 
-        var action = () => purchaseOrder.UpdateLine(lineId, "Updated Material Name", 20, 30.00m, "new notes");
+        var action = () => purchaseOrder.UpdateLine(lineId, "Updated Material Name", 20, 30.00m, "new notes", ValidCreatedBy);
 
         action.Should().Throw<InvalidOperationException>()
             .WithMessage("Cannot update lines in completed orders");
@@ -371,9 +371,9 @@ public class PurchaseOrderTests
     public void TotalAmount_WithMultipleLines_ShouldCalculateCorrectTotal()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "line 1");
-        purchaseOrder.AddLine("MAT002", "Material 2", 5, 100.00m, "line 2");
-        purchaseOrder.AddLine("MAT003", "Material 3", 3, 33.33m, "line 3");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "line 1", ValidCreatedBy);
+        purchaseOrder.AddLine("MAT002", "Material 2", 5, 100.00m, "line 2", ValidCreatedBy);
+        purchaseOrder.AddLine("MAT003", "Material 3", 3, 33.33m, "line 3", ValidCreatedBy);
 
         purchaseOrder.TotalAmount.Should().Be(854.99m);
     }
@@ -441,11 +441,11 @@ public class PurchaseOrderTests
     public void ClearAllLines_InTransitOrder_ShouldClearLinesSuccessfully()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "line 1");
-        purchaseOrder.AddLine("MAT002", "Material 2", 5, 100.00m, "line 2");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "line 1", ValidCreatedBy);
+        purchaseOrder.AddLine("MAT002", "Material 2", 5, 100.00m, "line 2", ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.InTransit, ValidCreatedBy);
 
-        purchaseOrder.ClearAllLines();
+        purchaseOrder.ClearAllLines(ValidCreatedBy);
 
         purchaseOrder.Lines.Should().BeEmpty();
         purchaseOrder.TotalAmount.Should().Be(0);
@@ -455,12 +455,12 @@ public class PurchaseOrderTests
     public void ClearAllLines_CompletedOrder_ShouldThrowInvalidOperationException()
     {
         var purchaseOrder = CreateValidPurchaseOrder();
-        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "line 1");
+        purchaseOrder.AddLine(ValidMaterialId, ValidName, 10, 25.50m, "line 1", ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.InTransit, ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Received, ValidCreatedBy);
         purchaseOrder.ChangeStatus(PurchaseOrderStatus.Completed, ValidCreatedBy);
 
-        var action = () => purchaseOrder.ClearAllLines();
+        var action = () => purchaseOrder.ClearAllLines(ValidCreatedBy);
 
         action.Should().Throw<InvalidOperationException>()
             .WithMessage("Cannot clear lines from completed orders");

--- a/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
@@ -64,7 +64,7 @@ public sealed class UpdatePurchaseOrderHandlerTests
             "Test notes",
             "system");
 
-        existingOrder.AddLine(ValidMaterialId, ValidMaterialName, 10, 25.50m, "Line notes");
+        existingOrder.AddLine(ValidMaterialId, ValidMaterialName, 10, 25.50m, "Line notes", "system");
         var existingLineId = existingOrder.Lines.First().Id;
 
         _repositoryMock


### PR DESCRIPTION
## What the issue was

`PurchaseOrder.AddLine`, `RemoveLine`, `UpdateLine`, and `ClearAllLines` all hardcoded `UpdatedBy = CreatedBy` instead of accepting the actual caller's identity. This meant that when User B edited the lines of an order created by User A, the aggregate's `UpdatedBy` / `UpdatedAt` audit stamp was silently attributed to User A — the original creator — regardless of who actually performed the edit.

The sibling methods `Update(...)` and `ChangeStatus(...)` already accepted a `string updatedBy` parameter and assigned it correctly; the line-mutation methods were simply written without that parameter.

## How it was fixed / handled

Added a `string updatedBy` parameter to all four methods (`AddLine`, `RemoveLine`, `UpdateLine`, `ClearAllLines`) in `PurchaseOrder.cs`, replacing the incorrect `UpdatedBy = CreatedBy` assignment with `UpdatedBy = updatedBy`.

Updated the two callers:
- `CreatePurchaseOrderHandler` — passes the already-resolved `createdBy` string to `AddLine`
- `UpdatePurchaseOrderHandler` — passes the already-resolved `updatedBy` string to `RemoveLine`, `UpdateLine`, and `AddLine`

All existing domain and handler unit tests updated to the new signatures. 129 tests pass.

## Files changed
- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs`
- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs`
- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs`
- `backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs`
- `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs`

Closes #3254