### PR TITLE
fix(photobank): store Photo timestamps without time zone

### DIFF
--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260624115315_AlignPhotoTimestampsWithoutTimeZone.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260624115315_AlignPhotoTimestampsWithoutTimeZone.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624115315_AlignPhotoTimestampsWithoutTimeZone")]
+    partial class AlignPhotoTimestampsWithoutTimeZone
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260624115315_AlignPhotoTimestampsWithoutTimeZone.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260624115315_AlignPhotoTimestampsWithoutTimeZone.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AlignPhotoTimestampsWithoutTimeZone : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Convert timestamptz -> timestamp (without time zone), interpreting the stored
+            // instant as UTC so the naive value matches the application's UTC convention
+            // regardless of the database session timezone.
+            migrationBuilder.Sql(
+                "ALTER TABLE public.\"Photos\" " +
+                "ALTER COLUMN \"TakenAt\" TYPE timestamp USING \"TakenAt\" AT TIME ZONE 'UTC';");
+
+            migrationBuilder.Sql(
+                "ALTER TABLE public.\"Photos\" " +
+                "ALTER COLUMN \"LastAutoTaggedAt\" TYPE timestamp USING \"LastAutoTaggedAt\" AT TIME ZONE 'UTC';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Revert to timestamptz, interpreting the naive timestamp as UTC.
+            migrationBuilder.Sql(
+                "ALTER TABLE public.\"Photos\" " +
+                "ALTER COLUMN \"TakenAt\" TYPE timestamp with time zone USING \"TakenAt\" AT TIME ZONE 'UTC';");
+
+            migrationBuilder.Sql(
+                "ALTER TABLE public.\"Photos\" " +
+                "ALTER COLUMN \"LastAutoTaggedAt\" TYPE timestamp with time zone USING \"LastAutoTaggedAt\" AT TIME ZONE 'UTC';");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Photobank/PhotoConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/PhotoConfiguration.cs
@@ -20,6 +20,8 @@ namespace Anela.Heblo.Persistence.Photobank
             builder.Property(x => x.MimeType).HasMaxLength(50);
             builder.Property(x => x.IndexedAt).IsRequired().AsUtcTimestamp();
             builder.Property(x => x.ModifiedAt).IsRequired().AsUtcTimestamp();
+            builder.Property(x => x.TakenAt).AsUtcTimestamp();
+            builder.Property(x => x.LastAutoTaggedAt).AsUtcTimestamp();
             builder.HasIndex(x => x.FolderPath).HasDatabaseName("IX_Photos_FolderPath");
             builder.HasMany(x => x.Tags)
                 .WithOne(x => x.Photo)

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotoSchemaTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotoSchemaTests.cs
@@ -1,0 +1,44 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+// Regression guard for the photobank-auto-tag job failure:
+// "Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone'".
+// The global DbContext convention forces DateTime values to Kind=Unspecified, which is only
+// valid for 'timestamp without time zone' columns. Every Photo DateTime column must therefore
+// be mapped to 'timestamp' (without time zone) via AsUtcTimestamp(), or writes throw at runtime.
+public class PhotoSchemaTests
+{
+    private static ApplicationDbContext NewNpgsqlContext()
+    {
+        // Npgsql provider so relational column-type metadata resolves; no connection is opened
+        // because only the model is inspected.
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql("Host=localhost;Database=schema_inspection")
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    [Theory]
+    [InlineData(nameof(Photo.IndexedAt))]
+    [InlineData(nameof(Photo.ModifiedAt))]
+    [InlineData(nameof(Photo.TakenAt))]
+    [InlineData(nameof(Photo.LastAutoTaggedAt))]
+    public void Photo_DateTimeColumns_AreTimestampWithoutTimeZone(string propertyName)
+    {
+        using var db = NewNpgsqlContext();
+
+        var property = db.Model
+            .FindEntityType(typeof(Photo))!
+            .FindProperty(propertyName)!;
+
+        property.GetColumnType().Should().Be(
+            "timestamp",
+            $"{propertyName} stores UTC and must map to 'timestamp without time zone' to match the " +
+            "global UTC->Unspecified converter; 'timestamp with time zone' rejects Unspecified writes");
+    }
+}


### PR DESCRIPTION
The `photobank-auto-tag` job crashed writing `LastAutoTaggedAt` with *"Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone'"*, because the global DbContext convention forces every DateTime to `Kind=Unspecified` (valid only for `timestamp without time zone`), yet `LastAutoTaggedAt` and `TakenAt` were never opted into that column type via `AsUtcTimestamp()` and defaulted to `timestamptz`. This maps both columns to `timestamp` (without time zone) and adds a UTC-preserving migration to alter the existing columns. A new schema regression test guards that all `Photo` DateTime columns map to `timestamp`.

**Note:** migrations are applied manually in this project — apply `AlignPhotoTimestampsWithoutTimeZone` to each target database.