### PR TITLE
#3284: add unit tests for UpdateProductCompositionOrderRequestValidator

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Validators/UpdateProductCompositionOrderRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Validators/UpdateProductCompositionOrderRequestValidatorTests.cs
@@ -1,5 +1,4 @@
 using Anela.Heblo.Application.Features.Catalog.UseCases.UpdateProductCompositionOrder;
-using FluentAssertions;
 using FluentValidation.TestHelper;
 using Xunit;
 
@@ -112,9 +111,8 @@ public class UpdateProductCompositionOrderRequestValidatorTests
 
         var result = _validator.TestValidate(request);
 
-        result.Errors.Should().Contain(e =>
-            e.PropertyName == "Order[0].IngredientProductCode" &&
-            e.ErrorMessage == "Ingredient product code is required");
+        result.ShouldHaveValidationErrorFor("Order[0].IngredientProductCode")
+            .WithErrorMessage("Ingredient product code is required");
     }
 
     [Fact]
@@ -131,9 +129,8 @@ public class UpdateProductCompositionOrderRequestValidatorTests
 
         var result = _validator.TestValidate(request);
 
-        result.Errors.Should().Contain(e =>
-            e.PropertyName == "Order[0].IngredientProductCode" &&
-            e.ErrorMessage == "Ingredient product code cannot exceed 50 characters");
+        result.ShouldHaveValidationErrorFor("Order[0].IngredientProductCode")
+            .WithErrorMessage("Ingredient product code cannot exceed 50 characters");
     }
 
     [Fact]
@@ -150,7 +147,7 @@ public class UpdateProductCompositionOrderRequestValidatorTests
 
         var result = _validator.TestValidate(request);
 
-        result.Errors.Should().NotContain(e => e.PropertyName == "Order[0].IngredientProductCode");
+        result.ShouldNotHaveValidationErrorFor("Order[0].IngredientProductCode");
     }
 
     [Theory]
@@ -170,9 +167,8 @@ public class UpdateProductCompositionOrderRequestValidatorTests
 
         var result = _validator.TestValidate(request);
 
-        result.Errors.Should().Contain(e =>
-            e.PropertyName == "Order[0].SortOrder" &&
-            e.ErrorMessage == "Sort order must be greater than 0");
+        result.ShouldHaveValidationErrorFor("Order[0].SortOrder")
+            .WithErrorMessage("Sort order must be greater than 0");
     }
 
     [Theory]
@@ -192,13 +188,14 @@ public class UpdateProductCompositionOrderRequestValidatorTests
 
         var result = _validator.TestValidate(request);
 
-        result.Errors.Should().NotContain(e => e.PropertyName == "Order[0].SortOrder");
+        result.ShouldNotHaveValidationErrorFor("Order[0].SortOrder");
     }
 
     [Theory]
     [InlineData("")]
     [InlineData(null)]
-    public void ProductCode_EmptyOrNull_FailsValidation(string? productCode)
+    [InlineData("   ")]
+    public void ProductCode_EmptyOrNullOrWhitespace_FailsValidation(string? productCode)
     {
         var request = ValidRequest();
         request.ProductCode = productCode!;
@@ -236,9 +233,9 @@ public class UpdateProductCompositionOrderRequestValidatorTests
 
         var result = _validator.TestValidate(request);
 
-        result.Errors.Should().Contain(e => e.PropertyName == "Order[0].IngredientProductCode");
-        result.Errors.Should().Contain(e => e.PropertyName == "Order[0].SortOrder");
-        result.Errors.Should().NotContain(e => e.PropertyName == "Order[1].IngredientProductCode");
-        result.Errors.Should().NotContain(e => e.PropertyName == "Order[1].SortOrder");
+        result.ShouldHaveValidationErrorFor("Order[0].IngredientProductCode");
+        result.ShouldHaveValidationErrorFor("Order[0].SortOrder");
+        result.ShouldNotHaveValidationErrorFor("Order[1].IngredientProductCode");
+        result.ShouldNotHaveValidationErrorFor("Order[1].SortOrder");
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Validators/UpdateProductCompositionOrderRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Validators/UpdateProductCompositionOrderRequestValidatorTests.cs
@@ -1,0 +1,244 @@
+using Anela.Heblo.Application.Features.Catalog.UseCases.UpdateProductCompositionOrder;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Validators;
+
+public class UpdateProductCompositionOrderRequestValidatorTests
+{
+    private readonly UpdateProductCompositionOrderRequestValidator _validator;
+
+    public UpdateProductCompositionOrderRequestValidatorTests()
+    {
+        _validator = new UpdateProductCompositionOrderRequestValidator();
+    }
+
+    private static UpdateProductCompositionOrderRequest ValidRequest() => new()
+    {
+        ProductCode = "PROD-001",
+        Order = new List<IngredientOrderItem>
+        {
+            new() { IngredientProductCode = "MAT-A", SortOrder = 1 },
+            new() { IngredientProductCode = "MAT-B", SortOrder = 2 },
+        }
+    };
+
+    [Fact]
+    public void ValidRequest_UniqueIngredientCodes_PassesAllValidation()
+    {
+        var result = _validator.TestValidate(ValidRequest());
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Order_NullValue_FailsValidation()
+    {
+        var request = new UpdateProductCompositionOrderRequest { ProductCode = "PROD-001", Order = null! };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Order)
+            .WithErrorMessage("Order list is required");
+    }
+
+    [Fact]
+    public void Order_EmptyList_PassesValidation()
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>()
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Order);
+    }
+
+    [Fact]
+    public void Order_DuplicateIngredientCodes_FailsValidation()
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = "MAT-A", SortOrder = 1 },
+                new() { IngredientProductCode = "MAT-A", SortOrder = 2 },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Order)
+            .WithErrorMessage("Ingredient product codes must be unique within the order list");
+    }
+
+    [Fact]
+    public void Order_MultipleDuplicateCodes_FailsValidation()
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = "MAT-A", SortOrder = 1 },
+                new() { IngredientProductCode = "MAT-B", SortOrder = 2 },
+                new() { IngredientProductCode = "MAT-A", SortOrder = 3 },
+                new() { IngredientProductCode = "MAT-B", SortOrder = 4 },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Order);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IngredientProductCode_EmptyOrWhitespace_FailsValidation(string code)
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = code, SortOrder = 1 },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Order[0].IngredientProductCode" &&
+            e.ErrorMessage == "Ingredient product code is required");
+    }
+
+    [Fact]
+    public void IngredientProductCode_ExceedsMaxLength_FailsValidation()
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = new string('X', 51), SortOrder = 1 },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Order[0].IngredientProductCode" &&
+            e.ErrorMessage == "Ingredient product code cannot exceed 50 characters");
+    }
+
+    [Fact]
+    public void IngredientProductCode_ExactlyMaxLength_PassesValidation()
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = new string('X', 50), SortOrder = 1 },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Order[0].IngredientProductCode");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void SortOrder_ZeroOrNegative_FailsValidation(int sortOrder)
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = "MAT-A", SortOrder = sortOrder },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Order[0].SortOrder" &&
+            e.ErrorMessage == "Sort order must be greater than 0");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(100)]
+    public void SortOrder_PositiveValue_PassesValidation(int sortOrder)
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = "MAT-A", SortOrder = sortOrder },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.Errors.Should().NotContain(e => e.PropertyName == "Order[0].SortOrder");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ProductCode_EmptyOrNull_FailsValidation(string? productCode)
+    {
+        var request = ValidRequest();
+        request.ProductCode = productCode!;
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.ProductCode)
+            .WithErrorMessage("Product code is required");
+    }
+
+    [Fact]
+    public void ProductCode_ExceedsMaxLength_FailsValidation()
+    {
+        var request = ValidRequest();
+        request.ProductCode = new string('P', 51);
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.ProductCode)
+            .WithErrorMessage("Product code cannot exceed 50 characters");
+    }
+
+    [Fact]
+    public void MultipleInvalidItems_AllItemErrorsReported()
+    {
+        var request = new UpdateProductCompositionOrderRequest
+        {
+            ProductCode = "PROD-001",
+            Order = new List<IngredientOrderItem>
+            {
+                new() { IngredientProductCode = "", SortOrder = 0 },
+                new() { IngredientProductCode = "MAT-B", SortOrder = 1 },
+            }
+        };
+
+        var result = _validator.TestValidate(request);
+
+        result.Errors.Should().Contain(e => e.PropertyName == "Order[0].IngredientProductCode");
+        result.Errors.Should().Contain(e => e.PropertyName == "Order[0].SortOrder");
+        result.Errors.Should().NotContain(e => e.PropertyName == "Order[1].IngredientProductCode");
+        result.Errors.Should().NotContain(e => e.PropertyName == "Order[1].SortOrder");
+    }
+}


### PR DESCRIPTION
## What the issue was

`UpdateProductCompositionOrderRequestValidator` had 0% line coverage. The key untested business invariant was the **uniqueness constraint** on ingredient codes in a composition reorder request — duplicate codes would silently pass if the rule ever broke, leading to data corruption in the ERP system.

Also untested: `SortOrder > 0` per ingredient line, `IngredientProductCode` NotEmpty/MaximumLength(50), and the `Order` list NotNull check.

## How it was fixed / handled

Added 19 FluentValidation unit tests in a new file `backend/test/Anela.Heblo.Tests/Features/Catalog/Validators/UpdateProductCompositionOrderRequestValidatorTests.cs` covering:

- Valid request with unique codes → passes all validation
- Duplicate ingredient codes → error on `Order` with correct message
- Null `Order` → error with correct message
- Empty `Order` list → passes (no `NotEmpty` rule on `Order`)
- `IngredientProductCode` empty/whitespace → error per item
- `IngredientProductCode` > 50 chars → error; exactly 50 → passes
- `SortOrder` zero or negative → error; positive → passes
- Multiple invalid items in same list → errors reported per item index

All 19 tests pass. No production code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CENmvywScX9Vo2T6nQUQiG)_

Closes #3284