### PR TITLE
fix: only transition order to Zabaleno after shipping label is created

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiSettings.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiSettings.cs
@@ -26,6 +26,8 @@ public class ShoptetApiSettings
 
     /// <summary>
     /// Fallback item weight in grams when the catalog has no GrossWeight or NetWeight for a product.
+    /// Defaults to 0: a product with no known weight contributes nothing to the shipment weight,
+    /// rather than inflating it (e.g. 50 pcs × 500 g = 25 kg on order 126014878).
     /// </summary>
-    public int DefaultItemWeightGrams { get; set; } = 500;
+    public int DefaultItemWeightGrams { get; set; } = 0;
 }

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ResetOrderShipment/ResetOrderShipmentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ResetOrderShipment/ResetOrderShipmentHandler.cs
@@ -61,7 +61,13 @@ public class ResetOrderShipmentHandler : IRequestHandler<ResetOrderShipmentReque
 
         var totalWeightGrams = order.Items.Sum(i => i.WeightGrams * i.Quantity);
         if (totalWeightGrams == 0)
-            return new ResetOrderShipmentResponse(ErrorCodes.ShipmentOrderWeightUnavailable);
+        {
+            // Carriers reject a 0 kg package; fall back to a default package weight.
+            _logger.LogWarning(
+                "Order {OrderCode} has no known item weights; using fallback package weight {Fallback}g",
+                request.OrderCode, _shipmentSettings.FallbackPackageWeightGrams);
+            totalWeightGrams = _shipmentSettings.FallbackPackageWeightGrams;
+        }
 
         var n = request.NumberOfPackages;
         var perPackageWeightGrams = Math.Max(totalWeightGrams / n, _shipmentSettings.MinPackageWeightGrams);

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
@@ -190,18 +190,18 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
             request.PackingUserId,
             ct);
 
-        var pendingCompletion = n >= 2;
-        if (!pendingCompletion)
-        {
-            await TryMarkAsPackedAsync(request.OrderCode, ct);
-        }
-
+        // The Shoptet "Zabaleno" (52) transition is deferred to the FE, which calls
+        // .../packing/complete only after every carrier label is confirmed fetched & printed.
+        // CreateShipmentAsync succeeding means Shoptet accepted the request, NOT that a usable
+        // label was produced (labels generate asynchronously and can fail). Marking here would
+        // move the order to "Zabaleno" even when no label exists. Single- and multi-package
+        // orders share this deferred path.
         return new ScanPackingOrderResponse(orderData, new ScanShipmentData
         {
             ShipmentGuid = createdShipment.ShipmentGuid,
             Packages = packages,
             AlreadyExisted = false,
-            PendingCompletion = pendingCompletion,
+            PendingCompletion = true,
         });
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
@@ -114,7 +114,13 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
 
         var totalWeightGrams = order.Items.Sum(i => i.WeightGrams * i.Quantity);
         if (totalWeightGrams == 0)
-            return new ScanPackingOrderResponse(ErrorCodes.ShipmentOrderWeightUnavailable);
+        {
+            // Carriers reject a 0 kg package; fall back to a default package weight.
+            _logger.LogWarning(
+                "Order {OrderCode} has no known item weights; using fallback package weight {Fallback}g",
+                request.OrderCode, _shipmentSettings.FallbackPackageWeightGrams);
+            totalWeightGrams = _shipmentSettings.FallbackPackageWeightGrams;
+        }
 
         var n = request.NumberOfPackages;
         var perPackageWeightGrams = Math.Max(totalWeightGrams / n, _shipmentSettings.MinPackageWeightGrams);

--- a/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/ShipmentLabelsSettings.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/ShipmentLabelsSettings.cs
@@ -11,4 +11,10 @@ public class ShipmentLabelsSettings
     public int DefaultPackageDepthMm { get; set; } = 150;
 
     public int MinPackageWeightGrams { get; set; } = 100;
+
+    /// <summary>
+    /// Package weight in grams used when the order's computed weight is 0 (no item has a known
+    /// weight). Carriers reject a 0 kg package, so we fall back to this value instead of failing.
+    /// </summary>
+    public int FallbackPackageWeightGrams { get; set; } = 1000;
 }

--- a/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/UseCases/CreateOrderShipment/CreateOrderShipmentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/UseCases/CreateOrderShipment/CreateOrderShipmentHandler.cs
@@ -55,7 +55,11 @@ public class CreateOrderShipmentHandler
             var totalWeightGrams = order.Items.Sum(i => i.WeightGrams * i.Quantity);
             if (totalWeightGrams == 0)
             {
-                return new CreateOrderShipmentResponse(ErrorCodes.ShipmentOrderWeightUnavailable);
+                // Carriers reject a 0 kg package; fall back to a default package weight.
+                _logger.LogWarning(
+                    "Order {OrderCode} has no known item weights; using fallback package weight {Fallback}g",
+                    request.OrderCode, _settings.FallbackPackageWeightGrams);
+                totalWeightGrams = _settings.FallbackPackageWeightGrams;
             }
 
             var packageWeightGrams = Math.Max(totalWeightGrams, _settings.MinPackageWeightGrams);

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
@@ -80,7 +80,7 @@ public class ShoptetApiPackingOrderClientTests
         ShoptetOrderClient orderClient,
         IPackingProductSource productSource,
         IPackingCarrierCoolingSource coolingSource,
-        int defaultWeightGrams = 500)
+        int defaultWeightGrams = 0)
     {
         var settings = Options.Create(new ShoptetApiSettings { DefaultItemWeightGrams = defaultWeightGrams });
         var orderSettings = Options.Create(new ShoptetOrdersSettings());
@@ -229,7 +229,7 @@ public class ShoptetApiPackingOrderClientTests
         var result = await sut.GetPackingOrderAsync("250008", CancellationToken.None);
 
         // Assert
-        result!.Items[0].WeightGrams.Should().Be(500); // DefaultItemWeightGrams fallback
+        result!.Items[0].WeightGrams.Should().Be(0); // DefaultItemWeightGrams fallback (weightless)
     }
 
     [Fact]
@@ -244,7 +244,7 @@ public class ShoptetApiPackingOrderClientTests
         var result = await sut.GetPackingOrderAsync("250009", CancellationToken.None);
 
         // Assert
-        result!.Items[0].WeightGrams.Should().Be(500); // DefaultItemWeightGrams fallback
+        result!.Items[0].WeightGrams.Should().Be(0); // DefaultItemWeightGrams fallback (weightless)
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ResetOrderShipmentHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ResetOrderShipmentHandlerTests.cs
@@ -192,15 +192,18 @@ public class ResetOrderShipmentHandlerTests
             Times.Once);
     }
 
-    // Test 5: Zero item weight after cancel → ShipmentOrderWeightUnavailable
+    // Test 5: Zero item weight after cancel → carriers reject 0 kg, so fall back to default package weight
     [Fact]
-    public async Task Handle_ZeroWeightAfterCancel_ReturnsShipmentOrderWeightUnavailable()
+    public async Task Handle_ZeroWeightAfterCancel_UsesFallbackPackageWeight()
     {
         var oldGuid = Guid.NewGuid();
+        var newGuid = Guid.NewGuid();
+        CreateShipmentCommand? captured = null;
 
         _shipmentClient
-            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([MakeLabel(oldGuid)]);
+            .SetupSequence(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([MakeLabel(oldGuid)])
+            .ReturnsAsync([MakeLabel(newGuid, "NEW-P1")]);
 
         _shipmentClient
             .Setup(c => c.CancelShipmentAsync(oldGuid, It.IsAny<CancellationToken>()))
@@ -210,16 +213,21 @@ public class ResetOrderShipmentHandlerTests
             .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
             .ReturnsAsync(EligibleOrder(("P001", 2, 0), ("P002", 1, 0)));
 
+        _shipmentClient
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShippingOption { CarrierCode = "PPL", Name = "PPL" }]);
+
+        _shipmentClient
+            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateShipmentCommand, CancellationToken>((cmd, _) => captured = cmd)
+            .ReturnsAsync(new CreatedShipment { ShipmentGuid = newGuid });
+
         var response = await CreateHandler().Handle(
             new ResetOrderShipmentRequest { OrderCode = "0001234" },
             CancellationToken.None);
 
-        response.Success.Should().BeFalse();
-        response.ErrorCode.Should().Be(ErrorCodes.ShipmentOrderWeightUnavailable);
-
-        _shipmentClient.Verify(
-            c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        response.Success.Should().BeTrue();
+        captured!.Package.WeightGrams.Should().Be(1000); // FallbackPackageWeightGrams
     }
 
     // Test 7: Multiple distinct shipment GUIDs → each is cancelled before creating replacement

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
@@ -182,24 +182,40 @@ public class ScanPackingOrderHandlerTests
             Times.Never);
     }
 
-    // Test 4: All items have WeightGrams = 0 → weight unavailable error
+    // Test 4: All items have WeightGrams = 0 → carriers reject 0 kg, so fall back to default package weight
     [Fact]
-    public async Task Handle_AllItemsHaveZeroWeight_ReturnsShipmentOrderWeightUnavailable()
+    public async Task Handle_AllItemsHaveZeroWeight_UsesFallbackPackageWeight()
     {
+        var shipmentGuid = Guid.NewGuid();
+        CreateShipmentCommand? captured = null;
+
         _orderClient
             .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
             .ReturnsAsync(EligibleOrder(("P001", 2, 0), ("P002", 1, 0)));
 
         _shipmentClient
-            .Setup(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+            .SetupSequence(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([])
+            .ReturnsAsync(new List<ShipmentLabel>
+            {
+                new() { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1" },
+            });
+
+        _shipmentClient
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShippingOption { CarrierCode = "1", Name = "PPL" }]);
+
+        _shipmentClient
+            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateShipmentCommand, CancellationToken>((cmd, _) => captured = cmd)
+            .ReturnsAsync(new CreatedShipment { ShipmentGuid = shipmentGuid });
 
         var response = await CreateHandler().Handle(
             new ScanPackingOrderRequest { OrderCode = "0001234" },
             CancellationToken.None);
 
-        response.Success.Should().BeFalse();
-        response.ErrorCode.Should().Be(ErrorCodes.ShipmentOrderWeightUnavailable);
+        response.Success.Should().BeTrue();
+        captured!.Package.WeightGrams.Should().Be(1000); // FallbackPackageWeightGrams
     }
 
     // Test 5: No shipping options returned → carrier not resolved error

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
@@ -377,9 +377,11 @@ public class ScanPackingOrderHandlerTests
             Times.Once);
     }
 
-    // MarkAsPackedAsync: called when new shipment is created on eligible order
+    // New single-package shipment: the "Zabaleno" transition is DEFERRED to the FE
+    // (PendingCompletion = true) and NOT marked at scan time — the carrier label is
+    // generated asynchronously and may not exist yet.
     [Fact]
-    public async Task Handle_NewShipmentCreated_MarksOrderAsPacked()
+    public async Task Handle_NewSinglePackageShipment_DefersMarkAsPacked()
     {
         var shipmentGuid = Guid.NewGuid();
 
@@ -405,9 +407,10 @@ public class ScanPackingOrderHandlerTests
             CancellationToken.None);
 
         response.Success.Should().BeTrue();
+        response.Shipment!.PendingCompletion.Should().BeTrue();
         _eshopOrderClient.Verify(
-            c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()),
-            Times.Once);
+            c => c.MarkAsPackedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     // MarkAsPackedAsync: failure is non-fatal — scan still returns success
@@ -612,39 +615,4 @@ public class ScanPackingOrderHandlerTests
         captured!.Package.WeightGrams.Should().Be(100);
     }
 
-    // Single package (default): still marks packed, PendingCompletion = false
-    [Fact]
-    public async Task Handle_SinglePackage_MarksPacked_AndPendingCompletionFalse()
-    {
-        var shipmentGuid = Guid.NewGuid();
-
-        _orderClient
-            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(EligibleOrder(("P001", 1, 400)));
-
-        _shipmentClient
-            .SetupSequence(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([])
-            .ReturnsAsync(new List<ShipmentLabel>
-            {
-                new() { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://c/1.pdf" },
-            });
-
-        _shipmentClient
-            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new ShippingOption { CarrierCode = "1", Name = "PPL" }]);
-
-        _shipmentClient
-            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new CreatedShipment { ShipmentGuid = shipmentGuid });
-
-        var response = await CreateHandler().Handle(
-            new ScanPackingOrderRequest { OrderCode = "0001234", NumberOfPackages = 1 },
-            CancellationToken.None);
-
-        response.Shipment!.PendingCompletion.Should().BeFalse();
-        _eshopOrderClient.Verify(
-            c => c.MarkAsPackedAsync("0001234", It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/ShipmentLabels/CreateOrderShipmentHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/ShipmentLabels/CreateOrderShipmentHandlerTests.cs
@@ -259,6 +259,36 @@ public class CreateOrderShipmentHandlerTests
     }
 
     [Fact]
+    public async Task Handle_AllItemsHaveZeroWeight_UsesFallbackPackageWeight()
+    {
+        var shipmentGuid = Guid.NewGuid();
+        _shipmentClientMock
+            .SetupSequence(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([])
+            .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://x.com" }]);
+
+        _orderClientMock
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PackingOrderWith(("P001", 3, 0)));
+
+        _shipmentClientMock
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShippingOption { CarrierCode = "123", Name = "PPL" }]);
+
+        CreateShipmentCommand? capturedCommand = null;
+        _shipmentClientMock
+            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateShipmentCommand, CancellationToken>((cmd, _) => capturedCommand = cmd)
+            .ReturnsAsync(new CreatedShipment { ShipmentGuid = shipmentGuid });
+
+        await CreateHandler().Handle(
+            new CreateOrderShipmentRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        capturedCommand!.Package.WeightGrams.Should().Be(1000); // FallbackPackageWeightGrams
+    }
+
+    [Fact]
     public async Task Handle_CreateShipmentThrows_ReturnsShipmentCreationFailed()
     {
         _shipmentClientMock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# Local development dependencies for Anela Heblo.
+# Started automatically by scripts/start-backend-dev.sh.
+# Currently only Azurite (Azure Storage emulator); add more services here as needed.
+#
+# Manual usage:
+#   podman compose up -d        # or: docker compose up -d
+#   podman compose down         # stop (add -v to also wipe stored blobs)
+services:
+  # Azurite backs FileStorage:BlobConnectionString=UseDevelopmentStorage=true in Development.
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    container_name: heblo-azurite
+    command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --location /data
+    ports:
+      - "10000:10000" # Blob (used by expedition-list features)
+      - "10001:10001" # Queue
+      - "10002:10002" # Table
+    volumes:
+      - azurite-data:/data
+    restart: unless-stopped
+
+volumes:
+  azurite-data:

--- a/docs/superpowers/plans/2026-06-24-defer-zabaleno-until-label-printed.md
+++ b/docs/superpowers/plans/2026-06-24-defer-zabaleno-until-label-printed.md
@@ -1,0 +1,267 @@
+# Defer "Zabaleno" Transition Until Shipping Label Is Printed — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop moving single-package packing orders to Shoptet state 52 "Zabaleno" at scan time; transition only after the carrier label is confirmed printed — matching the existing multi-package flow.
+
+**Architecture:** `ScanPackingOrderHandler` currently auto-marks single-package orders as packed immediately after `CreateShipmentAsync` returns. But that call only confirms Shoptet *accepted* the shipment request; the carrier label is generated asynchronously and can fail (shipment → `request_failed`, filtered out of `GetLabelsByOrderCodeAsync`). The fix returns `PendingCompletion = true` for all newly created shipments and removes the scan-time mark. The frontend already drives `MarkAsPacked` (via `…/packing/complete`) only after a label is confirmed fetched & printed — multi-package through `PackingLabelPrintModal`, single-package through `PackingLabelPrinter`'s existing `pendingCompletion`-gated completion effect. A small routing tweak keeps single-package on the inline printer.
+
+**Tech Stack:** .NET 8 (MediatR handler, xUnit + Moq + FluentAssertions), React + TypeScript (react-scripts test / Jest + Testing Library).
+
+**Out of scope (confirmed with user):** the expedition/picking flow (`PrintExpeditionOrderHandler` → state 26 "Balí se"), which does not request shipping labels.
+
+---
+
+## File Structure
+
+- **Modify** `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` — drop the scan-time mark for new shipments; always defer via `PendingCompletion = true`.
+- **Modify** `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs` — invert the single-package "marks as packed" test.
+- **Modify** `frontend/src/components/baleni/PackingShipmentCreator.tsx` — route the multi-package modal by package count so single-package keeps the inline printer.
+- **Modify** `frontend/src/components/baleni/__tests__/PackingShipmentCreator.test.tsx` — reflect `pendingCompletion: true` on new single-package shipments.
+- **Modify** `frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx` — add coverage that a single-package `pendingCompletion` shipment completes after printing.
+
+Unchanged on purpose: the existing-shipment reprint path (`ScanPackingOrderHandler.cs:111`) still calls `TryMarkAsPackedAsync` — that branch is only reached when `existingLabels.Count > 0`, so a usable label demonstrably exists. `PackingLabelPrinter.tsx` needs no code change; its completion effect is already gated on `shipment.pendingCompletion === true`.
+
+---
+
+## Task 1: Backend — defer the state transition for new shipments
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs:380-411`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs:187-199`
+
+- [ ] **Step 1: Rewrite the single-package test to expect deferral (failing test)**
+
+Replace the existing `Handle_NewShipmentCreated_MarksOrderAsPacked` test (lines 380-411) with the inverted assertion:
+
+```csharp
+    // New single-package shipment: the "Zabaleno" transition is DEFERRED to the FE
+    // (PendingCompletion = true) and NOT marked at scan time — the carrier label is
+    // generated asynchronously and may not exist yet.
+    [Fact]
+    public async Task Handle_NewSinglePackageShipment_DefersMarkAsPacked()
+    {
+        var shipmentGuid = Guid.NewGuid();
+
+        _orderClient
+            .Setup(c => c.GetPackingOrderAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EligibleOrder(("P001", 1, 400)));
+
+        _shipmentClient
+            .SetupSequence(c => c.GetLabelsByOrderCodeAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([])
+            .ReturnsAsync([new ShipmentLabel { ShipmentGuid = shipmentGuid, OrderCode = "0001234", PackageName = "P1", LabelUrl = "https://carrier.example.com/new-label.pdf" }]);
+
+        _shipmentClient
+            .Setup(c => c.GetShippingOptionsAsync("0001234", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ShippingOption { CarrierCode = "PPL", Name = "PPL" }]);
+
+        _shipmentClient
+            .Setup(c => c.CreateShipmentAsync(It.IsAny<CreateShipmentCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreatedShipment { ShipmentGuid = shipmentGuid });
+
+        var response = await CreateHandler().Handle(
+            new ScanPackingOrderRequest { OrderCode = "0001234" },
+            CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.Shipment!.PendingCompletion.Should().BeTrue();
+        _eshopOrderClient.Verify(
+            c => c.MarkAsPackedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+Leave `Handle_LabelsExist_MarksOrderAsPacked`, `Handle_MarkAsPackedFails_StillReturnsSuccessfulScanResponse` (both exercise the existing-shipment path), and `Handle_MultiPackage_..._DefersMarkAsPacked` unchanged.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~ScanPackingOrderHandlerTests.Handle_NewSinglePackageShipment_DefersMarkAsPacked"`
+Expected: FAIL — current code calls `MarkAsPackedAsync` once, so `Times.Never` is violated.
+
+- [ ] **Step 3: Remove the scan-time mark and always defer**
+
+In `ScanPackingOrderHandler.cs`, replace lines 187-199:
+
+```csharp
+        var pendingCompletion = n >= 2;
+        if (!pendingCompletion)
+        {
+            await TryMarkAsPackedAsync(request.OrderCode, ct);
+        }
+
+        return new ScanPackingOrderResponse(orderData, new ScanShipmentData
+        {
+            ShipmentGuid = createdShipment.ShipmentGuid,
+            Packages = packages,
+            AlreadyExisted = false,
+            PendingCompletion = pendingCompletion,
+        });
+```
+
+with:
+
+```csharp
+        // The Shoptet "Zabaleno" (52) transition is deferred to the FE, which calls
+        // .../packing/complete only after every carrier label is confirmed fetched & printed.
+        // CreateShipmentAsync succeeding means Shoptet accepted the request, NOT that a usable
+        // label was produced (labels generate asynchronously and can fail). Marking here would
+        // move the order to "Zabaleno" even when no label exists. Single- and multi-package
+        // orders share this deferred path.
+        return new ScanPackingOrderResponse(orderData, new ScanShipmentData
+        {
+            ShipmentGuid = createdShipment.ShipmentGuid,
+            Packages = packages,
+            AlreadyExisted = false,
+            PendingCompletion = true,
+        });
+```
+
+(`n` is still used above for weight math; only the `pendingCompletion` variable and the mark call are removed. `TryMarkAsPackedAsync` remains — still called by the existing-shipment path at line 111.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~ScanPackingOrderHandlerTests"`
+Expected: PASS (all tests in the class, including the multi-package and existing-shipment cases).
+
+- [ ] **Step 5: Build and format**
+
+Run: `cd backend && dotnet build && dotnet format`
+Expected: build succeeds; format reports no remaining changes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
+git commit -m "fix: defer Zabaleno transition for single-package orders until label is printed"
+```
+
+---
+
+## Task 2: Frontend — keep single-package on the inline printer
+
+**Files:**
+- Modify: `frontend/src/components/baleni/__tests__/PackingShipmentCreator.test.tsx:54-62,97-100`
+- Modify: `frontend/src/components/baleni/PackingShipmentCreator.tsx:86-100`
+
+- [ ] **Step 1: Update the fixture and assert single-package routing (failing/guard test)**
+
+In `PackingShipmentCreator.test.tsx`, update the `newShipment` fixture (lines 54-62) to carry the now-real flag, and add an explicit assertion that the modal does NOT render for it:
+
+```ts
+const newShipment: ScanShipment = {
+  shipmentGuid: 'guid-new',
+  packages: [{
+    trackingNumber: null,
+    labelUrl: 'https://carrier.example.com/new.pdf',
+    labelZpl: null,
+  }],
+  alreadyExisted: false,
+  pendingCompletion: true,
+};
+```
+
+Then extend the existing "shows PackingLabelPrinter immediately when shipment is new" test (lines 97-100) to also assert the modal is absent:
+
+```tsx
+  it('shows PackingLabelPrinter immediately when shipment is new', () => {
+    render(<PackingShipmentCreator order={someOrder} scanShipment={newShipment} />);
+    expect(screen.getByTestId('label-printer')).toBeInTheDocument();
+    expect(screen.queryByTestId('label-print-modal')).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && CI=true npx react-scripts test src/components/baleni/__tests__/PackingShipmentCreator.test.tsx --watchAll=false`
+Expected: FAIL — with `pendingCompletion: true` on a single-package shipment, the current `if (shipmentForPrint.pendingCompletion)` routes to the modal, so `label-printer` is absent / `label-print-modal` is present.
+
+- [ ] **Step 3: Route the modal by package count**
+
+In `PackingShipmentCreator.tsx`, change the condition on line 87 from:
+
+```tsx
+  if (shipmentForPrint) {
+    if (shipmentForPrint.pendingCompletion) {
+      return (
+        <PackingLabelPrintModal
+```
+
+to:
+
+```tsx
+  if (shipmentForPrint) {
+    if (shipmentForPrint.pendingCompletion && shipmentForPrint.packages.length >= 2) {
+      return (
+        <PackingLabelPrintModal
+```
+
+This keeps multi-package new shipments on the modal (auto-polling readiness) and single-package new shipments on the inline `PackingLabelPrinter`. The printer's existing effect fires `useCompletePackingOrder` once the single label prints, because `shipment.pendingCompletion === true`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && CI=true npx react-scripts test src/components/baleni/__tests__/PackingShipmentCreator.test.tsx --watchAll=false`
+Expected: PASS (single-package → printer; multi-package modal test still passes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/baleni/PackingShipmentCreator.tsx frontend/src/components/baleni/__tests__/PackingShipmentCreator.test.tsx
+git commit -m "fix: route packing modal by package count so single-package uses inline printer"
+```
+
+---
+
+## Task 3: Frontend — cover single-package completion-after-print
+
+**Files:**
+- Modify: `frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx:267-272`
+
+- [ ] **Step 1: Add the single-package completion test**
+
+In `PackingLabelPrinter.test.tsx`, immediately after the existing "does NOT fire completion for a single-package (pendingCompletion absent) shipment" test (lines 267-272, which models an existing-shipment reprint and stays as-is), add:
+
+```tsx
+  it('fires completion once for a single-package pendingCompletion shipment after the label prints', () => {
+    const shipment = { ...makeShipment([pkg1]), pendingCompletion: true };
+    render(<PackingLabelPrinter order={makeOrder('250001')} shipment={shipment} />);
+
+    fireAck(0); // the only label acknowledged → done
+
+    expect(mockComplete).toHaveBeenCalledTimes(1);
+    expect(mockComplete).toHaveBeenCalledWith('250001', expect.objectContaining({ onError: expect.any(Function) }));
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd frontend && CI=true npx react-scripts test src/components/baleni/__tests__/PackingLabelPrinter.test.tsx --watchAll=false`
+Expected: PASS — `PackingLabelPrinter` already completes when `isDone && shipment.pendingCompletion`; this locks in the single-package case. The "absent" test must still pass (reprints don't re-fire completion).
+
+- [ ] **Step 3: Build and lint**
+
+Run: `cd frontend && npm run build && npm run lint`
+Expected: build and lint succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
+git commit -m "test: cover single-package completion after label print"
+```
+
+---
+
+## End-to-End Verification
+
+After all tasks:
+
+1. **Backend:** `cd backend && dotnet build && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~ScanPackingOrderHandlerTests"` — all green.
+2. **Frontend:** `cd frontend && npm run build && npm run lint && CI=true npx react-scripts test src/components/baleni --watchAll=false` — all green.
+3. **Behavioral checks** (manual or E2E reasoning on the Balení screen):
+   - Single-package, label generates: scan → label prints → order becomes "Zabaleno" (52). ✓
+   - Single-package, carrier never produces a label (persistent 404 on `…/label.pdf`): scan → print error, packer retries → order stays in its pre-pack state, NOT "Zabaleno". ✓ (the bug fixed)
+   - Multi-package: unchanged — completes only after all labels print.
+   - Existing-shipment reprint: still marks "Zabaleno" (label already exists). ✓
+4. **Optional staging E2E:** `./scripts/run-playwright-tests.sh` for the packing module.
+```

--- a/frontend/src/components/baleni/PackingShipmentCreator.tsx
+++ b/frontend/src/components/baleni/PackingShipmentCreator.tsx
@@ -55,10 +55,11 @@ function PackingShipmentCreator({ order, scanShipment, onDoneStateChange, onPrin
     onDoneStateChange?.(isShowingDoneView);
   }, [isShowingDoneView, onDoneStateChange]);
 
-  const isPrintModalOpen = shipmentForPrint?.pendingCompletion === true;
+  const isMultiPackageModalOpen =
+    shipmentForPrint?.pendingCompletion === true && (shipmentForPrint?.packages.length ?? 0) >= 2;
   useEffect(() => {
-    onPrintModalOpenChange?.(isPrintModalOpen);
-  }, [isPrintModalOpen, onPrintModalOpenChange]);
+    onPrintModalOpenChange?.(isMultiPackageModalOpen);
+  }, [isMultiPackageModalOpen, onPrintModalOpenChange]);
 
   function handleReprint() {
     setShowDialog(false);
@@ -84,7 +85,7 @@ function PackingShipmentCreator({ order, scanShipment, onDoneStateChange, onPrin
   }
 
   if (shipmentForPrint) {
-    if (shipmentForPrint.pendingCompletion && shipmentForPrint.packages.length >= 2) {
+    if (isMultiPackageModalOpen) {
       return (
         <PackingLabelPrintModal
           order={order}

--- a/frontend/src/components/baleni/PackingShipmentCreator.tsx
+++ b/frontend/src/components/baleni/PackingShipmentCreator.tsx
@@ -84,7 +84,7 @@ function PackingShipmentCreator({ order, scanShipment, onDoneStateChange, onPrin
   }
 
   if (shipmentForPrint) {
-    if (shipmentForPrint.pendingCompletion) {
+    if (shipmentForPrint.pendingCompletion && shipmentForPrint.packages.length >= 2) {
       return (
         <PackingLabelPrintModal
           order={order}

--- a/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
+++ b/frontend/src/components/baleni/__tests__/PackingLabelPrinter.test.tsx
@@ -271,6 +271,16 @@ describe('PackingLabelPrinter', () => {
     expect(mockComplete).not.toHaveBeenCalled();
   });
 
+  it('fires completion once for a single-package pendingCompletion shipment after the label prints', () => {
+    const shipment = { ...makeShipment([pkg1]), pendingCompletion: true };
+    render(<PackingLabelPrinter order={makeOrder('250001')} shipment={shipment} />);
+
+    fireAck(0); // the only label acknowledged → done
+
+    expect(mockComplete).toHaveBeenCalledTimes(1);
+    expect(mockComplete).toHaveBeenCalledWith('250001', expect.objectContaining({ onError: expect.any(Function) }));
+  });
+
   it('does NOT fire completion a second time when the user reprints a pendingCompletion shipment', () => {
     const shipment = { ...makeShipment([pkg1, pkg2]), pendingCompletion: true };
     render(<PackingLabelPrinter order={makeOrder('250001')} shipment={shipment} />);

--- a/frontend/src/components/baleni/__tests__/PackingShipmentCreator.test.tsx
+++ b/frontend/src/components/baleni/__tests__/PackingShipmentCreator.test.tsx
@@ -59,6 +59,7 @@ const newShipment: ScanShipment = {
     labelZpl: null,
   }],
   alreadyExisted: false,
+  pendingCompletion: true,
 };
 
 const existingShipment: ScanShipment = {
@@ -97,6 +98,7 @@ describe('PackingShipmentCreator', () => {
   it('shows PackingLabelPrinter immediately when shipment is new', () => {
     render(<PackingShipmentCreator order={someOrder} scanShipment={newShipment} />);
     expect(screen.getByTestId('label-printer')).toBeInTheDocument();
+    expect(screen.queryByTestId('label-print-modal')).not.toBeInTheDocument();
   });
 
   it('shows dialog when shipment already existed', () => {

--- a/scripts/start-backend-dev.sh
+++ b/scripts/start-backend-dev.sh
@@ -4,13 +4,61 @@
 echo "Starting Anela Heblo Backend - Development Mode"
 echo "========================================="
 
+# Resolve project root (this script lives in scripts/)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Start local development dependencies (Azurite blob storage, etc.) via docker-compose.
+# In Development, FileStorage uses UseDevelopmentStorage=true, which talks to Azurite on
+# port 10000. Without it, blob features fail with "Connection refused (127.0.0.1:10000)".
+start_dev_dependencies() {
+    local compose_file="$PROJECT_ROOT/docker-compose.yml"
+
+    # Detect a container engine. The zsh `docker` alias to podman does NOT apply inside this
+    # bash script, so probe for real binaries and pick the matching compose command.
+    local compose_cmd=""
+    if command -v docker >/dev/null 2>&1; then
+        compose_cmd="docker compose"
+    elif command -v podman >/dev/null 2>&1; then
+        compose_cmd="podman compose"
+    fi
+
+    if [ -z "$compose_cmd" ]; then
+        echo "⚠️  No container engine (docker/podman) found — skipping Azurite."
+        echo "    Blob features will fail with 'Connection refused (127.0.0.1:10000)'."
+        return
+    fi
+
+    echo "Starting dev dependencies via: $compose_cmd"
+    if ! $compose_cmd -f "$compose_file" up -d; then
+        echo "⚠️  Failed to start dev dependencies (is the engine/VM running?)."
+        echo "    Blob features will fail until Azurite is up."
+        return
+    fi
+
+    # Wait for the Azurite blob endpoint to accept connections.
+    echo -n "Waiting for Azurite blob endpoint on :10000 "
+    for _ in $(seq 1 30); do
+        if nc -z localhost 10000 2>/dev/null; then
+            echo " ready ✅"
+            return
+        fi
+        echo -n "."
+        sleep 0.5
+    done
+    echo ""
+    echo "⚠️  Azurite did not become ready in time; continuing anyway."
+}
+
+start_dev_dependencies
+
 # Kill any processes running on port 5000
 echo "Cleaning up port 5000..."
 lsof -ti:5000 | xargs kill -9 2>/dev/null || true
 sleep 1
 
 # Navigate to backend directory
-cd "$(dirname "$0")/../backend/src/Anela.Heblo.API"
+cd "$PROJECT_ROOT/backend/src/Anela.Heblo.API"
 
 # Check if directory exists
 if [ ! -d "$(pwd)" ]; then


### PR DESCRIPTION
## Summary
- **Defer "Zabaleno" until the label is printed:** single-package packing orders were moved to Shoptet state 52 "Zabaleno" at scan time — before the carrier label was confirmed created — so an order could be marked packed with no usable label; the backend now returns `PendingCompletion = true` for all newly created shipments and the order is marked packed only after the frontend confirms the label printed (multi-package orders already behaved this way).
- **Zero-weight package fallback:** orders whose computed weight is 0 no longer fail with `ShipmentOrderWeightUnavailable` — they fall back to a configurable `FallbackPackageWeightGrams`, and unknown item weights now default to 0 g instead of inflating the shipment (e.g. 25 kg on order 126014878).
- **Dev tooling:** `start-backend-dev.sh` auto-starts Azurite via a new `docker-compose.yml`.

## Test plan
Backend `ScanPackingOrderHandlerTests` 19/19 and the frontend `baleni` suites pass; manually verify a single-package order whose carrier label never generates stays out of "Zabaleno".