### PR TITLE
fix: omit FlexiBee warehouse for non-stock invoice items

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiInvoiceMappingProfile.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiInvoiceMappingProfile.cs
@@ -63,7 +63,7 @@ public class FlexiInvoiceMappingProfile : BaseFlexiProfile
             .ForMember(dest => dest.SumTotalC, opt => opt.MapFrom(src => src.ItemPrice.CurrencyCode != "CZK" ? (decimal?)Math.Round(src.ItemPrice.TotalWithVat, 2) : null))
             .ForMember(dest => dest.Currency, opt => opt.MapFrom(src => $"code:{src.ItemPrice.CurrencyCode}"))
             .ForMember(dest => dest.PriceList, opt => opt.MapFrom(src => string.IsNullOrEmpty(src.Code) || src.Code.StartsWith("SHIPPING") || src.Code.StartsWith("BILLING") ? null : $"code:{src.Code}"))
-            .ForMember(dest => dest.Store, opt => opt.MapFrom(src => string.IsNullOrEmpty(src.Code) || src.Code.StartsWith("SHIPPING") || src.Code.StartsWith("BILLING") ? null : "code:ZBOZI"))
+            .ForMember(dest => dest.Store, opt => opt.MapFrom(src => src.IsNonStock || string.IsNullOrEmpty(src.Code) || src.Code.StartsWith("SHIPPING") || src.Code.StartsWith("BILLING") ? null : "code:ZBOZI"))
             .ForMember(dest => dest.VatRateType, opt => opt.MapFrom(src => MapVatRateType(src.ItemPrice.VatRate)))
             .ForMember(dest => dest.PriceVatType, opt => opt.MapFrom(src => "typCeny.bezDph"))
             .ForMember(dest => dest.CopyCategoryVatReport, opt => opt.MapFrom(src => true))

--- a/backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/Transformations/GiftWithoutVATIssuedInvoiceImportTransformation.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Invoices/Infrastructure/Transformations/GiftWithoutVATIssuedInvoiceImportTransformation.cs
@@ -9,9 +9,15 @@ public class GiftWithoutVATIssuedInvoiceImportTransformation : IIssuedInvoiceImp
 
     public Task<IssuedInvoiceDetail> TransformAsync(IssuedInvoiceDetail invoiceDetail, CancellationToken cancellationToken = default)
     {
-        // TODO: Implement gift transformation logic once domain model is properly defined
-        // This transformation should modify invoiceDetail items for gift products
-        // Setting VAT category, store, and accounting classification
+        // GOODYDO0001 is a non-stock gift product; FlexiBee rejects a warehouse (sklad)
+        // on non-stock items. Flag it so the FlexiBee mapper omits the warehouse.
+        foreach (var item in invoiceDetail.Items)
+        {
+            if (item.Code == ProductCode)
+            {
+                item.IsNonStock = true;
+            }
+        }
 
         return Task.FromResult(invoiceDetail);
     }

--- a/backend/src/Anela.Heblo.Domain/Features/Invoices/IssuedInvoiceDetailItem.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Invoices/IssuedInvoiceDetailItem.cs
@@ -17,5 +17,7 @@
         public InvoicePrice ItemPrice { get; set; }
 
         public InvoicePrice BuyPrice { get; set; }
+
+        public bool IsNonStock { get; set; }
     }
 }

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Invoices/FlexiInvoiceMappingProfileStoreTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Invoices/FlexiInvoiceMappingProfileStoreTests.cs
@@ -1,0 +1,73 @@
+using Anela.Heblo.Adapters.Flexi.Invoices;
+using Anela.Heblo.Domain.Features.Invoices;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Rem.FlexiBeeSDK.Model.Invoices;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Invoices;
+
+public class FlexiInvoiceMappingProfileStoreTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(
+            c => c.AddProfile<FlexiInvoiceMappingProfile>(),
+            NullLoggerFactory.Instance);
+        return config.CreateMapper();
+    }
+
+    private static IssuedInvoiceDetail BuildInvoice(IssuedInvoiceDetailItem item) => new()
+    {
+        Code = "INV1",
+        OrderCode = "ORD1",
+        Customer = new InvoiceCustomer { Name = "Test" },
+        BillingAddress = new InvoiceAddress { Street = "S", City = "C", CountryCode = "CZ" },
+        DeliveryAddress = new InvoiceAddress { Street = "S", City = "C", CountryCode = "CZ" },
+        Price = new InvoicePrice { CurrencyCode = "CZK", WithoutVat = 78m, WithVat = 94.38m, Vat = 16.38m },
+        Items = new List<IssuedInvoiceDetailItem> { item },
+    };
+
+    private static IssuedInvoiceDetailItem BuildItem(string code, bool isNonStock) => new()
+    {
+        Code = code,
+        Name = "Item",
+        Amount = 1m,
+        IsNonStock = isNonStock,
+        ItemPrice = new InvoicePrice
+        {
+            CurrencyCode = "CZK",
+            WithoutVat = 78m,
+            WithVat = 94.38m,
+            Vat = 16.38m,
+            TotalWithoutVat = 78m,
+            TotalWithVat = 94.38m,
+            VatRate = "high",
+        },
+    };
+
+    [Fact]
+    public void NonStockItem_OmitsWarehouse()
+    {
+        var mapper = CreateMapper();
+
+        var flexi = mapper.Map<IssuedInvoiceDetailFlexiDto>(
+            BuildInvoice(BuildItem("GOODYDO0001", isNonStock: true)));
+
+        flexi.Items.Should().HaveCount(1);
+        flexi.Items[0].Store.Should().BeNull();
+    }
+
+    [Fact]
+    public void StockProductItem_AssignsWarehouse()
+    {
+        var mapper = CreateMapper();
+
+        var flexi = mapper.Map<IssuedInvoiceDetailFlexiDto>(
+            BuildInvoice(BuildItem("P1", isNonStock: false)));
+
+        flexi.Items.Should().HaveCount(1);
+        flexi.Items[0].Store.Should().Be("code:ZBOZI");
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Invoices/Infrastructure/Transformations/GiftWithoutVATIssuedInvoiceImportTransformationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Invoices/Infrastructure/Transformations/GiftWithoutVATIssuedInvoiceImportTransformationTests.cs
@@ -1,0 +1,92 @@
+using Anela.Heblo.Application.Features.Invoices.Infrastructure.Transformations;
+using Anela.Heblo.Domain.Features.Invoices;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Invoices.Infrastructure.Transformations;
+
+public class GiftWithoutVATIssuedInvoiceImportTransformationTests
+{
+    private const string GiftCode = "GOODYDO0001";
+
+    private readonly GiftWithoutVATIssuedInvoiceImportTransformation _transformation = new();
+
+    [Fact]
+    public async Task TransformAsync_WithGiftItem_FlagsItemAsNonStock()
+    {
+        // Arrange
+        var invoiceDetail = new IssuedInvoiceDetail
+        {
+            Items = new List<IssuedInvoiceDetailItem>
+            {
+                new() { Code = GiftCode, Name = "Gift" }
+            }
+        };
+
+        // Act
+        var result = await _transformation.TransformAsync(invoiceDetail);
+
+        // Assert
+        Assert.Single(result.Items);
+        Assert.True(result.Items[0].IsNonStock);
+    }
+
+    [Fact]
+    public async Task TransformAsync_WithNonGiftItems_LeavesItemsAsStock()
+    {
+        // Arrange
+        var invoiceDetail = new IssuedInvoiceDetail
+        {
+            Items = new List<IssuedInvoiceDetailItem>
+            {
+                new() { Code = "OTHER001", Name = "Product A" },
+                new() { Code = "SHIPPING", Name = "Shipping" }
+            }
+        };
+
+        // Act
+        var result = await _transformation.TransformAsync(invoiceDetail);
+
+        // Assert
+        Assert.Equal(2, result.Items.Count);
+        Assert.All(result.Items, item => Assert.False(item.IsNonStock));
+    }
+
+    [Fact]
+    public async Task TransformAsync_WithMixedItems_FlagsOnlyGiftItem()
+    {
+        // Arrange
+        var invoiceDetail = new IssuedInvoiceDetail
+        {
+            Items = new List<IssuedInvoiceDetailItem>
+            {
+                new() { Code = "OTHER001", Name = "Product A" },
+                new() { Code = GiftCode, Name = "Gift" },
+                new() { Code = "OTHER002", Name = "Product B" }
+            }
+        };
+
+        // Act
+        var result = await _transformation.TransformAsync(invoiceDetail);
+
+        // Assert
+        Assert.False(result.Items[0].IsNonStock);
+        Assert.True(result.Items[1].IsNonStock);
+        Assert.False(result.Items[2].IsNonStock);
+    }
+
+    [Fact]
+    public async Task TransformAsync_WithEmptyItemsList_ReturnsInvoiceUnchanged()
+    {
+        // Arrange
+        var invoiceDetail = new IssuedInvoiceDetail
+        {
+            Items = new List<IssuedInvoiceDetailItem>()
+        };
+
+        // Act
+        var result = await _transformation.TransformAsync(invoiceDetail);
+
+        // Assert
+        Assert.Empty(result.Items);
+    }
+}


### PR DESCRIPTION
Fixes the nightly issued-invoice sync failing for non-stock gift SKU `GOODYDO0001`, which FlexiBee rejects with *"U neskladového zboží nelze vybrat sklad!"* because the payload assigned a warehouse (`sklad`). Adds an `IsNonStock` flag to the invoice item, sets it for `GOODYDO0001` in the (previously stub) gift import transformation, and makes the FlexiBee mapper omit the warehouse when the flag is set (ceník/`PriceList` is left untouched, since only the warehouse is rejected). Covered by new unit tests for both the transformation and the mapper.

Note: the unrelated, pre-existing `LedgerSyncServiceTests.SyncAsync_WhenNoWatermark_FetchesFromInitialBackfillDate` fails on a UTC+1 machine due to a timezone offset — it fails identically on clean `main` and is not touched by this change.

Closes #3321