### PR TITLE
#3282: Unit tests for GetCalendarViewHandler

### DIFF
--- a/artifacts/feat-3282/arch-review.r1.md
+++ b/artifacts/feat-3282/arch-review.r1.md
@@ -1,0 +1,301 @@
+# Architecture Review: Unit Tests for GetCalendarViewHandler
+
+## Skip Design: false
+
+---
+
+## Architectural Fit Assessment
+
+This feature adds a pure test file — no production code changes, no new abstractions, no schema impact. The work is a straightforward application of the project's existing unit-test conventions to a handler that has been left uncovered.
+
+The handler under test (`GetCalendarViewHandler`) is a clean, side-effect-free MediatR handler: one repository call, in-memory LINQ filtering, a mapping loop, and a single try/catch. There are no circular dependencies, no ambient state, and no infrastructure concerns to mock beyond `IManufactureOrderRepository` and `ILogger<GetCalendarViewHandler>`. All domain types required to build test data (`ManufactureOrder`, `ManufactureOrderSemiProduct`, `ManufactureOrderProduct`) are already accessible from the test assembly.
+
+The 13 test cases described in the spec cover every branch in the handler — the spec is complete and correctly scoped.
+
+---
+
+## Proposed Architecture
+
+### Component Overview
+
+One new file:
+
+```
+backend/test/Anela.Heblo.Tests/
+  Features/
+    Manufacture/
+      UseCases/
+        GetCalendarView/
+          GetCalendarViewHandlerTests.cs    ← NEW
+```
+
+No subdirectory or helper file is needed. All test data construction fits comfortably inside private factory methods in the test class itself, following the same pattern as `GetManufactureOrderHandlerTests.cs`.
+
+### Key Design Decisions
+
+#### Decision 1: One class, private factory methods — no shared base class
+
+**Options considered:**
+
+- (A) Single test class with private `CreateOrder(...)` helper methods.
+- (B) Shared `ManufactureOrderTestBuilder` class reused across test files.
+
+**Chosen approach:** Option A.
+
+**Rationale:** Only one test file needs this data today. A builder class is the right call when three or more test files converge on the same domain object construction — that threshold is not met here. Option A matches `GetManufactureOrderHandlerTests.cs` exactly and keeps the file self-contained. If a second or third handler test class later needs similar helpers, extract at that point.
+
+#### Decision 2: `InitializeState` for state assignment, not reflection
+
+**Options considered:**
+
+- (A) `order.InitializeState(ManufactureOrderState.Cancelled, ...)` — the public API the domain explicitly provides for this purpose.
+- (B) Direct assignment via `InternalsVisibleTo` (the internal setter is technically accessible from the test assembly).
+
+**Chosen approach:** Option A.
+
+**Rationale:** The spec brief confirms that `InternalsVisibleTo` is set, so Option B is technically possible. However, the existing test suite consistently uses `InitializeState`. Using the internal setter directly would be a silent deviation from the established pattern with no benefit — and it couples tests to an implementation detail. `InitializeState` is the sanctioned construction path.
+
+#### Decision 3: `Products = null` by explicit assignment, not default
+
+**Options considered:**
+
+- (A) `new ManufactureOrder { ... }` leaves `Products` as `new List<...>()` (the field default). To test the null branch the test must explicitly set `order.Products = null!`.
+- (B) Create a separate domain subtype or constructor overload that allows null.
+
+**Chosen approach:** Option A.
+
+**Rationale:** `ManufactureOrder.Products` is declared as `List<ManufactureOrderProduct> Products { get; set; } = new()`, so the default is not null. The test must assign `null!` after construction. This is intentional and documents the defensive behaviour being tested (`?? new List<>()`). Option B is unnecessary complexity.
+
+#### Decision 4: Mock `ILogger` with `Mock.Of<>()`, not a full `new Mock<>`
+
+**Options considered:**
+
+- (A) `Mock.Of<ILogger<GetCalendarViewHandler>>()` — a null-object mock, no setup required.
+- (B) `new Mock<ILogger<GetCalendarViewHandler>>()` and verify log calls.
+
+**Chosen approach:** Option A for all tests except FR-8.
+
+**Rationale:** Logging is a side effect, not an output. Verifying log calls adds test fragility with no correctness value. The exception-handling test (FR-8) only needs to assert on the returned response — log verification is still unnecessary.
+
+#### Decision 5: Anchor dates as constants, not `DateTime.UtcNow`
+
+**Options considered:**
+
+- (A) Fixed anchor `new DateTime(2025, 6, 15)` (or similar) — deterministic across all test runs.
+- (B) `DateTime.UtcNow` — test data shifts with wall-clock time.
+
+**Chosen approach:** Option A.
+
+**Rationale:** The boundary tests (FR-2, FR-3) require exact equality between `PlannedDate` and `DateOnly.FromDateTime(request.StartDate/EndDate)`. Using `DateTime.UtcNow` creates time-zone sensitivity risk and makes test output non-reproducible. Fixed dates remove both concerns with zero cost.
+
+---
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create one new directory and one new file:
+
+```
+backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/
+    GetCalendarViewHandlerTests.cs
+```
+
+The parent directory `UseCases/` already exists (see `GetManufactureStockTakingHistory/`). Create only `GetCalendarView/`.
+
+### Interfaces and Contracts
+
+No new interfaces. The test class depends on:
+
+| Type | Source | Usage |
+|---|---|---|
+| `IManufactureOrderRepository` | `Anela.Heblo.Domain` | `new Mock<IManufactureOrderRepository>()` |
+| `ILogger<GetCalendarViewHandler>` | `Microsoft.Extensions.Logging` | `Mock.Of<ILogger<...>>()` |
+| `GetCalendarViewHandler` | `Anela.Heblo.Application` | system under test |
+| `GetCalendarViewRequest` | `Anela.Heblo.Application` | request input |
+| `GetCalendarViewResponse` | `Anela.Heblo.Application` | result assertions |
+| `CalendarEventDto` | `Anela.Heblo.Application` | result assertions |
+| `ManufactureOrder` | `Anela.Heblo.Domain` | test data |
+| `ManufactureOrderSemiProduct` | `Anela.Heblo.Domain` | test data |
+| `ManufactureOrderProduct` | `Anela.Heblo.Domain` | test data |
+| `ManufactureOrderState` | `Anela.Heblo.Domain` | test data + assertions |
+| `ErrorCodes` | `Anela.Heblo.Application.Shared` | FR-8 assertion |
+
+### Data Flow
+
+```
+[Test arranges orders + state]
+        |
+        v
+Mock<IManufactureOrderRepository>
+  .Setup(GetOrdersForDateRangeAsync(...))
+  .ReturnsAsync(orders)
+        |
+        v
+GetCalendarViewHandler.Handle(request, CancellationToken.None)
+        |
+        |--- (handler) filters Cancelled, filters PlannedDate range
+        |--- (handler) maps SemiProduct / Products
+        |--- (handler) sorts by Date
+        v
+GetCalendarViewResponse
+        |
+        v
+FluentAssertions on response.Events / response.ErrorCode
+```
+
+No async coordination issues — all mocks return completed tasks synchronously via `ReturnsAsync`.
+
+### Recommended test class skeleton
+
+```csharp
+namespace Anela.Heblo.Tests.Features.Manufacture.UseCases.GetCalendarView;
+
+public class GetCalendarViewHandlerTests
+{
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly GetCalendarViewHandler _handler;
+
+    // Anchor dates — fixed for deterministic boundary tests
+    private static readonly DateTime StartDate = new DateTime(2025, 6, 1);
+    private static readonly DateTime EndDate   = new DateTime(2025, 6, 30);
+    private static readonly DateOnly  MidDate  = new DateOnly(2025, 6, 15);
+
+    public GetCalendarViewHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _handler = new GetCalendarViewHandler(
+            _repositoryMock.Object,
+            Mock.Of<ILogger<GetCalendarViewHandler>>());
+    }
+
+    private static GetCalendarViewRequest MakeRequest() => new()
+    {
+        StartDate = StartDate,
+        EndDate   = EndDate
+    };
+
+    private static ManufactureOrder MakeOrder(int id, DateOnly plannedDate,
+        ManufactureOrderState state = ManufactureOrderState.Planned)
+    {
+        var order = new ManufactureOrder
+        {
+            Id          = id,
+            OrderNumber = $"MO-2025-{id:000}",
+            CreatedDate = DateTime.UtcNow,
+            CreatedByUser = "Test",
+            PlannedDate = plannedDate
+        };
+        order.InitializeState(state, DateTime.UtcNow, "Test");
+        return order;
+    }
+
+    private void SetupRepository(List<ManufactureOrder> orders)
+    {
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(orders);
+    }
+
+    // --- FR-1 ---
+    [Fact]
+    public async Task Handle_WithCancelledOrderInRange_ExcludesCancelledOrder() { ... }
+
+    // --- FR-2 ---
+    [Fact]
+    public async Task Handle_WithOrderOnStartDateBoundary_IncludesEvent() { ... }
+
+    [Fact]
+    public async Task Handle_WithOrderOnEndDateBoundary_IncludesEvent() { ... }
+
+    // --- FR-3 ---
+    [Fact]
+    public async Task Handle_WithOrderBeforeStartDate_ExcludesEvent() { ... }
+
+    [Fact]
+    public async Task Handle_WithOrderAfterEndDate_ExcludesEvent() { ... }
+
+    // --- FR-4 ---
+    [Fact]
+    public async Task Handle_WithNullSemiProduct_SetsEventSemiProductToNull() { ... }
+
+    // --- FR-5 ---
+    [Fact]
+    public async Task Handle_WithSemiProductContainingSuffix_StripsProductNameSuffix() { ... }
+
+    [Fact]
+    public async Task Handle_WithSemiProductWithoutSuffix_LeavesProductNameUnchanged() { ... }
+
+    [Fact]
+    public async Task Handle_WithNonNullSemiProduct_MapsSemiProductDtoCorrectly() { ... }
+
+    // --- FR-6 ---
+    [Fact]
+    public async Task Handle_WithNullProducts_SetsEventProductsToEmptyList() { ... }
+
+    // --- FR-7 ---
+    [Fact]
+    public async Task Handle_WithNonNullProducts_MapsProductDtosCorrectly() { ... }
+
+    // --- FR-8 ---
+    [Fact]
+    public async Task Handle_WhenRepositoryThrows_ReturnsInternalServerError() { ... }
+
+    // --- FR-9 ---
+    [Fact]
+    public async Task Handle_WithMultipleOrdersAtDifferentDates_ReturnsSortedByDateAscending() { ... }
+}
+```
+
+### Critical implementation notes per test
+
+**FR-6 (null Products):** `ManufactureOrder.Products` defaults to `new List<>()`. The test must explicitly set `order.Products = null!` after `MakeOrder()`. Without this the Products branch is never null and the test trivially passes while exercising the wrong code path.
+
+**FR-3 (date boundary exclusion):** The handler applies a second date filter *after* calling the repository. The repository mock must return the out-of-range order — simulating a repository that returns data slightly outside the requested window. Do not restrict the mock to matching exact dates (`DateOnly` args); use `It.IsAny<DateOnly>()` to keep the setup permissive.
+
+**FR-8 (exception handling):** Use `.ThrowsAsync(new Exception("db failure"))`. Assert `result.Success == false` and `result.ErrorCode == ErrorCodes.InternalServerError`. Do not wrap the `Handle` call in try/catch — FluentAssertions `Awaiting(...).Should().NotThrowAsync()` idiom is cleaner and more explicit.
+
+**FR-5 (title suffix stripping):** The handler expression is:
+```csharp
+order.SemiProduct?.ProductName?.Replace(" - meziprodukt", "") ?? order.OrderNumber
+```
+"Plain Name" (no suffix) should produce `"Plain Name"` — the `Replace` call is a no-op when the substring is absent. Both sub-cases (with suffix, without suffix) need a separate test method to give clear failure messages.
+
+**FR-1 (cancelled order):** The easiest construction path is `MakeOrder(id: 2, ..., state: ManufactureOrderState.Cancelled)`. The `InitializeState` method accepts `Cancelled` as the initial state — there is no state-machine enforcement in `InitializeState`, only in `ChangeState`.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| FR-6 null Products test passes vacuously because default is `new List<>()` | Medium | Explicitly assign `order.Products = null!` in the test body and add an inline comment explaining why. |
+| FR-3 tests pass vacuously if the repository mock filters by exact date args | Low | Mock with `It.IsAny<DateOnly>()` so out-of-range orders are returned and the in-handler filter is actually exercised. |
+| Title-stripping logic uses `Replace` not `TrimEnd` — the suffix must appear verbatim | Low | Use `"Argan Cream - meziprodukt"` (exact casing and spacing) as the test ProductName. |
+| `Handle_WhenRepositoryThrows` might accidentally swallow legitimate assertion failures | Low | Assert on the returned response, not inside a try/catch; let xUnit surface assertion exceptions normally. |
+| Coverage does not reach 60% if test data bypasses a branch | Low | Verify after adding all 13 tests with `dotnet test --collect:"XPlat Code Coverage"`. |
+
+---
+
+## Specification Amendments
+
+**Amendment 1 — FR-6 construction detail (clarification, not a change):**
+The spec says "order with Products = null". Because the domain type initializes `Products` to `new List<>()`, the test must perform an explicit null assignment. The spec is correct in intent; the implementor just needs to be aware of this. No spec text change required.
+
+**Amendment 2 — FR-5 title fallback when SemiProduct is null (gap):**
+The spec covers both "with suffix" and "without suffix" when SemiProduct is non-null. It does not explicitly test the title fallback to `order.OrderNumber` when `SemiProduct` is null and `ProductName` is null. FR-4 (null SemiProduct) covers `event.SemiProduct == null` but does not assert on `event.Title`. The FR-4 test should additionally assert that `event.Title == order.OrderNumber` to confirm the null-coalescing fallback branch. This is a minor gap — add the title assertion to the FR-4 test without creating a new test case.
+
+**Amendment 3 — CalendarEventProductDto field scope (clarification):**
+The spec lists `ProductCode`, `ProductName`, `PlannedQuantity`, `ActualQuantity` for FR-7. These are the only fields on `CalendarEventProductDto`. The implementation does not map `LotNumber`, `ExpirationDate`, or `SemiProductCode` — they are not present on the DTO. No test data needs to supply them.
+
+---
+
+## Prerequisites
+
+- No new NuGet packages. xUnit, Moq, and FluentAssertions are all present in `Anela.Heblo.Tests.csproj`.
+- No changes to production code.
+- No changes to `InternalsVisibleTo` — the declaration is already present in `Anela.Heblo.Domain.csproj`.
+- Create the directory `backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/` before creating the test file.
+- Run `dotnet build` from `backend/` before running tests to confirm the new file compiles cleanly.
+- After adding tests, run `dotnet test --collect:"XPlat Code Coverage"` and confirm `GetCalendarViewHandler` line coverage reaches ≥60%.

--- a/artifacts/feat-3282/brief.md
+++ b/artifacts/feat-3282/brief.md
@@ -1,0 +1,28 @@
+## Module / File
+backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandler.cs
+
+## Coverage
+Line coverage: 10.6% (filter threshold: 60%)
+
+## What's not tested
+The handler performs a two-stage filter that no test exercises:
+1. **Cancelled-state exclusion**: after the DB query by date range, orders with `State == ManufactureOrderState.Cancelled` are filtered out in memory. A test with a cancelled order in the range would confirm the filter is applied; regression here would surface cancelled orders on the calendar.
+2. **PlannedDate boundary check**: even though orders are already queried by date range, each order's `PlannedDate` is re-checked against the request bounds before creating a `CalendarEventDto`. An order returned by the repository whose PlannedDate falls outside the window would be silently dropped.
+3. **SemiProduct null guard**: when `order.SemiProduct` is null, the event's `SemiProduct` property is null rather than a DTO. No test verifies both branches (order with and without semi-product).
+4. **Products null guard**: `order.Products` being null falls back to an empty list rather than a null reference.
+5. **Title formatting**: the `ProductName.Replace(" - meziprodukt", "")` strip on the semi-product name has no assertion.
+
+## Why it matters
+The manufacture calendar is the primary planning view for production staff. If cancelled orders appear, planners would act on stale data. If the SemiProduct null guard breaks, the UI would receive a null where it expects an object, causing crashes for orders without semi-products.
+
+## Suggested approach
+Unit tests with a mocked `IManufactureOrderRepository`:
+- Return a mix of active and cancelled orders → verify cancelled ones are excluded from events
+- Order with PlannedDate at the exact start/end boundary → verify inclusion
+- Order with SemiProduct = null → verify event.SemiProduct is null
+- Order with non-null SemiProduct containing " - meziprodukt" suffix → verify title stripped correctly
+- Order with null Products → verify event.Products is empty list
+Estimated effort: ~2 hours.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-22. Based on CI run #27941952679 (9463aa5983b2a6d201782725aeeaaba777d8c07d)._

--- a/artifacts/feat-3282/design.r1.md
+++ b/artifacts/feat-3282/design.r1.md
@@ -1,0 +1,137 @@
+# Design: Unit Tests for GetCalendarViewHandler
+
+## Component Design
+
+### Test Class: `GetCalendarViewHandlerTests`
+
+**Location:** `backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs`
+
+**Namespace:** `Anela.Heblo.Tests.Features.Manufacture.UseCases.GetCalendarView`
+
+**Responsibilities:** Verify all five conditional branches inside `GetCalendarViewHandler.Handle` — state filtering, date-boundary enforcement, SemiProduct null/non-null mapping, Products null fallback, title-string stripping, sort order, and exception handling.
+
+**Dependencies (constructor-injected mocks):**
+
+| Field | Type | Purpose |
+|---|---|---|
+| `_repositoryMock` | `Mock<IManufactureOrderRepository>` | Controls `GetOrdersForDateRangeAsync` return value |
+| `_loggerMock` | `Mock<ILogger<GetCalendarViewHandler>>` | Satisfies constructor; not asserted on |
+| `_handler` | `GetCalendarViewHandler` | System under test, created in constructor |
+
+**Anchor dates (constants, not computed):**
+
+| Constant | Value | Type |
+|---|---|---|
+| `StartDate` | `new DateTime(2025, 6, 1)` | `DateTime` |
+| `EndDate` | `new DateTime(2025, 6, 30)` | `DateTime` |
+| `StartDateOnly` | `new DateOnly(2025, 6, 1)` | `DateOnly` (derived inline or as constant) |
+| `EndDateOnly` | `new DateOnly(2025, 6, 30)` | `DateOnly` |
+
+**Repository mock pattern:** All setups use `It.IsAny<DateOnly>()` for both date parameters. The handler's in-memory second-pass filter — not the repository — is what the boundary tests exercise.
+
+**Test method naming convention:** `Handle_{Scenario}_{ExpectedOutcome}` — consistent with the existing `GetManufactureOrderHandlerTests` in the same project.
+
+---
+
+### Helper: `CreateOrder`
+
+A private static factory method that constructs a `ManufactureOrder` with deterministic values:
+
+```
+private static ManufactureOrder CreateOrder(
+    string orderNumber,
+    DateOnly plannedDate,
+    ManufactureOrderState state = ManufactureOrderState.Planned)
+```
+
+- Calls `order.InitializeState(state, DateTime.UtcNow, "Test User")` to bypass the state-machine guard (required for the `Cancelled` state, which cannot be reached via `ChangeState` from any reachable state in these tests).
+- Sets `order.Products = new List<ManufactureOrderProduct>()` explicitly; overridden to `null!` in the Products-null test.
+- Leaves `order.SemiProduct = null` by default; assigned explicitly in SemiProduct tests.
+
+---
+
+## Data Schemas
+
+### Test Input: `GetCalendarViewRequest`
+
+```csharp
+new GetCalendarViewRequest
+{
+    StartDate = new DateTime(2025, 6, 1),
+    EndDate   = new DateTime(2025, 6, 30)
+}
+```
+
+Used verbatim across all test methods (extracted to a local or shared builder).
+
+### Domain Object Shapes Used in Tests
+
+**`ManufactureOrder` (minimal baseline):**
+
+| Property | Test value |
+|---|---|
+| `Id` | Sequential int (1, 2, …) |
+| `OrderNumber` | `"MO-2025-001"` etc. |
+| `PlannedDate` | Varied per test (see boundary table below) |
+| `State` | Set via `InitializeState(...)` |
+| `SemiProduct` | `null` or populated object |
+| `Products` | `new List<>()`, `null!`, or populated list |
+
+**Boundary values for `PlannedDate` (FR-2 / FR-3):**
+
+| Test case | `PlannedDate` | Expected in result |
+|---|---|---|
+| Exactly StartDate | `new DateOnly(2025, 6, 1)` | Included |
+| Exactly EndDate | `new DateOnly(2025, 6, 30)` | Included |
+| One day before StartDate | `new DateOnly(2025, 5, 31)` | Excluded |
+| One day after EndDate | `new DateOnly(2025, 7, 1)` | Excluded |
+
+**`ManufactureOrderSemiProduct` (FR-5):**
+
+| Property | Test value |
+|---|---|
+| `ProductCode` | `"SP-001"` |
+| `ProductName` | `"Argan Cream - meziprodukt"` or `"Plain Name"` |
+| `PlannedQuantity` | `500m` |
+| `ActualQuantity` | `480m` |
+| `BatchMultiplier` | `1.5m` |
+
+**`ManufactureOrderProduct` (FR-7):**
+
+| Property | Test value |
+|---|---|
+| `ProductCode` | `"PROD-001"`, `"PROD-002"` |
+| `ProductName` | `"Product One"`, `"Product Two"` |
+| `PlannedQuantity` | `100m`, `200m` |
+| `ActualQuantity` | `90m`, `195m` |
+
+### Expected Output: `CalendarEventDto` fields verified per test
+
+| Field | Verified in |
+|---|---|
+| `Title` | FR-4 (equals `OrderNumber`), FR-5 (stripped or unstripped name) |
+| `SemiProduct` | FR-4 (is null), FR-5 (all 5 DTO fields match source) |
+| `Products.Count` | FR-6 (0), FR-7 (2) |
+| `Products[n].ProductCode/Name/PlannedQuantity/ActualQuantity` | FR-7 |
+| `Events.Count` | FR-1 (1 event, not 2) |
+| `Events` ordered ascending by `Date` | FR-9 |
+| `Success` | FR-8 (false) |
+| `ErrorCode` | FR-8 (`ErrorCodes.InternalServerError`) |
+
+### Test Coverage Matrix
+
+| FR | Test method (illustrative name) | Branch exercised |
+|---|---|---|
+| FR-1 | `Handle_WithCancelledOrder_ExcludesCancelledAndIncludesPlanned` | State != Cancelled filter |
+| FR-2a | `Handle_PlannedDateEqualsStartDate_IsIncluded` | Boundary: == StartDate |
+| FR-2b | `Handle_PlannedDateEqualsEndDate_IsIncluded` | Boundary: == EndDate |
+| FR-3a | `Handle_PlannedDateBeforeStartDate_IsExcluded` | Boundary: < StartDate |
+| FR-3b | `Handle_PlannedDateAfterEndDate_IsExcluded` | Boundary: > EndDate |
+| FR-4 | `Handle_WithNullSemiProduct_SemiProductIsNullAndTitleIsOrderNumber` | SemiProduct null branch |
+| FR-5a | `Handle_WithSemiProductNameContainingSuffix_TitleIsStripped` | Title strip: `" - meziprodukt"` |
+| FR-5b | `Handle_WithSemiProductNameWithoutSuffix_TitleIsUnchanged` | Title strip: no suffix |
+| FR-5c | `Handle_WithNonNullSemiProduct_DtoFieldsMatchSource` | SemiProduct DTO mapping |
+| FR-6 | `Handle_WithNullProducts_EventProductsIsEmptyList` | Products null → `?? new List<>()` |
+| FR-7 | `Handle_WithTwoProducts_EventProductsMappedCorrectly` | Products mapping |
+| FR-8 | `Handle_WhenRepositoryThrows_ReturnsInternalServerError` | catch block |
+| FR-9 | `Handle_WithUnorderedDates_EventsSortedAscending` | `OrderBy(e => e.Date)` |

--- a/artifacts/feat-3282/impl/write-calendar-view-handler-tests.r1.md
+++ b/artifacts/feat-3282/impl/write-calendar-view-handler-tests.r1.md
@@ -1,0 +1,33 @@
+# write-calendar-view-handler-tests — Implementation Report
+
+## What was implemented
+
+Unit tests for `GetCalendarViewHandler` covering all branches of the handler logic.
+
+## Files created
+
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs`
+
+## Files modified
+
+None.
+
+## Test results
+
+**13 passed, 0 failed, 0 skipped.**
+
+### Test cases
+
+1. `Handle_WithCancelledOrderInRange_ExcludesCancelledOrder` — cancelled orders are excluded from the calendar view
+2. `Handle_WithOrderOnStartDateBoundary_IncludesEvent` — orders exactly on the start date are included
+3. `Handle_WithOrderOnEndDateBoundary_IncludesEvent` — orders exactly on the end date are included
+4. `Handle_WithOrderBeforeStartDate_ExcludesEvent` — orders before the start date are excluded
+5. `Handle_WithOrderAfterEndDate_ExcludesEvent` — orders after the end date are excluded
+6. `Handle_WithNullSemiProduct_SetsEventSemiProductToNull` — null SemiProduct maps to null in the DTO
+7. `Handle_WithSemiProductContainingSuffix_StripsProductNameSuffix` — ` - meziprodukt` suffix is stripped from ProductName
+8. `Handle_WithSemiProductWithoutSuffix_LeavesProductNameUnchanged` — ProductName without suffix is unchanged
+9. `Handle_WithNonNullSemiProduct_MapsSemiProductDtoCorrectly` — all SemiProduct fields map correctly to DTO
+10. `Handle_WithNullProducts_SetsEventProductsToEmptyList` — null Products list maps to empty list in DTO
+11. `Handle_WithNonNullProducts_MapsProductDtosCorrectly` — all Product fields map correctly to DTOs
+12. `Handle_WhenRepositoryThrows_ReturnsInternalServerError` — repository exception returns `ErrorCodes.InternalServerError`
+13. `Handle_WithMultipleOrdersAtDifferentDates_ReturnsSortedByDateAscending` — results are sorted by date ascending

--- a/artifacts/feat-3282/spec.r1.md
+++ b/artifacts/feat-3282/spec.r1.md
@@ -1,0 +1,177 @@
+# Specification: Unit Tests for GetCalendarViewHandler
+
+## Summary
+
+`GetCalendarViewHandler` currently has 10.6% line coverage against a 60% threshold. This specification defines a suite of unit tests covering the five untested branches in the handler: cancelled-order exclusion, PlannedDate boundary enforcement, SemiProduct null/non-null mapping, Products null fallback, and the title-formatting strip for the " - meziprodukt" suffix.
+
+## Background
+
+The manufacture calendar is the primary planning view for production staff. The handler (`GetCalendarViewHandler`) performs two filtering stages after the repository call — a state check and a date-boundary check — plus several conditional mappings before building `CalendarEventDto` objects. None of these paths are exercised today. Regression in the cancelled-order filter would surface stale data to planners; a broken SemiProduct null guard would cause the frontend to receive an unexpected null where it expects an object, crashing the calendar view.
+
+## Functional Requirements
+
+### FR-1: Cancelled-order exclusion filter
+
+The handler must exclude orders whose `State == ManufactureOrderState.Cancelled` from the returned event list, even when such orders fall within the requested date range.
+
+**Acceptance criteria:**
+- Given the repository returns one active order (State = Planned) and one cancelled order (State = Cancelled), both with PlannedDate inside the request window, the response contains exactly one event corresponding to the active order.
+- The cancelled order's Id does not appear in `response.Events`.
+
+### FR-2: PlannedDate boundary inclusion
+
+An order whose `PlannedDate` equals exactly `DateOnly.FromDateTime(request.StartDate)` or exactly `DateOnly.FromDateTime(request.EndDate)` must be included in the response.
+
+**Acceptance criteria:**
+- Given an order with PlannedDate == StartDate boundary, the response contains one event with that order's Id.
+- Given an order with PlannedDate == EndDate boundary, the response contains one event with that order's Id.
+
+### FR-3: PlannedDate boundary exclusion
+
+An order returned by the repository whose `PlannedDate` falls outside the request window (before StartDate or after EndDate) must be silently dropped.
+
+**Acceptance criteria:**
+- Given the repository returns an order with PlannedDate one day before StartDate, the response contains zero events.
+- Given the repository returns an order with PlannedDate one day after EndDate, the response contains zero events.
+
+### FR-4: SemiProduct null branch
+
+When `order.SemiProduct` is null, `CalendarEventDto.SemiProduct` must be null (not a default-constructed object).
+
+**Acceptance criteria:**
+- Given an order with SemiProduct = null, the corresponding event's `SemiProduct` property is null.
+
+### FR-5: SemiProduct non-null branch and title formatting
+
+When `order.SemiProduct` is non-null, `CalendarEventDto.SemiProduct` must be a fully populated `CalendarEventSemiProductDto`. The event's `Title` must be the SemiProduct's `ProductName` with the literal suffix " - meziprodukt" stripped.
+
+**Acceptance criteria:**
+- Given an order with `SemiProduct.ProductName = "Argan Cream - meziprodukt"`, the event title is `"Argan Cream"`.
+- Given an order with `SemiProduct.ProductName = "Plain Name"` (no suffix), the event title is `"Plain Name"`.
+- `CalendarEventDto.SemiProduct.ProductCode`, `ProductName`, `PlannedQuantity`, `ActualQuantity`, and `BatchMultiplier` match the source `ManufactureOrderSemiProduct` values exactly.
+
+### FR-6: Products null fallback
+
+When `order.Products` is null, `CalendarEventDto.Products` must be an empty list (not null).
+
+**Acceptance criteria:**
+- Given an order with Products = null, the corresponding event's `Products` is an empty `List<CalendarEventProductDto>` (not null, count == 0).
+
+### FR-7: Products non-null mapping
+
+When `order.Products` is a non-empty list, each product is mapped to `CalendarEventProductDto` with correct field values.
+
+**Acceptance criteria:**
+- Given an order with two products, the event's `Products` has count 2, and each item's `ProductCode`, `ProductName`, `PlannedQuantity`, `ActualQuantity` match the source.
+
+### FR-8: Repository exception handling
+
+When the repository throws an exception, the handler catches it, logs the error, and returns a response with `ErrorCodes.InternalServerError` (no unhandled exception propagates).
+
+**Acceptance criteria:**
+- Given `GetOrdersForDateRangeAsync` throws any `Exception`, `Handle` returns without throwing.
+- The returned `GetCalendarViewResponse` carries `ErrorCodes.InternalServerError`.
+
+### FR-9: Events sorted by date
+
+When the repository returns orders with different PlannedDates, the events in the response are ordered ascending by `Date`.
+
+**Acceptance criteria:**
+- Given orders with PlannedDates in reverse order, `response.Events` is ascending by `Date`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+Tests must complete in under 5 seconds total; each test case in under 1 second. No I/O, real database, or network calls — all dependencies are mocked.
+
+### NFR-2: Test isolation
+
+Each test must be fully independent. No shared mutable state between test cases. The repository mock is configured fresh per test (constructor or per-test setup).
+
+### NFR-3: Maintainability
+
+Follow the project's existing naming convention: `[MethodName]_[Scenario]_[ExpectedBehavior]()`. Use Moq for mocking `IManufactureOrderRepository` and `ILogger<GetCalendarViewHandler>`. Use FluentAssertions for assertions. Mirror the project's Arrange/Act/Assert structure.
+
+### NFR-4: Coverage target
+
+After these tests are added, line coverage for `GetCalendarViewHandler` must reach at least 60%.
+
+## Data Model
+
+No new entities or schema changes. The tests operate on the existing domain types:
+
+- `ManufactureOrder` — aggregate with `Id`, `OrderNumber`, `PlannedDate` (DateOnly), `State` (ManufactureOrderState), `SemiProduct` (ManufactureOrderSemiProduct?), `Products` (List\<ManufactureOrderProduct\>?)
+- `ManufactureOrderSemiProduct` — value type with `ProductCode`, `ProductName`, `PlannedQuantity`, `ActualQuantity` (decimal?), `BatchMultiplier`
+- `ManufactureOrderProduct` — value type with `ProductCode`, `ProductName`, `PlannedQuantity`, `ActualQuantity` (decimal?)
+- `ManufactureOrderState` — enum values: Draft=1, Planned=2, SemiProductManufactured=4, Completed=5, Cancelled=6
+
+## API / Interface Design
+
+This feature adds no new API surface. The tests call `GetCalendarViewHandler.Handle(request, CancellationToken.None)` directly.
+
+**Test class location:**
+`backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs`
+
+**Handler constructor signature (under test):**
+```csharp
+public GetCalendarViewHandler(
+    IManufactureOrderRepository repository,
+    ILogger<GetCalendarViewHandler> logger)
+```
+
+**Repository method under mock:**
+```csharp
+Task<List<ManufactureOrder>> GetOrdersForDateRangeAsync(
+    DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default);
+```
+
+**Request shape:**
+```csharp
+new GetCalendarViewRequest
+{
+    StartDate = new DateTime(2025, 6, 1),
+    EndDate   = new DateTime(2025, 6, 30)
+}
+```
+
+**Test cases to implement:**
+
+| Test method | Scenario | Assert |
+|---|---|---|
+| `Handle_WithCancelledOrderInRange_ExcludesCancelledOrder` | One Planned + one Cancelled order, both in range | Events.Count == 1, Id matches Planned order |
+| `Handle_WithOrderOnStartDateBoundary_IncludesEvent` | PlannedDate == StartDate | Events.Count == 1 |
+| `Handle_WithOrderOnEndDateBoundary_IncludesEvent` | PlannedDate == EndDate | Events.Count == 1 |
+| `Handle_WithOrderBeforeStartDate_ExcludesEvent` | PlannedDate == StartDate - 1 day | Events is empty |
+| `Handle_WithOrderAfterEndDate_ExcludesEvent` | PlannedDate == EndDate + 1 day | Events is empty |
+| `Handle_WithNullSemiProduct_SetsEventSemiProductToNull` | order.SemiProduct == null | event.SemiProduct is null |
+| `Handle_WithSemiProductContainingSuffix_StripsProductNameSuffix` | ProductName == "X - meziprodukt" | event.Title == "X" |
+| `Handle_WithSemiProductWithoutSuffix_LeavesProductNameUnchanged` | ProductName == "Plain Name" | event.Title == "Plain Name" |
+| `Handle_WithNonNullSemiProduct_MapsSemiProductDtoCorrectly` | SemiProduct fully populated | DTO fields match source |
+| `Handle_WithNullProducts_SetsEventProductsToEmptyList` | order.Products == null | event.Products not null, Count == 0 |
+| `Handle_WithNonNullProducts_MapsProductDtosCorrectly` | Two products | event.Products.Count == 2, fields match |
+| `Handle_WhenRepositoryThrows_ReturnsInternalServerError` | Repository throws Exception | response has InternalServerError, no throw |
+| `Handle_WithMultipleOrdersAtDifferentDates_ReturnsSortedByDateAscending` | Two orders, dates reversed | Events[0].Date < Events[1].Date |
+
+## Dependencies
+
+- `Anela.Heblo.Domain.Features.Manufacture.IManufactureOrderRepository` — mocked via Moq
+- `Microsoft.Extensions.Logging.ILogger<GetCalendarViewHandler>` — mocked via Moq (`Mock.Of<ILogger<...>>()` or `new Mock<ILogger<...>>()`)
+- xUnit, FluentAssertions, Moq — already present in `Anela.Heblo.Tests.csproj`
+- `ManufactureOrder` must be constructable in tests; if the constructor is private or enforces invariants via the state machine, test instances must be built using whatever factory or builder pattern the domain exposes (or object initializers if the setters are accessible). Assumption: `ManufactureOrder` properties have at least `internal` setters reachable from the test project, or a public parameterless constructor is available.
+
+## Out of Scope
+
+- Integration tests against a real database or the HTTP layer
+- Tests for `GetOrdersForDateRangeAsync` implementation (repository-layer concern)
+- Tests for other manufacture use cases
+- Changes to the handler implementation itself — tests must pass against the existing code
+- E2E or Playwright tests
+
+## Open Questions
+
+1. **ManufactureOrder constructability**: The domain exploration noted that `State` has an internal setter and that `ChangeState` enforces a state machine. Can tests set `State = ManufactureOrderState.Cancelled` directly (e.g., via object initializer or reflection), or is a factory/builder needed? If `internal` setters are not visible from the test assembly, `InternalsVisibleTo` or a test-builder helper must be added.
+
+2. **ManufactureOrderSemiProduct and ManufactureOrderProduct constructability**: Are these plain classes with public setters, or do they enforce invariants? If parameterless constructors are absent, sample test data setup may need a different approach.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3282/state.json
+++ b/artifacts/feat-3282/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-06-22T18:23:16.810135Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T18:23:32.366126Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T18:25:34.154654Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-22T18:25:34.361048Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3282/state.json
+++ b/artifacts/feat-3282/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-06-22T18:28:26.519507Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T18:28:38.851008Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T19:24:10.783059Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3282/state.json
+++ b/artifacts/feat-3282/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-06-22T18:25:34.154654Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T18:25:34.361048Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T18:28:26.519507Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "write-calendar-view-handler-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3282/state.json
+++ b/artifacts/feat-3282/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3282",
+  "issue_number": 3282,
+  "created_at": "2026-06-22T18:14:27.453142Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-22T18:15:11.094572Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3282/state.json
+++ b/artifacts/feat-3282/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-22T18:28:26.519507Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-22T18:28:38.851008Z"
     }
   },
   "tasks": [
     {
       "name": "write-calendar-view-handler-tests",
-      "status": "pending",
+      "status": "completed",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-22T19:24:03.526931Z"
     }
   ]
 }

--- a/artifacts/feat-3282/state.json
+++ b/artifacts/feat-3282/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-06-22T18:19:12.084817Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T18:19:16.572575Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T18:23:16.810135Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-22T18:23:32.366126Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3282/state.json
+++ b/artifacts/feat-3282/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-22T18:15:11.094572Z"
+      "status": "completed",
+      "updated_at": "2026-06-22T18:19:12.084817Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-22T18:19:16.572575Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3282/task-context/write-calendar-view-handler-tests.md
+++ b/artifacts/feat-3282/task-context/write-calendar-view-handler-tests.md
@@ -1,0 +1,426 @@
+# Task Plan: GetCalendarViewHandler Unit Tests
+
+Feature: feat-3282 — Coverage Gap: Manufacture GetCalendarViewHandler
+
+## Overview
+
+Write 13 unit tests for `GetCalendarViewHandler` in a new file at:
+`backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs`
+
+---
+
+### task: write-calendar-view-handler-tests
+
+**Goal:** Create the test file with all 13 test cases covering date boundary filtering, cancelled-order exclusion, SemiProduct/Products mapping, sorting, and error handling.
+
+**Step 1 — Create the directory**
+
+```
+backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/
+```
+
+This directory does not exist yet. Create it before writing the file.
+
+**Step 2 — Write the test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs` with the exact content below:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetCalendarView;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.UseCases.GetCalendarView;
+
+public class GetCalendarViewHandlerTests
+{
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly GetCalendarViewHandler _handler;
+
+    // Fixed date range used across all tests
+    private static readonly DateTime StartDate = new DateTime(2025, 6, 1);
+    private static readonly DateTime EndDate = new DateTime(2025, 6, 30);
+
+    public GetCalendarViewHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _handler = new GetCalendarViewHandler(
+            _repositoryMock.Object,
+            Mock.Of<ILogger<GetCalendarViewHandler>>());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static ManufactureOrder CreateOrder(
+        int id,
+        string orderNumber,
+        DateOnly plannedDate,
+        ManufactureOrderState state = ManufactureOrderState.Planned)
+    {
+        var order = new ManufactureOrder
+        {
+            Id = id,
+            OrderNumber = orderNumber,
+            PlannedDate = plannedDate
+        };
+        order.InitializeState(state, DateTime.UtcNow, "Test User");
+        return order;
+    }
+
+    private void SetupRepository(List<ManufactureOrder> orders)
+    {
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(orders);
+    }
+
+    private static GetCalendarViewRequest BuildRequest() =>
+        new GetCalendarViewRequest { StartDate = StartDate, EndDate = EndDate };
+
+    // ---------------------------------------------------------------------------
+    // Cancelled-order filtering
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithCancelledOrderInRange_ExcludesCancelledOrder()
+    {
+        // Arrange
+        var plannedOrder = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15), ManufactureOrderState.Planned);
+        var cancelledOrder = CreateOrder(2, "MO-2025-002", new DateOnly(2025, 6, 16), ManufactureOrderState.Cancelled);
+        SetupRepository(new List<ManufactureOrder> { plannedOrder, cancelledOrder });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+        result.Events[0].Id.Should().Be(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Date boundary inclusion
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithOrderOnStartDateBoundary_IncludesEvent()
+    {
+        // Arrange — PlannedDate == StartDate (June 1)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 1));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderOnEndDateBoundary_IncludesEvent()
+    {
+        // Arrange — PlannedDate == EndDate (June 30)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 30));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Date boundary exclusion
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithOrderBeforeStartDate_ExcludesEvent()
+    {
+        // Arrange — PlannedDate == May 31 (one day before StartDate)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 5, 31));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderAfterEndDate_ExcludesEvent()
+    {
+        // Arrange — PlannedDate == July 1 (one day after EndDate)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 7, 1));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------------------
+    // SemiProduct — null case
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNullSemiProduct_SetsEventSemiProductToNull()
+    {
+        // Arrange — SemiProduct is null; Title should fall back to OrderNumber
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = null;
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var ev = result.Events[0];
+        ev.SemiProduct.Should().BeNull();
+        ev.Title.Should().Be(order.OrderNumber);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SemiProduct — title suffix stripping
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithSemiProductContainingSuffix_StripsProductNameSuffix()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI001",
+            ProductName = "Argan Cream - meziprodukt",
+            PlannedQuantity = 500m,
+            BatchMultiplier = 1m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events[0].Title.Should().Be("Argan Cream");
+    }
+
+    [Fact]
+    public async Task Handle_WithSemiProductWithoutSuffix_LeavesProductNameUnchanged()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI002",
+            ProductName = "Plain Name",
+            PlannedQuantity = 200m,
+            BatchMultiplier = 1m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events[0].Title.Should().Be("Plain Name");
+    }
+
+    // ---------------------------------------------------------------------------
+    // SemiProduct — DTO field mapping
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNonNullSemiProduct_MapsSemiProductDtoCorrectly()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI003",
+            ProductName = "Rose Hip Oil - meziprodukt",
+            PlannedQuantity = 750m,
+            ActualQuantity = 800m,
+            BatchMultiplier = 2.5m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var sp = result.Events[0].SemiProduct;
+        sp.Should().NotBeNull();
+        sp!.ProductCode.Should().Be("SEMI003");
+        sp.ProductName.Should().Be("Rose Hip Oil - meziprodukt");
+        sp.PlannedQuantity.Should().Be(750m);
+        sp.ActualQuantity.Should().Be(800m);
+        sp.BatchMultiplier.Should().Be(2.5m);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Products — null collection
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNullProducts_SetsEventProductsToEmptyList()
+    {
+        // Arrange — Products must be explicitly set to null! because the
+        // property default is new List<ManufactureOrderProduct>()
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.Products = null!;
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var ev = result.Events[0];
+        ev.Products.Should().NotBeNull();
+        ev.Products.Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Products — DTO field mapping
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNonNullProducts_MapsProductDtosCorrectly()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.Products.Add(new ManufactureOrderProduct
+        {
+            ProductCode = "PROD001",
+            ProductName = "Product Alpha",
+            PlannedQuantity = 100m,
+            ActualQuantity = 95m,
+            SemiProductCode = "SEMI001"
+        });
+        order.Products.Add(new ManufactureOrderProduct
+        {
+            ProductCode = "PROD002",
+            ProductName = "Product Beta",
+            PlannedQuantity = 200m,
+            ActualQuantity = null,
+            SemiProductCode = "SEMI001"
+        });
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var products = result.Events[0].Products;
+        products.Should().HaveCount(2);
+
+        products[0].ProductCode.Should().Be("PROD001");
+        products[0].ProductName.Should().Be("Product Alpha");
+        products[0].PlannedQuantity.Should().Be(100m);
+        products[0].ActualQuantity.Should().Be(95m);
+
+        products[1].ProductCode.Should().Be("PROD002");
+        products[1].ProductName.Should().Be("Product Beta");
+        products[1].PlannedQuantity.Should().Be(200m);
+        products[1].ActualQuantity.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Error handling
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WhenRepositoryThrows_ReturnsInternalServerError()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database connection lost"));
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert — handler must swallow the exception and return an error response
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Sorting
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithMultipleOrdersAtDifferentDates_ReturnsSortedByDateAscending()
+    {
+        // Arrange — deliberately add later date first to verify sort
+        var laterOrder = CreateOrder(2, "MO-2025-002", new DateOnly(2025, 6, 20));
+        var earlierOrder = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 5));
+        SetupRepository(new List<ManufactureOrder> { laterOrder, earlierOrder });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(2);
+        result.Events[0].Date.Should().BeBefore(result.Events[1].Date);
+    }
+}
+```
+
+**Step 3 — Verify**
+
+Run the following command from the repository root to confirm all 13 tests pass and none are skipped:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetCalendarViewHandlerTests" \
+  --no-build \
+  --verbosity normal
+```
+
+If `--no-build` fails (first run), drop it:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetCalendarViewHandlerTests" \
+  --verbosity normal
+```
+
+Expected output: **13 passed, 0 failed, 0 skipped.**
+
+Also run the full build and format check to satisfy project validation requirements:
+
+```bash
+dotnet build backend/Anela.Heblo.sln && dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+**Key implementation notes:**
+
+- `InitializeState(state, DateTime.UtcNow, "Test User")` is the only valid way to set `State` on `ManufactureOrder` (the setter is `internal`).
+- `order.Products = null!` is required for the null-Products test because the property defaults to `new List<ManufactureOrderProduct>()`.
+- Repository is mocked with `It.IsAny<DateOnly>()` for both date arguments — the handler converts `DateTime` → `DateOnly` internally, so exact-value matching would couple the test to that conversion detail unnecessarily.
+- The test namespace `Anela.Heblo.Tests.Features.Manufacture.UseCases.GetCalendarView` matches the directory structure required by the project conventions (see `docs/architecture/filesystem.md`).
+- No AutoMapper mock needed — the handler builds DTOs by hand.

--- a/artifacts/feat-3282/task-plan.r1.md
+++ b/artifacts/feat-3282/task-plan.r1.md
@@ -1,0 +1,426 @@
+# Task Plan: GetCalendarViewHandler Unit Tests
+
+Feature: feat-3282 — Coverage Gap: Manufacture GetCalendarViewHandler
+
+## Overview
+
+Write 13 unit tests for `GetCalendarViewHandler` in a new file at:
+`backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs`
+
+---
+
+### task: write-calendar-view-handler-tests
+
+**Goal:** Create the test file with all 13 test cases covering date boundary filtering, cancelled-order exclusion, SemiProduct/Products mapping, sorting, and error handling.
+
+**Step 1 — Create the directory**
+
+```
+backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/
+```
+
+This directory does not exist yet. Create it before writing the file.
+
+**Step 2 — Write the test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs` with the exact content below:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetCalendarView;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.UseCases.GetCalendarView;
+
+public class GetCalendarViewHandlerTests
+{
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly GetCalendarViewHandler _handler;
+
+    // Fixed date range used across all tests
+    private static readonly DateTime StartDate = new DateTime(2025, 6, 1);
+    private static readonly DateTime EndDate = new DateTime(2025, 6, 30);
+
+    public GetCalendarViewHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _handler = new GetCalendarViewHandler(
+            _repositoryMock.Object,
+            Mock.Of<ILogger<GetCalendarViewHandler>>());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static ManufactureOrder CreateOrder(
+        int id,
+        string orderNumber,
+        DateOnly plannedDate,
+        ManufactureOrderState state = ManufactureOrderState.Planned)
+    {
+        var order = new ManufactureOrder
+        {
+            Id = id,
+            OrderNumber = orderNumber,
+            PlannedDate = plannedDate
+        };
+        order.InitializeState(state, DateTime.UtcNow, "Test User");
+        return order;
+    }
+
+    private void SetupRepository(List<ManufactureOrder> orders)
+    {
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(orders);
+    }
+
+    private static GetCalendarViewRequest BuildRequest() =>
+        new GetCalendarViewRequest { StartDate = StartDate, EndDate = EndDate };
+
+    // ---------------------------------------------------------------------------
+    // Cancelled-order filtering
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithCancelledOrderInRange_ExcludesCancelledOrder()
+    {
+        // Arrange
+        var plannedOrder = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15), ManufactureOrderState.Planned);
+        var cancelledOrder = CreateOrder(2, "MO-2025-002", new DateOnly(2025, 6, 16), ManufactureOrderState.Cancelled);
+        SetupRepository(new List<ManufactureOrder> { plannedOrder, cancelledOrder });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+        result.Events[0].Id.Should().Be(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Date boundary inclusion
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithOrderOnStartDateBoundary_IncludesEvent()
+    {
+        // Arrange — PlannedDate == StartDate (June 1)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 1));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderOnEndDateBoundary_IncludesEvent()
+    {
+        // Arrange — PlannedDate == EndDate (June 30)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 30));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Date boundary exclusion
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithOrderBeforeStartDate_ExcludesEvent()
+    {
+        // Arrange — PlannedDate == May 31 (one day before StartDate)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 5, 31));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderAfterEndDate_ExcludesEvent()
+    {
+        // Arrange — PlannedDate == July 1 (one day after EndDate)
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 7, 1));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Events.Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------------------
+    // SemiProduct — null case
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNullSemiProduct_SetsEventSemiProductToNull()
+    {
+        // Arrange — SemiProduct is null; Title should fall back to OrderNumber
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = null;
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var ev = result.Events[0];
+        ev.SemiProduct.Should().BeNull();
+        ev.Title.Should().Be(order.OrderNumber);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SemiProduct — title suffix stripping
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithSemiProductContainingSuffix_StripsProductNameSuffix()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI001",
+            ProductName = "Argan Cream - meziprodukt",
+            PlannedQuantity = 500m,
+            BatchMultiplier = 1m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events[0].Title.Should().Be("Argan Cream");
+    }
+
+    [Fact]
+    public async Task Handle_WithSemiProductWithoutSuffix_LeavesProductNameUnchanged()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI002",
+            ProductName = "Plain Name",
+            PlannedQuantity = 200m,
+            BatchMultiplier = 1m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events[0].Title.Should().Be("Plain Name");
+    }
+
+    // ---------------------------------------------------------------------------
+    // SemiProduct — DTO field mapping
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNonNullSemiProduct_MapsSemiProductDtoCorrectly()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI003",
+            ProductName = "Rose Hip Oil - meziprodukt",
+            PlannedQuantity = 750m,
+            ActualQuantity = 800m,
+            BatchMultiplier = 2.5m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var sp = result.Events[0].SemiProduct;
+        sp.Should().NotBeNull();
+        sp!.ProductCode.Should().Be("SEMI003");
+        sp.ProductName.Should().Be("Rose Hip Oil - meziprodukt");
+        sp.PlannedQuantity.Should().Be(750m);
+        sp.ActualQuantity.Should().Be(800m);
+        sp.BatchMultiplier.Should().Be(2.5m);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Products — null collection
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNullProducts_SetsEventProductsToEmptyList()
+    {
+        // Arrange — Products must be explicitly set to null! because the
+        // property default is new List<ManufactureOrderProduct>()
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.Products = null!;
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var ev = result.Events[0];
+        ev.Products.Should().NotBeNull();
+        ev.Products.Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Products — DTO field mapping
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithNonNullProducts_MapsProductDtosCorrectly()
+    {
+        // Arrange
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.Products.Add(new ManufactureOrderProduct
+        {
+            ProductCode = "PROD001",
+            ProductName = "Product Alpha",
+            PlannedQuantity = 100m,
+            ActualQuantity = 95m,
+            SemiProductCode = "SEMI001"
+        });
+        order.Products.Add(new ManufactureOrderProduct
+        {
+            ProductCode = "PROD002",
+            ProductName = "Product Beta",
+            PlannedQuantity = 200m,
+            ActualQuantity = null,
+            SemiProductCode = "SEMI001"
+        });
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(1);
+        var products = result.Events[0].Products;
+        products.Should().HaveCount(2);
+
+        products[0].ProductCode.Should().Be("PROD001");
+        products[0].ProductName.Should().Be("Product Alpha");
+        products[0].PlannedQuantity.Should().Be(100m);
+        products[0].ActualQuantity.Should().Be(95m);
+
+        products[1].ProductCode.Should().Be("PROD002");
+        products[1].ProductName.Should().Be("Product Beta");
+        products[1].PlannedQuantity.Should().Be(200m);
+        products[1].ActualQuantity.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Error handling
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WhenRepositoryThrows_ReturnsInternalServerError()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database connection lost"));
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert — handler must swallow the exception and return an error response
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Sorting
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WithMultipleOrdersAtDifferentDates_ReturnsSortedByDateAscending()
+    {
+        // Arrange — deliberately add later date first to verify sort
+        var laterOrder = CreateOrder(2, "MO-2025-002", new DateOnly(2025, 6, 20));
+        var earlierOrder = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 5));
+        SetupRepository(new List<ManufactureOrder> { laterOrder, earlierOrder });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Events.Should().HaveCount(2);
+        result.Events[0].Date.Should().BeBefore(result.Events[1].Date);
+    }
+}
+```
+
+**Step 3 — Verify**
+
+Run the following command from the repository root to confirm all 13 tests pass and none are skipped:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetCalendarViewHandlerTests" \
+  --no-build \
+  --verbosity normal
+```
+
+If `--no-build` fails (first run), drop it:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetCalendarViewHandlerTests" \
+  --verbosity normal
+```
+
+Expected output: **13 passed, 0 failed, 0 skipped.**
+
+Also run the full build and format check to satisfy project validation requirements:
+
+```bash
+dotnet build backend/Anela.Heblo.sln && dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+**Key implementation notes:**
+
+- `InitializeState(state, DateTime.UtcNow, "Test User")` is the only valid way to set `State` on `ManufactureOrder` (the setter is `internal`).
+- `order.Products = null!` is required for the null-Products test because the property defaults to `new List<ManufactureOrderProduct>()`.
+- Repository is mocked with `It.IsAny<DateOnly>()` for both date arguments — the handler converts `DateTime` → `DateOnly` internally, so exact-value matching would couple the test to that conversion detail unnecessarily.
+- The test namespace `Anela.Heblo.Tests.Features.Manufacture.UseCases.GetCalendarView` matches the directory structure required by the project conventions (see `docs/architecture/filesystem.md`).
+- No AutoMapper mock needed — the handler builds DTOs by hand.

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
@@ -1,0 +1,277 @@
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetCalendarView;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.UseCases.GetCalendarView;
+
+public class GetCalendarViewHandlerTests
+{
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly GetCalendarViewHandler _handler;
+
+    private static readonly DateTime StartDate = new DateTime(2025, 6, 1);
+    private static readonly DateTime EndDate = new DateTime(2025, 6, 30);
+
+    public GetCalendarViewHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _handler = new GetCalendarViewHandler(
+            _repositoryMock.Object,
+            Mock.Of<ILogger<GetCalendarViewHandler>>());
+    }
+
+    private static ManufactureOrder CreateOrder(
+        int id,
+        string orderNumber,
+        DateOnly plannedDate,
+        ManufactureOrderState state = ManufactureOrderState.Planned)
+    {
+        var order = new ManufactureOrder
+        {
+            Id = id,
+            OrderNumber = orderNumber,
+            PlannedDate = plannedDate
+        };
+        order.InitializeState(state, DateTime.UtcNow, "Test User");
+        return order;
+    }
+
+    private void SetupRepository(List<ManufactureOrder> orders)
+    {
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(orders);
+    }
+
+    private static GetCalendarViewRequest BuildRequest() =>
+        new GetCalendarViewRequest { StartDate = StartDate, EndDate = EndDate };
+
+    [Fact]
+    public async Task Handle_WithCancelledOrderInRange_ExcludesCancelledOrder()
+    {
+        var plannedOrder = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15), ManufactureOrderState.Planned);
+        var cancelledOrder = CreateOrder(2, "MO-2025-002", new DateOnly(2025, 6, 16), ManufactureOrderState.Cancelled);
+        SetupRepository(new List<ManufactureOrder> { plannedOrder, cancelledOrder });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+        result.Events[0].Id.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderOnStartDateBoundary_IncludesEvent()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 1));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderOnEndDateBoundary_IncludesEvent()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 30));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Events.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderBeforeStartDate_ExcludesEvent()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 5, 31));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithOrderAfterEndDate_ExcludesEvent()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 7, 1));
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithNullSemiProduct_SetsEventSemiProductToNull()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = null;
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Events.Should().HaveCount(1);
+        var ev = result.Events[0];
+        ev.SemiProduct.Should().BeNull();
+        ev.Title.Should().Be(order.OrderNumber);
+    }
+
+    [Fact]
+    public async Task Handle_WithSemiProductContainingSuffix_StripsProductNameSuffix()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI001",
+            ProductName = "Argan Cream - meziprodukt",
+            PlannedQuantity = 500m,
+            BatchMultiplier = 1m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Events[0].Title.Should().Be("Argan Cream");
+    }
+
+    [Fact]
+    public async Task Handle_WithSemiProductWithoutSuffix_LeavesProductNameUnchanged()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI002",
+            ProductName = "Plain Name",
+            PlannedQuantity = 200m,
+            BatchMultiplier = 1m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Events[0].Title.Should().Be("Plain Name");
+    }
+
+    [Fact]
+    public async Task Handle_WithNonNullSemiProduct_MapsSemiProductDtoCorrectly()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.SemiProduct = new ManufactureOrderSemiProduct
+        {
+            ProductCode = "SEMI003",
+            ProductName = "Rose Hip Oil - meziprodukt",
+            PlannedQuantity = 750m,
+            ActualQuantity = 800m,
+            BatchMultiplier = 2.5m
+        };
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Events.Should().HaveCount(1);
+        var sp = result.Events[0].SemiProduct;
+        sp.Should().NotBeNull();
+        sp!.ProductCode.Should().Be("SEMI003");
+        sp.ProductName.Should().Be("Rose Hip Oil - meziprodukt");
+        sp.PlannedQuantity.Should().Be(750m);
+        sp.ActualQuantity.Should().Be(800m);
+        sp.BatchMultiplier.Should().Be(2.5m);
+    }
+
+    [Fact]
+    public async Task Handle_WithNullProducts_SetsEventProductsToEmptyList()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.Products = null!;
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Events.Should().HaveCount(1);
+        var ev = result.Events[0];
+        ev.Products.Should().NotBeNull();
+        ev.Products.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithNonNullProducts_MapsProductDtosCorrectly()
+    {
+        var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
+        order.Products.Add(new ManufactureOrderProduct
+        {
+            ProductCode = "PROD001",
+            ProductName = "Product Alpha",
+            PlannedQuantity = 100m,
+            ActualQuantity = 95m,
+            SemiProductCode = "SEMI001"
+        });
+        order.Products.Add(new ManufactureOrderProduct
+        {
+            ProductCode = "PROD002",
+            ProductName = "Product Beta",
+            PlannedQuantity = 200m,
+            ActualQuantity = null,
+            SemiProductCode = "SEMI001"
+        });
+        SetupRepository(new List<ManufactureOrder> { order });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Events.Should().HaveCount(1);
+        var products = result.Events[0].Products;
+        products.Should().HaveCount(2);
+
+        products[0].ProductCode.Should().Be("PROD001");
+        products[0].ProductName.Should().Be("Product Alpha");
+        products[0].PlannedQuantity.Should().Be(100m);
+        products[0].ActualQuantity.Should().Be(95m);
+
+        products[1].ProductCode.Should().Be("PROD002");
+        products[1].ProductName.Should().Be("Product Beta");
+        products[1].PlannedQuantity.Should().Be(200m);
+        products[1].ActualQuantity.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryThrows_ReturnsInternalServerError()
+    {
+        _repositoryMock
+            .Setup(r => r.GetOrdersForDateRangeAsync(
+                It.IsAny<DateOnly>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database connection lost"));
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
+    }
+
+    [Fact]
+    public async Task Handle_WithMultipleOrdersAtDifferentDates_ReturnsSortedByDateAscending()
+    {
+        var laterOrder = CreateOrder(2, "MO-2025-002", new DateOnly(2025, 6, 20));
+        var earlierOrder = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 5));
+        SetupRepository(new List<ManufactureOrder> { laterOrder, earlierOrder });
+
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        result.Events.Should().HaveCount(2);
+        result.Events[0].Date.Should().BeBefore(result.Events[1].Date);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
@@ -124,6 +124,7 @@ public class GetCalendarViewHandlerTests
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
+        result.Success.Should().BeTrue();
         result.Events.Should().HaveCount(1);
         var ev = result.Events[0];
         ev.SemiProduct.Should().BeNull();
@@ -145,6 +146,7 @@ public class GetCalendarViewHandlerTests
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
+        result.Success.Should().BeTrue();
         result.Events[0].Title.Should().Be("Argan Cream");
     }
 
@@ -163,6 +165,7 @@ public class GetCalendarViewHandlerTests
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
+        result.Success.Should().BeTrue();
         result.Events[0].Title.Should().Be("Plain Name");
     }
 
@@ -182,6 +185,7 @@ public class GetCalendarViewHandlerTests
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
+        result.Success.Should().BeTrue();
         result.Events.Should().HaveCount(1);
         var sp = result.Events[0].SemiProduct;
         sp.Should().NotBeNull();
@@ -201,6 +205,7 @@ public class GetCalendarViewHandlerTests
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
+        result.Success.Should().BeTrue();
         result.Events.Should().HaveCount(1);
         var ev = result.Events[0];
         ev.Products.Should().NotBeNull();
@@ -231,6 +236,7 @@ public class GetCalendarViewHandlerTests
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
+        result.Success.Should().BeTrue();
         result.Events.Should().HaveCount(1);
         var products = result.Events[0].Products;
         products.Should().HaveCount(2);
@@ -271,6 +277,7 @@ public class GetCalendarViewHandlerTests
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
+        result.Success.Should().BeTrue();
         result.Events.Should().HaveCount(2);
         result.Events[0].Date.Should().BeBefore(result.Events[1].Date);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
@@ -36,7 +36,7 @@ public class GetCalendarViewHandlerTests
             OrderNumber = orderNumber,
             PlannedDate = plannedDate
         };
-        order.InitializeState(state, DateTime.UtcNow, "Test User");
+        order.InitializeState(state, new DateTime(2025, 6, 1), "Test User");
         return order;
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs
@@ -200,7 +200,7 @@ public class GetCalendarViewHandlerTests
     public async Task Handle_WithNullProducts_SetsEventProductsToEmptyList()
     {
         var order = CreateOrder(1, "MO-2025-001", new DateOnly(2025, 6, 15));
-        order.Products = null!;
+        order.Products = null!; // Products defaults to new List<>; force null to exercise the null-fallback branch
         SetupRepository(new List<ManufactureOrder> { order });
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);


### PR DESCRIPTION
## What the issue was

`GetCalendarViewHandler` had only 10.6% line coverage against a 60% threshold. The handler's two-stage filter (cancelled-order exclusion + PlannedDate boundary re-check), SemiProduct/Products null guards, title-formatting strip, sorting, and exception-handling path were all untested, leaving the manufacture calendar — the primary planning view for production staff — unprotected against regressions.

## How it was fixed / handled

Added 13 unit tests in a new file `backend/test/Anela.Heblo.Tests/Features/Manufacture/UseCases/GetCalendarView/GetCalendarViewHandlerTests.cs` covering:

- Cancelled-order exclusion (in-memory filter after repository call)
- PlannedDate inclusive boundary (exact start/end match included)
- PlannedDate exclusive boundary (one day outside range dropped)
- SemiProduct null branch → event.SemiProduct is null, title falls back to OrderNumber
- SemiProduct non-null → title suffix `" - meziprodukt"` stripped correctly; DTO fields mapped correctly
- Products null fallback → empty list (not null)
- Products non-null → all fields mapped correctly
- Repository exception → returns InternalServerError without propagating
- Multi-order sort → events ordered ascending by Date

All 13 tests pass. Uses Moq + FluentAssertions + xUnit, matching the existing test conventions. `InitializeState()` used for State assignment (per existing pattern).

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and state artifacts are committed in `artifacts/feat-3282/` on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_0167Pw99W693RAj3K2JNKufr)_

Closes #3282