### PR TITLE
fix: dedup bank statements against global TransferId constraint

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs
@@ -88,13 +88,22 @@ public class ImportBankStatementHandler : IRequestHandler<ImportBankStatementReq
                 "Bank client returned {StatementCount} statements - Account: {AccountName}",
                 statements.Count, request.AccountName);
 
-            var existingTransfers = await _repository.GetExistingTransfersAsync(
-                accountSetting.Name, request.DateFrom, request.DateTo, cancellationToken);
+            // Collapse statements the bank returned more than once in a single response so we never
+            // attempt to insert the same TransferId twice within one run.
+            var uniqueStatements = statements
+                .GroupBy(s => s.StatementId)
+                .Select(g => g.First())
+                .ToList();
+
+            // Dedup against the GLOBAL unique constraint on TransferId (IX_BankStatements_TransferId).
+            // Scoping by account/date would miss statements already stored under a different window.
+            var existingTransfers = await _repository.GetExistingResultsByTransferIdsAsync(
+                uniqueStatements.Select(s => s.StatementId).ToList(), cancellationToken);
 
             var imports = new List<BankStatementImportDto>();
             var skippedCount = 0;
 
-            foreach (var statement in statements)
+            foreach (var statement in uniqueStatements)
             {
                 if (existingTransfers.TryGetValue(statement.StatementId, out var existingResult)
                     && existingResult == ImportStatus.Success)
@@ -150,33 +159,35 @@ public class ImportBankStatementHandler : IRequestHandler<ImportBankStatementReq
         bool isRetry,
         CancellationToken cancellationToken)
     {
+        _logger.LogInformation("Processing statement {StatementId} (retry={IsRetry})", statement.StatementId, isRetry);
+
+        int itemCount;
+        string resultStatus;
         try
         {
-            _logger.LogInformation("Processing statement {StatementId} (retry={IsRetry})", statement.StatementId, isRetry);
-
             var aboData = await client.GetStatementAsync(statement.StatementId);
             var importResult = await _bankStatementImportService.ImportStatementAsync(accountSetting.FlexiBeeId, aboData.Data);
-            var resultStatus = importResult.IsSuccess
+            itemCount = aboData.ItemCount;
+            resultStatus = importResult.IsSuccess
                 ? ImportStatus.Success
                 : importResult.ErrorMessage ?? ImportStatus.UnknownError;
-
-            var saved = isRetry
-                ? await UpsertExistingAsync(statement, accountSetting, aboData.ItemCount, resultStatus, cancellationToken)
-                : await InsertNewAsync(statement, accountSetting, aboData.ItemCount, resultStatus);
-
-            _logger.LogInformation("Processed statement {StatementId} with result: {Result}",
-                statement.StatementId, resultStatus);
-            return _mapper.Map<BankStatementImportDto>(saved);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error processing statement {StatementId}", statement.StatementId);
-            var errorStatus = $"{ImportStatus.ProcessingError}: {ex.Message}";
-            var saved = isRetry
-                ? await UpsertExistingAsync(statement, accountSetting, 0, errorStatus, cancellationToken)
-                : await InsertNewAsync(statement, accountSetting, 0, errorStatus);
-            return _mapper.Map<BankStatementImportDto>(saved);
+            itemCount = 0;
+            resultStatus = $"{ImportStatus.ProcessingError}: {ex.Message}";
         }
+
+        // Persist exactly once. A persistence failure propagates to Handle's catch and must NOT
+        // trigger a second insert, which would poison the shared DbContext change tracker.
+        var saved = isRetry
+            ? await UpsertExistingAsync(statement, accountSetting, itemCount, resultStatus, cancellationToken)
+            : await InsertNewAsync(statement, accountSetting, itemCount, resultStatus);
+
+        _logger.LogInformation("Processed statement {StatementId} with result: {Result}",
+            statement.StatementId, resultStatus);
+        return _mapper.Map<BankStatementImportDto>(saved);
     }
 
     private async Task<BankStatementImport> InsertNewAsync(

--- a/backend/src/Anela.Heblo.Domain/Features/Bank/IBankStatementImportRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Bank/IBankStatementImportRepository.cs
@@ -13,8 +13,8 @@ public interface IBankStatementImportRepository
     Task<BankStatementImport?> GetByIdAsync(int id);
     Task<BankStatementImport> AddAsync(BankStatementImport bankStatement);
 
-    Task<IReadOnlyDictionary<string, string>> GetExistingTransfersAsync(
-        string account, DateTime dateFrom, DateTime dateTo, CancellationToken cancellationToken = default);
+    Task<IReadOnlyDictionary<string, string>> GetExistingResultsByTransferIdsAsync(
+        IReadOnlyCollection<string> transferIds, CancellationToken cancellationToken = default);
 
     Task<DateTime?> GetMaxStatementDateAsync(string account, CancellationToken cancellationToken = default);
 

--- a/backend/src/Anela.Heblo.Persistence/Features/Bank/BankStatementImportRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Bank/BankStatementImportRepository.cs
@@ -83,19 +83,32 @@ public class BankStatementImportRepository : IBankStatementImportRepository
 
     public async Task<BankStatementImport> AddAsync(BankStatementImport bankStatement)
     {
-        _context.BankStatements.Add(bankStatement);
-        await _context.SaveChangesAsync();
+        var entry = _context.BankStatements.Add(bankStatement);
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            // A failed INSERT leaves the entity tracked as Added; detach it so it cannot
+            // be re-attempted by a later SaveChanges on the shared scoped DbContext.
+            entry.State = EntityState.Detached;
+            throw;
+        }
         return bankStatement;
     }
 
-    public async Task<IReadOnlyDictionary<string, string>> GetExistingTransfersAsync(
-        string account, DateTime dateFrom, DateTime dateTo, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyDictionary<string, string>> GetExistingResultsByTransferIdsAsync(
+        IReadOnlyCollection<string> transferIds, CancellationToken cancellationToken = default)
     {
+        if (transferIds.Count == 0)
+            return new Dictionary<string, string>();
+
+        // Dedup against the GLOBAL unique constraint (IX_BankStatements_TransferId), not by
+        // account/date, so a statement already stored under a different window is still detected.
         return await _context.BankStatements
             .AsNoTracking()
-            .Where(bs => bs.Account == account
-                && bs.StatementDate.Date >= dateFrom.Date
-                && bs.StatementDate.Date <= dateTo.Date)
+            .Where(bs => transferIds.Contains(bs.TransferId))
             .Select(bs => new { bs.TransferId, bs.ImportResult })
             .ToDictionaryAsync(x => x.TransferId, x => x.ImportResult, cancellationToken);
     }
@@ -113,8 +126,16 @@ public class BankStatementImportRepository : IBankStatementImportRepository
 
     public async Task<BankStatementImport> UpdateAsync(BankStatementImport bankStatement)
     {
-        _context.BankStatements.Update(bankStatement);
-        await _context.SaveChangesAsync();
+        var entry = _context.BankStatements.Update(bankStatement);
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            entry.State = EntityState.Detached;
+            throw;
+        }
         return bankStatement;
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportRepositoryIntegrationTests.cs
@@ -165,6 +165,42 @@ public class BankStatementImportRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task AddAsync_OnDuplicateTransferId_DetachesEntity_LeavingContextClean()
+    {
+        // Arrange - an existing row claims the TransferId.
+        await SeedAsync("DUP-1", "ShoptetPay-CZK");
+
+        var clashing = new BankStatementImport("DUP-1", DateTime.UtcNow);
+        clashing.Account = "ShoptetPay-CZK";
+        clashing.Currency = CurrencyCode.CZK;
+        var prop = typeof(BankStatementImport).GetProperty("ImportResult");
+        prop?.SetValue(clashing, "OK");
+
+        // Act - the insert violates IX_BankStatements_TransferId.
+        var act = async () => await _repository.AddAsync(clashing);
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        // Assert - the failed entity was detached, so a later save on the same context succeeds
+        // (it does NOT re-attempt the poisoned insert).
+        _context.Entry(clashing).State.Should().Be(EntityState.Detached);
+        var saved = await SeedAsync("CLEAN-1", "ShoptetPay-CZK");
+        saved.Id.Should().NotBe(0);
+    }
+
+    [Fact]
+    public async Task GetExistingResultsByTransferIdsAsync_MatchesByTransferId_AcrossAccounts()
+    {
+        await SeedAsync("A-1", "ShoptetPay-CZK", "OK");
+        await SeedAsync("B-1", "Comgate-EUR", $"{ImportStatus.ProcessingError}: x");
+
+        var map = await _repository.GetExistingResultsByTransferIdsAsync(new[] { "A-1", "B-1", "NOPE" });
+
+        map.Should().HaveCount(2);
+        map["A-1"].Should().Be("OK");
+        map["B-1"].Should().StartWith(ImportStatus.ProcessingError);
+    }
+
+    [Fact]
     public async Task GetFilteredAsync_TransferIdAndAccount_CombineWithAndSemantics()
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportRepositoryTests.cs
@@ -443,19 +443,33 @@ public class BankStatementImportRepositoryTests : IDisposable
     }
 
     [Fact]
-    public async Task GetExistingTransfersAsync_ReturnsTransferIdToResultMap_InRangeForAccount()
+    public async Task GetExistingResultsByTransferIdsAsync_MatchesByTransferId_IgnoringAccountAndDate()
     {
         await SeedAsync("OK1", "ComgateCZK", new DateTime(2026, 6, 10), ImportStatus.Success);
         await SeedAsync("ERR1", "ComgateCZK", new DateTime(2026, 6, 11), $"{ImportStatus.ProcessingError}: x");
-        await SeedAsync("OUT", "ComgateCZK", new DateTime(2026, 6, 20), ImportStatus.Success); // out of range
-        await SeedAsync("OTHER", "ComgateEUR", new DateTime(2026, 6, 10), ImportStatus.Success); // other account
+        // Stored under a different account and far outside any single import window - must still match.
+        await SeedAsync("OLD", "ComgateEUR", new DateTime(2025, 1, 1), ImportStatus.Success);
+        await SeedAsync("UNREQUESTED", "ComgateCZK", new DateTime(2026, 6, 10), ImportStatus.Success);
 
-        var map = await _repository.GetExistingTransfersAsync(
-            "ComgateCZK", new DateTime(2026, 6, 10), new DateTime(2026, 6, 12));
+        var map = await _repository.GetExistingResultsByTransferIdsAsync(
+            new[] { "OK1", "ERR1", "OLD", "MISSING" });
 
-        map.Should().HaveCount(2);
+        map.Should().HaveCount(3);
         map["OK1"].Should().Be(ImportStatus.Success);
         map["ERR1"].Should().StartWith(ImportStatus.ProcessingError);
+        map["OLD"].Should().Be(ImportStatus.Success);
+        map.Should().NotContainKey("UNREQUESTED");
+        map.Should().NotContainKey("MISSING");
+    }
+
+    [Fact]
+    public async Task GetExistingResultsByTransferIdsAsync_WithEmptyInput_ReturnsEmpty()
+    {
+        await SeedAsync("OK1", "ComgateCZK", new DateTime(2026, 6, 10), ImportStatus.Success);
+
+        var map = await _repository.GetExistingResultsByTransferIdsAsync(Array.Empty<string>());
+
+        map.Should().BeEmpty();
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
@@ -5,6 +5,7 @@ using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Shared;
 using AutoMapper;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -124,7 +125,7 @@ public class ImportBankStatementHandlerTests
             {
                 new BankStatementHeader { StatementId = "DONE", Date = from },
             });
-        _mockRepository.Setup(r => r.GetExistingTransfersAsync("ComgateCZK", from, to, It.IsAny<CancellationToken>()))
+        _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<string, string> { ["DONE"] = ImportStatus.Success });
 
         var response = await _handler.Handle(request, CancellationToken.None);
@@ -151,7 +152,7 @@ public class ImportBankStatementHandlerTests
             {
                 new BankStatementHeader { StatementId = "RETRY", Date = from },
             });
-        _mockRepository.Setup(r => r.GetExistingTransfersAsync("ComgateCZK", from, to, It.IsAny<CancellationToken>()))
+        _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<string, string> { ["RETRY"] = $"{ImportStatus.ProcessingError}: old" });
         _mockBankClient.Setup(x => x.GetStatementAsync("RETRY"))
             .ReturnsAsync(new BankStatementData { Data = "abo", ItemCount = 3 });
@@ -212,7 +213,7 @@ public class ImportBankStatementHandlerTests
             {
                 new BankStatementHeader { StatementId = "FAIL", Date = from },
             });
-        _mockRepository.Setup(r => r.GetExistingTransfersAsync("ComgateCZK", from, to, It.IsAny<CancellationToken>()))
+        _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<string, string>());
         _mockBankClient.Setup(x => x.GetStatementAsync("FAIL"))
             .ThrowsAsync(new Exception("bank unavailable"));
@@ -288,5 +289,79 @@ public class ImportBankStatementHandlerTests
         captured.LastValidImportDate.Should().BeNull();
         captured.LastErrorMessage.Should().Be("bank client unavailable");
         captured.ConsecutiveFailureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_CollapsesDuplicateStatementIdsInResponse_ProcessesOnce()
+    {
+        var from = new DateTime(2026, 6, 10);
+        var to = new DateTime(2026, 6, 10);
+        var request = new ImportBankStatementRequest("ComgateCZK", from, to);
+
+        // Bank returns the same StatementId twice in a single response.
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", from, to))
+            .ReturnsAsync(new List<BankStatementHeader>
+            {
+                new BankStatementHeader { StatementId = "DUP", Date = from },
+                new BankStatementHeader { StatementId = "DUP", Date = from },
+            });
+        _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        _mockBankClient.Setup(x => x.GetStatementAsync("DUP"))
+            .ReturnsAsync(new BankStatementData { Data = "abo", ItemCount = 1 });
+        _mockImportService.Setup(x => x.ImportStatementAsync(1, "abo"))
+            .ReturnsAsync(Result<bool>.Success(true));
+        _mockRepository.Setup(r => r.AddAsync(It.IsAny<BankStatementImport>()))
+            .ReturnsAsync((BankStatementImport b) => b);
+        _mockMapper.Setup(m => m.Map<Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto>(
+                It.IsAny<BankStatementImport>()))
+            .Returns(new Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto
+            {
+                TransferId = "DUP",
+                ImportResult = ImportStatus.Success,
+            });
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.SuccessCount.Should().Be(1);
+        _mockBankClient.Verify(x => x.GetStatementAsync("DUP"), Times.Once);
+        _mockRepository.Verify(r => r.AddAsync(It.IsAny<BankStatementImport>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotDoubleInsert_WhenPersistenceFails()
+    {
+        var from = new DateTime(2026, 6, 10);
+        var to = new DateTime(2026, 6, 10);
+        var request = new ImportBankStatementRequest("ComgateCZK", from, to);
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", from, to))
+            .ReturnsAsync(new List<BankStatementHeader>
+            {
+                new BankStatementHeader { StatementId = "X", Date = from },
+            });
+        _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        _mockBankClient.Setup(x => x.GetStatementAsync("X"))
+            .ReturnsAsync(new BankStatementData { Data = "abo", ItemCount = 2 });
+        _mockImportService.Setup(x => x.ImportStatementAsync(1, "abo"))
+            .ReturnsAsync(Result<bool>.Success(true));
+        // The INSERT fails (e.g. duplicate-key violation surfaced by the DB).
+        _mockRepository.Setup(r => r.AddAsync(It.IsAny<BankStatementImport>()))
+            .ThrowsAsync(new DbUpdateException("duplicate key", (Exception?)null));
+
+        BankImportState? captured = null;
+        _mockStateRepository
+            .Setup(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()))
+            .Callback<BankImportState, CancellationToken>((s, _) => captured = s);
+
+        await Assert.ThrowsAsync<DbUpdateException>(
+            () => _handler.Handle(request, CancellationToken.None));
+
+        // Persistence is attempted exactly once - the error path must not re-insert.
+        _mockRepository.Verify(r => r.AddAsync(It.IsAny<BankStatementImport>()), Times.Once);
+        // The failure is still recorded on the watermark state.
+        _mockStateRepository.Verify(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()), Times.Once);
+        captured!.LastRunStatus.Should().Be(BankImportState.StatusError);
     }
 }


### PR DESCRIPTION
## Problem

The Shoptet/Comgate bank-import jobs crashed with `23505: duplicate key value violates unique constraint "IX_BankStatements_TransferId"`, surfacing misleadingly at the watermark save in `BankImportStateRepository.UpsertAsync`.

## Root cause

Dedup was scoped to **account + statement-date range**, but the unique index is **global** on `TransferId` — so a statement already stored under a different window slipped past dedup and caused a duplicate INSERT; because the scoped `ApplicationDbContext` is shared across repos, the failed (still-`Added`) entity poisoned the next `SaveChanges` (the watermark upsert).

## Fix

Dedup now looks up the actual returned `TransferId`s globally (`GetExistingResultsByTransferIdsAsync`), duplicate `StatementId`s within one bank response are collapsed, each statement is persisted exactly once (bank/import errors no longer re-insert), and repositories detach entities on `DbUpdateException` so a failed save cannot corrupt a later one. Covered by new unit and Postgres-container integration tests (125 bank tests pass).