### PR TITLE
#3303: BlockOrderProcessingHandler tests already exist — false positive

### DIFF
--- a/artifacts/feat-3303/arch-review.r1.md
+++ b/artifacts/feat-3303/arch-review.r1.md
@@ -1,0 +1,56 @@
+# Architecture Review: Unit Tests for BlockOrderProcessingHandler
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This issue requests unit tests for `BlockOrderProcessingHandler`. Investigation reveals that the test file already exists and is fully implemented:
+
+- **Path:** `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs`
+- **Added:** commit `dfcbebc` on 2026-06-18, five days before the arch-review issue was filed
+- **Coverage:** 10 tests covering all 8 functional requirements from the spec (happy paths, invalid state guard, API throw scenarios, cancellation propagation)
+- **Test run:** `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`
+
+The arch-review routine that filed this issue appears to have missed the existing test directory (`Application/ShoptetOrders/`) because it looked for tests under `Features/ShoptetOrders/` (which does not exist).
+
+## Proposed Architecture
+
+No new code required. The implementation is already in place and correct.
+
+### Component Overview
+
+```
+backend/test/Anela.Heblo.Tests/
+  Application/
+    ShoptetOrders/
+      BlockOrderProcessingHandlerTests.cs  ← already exists, 10 tests, all passing
+```
+
+The handler itself (`BlockOrderProcessingHandler`) follows the established MediatR handler pattern with two independent try/catch blocks:
+- Block 1 (critical): status fetch + guard check + status update — any exception → `InternalServerError`
+- Block 2 (non-critical): remark fetch + append + update — non-cancel exceptions swallowed with `LogLevel.Warning`
+
+## Key Design Decisions
+
+#### Decision 1: No changes needed
+**Options considered:** Add missing tests vs. close as already resolved
+**Chosen approach:** Close as already resolved — verify tests pass and create PR to document the finding
+**Rationale:** The tests were written alongside the handler implementation and cover all identified risk scenarios. No production or test code changes are needed.
+
+## Implementation Guidance
+
+None required.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Arch-review false positive repeats | Low | PR documents why issue was false positive; arch-review bot should be updated to scan `Application/` in addition to `Features/` |
+
+## Specification Amendments
+
+None.
+
+## Prerequisites
+
+None.

--- a/artifacts/feat-3303/brief.md
+++ b/artifacts/feat-3303/brief.md
@@ -1,0 +1,28 @@
+## Module
+ShoptetOrders
+
+## Finding
+`BlockOrderProcessingHandler.Handle` (`backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderProcessingHandler.cs`, lines 33–39) contains the module's only non-trivial branch: a guard that rejects blocking when the current Shoptet order status is not in `ShoptetOrdersSettings.AllowedBlockSourceStateIds`:
+
+```csharp
+if (!_settings.Value.AllowedBlockSourceStateIds.Contains(currentStatusId))
+{
+    return new BlockOrderProcessingResponse(
+        ErrorCodes.ShoptetOrderInvalidSourceState, ...);
+}
+```
+
+There are no tests for this handler in `backend/test/Anela.Heblo.Tests/Features/ShoptetOrders/` (directory does not exist). The existing test files (`ShoptetOrderClientTests.cs`, `ShoptetOrderClient_SetAdditionalFieldTests.cs`) cover only the adapter, not the handler.
+
+## Why it matters
+The source-state guard is safety-critical: it prevents operators from accidentally blocking orders that are already shipped, invoiced, or otherwise in a terminal state. A misconfigured `AllowedBlockSourceStateIds` (e.g., an empty array) would silently block no orders, or a wrong entry would allow blocking orders in the wrong state. Without unit tests, regressions in this logic are invisible until a live order is incorrectly blocked.
+
+## Suggested fix
+Add a handler unit test class at `backend/test/Anela.Heblo.Tests/Features/ShoptetOrders/BlockOrderProcessingHandlerTests.cs` covering:
+1. Happy path: status in `AllowedBlockSourceStateIds` → status update and remark append called, `Success = true`.
+2. Invalid source state: status not in allowed list → returns `ShoptetOrderInvalidSourceState`, no status update called.
+3. Status API throws → returns `InternalServerError`, no remark call.
+4. Remark append throws non-cancel exception → order is still blocked (success), only a warning is logged.
+
+---
+_Filed by daily arch-review routine on 2026-06-23._

--- a/artifacts/feat-3303/design.r1.md
+++ b/artifacts/feat-3303/design.r1.md
@@ -1,0 +1,16 @@
+# Design: Unit Tests for BlockOrderProcessingHandler
+
+## Component Design
+
+No new components required. The test class already exists at:
+
+`backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs`
+
+**Class structure (as implemented):**
+- Shared fixtures: `Mock<IEshopOrderClient>`, `Mock<ILogger<BlockOrderProcessingHandler>>`, `ShoptetOrdersSettings` initialized in constructor
+- `CreateHandler()` factory method for test isolation
+- 10 `[Fact]` test methods covering all spec scenarios
+
+## Data Schemas
+
+No new schemas. Tests operate entirely on in-memory objects with no persistence.

--- a/artifacts/feat-3303/impl/verify-existing-tests.r1.md
+++ b/artifacts/feat-3303/impl/verify-existing-tests.r1.md
@@ -1,0 +1,54 @@
+# Implementation: verify-existing-tests
+
+## What was implemented
+
+No code was written. Investigation confirmed the requested tests already exist and fully pass.
+
+The arch-review routine that filed issue #3303 searched for tests under `Features/ShoptetOrders/` (which does not exist), missing the actual location at `Application/ShoptetOrders/`. The file `BlockOrderProcessingHandlerTests.cs` was added in commit `dfcbebc` on 2026-06-18 — five days before the issue was filed on 2026-06-23.
+
+## Files created/modified
+
+None.
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs` — already exists, 10 tests
+
+Test run result:
+```
+Passed!  - Failed: 0, Passed: 10, Skipped: 0, Total: 10, Duration: 52 ms
+```
+
+Coverage against spec:
+- FR-1 (happy path, empty remark): Handle_OrderInAllowedState_ChangesStatusAndUpdatesEshopRemark ✅
+- FR-2 (happy path, appended remark): Handle_OrderInSecondAllowedState_Succeeds + Handle_OrderInAllowedState_AppendsNoteToExistingEshopRemark ✅
+- FR-3 (invalid source state): Handle_OrderInDisallowedState_ReturnsInvalidSourceStateError_WithoutCallingShoptet ✅
+- FR-4 (status fetch throws): Handle_ShoptetApiThrowsOnStatusFetch_ReturnsInternalServerError ✅
+- FR-5 (status update throws): Handle_ShoptetApiThrowsOnStatusUpdate_ReturnsInternalServerError ✅
+- FR-6 (remark fetch throws, non-cancel): Handle_ShoptetApiThrowsOnGetEshopRemark_ReturnsSuccessAndLogsWarning ✅
+- FR-7 (remark update throws, non-cancel): Handle_ShoptetApiThrowsOnUpdateEshopRemark_ReturnsSuccessAndLogsWarning ✅
+- FR-8 (OperationCanceledException propagates): Handle_CancellationOnRemarkStep_PropagatesOperationCanceledException ✅
+
+## How to verify
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~BlockOrderProcessingHandlerTests" --no-restore
+```
+
+Expected: `Passed: 10, Failed: 0`
+
+## Notes
+
+The arch-review bot should be updated to scan both `Application/` and `Features/` subdirectories when checking for handler test coverage, to avoid filing duplicate issues for already-covered handlers.
+
+## PR Summary
+
+Issue #3303 was a false positive from the arch-review routine. The `BlockOrderProcessingHandler` source-state guard already has complete unit test coverage (10 tests, all passing) in `BlockOrderProcessingHandlerTests.cs`, added alongside the handler implementation in commit `dfcbebc` on 2026-06-18. The arch-review bot searched the wrong directory (`Features/ShoptetOrders/` instead of `Application/ShoptetOrders/`) and incorrectly reported missing coverage.
+
+### Changes
+
+No production or test code changes were made. This PR exists to close the false-positive issue with documentation.
+
+## Status
+DONE

--- a/artifacts/feat-3303/review/verify-existing-tests.r1.md
+++ b/artifacts/feat-3303/review/verify-existing-tests.r1.md
@@ -1,0 +1,17 @@
+# Code Review: Unit Tests for BlockOrderProcessingHandler
+
+## Summary
+The implementation task was verification-only: confirm that `BlockOrderProcessingHandlerTests.cs` exists, contains 10 passing tests, and covers all 8 functional requirements from the spec. The impl artifact documents a clean test run (`Passed: 10, Failed: 0`) and maps each test to its corresponding FR. No code was written or modified, which is correct for this task.
+
+## Review Result: PASS
+
+### task: verify-existing-tests
+**Status:** PASS
+
+All acceptance criteria are met:
+- `dotnet test` reports `Passed: 10, Failed: 0`
+- All 8 FRs are mapped to specific, named test methods with no gaps
+- The impl correctly identifies the root cause of the false-positive issue (wrong directory scan path in the arch-review bot) without making any unauthorized changes
+
+## Overall Notes
+The observation about the arch-review bot scanning `Features/ShoptetOrders/` instead of `Application/ShoptetOrders/` is a useful finding and is appropriately noted without acting on it unilaterally. If that bot misconfiguration is not fixed, duplicate issues will continue to be filed for already-covered handlers — worth tracking as a follow-up.

--- a/artifacts/feat-3303/spec.r1.md
+++ b/artifacts/feat-3303/spec.r1.md
@@ -1,0 +1,182 @@
+# Specification: Unit Tests for BlockOrderProcessingHandler
+
+## Summary
+
+`BlockOrderProcessingHandler` contains the sole safety-critical branch in the ShoptetOrders module — a source-state guard that prevents blocking orders already in terminal states. This specification defines the unit-test suite that must be added to protect that guard and its surrounding logic from silent regression.
+
+## Background
+
+The daily architecture review (2026-06-23) found that `BlockOrderProcessingHandler.Handle` has no handler-level unit tests. The existing test files (`ShoptetOrderClientTests.cs`, `ShoptetOrderClient_SetAdditionalFieldTests.cs`) cover only the Shoptet HTTP adapter. The handler's source-state guard is safety-critical: a misconfigured `AllowedBlockSourceStateIds` (empty array, or a wrong status ID) would silently allow — or silently block — orders that should not be touched. Integration tests exist but are environment-gated and do not run in PR CI, leaving handler logic fully uncovered during development.
+
+Investigation of the codebase revealed that a file at `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs` already exists and covers most of the scenarios called for in the brief. This specification therefore documents the **complete intended test coverage** so it can be verified against the existing file and gaps can be filled.
+
+## Functional Requirements
+
+### FR-1: Happy path — status in allowed list, empty remark
+
+When `GetOrderStatusIdAsync` returns a status ID present in `AllowedBlockSourceStateIds`, the handler must:
+- Call `UpdateStatusAsync` with `request.OrderCode` and `settings.BlockedStatusId`.
+- Call `GetEshopRemarkAsync`, then `UpdateEshopRemarkAsync` with exactly `request.Note` (no leading newline) when the existing remark is empty or whitespace.
+- Return a response where `Success = true` and `ErrorCode` is null.
+
+**Acceptance criteria:**
+- `UpdateStatusAsync` is called exactly once with the correct `orderCode` and `BlockedStatusId`.
+- `UpdateEshopRemarkAsync` is called exactly once; the written remark equals `request.Note`.
+- `response.Success` is `true`.
+
+### FR-2: Happy path — status in allowed list, existing remark appended
+
+When the order already has a non-empty eshop remark, the handler must append the note with a `\n` separator.
+
+**Acceptance criteria:**
+- `UpdateEshopRemarkAsync` is called with `"{existingRemark}\n{request.Note}"`.
+- `response.Success` is `true`.
+
+### FR-3: Invalid source state — status not in allowed list
+
+When `GetOrderStatusIdAsync` returns a status ID **not** present in `AllowedBlockSourceStateIds`:
+- The handler must return a failure response with `ErrorCode = ShoptetOrderInvalidSourceState`.
+- `UpdateStatusAsync` must **not** be called.
+- Remark methods must **not** be called.
+
+**Acceptance criteria:**
+- `response.Success` is `false`.
+- `response.ErrorCode` equals `ErrorCodes.ShoptetOrderInvalidSourceState`.
+- `UpdateStatusAsync` is never invoked (verified via mock).
+- `GetEshopRemarkAsync` and `UpdateEshopRemarkAsync` are never invoked.
+
+### FR-4: Status API throws — internal error, no remark side-effect
+
+When `GetOrderStatusIdAsync` throws any exception:
+- The handler must return `ErrorCode = InternalServerError`.
+- `UpdateStatusAsync` must not be called.
+- Remark methods must not be called.
+- The exception must be logged at `LogLevel.Error`.
+
+**Acceptance criteria:**
+- `response.Success` is `false`.
+- `response.ErrorCode` equals `ErrorCodes.InternalServerError`.
+- No call to `UpdateStatusAsync`, `GetEshopRemarkAsync`, or `UpdateEshopRemarkAsync`.
+
+### FR-5: Status update throws — internal error, no remark side-effect
+
+When `UpdateStatusAsync` throws:
+- The handler must return `ErrorCode = InternalServerError`.
+- Remark methods must not be called.
+
+**Acceptance criteria:**
+- `response.Success` is `false`.
+- `response.ErrorCode` equals `ErrorCodes.InternalServerError`.
+- `GetEshopRemarkAsync` and `UpdateEshopRemarkAsync` are never invoked.
+
+### FR-6: Remark fetch throws non-cancellation exception — success, warning logged
+
+When `GetEshopRemarkAsync` throws a non-`OperationCanceledException`:
+- The handler must still return success (block 1 completed).
+- The exception must be logged at `LogLevel.Warning`; the log message must contain `request.OrderCode`.
+- `UpdateEshopRemarkAsync` must not be called.
+
+**Acceptance criteria:**
+- `response.Success` is `true`.
+- Logger received exactly one `LogLevel.Warning` call whose message includes the order code.
+- `UpdateEshopRemarkAsync` is never invoked.
+
+### FR-7: Remark update throws non-cancellation exception — success, warning logged
+
+When `UpdateEshopRemarkAsync` throws a non-`OperationCanceledException`:
+- The handler must still return success.
+- The exception must be logged at `LogLevel.Warning`.
+
+**Acceptance criteria:**
+- `response.Success` is `true`.
+- Logger received at least one `LogLevel.Warning` call.
+
+### FR-8: OperationCanceledException propagates from remark block
+
+When `GetEshopRemarkAsync` (or `UpdateEshopRemarkAsync`) throws `OperationCanceledException`, the exception must **not** be swallowed — it propagates to the caller.
+
+**Acceptance criteria:**
+- `Assert.ThrowsAsync<OperationCanceledException>` (or FluentAssertions equivalent) succeeds.
+- No response object is returned.
+
+## Non-Functional Requirements
+
+### NFR-1: Test isolation
+
+Each test must be fully independent. Shared state (mock setup, settings) must be reset per test. The test class may use a constructor-level fixture with a `CreateHandler()` factory method; mock `Setup` calls are per-test.
+
+### NFR-2: Framework alignment
+
+Tests must use xUnit + FluentAssertions + Moq, consistent with the existing test files in the project (`ShoptetOrderClient_SetAdditionalFieldTests.cs`).
+
+### NFR-3: No I/O
+
+All tests are pure unit tests. `IEshopOrderClient` and `ILogger<BlockOrderProcessingHandler>` are mocked via Moq. No network calls, no database, no file system access.
+
+### NFR-4: CI compatibility
+
+The test class must not carry any `[Trait("Category", "Integration")]` or environment-variable guards. It must run unconditionally in `dotnet test`.
+
+## Data Model
+
+No new persistence entities. The test operates on the following in-memory values:
+
+| Symbol | Type | Role |
+|---|---|---|
+| `BlockOrderProcessingRequest` | class | Handler input: `OrderCode` (string), `Note` (string) |
+| `BlockOrderProcessingResponse` | class | Handler output: `Success` (bool), `ErrorCode` (ErrorCodes?), `Params` (dict?) |
+| `ShoptetOrdersSettings` | class | `AllowedBlockSourceStateIds` (int[]), `BlockedStatusId` (int) |
+| `IEshopOrderClient` | interface | Dependency mock: `GetOrderStatusIdAsync`, `UpdateStatusAsync`, `GetEshopRemarkAsync`, `UpdateEshopRemarkAsync` |
+
+## API / Interface Design
+
+This feature adds no public API surface. The file being created is:
+
+```
+backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs
+```
+
+Test class skeleton:
+
+```csharp
+public class BlockOrderProcessingHandlerTests
+{
+    private readonly Mock<IEshopOrderClient> _clientMock = new();
+    private readonly Mock<ILogger<BlockOrderProcessingHandler>> _loggerMock = new();
+    private readonly ShoptetOrdersSettings _settings = new()
+    {
+        AllowedBlockSourceStateIds = [26, -2],
+        BlockedStatusId = 99
+    };
+
+    private BlockOrderProcessingHandler CreateHandler() =>
+        new(_clientMock.Object,
+            Options.Create(_settings),
+            _loggerMock.Object);
+}
+```
+
+Each test method calls `CreateHandler()`, sets up mocks for the specific scenario, invokes `handler.Handle(request, CancellationToken.None)`, and asserts on the response and mock invocations.
+
+## Dependencies
+
+- `Anela.Heblo.Application` — contains `BlockOrderProcessingHandler`, `BlockOrderProcessingRequest`, `BlockOrderProcessingResponse`, `ShoptetOrdersSettings`, `IEshopOrderClient`, `ErrorCodes`.
+- `Microsoft.Extensions.Options` — `IOptions<T>` / `Options.Create(...)`.
+- `Microsoft.Extensions.Logging` — `ILogger<T>`, `NullLogger`.
+- `xUnit` — test runner (already referenced in `Anela.Heblo.Tests.csproj`).
+- `FluentAssertions` — assertion library (already referenced).
+- `Moq` — mocking framework (already referenced).
+
+## Out of Scope
+
+- Integration tests against a live or sandboxed Shoptet store.
+- Tests for `BlockOrderRequest` (HTTP contract), the MVC controller, or the Shoptet HTTP adapter.
+- Tests for the remark read-modify-write race condition (two concurrent calls).
+- Tests for `OperationCanceledException` thrown from the critical block (block 1); this is not specially handled and would surface as `InternalServerError` — acceptable but not specified here.
+- Any changes to production code.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3303/state.json
+++ b/artifacts/feat-3303/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-23T09:38:15.207255Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-23T09:38:45.710834Z"
+      "status": "completed",
+      "updated_at": "2026-06-23T09:40:10.273158Z"
     }
   },
   "tasks": [
     {
       "name": "verify-existing-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-23T09:38:45.964548Z"
+      "updated_at": "2026-06-23T09:40:10.010592Z"
     }
   ]
 }

--- a/artifacts/feat-3303/state.json
+++ b/artifacts/feat-3303/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3303",
+  "issue_number": 3303,
+  "created_at": "2026-06-23T09:14:49.172414Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-23T09:37:12.532288Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3303/state.json
+++ b/artifacts/feat-3303/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-23T09:38:15.207255Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-23T09:38:45.710834Z"
     }
   },
   "tasks": [
     {
       "name": "verify-existing-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-23T09:38:45.964548Z"
     }
   ]
 }

--- a/artifacts/feat-3303/state.json
+++ b/artifacts/feat-3303/state.json
@@ -9,21 +9,28 @@
       "updated_at": "2026-06-23T09:37:12.532288Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-23T09:38:14.191227Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-23T09:38:14.711651Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-23T09:38:15.207255Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "verify-existing-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3303/task-context/verify-existing-tests.md
+++ b/artifacts/feat-3303/task-context/verify-existing-tests.md
@@ -1,0 +1,20 @@
+### task: verify-existing-tests
+
+**Goal:** Confirm the existing `BlockOrderProcessingHandlerTests.cs` covers all required scenarios and passes CI.
+
+**Context:**
+- Test file: `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs`
+- Added in commit `dfcbebc` on 2026-06-18
+- Covers: happy path (empty remark), happy path (appended remark), invalid source state guard, status fetch throws, status update throws, remark fetch throws (non-cancel), remark update throws (non-cancel), `OperationCanceledException` propagation
+
+**Files to create/modify:** None — verification only.
+
+**Implementation steps:**
+1. Run `dotnet test --filter "FullyQualifiedName~BlockOrderProcessingHandlerTests"` and confirm all 10 tests pass.
+2. Write the impl artifact documenting the result.
+
+**Tests to write:** N/A — tests already exist.
+
+**Acceptance criteria:**
+- `dotnet test` reports `Passed: 10, Failed: 0`
+- All 8 functional requirements from the spec are covered by the existing tests

--- a/artifacts/feat-3303/task-plan.r1.md
+++ b/artifacts/feat-3303/task-plan.r1.md
@@ -1,0 +1,28 @@
+# Task Plan: Unit Tests for BlockOrderProcessingHandler
+
+## Summary
+
+The implementation requested by this issue already exists. The single task below verifies and documents this finding.
+
+---
+
+### task: verify-existing-tests
+
+**Goal:** Confirm the existing `BlockOrderProcessingHandlerTests.cs` covers all required scenarios and passes CI.
+
+**Context:**
+- Test file: `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs`
+- Added in commit `dfcbebc` on 2026-06-18
+- Covers: happy path (empty remark), happy path (appended remark), invalid source state guard, status fetch throws, status update throws, remark fetch throws (non-cancel), remark update throws (non-cancel), `OperationCanceledException` propagation
+
+**Files to create/modify:** None — verification only.
+
+**Implementation steps:**
+1. Run `dotnet test --filter "FullyQualifiedName~BlockOrderProcessingHandlerTests"` and confirm all 10 tests pass.
+2. Write the impl artifact documenting the result.
+
+**Tests to write:** N/A — tests already exist.
+
+**Acceptance criteria:**
+- `dotnet test` reports `Passed: 10, Failed: 0`
+- All 8 functional requirements from the spec are covered by the existing tests


### PR DESCRIPTION
## What the issue was

Issue #3303 (arch-review) reported that `BlockOrderProcessingHandler` had no unit tests, specifically the source-state guard that rejects blocking when the current Shoptet order status is not in `AllowedBlockSourceStateIds`.

## How it was fixed / handled

This is a **false positive**. The test file already exists and fully covers all required scenarios:

- **File:** `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs`
- **Added:** commit `dfcbebc` on 2026-06-18, five days before this issue was filed
- **Test run:** `Passed: 10, Failed: 0`

All 8 spec scenarios are covered:
- ✅ Happy path — empty remark
- ✅ Happy path — existing remark appended
- ✅ Invalid source state → `ShoptetOrderInvalidSourceState`, no Shoptet calls
- ✅ Status fetch throws → `InternalServerError`
- ✅ Status update throws → `InternalServerError`, no remark calls
- ✅ Remark fetch throws (non-cancel) → success, warning logged with order code
- ✅ Remark update throws (non-cancel) → success, warning logged
- ✅ `OperationCanceledException` from remark block → propagates to caller

**Root cause of false positive:** The arch-review routine searched for tests under `Features/ShoptetOrders/` (which does not exist in the test project), missing the actual location at `Application/ShoptetOrders/`. The bot should be updated to scan `Application/` as well.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3303/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmePRPMzeZRQXsLcw2AJZZ)_