### PR TITLE
#3263: Remove infrastructure exception leakage from BackfillArticleRequestedByHandler

### DIFF
--- a/artifacts/feat-3263/arch-review.r1.md
+++ b/artifacts/feat-3263/arch-review.r1.md
@@ -1,0 +1,185 @@
+# Architecture Review: Remove Infrastructure Exception Leakage from BackfillArticleRequestedByHandler
+
+## Skip Design: false
+
+## Architectural Fit Assessment
+
+The violation is real and clear-cut. `BackfillArticleRequestedByHandler` (Application layer) currently imports `Microsoft.Identity.Client` directly — confirmed at line 6 of the handler — and catches `MsalException` and `Microsoft.Graph.Models.ODataErrors.ODataError` by their SDK types. `GraphArticleUserResolver` (UserManagement module, Application layer) is the adapter that should absorb these infrastructure details, but at present it is a thin pass-through that lets both exception types escape to the caller unchanged.
+
+The fix is well-contained. `GraphArticleUserResolver` is the single call site for `IGraphService.GetGroupMembersAsync` in the Article flow. `GraphService.GetGroupMembersAsync` already re-throws `MsalException`, `ODataError`, `UnauthorizedAccessException`, and generic `Exception` after logging, so no logging is lost by wrapping at the adapter level.
+
+The spec is accurate, achievable, and well-scoped. There are no ambiguities that would block implementation.
+
+One nuance not fully addressed in the spec: `Microsoft.Graph` and `Microsoft.Identity.Web` are used by other Application-layer services (`GraphService`, `GraphPlannerService`, `GraphCatalogDocumentsStorage`). FR-5 (remove those PackageReferences from Application.csproj) is correct only if the new domain exceptions do not reference any Graph/MSAL types — which is true by design — but the packages will remain referenced because of those other files. The build gate in FR-5 ("if build still passes") will correctly prevent removal. This is not a spec error, just an expected outcome worth documenting explicitly.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Application/Features/Article/Contracts/
+  IArticleUserResolver.cs                 ← add XML <exception> docs + no type change
+  ArticleUserResolverAuthException.cs     ← NEW domain exception
+  ArticleUserResolverServiceException.cs  ← NEW domain exception
+
+Application/Features/UserManagement/Infrastructure/
+  GraphArticleUserResolver.cs             ← add try/catch, translate MsalException → Auth, ODataError → Service
+
+Application/Features/Article/Admin/
+  BackfillArticleRequestedByHandler.cs    ← swap catch types, remove MSAL using
+
+Tests/Article/Admin/
+  BackfillArticleRequestedByHandlerTests.cs ← swap two mock throw types
+```
+
+No new files outside the Contracts folder. No interface signature changes. No DI registration changes.
+
+### Key Design Decisions
+
+#### Decision 1: Exception placement — Application/Contracts vs Application/Shared
+**Options considered:**
+- `Application/Shared/` — alongside `ErrorCodes` and other cross-cutting application types.
+- `Application/Features/Article/Contracts/` — co-located with `IArticleUserResolver`, the interface that declares the exception contract.
+
+**Chosen approach:** `Application/Features/Article/Contracts/`
+
+**Rationale:** These exceptions are part of the contract that `IArticleUserResolver` exposes to its consumers. They are Article-owned, not shared across the application. Placing them beside the interface makes the contract self-contained: a developer reading `IArticleUserResolver.cs` finds the XML doc referencing the exception types, and those types are in the same directory. The existing precedent in this codebase is that domain exceptions live near their owning feature contracts (`ProductMarginsException` under `Catalog/Infrastructure/Exceptions/`, `OutlookCalendarSyncException` under `Marketing/Services/`). The Contracts subfolder is the correct placement for the Article module.
+
+#### Decision 2: Exception class shape — plain class vs record
+**Options considered:**
+- C# records (concise, value-equality).
+- Plain classes extending `Exception`.
+
+**Chosen approach:** Plain classes extending `Exception`.
+
+**Rationale:** Project rule: DTOs are classes, not records (OpenAPI generator issue). More specifically, exception types must extend `Exception` and `Exception` is not a record-compatible base. The existing codebase exception pattern (`ProductMarginsException`, `OutlookCalendarSyncException`) uses plain classes with `(string message, Exception innerException)` constructors. Follow that pattern exactly.
+
+#### Decision 3: Translation layer — GraphArticleUserResolver vs GraphService
+**Options considered:**
+- Translate inside `GraphService.GetGroupMembersAsync` itself — wrap the re-throws into domain exceptions.
+- Translate inside `GraphArticleUserResolver.ResolveByGroupAsync` — wrap the `_graph.GetGroupMembersAsync(...)` call.
+
+**Chosen approach:** Translate inside `GraphArticleUserResolver`.
+
+**Rationale:** `GraphService` is owned by the UserManagement module and is used by multiple consumers (`GetGroupMembersHandler`, `GraphCatalogDocumentsStorage`, `GraphPlannerService`). Translating at `GraphService` would change the exception contract for all callers, not just the Article flow, and those callers have their own catch/handling today. `GraphArticleUserResolver` is a single-purpose adapter that bridges the UserManagement infrastructure into the Article contract — translating there keeps the change isolated to the Article dependency boundary and leaves `GraphService` unchanged.
+
+#### Decision 4: Naming — Auth vs Msal, Service vs OData
+**Options considered:**
+- `MsalArticleUserResolverException` / `ODataArticleUserResolverException` — names that leak the SDK.
+- `ArticleUserResolverAuthException` / `ArticleUserResolverServiceException` — names that express the semantic meaning.
+
+**Chosen approach:** `ArticleUserResolverAuthException` / `ArticleUserResolverServiceException` (as spec'd).
+
+**Rationale:** The entire point of the refactor is to remove SDK type references from the Application layer. Exception names that mention MSAL or OData would re-introduce the same conceptual leak even without a compile-time dependency. The semantic names (`Auth` = authentication/token failure, `Service` = upstream service error) map cleanly to the `ErrorCodes.ConfigurationError` and `ErrorCodes.ExternalServiceError` response values already used in the handler.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Article/Contracts/
+  ArticleUserResolverAuthException.cs     ← new file
+  ArticleUserResolverServiceException.cs  ← new file
+  IArticleUserResolver.cs                 ← modified (XML docs only)
+
+backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/
+  GraphArticleUserResolver.cs             ← modified (try/catch added)
+
+backend/src/Anela.Heblo.Application/Features/Article/Admin/
+  BackfillArticleRequestedByHandler.cs    ← modified (catch types + using)
+
+backend/test/Anela.Heblo.Tests/Article/Admin/
+  BackfillArticleRequestedByHandlerTests.cs ← modified (two test methods)
+```
+
+### Interfaces and Contracts
+
+`IArticleUserResolver` signature does not change. Add XML doc to the method:
+
+```csharp
+/// <exception cref="ArticleUserResolverAuthException">
+///   Thrown when token acquisition for the directory service fails.
+/// </exception>
+/// <exception cref="ArticleUserResolverServiceException">
+///   Thrown when the directory service returns an error response.
+/// </exception>
+/// <exception cref="UnauthorizedAccessException">
+///   Thrown when the caller lacks permission to read the group.
+/// </exception>
+Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+    string groupId,
+    CancellationToken cancellationToken);
+```
+
+New exception classes follow the established project pattern:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+public class ArticleUserResolverAuthException : Exception
+{
+    public ArticleUserResolverAuthException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+```
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+public class ArticleUserResolverServiceException : Exception
+{
+    public ArticleUserResolverServiceException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+```
+
+### Data Flow
+
+**Before (broken):**
+```
+BackfillArticleRequestedByHandler
+  → IArticleUserResolver.ResolveByGroupAsync
+    → GraphArticleUserResolver (pass-through)
+      → GraphService.GetGroupMembersAsync
+        throws MsalException / ODataError
+      ← MsalException / ODataError (unmodified)
+    ← MsalException / ODataError (unmodified)
+  ← handler catches SDK types directly (violation)
+```
+
+**After (fixed):**
+```
+BackfillArticleRequestedByHandler
+  → IArticleUserResolver.ResolveByGroupAsync
+    → GraphArticleUserResolver (translating adapter)
+      → GraphService.GetGroupMembersAsync
+        throws MsalException / ODataError
+      GraphArticleUserResolver catches MsalException → throws ArticleUserResolverAuthException
+      GraphArticleUserResolver catches ODataError   → throws ArticleUserResolverServiceException
+    ← ArticleUserResolverAuthException / ArticleUserResolverServiceException
+  ← handler catches domain types only (clean)
+```
+
+`UnauthorizedAccessException` propagates unchanged through both layers — the handler already catches it at line 53 and returns `ErrorCodes.Forbidden`. No change needed there.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `Microsoft.Graph` and `Microsoft.Identity.Web` remain in Application.csproj after FR-5 attempt | Low | Expected. Other Graph-using services (`GraphService`, `GraphPlannerService`, `GraphCatalogDocumentsStorage`) require them. The build gate in FR-5 catches this automatically. Note this in the PR description so it is not revisited. |
+| `GraphService.GetGroupMembersAsync` also logs before re-throwing — double-logging if adapter wraps | Low | Acceptable duplication. The log at `GraphService` captures SDK-level detail (MSAL error code, OData code); the log at the handler captures business context (GroupId, operation). They serve different diagnostic purposes. No change needed to logging. |
+| Test project references `Microsoft.Graph` transitively via `Anela.Heblo.Application` — tests for the old ODataError throw still compile after FR-6 | Low | The test project references Application which still carries `Microsoft.Graph`. The two test cases that throw `MsalUiRequiredException` and `ODataError` must be updated to throw the new domain exceptions; they would fail (wrong error code) if left unchanged even though they still compile. The test build gate enforces correctness. |
+| Handler's `catch (Exception)` block at line 59 remains a safety net for truly unexpected errors | None | No change required. The four catch blocks in the handler — `Auth`, `Service`, `Unauthorized`, `Exception` — remain structurally identical; only two type names change. |
+
+## Specification Amendments
+
+**Amendment 1 — FR-5 expected outcome:** The spec says "Remove the two PackageReferences if build still passes." Clarify in the implementation PR that the build will NOT pass without those references because `GraphService`, `GraphPlannerService`, and `GraphCatalogDocumentsStorage` all use `Microsoft.Graph` and/or `Microsoft.Identity.Web` types. FR-5 is effectively a verification step, not a removal step. The meaningful metric is that `BackfillArticleRequestedByHandler.cs` no longer imports `Microsoft.Identity.Client` — that `using` is the actual artifact of the dependency violation.
+
+**Amendment 2 — Test file has no `using Microsoft.Graph.Models.ODataErrors;` at top-level but constructs `ODataError` inline.** When updating `BackfillArticleRequestedByHandlerTests.cs`, remove the `using Microsoft.Identity.Client;` at line 7 and the `ODataError` construction once those are replaced. Confirm the test file compiles cleanly without those namespaces.
+
+## Prerequisites
+
+- No migration changes.
+- No DI registration changes.
+- No other PR or branch changes in flight that touch `GraphArticleUserResolver`, `IArticleUserResolver`, or `BackfillArticleRequestedByHandler`.
+- Validate: `dotnet build` + `dotnet test --filter "FullyQualifiedName~BackfillArticleRequestedByHandlerTests"` must pass before closing.

--- a/artifacts/feat-3263/brief.md
+++ b/artifacts/feat-3263/brief.md
@@ -1,0 +1,25 @@
+## Module
+Article
+
+## Finding
+`BackfillArticleRequestedByHandler` directly catches `MsalException` (from `Microsoft.Identity.Client`) and `Microsoft.Graph.Models.ODataErrors.ODataError` (from the Graph SDK) inside the Application layer:
+
+```
+backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs
+  line 6:   using Microsoft.Identity.Client;
+  line 45:  catch (MsalException ex) { … ErrorCodes.ConfigurationError … }
+  line 49:  catch (Microsoft.Graph.Models.ODataErrors.ODataError ex) { … ErrorCodes.ExternalServiceError … }
+```
+
+The Application project's `Anela.Heblo.Application.csproj` carries a direct `<PackageReference>` on `Microsoft.Graph` (5.92.0) and `Microsoft.Identity.Web` (3.14.1) to support this.
+
+`IArticleUserResolver.ResolveByGroupAsync` (the contract in `Contracts/IArticleUserResolver.cs`) has no documented exception contract, so MSAL and OData exceptions escape from the adapter implementation and force the handler to know about them.
+
+## Why it matters
+The Application layer must not depend on infrastructure packages (Clean Architecture dependency rule). By catching `MsalException` and `ODataError`, the handler takes on knowledge of which SDK powers `IArticleUserResolver`. If the adapter is ever swapped (different identity provider, different Graph SDK version) the handler must change too — defeating the abstraction. It also makes `BackfillArticleRequestedByHandler` untestable without MSAL/Graph stubs.
+
+## Suggested fix
+Translate infrastructure exceptions inside the `IArticleUserResolver` adapter implementation (which lives in the UserManagement or Adapters layer). Define a small set of domain exceptions in the Application/Domain layer — e.g. `ExternalAuthServiceException`, `ExternalServiceUnavailableException` — or reuse the existing `ErrorCodes` result pattern by returning a typed `Result<IReadOnlyList<ArticleUserMatch>>` from `ResolveByGroupAsync`. The handler then handles only domain outcomes; `MsalException` and `ODataError` never cross the layer boundary, and `Microsoft.Identity.Client`/`Microsoft.Graph` references can be removed from the Application project.
+
+---
+_Filed by daily arch-review routine on 2026-06-22._

--- a/artifacts/feat-3263/design.r1.md
+++ b/artifacts/feat-3263/design.r1.md
@@ -1,0 +1,119 @@
+# Design: Remove Infrastructure Exception Leakage from BackfillArticleRequestedByHandler
+
+## Component Design
+
+### New: Domain Exception Types
+**Location:** `Application/Features/Article/Contracts/ArticleUserResolverAuthException.cs`, `Application/Features/Article/Contracts/ArticleUserResolverServiceException.cs`
+
+**Responsibility:** Represent failure modes of `IArticleUserResolver` in domain terms, decoupled from any SDK. Both are plain `Exception` subclasses with a single constructor `(string message, Exception innerException)`.
+
+**Interface:**
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+public class ArticleUserResolverAuthException : Exception
+{
+    public ArticleUserResolverAuthException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+
+public class ArticleUserResolverServiceException : Exception
+{
+    public ArticleUserResolverServiceException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+```
+
+---
+
+### Modified: `IArticleUserResolver`
+**Location:** `Application/Features/Article/Contracts/IArticleUserResolver.cs`
+
+**Change:** Add XML doc to `ResolveByGroupAsync` declaring the two new exceptions as part of the contract.
+
+```csharp
+/// <summary>
+/// Resolves article users belonging to the specified group.
+/// </summary>
+/// <exception cref="ArticleUserResolverAuthException">
+///   Thrown when token acquisition for the underlying service fails.
+/// </exception>
+/// <exception cref="ArticleUserResolverServiceException">
+///   Thrown when the underlying service returns an error response.
+/// </exception>
+Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(string groupId, CancellationToken ct);
+```
+
+---
+
+### Modified: `GraphArticleUserResolver` (Infrastructure adapter)
+**Location:** `Infrastructure/…/GraphArticleUserResolver.cs`
+
+**Responsibility:** Sole site of SDK-to-domain exception translation. Catches `MsalException` and `ODataError` from their respective SDK namespaces and re-throws as the domain exceptions defined above. `UnauthorizedAccessException` is not caught here and propagates unchanged.
+
+**Translated try/catch block (wraps the Graph call only):**
+```csharp
+try
+{
+    var members = await _graph.GetGroupMembersAsync(groupId, ct);
+    return members.Select(m => new ArticleUserMatch(m.Id, m.DisplayName)).ToList();
+}
+catch (MsalException ex)
+{
+    throw new ArticleUserResolverAuthException("Graph token acquisition failed.", ex);
+}
+catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)
+{
+    throw new ArticleUserResolverServiceException("Graph OData error.", ex);
+}
+```
+
+No other catch blocks are added. No other class performs this translation.
+
+---
+
+### Modified: `BackfillArticleRequestedByHandler`
+**Location:** `Application/Features/Article/Commands/BackfillArticleRequestedBy/BackfillArticleRequestedByHandler.cs`
+
+**Changes:**
+- Replace `catch (MsalException ex)` with `catch (ArticleUserResolverAuthException ex)`
+- Replace `catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)` with `catch (ArticleUserResolverServiceException ex)`
+- Remove `using Microsoft.Identity.Client;`
+
+The handler logic inside each catch block remains unchanged (same log level, same error propagation/return). The handler has no remaining direct dependency on infrastructure SDK namespaces after this change.
+
+---
+
+### Modified: `BackfillArticleRequestedByHandlerTests`
+**Location:** `Application.Tests/Features/Article/Commands/BackfillArticleRequestedBy/BackfillArticleRequestedByHandlerTests.cs`
+
+**Changes:**
+- Mock setup that previously threw `MsalUiRequiredException` now throws `new ArticleUserResolverAuthException("...", new Exception())`
+- Mock setup that previously threw `new Microsoft.Graph.Models.ODataErrors.ODataError()` now throws `new ArticleUserResolverServiceException("...", new Exception())`
+
+Test assertions and expected handler outcomes are unchanged.
+
+---
+
+### Attempted (expected no-op): `Application.csproj` dependency removal
+**Location:** `src/Application/Application.csproj`
+
+Attempt removal of `Microsoft.Graph` and `Microsoft.Identity.Web` package references. Expected to fail because other services in the Application layer depend on them. No action taken if references cannot be removed cleanly.
+
+---
+
+## Component Boundaries Summary
+
+| Layer | Component | SDK dependency after change |
+|---|---|---|
+| Application | `ArticleUserResolverAuthException` | None |
+| Application | `ArticleUserResolverServiceException` | None |
+| Application | `IArticleUserResolver` | None |
+| Application | `BackfillArticleRequestedByHandler` | None (SDK usings removed) |
+| Infrastructure | `GraphArticleUserResolver` | `MsalException`, `ODataError` (translation point) |
+
+---
+
+## Data Schemas
+
+No database schema changes. No API request/response shape changes. No new DTOs. No DI registration changes.

--- a/artifacts/feat-3263/impl/create-domain-exceptions.r1.md
+++ b/artifacts/feat-3263/impl/create-domain-exceptions.r1.md
@@ -1,0 +1,27 @@
+# Implementation: create-domain-exceptions
+
+## What was implemented
+Created two new domain exception classes in `Application/Features/Article/Contracts/`:
+- `ArticleUserResolverAuthException` — wraps infrastructure auth failures (MsalException)
+- `ArticleUserResolverServiceException` — wraps infrastructure service failures (ODataError)
+
+Both are plain sealed classes extending `Exception` with `(string message, Exception innerException)` constructors. No SDK references. Build passes with 0 errors.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverAuthException.cs` — new domain exception for auth failures
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverServiceException.cs` — new domain exception for service failures
+
+## Tests
+No tests in this task — the exception classes are trivial value types. Integration tested in task fix-handler-and-tests.
+
+## How to verify
+```
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --no-restore
+```
+Build completes with 0 errors.
+
+## Notes
+Exception classes use `sealed` modifier, which is a slight tightening of the spec (which only said `class`). The design doc showed plain classes but sealed is appropriate here since no subclassing is intended.
+
+## Status
+DONE

--- a/artifacts/feat-3263/impl/fix-handler-and-tests.r1.md
+++ b/artifacts/feat-3263/impl/fix-handler-and-tests.r1.md
@@ -1,0 +1,41 @@
+# Implementation: fix-handler-and-tests
+
+## What was implemented
+1. Removed `using Microsoft.Identity.Client;` from `BackfillArticleRequestedByHandler.cs`
+2. Replaced `catch (MsalException ex)` with `catch (ArticleUserResolverAuthException ex)` — same log message, same return code (`ConfigurationError`)
+3. Replaced `catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)` with `catch (ArticleUserResolverServiceException ex)` — same log message, same return code (`ExternalServiceError`)
+4. Removed `using Microsoft.Identity.Client;` from `BackfillArticleRequestedByHandlerTests.cs`
+5. Renamed `Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError` → `Handle_WhenResolverThrowsAuthException_ReturnsConfigurationError`; mock throws `ArticleUserResolverAuthException` instead of `MsalUiRequiredException`
+6. Renamed `Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError` → `Handle_WhenResolverThrowsServiceException_ReturnsExternalServiceError`; mock throws `ArticleUserResolverServiceException` instead of `ODataError`
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs` — removed SDK using and catch types
+- `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs` — removed SDK using, updated two test methods
+
+## Tests
+All 11 tests in `BackfillArticleRequestedByHandlerTests` pass. Test count unchanged.
+
+## How to verify
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~BackfillArticleRequestedBy" --no-restore
+```
+Result: All tests pass (exit code 0).
+
+## Notes
+- `BackfillArticleRequestedByHandler.cs` now has zero SDK-specific references in the Article feature namespace
+- `UnauthorizedAccessException` and generic `Exception` catch blocks in the handler are unchanged
+- The csproj package references for `Microsoft.Graph` and `Microsoft.Identity.Web` remain — they are needed by `GraphService`, `GraphPlannerService`, and `GraphCatalogDocumentsStorage` in the Application project. The architectural violation (SDK catch in handler) is resolved; removing those package references is not possible without a larger refactor.
+
+## PR Summary
+Fixed a Clean Architecture violation where `BackfillArticleRequestedByHandler` caught `MsalException` and `ODataError` (infrastructure SDK types) directly in the Application layer. The fix introduces two domain exceptions (`ArticleUserResolverAuthException`, `ArticleUserResolverServiceException`) in the Article contracts namespace and moves exception translation to `GraphArticleUserResolver`, the adapter that already has legitimate access to those SDK types. The handler now catches only domain exceptions, making it fully testable without SDK stubs.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverAuthException.cs` — new domain exception for auth failures
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverServiceException.cs` — new domain exception for service failures
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs` — added XML exception contract docs
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs` — catches MsalException and ODataError, translates to domain exceptions
+- `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs` — catches domain exceptions only; removed `using Microsoft.Identity.Client`
+- `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs` — updated two tests to throw domain exceptions
+
+## Status
+DONE

--- a/artifacts/feat-3263/impl/update-interface-and-adapter.r1.md
+++ b/artifacts/feat-3263/impl/update-interface-and-adapter.r1.md
@@ -1,0 +1,24 @@
+# Implementation: update-interface-and-adapter
+
+## What was implemented
+1. Added XML `<exception>` doc comments to `IArticleUserResolver.ResolveByGroupAsync` documenting `ArticleUserResolverAuthException`, `ArticleUserResolverServiceException`, and `UnauthorizedAccessException`.
+2. Updated `GraphArticleUserResolver.ResolveByGroupAsync` to catch `MsalException` (from `Microsoft.Identity.Client`) and `Microsoft.Graph.Models.ODataErrors.ODataError`, wrapping them in the new domain exceptions with original exception as `InnerException`. `UnauthorizedAccessException` and generic `Exception` propagate unchanged.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs` — added XML doc to `ResolveByGroupAsync`
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs` — added try/catch with exception translation; added `using Microsoft.Identity.Client;`
+
+## Tests
+No new tests in this task — the adapter translation is covered by the handler tests in task fix-handler-and-tests.
+
+## How to verify
+```
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --no-restore
+```
+Build completes with 0 errors, 142 warnings (pre-existing).
+
+## Notes
+The `using Microsoft.Identity.Client;` was added to `GraphArticleUserResolver.cs` to reference `MsalException`. This is appropriate since this file is in the `UserManagement.Infrastructure` namespace, where SDK dependencies are permitted.
+
+## Status
+DONE

--- a/artifacts/feat-3263/review/create-domain-exceptions.r1.md
+++ b/artifacts/feat-3263/review/create-domain-exceptions.r1.md
@@ -1,0 +1,11 @@
+# Code Review: create-domain-exceptions
+
+## Summary
+The implementation successfully created two new domain exception classes for the Article module. Both exceptions are properly located in the `Contracts` folder, follow the correct naming conventions, and are implemented exactly as specified.
+
+## Review Result: PASS
+
+### task: create-domain-exceptions
+**Status:** PASS
+
+All acceptance criteria met. No issues detected.

--- a/artifacts/feat-3263/review/fix-handler-and-tests.r1.md
+++ b/artifacts/feat-3263/review/fix-handler-and-tests.r1.md
@@ -1,0 +1,11 @@
+# Code Review: fix-handler-and-tests
+
+## Summary
+All acceptance criteria met. Handler has no SDK imports or catch blocks; domain exception catches are in place with correct return codes. Test file removes the MSAL using and both test methods throw domain exceptions. All 11 tests pass.
+
+## Review Result: PASS
+
+### task: fix-handler-and-tests
+**Status:** PASS
+
+Note: An earlier reviewer run incorrectly read main-repo files instead of the worktree. Worktree inspection confirmed all changes are correctly applied; dotnet test exit code 0 confirms tests pass.

--- a/artifacts/feat-3263/review/update-interface-and-adapter.r1.md
+++ b/artifacts/feat-3263/review/update-interface-and-adapter.r1.md
@@ -1,0 +1,9 @@
+# Code Review: update-interface-and-adapter
+
+## Summary
+All acceptance criteria met. Interface documents three exception types without SDK-specific references. Adapter has explicit catch blocks for MsalException and ODataError, each wrapping original exception as InnerException. Build succeeds with 0 errors.
+
+## Review Result: PASS
+
+### task: update-interface-and-adapter
+**Status:** PASS

--- a/artifacts/feat-3263/spec.r1.md
+++ b/artifacts/feat-3263/spec.r1.md
@@ -1,0 +1,169 @@
+# Specification: Remove Infrastructure Exception Leakage from BackfillArticleRequestedByHandler
+
+## Summary
+
+`BackfillArticleRequestedByHandler` (Application layer) directly catches `MsalException` and `ODataError` — types from `Microsoft.Identity.Client` and the Graph SDK — which violates the Clean Architecture dependency rule and forces the Application project to carry `Microsoft.Graph` and `Microsoft.Identity.Web` package references. This feature replaces those two infrastructure catches with catches of two new domain exceptions defined inside the Application layer, and moves the translation of MSAL/OData exceptions to the adapter (`GraphArticleUserResolver`) where infrastructure types are already permitted.
+
+## Background
+
+The Application project (`Anela.Heblo.Application`) currently references `Microsoft.Graph` 5.92.0 and `Microsoft.Identity.Web` 3.14.1 solely to support the two `catch` blocks in `BackfillArticleRequestedByHandler`. The abstraction `IArticleUserResolver` is meant to hide the identity-provider implementation, but because its exception contract is undocumented the MSAL and OData exceptions propagate freely through `GraphArticleUserResolver.ResolveByGroupAsync` all the way up to the handler.
+
+The existing exception-class pattern in the codebase (`OutlookCalendarSyncException` in Application, `GridLayoutPersistenceException` in Domain) confirms that simple classes extending `Exception` are the accepted mechanism for communicating infrastructure failures upward without leaking SDK types.
+
+Tests in `BackfillArticleRequestedByHandlerTests.cs` also import `Microsoft.Identity.Client` and `Microsoft.Graph.Models.ODataErrors` to construct test doubles; these usages disappear once the handler no longer catches those types.
+
+## Functional Requirements
+
+### FR-1: Define two domain exception types in the Application layer
+
+Create two exception classes inside `Anela.Heblo.Application`:
+
+- `ArticleUserResolverAuthException` — raised when token acquisition fails (i.e., MSAL configuration is wrong or a token cannot be obtained). Maps to `ErrorCodes.ConfigurationError` in the handler.
+- `ArticleUserResolverServiceException` — raised when the upstream directory service returns an error response (i.e., OData/Graph API error). Maps to `ErrorCodes.ExternalServiceError` in the handler.
+
+Both classes extend `Exception`. Both accept a `string message` and an `Exception innerException` constructor parameter so the original SDK exception is preserved for logging.
+
+**Suggested location:** `backend/src/Anela.Heblo.Application/Features/Article/Contracts/` alongside `IArticleUserResolver.cs`, since they form the contract of that interface.
+
+**Acceptance criteria:**
+- `ArticleUserResolverAuthException` compiles with no reference to `Microsoft.Identity.Client` or `Microsoft.Graph`.
+- `ArticleUserResolverServiceException` compiles with no reference to `Microsoft.Identity.Client` or `Microsoft.Graph`.
+- Both classes carry the inner exception from the infrastructure layer.
+
+### FR-2: Update IArticleUserResolver XML doc to declare the exception contract
+
+Add an XML `<exception>` doc comment to `ResolveByGroupAsync` in `IArticleUserResolver.cs` stating that `ArticleUserResolverAuthException` is thrown on token failure and `ArticleUserResolverServiceException` is thrown on upstream service error. `UnauthorizedAccessException` (BCL) remains part of the contract and should also be documented.
+
+**Acceptance criteria:**
+- The interface file lists all three throwable exception types in XML doc comments.
+- No SDK-specific types are referenced in the interface file.
+
+### FR-3: Translate infrastructure exceptions in GraphArticleUserResolver
+
+In `GraphArticleUserResolver.ResolveByGroupAsync`, wrap the call to `_graph.GetGroupMembersAsync(...)` in a try/catch that:
+
+- Catches `MsalException` → wraps and re-throws as `ArticleUserResolverAuthException`.
+- Catches `Microsoft.Graph.Models.ODataErrors.ODataError` → wraps and re-throws as `ArticleUserResolverServiceException`.
+- Does **not** catch `UnauthorizedAccessException` (let it propagate as-is; the handler already handles it as a BCL type).
+- Does **not** catch the generic `Exception` (let unexpected failures propagate to the handler's existing generic catch).
+
+`GraphService.GetGroupMembersAsync` already re-throws all three exception types (MSAL, OData, Unauthorized) so they will reliably arrive at `GraphArticleUserResolver`.
+
+**Acceptance criteria:**
+- `GraphArticleUserResolver.ResolveByGroupAsync` has explicit catch blocks for `MsalException` and `ODataError`.
+- Each catch wraps the original exception as `innerException` in the new domain exception.
+- After the change, `MsalException` and `ODataError` cannot escape `GraphArticleUserResolver`.
+
+### FR-4: Update BackfillArticleRequestedByHandler to catch only domain exceptions
+
+Replace the two infrastructure catches in `BackfillArticleRequestedByHandler.Handle(...)`:
+
+- Remove `catch (MsalException ex)` → replace with `catch (ArticleUserResolverAuthException ex)`.
+- Remove `catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)` → replace with `catch (ArticleUserResolverServiceException ex)`.
+- Remove the `using Microsoft.Identity.Client;` directive.
+- The `UnauthorizedAccessException` catch and the generic `Exception` catch remain unchanged.
+
+Log messages in both new catches should be identical in content to the original ones so that existing log-monitoring queries continue to work.
+
+**Acceptance criteria:**
+- `BackfillArticleRequestedByHandler.cs` has no `using` directive for `Microsoft.Identity.Client` or `Microsoft.Graph`.
+- The handler returns `ErrorCodes.ConfigurationError` on `ArticleUserResolverAuthException`.
+- The handler returns `ErrorCodes.ExternalServiceError` on `ArticleUserResolverServiceException`.
+- Handler behaviour for all other exception types is unchanged.
+
+### FR-5: Remove Microsoft.Graph and Microsoft.Identity.Web from Application project
+
+After FR-1–FR-4 are complete, remove from `Anela.Heblo.Application.csproj`:
+
+```xml
+<PackageReference Include="Microsoft.Graph" Version="5.92.0" />
+<PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+```
+
+Verify that the project still builds after removal (these packages may be transitive dependencies via other paths; if so, the build error will make that visible and the reference should be retained with a comment explaining why).
+
+**Acceptance criteria:**
+- `dotnet build` succeeds after the package references are removed (or a comment explains why a reference must remain).
+- No remaining `using Microsoft.Identity.Client` or `using Microsoft.Graph` directives exist in the Application project except inside `Features/UserManagement/` (which is the legitimate infrastructure-adjacent slice).
+
+### FR-6: Update BackfillArticleRequestedByHandlerTests
+
+In `BackfillArticleRequestedByHandlerTests.cs`:
+
+- Remove `using Microsoft.Identity.Client;` and any `using Microsoft.Graph...` directives.
+- Replace the test `Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError` so that the mock throws `ArticleUserResolverAuthException` instead of `MsalUiRequiredException`.
+- Replace the test `Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError` so that the mock throws `ArticleUserResolverServiceException` instead of `Microsoft.Graph.Models.ODataErrors.ODataError`.
+- All other tests remain unchanged.
+
+**Acceptance criteria:**
+- Test project compiles with no reference to `Microsoft.Identity.Client` or `Microsoft.Graph` types (unless those are already used by other test classes, which would be a separate concern).
+- Both updated tests pass.
+- Total test count for the file is unchanged.
+
+## Non-Functional Requirements
+
+### NFR-1: Behaviour Equivalence
+
+The observable runtime behaviour of `BackfillArticleRequestedByHandler` must be identical before and after the change. The same `ErrorCodes` values must be returned for the same failure conditions. Log messages must be equivalent so that existing alerting is unaffected.
+
+### NFR-2: Inner Exception Preservation
+
+The original `MsalException` / `ODataError` instance must be stored as `InnerException` on the wrapping domain exception so that full SDK stack traces are available in logs and APM tooling. Do not swallow or discard the original exception.
+
+### NFR-3: Layering Compliance
+
+After this change, no file under `Anela.Heblo.Application/Features/Article/` may contain a `using` directive for `Microsoft.Identity.Client` or `Microsoft.Graph.*`. This can be confirmed with a simple `grep`.
+
+### NFR-4: Build and Test
+
+`dotnet build` and `dotnet format` (backend) must pass clean. All existing unit tests must pass.
+
+## Data Model
+
+No database schema changes. No new domain entities. The only new types are two exception classes.
+
+| Type | Namespace | Base |
+|---|---|---|
+| `ArticleUserResolverAuthException` | `Anela.Heblo.Application.Features.Article.Contracts` | `Exception` |
+| `ArticleUserResolverServiceException` | `Anela.Heblo.Application.Features.Article.Contracts` | `Exception` |
+
+## API / Interface Design
+
+No API surface changes. No new endpoints. No changes to request/response DTOs or `ErrorCodes` values. The existing `ErrorCodes.ConfigurationError` and `ErrorCodes.ExternalServiceError` enum members are reused as-is.
+
+The updated `IArticleUserResolver` interface (documentation-only change):
+
+```csharp
+/// <exception cref="ArticleUserResolverAuthException">
+/// Thrown when token acquisition fails (misconfigured credentials or expired app secret).
+/// </exception>
+/// <exception cref="ArticleUserResolverServiceException">
+/// Thrown when the upstream directory service returns an error response.
+/// </exception>
+/// <exception cref="UnauthorizedAccessException">
+/// Thrown when the application lacks the required directory permissions.
+/// </exception>
+Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+    string groupId,
+    CancellationToken cancellationToken);
+```
+
+## Dependencies
+
+- `GraphArticleUserResolver` lives at `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`. It already references `Microsoft.Identity.Client` (transitively via `GraphService`) — this is acceptable because it is in the `UserManagement.Infrastructure` sub-namespace.
+- `GraphService.GetGroupMembersAsync` already re-throws `MsalException`, `ODataError`, and `UnauthorizedAccessException` — no changes needed there.
+- `Microsoft.Graph` and `Microsoft.Identity.Web` remain as package references in the Application project until FR-5 confirms they can be removed. If they are pulled in transitively by another feature's legitimate dependency (e.g. `Adapters.Microsoft365`), the Application project reference may be unnecessary but harmless; the important change is removing the Application-layer *catch* blocks, not necessarily the package references.
+
+## Out of Scope
+
+- Refactoring `GraphService` exception handling strategy (logs and re-throws — this is acceptable and unrelated to the violation).
+- Adding retry logic or circuit-breaker policy to `IArticleUserResolver`.
+- Changing the `ErrorCodes` enum or adding Article-module-specific error codes (2408+) for these failures. The existing general codes are sufficient.
+- Moving `GraphArticleUserResolver` out of the Application project into a separate Adapters project — this is a larger structural change and is not required to fix the violation.
+- Any changes to other callers of `IGraphService` that are not part of the Article backfill flow.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3263/state.json
+++ b/artifacts/feat-3263/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T15:14:29.546216Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T15:18:50.229454Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-22T15:18:53.517739Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3263/state.json
+++ b/artifacts/feat-3263/state.json
@@ -21,28 +21,28 @@
       "updated_at": "2026-06-22T15:25:37.754700Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-22T15:52:45.950970Z"
     }
   },
   "tasks": [
     {
       "name": "create-domain-exceptions",
-      "status": "pending",
+      "status": "completed",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-22T15:32:16.811407Z"
     },
     {
       "name": "update-interface-and-adapter",
-      "status": "pending",
+      "status": "completed",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-22T15:34:37.967089Z"
     },
     {
       "name": "fix-handler-and-tests",
-      "status": "pending",
+      "status": "completed",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-22T15:52:42.030226Z"
     }
   ]
 }

--- a/artifacts/feat-3263/state.json
+++ b/artifacts/feat-3263/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-06-22T15:18:50.229454Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T15:18:53.517739Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T15:21:29.740056Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-22T15:21:45.054939Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3263/state.json
+++ b/artifacts/feat-3263/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3263",
+  "issue_number": 3263,
+  "created_at": "2026-06-22T15:14:04.010209Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-22T15:14:29.546216Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3263/state.json
+++ b/artifacts/feat-3263/state.json
@@ -17,13 +17,32 @@
       "updated_at": "2026-06-22T15:22:50.181888Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T15:22:54.128603Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T15:25:37.754700Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "create-domain-exceptions",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "update-interface-and-adapter",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "fix-handler-and-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3263/state.json
+++ b/artifacts/feat-3263/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-06-22T15:21:29.740056Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T15:21:45.054939Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T15:22:50.181888Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-22T15:22:54.128603Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3263/task-context/create-domain-exceptions.md
+++ b/artifacts/feat-3263/task-context/create-domain-exceptions.md
@@ -1,0 +1,53 @@
+### task: create-domain-exceptions
+
+**What and why:** Create two new Article-module exception classes in the `Contracts` folder alongside `IArticleUserResolver`. These are the clean Application-layer exception types that `BackfillArticleRequestedByHandler` will catch instead of the SDK-specific ones.
+
+**Files to create:**
+
+`backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverAuthException.cs`
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Thrown by <see cref="IArticleUserResolver"/> implementations when token acquisition
+/// or authentication for the underlying identity provider fails.
+/// Wraps infrastructure-specific auth exceptions (e.g. MsalException) so that
+/// Application-layer consumers remain decoupled from SDK packages.
+/// </summary>
+public sealed class ArticleUserResolverAuthException : Exception
+{
+    public ArticleUserResolverAuthException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+```
+
+`backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverServiceException.cs`
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Thrown by <see cref="IArticleUserResolver"/> implementations when the remote
+/// directory service returns an error response (e.g. an OData error from Microsoft Graph).
+/// Wraps infrastructure-specific service exceptions so that Application-layer consumers
+/// remain decoupled from SDK packages.
+/// </summary>
+public sealed class ArticleUserResolverServiceException : Exception
+{
+    public ArticleUserResolverServiceException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+```
+
+**Verify build:**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+Build must succeed with zero errors before committing.
+
+**Commit:** `refactor(article): add ArticleUserResolverAuthException and ArticleUserResolverServiceException`
+
+---

--- a/artifacts/feat-3263/task-context/fix-handler-and-tests.md
+++ b/artifacts/feat-3263/task-context/fix-handler-and-tests.md
@@ -1,0 +1,144 @@
+### task: fix-handler-and-tests
+
+**What and why:** Remove the `Microsoft.Identity.Client` using from `BackfillArticleRequestedByHandler` and swap its two infrastructure-specific catch blocks to use the new Article-domain exceptions. Then update the two corresponding test methods to throw the new domain exceptions instead of the SDK types, and remove the `using Microsoft.Identity.Client` from the test file.
+
+**Step 1 — Update the handler (run tests first to confirm they fail, then fix).**
+
+Before editing, run the test suite to establish the failing baseline:
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet test --filter "FullyQualifiedName~BackfillArticleRequestedBy"
+```
+
+Expected: `Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError` and `Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError` fail (or the entire suite fails to compile once the test usings are removed). This confirms the tests drive the implementation.
+
+**File to modify:**
+
+`backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+
+- Remove the line `using Microsoft.Identity.Client;`
+- Replace the `catch (MsalException ex)` block with `catch (ArticleUserResolverAuthException ex)`
+- Replace the `catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)` block with `catch (ArticleUserResolverServiceException ex)`
+- Keep the log messages and return values unchanged.
+
+Complete updated using block and catch section:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Article;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+Complete updated catch section (replace lines 43–62 in the original):
+
+```csharp
+        catch (ArticleUserResolverAuthException ex)
+        {
+            _logger.LogError(ex, "Graph token acquisition failed for backfill of group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.ConfigurationError);
+        }
+        catch (ArticleUserResolverServiceException ex)
+        {
+            _logger.LogError(ex, "Graph OData error during backfill for group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.ExternalServiceError);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogError(ex, "Graph access denied during backfill for group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.Forbidden);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during backfill for group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.InternalServerError);
+        }
+```
+
+**Step 2 — Update the tests.**
+
+`backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs`
+
+- Remove the line `using Microsoft.Identity.Client;`
+- Replace the body of `Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError` mock setup with `ArticleUserResolverAuthException`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError()
+    {
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArticleUserResolverAuthException(
+                "token failed",
+                new Exception("inner")));
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ConfigurationError);
+    }
+```
+
+- Replace the body of `Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError` mock setup with `ArticleUserResolverServiceException`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError()
+    {
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArticleUserResolverServiceException(
+                "odata error",
+                new Exception("inner")));
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ExternalServiceError);
+    }
+```
+
+**Step 3 — Attempt to remove packages from Application.csproj.**
+
+Open `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` and attempt to remove both:
+
+```xml
+<PackageReference Include="Microsoft.Graph" Version="5.92.0" />
+<PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+```
+
+Then run:
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+**Expected outcome:** Build will fail. These packages are referenced by `GraphService.cs`, `GraphPlannerService.cs`, `GraphOneDriveService.cs`, `GraphCatalogDocumentsStorage.cs`, and `UserManagementModule.cs` — all of which remain in the Application project. Restore both `PackageReference` lines and add a comment:
+
+```xml
+<!-- Microsoft.Graph and Microsoft.Identity.Web are still required by
+     GraphService, GraphPlannerService, GraphOneDriveService, and
+     GraphCatalogDocumentsStorage. Remove only after those services are
+     moved to infrastructure adapters (out of scope for feat-3263). -->
+<PackageReference Include="Microsoft.Graph" Version="5.92.0" />
+<PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+```
+
+**Step 4 — Run full targeted test suite.**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet test --filter "FullyQualifiedName~BackfillArticleRequestedBy"
+```
+
+All tests must pass (11 tests total: the two updated ones plus the 9 unchanged ones).
+
+**Step 5 — Final build check.**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+Zero errors and zero warnings added by this change.
+
+**Commit:** `refactor(article): remove infrastructure exception leakage from BackfillArticleRequestedByHandler`

--- a/artifacts/feat-3263/task-context/update-interface-and-adapter.md
+++ b/artifacts/feat-3263/task-context/update-interface-and-adapter.md
@@ -1,0 +1,103 @@
+### task: update-interface-and-adapter
+
+**What and why:** Add XML `<exception>` doc tags to `IArticleUserResolver.ResolveByGroupAsync` so callers know which exceptions to expect. Then add a `try/catch` block inside `GraphArticleUserResolver.ResolveByGroupAsync` to catch the two infrastructure-specific exception types and re-throw them as the new Article-domain exceptions.
+
+**File to modify (XML doc):**
+
+`backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs`
+
+Replace the current interface method signature block with:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Article-owned read-only abstraction for resolving the set of users associated
+/// with a directory group (used by the RequestedBy backfill admin command).
+/// Implemented by the UserManagement module via an adapter.
+/// </summary>
+public interface IArticleUserResolver
+{
+    /// <summary>
+    /// Resolves the members of the given directory group.
+    /// </summary>
+    /// <param name="groupId">The group identifier to resolve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A read-only list of matched users.</returns>
+    /// <exception cref="ArticleUserResolverAuthException">
+    /// Thrown when token acquisition or authentication fails.
+    /// </exception>
+    /// <exception cref="ArticleUserResolverServiceException">
+    /// Thrown when the remote directory service returns an error response.
+    /// </exception>
+    /// <exception cref="UnauthorizedAccessException">
+    /// Thrown when the caller lacks permission to read the group.
+    /// </exception>
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record ArticleUserMatch(string Id, string DisplayName);
+```
+
+**File to modify (try/catch):**
+
+`backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`
+
+Replace the entire file content with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Services;
+using Microsoft.Identity.Client;
+
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class GraphArticleUserResolver : IArticleUserResolver
+{
+    private readonly IGraphService _graph;
+
+    public GraphArticleUserResolver(IGraphService graph)
+    {
+        _graph = graph;
+    }
+
+    public async Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
+            return members
+                .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+                .ToList();
+        }
+        catch (MsalException ex)
+        {
+            throw new ArticleUserResolverAuthException(
+                $"Token acquisition failed for group {groupId}.", ex);
+        }
+        catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)
+        {
+            throw new ArticleUserResolverServiceException(
+                $"Graph OData error for group {groupId}.", ex);
+        }
+        // UnauthorizedAccessException and Exception propagate as-is;
+        // BackfillArticleRequestedByHandler already catches both.
+    }
+}
+```
+
+**Verify build:**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+Build must succeed with zero errors before committing.
+
+**Commit:** `refactor(article): wrap infrastructure exceptions in GraphArticleUserResolver`
+
+---

--- a/artifacts/feat-3263/task-plan.r1.md
+++ b/artifacts/feat-3263/task-plan.r1.md
@@ -1,0 +1,311 @@
+# Task Plan: Remove Infrastructure Exception Leakage from BackfillArticleRequestedByHandler
+
+**Feature:** feat-3263
+**Type:** Pure backend refactoring — no UI changes.
+
+**Goal:** Replace the `MsalException` and `Microsoft.Graph.Models.ODataErrors.ODataError` catches in `BackfillArticleRequestedByHandler` (an Application-layer class) with Article-owned domain exceptions. The infrastructure-specific exception types must be caught and re-wrapped inside `GraphArticleUserResolver` (the adapter that lives in the UserManagement infrastructure layer), which is the only place where infrastructure packages are legitimately visible.
+
+---
+
+### task: create-domain-exceptions
+
+**What and why:** Create two new Article-module exception classes in the `Contracts` folder alongside `IArticleUserResolver`. These are the clean Application-layer exception types that `BackfillArticleRequestedByHandler` will catch instead of the SDK-specific ones.
+
+**Files to create:**
+
+`backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverAuthException.cs`
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Thrown by <see cref="IArticleUserResolver"/> implementations when token acquisition
+/// or authentication for the underlying identity provider fails.
+/// Wraps infrastructure-specific auth exceptions (e.g. MsalException) so that
+/// Application-layer consumers remain decoupled from SDK packages.
+/// </summary>
+public sealed class ArticleUserResolverAuthException : Exception
+{
+    public ArticleUserResolverAuthException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+```
+
+`backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverServiceException.cs`
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Thrown by <see cref="IArticleUserResolver"/> implementations when the remote
+/// directory service returns an error response (e.g. an OData error from Microsoft Graph).
+/// Wraps infrastructure-specific service exceptions so that Application-layer consumers
+/// remain decoupled from SDK packages.
+/// </summary>
+public sealed class ArticleUserResolverServiceException : Exception
+{
+    public ArticleUserResolverServiceException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
+```
+
+**Verify build:**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+Build must succeed with zero errors before committing.
+
+**Commit:** `refactor(article): add ArticleUserResolverAuthException and ArticleUserResolverServiceException`
+
+---
+
+### task: update-interface-and-adapter
+
+**What and why:** Add XML `<exception>` doc tags to `IArticleUserResolver.ResolveByGroupAsync` so callers know which exceptions to expect. Then add a `try/catch` block inside `GraphArticleUserResolver.ResolveByGroupAsync` to catch the two infrastructure-specific exception types and re-throw them as the new Article-domain exceptions.
+
+**File to modify (XML doc):**
+
+`backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs`
+
+Replace the current interface method signature block with:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Article-owned read-only abstraction for resolving the set of users associated
+/// with a directory group (used by the RequestedBy backfill admin command).
+/// Implemented by the UserManagement module via an adapter.
+/// </summary>
+public interface IArticleUserResolver
+{
+    /// <summary>
+    /// Resolves the members of the given directory group.
+    /// </summary>
+    /// <param name="groupId">The group identifier to resolve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A read-only list of matched users.</returns>
+    /// <exception cref="ArticleUserResolverAuthException">
+    /// Thrown when token acquisition or authentication fails.
+    /// </exception>
+    /// <exception cref="ArticleUserResolverServiceException">
+    /// Thrown when the remote directory service returns an error response.
+    /// </exception>
+    /// <exception cref="UnauthorizedAccessException">
+    /// Thrown when the caller lacks permission to read the group.
+    /// </exception>
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record ArticleUserMatch(string Id, string DisplayName);
+```
+
+**File to modify (try/catch):**
+
+`backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`
+
+Replace the entire file content with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Services;
+using Microsoft.Identity.Client;
+
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class GraphArticleUserResolver : IArticleUserResolver
+{
+    private readonly IGraphService _graph;
+
+    public GraphArticleUserResolver(IGraphService graph)
+    {
+        _graph = graph;
+    }
+
+    public async Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
+            return members
+                .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+                .ToList();
+        }
+        catch (MsalException ex)
+        {
+            throw new ArticleUserResolverAuthException(
+                $"Token acquisition failed for group {groupId}.", ex);
+        }
+        catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)
+        {
+            throw new ArticleUserResolverServiceException(
+                $"Graph OData error for group {groupId}.", ex);
+        }
+        // UnauthorizedAccessException and Exception propagate as-is;
+        // BackfillArticleRequestedByHandler already catches both.
+    }
+}
+```
+
+**Verify build:**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+Build must succeed with zero errors before committing.
+
+**Commit:** `refactor(article): wrap infrastructure exceptions in GraphArticleUserResolver`
+
+---
+
+### task: fix-handler-and-tests
+
+**What and why:** Remove the `Microsoft.Identity.Client` using from `BackfillArticleRequestedByHandler` and swap its two infrastructure-specific catch blocks to use the new Article-domain exceptions. Then update the two corresponding test methods to throw the new domain exceptions instead of the SDK types, and remove the `using Microsoft.Identity.Client` from the test file.
+
+**Step 1 — Update the handler (run tests first to confirm they fail, then fix).**
+
+Before editing, run the test suite to establish the failing baseline:
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet test --filter "FullyQualifiedName~BackfillArticleRequestedBy"
+```
+
+Expected: `Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError` and `Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError` fail (or the entire suite fails to compile once the test usings are removed). This confirms the tests drive the implementation.
+
+**File to modify:**
+
+`backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+
+- Remove the line `using Microsoft.Identity.Client;`
+- Replace the `catch (MsalException ex)` block with `catch (ArticleUserResolverAuthException ex)`
+- Replace the `catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)` block with `catch (ArticleUserResolverServiceException ex)`
+- Keep the log messages and return values unchanged.
+
+Complete updated using block and catch section:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Article;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+Complete updated catch section (replace lines 43–62 in the original):
+
+```csharp
+        catch (ArticleUserResolverAuthException ex)
+        {
+            _logger.LogError(ex, "Graph token acquisition failed for backfill of group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.ConfigurationError);
+        }
+        catch (ArticleUserResolverServiceException ex)
+        {
+            _logger.LogError(ex, "Graph OData error during backfill for group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.ExternalServiceError);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogError(ex, "Graph access denied during backfill for group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.Forbidden);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during backfill for group {GroupId}", request.GroupId);
+            return new BackfillArticleRequestedByResponse(ErrorCodes.InternalServerError);
+        }
+```
+
+**Step 2 — Update the tests.**
+
+`backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs`
+
+- Remove the line `using Microsoft.Identity.Client;`
+- Replace the body of `Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError` mock setup with `ArticleUserResolverAuthException`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError()
+    {
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArticleUserResolverAuthException(
+                "token failed",
+                new Exception("inner")));
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ConfigurationError);
+    }
+```
+
+- Replace the body of `Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError` mock setup with `ArticleUserResolverServiceException`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError()
+    {
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArticleUserResolverServiceException(
+                "odata error",
+                new Exception("inner")));
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ExternalServiceError);
+    }
+```
+
+**Step 3 — Attempt to remove packages from Application.csproj.**
+
+Open `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` and attempt to remove both:
+
+```xml
+<PackageReference Include="Microsoft.Graph" Version="5.92.0" />
+<PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+```
+
+Then run:
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+**Expected outcome:** Build will fail. These packages are referenced by `GraphService.cs`, `GraphPlannerService.cs`, `GraphOneDriveService.cs`, `GraphCatalogDocumentsStorage.cs`, and `UserManagementModule.cs` — all of which remain in the Application project. Restore both `PackageReference` lines and add a comment:
+
+```xml
+<!-- Microsoft.Graph and Microsoft.Identity.Web are still required by
+     GraphService, GraphPlannerService, GraphOneDriveService, and
+     GraphCatalogDocumentsStorage. Remove only after those services are
+     moved to infrastructure adapters (out of scope for feat-3263). -->
+<PackageReference Include="Microsoft.Graph" Version="5.92.0" />
+<PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+```
+
+**Step 4 — Run full targeted test suite.**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet test --filter "FullyQualifiedName~BackfillArticleRequestedBy"
+```
+
+All tests must pass (11 tests total: the two updated ones plus the 9 unchanged ones).
+
+**Step 5 — Final build check.**
+
+```
+cd /home/user/worktrees/feature-3263-Arch-Review-Article-Backfillarticlerequestedbyhand/backend && dotnet build
+```
+
+Zero errors and zero warnings added by this change.
+
+**Commit:** `refactor(article): remove infrastructure exception leakage from BackfillArticleRequestedByHandler`

--- a/backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs
@@ -3,7 +3,6 @@ using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Article;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Microsoft.Identity.Client;
 
 namespace Anela.Heblo.Application.Features.Article.Admin;
 
@@ -40,12 +39,12 @@ public sealed class BackfillArticleRequestedByHandler
         {
             members = await _userResolver.ResolveByGroupAsync(request.GroupId, ct);
         }
-        catch (MsalException ex)
+        catch (ArticleUserResolverAuthException ex)
         {
             _logger.LogError(ex, "Graph token acquisition failed for backfill of group {GroupId}", request.GroupId);
             return new BackfillArticleRequestedByResponse(ErrorCodes.ConfigurationError);
         }
-        catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)
+        catch (ArticleUserResolverServiceException ex)
         {
             _logger.LogError(ex, "Graph OData error during backfill for group {GroupId}", request.GroupId);
             return new BackfillArticleRequestedByResponse(ErrorCodes.ExternalServiceError);

--- a/backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverAuthException.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverAuthException.cs
@@ -1,0 +1,13 @@
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Thrown by <see cref="IArticleUserResolver"/> implementations when token acquisition
+/// or authentication for the underlying identity provider fails.
+/// Wraps infrastructure-specific auth exceptions (e.g. MsalException) so that
+/// Application-layer consumers remain decoupled from SDK packages.
+/// </summary>
+public sealed class ArticleUserResolverAuthException : Exception
+{
+    public ArticleUserResolverAuthException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverServiceException.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/Contracts/ArticleUserResolverServiceException.cs
@@ -1,0 +1,13 @@
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Thrown by <see cref="IArticleUserResolver"/> implementations when the remote
+/// directory service returns an error response (e.g. an OData error from Microsoft Graph).
+/// Wraps infrastructure-specific service exceptions so that Application-layer consumers
+/// remain decoupled from SDK packages.
+/// </summary>
+public sealed class ArticleUserResolverServiceException : Exception
+{
+    public ArticleUserResolverServiceException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs
@@ -7,6 +7,21 @@ namespace Anela.Heblo.Application.Features.Article.Contracts;
 /// </summary>
 public interface IArticleUserResolver
 {
+    /// <summary>
+    /// Resolves the members of the given directory group.
+    /// </summary>
+    /// <param name="groupId">The group identifier to resolve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A read-only list of matched users.</returns>
+    /// <exception cref="ArticleUserResolverAuthException">
+    /// Thrown when token acquisition or authentication fails.
+    /// </exception>
+    /// <exception cref="ArticleUserResolverServiceException">
+    /// Thrown when the remote directory service returns an error response.
+    /// </exception>
+    /// <exception cref="UnauthorizedAccessException">
+    /// Thrown when the caller lacks permission to read the group.
+    /// </exception>
     Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
         string groupId,
         CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs
+++ b/backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Features.UserManagement.Services;
+using Microsoft.Identity.Client;
 
 namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
 
@@ -16,9 +17,24 @@ internal sealed class GraphArticleUserResolver : IArticleUserResolver
         string groupId,
         CancellationToken cancellationToken)
     {
-        var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
-        return members
-            .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
-            .ToList();
+        try
+        {
+            var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
+            return members
+                .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+                .ToList();
+        }
+        catch (MsalException ex)
+        {
+            throw new ArticleUserResolverAuthException(
+                $"Token acquisition failed for group {groupId}.", ex);
+        }
+        catch (Microsoft.Graph.Models.ODataErrors.ODataError ex)
+        {
+            throw new ArticleUserResolverServiceException(
+                $"Graph OData error for group {groupId}.", ex);
+        }
+        // UnauthorizedAccessException and Exception propagate as-is;
+        // BackfillArticleRequestedByHandler already catches both.
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs
@@ -4,7 +4,6 @@ using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Identity.Client;
 using Moq;
 using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
 
@@ -183,10 +182,10 @@ public class BackfillArticleRequestedByHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenResolverThrowsMsalException_ReturnsConfigurationError()
+    public async Task Handle_WhenResolverThrowsAuthException_ReturnsConfigurationError()
     {
         _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new MsalUiRequiredException("err_code", "token failed"));
+            .ThrowsAsync(new ArticleUserResolverAuthException("token failed", new Exception()));
 
         var response = await CreateHandler().Handle(
             new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
@@ -196,10 +195,10 @@ public class BackfillArticleRequestedByHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenResolverThrowsODataError_ReturnsExternalServiceError()
+    public async Task Handle_WhenResolverThrowsServiceException_ReturnsExternalServiceError()
     {
         _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Microsoft.Graph.Models.ODataErrors.ODataError());
+            .ThrowsAsync(new ArticleUserResolverServiceException("service error", new Exception()));
 
         var response = await CreateHandler().Handle(
             new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);


### PR DESCRIPTION
## What the issue was

`BackfillArticleRequestedByHandler` (Application layer) directly caught `MsalException` and `Microsoft.Graph.Models.ODataErrors.ODataError` — infrastructure SDK types — violating the Clean Architecture dependency rule. This forced the Application project to carry `Microsoft.Graph` and `Microsoft.Identity.Web` package references, and made the handler untestable without MSAL/Graph stubs.

## How it was fixed

Introduced two domain exception types in the Article contracts namespace:
- `ArticleUserResolverAuthException` — represents token acquisition failure
- `ArticleUserResolverServiceException` — represents upstream directory service errors

Exception translation was moved to `GraphArticleUserResolver` (the adapter, which already has legitimate access to SDK types): it now catches `MsalException` and `ODataError` and re-throws them as the domain exceptions with the original exception preserved as `InnerException`. `BackfillArticleRequestedByHandler` catches only domain exceptions; it no longer imports `Microsoft.Identity.Client` or `Microsoft.Graph`. Tests were updated to throw domain exceptions instead of SDK types.

Note: `Microsoft.Graph` and `Microsoft.Identity.Web` package references remain in Application.csproj — they are required by `GraphService`, `GraphPlannerService`, and `GraphCatalogDocumentsStorage`. The architectural violation (SDK catch blocks in a handler) is resolved.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in `artifacts/feat-3263/` on this branch.

Closes #3263

---
_Generated by [Claude Code](https://claude.ai/code/session_01AT43Se2D4QPRrzJU82SRkN)_