### PR TITLE
#3320: surface setActive error in UsersGrid

### DIFF
--- a/artifacts/feat-3320/arch-review.r1.md
+++ b/artifacts/feat-3320/arch-review.r1.md
@@ -1,0 +1,3 @@
+## Architecture Review
+
+No architectural concerns. This is a pure UI fix: add a missing error render path. Matches the existing pattern exactly. No new dependencies, API changes, or state changes required.

--- a/artifacts/feat-3320/brief.md
+++ b/artifacts/feat-3320/brief.md
@@ -1,0 +1,36 @@
+## Module
+Users (frontend)
+
+## Finding
+`frontend/src/components/pages/access/UsersGrid.tsx` shows inline error messages for two of its three mutations but silently drops the third.
+
+```tsx
+// Line 195-196 — shown:
+{createLocalUser.isError && (
+  <p>Failed to create operator. Please try again.</p>
+)}
+// Line 197-200 — shown:
+{setCanPack.isError && (
+  <p>Failed to update packing permission. Please try again.</p>
+)}
+// Lines 288-300 — setActive.mutate() is called but setActive.isError is never rendered
+```
+
+When the toggle-active/disable button (line 288) fails, no error is surfaced to the user. The mutation silently errors while the button label stays at its pre-click state (because the query cache is only invalidated on success).
+
+## Why it matters
+Toggling a user between active and disabled is a privileged, consequential action. Silently dropping its failure leaves the operator believing the action succeeded when it did not. The inconsistency is visible within the same component — the other two mutations both surface errors — so this is a gap rather than a deliberate design choice. Violates "missing error/loading states" for frontend code.
+
+## Suggested fix
+Add the missing error paragraph alongside the other two, in the filters/create-form card (lines 195-200):
+
+```tsx
+{setActive.isError && (
+  <p>Failed to update user status. Please try again.</p>
+)}
+```
+
+Minimal change, matches the existing error display pattern exactly.
+
+---
+_Filed by daily arch-review routine on 2026-06-23._

--- a/artifacts/feat-3320/code-review.r1.md
+++ b/artifacts/feat-3320/code-review.r1.md
@@ -1,0 +1,18 @@
+## Review Result: CLEAN
+
+## What was done well
+
+- The addition is exactly surgical: one `isError` guard block inserted after the two existing peer blocks, touching nothing else.
+- Message wording ("Failed to update user status. Please try again.") follows the established sentence pattern used by `createLocalUser.isError` and `setCanPack.isError`.
+- CSS classes (`text-sm text-red-600`) are identical to both peer blocks — visually and structurally consistent.
+- Placement is correct: the new block sits inside the same container `<div>` as the other error paragraphs and immediately after the last existing one, matching the logical grouping.
+- `setActive` is already declared at line 55 via `useSetUserActive()`, so no hook import or instantiation was needed; the diff is minimal.
+
+## Blocking
+
+- None
+
+## Advisory
+
+- The three error paragraphs render independently and could theoretically stack if multiple mutations error simultaneously. That is the same behaviour as the pre-existing peers, so it is consistent rather than a new defect. No change required.
+- There is no `data-testid` or accessible role on these error paragraphs, which mirrors how the existing peer errors are written. Adding one would make E2E assertions easier but is out of scope for this single-line fix.

--- a/artifacts/feat-3320/design.r1.md
+++ b/artifacts/feat-3320/design.r1.md
@@ -1,0 +1,11 @@
+## Design
+
+Add one JSX block after the `setCanPack.isError` block (line 200):
+
+```tsx
+{setActive.isError && (
+  <p className="text-sm text-red-600">Failed to update user status. Please try again.</p>
+)}
+```
+
+Matches existing style exactly.

--- a/artifacts/feat-3320/impl/fix-set-active-error.r1.md
+++ b/artifacts/feat-3320/impl/fix-set-active-error.r1.md
@@ -1,0 +1,16 @@
+## Implementation: fix-set-active-error
+
+**File changed:** `frontend/src/components/pages/access/UsersGrid.tsx`
+
+**Change:** Added the missing `setActive.isError` error paragraph after the existing `setCanPack.isError` block (line ~200), matching the exact pattern of the two existing error displays:
+
+```tsx
+{setActive.isError && (
+  <p className="text-sm text-red-600">Failed to update user status. Please try again.</p>
+)}
+```
+
+**Verification:**
+- `npm run build` — passes, no TypeScript errors
+- `eslint UsersGrid.tsx` — no issues
+- Pre-existing lint errors elsewhere in the repo are unrelated to this change

--- a/artifacts/feat-3320/spec.r1.md
+++ b/artifacts/feat-3320/spec.r1.md
@@ -1,0 +1,9 @@
+## Spec: Fix missing setActive error display in UsersGrid
+
+**Goal:** Surface mutation errors from `setActive` to the user in `UsersGrid.tsx`, consistent with how `createLocalUser` and `setCanPack` errors are already shown.
+
+**Scope:** Single-line addition in `frontend/src/components/pages/access/UsersGrid.tsx`, inserting `{setActive.isError && <p>...</p>}` alongside the existing error paragraphs at lines 195-200.
+
+**Acceptance criteria:**
+- When `setActive.mutate(...)` fails, a red error paragraph appears below the form card.
+- No other behaviour changes.

--- a/artifacts/feat-3320/state.json
+++ b/artifacts/feat-3320/state.json
@@ -5,25 +5,32 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-24T06:16:16.213832Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-24T06:16:16.527160Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-24T06:16:16.764315Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-24T06:16:16.995816Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-set-active-error",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3320/state.json
+++ b/artifacts/feat-3320/state.json
@@ -21,20 +21,20 @@
       "updated_at": "2026-06-24T06:16:16.995816Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-24T06:20:53.212957Z"
+      "status": "completed",
+      "updated_at": "2026-06-24T06:22:45.283221Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-06-24T06:21:45.688912Z"
+      "status": "completed",
+      "updated_at": "2026-06-24T06:22:44.817426Z"
     }
   },
   "tasks": [
     {
       "name": "fix-set-active-error",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-24T06:20:53.480860Z"
+      "updated_at": "2026-06-24T06:22:45.050715Z"
     }
   ]
 }

--- a/artifacts/feat-3320/state.json
+++ b/artifacts/feat-3320/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "in_progress",
       "updated_at": "2026-06-24T06:20:53.212957Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-24T06:21:45.688912Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3320/state.json
+++ b/artifacts/feat-3320/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3320",
+  "issue_number": 3320,
+  "created_at": "2026-06-24T06:15:13.061561Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3320/state.json
+++ b/artifacts/feat-3320/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-24T06:16:16.995816Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-24T06:20:53.212957Z"
     }
   },
   "tasks": [
     {
       "name": "fix-set-active-error",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-24T06:20:53.480860Z"
     }
   ]
 }

--- a/artifacts/feat-3320/task-context/fix-set-active-error.md
+++ b/artifacts/feat-3320/task-context/fix-set-active-error.md
@@ -1,0 +1,13 @@
+### task: fix-set-active-error
+
+**File:** `frontend/src/components/pages/access/UsersGrid.tsx`
+
+**Change:** After line 200 (after the `setCanPack.isError` block), insert:
+
+```tsx
+{setActive.isError && (
+  <p className="text-sm text-red-600">Failed to update user status. Please try again.</p>
+)}
+```
+
+No other changes.

--- a/artifacts/feat-3320/task-plan.r1.md
+++ b/artifacts/feat-3320/task-plan.r1.md
@@ -1,0 +1,13 @@
+### task: fix-set-active-error
+
+**File:** `frontend/src/components/pages/access/UsersGrid.tsx`
+
+**Change:** After line 200 (after the `setCanPack.isError` block), insert:
+
+```tsx
+{setActive.isError && (
+  <p className="text-sm text-red-600">Failed to update user status. Please try again.</p>
+)}
+```
+
+No other changes.

--- a/frontend/src/components/pages/access/UsersGrid.tsx
+++ b/frontend/src/components/pages/access/UsersGrid.tsx
@@ -198,6 +198,9 @@ const UsersGrid: React.FC = () => {
         {setCanPack.isError && (
           <p className="text-sm text-red-600">Failed to update packing permission. Please try again.</p>
         )}
+        {setActive.isError && (
+          <p className="text-sm text-red-600">Failed to update user status. Please try again.</p>
+        )}
       </div>
 
       {/* Grid */}


### PR DESCRIPTION
Closes #3320

## What the issue was

`UsersGrid.tsx` surfaces inline error messages for `createLocalUser` and `setCanPack` mutations, but silently drops errors from the `setActive` mutation (toggle user active/disabled). When the toggle-active call fails, the operator sees no feedback and may assume the action succeeded — a potentially dangerous gap for a privileged action.

## How it was fixed

Added the missing error paragraph immediately after the existing `setCanPack.isError` block, using the identical pattern and CSS classes already used by the two peer blocks:

```tsx
{setActive.isError && (
  <p className="text-sm text-red-600">Failed to update user status. Please try again.</p>
)}
```

`setActive` was already declared via `useSetUserActive()` — no hook wiring needed. Build passes, no lint issues introduced.

## Artifacts

Brief, spec, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3320/`.

## Code review

## Review Result: CLEAN

The addition is exactly surgical: one `isError` guard block inserted after the two existing peer blocks, touching nothing else. Message wording and CSS classes are identical to both peer blocks. No blocking issues found.

**Advisory only:**
- Three error paragraphs could theoretically stack if multiple mutations error simultaneously — consistent with pre-existing peer behaviour, not a regression.
- No `data-testid` on error paragraphs — matches existing peers, out of scope for this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rkw2q6NB2gXA3ejDGLeSBz)_