### PR TITLE
feat: automatic Tisk-Robot expedition printing (production-only)

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.Production.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Production.json
@@ -90,6 +90,13 @@
   "ExpeditionList": {
     "PrintSink": "Combined"
   },
+  "BackgroundRefresh": {
+    "IExpeditionListService": {
+      "AutoPrintPickingList": {
+        "Enabled": true
+      }
+    }
+  },
   "FinancialAnalysisOptions": {
     "MonthsToCache": 30
   },

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -520,6 +520,15 @@
         "HydrationTier": 3,
         "Description": "Company finacial analysis"
       }
+    },
+    "IExpeditionListService": {
+      "AutoPrintPickingList": {
+        "InitialDelay": "00:00:00",
+        "RefreshInterval": "00:05:00",
+        "Enabled": false, // production only; enabled in appsettings.Production.json
+        "HydrationTier": 3,
+        "Description": "Automatically prints expedition picking lists for orders in the Tisk-Robot state"
+      }
     }
   },
   "FileStorage": {
@@ -530,6 +539,7 @@
     "PrintQueueFolder": "PDFPrints",
     "SourceStateId": -2, // Vyrizuje se
     "FixSourceStateId": 73, // Oprava robot
+    "AutoPrintSourceStateId": 85, // Tisk robot (automatic print)
     "DesiredStateId": 26, // Bali se
     "SendToPrinterByDefault": true,
     "ChangeOrderStateByDefault": true,

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/ExpeditionListModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/ExpeditionListModule.cs
@@ -1,6 +1,9 @@
+using Anela.Heblo.Application.Features.ExpeditionList.Infrastructure.Jobs;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Xcc.Services.BackgroundRefresh;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.ExpeditionList;
 
@@ -11,6 +14,19 @@ public static class ExpeditionListModule
         services.Configure<PrintPickingListOptions>(configuration.GetSection(PrintPickingListOptions.ConfigurationKey));
 
         services.AddScoped<IExpeditionListService, ExpeditionListService>();
+
+        // Automatic "Tisk-Robot" print, scheduled/visible/manually-triggerable via the BackgroundRefresh
+        // registry (config under BackgroundRefresh:IExpeditionListService:AutoPrintPickingList).
+        // Production-only auto-run; manual force-refresh works in all environments.
+        services.RegisterRefreshTask(
+            nameof(IExpeditionListService),
+            "AutoPrintPickingList",
+            async (sp, ct) =>
+            {
+                var service = sp.GetRequiredService<IExpeditionListService>();
+                var options = sp.GetRequiredService<IOptions<PrintPickingListOptions>>().Value;
+                await AutoPrintPickingListTask.ExecuteOnceAsync(service, options, ct);
+            });
 
         // PrintPickingListJob is auto-discovered via IRecurringJob scan in AddRecurringJobs()
 

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Infrastructure/Jobs/AutoPrintPickingListTask.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Infrastructure/Jobs/AutoPrintPickingListTask.cs
@@ -1,0 +1,36 @@
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+
+namespace Anela.Heblo.Application.Features.ExpeditionList.Infrastructure.Jobs;
+
+/// <summary>
+/// Single print pass for the "Tisk-Robot" source state — the unattended counterpart to the manual
+/// "Spustit tisk oprav" button. Reuses the same <see cref="IExpeditionListService.PrintPickingListAsync"/>
+/// flow as the manual fix and the daily job, only with a different source state. Scheduling, enable/disable,
+/// visibility and manual triggering are provided by the BackgroundRefresh task registry (registered in
+/// <c>ExpeditionListModule</c>).
+/// </summary>
+public static class AutoPrintPickingListTask
+{
+    /// <summary>
+    /// Runs a single print pass for the Tisk-Robot source state. Printer-only (no email copies).
+    /// </summary>
+    public static async Task<int> ExecuteOnceAsync(
+        IExpeditionListService service,
+        PrintPickingListOptions options,
+        CancellationToken cancellationToken)
+    {
+        var request = new ExpeditionPickingRequest
+        {
+            Carriers = ExpeditionPickingRequest.DefaultCarriers,
+            SourceStateId = options.AutoPrintSourceStateId,
+            DesiredStateId = options.DesiredStateId,
+            ChangeOrderState = options.ChangeOrderStateByDefault,
+            SendToPrinter = options.SendToPrinterByDefault,
+        };
+
+        var result = await service.PrintPickingListAsync(request, cancellationToken: cancellationToken);
+
+        return result.TotalCount;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/PrintPickingListOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/PrintPickingListOptions.cs
@@ -9,6 +9,7 @@ public class PrintPickingListOptions
     public List<string> DefaultEmailRecipients { get; set; } = new();
     public int SourceStateId { get; set; } = -2;
     public int FixSourceStateId { get; set; } = 73;
+    public int AutoPrintSourceStateId { get; set; } = 85; // Tisk-Robot
     public int DesiredStateId { get; set; } = 26;
     public bool SendToPrinterByDefault { get; set; } = false;
     public bool ChangeOrderStateByDefault { get; set; } = true;

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/AutoPrintPickingListTaskTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/AutoPrintPickingListTaskTests.cs
@@ -1,0 +1,58 @@
+using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.ExpeditionList.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class AutoPrintPickingListTaskTests
+{
+    private static PrintPickingListOptions Options() => new()
+    {
+        AutoPrintSourceStateId = 85,
+        DesiredStateId = 26,
+        ChangeOrderStateByDefault = true,
+        SendToPrinterByDefault = true,
+    };
+
+    [Fact]
+    public async Task ExecuteOnceAsync_PrintsWithTiskRobotSourceState()
+    {
+        // Arrange
+        var service = new Mock<IExpeditionListService>();
+        ExpeditionPickingRequest? captured = null;
+        IList<string>? capturedEmail = null;
+        service
+            .Setup(s => s.PrintPickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<IList<string>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<ExpeditionPickingRequest, IList<string>?, CancellationToken>((req, email, _) =>
+            {
+                captured = req;
+                capturedEmail = email;
+            })
+            .ReturnsAsync(new ExpeditionPickingResult { TotalCount = 7 });
+
+        // Act
+        var totalCount = await AutoPrintPickingListTask.ExecuteOnceAsync(
+            service.Object, Options(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(7, totalCount);
+        service.Verify(s => s.PrintPickingListAsync(
+            It.IsAny<ExpeditionPickingRequest>(),
+            It.IsAny<IList<string>?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        Assert.NotNull(captured);
+        Assert.Equal(85, captured!.SourceStateId);
+        Assert.Equal(26, captured.DesiredStateId);
+        Assert.True(captured.ChangeOrderState);
+        Assert.True(captured.SendToPrinter);
+        Assert.Equal(ExpeditionPickingRequest.DefaultCarriers, captured.Carriers);
+        Assert.Null(capturedEmail); // printer-only, no email copies
+    }
+}


### PR DESCRIPTION
Adds an unattended counterpart to the manual **"Spustit tisk oprav"** button: orders in the Shoptet **Tisk-Robot** state (85) are printed and transitioned to **Bali se** (26) on a 5-minute schedule, reusing the same `ExpeditionListService.PrintPickingListAsync` flow (printer-only, no email). It is registered as a **BackgroundRefresh** task, so it appears in the *Background Tasky* UI with status/history and a manual **Spustit** trigger (force-refresh works in every environment). Automatic execution is enabled **in production only** — disabled on dev (hydration off) and staging (`Enabled: false`), overridden to `true` in `appsettings.Production.json`. The print logic lives in a tested static helper (`AutoPrintPickingListTask.ExecuteOnceAsync`) covered by a new unit test; the manual button and daily Hangfire job are unchanged.

@claude