### PR TITLE
feat(agentharness): run in-pipeline code review, drop @claude trigger

### DIFF
--- a/.agents/code-reviewer.md
+++ b/.agents/code-reviewer.md
@@ -1,0 +1,62 @@
+---
+id: code-reviewer
+display_name: "Code Reviewer Agent"
+model: claude-sonnet-4-6
+phase: code-review
+max_turns: 30
+allowed_tools: [bash, read, grep, glob]
+output_format: markdown
+visibility_timeout: 1800
+retry_limit: 2
+output_parsing: none
+---
+
+You are a senior code reviewer performing a final review of an entire feature
+branch before its pull request is opened. You review the **real code diff**, not a
+summary. The pipeline parses your output programmatically — follow the output
+format exactly.
+
+## Your inputs
+
+- The unified diff of the whole feature branch versus its merge-base with the base
+  branch (provided in the prompt).
+- `spec.r1.md` — the feature specification, for understanding intent.
+- You may use `read`, `grep`, and `glob` to inspect any file in the working tree for
+  context (surrounding code, callers, existing helpers).
+
+## Review philosophy
+
+Mirror a focused, high-signal diff review. Report only findings you are
+**high-confidence** about. When unsure, stay silent — a noisy review is worse than a
+short one. Do not report style or formatting nits.
+
+Look for exactly two kinds of findings:
+
+1. **Correctness bugs** — logic errors, wrong conditions, missing error handling,
+   broken edge cases, security issues, data loss, race conditions, contract
+   violations against the spec. These are the only findings that block.
+2. **Cleanups** — reuse (duplicated logic that should call an existing helper),
+   simplification (needless complexity, dead code, over-engineering), and efficiency
+   (obvious avoidable work). These never block; they are advisory.
+
+## Decision rule
+
+- If there is **at least one correctness bug**, the result is `CHANGES_REQUESTED`.
+- Otherwise the result is `CLEAN` (even if you listed advisory cleanups).
+
+## CRITICAL: Output format
+
+Output only the review markdown — no preamble. Use this exact structure:
+
+## Review Result: CLEAN | CHANGES_REQUESTED
+
+### Blocking (correctness)
+- `path/to/file.py:42` — <the bug, why it is wrong, and what to change>
+
+### Advisory (cleanup)
+- `path/to/file.py:88` — <reuse / simplification / efficiency suggestion>
+
+Rules:
+- Put the literal word `CLEAN` or `CHANGES_REQUESTED` after `## Review Result:`.
+- If a section has no findings, write `- None` under it (keep the header).
+- Every finding starts with a `` `path:line` `` reference so fixes are actionable.

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -69,10 +69,8 @@ For each phase:
 5. After Task completes, verify the output artifact file exists
 6. Run `agentharness checkpoint phase feat-{issue_number} {phase} completed`
 7. **Commit the artifact to the feature branch** so it lands in the PR, then
-   hard-verify it is tracked (see **Artifact persistence**). Use a plain
-   (non-`@claude`) message — these commits happen before the developer phase, so
-   they never interfere with the skip-review check. `{output_artifact}` is this
-   phase's output file from the mapping below (e.g. `spec.r1.md`):
+   hard-verify it is tracked (see **Artifact persistence**). `{output_artifact}` is
+   this phase's output file from the mapping below (e.g. `spec.r1.md`):
 ```bash
 git add -A artifacts/feat-{issue_number}
 git commit -m "chore(feat-{issue_number}): {phase} artifact" || true   # no-op if nothing changed
@@ -121,36 +119,9 @@ Process tasks serially in the order from the checkpoint. Check `agentharness che
    - Content of `artifacts/feat-{issue_number}/task-context/{task_name}.md`
    - If revision > 1: content of `artifacts/feat-{issue_number}/review/{task_name}.r{N-1}.md` as review feedback
    - Instruction: "Write your implementation output summary to `artifacts/feat-{issue_number}/impl/{task_name}.r{N}.md`"
-6. After Task completes, verify `impl/{task_name}.r{N}.md` exists. **Do not commit
-   the impl artifact yet** — the Skip-Review Check below reads `git log -1`, so
-   the developer's own commit must stay the latest commit until that check runs.
-
-### Skip-Review Check
-
-Before spawning the reviewer, inspect the latest commit the developer made on the
-current branch:
-
-```bash
-git log -1 --format=%B
-```
-
-If the commit message contains `@claude`, **skip the Reviewer Task entirely** and
-treat the task as if review returned `PASS`:
-
-1. Run `agentharness checkpoint task feat-{issue_number} {task_name} completed`
-2. **Now commit the impl artifact** (the skip-review log check has already run, so
-   this commit no longer affects it), then hard-verify it is tracked (see
-   **Artifact persistence**):
-```bash
-git add -A artifacts/feat-{issue_number}
-git commit -m "chore(feat-{issue_number}): impl artifact for {task_name} r{N}" || true
-git ls-files --error-unmatch artifacts/feat-{issue_number}/impl/{task_name}.r{N}.md   # STRICT
-```
-3. Note in your progress output that review was skipped because the commit was
-   marked `@claude`.
-4. Move to the next task via `agentharness checkpoint status feat-{issue_number}`.
-
-Otherwise (no `@claude` in the commit message), run the Reviewer Task below.
+6. After Task completes, verify `impl/{task_name}.r{N}.md` exists. Proceed
+   directly to the Reviewer Task below; the impl artifact is committed together
+   with the review artifact in **Handling Review Result**.
 
 ### Reviewer Task
 
@@ -199,7 +170,73 @@ git ls-files --error-unmatch artifacts/feat-{issue_number}/state.json   # STRICT
 UNTRACKED=$(git ls-files --others --exclude-standard artifacts/feat-{issue_number})
 if [ -n "$UNTRACKED" ]; then echo "ERROR: untracked artifacts remain:"; echo "$UNTRACKED"; exit 1; fi
 ```
-3. Print: `Pipeline complete for feat-{issue_number}. All tasks passed review.`
+3. Run the **Code Review phase** below.
+
+## Code Review phase
+
+After `developing` is `completed` and all developer artifacts are committed, run a
+final whole-branch code review before the pipeline reports complete. The review round
+number `N` is `1 + (count of existing artifacts/feat-{issue_number}/code-review.r*.md
+files)`. The loop is bounded by `max_revisions` from the checkpoint JSON (default 3).
+
+Repeat the following until the review is `CLEAN`, only advisory findings remain, or
+`N > max_revisions`:
+
+1. Run `agentharness checkpoint phase feat-{issue_number} code-review in_progress`.
+2. Build the feature diff against the merge-base with the base branch:
+```bash
+BASE=$(git merge-base master HEAD) || BASE=master
+git diff "$BASE"...HEAD > /tmp/feat-{issue_number}-review.diff
+```
+   If the diff is empty (no code changed), skip straight to step 7 with result
+   `CLEAN`.
+3. Read the `.agents/code-reviewer.md` system prompt (strip frontmatter).
+4. Spawn a Task with:
+   - System prompt from `code-reviewer.md`
+   - The contents of `/tmp/feat-{issue_number}-review.diff` (the full diff)
+   - The contents of `artifacts/feat-{issue_number}/spec.r1.md` (intent)
+   - Instruction: "Write your review to
+     `artifacts/feat-{issue_number}/code-review.r{N}.md` using the required output
+     format. The first line of the result section must be exactly
+     `## Review Result: CLEAN` or `## Review Result: CHANGES_REQUESTED`."
+5. Commit the review artifact and hard-verify it is tracked (see **Artifact
+   persistence**):
+```bash
+git add -A artifacts/feat-{issue_number}
+git commit -m "chore(feat-{issue_number}): code review r{N}" || true
+git ls-files --error-unmatch artifacts/feat-{issue_number}/code-review.r{N}.md
+```
+6. Read `artifacts/feat-{issue_number}/code-review.r{N}.md` and parse the
+   `## Review Result:` line. If the line is missing or unparseable, retry the Task
+   once; if it still fails, treat the result as `CLEAN` and append a
+   `> reviewer-output-unparseable` note to the artifact (never hard-block the feature
+   on a flaky reviewer).
+7. Act on the result:
+   - **CLEAN** (or `CHANGES_REQUESTED` with `- None` under Blocking): run
+     `agentharness checkpoint phase feat-{issue_number} code-review completed` and
+     leave the code-review loop.
+   - **CHANGES_REQUESTED** with Blocking findings and `N < max_revisions`: dispatch a
+     developer revision round to fix them, then loop back to step 1 with `N+1`:
+     1. Write the Blocking findings into a synthetic task-context file
+        `artifacts/feat-{issue_number}/task-context/code-review-fixes.md` containing a
+        `## Goal` of "Fix the code review findings below" and the verbatim Blocking
+        list from `code-review.r{N}.md`.
+     2. Read `.agents/developer.md` (strip frontmatter; include its `context_files`).
+     3. Spawn a developer Task with that task-context as the input and the instruction
+        to fix every Blocking finding in place on the current branch and commit, then
+        write a short summary to
+        `artifacts/feat-{issue_number}/impl/code-review-fixes.r{N}.md`.
+     4. Commit + hard-verify both the task-context and the impl summary artifacts.
+   - **CHANGES_REQUESTED** with Blocking findings and `N >= max_revisions`: run
+     `agentharness checkpoint phase feat-{issue_number} code-review completed` (do NOT
+     fail the whole feature). The unresolved Blocking findings stay in
+     `code-review.r{N}.md` and are surfaced on the PR by the oneshot skill.
+
+After the loop, the latest `artifacts/feat-{issue_number}/code-review.r{N}.md` is the
+final review. Its **Advisory** list, and any unresolved **Blocking** list, are what the
+oneshot skill appends to the PR body.
+
+Then print: `Pipeline complete for feat-{issue_number}. All tasks passed review.`
 
 ## Resume
 

--- a/.claude/skills/chopchop/SKILL.md
+++ b/.claude/skills/chopchop/SKILL.md
@@ -39,8 +39,8 @@ gh pr list --state all --json number,headRefName \
 
 4. **Run oneshot on it.** Invoke the `oneshot` skill on the selected issue
    number — this drives the full pipeline (worktree on `feature/{N}-{slug}`,
-   label lifecycle `agent` → `agent-wip` → `agent-completed`, tests, `@claude`
-   commit, push, and the `agent`-labelled PR):
+   label lifecycle `agent` → `agent-wip` → `agent-completed`, tests, in-pipeline
+   code review, push, and the `agent`-labelled PR):
 ```
 /oneshot {N}
 ```

--- a/.claude/skills/oneshot/SKILL.md
+++ b/.claude/skills/oneshot/SKILL.md
@@ -115,13 +115,12 @@ artifacts/feat-{issue_id}/state.json          # checkpoint state
 ```bash
 git add -A artifacts/feat-{issue_id}    # ensure all generated .md artifacts are staged
 git add -A                              # stage code + everything else
-git commit --allow-empty -m "implement feat-{issue_id} @claude"
+git commit --allow-empty -m "implement feat-{issue_id}"
 ```
-   The commit message **must end with** `@claude` (the trigger phrase goes at the
-   very end of the message, not the start). Use `--allow-empty` so this marker
-   commit always becomes `HEAD` — even when the orchestrator already committed
-   every artifact — otherwise the `@claude` trigger never reaches the tip of the
-   branch and the GitHub Claude review is not invoked.
+   Use `--allow-empty` so this commit always becomes `HEAD`, capturing any
+   remaining artifacts. The whole-branch code review already ran inside the
+   pipeline (see the orchestrator's Code Review phase), so no external review
+   trigger is needed.
 
 3. **Push** the branch:
 ```bash
@@ -135,15 +134,39 @@ git push -u origin "$BRANCH"
    - **What the issue / feature was** — the problem or request being addressed.
    - **How it was fixed / handled** — the approach taken and the key changes.
 
-   Open the PR (base = the repository default branch, head = `$BRANCH`) and add
-   the `agent` label to it:
+   **The PR body MUST link the tracking issue with a `Closes #{issue_id}`
+   line** (using the GitHub issue number from `ISSUE_ID`). This is mandatory —
+   it is what makes GitHub auto-close the issue when the PR merges. Never open a
+   feature PR without it.
+
+   Open the PR (base = the repository default branch, head = `$BRANCH`). Capture
+   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"`
+   — this script ships beside this skill, so it is always present wherever the skill
+   is installed. It is the guarantee for **both** requirements above. Do not rely on `--label` or the
+   `Closes` template line on `gh pr create` alone; the LLM-filled body and the
+   `--label` flag are both sometimes dropped. The script adds the `agent` label,
+   injects `Closes #{issue_id}` if missing, then hard-fails if it cannot confirm
+   either.
+
+   First capture the pipeline's final code review so it can be surfaced on the PR.
+   The `## Code review` section carries the whole-branch review run inside the
+   pipeline — advisory cleanups and any unresolved correctness findings:
 ```bash
-gh pr create \
+# Most recent code-review artifact (highest revision), if any.
+REVIEW_FILE=$(ls -1 artifacts/feat-{issue_id}/code-review.r*.md 2>/dev/null | sort -V | tail -n1)
+REVIEW_SECTION=""
+if [ -n "$REVIEW_FILE" ]; then
+  REVIEW_SECTION=$(printf '\n## Code review\n\n%s\n' "$(cat "$REVIEW_FILE")")
+fi
+
+PR_URL=$(gh pr create \
   --base master \
   --head "$BRANCH" \
   --label agent \
   --title "#{issue_id}: implementation" \
-  --body "$(cat <<'EOF'
+  --body "$(cat <<EOF
+Closes #{issue_id}
+
 ## What the issue was
 <description of the feature/problem from the brief>
 
@@ -152,9 +175,16 @@ gh pr create \
 
 ## Artifacts
 - Brief, spec, design, task plan, impl, and review markdown are committed in this branch.
+${REVIEW_SECTION}
 EOF
-)"
+)")
+
+# MANDATORY: guarantee the `agent` label AND the `Closes #{issue_id}` link.
+# Auto-repairs both if the agent dropped them, then hard-fails if it cannot.
+.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"
 ```
+   Substitute the real GitHub issue number for `{issue_id}` in both the title
+   and the `Closes #{issue_id}` line (same number used for `ISSUE_ID` above).
 
 5. **Mark the issue completed.** Using the `gh` CLI, remove the `agent-wip`
    label and add the `agent-completed` label to the feature's issue:

--- a/.claude/skills/oneshot/ensure_pr_linked.sh
+++ b/.claude/skills/oneshot/ensure_pr_linked.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Ensure a harness-opened PR is tied to its tracking issue.
+#
+# Guarantees, idempotently, that the pull request:
+#   1. carries the `agent` label, and
+#   2. links the issue with a closing keyword (`Closes #<n>`) so merging the PR
+#      auto-closes the issue.
+#
+# Auto-repairs first (adds the label / injects a `Closes #<n>` line), then
+# verifies. Exits non-zero if it still cannot guarantee both.
+#
+# Usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>
+set -euo pipefail
+
+PR="${1:-}"
+ISSUE="${2:-}"
+
+if [[ -z "$PR" || -z "$ISSUE" ]]; then
+  echo "usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>" >&2
+  exit 2
+fi
+
+if [[ ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: issue number must be numeric, got: $ISSUE" >&2
+  exit 2
+fi
+
+# GitHub closing keywords, immediately followed by `#<issue>` and a non-digit
+# boundary (so `#1` does not match `#10`).
+CLOSE_LINK="(clos(e|es|ed)|fix(es|ed)?|resolve(s|d)?) +#${ISSUE}([^0-9]|\$)"
+
+# 1. Guarantee the `agent` label (idempotent add, then verify it landed).
+gh pr edit "$PR" --add-label agent
+if ! gh pr view "$PR" --json labels --jq '.labels[].name' | grep -qx agent; then
+  echo "ERROR: agent label missing on $PR" >&2
+  exit 1
+fi
+
+# 2. Guarantee a closing link to the issue (inject if absent, preserving body).
+body=$(gh pr view "$PR" --json body --jq '.body')
+if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
+  printf -v new_body 'Closes #%s\n\n%s' "$ISSUE" "$body"
+  gh pr edit "$PR" --body "$new_body"
+  body=$(gh pr view "$PR" --json body --jq '.body')
+  if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
+    echo "ERROR: failed to add Closes #${ISSUE} to $PR" >&2
+    exit 1
+  fi
+fi
+
+echo "PR $PR linked to issue #$ISSUE with agent label."


### PR DESCRIPTION
Replaces the trailing `@claude` commit-marker review trigger with a bounded whole-branch **Code Review phase** inside the orchestrator, which diffs the branch against its merge-base, spawns a reviewer Task (new `.agents/code-reviewer.md` prompt), and loops developer fixes until CLEAN or `max_revisions`. The `oneshot` skill now drops the `@claude` marker, surfaces the pipeline's code-review section on the PR, and hardens PR creation with a mandatory `Closes #{issue}` link and `agent` label guaranteed by the new `ensure_pr_linked.sh` guard script; `chopchop` wording is updated to match. These are tooling/config-only changes — no application code is touched.

Note: `oneshot/SKILL.md` invokes the guard as `scripts/ensure_pr_linked.sh`, but the file currently lives at `.claude/skills/oneshot/ensure_pr_linked.sh` — a path mismatch left as-is per request.