### PR TITLE
refactor: make ImportBankStatementHandler sole owner of BankImportState (#3279)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Bank/Infrastructure/Jobs/BankImportJobBase.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/Infrastructure/Jobs/BankImportJobBase.cs
@@ -55,7 +55,6 @@ public abstract class BankImportJobBase : IRecurringJob
             return;
         }
 
-        var runStartedAt = DateTime.UtcNow;
         var targetEnd = GetTargetEndDate(DateTime.Today);
         var state = await _stateRepository.GetByAccountAsync(AccountName, cancellationToken)
                     ?? new BankImportState(AccountName);
@@ -72,27 +71,19 @@ public abstract class BankImportJobBase : IRecurringJob
 
             if (response.HasErrors)
             {
-                state.RecordFailure(
-                    $"{response.ErrorCount} statement(s) failed in range {dateFrom:yyyy-MM-dd}..{targetEnd:yyyy-MM-dd}",
-                    runStartedAt, DateTime.UtcNow);
                 _logger.LogError(
                     "{JobName} completed WITH ERRORS - Success: {Success}, Errors: {Errors}, Skipped: {Skipped}. Watermark NOT advanced (stuck at {Watermark:yyyy-MM-dd}).",
                     Metadata.JobName, response.SuccessCount, response.ErrorCount, response.SkippedCount, state.LastValidImportDate);
             }
             else
             {
-                state.RecordSuccess(targetEnd, runStartedAt, DateTime.UtcNow);
                 _logger.LogInformation(
                     "{JobName} completed - Success: {Success}, Skipped: {Skipped}. Watermark advanced to {Watermark:yyyy-MM-dd}.",
                     Metadata.JobName, response.SuccessCount, response.SkippedCount, targetEnd);
             }
-
-            await _stateRepository.UpsertAsync(state, cancellationToken);
         }
         catch (Exception ex)
         {
-            state.RecordFailure(ex.Message, runStartedAt, DateTime.UtcNow);
-            await _stateRepository.UpsertAsync(state, cancellationToken);
             _logger.LogError(ex, "{JobName} failed", Metadata.JobName);
             throw;
         }

--- a/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs
@@ -78,58 +78,69 @@ public class ImportBankStatementHandler : IRequestHandler<ImportBankStatementReq
                     daysBehind, request.AccountName, state.LastValidImportDate.Value.Date);
         }
 
-        var client = _factory.GetClient(accountSetting);
-
-        var statements = await client.GetStatementsAsync(accountSetting.AccountNumber, request.DateFrom, request.DateTo);
-
-        _logger.LogInformation(
-            "Bank client returned {StatementCount} statements - Account: {AccountName}",
-            statements.Count, request.AccountName);
-
-        var existingTransfers = await _repository.GetExistingTransfersAsync(
-            accountSetting.Name, request.DateFrom, request.DateTo, cancellationToken);
-
-        var imports = new List<BankStatementImportDto>();
-        var skippedCount = 0;
-
-        foreach (var statement in statements)
+        try
         {
-            if (existingTransfers.TryGetValue(statement.StatementId, out var existingResult)
-                && existingResult == ImportStatus.Success)
+            var client = _factory.GetClient(accountSetting);
+
+            var statements = await client.GetStatementsAsync(accountSetting.AccountNumber, request.DateFrom, request.DateTo);
+
+            _logger.LogInformation(
+                "Bank client returned {StatementCount} statements - Account: {AccountName}",
+                statements.Count, request.AccountName);
+
+            var existingTransfers = await _repository.GetExistingTransfersAsync(
+                accountSetting.Name, request.DateFrom, request.DateTo, cancellationToken);
+
+            var imports = new List<BankStatementImportDto>();
+            var skippedCount = 0;
+
+            foreach (var statement in statements)
             {
-                skippedCount++;
-                _logger.LogDebug("Skipping already-imported statement {StatementId}", statement.StatementId);
-                continue;
+                if (existingTransfers.TryGetValue(statement.StatementId, out var existingResult)
+                    && existingResult == ImportStatus.Success)
+                {
+                    skippedCount++;
+                    _logger.LogDebug("Skipping already-imported statement {StatementId}", statement.StatementId);
+                    continue;
+                }
+
+                var isRetry = existingTransfers.ContainsKey(statement.StatementId);
+                imports.Add(await ProcessStatementAsync(client, statement, accountSetting, isRetry, cancellationToken));
             }
 
-            var isRetry = existingTransfers.ContainsKey(statement.StatementId);
-            imports.Add(await ProcessStatementAsync(client, statement, accountSetting, isRetry, cancellationToken));
+            totalSw.Stop();
+            var runFinishedAt = DateTime.UtcNow;
+
+            var successCount = imports.Count(i => i.ImportResult == ImportStatus.Success);
+            var errorCount = imports.Count - successCount;
+
+            if (errorCount == 0)
+                state.RecordSuccess(request.DateTo, runStartedAt, runFinishedAt);
+            else
+                state.RecordFailure($"{errorCount} statement(s) failed", runStartedAt, runFinishedAt);
+
+            await _stateRepository.UpsertAsync(state, cancellationToken);
+
+            _logger.LogInformation(
+                "Bank import COMPLETED - Account: {AccountName}, Attempted: {Attempted}, Success: {SuccessCount}, Errors: {ErrorCount}, Skipped: {SkippedCount}, Duration: {Duration}ms",
+                request.AccountName, imports.Count, successCount, errorCount, skippedCount, totalSw.ElapsedMilliseconds);
+
+            return new ImportBankStatementResponse
+            {
+                Statements = imports,
+                SuccessCount = successCount,
+                ErrorCount = errorCount,
+                SkippedCount = skippedCount,
+            };
         }
-
-        totalSw.Stop();
-        var runFinishedAt = DateTime.UtcNow;
-
-        var successCount = imports.Count(i => i.ImportResult == ImportStatus.Success);
-        var errorCount = imports.Count - successCount;
-
-        if (errorCount == 0)
-            state.RecordSuccess(request.DateTo, runStartedAt, runFinishedAt);
-        else
-            state.RecordFailure($"{errorCount} statement(s) failed", runStartedAt, runFinishedAt);
-
-        await _stateRepository.UpsertAsync(state, cancellationToken);
-
-        _logger.LogInformation(
-            "Bank import COMPLETED - Account: {AccountName}, Attempted: {Attempted}, Success: {SuccessCount}, Errors: {ErrorCount}, Skipped: {SkippedCount}, Duration: {Duration}ms",
-            request.AccountName, imports.Count, successCount, errorCount, skippedCount, totalSw.ElapsedMilliseconds);
-
-        return new ImportBankStatementResponse
+        catch (Exception ex)
         {
-            Statements = imports,
-            SuccessCount = successCount,
-            ErrorCount = errorCount,
-            SkippedCount = skippedCount,
-        };
+            state.RecordFailure(ex.Message, runStartedAt, DateTime.UtcNow);
+            await _stateRepository.UpsertAsync(state, cancellationToken);
+            _logger.LogError(
+                ex, "Bank import FAILED - Account: {AccountName}", request.AccountName);
+            throw;
+        }
     }
 
     private async Task<BankStatementImportDto> ProcessStatementAsync(

--- a/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs
@@ -136,7 +136,7 @@ public class ImportBankStatementHandler : IRequestHandler<ImportBankStatementReq
         catch (Exception ex)
         {
             state.RecordFailure(ex.Message, runStartedAt, DateTime.UtcNow);
-            await _stateRepository.UpsertAsync(state, cancellationToken);
+            await _stateRepository.UpsertAsync(state, CancellationToken.None);
             _logger.LogError(
                 ex, "Bank import FAILED - Account: {AccountName}", request.AccountName);
             throw;

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
@@ -264,4 +264,29 @@ public class ImportBankStatementHandlerTests
         captured.Should().BeSameAs(existingState);
         captured!.LastValidImportDate.Should().Be(to.Date);
     }
+
+    [Fact]
+    public async Task Handle_RecordsFailure_AndRethrows_WhenImportThrows()
+    {
+        var from = new DateTime(2026, 6, 10);
+        var to = new DateTime(2026, 6, 12);
+        var request = new ImportBankStatementRequest("ComgateCZK", from, to);
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", from, to))
+            .ThrowsAsync(new InvalidOperationException("bank client unavailable"));
+
+        BankImportState? captured = null;
+        _mockStateRepository
+            .Setup(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()))
+            .Callback<BankImportState, CancellationToken>((s, _) => captured = s);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(request, CancellationToken.None));
+
+        _mockStateRepository.Verify(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()), Times.Once);
+        captured!.LastRunStatus.Should().Be(BankImportState.StatusError);
+        captured.LastValidImportDate.Should().BeNull();
+        captured.LastErrorMessage.Should().Be("bank client unavailable");
+        captured.ConsecutiveFailureCount.Should().Be(1);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/Infrastructure/Jobs/BankImportJobBaseTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/Infrastructure/Jobs/BankImportJobBaseTests.cs
@@ -100,8 +100,10 @@ public sealed class BankImportJobBaseTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_AdvancesWatermark_OnZeroErrorRun()
+    public async Task ExecuteAsync_DoesNotWriteState_OnZeroErrorRun()
     {
+        // The handler owns BankImportState; the job must not write it (regression guard
+        // against the double-write fixed in #3279).
         var state = new BankImportState(TestAccountName);
         state.RecordSuccess(new DateTime(2026, 6, 10), DateTime.UtcNow, DateTime.UtcNow);
         _stateRepo.Setup(r => r.GetByAccountAsync(TestAccountName, It.IsAny<CancellationToken>()))
@@ -109,19 +111,13 @@ public sealed class BankImportJobBaseTests
         _mediator.Setup(m => m.Send(It.IsAny<ImportBankStatementRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ImportBankStatementResponse { SuccessCount = 0, ErrorCount = 0 }); // 0 docs = valid
 
-        BankImportState? saved = null;
-        _stateRepo.Setup(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()))
-            .Callback<BankImportState, CancellationToken>((s, _) => saved = s)
-            .Returns(Task.CompletedTask);
-
         await CreateJob(targetEnd: new DateTime(2026, 6, 14)).ExecuteAsync(CancellationToken.None);
 
-        saved!.LastValidImportDate.Should().Be(new DateTime(2026, 6, 14));
-        saved.LastRunStatus.Should().Be(BankImportState.StatusOk);
+        _stateRepo.Verify(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task ExecuteAsync_DoesNotAdvanceWatermark_OnErrorRun()
+    public async Task ExecuteAsync_DoesNotWriteState_OnErrorRun()
     {
         var state = new BankImportState(TestAccountName);
         state.RecordSuccess(new DateTime(2026, 6, 10), DateTime.UtcNow, DateTime.UtcNow);
@@ -130,15 +126,25 @@ public sealed class BankImportJobBaseTests
         _mediator.Setup(m => m.Send(It.IsAny<ImportBankStatementRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ImportBankStatementResponse { SuccessCount = 1, ErrorCount = 2 });
 
-        BankImportState? saved = null;
-        _stateRepo.Setup(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()))
-            .Callback<BankImportState, CancellationToken>((s, _) => saved = s)
-            .Returns(Task.CompletedTask);
-
         await CreateJob(targetEnd: new DateTime(2026, 6, 14)).ExecuteAsync(CancellationToken.None);
 
-        saved!.LastValidImportDate.Should().Be(new DateTime(2026, 6, 10)); // unchanged
-        saved.LastRunStatus.Should().Be(BankImportState.StatusError);
+        _stateRepo.Verify(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotWriteState_AndRethrows_WhenHandlerThrows()
+    {
+        var state = new BankImportState(TestAccountName);
+        state.RecordSuccess(new DateTime(2026, 6, 10), DateTime.UtcNow, DateTime.UtcNow);
+        _stateRepo.Setup(r => r.GetByAccountAsync(TestAccountName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(state);
+        _mediator.Setup(m => m.Send(It.IsAny<ImportBankStatementRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("bank client unavailable"));
+
+        var act = () => CreateJob(targetEnd: new DateTime(2026, 6, 14)).ExecuteAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _stateRepo.Verify(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Fixes the SRP violation and double-write in the Bank module (#3279) where `BankImportState` was loaded, mutated, and persisted by both `ImportBankStatementHandler` and `BankImportJobBase` in the same DI scope, causing the job's write to overwrite the handler's. The handler is now the single owner of every state transition — success, partial-failure, and unhandled-exception — via one try/catch, while `BankImportJobBase` stops writing state and only reads it for date-range resolution plus logging the run outcome. Net effect: exactly one `UpsertAsync` per run, always from the handler. Tests were updated so the job tests assert it never writes state, with new exception-path coverage added for both the handler and the job.

Closes #3279