### PR TITLE
#3331: fix Analytics exception leakage in error responses

### DIFF
--- a/artifacts/feat-3331/arch-review.r1.md
+++ b/artifacts/feat-3331/arch-review.r1.md
@@ -1,0 +1,193 @@
+# Architecture Review: Analytics – Remove Internal Exception Messages from Error Responses
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change aligns directly with the established handler pattern used throughout the codebase. The rest of the application — `GetDqtRunDetailHandler`, `GetDqtRunsHandler`, `RunDqtHandler`, and many others — already follows the correct pattern: inject `ILogger<T>` via constructor, call `_logger.LogError(ex, "…")` in the catch block, and return an error response containing only an `ErrorCode` with no exception text in `Params`.
+
+The three affected files are outliers that were written without the logger and incorrectly forwarded `ex.Message` into the response payload. No architectural change is needed — this is a conformance fix that brings three files into alignment with a pattern that already exists everywhere else.
+
+The only structural difference worth noting: `InvoiceImportStatisticsTile` returns an anonymous `object` (the `ITile.LoadDataAsync` contract returns `Task<object>`) rather than a `BaseResponse`-derived type, so it cannot use the shared `CreateErrorResponse` helper. The fix for that file is narrower — remove the `details` property from the anonymous error object. This difference is already captured in the spec and requires no further accommodation.
+
+Integration points:
+- `Microsoft.Extensions.Logging.ILogger<T>` — already a transitive dependency of the host; no new package references.
+- `ErrorCodes.InternalServerError` (value `0010`, HTTP 500) — already defined in `Shared/ErrorCodes.cs` and used by both handlers. The spec requires this value to be preserved.
+- `CreateErrorResponse(ErrorCodes errorCode, params (string key, string value)[] parameters)` — private static helper in both handler classes. Its `params` signature makes extra arguments optional; no signature change is needed.
+- `BaseResponse.Params` — `Dictionary<string, string>?`; already nullable; passing no extra parameters causes it to serialize as `null`, which is the desired after-state.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+GetMarginReportHandler
+  + ILogger<GetMarginReportHandler> _logger   [ADD]
+  catch (Exception ex)
+    - was: CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message))
+    + now: _logger.LogError(ex, "Unhandled exception in GetMarginReportHandler")
+            CreateErrorResponse(ErrorCodes.InternalServerError)
+
+GetProductMarginAnalysisHandler
+  + ILogger<GetProductMarginAnalysisHandler> _logger   [ADD]
+  catch (Exception ex)
+    - was: CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message))
+    + now: _logger.LogError(ex, "Unhandled exception in GetProductMarginAnalysisHandler")
+            CreateErrorResponse(ErrorCodes.InternalServerError)
+
+InvoiceImportStatisticsTile
+  + ILogger<InvoiceImportStatisticsTile> _logger   [ADD]
+  catch (Exception ex)
+    - was: new { status = "error", error = "...", details = ex.Message }
+    + now: _logger.LogError(ex, "Unhandled exception in InvoiceImportStatisticsTile")
+            new { status = "error", error = "Nepodařilo se načíst statistiky importu faktur" }
+```
+
+All three changes are leaf-level within their respective files. No callers, no shared infrastructure, no DI registrations are touched.
+
+### Key Design Decisions
+
+#### Decision 1: Preserve ErrorCodes.InternalServerError (not ErrorCodes.Exception)
+
+**Options considered:**
+- Keep `ErrorCodes.InternalServerError` (value `0010`) as currently used in the two handlers.
+- Switch to `ErrorCodes.Exception` (value `0099`) to match the DataQuality handler pattern (`GetDqtRunDetailHandler`, `GetDqtRunsHandler`).
+
+**Chosen approach:** Preserve `ErrorCodes.InternalServerError`. Do not change the error code value.
+
+**Rationale:** The spec explicitly states the `ErrorCode` value must not change (NFR-1, Out of Scope section). The frontend may already interpret `0010` vs `0099` differently. This fix is about removing information leakage, not normalising error codes. A separate clean-up could unify error codes later, but it is out of scope here.
+
+#### Decision 2: No change to CreateErrorResponse helper signature
+
+**Options considered:**
+- Remove the `params (string key, string value)[] parameters` parameter from the private `CreateErrorResponse` helper since it will no longer be called with extra params.
+- Leave the signature unchanged.
+
+**Chosen approach:** Leave the helper signature unchanged.
+
+**Rationale:** `CreateErrorResponse` is called with legitimate `Params` in the non-exception error paths (e.g., `AnalysisDataNotAvailable` with product/period context, `ProductNotFoundForAnalysis` with productId). Removing the parameter would require changing those call sites, which is outside the scope of this fix.
+
+#### Decision 3: No change to InvoiceImportStatisticsTile response shape beyond removing details
+
+**Options considered:**
+- Convert `InvoiceImportStatisticsTile` to use a typed `BaseResponse`-derived class for error cases.
+- Only remove the `details` property from the existing anonymous object.
+
+**Chosen approach:** Remove only the `details` property. Keep the anonymous object pattern.
+
+**Rationale:** Switching to `BaseResponse` would change the serialised response shape seen by the frontend and is explicitly listed as out of scope. The `ITile` contract returns `Task<object>`, so anonymous objects are an accepted pattern in this location.
+
+#### Decision 4: Log message template
+
+**Options considered:**
+- Generic message: `"Unhandled exception in {HandlerName}"` with a string literal for the handler name.
+- Contextual message: include request parameters (e.g., product ID, date range) in the log template.
+
+**Chosen approach:** Use a simple literal string with the class name embedded, following the brevity of `GetDqtRunsHandler` (`"Error getting DQT runs"`). No request parameters in the message template.
+
+**Rationale:** Structured context (product ID, date range) is already available in the request object. Adding it would require non-trivial changes to capture request state in the catch block. The exception object itself — passed as the first argument to `LogError` — already carries the full stack trace and exception type, which is sufficient for diagnosis. Keep the change minimal.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Changes are confined to three existing files:
+
+```
+backend/src/Anela.Heblo.Application/Features/Analytics/
+  UseCases/GetMarginReport/GetMarginReportHandler.cs          [MODIFY]
+  UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs  [MODIFY]
+  DashboardTiles/InvoiceImportStatisticsTile.cs               [MODIFY]
+```
+
+### Interfaces and Contracts
+
+**ILogger<T> injection pattern** — copy exactly from `GetDqtRunDetailHandler`:
+
+```csharp
+// Field
+private readonly ILogger<T> _logger;
+
+// Constructor parameter (appended after existing parameters)
+ILogger<T> logger
+
+// Assignment in constructor body
+_logger = logger;
+```
+
+The `using Microsoft.Extensions.Logging;` directive must be added to the using block of all three files (currently absent from all three).
+
+**Logging call in catch block:**
+
+```csharp
+_logger.LogError(ex, "Unhandled exception in GetMarginReportHandler");
+```
+
+The exception object is the first argument. The message string is a literal — no interpolation, no structured properties beyond what the exception itself carries.
+
+**GetMarginReportHandler and GetProductMarginAnalysisHandler — catch block after:**
+
+```csharp
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Unhandled exception in GetMarginReportHandler");
+    return CreateErrorResponse(ErrorCodes.InternalServerError);
+}
+```
+
+**InvoiceImportStatisticsTile — catch block after:**
+
+```csharp
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Unhandled exception in InvoiceImportStatisticsTile");
+    return new
+    {
+        status = "error",
+        error = "Nepodařilo se načíst statistiky importu faktur"
+    };
+}
+```
+
+### Data Flow
+
+**Before (error path):**
+```
+Exception thrown in repository/service
+  → caught in handler catch block
+  → ex.Message copied into Params dictionary / anonymous object
+  → serialised JSON includes "details": "<raw exception text>"
+  → returned to browser client
+  → no server-side log entry
+```
+
+**After (error path):**
+```
+Exception thrown in repository/service
+  → caught in handler catch block
+  → _logger.LogError(ex, "...") writes full exception to structured log (Azure Monitor)
+  → response created with ErrorCode only, no exception text
+  → serialised JSON: { "success": false, "errorCode": 10, "params": null }
+  → returned to browser client
+```
+
+The success path is completely unchanged in all three files.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Frontend currently reads `params.details` to display diagnostic text to the user | Low | The spec states `params` is already nullable in `BaseResponse` and the frontend must handle the null case. Verify by grep for `params?.details` or `params.details` in frontend code before merging. |
+| `BaseResponse(Exception ex)` constructor (line 44–53 of `BaseResponse.cs`) also leaks `ex.Message` via `Params["ErrorMessage"]` | Medium | This constructor is not called by the three affected files and is explicitly out of scope. It should be addressed as a follow-up. Document as a known issue. |
+| ILogger<T> constructor parameter order breaks an existing test that manually constructs the handler | Low | Check for unit tests that `new` the handler directly. If any exist, add the logger parameter using `NullLogger<T>.Instance`. |
+| Silent regression: `ErrorCodes.InternalServerError` vs `ErrorCodes.Exception` | Low | No change to error code values in this fix; no regression possible on that axis. |
+
+## Specification Amendments
+
+None. The spec is complete and accurate. One observation to carry forward as a separate issue (not blocking this fix):
+
+- `BaseResponse(Exception ex)` constructor at `Shared/BaseResponse.cs` lines 44–53 places `ex.Message` and `ex.ToString()` into `Params["ErrorMessage"]` and `Params["ExceptionType"]`. No handler in the three affected files calls this constructor, but other handlers in the codebase might. This should be audited in a follow-up task.
+
+## Prerequisites
+
+None. All required types (`ILogger<T>`, `ErrorCodes.InternalServerError`, `CreateErrorResponse`) already exist. No migrations, no config changes, no new NuGet packages, no DI registration changes are required. Implementation can start immediately.

--- a/artifacts/feat-3331/brief.md
+++ b/artifacts/feat-3331/brief.md
@@ -1,0 +1,33 @@
+## Module
+Analytics
+
+## Finding
+Three locations catch `Exception` and include `ex.Message` verbatim in the response payload returned to callers:
+
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs:74`
+  ```csharp
+  catch (Exception ex)
+  {
+      return CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message));
+  }
+  ```
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs:61–63` — identical pattern
+- `backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs:87`
+  ```csharp
+  catch (Exception ex)
+  {
+      return new { status = "error", error = "...", details = ex.Message };
+  }
+  ```
+
+## Why it matters
+`ex.Message` from unhandled infrastructure exceptions regularly contains sensitive internal detail: PostgreSQL connection strings, EF Core query text, stack-frame snippets from Npgsql, internal type names, file paths. Forwarding this to authenticated browser clients violates OWASP A05 (Security Misconfiguration / information leakage). It also couples the frontend contract to internal error text that changes between library versions.
+
+## Suggested fix
+- Log the full exception server-side (structured logging — `ILogger.LogError(ex, "...")`)
+- Return a fixed, opaque string (e.g. `"An unexpected error occurred."`) or no `details` field at all
+- Remove the `("details", ex.Message)` parameter from `CreateErrorResponse` at all three call sites
+- The `ErrorCodes.InternalServerError` value and `Params` dictionary remain; only the `ex.Message` string is removed
+
+---
+_Filed by daily arch-review routine on 2026-06-24._

--- a/artifacts/feat-3331/code-review.r1.md
+++ b/artifacts/feat-3331/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3331/design.r1.md
+++ b/artifacts/feat-3331/design.r1.md
@@ -1,0 +1,66 @@
+# Design: Analytics – Remove Internal Exception Messages from Error Responses
+
+## Component Design
+
+### Affected handlers and tiles
+
+Three files require identical structural changes: inject `ILogger<T>`, add a `using Microsoft.Extensions.Logging;` directive, and replace the leaking catch block with a logging call followed by an opaque error return.
+
+**GetMarginReportHandler**
+Path: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+
+- Add constructor parameter `ILogger<GetMarginReportHandler> logger`; assign to `_logger`.
+- In `catch (Exception ex)`: call `_logger.LogError(ex, "Unhandled exception in GetMarginReportHandler")`, then return `CreateErrorResponse(ErrorCodes.InternalServerError)` with no additional parameters.
+
+**GetProductMarginAnalysisHandler**
+Path: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`
+
+- Same injection and catch-block change as above; log message: `"Unhandled exception in GetProductMarginAnalysisHandler"`.
+
+**InvoiceImportStatisticsTile**
+Path: `backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs`
+
+- Same injection pattern.
+- In `catch (Exception ex)`: call `_logger.LogError(ex, "Unhandled exception in InvoiceImportStatisticsTile")`, then return `new { status = "error", error = "Nepodařilo se načíst statistiky importu faktur" }` — omitting the `details` property entirely.
+
+### Unchanged components
+
+- `CreateErrorResponse` helper — signature unchanged; the call simply drops the `("details", ex.Message)` argument tuple.
+- `BaseResponse` / `GetMarginReportResponse` / `GetProductMarginAnalysisResponse` — no changes.
+- `ErrorCodes.InternalServerError` — no changes.
+
+## Data Schemas
+
+No database or domain model changes.
+
+### API response shapes (error case only)
+
+**GetMarginReport and GetProductMarginAnalysis endpoints**
+
+Before:
+```json
+{ "success": false, "errorCode": 10, "params": { "details": "<raw exception text>" } }
+```
+
+After:
+```json
+{ "success": false, "errorCode": 10, "params": null }
+```
+
+**InvoiceImportStatisticsTile data**
+
+Before:
+```json
+{ "status": "error", "error": "Nepodařilo se načíst statistiky importu faktur", "details": "<raw exception text>" }
+```
+
+After:
+```json
+{ "status": "error", "error": "Nepodařilo se načíst statistiky importu faktur" }
+```
+
+### Structured log entry (all three sites)
+
+Level: `LogError`
+Template: `"Unhandled exception in {HandlerName}"` (class name substituted per site)
+Exception object passed as first argument so stack trace is captured by the logging provider.

--- a/artifacts/feat-3331/impl/fix-exception-leakage.r1.md
+++ b/artifacts/feat-3331/impl/fix-exception-leakage.r1.md
@@ -1,0 +1,48 @@
+# Implementation: fix-exception-leakage
+
+## What was implemented
+
+Removed `ex.Message` from API error responses in three Analytics handlers to prevent leakage of internal details (PostgreSQL connection strings, EF Core queries, etc.). Added `ILogger<T>` injection to each handler so exceptions are still logged server-side. Updated unit tests to pass the new logger dependency and corrected assertions that expected the removed `"details"` param.
+
+## Files created/modified
+
+**Production code:**
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs` — added `ILogger<GetMarginReportHandler>` field + constructor param; catch block now calls `_logger.LogError(ex, ...)` and returns `CreateErrorResponse(ErrorCodes.InternalServerError)` with no params
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs` — same pattern as above for `GetProductMarginAnalysisHandler`
+- `backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs` — added `ILogger<InvoiceImportStatisticsTile>` field + constructor param; catch block now calls `_logger.LogError(ex, ...)` and returns anonymous object without `details` field
+
+**Test code (constructor and assertion fixes):**
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs` — pass `NullLogger<GetMarginReportHandler>.Instance`; removed `.Params.Should().ContainKey("details")` assertion from `Handle_RepositoryException_ReturnsInternalServerError`
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs` — same as above for `GetProductMarginAnalysisHandler`
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTileTests.cs` — pass `NullLogger<InvoiceImportStatisticsTile>.Instance` to constructor
+
+## Tests
+
+Existing unit tests cover all three handlers including the exception path (`Handle_RepositoryException_ReturnsInternalServerError`). Those tests were updated to reflect the behaviour change (no `"details"` key in params). No new tests written — this is a pure security refactor with no logic change.
+
+## How to verify
+
+1. `dotnet build Anela.Heblo.sln` — must succeed (confirmed: Build succeeded)
+2. `dotnet format Anela.Heblo.sln --verify-no-changes` — must produce no output (confirmed: clean)
+3. Trigger an exception in a dev/staging environment and confirm the API response body contains only `ErrorCode: InternalServerError` with no `details` field, while the application log contains the full exception.
+
+## Notes
+
+- `CreateErrorResponse` uses `params (string key, string value)[] parameters` so calling it with zero args is valid — no overload needed.
+- `NullLogger<T>.Instance` is the standard .NET testing pattern; no extra test dependency required (it's in `Microsoft.Extensions.Logging.Abstractions` which is already transitively referenced).
+- The task description said to modify only 3 files, but the 3 corresponding test files also needed updating to compile. All 6 files are in scope of this fix.
+
+## PR Summary
+
+Fixes a security issue where three Analytics handlers leaked internal exception details (`ex.Message`) in API responses, potentially exposing PostgreSQL connection strings and EF Core query text. ILogger is now injected into each handler; exceptions are logged server-side and a generic `InternalServerError` code is returned to the client.
+
+### Changes
+- `GetMarginReportHandler.cs` — inject ILogger, log exception, remove ex.Message from response
+- `GetProductMarginAnalysisHandler.cs` — inject ILogger, log exception, remove ex.Message from response
+- `InvoiceImportStatisticsTile.cs` — inject ILogger, log exception, remove details field from error response
+- `GetMarginReportHandlerTests.cs` — pass NullLogger; fix assertion
+- `GetProductMarginAnalysisHandlerTests.cs` — pass NullLogger; fix assertion
+- `InvoiceImportStatisticsTileTests.cs` — pass NullLogger to constructor
+
+## Status
+DONE

--- a/artifacts/feat-3331/review/fix-exception-leakage.r1.md
+++ b/artifacts/feat-3331/review/fix-exception-leakage.r1.md
@@ -1,0 +1,23 @@
+# Code Review: fix-exception-leakage
+
+## Summary
+
+All three production files were correctly modified: `ILogger<T>` is injected via constructor, `ex.Message` is removed from all three error response paths, and `_logger.LogError(ex, "...")` replaces it. The three corresponding test files were also correctly updated to pass `NullLogger<T>.Instance` and to remove the now-invalid `ContainKey("details")` assertion. Build and format both pass. This is a clean, minimal, spec-compliant fix.
+
+## Review Result: PASS
+
+### task: fix-exception-leakage
+**Status:** PASS
+
+All acceptance criteria are met:
+- `using Microsoft.Extensions.Logging;` added to all three files.
+- `private readonly ILogger<T> _logger;` field and constructor injection added to all three classes.
+- `("details", ex.Message)` removed from `CreateErrorResponse` calls in `GetMarginReportHandler` and `GetProductMarginAnalysisHandler`.
+- `details = ex.Message` removed from the anonymous error object in `InvoiceImportStatisticsTile`.
+- `_logger.LogError(ex, "Unhandled exception in {ClassName}")` added to all three catch blocks.
+- `dotnet build` passes. `dotnet format --verify-no-changes` passes.
+- Test files updated: `NullLogger<T>.Instance` passed to constructors; `ContainKey("details")` assertions removed.
+
+## Overall Notes
+
+The reviewer's initial read targeted the wrong path (main checkout instead of the worktree). Direct verification in the worktree confirms all changes are present and correct. No revision needed.

--- a/artifacts/feat-3331/spec.r1.md
+++ b/artifacts/feat-3331/spec.r1.md
@@ -1,0 +1,143 @@
+# Specification: Analytics – Remove Internal Exception Messages from Error Responses
+
+## Summary
+
+Three catch blocks in the Analytics module forward raw `ex.Message` strings into API response payloads sent to browser clients. This exposes internal infrastructure details (PostgreSQL connection strings, EF Core query text, Npgsql stack frames, file paths) to authenticated users, violating OWASP A05. The fix logs the full exception server-side using structured logging and replaces the client-facing payload with an opaque error code, matching the pattern already established in the rest of the codebase.
+
+## Background
+
+The Analytics module contains three catch blocks that pass `ex.Message` verbatim into the response body:
+
+1. `GetMarginReportHandler` (line 74) — uses the shared `CreateErrorResponse` helper with a `("details", ex.Message)` parameter tuple, producing `Params["details"] = <raw exception text>` in a `GetMarginReportResponse : BaseResponse`.
+2. `GetProductMarginAnalysisHandler` (lines 61–63) — identical pattern, same helper method, same `BaseResponse`-derived type.
+3. `InvoiceImportStatisticsTile` (line 74) — returns an anonymous `object` with a `details = ex.Message` property directly (this tile does not use `BaseResponse`).
+
+None of these three files inject `ILogger`, so no server-side record of the failure currently exists.
+
+The remainder of the application already follows the correct pattern, exemplified by `GetDqtRunDetailHandler`: inject `ILogger<T>`, call `_logger.LogError(ex, "…")` in the catch block, and return `ErrorCode = ErrorCodes.Exception` with no exception text in `Params`.
+
+## Functional Requirements
+
+### FR-1: Remove ex.Message from GetMarginReportHandler error response
+
+Remove the `("details", ex.Message)` argument from the `CreateErrorResponse` call in the `catch (Exception ex)` block (line 74). The call must remain `CreateErrorResponse(ErrorCodes.InternalServerError)` with no extra parameters, so `Params` is null or empty in the serialised response.
+
+**Acceptance criteria:**
+- The serialised JSON response for an unhandled exception no longer contains a `"details"` key or any `"params"` entry sourced from `ex.Message`.
+- `ErrorCode` in the response is `ErrorCodes.InternalServerError` (value 10).
+- A structured log entry at `LogError` level is written, including the full exception object as the first argument.
+- The log message template includes enough context to identify the failing handler (e.g., `"Unhandled exception in GetMarginReportHandler"`).
+
+### FR-2: Remove ex.Message from GetProductMarginAnalysisHandler error response
+
+Apply the same change to `GetProductMarginAnalysisHandler` (lines 61–63).
+
+**Acceptance criteria:**
+- Identical criteria to FR-1, with `GetProductMarginAnalysisHandler` as the handler name in the log message.
+- The `("details", ex.Message)` parameter tuple is removed from `CreateErrorResponse`.
+
+### FR-3: Remove ex.Message from InvoiceImportStatisticsTile error response
+
+Replace the anonymous object `new { status = "error", error = "...", details = ex.Message }` with an anonymous object that omits the `details` field entirely. The `error` field (localised Czech string `"Nepodařilo se načíst statistiky importu faktur"`) must be retained, as it is user-facing and does not originate from the exception.
+
+**Acceptance criteria:**
+- The serialised JSON response for an unhandled exception contains `status = "error"` and `error = "Nepodařilo se načíst statistiky importu faktur"` but does not contain a `details` key.
+- A structured log entry at `LogError` level is written, including the full exception object as the first argument.
+- The log message template identifies the tile (e.g., `"Unhandled exception in InvoiceImportStatisticsTile"`).
+
+### FR-4: Add ILogger injection to the three affected classes
+
+All three classes currently lack `ILogger`. Each must receive `ILogger<T>` (where `T` is the class) via constructor injection, following the existing pattern seen throughout the codebase.
+
+**Acceptance criteria:**
+- Each class declares a `private readonly ILogger<T> _logger` field.
+- The constructor accepts `ILogger<T> logger` and assigns it.
+- No changes to the DI registration are required (ASP.NET Core's built-in container resolves `ILogger<T>` automatically).
+
+## Non-Functional Requirements
+
+### NFR-1: No functional regression
+
+The fix is purely defensive; it must not alter the HTTP status code, the `ErrorCode` value, or any other field in the success path.
+
+**Acceptance criteria:**
+- `dotnet build` passes without warnings in the Analytics feature folder.
+- All existing unit/integration tests for the three affected handlers pass unchanged.
+
+### NFR-2: Consistency with existing error-handling pattern
+
+The resulting code must be indistinguishable in structure from the established pattern in handlers such as `GetDqtRunDetailHandler`, `GetDqtRunsHandler`, and `RunDqtHandler`.
+
+### NFR-3: Security
+
+After the change, no infrastructure exception text must appear in any field of the HTTP response body for the three affected endpoints/tiles, under any failure mode reachable via the `catch (Exception ex)` block.
+
+## Data Model
+
+No data model changes. The existing `BaseResponse.Params` dictionary remains; it simply must not be populated with exception text. `InvoiceImportStatisticsTile` returns an anonymous object; its shape changes only by removing the `details` property.
+
+## API / Interface Design
+
+### GetMarginReport endpoint
+
+**Before (error case):**
+```json
+{
+  "success": false,
+  "errorCode": 10,
+  "params": { "details": "<raw PostgreSQL / EF exception text>" }
+}
+```
+
+**After (error case):**
+```json
+{
+  "success": false,
+  "errorCode": 10,
+  "params": null
+}
+```
+
+### GetProductMarginAnalysis endpoint
+
+Same before/after shape as GetMarginReport.
+
+### InvoiceImportStatisticsTile data
+
+**Before (error case):**
+```json
+{
+  "status": "error",
+  "error": "Nepodařilo se načíst statistiky importu faktur",
+  "details": "<raw exception text>"
+}
+```
+
+**After (error case):**
+```json
+{
+  "status": "error",
+  "error": "Nepodařilo se načíst statistiky importu faktur"
+}
+```
+
+## Dependencies
+
+- `Microsoft.Extensions.Logging.ILogger<T>` — already a transitive dependency via the host; no new NuGet packages required.
+- The existing `ErrorCodes.InternalServerError` enum member — already defined (`= 0010`).
+- `CreateErrorResponse` private helper in both handlers — signature already accepts zero extra parameters (the `params` keyword makes them optional); no signature change is needed.
+
+## Out of Scope
+
+- Changes to any other catch block outside the three files named in the brief.
+- Frontend changes — the frontend must already handle the `errorCode`-only response gracefully (the `params` field is nullable in `BaseResponse`). If the frontend currently reads `params.details` to display a message, that is a separate issue outside this fix.
+- Adding a correlation-ID or request-ID to the response envelope.
+- Switching `InvoiceImportStatisticsTile` from anonymous objects to a typed `BaseResponse` subclass — that would be a broader refactor outside the stated scope.
+- Changing the `ErrorCodes.InternalServerError` value used by these handlers; the brief explicitly states it should remain.
+- `BaseResponse(Exception ex)` constructor (lines 44–53 of `BaseResponse.cs`) — this constructor also places `ex.Message` in `Params["ErrorMessage"]`, but it is not called by any of the three affected files and is outside the scope of this fix.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-25T05:22:30.336701Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T05:23:20.231177Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T05:33:45.784119Z"
     }
   },
   "tasks": [
     {
       "name": "fix-exception-leakage",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T05:23:20.454528Z"
+      "updated_at": "2026-06-25T05:33:45.583739Z"
     }
   ]
 }

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-06-25T05:21:30.463931Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T05:21:30.656696Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T05:22:30.336701Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-exception-leakage",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-06-25T05:17:17.468375Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T05:17:22.980813Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T05:20:12.926732Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T05:20:19.309584Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-06-25T05:20:12.926732Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T05:20:19.309584Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T05:21:30.463931Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T05:21:30.656696Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-25T05:22:30.336701Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T05:23:20.231177Z"
     }
   },
   "tasks": [
     {
       "name": "fix-exception-leakage",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T05:23:20.454528Z"
     }
   ]
 }

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T05:15:11.013082Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T05:17:17.468375Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T05:17:22.980813Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-06-25T05:33:45.784119Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-25T05:33:59.357505Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3331/state.json
+++ b/artifacts/feat-3331/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3331",
+  "issue_number": 3331,
+  "created_at": "2026-06-25T05:14:42.044957Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-25T05:15:11.013082Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3331/task-context/fix-exception-leakage.md
+++ b/artifacts/feat-3331/task-context/fix-exception-leakage.md
@@ -1,0 +1,49 @@
+# Task Plan: Analytics – Remove Internal Exception Messages from Error Responses
+
+## Overview
+
+Three catch blocks in the Analytics module expose raw `ex.Message` strings in API response payloads. This task injects `ILogger<T>` into each of the three affected classes, logs the exception server-side, and removes the exception message from the response.
+
+## Tasks
+
+### task: fix-exception-leakage
+
+**Goal**
+Fix the three catch blocks that expose `ex.Message` in API responses.
+
+**Files to modify**
+1. `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+2. `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`
+3. `backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs`
+
+**Changes per file**
+
+For GetMarginReportHandler and GetProductMarginAnalysisHandler:
+1. Add `using Microsoft.Extensions.Logging;` to the using block.
+2. Add `private readonly ILogger<T> _logger;` field (where T is the handler class).
+3. Add `ILogger<T> logger` as constructor parameter and assign `_logger = logger;` in the constructor body.
+4. In the `catch (Exception ex)` block: replace
+   `return CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message));`
+   with:
+   ```csharp
+   _logger.LogError(ex, "Unhandled exception in {HandlerName}");
+   return CreateErrorResponse(ErrorCodes.InternalServerError);
+   ```
+   (substitute the actual class name for {HandlerName})
+
+For InvoiceImportStatisticsTile:
+1. Add `using Microsoft.Extensions.Logging;` to the using block.
+2. Add `private readonly ILogger<InvoiceImportStatisticsTile> _logger;` field.
+3. Add `ILogger<InvoiceImportStatisticsTile> logger` as constructor parameter and assign.
+4. In the `catch (Exception ex)` block: replace
+   `return new { status = "error", error = "Nepodařilo se načíst statistiky importu faktur", details = ex.Message };`
+   with:
+   ```csharp
+   _logger.LogError(ex, "Unhandled exception in InvoiceImportStatisticsTile");
+   return new { status = "error", error = "Nepodařilo se načíst statistiky importu faktur" };
+   ```
+
+**Verification**
+- Run `dotnet build` from `backend/` — must succeed with no errors.
+- Run `dotnet format --verify-no-changes` or `dotnet format` to check formatting.
+- No other files should be modified.

--- a/artifacts/feat-3331/task-plan.r1.md
+++ b/artifacts/feat-3331/task-plan.r1.md
@@ -1,0 +1,49 @@
+# Task Plan: Analytics – Remove Internal Exception Messages from Error Responses
+
+## Overview
+
+Three catch blocks in the Analytics module expose raw `ex.Message` strings in API response payloads. This task injects `ILogger<T>` into each of the three affected classes, logs the exception server-side, and removes the exception message from the response.
+
+## Tasks
+
+### task: fix-exception-leakage
+
+**Goal**
+Fix the three catch blocks that expose `ex.Message` in API responses.
+
+**Files to modify**
+1. `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+2. `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`
+3. `backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs`
+
+**Changes per file**
+
+For GetMarginReportHandler and GetProductMarginAnalysisHandler:
+1. Add `using Microsoft.Extensions.Logging;` to the using block.
+2. Add `private readonly ILogger<T> _logger;` field (where T is the handler class).
+3. Add `ILogger<T> logger` as constructor parameter and assign `_logger = logger;` in the constructor body.
+4. In the `catch (Exception ex)` block: replace
+   `return CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message));`
+   with:
+   ```csharp
+   _logger.LogError(ex, "Unhandled exception in {HandlerName}");
+   return CreateErrorResponse(ErrorCodes.InternalServerError);
+   ```
+   (substitute the actual class name for {HandlerName})
+
+For InvoiceImportStatisticsTile:
+1. Add `using Microsoft.Extensions.Logging;` to the using block.
+2. Add `private readonly ILogger<InvoiceImportStatisticsTile> _logger;` field.
+3. Add `ILogger<InvoiceImportStatisticsTile> logger` as constructor parameter and assign.
+4. In the `catch (Exception ex)` block: replace
+   `return new { status = "error", error = "Nepodařilo se načíst statistiky importu faktur", details = ex.Message };`
+   with:
+   ```csharp
+   _logger.LogError(ex, "Unhandled exception in InvoiceImportStatisticsTile");
+   return new { status = "error", error = "Nepodařilo se načíst statistiky importu faktur" };
+   ```
+
+**Verification**
+- Run `dotnet build` from `backend/` — must succeed with no errors.
+- Run `dotnet format --verify-no-changes` or `dotnet format` to check formatting.
+- No other files should be modified.

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Domain.Features.Analytics;
 using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.Analytics.DashboardTiles;
 
@@ -8,6 +9,7 @@ public class InvoiceImportStatisticsTile : ITile
 {
     private readonly IAnalyticsRepository _analyticsRepository;
     private readonly TimeProvider _timeProvider;
+    private readonly ILogger<InvoiceImportStatisticsTile> _logger;
 
     public string Title => "Faktury importované včera";
     public string Description => "Počet faktur naimportovaných včera";
@@ -19,10 +21,12 @@ public class InvoiceImportStatisticsTile : ITile
 
     public InvoiceImportStatisticsTile(
         IAnalyticsRepository analyticsRepository,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ILogger<InvoiceImportStatisticsTile> logger)
     {
         _analyticsRepository = analyticsRepository;
         _timeProvider = timeProvider;
+        _logger = logger;
     }
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
@@ -79,11 +83,11 @@ public class InvoiceImportStatisticsTile : ITile
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Unhandled exception in InvoiceImportStatisticsTile");
             return new
             {
                 status = "error",
-                error = "Nepodařilo se načíst statistiky importu faktur",
-                details = ex.Message
+                error = "Nepodařilo se načíst statistiky importu faktur"
             };
         }
     }

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs
@@ -4,6 +4,7 @@ using Anela.Heblo.Application.Features.Analytics.Services;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Analytics;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetMarginReport;
 
@@ -17,17 +18,20 @@ public class GetMarginReportHandler : IRequestHandler<GetMarginReportRequest, Ge
     private readonly IProductFilterService _productFilterService;
     private readonly IReportBuilderService _reportBuilderService;
     private readonly IMarginCalculator _marginCalculator;
+    private readonly ILogger<GetMarginReportHandler> _logger;
 
     public GetMarginReportHandler(
         IAnalyticsRepository analyticsRepository,
         IProductFilterService productFilterService,
         IReportBuilderService reportBuilderService,
-        IMarginCalculator marginCalculator)
+        IMarginCalculator marginCalculator,
+        ILogger<GetMarginReportHandler> logger)
     {
         _analyticsRepository = analyticsRepository;
         _productFilterService = productFilterService;
         _reportBuilderService = reportBuilderService;
         _marginCalculator = marginCalculator;
+        _logger = logger;
     }
 
     public async Task<GetMarginReportResponse> Handle(GetMarginReportRequest request, CancellationToken cancellationToken)
@@ -71,7 +75,8 @@ public class GetMarginReportHandler : IRequestHandler<GetMarginReportRequest, Ge
         }
         catch (Exception ex)
         {
-            return CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message));
+            _logger.LogError(ex, "Unhandled exception in GetMarginReportHandler");
+            return CreateErrorResponse(ErrorCodes.InternalServerError);
         }
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.Application.Features.Analytics.Services;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Analytics;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginAnalysis;
 
@@ -15,15 +16,18 @@ public class GetProductMarginAnalysisHandler : IRequestHandler<GetProductMarginA
     private readonly IAnalyticsRepository _analyticsRepository;
     private readonly IReportBuilderService _reportBuilderService;
     private readonly IMarginCalculator _marginCalculator;
+    private readonly ILogger<GetProductMarginAnalysisHandler> _logger;
 
     public GetProductMarginAnalysisHandler(
         IAnalyticsRepository analyticsRepository,
         IReportBuilderService reportBuilderService,
-        IMarginCalculator marginCalculator)
+        IMarginCalculator marginCalculator,
+        ILogger<GetProductMarginAnalysisHandler> logger)
     {
         _analyticsRepository = analyticsRepository;
         _reportBuilderService = reportBuilderService;
         _marginCalculator = marginCalculator;
+        _logger = logger;
     }
 
     public async Task<GetProductMarginAnalysisResponse> Handle(GetProductMarginAnalysisRequest request, CancellationToken cancellationToken)
@@ -59,7 +63,8 @@ public class GetProductMarginAnalysisHandler : IRequestHandler<GetProductMarginA
         }
         catch (Exception ex)
         {
-            return CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message));
+            _logger.LogError(ex, "Unhandled exception in GetProductMarginAnalysisHandler");
+            return CreateErrorResponse(ErrorCodes.InternalServerError);
         }
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTileTests.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Features.Analytics.DashboardTiles;
 using Anela.Heblo.Domain.Features.Analytics;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -18,7 +19,7 @@ public class InvoiceImportStatisticsTileTests
         _analyticsRepositoryMock = new Mock<IAnalyticsRepository>();
         _timeProviderMock = new Mock<TimeProvider>();
         _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
-        _tile = new InvoiceImportStatisticsTile(_analyticsRepositoryMock.Object, _timeProviderMock.Object);
+        _tile = new InvoiceImportStatisticsTile(_analyticsRepositoryMock.Object, _timeProviderMock.Object, NullLogger<InvoiceImportStatisticsTile>.Instance);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs
@@ -11,6 +11,7 @@ using Anela.Heblo.Application.Features.Analytics.UseCases.GetMarginReport;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Analytics;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -36,7 +37,8 @@ public class GetMarginReportHandlerTests
             _analyticsRepositoryMock.Object,
             _productFilterServiceMock.Object,
             _reportBuilderServiceMock.Object,
-            new MarginCalculator());
+            new MarginCalculator(),
+            NullLogger<GetMarginReportHandler>.Instance);
 
         // Set up default service behaviors for all tests
         SetupDefaultServiceMocks();
@@ -448,7 +450,6 @@ public class GetMarginReportHandlerTests
         result.Should().NotBeNull();
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
-        result.Params.Should().ContainKey("details");
     }
 
     private static async IAsyncEnumerable<T> ThrowAsync<T>(Exception exception)

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs
@@ -10,6 +10,7 @@ using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginAnalys
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Analytics;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -32,7 +33,8 @@ public class GetProductMarginAnalysisHandlerTests
         _handler = new GetProductMarginAnalysisHandler(
             _analyticsRepositoryMock.Object,
             _reportBuilderServiceMock.Object,
-            new MarginCalculator());
+            new MarginCalculator(),
+            NullLogger<GetProductMarginAnalysisHandler>.Instance);
     }
 
     [Fact]
@@ -283,6 +285,5 @@ public class GetProductMarginAnalysisHandlerTests
         result.Should().NotBeNull();
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
-        result.Params.Should().ContainKey("details");
     }
 }


### PR DESCRIPTION
Closes #3331

## What the issue was

Three catch blocks in the Analytics module forwarded raw `ex.Message` strings into API response payloads sent to browser clients, violating OWASP A05 (Security Misconfiguration / information leakage). PostgreSQL connection strings, EF Core query text, Npgsql stack frames, and internal type names were all reachable via the `"details"` field in error responses.

Affected files:
- `GetMarginReportHandler.cs` — returned `CreateErrorResponse(ErrorCodes.InternalServerError, ("details", ex.Message))`
- `GetProductMarginAnalysisHandler.cs` — identical pattern
- `InvoiceImportStatisticsTile.cs` — returned `new { status = "error", error = "...", details = ex.Message }`

None of the three classes injected `ILogger`, so exceptions were neither logged server-side nor stripped from responses.

## How it was fixed

Added `ILogger<T>` constructor injection to all three classes. In each catch block, the exception is now logged via `_logger.LogError(ex, "Unhandled exception in {ClassName}")` and the response returns only the opaque `ErrorCodes.InternalServerError` code with no `Params` or `details` field — matching the pattern already established throughout the rest of the codebase.

Test files updated: `NullLogger<T>.Instance` passed to constructors; `result.Params.Should().ContainKey("details")` assertions removed to match the new contract.

## Artifacts
- Brief, spec, architecture review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3331/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtm87A69ec2yquUGGufwmt)_