### PR TITLE
#3334: Make TimeWindowParser injectable via TimeProvider

### DIFF
--- a/artifacts/feat-3334/arch-review.r1.md
+++ b/artifacts/feat-3334/arch-review.r1.md
@@ -1,0 +1,228 @@
+# Architecture Review: Inject TimeProvider into TimeWindowParser
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a textbook testability refactor. The pattern already exists in this codebase — `InvoiceImportStatisticsTile` shows the exact model: `TimeProvider` injected via constructor, stored as `private readonly TimeProvider _timeProvider`, consumed via `_timeProvider.GetUtcNow()` or `_timeProvider.GetLocalNow()`. The spec asks us to replicate that pattern for `TimeWindowParser`.
+
+The one genuine architectural question the spec raises — silently — is whether `TimeWindowParser` should remain a standalone service or be folded inline into its single caller. Given the spec explicitly scopes out `GetProductMarginAnalysisHandler` and `GetMarginReportHandler`, and the class name `TimeWindowParser` implies shared utility, keeping it as a distinct injectable service is the right call. Future handlers can reuse it without reaching back through another handler.
+
+The main integration points are:
+1. `TimeWindowParser` (source of the ambient date dependency)
+2. `GetProductMarginSummaryHandler` (sole current consumer, uses static call at line 31)
+3. `AnalyticsModule` (DI registration)
+4. `GetProductMarginSummaryHandlerTests` (tests that mirror `DateTime.Today` and must be frozen)
+
+`TimeProvider.System` is already registered as a singleton in `ServiceCollectionExtensions.cs` at line 132. No infrastructure change is needed.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ServiceCollectionExtensions
+  └─ AddSingleton(TimeProvider.System)           [already exists, no change]
+
+AnalyticsModule.AddAnalyticsModule()
+  └─ AddScoped<TimeWindowParser>()               [new]
+
+GetProductMarginSummaryHandler
+  ├─ IAnalyticsRepository          (existing)
+  ├─ IMarginCalculator             (existing)
+  ├─ IMonthlyBreakdownGenerator    (existing)
+  └─ TimeWindowParser              (new injection)
+       └─ TimeProvider             (singleton, resolved transitively)
+
+GetProductMarginSummaryHandlerTests
+  └─ FakeTimeProvider(frozenDate)  [replaces DateTime.Today usage in test body]
+```
+
+### Key Design Decisions
+
+#### Decision 1: Scoped vs Singleton lifetime for TimeWindowParser
+
+**Options considered:**
+- `AddSingleton<TimeWindowParser>()` — simplest, stateless class holds only an injected singleton
+- `AddScoped<TimeWindowParser>()` — consistent with other services registered in `AnalyticsModule`
+
+**Chosen approach:** `AddScoped<TimeWindowParser>()`
+
+**Rationale:** All other services in `AnalyticsModule` (`IProductFilterService`, `IReportBuilderService`, `IMarginCalculator`, `IMonthlyBreakdownGenerator`) are scoped. A singleton would also work given `TimeWindowParser` holds no mutable state, but matching the module's established lifetime convention avoids a subtle registration mismatch if the handler or its dependencies are ever scoped-chain-validated. `TimeProvider.System` is a singleton and is safe to inject into a scoped consumer.
+
+#### Decision 2: GetLocalNow vs GetUtcNow
+
+**Options considered:**
+- `_timeProvider.GetUtcNow().Date` — UTC date
+- `_timeProvider.GetLocalNow().Date` — local server date
+
+**Chosen approach:** `_timeProvider.GetLocalNow().Date`
+
+**Rationale:** The existing `TimeWindowParser` uses `DateTime.Today`, which returns the **local** date. The spec explicitly prescribes `_timeProvider.GetLocalNow().Date` (FR-1). The computed date ranges (year boundaries, month offsets) are relative to a business calendar, not a UTC timestamp. Using `GetLocalNow()` preserves the original semantics while gaining testability. This matches the correct call to use here — `InvoiceImportStatisticsTile` uses `GetUtcNow()` only because it computes UTC ranges for database queries; `TimeWindowParser` computes business date ranges, so local is appropriate.
+
+#### Decision 3: FakeTimeProvider vs Mock\<TimeProvider\>
+
+**Options considered:**
+- `Mock<TimeProvider>` via Moq — used in older tests (`GetProductMarginsHandlerTests` plan from 2026-06-03)
+- `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` — used in newer tests (`UpcomingProductionTileTests`)
+
+**Chosen approach:** `FakeTimeProvider`
+
+**Rationale:** `Microsoft.Extensions.TimeProvider.Testing` is already referenced in `Anela.Heblo.Tests.csproj` (version 8.1.0) and `UpcomingProductionTileTests` uses it as the current pattern. `FakeTimeProvider` requires no `Setup()` boilerplate — `new FakeTimeProvider(frozenDate)` is all you need. It is the more recent and ergonomic standard for this project; use it consistently going forward.
+
+#### Decision 4: ArgumentException on unrecognised time window
+
+**Options considered:**
+- Keep the silent fallback `_ => (new DateTime(today.Year, 1, 1), today)` — hides bugs
+- Throw `ArgumentException` — fails fast, surfaces bad input immediately
+
+**Chosen approach:** Throw `ArgumentException` with the offending value
+
+**Rationale:** The silent fallback makes invalid `TimeWindow` strings indistinguishable from `"current-year"` at the call site. The spec (FR-4) is correct: fail loudly. The handler already owns the `TimeWindow` value from the request; if it reaches `TimeWindowParser` with an unrecognised string it is a programming error, not a user-recoverable condition. `ArgumentException` is appropriate (not `ArgumentOutOfRangeException`, since the value is a string not a numeric range).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Modify only these four existing files:
+
+```
+backend/src/Anela.Heblo.Application/
+  Features/Analytics/
+    Services/
+      TimeWindowParser.cs                          ← convert static → instance, inject TimeProvider, throw on fallback
+    AnalyticsModule.cs                             ← add AddScoped<TimeWindowParser>()
+    UseCases/GetProductMarginSummary/
+      GetProductMarginSummaryHandler.cs            ← inject TimeWindowParser, replace static call
+
+backend/test/Anela.Heblo.Tests/
+  Features/Analytics/
+    GetProductMarginSummaryHandlerTests.cs         ← inject FakeTimeProvider + TimeWindowParser, freeze date
+```
+
+### Interfaces and Contracts
+
+`TimeWindowParser` is not given an interface — the spec explicitly excludes interface extraction (Out of Scope). Inject the concrete type directly, consistent with other concrete services in this module (`MarginCalculator`, `MonthlyBreakdownGenerator`).
+
+**New constructor for TimeWindowParser:**
+```csharp
+public TimeWindowParser(TimeProvider timeProvider)
+{
+    _timeProvider = timeProvider;
+}
+```
+
+**New method signature (unchanged externally):**
+```csharp
+public (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+```
+
+**New constructor for GetProductMarginSummaryHandler** — add `TimeWindowParser` as the last parameter, after existing three, to minimise test churn:
+```csharp
+public GetProductMarginSummaryHandler(
+    IAnalyticsRepository analyticsRepository,
+    IMarginCalculator marginCalculator,
+    IMonthlyBreakdownGenerator monthlyBreakdownGenerator,
+    TimeWindowParser timeWindowParser)
+```
+
+The call site at line 31 changes from:
+```csharp
+var (fromDate, toDate) = TimeWindowParser.ParseTimeWindow(request.TimeWindow);
+```
+to:
+```csharp
+var (fromDate, toDate) = _timeWindowParser.ParseTimeWindow(request.TimeWindow);
+```
+
+### Data Flow
+
+```
+HTTP request → GetProductMarginSummaryHandler.Handle()
+                  │
+                  ▼
+           _timeWindowParser.ParseTimeWindow(request.TimeWindow)
+                  │
+                  ▼
+           _timeProvider.GetLocalNow().Date   ← frozen in tests via FakeTimeProvider
+                  │
+                  ▼
+           (fromDate, toDate) tuple
+                  │
+                  ▼
+           _analyticsRepository.StreamProductsWithSalesAsync(fromDate, toDate, ...)
+```
+
+### Test Changes
+
+The existing `GetProductMarginSummaryHandlerTests` constructor must be updated. The handler's constructor gains `TimeWindowParser`, which itself needs a `TimeProvider`.
+
+**New test setup pattern:**
+```csharp
+private static readonly DateTimeOffset FrozenDate = new(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+public GetProductMarginSummaryHandlerTests()
+{
+    _analyticsRepositoryMock = new Mock<IAnalyticsRepository>();
+    _marginCalculator = new MarginCalculator();
+    _monthlyBreakdownGenerator = new MonthlyBreakdownGenerator(_marginCalculator);
+    var timeProvider = new FakeTimeProvider(FrozenDate);
+    var timeWindowParser = new TimeWindowParser(timeProvider);
+    _handler = new GetProductMarginSummaryHandler(
+        _analyticsRepositoryMock.Object,
+        _marginCalculator,
+        _monthlyBreakdownGenerator,
+        timeWindowParser);
+}
+```
+
+All test methods that reference `DateTime.Today` must replace those references with the frozen values derived from `FrozenDate`. For example, `Handle_ValidRequest_ReturnsCorrectResponse` currently captures `var today = DateTime.Today` and uses it to build `fromDate`/`toDate` expectations and fixture data. These must change to `FrozenDate.LocalDateTime.Date` (or a literal `new DateTime(2026, 1, 15)` aligned to the frozen date), so that mock `Setup()` matchers and assertions agree with what the frozen `TimeWindowParser` actually computes.
+
+The `Handle_DifferentTimeWindows_ParsesCorrectly` theory also mirrors `DateTime.Today` inline — replace with the frozen equivalent.
+
+Add one new test for the `ArgumentException` path:
+```csharp
+[Fact]
+public async Task Handle_UnknownTimeWindow_ThrowsArgumentException()
+{
+    var request = new GetProductMarginSummaryRequest
+    {
+        TimeWindow = "not-a-real-window",
+        GroupingMode = ProductGroupingMode.Products
+    };
+
+    Func<Task> act = () => _handler.Handle(request, CancellationToken.None);
+    await act.Should().ThrowAsync<ArgumentException>()
+        .WithMessage("*not-a-real-window*");
+}
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Test mock `Setup()` matchers that pass `fromDate`/`toDate` exactly will break if the frozen date differs from the clock at the time the test ran | High | Freeze to a fixed date (`2026-01-15`) in the test constructor; derive all fixture values from that constant, not from `DateTime.Today`. |
+| `GetLocalNow()` vs `GetUtcNow()` produces different dates at midnight near UTC offset boundaries | Low | The frozen test date should be set to noon UTC to avoid midnight edge cases in unit tests. `FrozenDate` should not be `00:00:00`. |
+| Handlers out of scope (`GetProductMarginAnalysisHandler`, `GetMarginReportHandler`) also call `TimeWindowParser.ParseTimeWindow()` statically — compile error if they are not updated | Medium | After converting `TimeWindowParser` from static to instance, the compiler will flag every static call site. Check those handlers — they are out of scope for behavior change but must be updated to accept an injected instance or continue to call a refactored version. See Specification Amendment #1 below. |
+
+## Specification Amendments
+
+### Amendment 1: Out-of-scope handlers will not compile after the static class is removed
+
+The spec lists `GetProductMarginAnalysisHandler` and `GetMarginReportHandler` as out of scope. However, if they call `TimeWindowParser.ParseTimeWindow()` as a static method today, removing `static` from the class will cause a compile error in those handlers. The implementer must verify whether these handlers use `TimeWindowParser` and, if so, inject it (without any behavior change to the handlers themselves). This is mechanical injection only — no logic change, no test authoring required for those handlers as part of this task. Verify with a grep before starting.
+
+### Amendment 2: Clarify ArgumentException message format
+
+The spec says throw `ArgumentException` with "the offending value" but does not specify the message string. Use:
+```csharp
+throw new ArgumentException($"Unknown time window value: '{timeWindow}'", nameof(timeWindow));
+```
+This makes the exception message testable (`WithMessage("*not-a-real-window*")`) and follows .NET conventions for `ArgumentException`.
+
+## Prerequisites
+
+- No migrations required.
+- No infrastructure changes required.
+- `TimeProvider.System` is already registered as a singleton (`ServiceCollectionExtensions.cs:132`).
+- `Microsoft.Extensions.TimeProvider.Testing` is already in `Anela.Heblo.Tests.csproj`.
+- Before starting: grep for all callers of `TimeWindowParser.ParseTimeWindow` to surface any call sites not mentioned in the spec.

--- a/artifacts/feat-3334/brief.md
+++ b/artifacts/feat-3334/brief.md
@@ -1,0 +1,56 @@
+## Module
+Analytics
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs:9`
+
+```csharp
+public static class TimeWindowParser
+{
+    public static (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = DateTime.Today;  // ← static ambient date
+        return timeWindow switch
+        {
+            "current-year" => (new DateTime(today.Year, 1, 1), today),
+            ...
+        };
+    }
+}
+```
+
+`DateTime.Today` is a static ambient value. Any unit test that exercises `GetProductMarginSummaryHandler` — which calls `TimeWindowParser.ParseTimeWindow` directly at line 31 — cannot control or freeze the date, making test assertions about the computed date range fragile and time-dependent.
+
+Compare with `InvoiceImportStatisticsTile`, which correctly uses the injected `TimeProvider` abstraction (`backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs:10,42`):
+```csharp
+var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().Date);
+```
+
+The project already has `TimeProvider` registered in DI (it's a `System.TimeProvider` — a .NET 8 built-in).
+
+## Why it matters
+- `GetProductMarginSummaryHandlerTests.cs` exists but any test that depends on a specific `fromDate`/`toDate` pair for a given `TimeWindow` string is clock-sensitive and will produce different results run on different days
+- The inconsistency with `InvoiceImportStatisticsTile` shows two competing patterns in the same module
+- Silent fallback to `"current-year"` for unrecognized `timeWindow` strings (the `_` arm) swallows typos silently — a logged warning or thrown `ArgumentException` would be safer
+
+## Suggested fix
+The smallest fix: convert `TimeWindowParser` from a `static class` to an instance class injected with `TimeProvider`:
+
+```csharp
+public class TimeWindowParser
+{
+    private readonly TimeProvider _timeProvider;
+    public TimeWindowParser(TimeProvider timeProvider) => _timeProvider = timeProvider;
+
+    public (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = _timeProvider.GetLocalNow().Date;
+        return timeWindow switch { ... };
+    }
+}
+```
+
+Register it in `AnalyticsModule.cs` and inject it into `GetProductMarginSummaryHandler`. `TimeProvider.System` can be used in tests for the real clock, or a `FakeTimeProvider` for deterministic date tests.
+
+---
+_Filed by daily arch-review routine on 2026-06-24._

--- a/artifacts/feat-3334/code-review.r1.md
+++ b/artifacts/feat-3334/code-review.r1.md
@@ -1,0 +1,59 @@
+# Code Review: feat-3334 (whole-branch)
+
+## Summary
+
+The implementation correctly converts `TimeWindowParser` from a static class to an injectable instance class backed by `System.TimeProvider`, registers it in `AnalyticsModule`, injects it into `GetProductMarginSummaryHandler`, replaces the silent fallback with `ArgumentException`, and updates the test file to use a frozen `FakeTimeProvider`. All five functional requirements from the spec are addressed. All 8 tests pass deterministically. No blocking issues found.
+
+## Review Result: CLEAN
+
+---
+
+### FR-1: Convert TimeWindowParser to injectable instance class
+**Status:** PASS
+
+`static class` → `public class`. Constructor `TimeWindowParser(TimeProvider timeProvider)` added; `_timeProvider` stored as `readonly` field. `DateTime.Today` replaced with `_timeProvider.GetLocalNow().Date` (consistent with existing `InvoiceImportStatisticsTile` pattern). All five named time windows remain present and return unchanged date range expressions.
+
+---
+
+### FR-2: Register TimeWindowParser in AnalyticsModule
+**Status:** PASS
+
+`services.AddScoped<TimeWindowParser>()` added before the existing `IMarginCalculator` and `IMonthlyBreakdownGenerator` registrations. `TimeProvider` is provided by the .NET 8 host as a singleton, so the dependency chain resolves at startup without `InvalidOperationException`.
+
+---
+
+### FR-3: Inject TimeWindowParser into GetProductMarginSummaryHandler
+**Status:** PASS
+
+`private readonly TimeWindowParser _timeWindowParser` field added. Constructor gains `TimeWindowParser timeWindowParser` parameter with correct assignment. Static call `TimeWindowParser.ParseTimeWindow(request.TimeWindow)` replaced with instance call `_timeWindowParser.ParseTimeWindow(request.TimeWindow)`. Change is minimal and surgical.
+
+---
+
+### FR-4: Replace silent fallback with ArgumentException
+**Status:** PASS
+
+`_ => throw new ArgumentException($"Unknown time window value: '{timeWindow}'", nameof(timeWindow))` — offending value included in message, parameter name correctly set via `nameof`. All five recognised time window strings continue to return correct date ranges.
+
+---
+
+### FR-5: Update tests to use frozen TimeProvider
+**Status:** PASS
+
+- `FrozenNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero)` and `FrozenDate = new DateTime(2026, 1, 15)` declared as static fields
+- `FakeTimeProvider(FrozenNow)` → `TimeWindowParser` → `_handler` wired in constructor
+- Zero occurrences of `DateTime.Today` remain in the test file (verified)
+- All four test methods that previously used `DateTime.Today` now reference `FrozenDate` / `FrozenDate.Year`
+- `ParseTimeWindow_UnknownValue_ThrowsArgumentException` added and asserts `ArgumentException` with message containing the bad value
+- 8 tests pass, 0 fail — deterministically
+
+---
+
+## Advisory / cleanup notes
+
+- **Dead `_` arm in `Handle_DifferentTimeWindows_ParsesCorrectly`**: The local `expectedDates` switch still contains `_ => (new DateTime(FrozenDate.Year, 1, 1), FrozenDate)`. This arm can never be reached because all `[InlineData]` values are known windows and unknown values now throw `ArgumentException` before reaching the assertion. Not blocking — the `[Theory]` tests cover what they claim to cover.
+
+---
+
+## Overall Notes
+
+All functional requirements met. The diff is clean, targeted, and does not disturb adjacent code. Tests are fully deterministic after this change.

--- a/artifacts/feat-3334/impl/inject-timewindowparser-into-handler.r1.md
+++ b/artifacts/feat-3334/impl/inject-timewindowparser-into-handler.r1.md
@@ -1,0 +1,19 @@
+# Implementation: inject-timewindowparser-into-handler
+
+## What was implemented
+`GetProductMarginSummaryHandler` now receives `TimeWindowParser` via constructor injection. The static call `TimeWindowParser.ParseTimeWindow(request.TimeWindow)` at line 31 was replaced with `_timeWindowParser.ParseTimeWindow(request.TimeWindow)`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` — added `private readonly TimeWindowParser _timeWindowParser` field; added `TimeWindowParser timeWindowParser` constructor parameter; replaced static method call with instance call
+
+## Tests
+N/A — handler constructor tests updated in next task.
+
+## How to verify
+`dotnet build` → 0 errors (verified: only pre-existing warnings remain).
+
+## PR Summary
+Injects `TimeWindowParser` into `GetProductMarginSummaryHandler` via constructor injection and replaces the static `TimeWindowParser.ParseTimeWindow()` call with the instance method. The build is now clean with no compile errors.
+
+## Status
+DONE

--- a/artifacts/feat-3334/impl/register-timewindowparser-in-analyticsmodule.r1.md
+++ b/artifacts/feat-3334/impl/register-timewindowparser-in-analyticsmodule.r1.md
@@ -1,0 +1,19 @@
+# Implementation: register-timewindowparser-in-analyticsmodule
+
+## What was implemented
+Added `services.AddScoped<TimeWindowParser>();` to `AnalyticsModule.AddAnalyticsModule`, immediately before the `IMarginCalculator` and `IMonthlyBreakdownGenerator` registrations. No `using` directive was needed as `TimeWindowParser` is in `Anela.Heblo.Application.Features.Analytics.Services`, already imported on line 3.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` — added `services.AddScoped<TimeWindowParser>();` at line 47
+
+## Tests
+N/A — DI registration verified by build and integration tests.
+
+## How to verify
+1. `dotnet build` — still expect one CS0120 error in `GetProductMarginSummaryHandler.cs` (not yet updated), but `AnalyticsModule.cs` itself is clean.
+
+## PR Summary
+Registers `TimeWindowParser` as a scoped DI service in `AnalyticsModule` so it can be injected into `GetProductMarginSummaryHandler`.
+
+## Status
+DONE

--- a/artifacts/feat-3334/impl/update-handler-tests.r1.md
+++ b/artifacts/feat-3334/impl/update-handler-tests.r1.md
@@ -1,0 +1,30 @@
+# Implementation: update-handler-tests
+
+## What was implemented
+Updated `GetProductMarginSummaryHandlerTests` to use `FakeTimeProvider` frozen at `2026-01-15 12:00:00 UTC`:
+- Added `FrozenNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero)` and `FrozenDate = new DateTime(2026, 1, 15)` constants
+- Created `FakeTimeProvider(FrozenNow)` → `TimeWindowParser` in constructor
+- Passed `TimeWindowParser` to `GetProductMarginSummaryHandler` constructor
+- Removed all `DateTime.Today` references; replaced with `FrozenDate` / `FrozenDate.Year`
+- Updated sales history dates to fall within the frozen range (Jan 2026)
+- Fixed `Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator` to pass `_timeWindowParser` to the local handler
+- Added `ParseTimeWindow_UnknownValue_ThrowsArgumentException` test covering FR-4
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` — replaced `DateTime.Today` with frozen `FakeTimeProvider`, added `TimeWindowParser` injection, added `ArgumentException` test
+
+## Tests
+All 8 tests pass: `dotnet test --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"` → 8 passed, 0 failed
+
+## How to verify
+```bash
+cd backend/test/Anela.Heblo.Tests
+dotnet test --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+Expected: 8 passed, 0 failed
+
+## PR Summary
+Updates `GetProductMarginSummaryHandlerTests` to use `FakeTimeProvider` with a frozen date (2026-01-15), eliminating all `DateTime.Today` calls and making tests fully deterministic. Adds a test for the new `ArgumentException` path when an unknown time window string is passed.
+
+## Status
+DONE

--- a/artifacts/feat-3334/impl/update-timewindowparser.r1.md
+++ b/artifacts/feat-3334/impl/update-timewindowparser.r1.md
@@ -1,0 +1,20 @@
+# Implementation: update-timewindowparser
+
+## What was implemented
+`TimeWindowParser` was converted from a static utility class to an injectable instance class. The class now receives a `TimeProvider` via constructor injection and uses it to determine the current date, replacing the hard-coded `DateTime.Today`. The silent catch-all fallback (`_ => (new DateTime(today.Year, 1, 1), today)`) was replaced with an `ArgumentException` that clearly identifies the unknown time window value.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs` — converted from `static class` with `static` method to injectable instance class with constructor accepting `TimeProvider`; `DateTime.Today` replaced with `_timeProvider.GetLocalNow().Date`; silent fallback replaced with `ArgumentException`
+
+## Tests
+N/A (tests updated in a later task)
+
+## How to verify
+1. Build the solution: `dotnet build` from the repo root — expect one compile error in `GetProductMarginSummaryHandler.cs` (CS0120) because it still calls `TimeWindowParser.ParseTimeWindow` as a static method. That error will be resolved in the subsequent task that updates the handler to inject and use the instance.
+2. Once the handler is updated and DI registration is added, the build should be clean.
+
+## PR Summary
+Converts `TimeWindowParser` from a static class to an injectable instance class that accepts `TimeProvider` via constructor injection. This enables testable, deterministic time handling and replaces the opaque silent fallback for unknown time window values with an `ArgumentException` that surfaces the bad input clearly.
+
+## Status
+DONE

--- a/artifacts/feat-3334/review/inject-timewindowparser-into-handler.r1.md
+++ b/artifacts/feat-3334/review/inject-timewindowparser-into-handler.r1.md
@@ -1,0 +1,18 @@
+# Code Review: inject-timewindowparser-into-handler
+
+## Summary
+The implementation correctly injects `TimeWindowParser` into `GetProductMarginSummaryHandler` via constructor parameter and replaces the static call with the instance method. The build compiles with 0 errors after this change.
+
+## Review Result: PASS
+
+### task: inject-timewindowparser-into-handler
+**Status:** PASS
+
+- `private readonly TimeWindowParser _timeWindowParser` field added ✓
+- `TimeWindowParser timeWindowParser` added as last constructor parameter ✓
+- `_timeWindowParser = timeWindowParser` assignment in constructor body ✓
+- Static call replaced: `_timeWindowParser.ParseTimeWindow(request.TimeWindow)` ✓
+- `dotnet build` → 0 errors ✓
+
+## Overall Notes
+None.

--- a/artifacts/feat-3334/review/register-timewindowparser-in-analyticsmodule.r1.md
+++ b/artifacts/feat-3334/review/register-timewindowparser-in-analyticsmodule.r1.md
@@ -1,0 +1,17 @@
+# Code Review: register-timewindowparser-in-analyticsmodule
+
+## Summary
+The implementation correctly adds `services.AddScoped<TimeWindowParser>();` in the right location in `AnalyticsModule.cs`. The namespace is already imported, no using directive was needed, and the lifetime (Scoped) matches the module convention.
+
+## Review Result: PASS
+
+### task: register-timewindowparser-in-analyticsmodule
+**Status:** PASS
+
+- `services.AddScoped<TimeWindowParser>();` added at the correct location ✓
+- Scoped lifetime matches other services in `AnalyticsModule` ✓
+- No unnecessary using directives added ✓
+- `TimeWindowParser` in `Anela.Heblo.Application.Features.Analytics.Services` already imported ✓
+
+## Overall Notes
+None.

--- a/artifacts/feat-3334/review/update-handler-tests.r1.md
+++ b/artifacts/feat-3334/review/update-handler-tests.r1.md
@@ -1,0 +1,23 @@
+# Code Review: update-handler-tests
+
+## Summary
+All test requirements from FR-5 are met. `FakeTimeProvider` is used correctly, all `DateTime.Today` references are eliminated, the `ArgumentException` test is present, and all 8 tests pass deterministically.
+
+## Review Result: PASS
+
+### task: update-handler-tests
+**Status:** PASS
+
+- `using Microsoft.Extensions.Time.Testing;` ✓ (correct namespace)
+- `FrozenNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero)` ✓
+- `FrozenDate = new DateTime(2026, 1, 15)` ✓
+- `new FakeTimeProvider(FrozenNow)` passed to `TimeWindowParser` ✓
+- `_timeWindowParser` passed to handler constructor ✓
+- No `DateTime.Today` in any test method ✓
+- `Handle_DifferentTimeWindows_ParsesCorrectly` asserts against `FrozenDate`-derived values ✓
+- `ParseTimeWindow_UnknownValue_ThrowsArgumentException` added ✓
+- `Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator` uses `_timeWindowParser` ✓
+- 8 tests pass, 0 fail ✓
+
+## Overall Notes
+None.

--- a/artifacts/feat-3334/review/update-timewindowparser.r1.md
+++ b/artifacts/feat-3334/review/update-timewindowparser.r1.md
@@ -1,0 +1,20 @@
+# Code Review: update-timewindowparser
+
+## Summary
+The implementation correctly converts `TimeWindowParser` from a static class to an injectable instance class. All required changes are present: `static class` → `class`, `TimeProvider` constructor injection, `_timeProvider.GetLocalNow().Date` replacing `DateTime.Today`, and `ArgumentException` replacing the silent fallback. The first reviewer read the pre-commit file state and incorrectly assessed the implementation; the committed code is fully compliant.
+
+## Review Result: PASS
+
+### task: update-timewindowparser
+**Status:** PASS
+
+Verified in committed file:
+- `public class TimeWindowParser` (not static) ✓
+- `private readonly TimeProvider _timeProvider` ✓
+- Constructor `TimeWindowParser(TimeProvider timeProvider)` ✓
+- `var today = _timeProvider.GetLocalNow().Date` ✓
+- `ArgumentException` on unrecognised time window ✓
+- All five named time windows return correct date ranges ✓
+
+## Overall Notes
+The build is expected to show one compile error (CS0120 in `GetProductMarginSummaryHandler.cs`) at this stage — that is by design; the handler update is a subsequent task.

--- a/artifacts/feat-3334/spec.r1.md
+++ b/artifacts/feat-3334/spec.r1.md
@@ -1,0 +1,157 @@
+# Specification: Inject TimeProvider into TimeWindowParser
+
+## Summary
+
+`TimeWindowParser` currently uses the static ambient `DateTime.Today`, making any test that relies on the computed date range clock-sensitive and non-deterministic. This change converts `TimeWindowParser` to an instance class that accepts the project-standard `System.TimeProvider` abstraction, aligns it with `InvoiceImportStatisticsTile` (the existing correct pattern), and replaces the silent fallback for unrecognised time-window strings with an explicit `ArgumentException`.
+
+## Background
+
+The Analytics module contains two competing patterns for obtaining "today":
+
+- `InvoiceImportStatisticsTile` (correct): uses injected `TimeProvider` via `_timeProvider.GetUtcNow().Date`.
+- `TimeWindowParser` (incorrect): calls `DateTime.Today` — a static ambient that cannot be controlled in tests.
+
+`GetProductMarginSummaryHandler` calls `TimeWindowParser.ParseTimeWindow` at line 31. The corresponding test file (`GetProductMarginSummaryHandlerTests.cs`) reproduces `DateTime.Today` inline in every test case, meaning assertions such as `result.FromDate.Should().Be(fromDate)` pass only when the test and the production code happen to call `DateTime.Today` within the same day. A test run spanning midnight, or a mocked test environment that freezes time, will silently produce wrong results.
+
+Additionally, the `_` (default) arm of the switch in `TimeWindowParser` silently falls back to `"current-year"` for any unrecognised input string, swallowing typos without any diagnostic signal.
+
+`System.TimeProvider` is already registered in DI (used by `InvoiceImportStatisticsTile` and other tiles). No new dependency needs to be introduced.
+
+## Functional Requirements
+
+### FR-1: Convert TimeWindowParser to an injectable instance class
+
+`TimeWindowParser` must be refactored from a `static class` with a `static` method to a non-static class that accepts `TimeProvider` via constructor injection.
+
+The instance method `ParseTimeWindow(string timeWindow)` must obtain the current date through `_timeProvider.GetLocalNow().Date` (matching the existing local-date semantics of `DateTime.Today`).
+
+**Acceptance criteria:**
+- `TimeWindowParser` is no longer `static`.
+- Constructor signature is `TimeWindowParser(TimeProvider timeProvider)`.
+- `ParseTimeWindow` no longer references `DateTime.Today` anywhere in its body.
+- All five named time windows (`current-year`, `current-and-previous-year`, `last-6-months`, `last-12-months`, `last-24-months`) continue to return the same date ranges as before when the real clock is used.
+
+### FR-2: Register TimeWindowParser in AnalyticsModule
+
+`TimeWindowParser` must be registered in the DI container inside `AnalyticsModule.AddAnalyticsModule` so that it can be injected into handlers.
+
+**Acceptance criteria:**
+- `AnalyticsModule.cs` contains `services.AddScoped<TimeWindowParser>()` (or equivalent lifetime; `Scoped` matches other services in this module).
+- The application starts without a `System.InvalidOperationException` about an unresolvable `TimeWindowParser` dependency.
+
+### FR-3: Inject TimeWindowParser into GetProductMarginSummaryHandler
+
+`GetProductMarginSummaryHandler` must receive `TimeWindowParser` as a constructor-injected dependency and call the instance method instead of the static one.
+
+**Acceptance criteria:**
+- `GetProductMarginSummaryHandler` constructor declares a `TimeWindowParser` parameter.
+- The static call `TimeWindowParser.ParseTimeWindow(request.TimeWindow)` at line 31 is replaced by `_timeWindowParser.ParseTimeWindow(request.TimeWindow)`.
+- No other callers of the static `TimeWindowParser.ParseTimeWindow` exist in the codebase after the change.
+
+### FR-4: Replace silent fallback with ArgumentException
+
+The `_` (default) arm of the `switch` in `ParseTimeWindow` must throw `ArgumentException` instead of silently falling back to `current-year`.
+
+**Acceptance criteria:**
+- Passing any string not in the recognised set throws `ArgumentException` with a message that includes the offending value.
+- All five recognised strings continue to return the correct date range.
+- Existing tests that pass valid `timeWindow` strings do not throw.
+
+### FR-5: Update GetProductMarginSummaryHandlerTests to use a frozen TimeProvider
+
+Existing tests in `GetProductMarginSummaryHandlerTests` must be updated to construct `TimeWindowParser` with a `FakeTimeProvider` set to a fixed, known date. Tests must no longer call `DateTime.Today` to derive expected values; expected dates must be hardcoded from the frozen instant.
+
+**Acceptance criteria:**
+- No occurrence of `DateTime.Today` remains in `GetProductMarginSummaryHandlerTests.cs`.
+- All existing test cases continue to pass deterministically regardless of when they are run.
+- The `Handle_DifferentTimeWindows_ParsesCorrectly` theory asserts `result.FromDate` and `result.ToDate` against dates derived from the frozen instant, not the system clock.
+- A new test case asserts that passing an unrecognised `timeWindow` string causes `ParseTimeWindow` to throw `ArgumentException`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+No performance impact. `TimeWindowParser` performs only in-memory date arithmetic; switching from static to instance invocation adds negligible overhead.
+
+### NFR-2: Security
+
+No security surface changes. The class handles only date computation.
+
+### NFR-3: Testability
+
+After this change, any test that needs a deterministic date range must supply a `FakeTimeProvider` (from `Microsoft.Extensions.TimeProvider.Testing` or equivalent). The real-clock `TimeProvider.System` remains available for production registration.
+
+### NFR-4: Consistency
+
+The implementation must match the pattern established by `InvoiceImportStatisticsTile`: inject `TimeProvider`, call `GetUtcNow()` or `GetLocalNow()` as appropriate for the semantic (local date for time-window parsing, same as the previous `DateTime.Today` behaviour).
+
+## Data Model
+
+No data model changes. `TimeWindowParser` computes a `(DateTime fromDate, DateTime toDate)` tuple and returns it; the shape of that tuple is unchanged.
+
+## API / Interface Design
+
+No public API or contract changes. `TimeWindowParser` is an internal application-layer service, not exposed via any controller or OpenAPI endpoint. The `GetProductMarginSummaryResponse.FromDate` and `ToDate` fields continue to be populated by the same logic.
+
+**Resulting class signature:**
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs
+public class TimeWindowParser
+{
+    private readonly TimeProvider _timeProvider;
+
+    public TimeWindowParser(TimeProvider timeProvider)
+        => _timeProvider = timeProvider;
+
+    public (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = _timeProvider.GetLocalNow().Date;
+        return timeWindow switch
+        {
+            "current-year"              => (new DateTime(today.Year, 1, 1), today),
+            "current-and-previous-year" => (new DateTime(today.Year - 1, 1, 1), today),
+            "last-6-months"             => (today.AddMonths(-6), today),
+            "last-12-months"            => (today.AddMonths(-12), today),
+            "last-24-months"            => (today.AddMonths(-24), today),
+            _ => throw new ArgumentException(
+                     $"Unrecognised time window: '{timeWindow}'.", nameof(timeWindow))
+        };
+    }
+}
+```
+
+**DI registration addition in `AnalyticsModule.cs`:**
+
+```csharp
+services.AddScoped<TimeWindowParser>();
+```
+
+**Handler constructor change:**
+
+```csharp
+public GetProductMarginSummaryHandler(
+    IAnalyticsRepository analyticsRepository,
+    IMarginCalculator marginCalculator,
+    IMonthlyBreakdownGenerator monthlyBreakdownGenerator,
+    TimeWindowParser timeWindowParser)   // added
+```
+
+## Dependencies
+
+- `System.TimeProvider` (.NET 8 built-in) — already registered in DI; no new package required.
+- `Microsoft.Extensions.TimeProvider.Testing` — already present in the test project (assumption based on its use elsewhere in the codebase; verify with `dotnet list package` if uncertain). Provides `FakeTimeProvider` for deterministic tests.
+
+## Out of Scope
+
+- Changing `GetProductMarginAnalysisHandler`, which accepts explicit `StartDate`/`EndDate` from the request and does not call `TimeWindowParser`.
+- Changing `GetMarginReportHandler` or `GetBankStatementImportStatisticsHandler` unless they are found to call `TimeWindowParser.ParseTimeWindow` (they do not, based on current code review).
+- Extracting `TimeWindowParser` behind an interface (`ITimeWindowParser`). A concrete class is sufficient for DI and test injection with `FakeTimeProvider`; adding an interface would be premature.
+- Changing the set of recognised `timeWindow` strings or their date-range semantics.
+- Frontend changes.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-25T08:24:53.059756Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T08:25:29.298595Z"
     }
   },
   "tasks": [
     {
       "name": "update-timewindowparser",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T08:25:29.702194Z"
     },
     {
       "name": "register-timewindowparser-in-analyticsmodule",

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T08:16:24.156664Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T08:18:34.112738Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T08:18:44.014925Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -17,13 +17,38 @@
       "updated_at": "2026-06-25T08:21:56.450921Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T08:22:22.279460Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T08:24:53.059756Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "update-timewindowparser",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "register-timewindowparser-in-analyticsmodule",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "inject-timewindowparser-into-handler",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "update-handler-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3334",
+  "issue_number": 3334,
+  "created_at": "2026-06-25T08:15:34.473285Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-25T08:16:24.156664Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-06-25T08:18:34.112738Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T08:18:44.014925Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T08:21:39.392751Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-25T08:21:56.450921Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T08:22:22.279460Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "update-timewindowparser",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T08:25:29.702194Z"
+      "updated_at": "2026-06-25T08:29:35.695384Z"
     },
     {
       "name": "register-timewindowparser-in-analyticsmodule",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T08:29:35.947822Z"
     },
     {
       "name": "inject-timewindowparser-into-handler",

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -40,15 +40,15 @@
     },
     {
       "name": "inject-timewindowparser-into-handler",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T08:30:19.588143Z"
+      "updated_at": "2026-06-25T08:32:08.833745Z"
     },
     {
       "name": "update-handler-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T08:32:15.708905Z"
     }
   ]
 }

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-06-25T08:24:53.059756Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T08:25:29.298595Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T09:07:44.885622Z"
     }
   },
   "tasks": [
@@ -46,9 +46,9 @@
     },
     {
       "name": "update-handler-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T08:32:15.708905Z"
+      "updated_at": "2026-06-25T09:07:40.618749Z"
     }
   ]
 }

--- a/artifacts/feat-3334/state.json
+++ b/artifacts/feat-3334/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "register-timewindowparser-in-analyticsmodule",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T08:29:35.947822Z"
+      "updated_at": "2026-06-25T08:30:14.897235Z"
     },
     {
       "name": "inject-timewindowparser-into-handler",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T08:30:19.588143Z"
     },
     {
       "name": "update-handler-tests",

--- a/artifacts/feat-3334/task-context/inject-timewindowparser-into-handler.md
+++ b/artifacts/feat-3334/task-context/inject-timewindowparser-into-handler.md
@@ -1,0 +1,80 @@
+### task: inject-timewindowparser-into-handler
+
+
+Replace the static `TimeWindowParser.ParseTimeWindow(...)` call in `GetProductMarginSummaryHandler` with constructor-injected instance usage.
+
+**File to modify:**
+`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs`
+
+**Step 1 — add field and update constructor.**
+
+Current constructor (lines 18–26):
+```csharp
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        IMarginCalculator marginCalculator,
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+    }
+```
+
+Current field declarations (lines 14–16):
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly IMarginCalculator _marginCalculator;
+    private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+```
+
+Replace both with:
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly IMarginCalculator _marginCalculator;
+    private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+    private readonly TimeWindowParser _timeWindowParser;
+
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        IMarginCalculator marginCalculator,
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator,
+        TimeWindowParser timeWindowParser)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+        _timeWindowParser = timeWindowParser;
+    }
+```
+
+**Step 2 — replace static call on line 31.**
+
+Current:
+```csharp
+        var (fromDate, toDate) = TimeWindowParser.ParseTimeWindow(request.TimeWindow);
+```
+
+Replace with:
+```csharp
+        var (fromDate, toDate) = _timeWindowParser.ParseTimeWindow(request.TimeWindow);
+```
+
+No new `using` directives are needed — `TimeWindowParser` is already imported via the existing `using Anela.Heblo.Application.Features.Analytics.Services;` on line 3.
+
+**Verify the solution now builds cleanly:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build
+```
+
+Expected output: `Build succeeded.` with zero errors.
+
+**Commit:**
+```
+git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
+git commit -m "feat: inject TimeWindowParser into GetProductMarginSummaryHandler (FR-3)"
+```
+
+---
+

--- a/artifacts/feat-3334/task-context/register-timewindowparser-in-analyticsmodule.md
+++ b/artifacts/feat-3334/task-context/register-timewindowparser-in-analyticsmodule.md
@@ -1,0 +1,41 @@
+### task: register-timewindowparser-in-analyticsmodule
+
+
+Add `services.AddScoped<TimeWindowParser>()` to `AnalyticsModule`. `TimeProvider.System` is already registered as a singleton by the host infrastructure — no extra registration needed for `TimeProvider` itself.
+
+**File to modify:**
+`backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs`
+
+Locate the block that registers `IMarginCalculator` and `IMonthlyBreakdownGenerator` (currently lines 47–48). Add the new registration immediately before those lines, keeping the existing comments intact.
+
+**Current block:**
+```csharp
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+```
+
+**Replace with:**
+```csharp
+        services.AddScoped<TimeWindowParser>();
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+```
+
+No additional `using` is needed — `TimeWindowParser` is in `Anela.Heblo.Application.Features.Analytics.Services`, which is already imported via line 3 (`using Anela.Heblo.Application.Features.Analytics.Services;`).
+
+**Verify:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build 2>&1 | grep "error" | head -10
+```
+
+Still expect the handler error. Module itself should be clean.
+
+**Commit:**
+```
+git add backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+git commit -m "feat: register TimeWindowParser as scoped service in AnalyticsModule"
+```
+
+---
+

--- a/artifacts/feat-3334/task-context/update-handler-tests.md
+++ b/artifacts/feat-3334/task-context/update-handler-tests.md
@@ -1,0 +1,393 @@
+### task: update-handler-tests
+
+
+Update `GetProductMarginSummaryHandlerTests` to:
+1. Construct `TimeWindowParser` with a `FakeTimeProvider` frozen at `2026-01-15`
+2. Remove all `DateTime.Today` references — use the frozen date instead
+3. Pass the `TimeWindowParser` instance to the handler constructor
+4. Add a test for the new `ArgumentException` path
+
+**File to modify:**
+`backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs`
+
+`FakeTimeProvider` is in `Microsoft.Extensions.TimeProvider.Testing` which is already a `PackageReference` in `Anela.Heblo.Tests.csproj`. No package installation needed.
+
+**Full replacement for the file:**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Analytics.Services;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
+using Anela.Heblo.Domain.Features.Analytics;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+/// <summary>
+/// Tests use a FakeTimeProvider frozen at 2026-01-15 so date arithmetic
+/// is deterministic regardless of when the suite runs.
+/// </summary>
+public class GetProductMarginSummaryHandlerTests
+{
+    // Frozen instant: 2026-01-15 12:00:00 UTC
+    private static readonly DateTimeOffset FrozenNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+    // The "today" date the parser will derive from FrozenNow
+    private static readonly DateTime FrozenDate = FrozenNow.Date; // 2026-01-15
+
+    private readonly Mock<IAnalyticsRepository> _analyticsRepositoryMock;
+    private readonly MarginCalculator _marginCalculator;
+    private readonly MonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+    private readonly TimeWindowParser _timeWindowParser;
+    private readonly GetProductMarginSummaryHandler _handler;
+
+    public GetProductMarginSummaryHandlerTests()
+    {
+        _analyticsRepositoryMock = new Mock<IAnalyticsRepository>();
+        _marginCalculator = new MarginCalculator();
+        _monthlyBreakdownGenerator = new MonthlyBreakdownGenerator(_marginCalculator);
+
+        var fakeTimeProvider = new FakeTimeProvider(FrozenNow);
+        _timeWindowParser = new TimeWindowParser(fakeTimeProvider);
+
+        _handler = new GetProductMarginSummaryHandler(
+            _analyticsRepositoryMock.Object,
+            _marginCalculator,
+            _monthlyBreakdownGenerator,
+            _timeWindowParser);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsCorrectResponse()
+    {
+        // Arrange
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products
+        };
+
+        // Frozen date is 2026-01-15, so current-year starts 2026-01-01
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1); // 2026-01-01
+        var toDate = FrozenDate;                            // 2026-01-15
+
+        var analyticsProducts = new List<AnalyticsProduct>
+        {
+            new AnalyticsProduct
+            {
+                ProductCode = "PROD001",
+                ProductName = "Product 1",
+                Type = AnalyticsProductType.Product,
+                MarginAmount = 100m,
+                M0Amount = 100m,
+                M1Amount = 100m,
+                M2Amount = 100m,
+                SalesHistory = new List<SalesDataPoint>
+                {
+                    new() { Date = new DateTime(FrozenDate.Year, 1, 10), AmountB2B = 10, AmountB2C = 5 }
+                }
+            },
+            new AnalyticsProduct
+            {
+                ProductCode = "PROD002",
+                ProductName = "Product 2",
+                Type = AnalyticsProductType.Product,
+                MarginAmount = 50m,
+                M0Amount = 50m,
+                M1Amount = 50m,
+                M2Amount = 50m,
+                SalesHistory = new List<SalesDataPoint>
+                {
+                    new() { Date = new DateTime(FrozenDate.Year, 1, 12), AmountB2B = 20, AmountB2C = 10 }
+                }
+            }
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(analyticsProducts.ToAsyncEnumerable());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TimeWindow.Should().Be("current-year");
+        result.FromDate.Should().Be(fromDate);
+        result.ToDate.Should().Be(toDate);
+        result.TotalMargin.Should().Be(3000m); // (15 * 100) + (30 * 50) = 1500 + 1500
+        result.TopProducts.Count.Should().Be(2);
+        Assert.True(result.MonthlyData.Any());
+    }
+
+    [Theory]
+    [InlineData("current-year")]
+    [InlineData("last-6-months")]
+    [InlineData("last-12-months")]
+    public async Task Handle_DifferentTimeWindows_ParsesCorrectly(string timeWindow)
+    {
+        // Arrange
+        var request = new GetProductMarginSummaryRequest { TimeWindow = timeWindow, GroupingMode = ProductGroupingMode.Products };
+
+        // All expected dates derive from FrozenDate (2026-01-15), never DateTime.Today
+        var expectedDates = timeWindow switch
+        {
+            "current-year" => (new DateTime(FrozenDate.Year, 1, 1), FrozenDate),
+            "last-6-months" => (FrozenDate.AddMonths(-6), FrozenDate),
+            "last-12-months" => (FrozenDate.AddMonths(-12), FrozenDate),
+            _ => throw new InvalidOperationException($"Unexpected timeWindow in test: {timeWindow}")
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.TimeWindow.Should().Be(timeWindow);
+        result.FromDate.Should().Be(expectedDates.Item1);
+        result.ToDate.Should().Be(expectedDates.Item2);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyProductList_ReturnsZeroMargin()
+    {
+        // Arrange
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products
+        };
+
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1);
+        var toDate = FrozenDate;
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.TotalMargin.Should().Be(0m);
+        result.TopProducts.Should().BeEmpty();
+        result.MonthlyData.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator()
+    {
+        // Arrange
+        var marginCalculatorMock = new Mock<IMarginCalculator>();
+        var monthlyBreakdownGeneratorMock = new Mock<IMonthlyBreakdownGenerator>();
+
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products,
+            MarginLevel = MarginLevel.M2
+        };
+
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1);
+        var toDate = FrozenDate;
+
+        var calculationResult = new MarginCalculationResult
+        {
+            GroupTotals = new Dictionary<string, decimal> { ["PROD001"] = 500m },
+            GroupProducts = new Dictionary<string, List<AnalyticsProduct>>
+            {
+                ["PROD001"] = new List<AnalyticsProduct>
+                {
+                    new AnalyticsProduct
+                    {
+                        ProductCode = "PROD001",
+                        ProductName = "Product 1",
+                        Type = AnalyticsProductType.Product,
+                        MarginAmount = 50m,
+                        M0Amount = 50m,
+                        M1Amount = 50m,
+                        M2Amount = 50m,
+                        SellingPrice = 100m,
+                        PurchasePrice = 50m,
+                        SalesHistory = new List<SalesDataPoint>
+                        {
+                            new() { Date = new DateTime(FrozenDate.Year, 1, 10), AmountB2B = 5, AmountB2C = 5 }
+                        }
+                    }
+                }
+            },
+            TotalMargin = 500m
+        };
+
+        var monthlyData = new List<MonthlyProductMarginDto>
+        {
+            new MonthlyProductMarginDto
+            {
+                Year = FrozenDate.Year,
+                Month = 1,
+                MonthDisplay = "Jan",
+                ProductSegments = new List<ProductMarginSegmentDto>(),
+                TotalMonthMargin = 500m
+            }
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        marginCalculatorMock
+            .Setup(x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(calculationResult);
+
+        marginCalculatorMock
+            .Setup(x => x.GetGroupDisplayName(
+                It.IsAny<string>(),
+                It.IsAny<ProductGroupingMode>(),
+                It.IsAny<List<AnalyticsProduct>>()))
+            .Returns<string, ProductGroupingMode, List<AnalyticsProduct>>((key, _, _) => key);
+
+        monthlyBreakdownGeneratorMock
+            .Setup(x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2))
+            .Returns(monthlyData);
+
+        // Note: this handler instance gets its own TimeWindowParser with the shared FakeTimeProvider
+        var handler = new GetProductMarginSummaryHandler(
+            _analyticsRepositoryMock.Object,
+            marginCalculatorMock.Object,
+            monthlyBreakdownGeneratorMock.Object,
+            _timeWindowParser);
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMargin.Should().Be(500m);
+        result.MonthlyData.Should().BeSameAs(monthlyData);
+
+        marginCalculatorMock.Verify(
+            x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        monthlyBreakdownGeneratorMock.Verify(
+            x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetMarginAmountForLevel_WithUndefinedEnumValue_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var product = new AnalyticsProduct
+        {
+            ProductCode = "PROD001",
+            ProductName = "Product 1",
+            Type = AnalyticsProductType.Product,
+            MarginAmount = 50m,
+            M0Amount = 10m,
+            M1Amount = 20m,
+            M2Amount = 30m,
+            SalesHistory = new List<SalesDataPoint>()
+        };
+        var undefined = (MarginLevel)99;
+
+        // Act
+        Action act = () => _marginCalculator.GetMarginAmountForLevel(product, undefined);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("marginLevel");
+    }
+
+    [Fact]
+    public void ParseTimeWindow_UnknownValue_ThrowsArgumentException()
+    {
+        // Arrange — _timeWindowParser is already wired to FakeTimeProvider
+
+        // Act
+        Action act = () => _timeWindowParser.ParseTimeWindow("not-a-real-window");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Unknown time window value: 'not-a-real-window'*")
+            .WithParameterName("timeWindow");
+    }
+}
+
+// Extension method to convert list to IAsyncEnumerable for testing
+public static class TestExtensions
+{
+    public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item;
+        }
+        await Task.CompletedTask; // Satisfy async requirement
+    }
+}
+```
+
+Key changes from the original:
+- Added `using Microsoft.Extensions.Time.Testing;`
+- Added `FrozenNow` and `FrozenDate` static readonly fields — single source of truth for the frozen instant
+- Constructor creates `FakeTimeProvider(FrozenNow)`, builds `TimeWindowParser`, passes it to handler
+- All `DateTime.Today` references replaced with `FrozenDate`
+- `Handle_DifferentTimeWindows_ParsesCorrectly`: the `_ =>` fallback now throws `InvalidOperationException` instead of silently mapping an unrecognised value (matching the new handler behaviour)
+- `Handle_ValidRequest_ReturnsCorrectResponse`: sales history dates updated to fall within `2026-01-01..2026-01-15` (the frozen current-year window) so the mock repository setup matches correctly
+- Added `ParseTimeWindow_UnknownValue_ThrowsArgumentException` test (new, covers FR-4)
+
+**Run all Analytics tests:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests" \
+  --verbosity normal
+```
+
+Expected: all 6 tests pass (5 original + 1 new ArgumentException test).
+
+**Run the full backend build and format check:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build && dotnet format --verify-no-changes
+```
+
+**Commit:**
+```
+git add backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
+git commit -m "test: update GetProductMarginSummaryHandlerTests to use FakeTimeProvider and cover ArgumentException path"
+```

--- a/artifacts/feat-3334/task-context/update-timewindowparser.md
+++ b/artifacts/feat-3334/task-context/update-timewindowparser.md
@@ -1,0 +1,84 @@
+### task: update-timewindowparser
+
+
+Convert `TimeWindowParser` from a static class to an injectable instance class that receives `TimeProvider` and replaces the silent fallback with `ArgumentException`.
+
+**File to modify:**
+`backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs`
+
+**Current content (full file):**
+```csharp
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public static class TimeWindowParser
+{
+    public static (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = DateTime.Today;
+
+        return timeWindow switch
+        {
+            "current-year" => (new DateTime(today.Year, 1, 1), today),
+            "current-and-previous-year" => (new DateTime(today.Year - 1, 1, 1), today),
+            "last-6-months" => (today.AddMonths(-6), today),
+            "last-12-months" => (today.AddMonths(-12), today),
+            "last-24-months" => (today.AddMonths(-24), today),
+            _ => (new DateTime(today.Year, 1, 1), today)
+        };
+    }
+}
+```
+
+**Replace with:**
+```csharp
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public class TimeWindowParser
+{
+    private readonly TimeProvider _timeProvider;
+
+    public TimeWindowParser(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    public (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = _timeProvider.GetLocalNow().Date;
+
+        return timeWindow switch
+        {
+            "current-year" => (new DateTime(today.Year, 1, 1), today),
+            "current-and-previous-year" => (new DateTime(today.Year - 1, 1, 1), today),
+            "last-6-months" => (today.AddMonths(-6), today),
+            "last-12-months" => (today.AddMonths(-12), today),
+            "last-24-months" => (today.AddMonths(-24), today),
+            _ => throw new ArgumentException($"Unknown time window value: '{timeWindow}'", nameof(timeWindow))
+        };
+    }
+}
+```
+
+Key changes:
+- `static class` → `class`
+- Constructor accepts `TimeProvider timeProvider`, stored as `_timeProvider`
+- `DateTime.Today` → `_timeProvider.GetLocalNow().Date`
+- Static method becomes instance method (remove `static` keyword)
+- Silent fallback `_ => (new DateTime(today.Year, 1, 1), today)` → `ArgumentException`
+
+**Verify the build compiles (expect two errors for the two remaining files that still need updating — that is fine at this stage):**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build 2>&1 | grep -E "error|warning" | head -20
+```
+
+Expected: errors in `GetProductMarginSummaryHandler.cs` about static call on non-static type. That is the compile signal that you must now fix the handler.
+
+**Commit:**
+```
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs
+git commit -m "refactor: convert TimeWindowParser to injectable instance class with TimeProvider"
+```
+
+---
+

--- a/artifacts/feat-3334/task-plan.r1.md
+++ b/artifacts/feat-3334/task-plan.r1.md
@@ -1,0 +1,604 @@
+# Implementation Plan: Inject TimeProvider into TimeWindowParser
+
+## Overview
+
+Four files change. The static `TimeWindowParser` becomes an injectable instance class, its single caller (`GetProductMarginSummaryHandler`) receives it via constructor injection, `AnalyticsModule` registers the new service, and the test suite drops `DateTime.Today` in favour of a frozen `FakeTimeProvider`.
+
+Static caller audit (run before touching anything): `TimeWindowParser.ParseTimeWindow` is called in exactly one place — `GetProductMarginSummaryHandler.cs:31`. No other callers exist.
+
+---
+
+### task: update-timewindowparser
+
+Convert `TimeWindowParser` from a static class to an injectable instance class that receives `TimeProvider` and replaces the silent fallback with `ArgumentException`.
+
+**File to modify:**
+`backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs`
+
+**Current content (full file):**
+```csharp
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public static class TimeWindowParser
+{
+    public static (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = DateTime.Today;
+
+        return timeWindow switch
+        {
+            "current-year" => (new DateTime(today.Year, 1, 1), today),
+            "current-and-previous-year" => (new DateTime(today.Year - 1, 1, 1), today),
+            "last-6-months" => (today.AddMonths(-6), today),
+            "last-12-months" => (today.AddMonths(-12), today),
+            "last-24-months" => (today.AddMonths(-24), today),
+            _ => (new DateTime(today.Year, 1, 1), today)
+        };
+    }
+}
+```
+
+**Replace with:**
+```csharp
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public class TimeWindowParser
+{
+    private readonly TimeProvider _timeProvider;
+
+    public TimeWindowParser(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    public (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = _timeProvider.GetLocalNow().Date;
+
+        return timeWindow switch
+        {
+            "current-year" => (new DateTime(today.Year, 1, 1), today),
+            "current-and-previous-year" => (new DateTime(today.Year - 1, 1, 1), today),
+            "last-6-months" => (today.AddMonths(-6), today),
+            "last-12-months" => (today.AddMonths(-12), today),
+            "last-24-months" => (today.AddMonths(-24), today),
+            _ => throw new ArgumentException($"Unknown time window value: '{timeWindow}'", nameof(timeWindow))
+        };
+    }
+}
+```
+
+Key changes:
+- `static class` → `class`
+- Constructor accepts `TimeProvider timeProvider`, stored as `_timeProvider`
+- `DateTime.Today` → `_timeProvider.GetLocalNow().Date`
+- Static method becomes instance method (remove `static` keyword)
+- Silent fallback `_ => (new DateTime(today.Year, 1, 1), today)` → `ArgumentException`
+
+**Verify the build compiles (expect two errors for the two remaining files that still need updating — that is fine at this stage):**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build 2>&1 | grep -E "error|warning" | head -20
+```
+
+Expected: errors in `GetProductMarginSummaryHandler.cs` about static call on non-static type. That is the compile signal that you must now fix the handler.
+
+**Commit:**
+```
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs
+git commit -m "refactor: convert TimeWindowParser to injectable instance class with TimeProvider"
+```
+
+---
+
+### task: register-timewindowparser-in-analyticsmodule
+
+Add `services.AddScoped<TimeWindowParser>()` to `AnalyticsModule`. `TimeProvider.System` is already registered as a singleton by the host infrastructure — no extra registration needed for `TimeProvider` itself.
+
+**File to modify:**
+`backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs`
+
+Locate the block that registers `IMarginCalculator` and `IMonthlyBreakdownGenerator` (currently lines 47–48). Add the new registration immediately before those lines, keeping the existing comments intact.
+
+**Current block:**
+```csharp
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+```
+
+**Replace with:**
+```csharp
+        services.AddScoped<TimeWindowParser>();
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+```
+
+No additional `using` is needed — `TimeWindowParser` is in `Anela.Heblo.Application.Features.Analytics.Services`, which is already imported via line 3 (`using Anela.Heblo.Application.Features.Analytics.Services;`).
+
+**Verify:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build 2>&1 | grep "error" | head -10
+```
+
+Still expect the handler error. Module itself should be clean.
+
+**Commit:**
+```
+git add backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+git commit -m "feat: register TimeWindowParser as scoped service in AnalyticsModule"
+```
+
+---
+
+### task: inject-timewindowparser-into-handler
+
+Replace the static `TimeWindowParser.ParseTimeWindow(...)` call in `GetProductMarginSummaryHandler` with constructor-injected instance usage.
+
+**File to modify:**
+`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs`
+
+**Step 1 — add field and update constructor.**
+
+Current constructor (lines 18–26):
+```csharp
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        IMarginCalculator marginCalculator,
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+    }
+```
+
+Current field declarations (lines 14–16):
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly IMarginCalculator _marginCalculator;
+    private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+```
+
+Replace both with:
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly IMarginCalculator _marginCalculator;
+    private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+    private readonly TimeWindowParser _timeWindowParser;
+
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        IMarginCalculator marginCalculator,
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator,
+        TimeWindowParser timeWindowParser)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+        _timeWindowParser = timeWindowParser;
+    }
+```
+
+**Step 2 — replace static call on line 31.**
+
+Current:
+```csharp
+        var (fromDate, toDate) = TimeWindowParser.ParseTimeWindow(request.TimeWindow);
+```
+
+Replace with:
+```csharp
+        var (fromDate, toDate) = _timeWindowParser.ParseTimeWindow(request.TimeWindow);
+```
+
+No new `using` directives are needed — `TimeWindowParser` is already imported via the existing `using Anela.Heblo.Application.Features.Analytics.Services;` on line 3.
+
+**Verify the solution now builds cleanly:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build
+```
+
+Expected output: `Build succeeded.` with zero errors.
+
+**Commit:**
+```
+git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
+git commit -m "feat: inject TimeWindowParser into GetProductMarginSummaryHandler (FR-3)"
+```
+
+---
+
+### task: update-handler-tests
+
+Update `GetProductMarginSummaryHandlerTests` to:
+1. Construct `TimeWindowParser` with a `FakeTimeProvider` frozen at `2026-01-15`
+2. Remove all `DateTime.Today` references — use the frozen date instead
+3. Pass the `TimeWindowParser` instance to the handler constructor
+4. Add a test for the new `ArgumentException` path
+
+**File to modify:**
+`backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs`
+
+`FakeTimeProvider` is in `Microsoft.Extensions.TimeProvider.Testing` which is already a `PackageReference` in `Anela.Heblo.Tests.csproj`. No package installation needed.
+
+**Full replacement for the file:**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Analytics.Services;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
+using Anela.Heblo.Domain.Features.Analytics;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+/// <summary>
+/// Tests use a FakeTimeProvider frozen at 2026-01-15 so date arithmetic
+/// is deterministic regardless of when the suite runs.
+/// </summary>
+public class GetProductMarginSummaryHandlerTests
+{
+    // Frozen instant: 2026-01-15 12:00:00 UTC
+    private static readonly DateTimeOffset FrozenNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+    // The "today" date the parser will derive from FrozenNow
+    private static readonly DateTime FrozenDate = FrozenNow.Date; // 2026-01-15
+
+    private readonly Mock<IAnalyticsRepository> _analyticsRepositoryMock;
+    private readonly MarginCalculator _marginCalculator;
+    private readonly MonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+    private readonly TimeWindowParser _timeWindowParser;
+    private readonly GetProductMarginSummaryHandler _handler;
+
+    public GetProductMarginSummaryHandlerTests()
+    {
+        _analyticsRepositoryMock = new Mock<IAnalyticsRepository>();
+        _marginCalculator = new MarginCalculator();
+        _monthlyBreakdownGenerator = new MonthlyBreakdownGenerator(_marginCalculator);
+
+        var fakeTimeProvider = new FakeTimeProvider(FrozenNow);
+        _timeWindowParser = new TimeWindowParser(fakeTimeProvider);
+
+        _handler = new GetProductMarginSummaryHandler(
+            _analyticsRepositoryMock.Object,
+            _marginCalculator,
+            _monthlyBreakdownGenerator,
+            _timeWindowParser);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsCorrectResponse()
+    {
+        // Arrange
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products
+        };
+
+        // Frozen date is 2026-01-15, so current-year starts 2026-01-01
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1); // 2026-01-01
+        var toDate = FrozenDate;                            // 2026-01-15
+
+        var analyticsProducts = new List<AnalyticsProduct>
+        {
+            new AnalyticsProduct
+            {
+                ProductCode = "PROD001",
+                ProductName = "Product 1",
+                Type = AnalyticsProductType.Product,
+                MarginAmount = 100m,
+                M0Amount = 100m,
+                M1Amount = 100m,
+                M2Amount = 100m,
+                SalesHistory = new List<SalesDataPoint>
+                {
+                    new() { Date = new DateTime(FrozenDate.Year, 1, 10), AmountB2B = 10, AmountB2C = 5 }
+                }
+            },
+            new AnalyticsProduct
+            {
+                ProductCode = "PROD002",
+                ProductName = "Product 2",
+                Type = AnalyticsProductType.Product,
+                MarginAmount = 50m,
+                M0Amount = 50m,
+                M1Amount = 50m,
+                M2Amount = 50m,
+                SalesHistory = new List<SalesDataPoint>
+                {
+                    new() { Date = new DateTime(FrozenDate.Year, 1, 12), AmountB2B = 20, AmountB2C = 10 }
+                }
+            }
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(analyticsProducts.ToAsyncEnumerable());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TimeWindow.Should().Be("current-year");
+        result.FromDate.Should().Be(fromDate);
+        result.ToDate.Should().Be(toDate);
+        result.TotalMargin.Should().Be(3000m); // (15 * 100) + (30 * 50) = 1500 + 1500
+        result.TopProducts.Count.Should().Be(2);
+        Assert.True(result.MonthlyData.Any());
+    }
+
+    [Theory]
+    [InlineData("current-year")]
+    [InlineData("last-6-months")]
+    [InlineData("last-12-months")]
+    public async Task Handle_DifferentTimeWindows_ParsesCorrectly(string timeWindow)
+    {
+        // Arrange
+        var request = new GetProductMarginSummaryRequest { TimeWindow = timeWindow, GroupingMode = ProductGroupingMode.Products };
+
+        // All expected dates derive from FrozenDate (2026-01-15), never DateTime.Today
+        var expectedDates = timeWindow switch
+        {
+            "current-year" => (new DateTime(FrozenDate.Year, 1, 1), FrozenDate),
+            "last-6-months" => (FrozenDate.AddMonths(-6), FrozenDate),
+            "last-12-months" => (FrozenDate.AddMonths(-12), FrozenDate),
+            _ => throw new InvalidOperationException($"Unexpected timeWindow in test: {timeWindow}")
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.TimeWindow.Should().Be(timeWindow);
+        result.FromDate.Should().Be(expectedDates.Item1);
+        result.ToDate.Should().Be(expectedDates.Item2);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyProductList_ReturnsZeroMargin()
+    {
+        // Arrange
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products
+        };
+
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1);
+        var toDate = FrozenDate;
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.TotalMargin.Should().Be(0m);
+        result.TopProducts.Should().BeEmpty();
+        result.MonthlyData.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator()
+    {
+        // Arrange
+        var marginCalculatorMock = new Mock<IMarginCalculator>();
+        var monthlyBreakdownGeneratorMock = new Mock<IMonthlyBreakdownGenerator>();
+
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products,
+            MarginLevel = MarginLevel.M2
+        };
+
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1);
+        var toDate = FrozenDate;
+
+        var calculationResult = new MarginCalculationResult
+        {
+            GroupTotals = new Dictionary<string, decimal> { ["PROD001"] = 500m },
+            GroupProducts = new Dictionary<string, List<AnalyticsProduct>>
+            {
+                ["PROD001"] = new List<AnalyticsProduct>
+                {
+                    new AnalyticsProduct
+                    {
+                        ProductCode = "PROD001",
+                        ProductName = "Product 1",
+                        Type = AnalyticsProductType.Product,
+                        MarginAmount = 50m,
+                        M0Amount = 50m,
+                        M1Amount = 50m,
+                        M2Amount = 50m,
+                        SellingPrice = 100m,
+                        PurchasePrice = 50m,
+                        SalesHistory = new List<SalesDataPoint>
+                        {
+                            new() { Date = new DateTime(FrozenDate.Year, 1, 10), AmountB2B = 5, AmountB2C = 5 }
+                        }
+                    }
+                }
+            },
+            TotalMargin = 500m
+        };
+
+        var monthlyData = new List<MonthlyProductMarginDto>
+        {
+            new MonthlyProductMarginDto
+            {
+                Year = FrozenDate.Year,
+                Month = 1,
+                MonthDisplay = "Jan",
+                ProductSegments = new List<ProductMarginSegmentDto>(),
+                TotalMonthMargin = 500m
+            }
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        marginCalculatorMock
+            .Setup(x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(calculationResult);
+
+        marginCalculatorMock
+            .Setup(x => x.GetGroupDisplayName(
+                It.IsAny<string>(),
+                It.IsAny<ProductGroupingMode>(),
+                It.IsAny<List<AnalyticsProduct>>()))
+            .Returns<string, ProductGroupingMode, List<AnalyticsProduct>>((key, _, _) => key);
+
+        monthlyBreakdownGeneratorMock
+            .Setup(x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2))
+            .Returns(monthlyData);
+
+        // Note: this handler instance gets its own TimeWindowParser with the shared FakeTimeProvider
+        var handler = new GetProductMarginSummaryHandler(
+            _analyticsRepositoryMock.Object,
+            marginCalculatorMock.Object,
+            monthlyBreakdownGeneratorMock.Object,
+            _timeWindowParser);
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMargin.Should().Be(500m);
+        result.MonthlyData.Should().BeSameAs(monthlyData);
+
+        marginCalculatorMock.Verify(
+            x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        monthlyBreakdownGeneratorMock.Verify(
+            x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                MarginLevel.M2),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetMarginAmountForLevel_WithUndefinedEnumValue_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var product = new AnalyticsProduct
+        {
+            ProductCode = "PROD001",
+            ProductName = "Product 1",
+            Type = AnalyticsProductType.Product,
+            MarginAmount = 50m,
+            M0Amount = 10m,
+            M1Amount = 20m,
+            M2Amount = 30m,
+            SalesHistory = new List<SalesDataPoint>()
+        };
+        var undefined = (MarginLevel)99;
+
+        // Act
+        Action act = () => _marginCalculator.GetMarginAmountForLevel(product, undefined);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("marginLevel");
+    }
+
+    [Fact]
+    public void ParseTimeWindow_UnknownValue_ThrowsArgumentException()
+    {
+        // Arrange — _timeWindowParser is already wired to FakeTimeProvider
+
+        // Act
+        Action act = () => _timeWindowParser.ParseTimeWindow("not-a-real-window");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Unknown time window value: 'not-a-real-window'*")
+            .WithParameterName("timeWindow");
+    }
+}
+
+// Extension method to convert list to IAsyncEnumerable for testing
+public static class TestExtensions
+{
+    public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> source)
+    {
+        foreach (var item in source)
+        {
+            yield return item;
+        }
+        await Task.CompletedTask; // Satisfy async requirement
+    }
+}
+```
+
+Key changes from the original:
+- Added `using Microsoft.Extensions.Time.Testing;`
+- Added `FrozenNow` and `FrozenDate` static readonly fields — single source of truth for the frozen instant
+- Constructor creates `FakeTimeProvider(FrozenNow)`, builds `TimeWindowParser`, passes it to handler
+- All `DateTime.Today` references replaced with `FrozenDate`
+- `Handle_DifferentTimeWindows_ParsesCorrectly`: the `_ =>` fallback now throws `InvalidOperationException` instead of silently mapping an unrecognised value (matching the new handler behaviour)
+- `Handle_ValidRequest_ReturnsCorrectResponse`: sales history dates updated to fall within `2026-01-01..2026-01-15` (the frozen current-year window) so the mock repository setup matches correctly
+- Added `ParseTimeWindow_UnknownValue_ThrowsArgumentException` test (new, covers FR-4)
+
+**Run all Analytics tests:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests" \
+  --verbosity normal
+```
+
+Expected: all 6 tests pass (5 original + 1 new ArgumentException test).
+
+**Run the full backend build and format check:**
+```bash
+cd /home/user/worktrees/feature-3334-Arch-Review-Analytics-Timewindowparser-Uses-Dateti/backend
+dotnet build && dotnet format --verify-no-changes
+```
+
+**Commit:**
+```
+git add backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
+git commit -m "test: update GetProductMarginSummaryHandlerTests to use FakeTimeProvider and cover ArgumentException path"
+```

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
@@ -44,6 +44,7 @@ public static class AnalyticsModule
         services.AddScoped<IPipelineBehavior<GetProductMarginAnalysisRequest, GetProductMarginAnalysisResponse>,
             ValidationResultBehavior<GetProductMarginAnalysisRequest, GetProductMarginAnalysisResponse>>();
 
+        services.AddScoped<TimeWindowParser>();
         services.AddScoped<IMarginCalculator, MarginCalculator>();
         services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
 

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs
@@ -1,10 +1,17 @@
 namespace Anela.Heblo.Application.Features.Analytics.Services;
 
-public static class TimeWindowParser
+public class TimeWindowParser
 {
-    public static (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    private readonly TimeProvider _timeProvider;
+
+    public TimeWindowParser(TimeProvider timeProvider)
     {
-        var today = DateTime.Today;
+        _timeProvider = timeProvider;
+    }
+
+    public (DateTime fromDate, DateTime toDate) ParseTimeWindow(string timeWindow)
+    {
+        var today = _timeProvider.GetLocalNow().Date;
 
         return timeWindow switch
         {
@@ -13,7 +20,7 @@ public static class TimeWindowParser
             "last-6-months" => (today.AddMonths(-6), today),
             "last-12-months" => (today.AddMonths(-12), today),
             "last-24-months" => (today.AddMonths(-24), today),
-            _ => (new DateTime(today.Year, 1, 1), today)
+            _ => throw new ArgumentException($"Unknown time window value: '{timeWindow}'", nameof(timeWindow))
         };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
@@ -14,21 +14,24 @@ public class GetProductMarginSummaryHandler : IRequestHandler<GetProductMarginSu
     private readonly IAnalyticsRepository _analyticsRepository;
     private readonly IMarginCalculator _marginCalculator;
     private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+    private readonly TimeWindowParser _timeWindowParser;
 
     public GetProductMarginSummaryHandler(
         IAnalyticsRepository analyticsRepository,
         IMarginCalculator marginCalculator,
-        IMonthlyBreakdownGenerator monthlyBreakdownGenerator)
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator,
+        TimeWindowParser timeWindowParser)
     {
         _analyticsRepository = analyticsRepository;
         _marginCalculator = marginCalculator;
         _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+        _timeWindowParser = timeWindowParser;
     }
 
     public async Task<GetProductMarginSummaryResponse> Handle(GetProductMarginSummaryRequest request, CancellationToken cancellationToken)
     {
         // 1. Parse time window and calculate date range
-        var (fromDate, toDate) = TimeWindowParser.ParseTimeWindow(request.TimeWindow);
+        var (fromDate, toDate) = _timeWindowParser.ParseTimeWindow(request.TimeWindow);
         var dateRange = new DateRange(fromDate, toDate);
 
         // 2. Stream products with Product/Goods types that have sales in the period

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
@@ -9,20 +9,21 @@ using Anela.Heblo.Application.Features.Analytics.Services;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
 using Anela.Heblo.Domain.Features.Analytics;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Analytics;
 
-/// <summary>
-/// 🔒 PERFORMANCE FIX: Updated tests for new streaming architecture
-/// Tests now use mocked analytics repository instead of direct catalog dependency
-/// </summary>
 public class GetProductMarginSummaryHandlerTests
 {
+    private static readonly DateTimeOffset FrozenNow = new(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTime FrozenDate = new(2026, 1, 15);
+
     private readonly Mock<IAnalyticsRepository> _analyticsRepositoryMock;
     private readonly MarginCalculator _marginCalculator;
     private readonly MonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+    private readonly TimeWindowParser _timeWindowParser;
     private readonly GetProductMarginSummaryHandler _handler;
 
     public GetProductMarginSummaryHandlerTests()
@@ -30,10 +31,13 @@ public class GetProductMarginSummaryHandlerTests
         _analyticsRepositoryMock = new Mock<IAnalyticsRepository>();
         _marginCalculator = new MarginCalculator();
         _monthlyBreakdownGenerator = new MonthlyBreakdownGenerator(_marginCalculator);
+        var timeProvider = new FakeTimeProvider(FrozenNow);
+        _timeWindowParser = new TimeWindowParser(timeProvider);
         _handler = new GetProductMarginSummaryHandler(
             _analyticsRepositoryMock.Object,
             _marginCalculator,
-            _monthlyBreakdownGenerator);
+            _monthlyBreakdownGenerator,
+            _timeWindowParser);
     }
 
     [Fact]
@@ -46,9 +50,8 @@ public class GetProductMarginSummaryHandlerTests
             GroupingMode = ProductGroupingMode.Products
         };
 
-        var today = DateTime.Today;
-        var fromDate = new DateTime(today.Year, 1, 1);
-        var toDate = today;
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1);
+        var toDate = FrozenDate;
 
         var analyticsProducts = new List<AnalyticsProduct>
         {
@@ -63,7 +66,7 @@ public class GetProductMarginSummaryHandlerTests
                 M2Amount = 100m,
                 SalesHistory = new List<SalesDataPoint>
                 {
-                    new() { Date = new DateTime(today.Year, 3, 15), AmountB2B = 10, AmountB2C = 5 }
+                    new() { Date = new DateTime(2026, 1, 10), AmountB2B = 10, AmountB2C = 5 }
                 }
             },
             new AnalyticsProduct
@@ -77,11 +80,10 @@ public class GetProductMarginSummaryHandlerTests
                 M2Amount = 50m,
                 SalesHistory = new List<SalesDataPoint>
                 {
-                    new() { Date = new DateTime(today.Year, 4, 20), AmountB2B = 20, AmountB2C = 10 }
+                    new() { Date = new DateTime(2026, 1, 12), AmountB2B = 20, AmountB2C = 10 }
                 }
             }
         };
-
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
@@ -109,13 +111,12 @@ public class GetProductMarginSummaryHandlerTests
     {
         // Arrange
         var request = new GetProductMarginSummaryRequest { TimeWindow = timeWindow, GroupingMode = ProductGroupingMode.Products };
-        var today = DateTime.Today;
         var expectedDates = timeWindow switch
         {
-            "current-year" => (new DateTime(today.Year, 1, 1), today),
-            "last-6-months" => (today.AddMonths(-6), today),
-            "last-12-months" => (today.AddMonths(-12), today),
-            _ => (new DateTime(today.Year, 1, 1), today)
+            "current-year" => (new DateTime(FrozenDate.Year, 1, 1), FrozenDate),
+            "last-6-months" => (FrozenDate.AddMonths(-6), FrozenDate),
+            "last-12-months" => (FrozenDate.AddMonths(-12), FrozenDate),
+            _ => (new DateTime(FrozenDate.Year, 1, 1), FrozenDate)
         };
 
         _analyticsRepositoryMock
@@ -142,10 +143,8 @@ public class GetProductMarginSummaryHandlerTests
             GroupingMode = ProductGroupingMode.Products
         };
 
-        var today = DateTime.Today;
-        var fromDate = new DateTime(today.Year, 1, 1);
-        var toDate = today;
-
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1);
+        var toDate = FrozenDate;
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
@@ -175,9 +174,8 @@ public class GetProductMarginSummaryHandlerTests
             MarginLevel = MarginLevel.M2
         };
 
-        var today = DateTime.Today;
-        var fromDate = new DateTime(today.Year, 1, 1);
-        var toDate = today;
+        var fromDate = new DateTime(FrozenDate.Year, 1, 1);
+        var toDate = FrozenDate;
 
         var calculationResult = new MarginCalculationResult
         {
@@ -199,7 +197,7 @@ public class GetProductMarginSummaryHandlerTests
                         PurchasePrice = 50m,
                         SalesHistory = new List<SalesDataPoint>
                         {
-                            new() { Date = new DateTime(today.Year, 3, 1), AmountB2B = 5, AmountB2C = 5 }
+                            new() { Date = new DateTime(2026, 1, 10), AmountB2B = 5, AmountB2C = 5 }
                         }
                     }
                 }
@@ -211,9 +209,9 @@ public class GetProductMarginSummaryHandlerTests
         {
             new MonthlyProductMarginDto
             {
-                Year = today.Year,
-                Month = 3,
-                MonthDisplay = "Mar",
+                Year = 2026,
+                Month = 1,
+                MonthDisplay = "Jan",
                 ProductSegments = new List<ProductMarginSegmentDto>(),
                 TotalMonthMargin = 500m
             }
@@ -251,7 +249,8 @@ public class GetProductMarginSummaryHandlerTests
         var handler = new GetProductMarginSummaryHandler(
             _analyticsRepositoryMock.Object,
             marginCalculatorMock.Object,
-            monthlyBreakdownGeneratorMock.Object);
+            monthlyBreakdownGeneratorMock.Object,
+            _timeWindowParser);
 
         // Act
         var result = await handler.Handle(request, CancellationToken.None);
@@ -303,6 +302,24 @@ public class GetProductMarginSummaryHandlerTests
         act.Should().Throw<ArgumentOutOfRangeException>()
             .WithParameterName("marginLevel");
     }
+
+    [Fact]
+    public async Task ParseTimeWindow_UnknownValue_ThrowsArgumentException()
+    {
+        // Arrange
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "not-a-real-window",
+            GroupingMode = ProductGroupingMode.Products
+        };
+
+        // Act
+        Func<Task> act = () => _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*not-a-real-window*");
+    }
 }
 
 // Extension method to convert list to IAsyncEnumerable for testing
@@ -314,6 +331,6 @@ public static class TestExtensions
         {
             yield return item;
         }
-        await Task.CompletedTask; // Satisfy async requirement
+        await Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Closes #3334

## What the issue was

`TimeWindowParser` used `DateTime.Today` directly — a static ambient that cannot be controlled in tests. Every test that relied on the computed date range was clock-sensitive and non-deterministic. Additionally, any unrecognised `timeWindow` string silently fell back to `current-year`, swallowing typos without any diagnostic.

## How it was fixed / handled

- **`TimeWindowParser`** converted from `static class` to injectable instance class; constructor accepts `TimeProvider` and replaces `DateTime.Today` with `_timeProvider.GetLocalNow().Date`. Silent `_` fallback replaced with `ArgumentException` that names the bad value.
- **`AnalyticsModule`** registers `TimeWindowParser` as a scoped service so it resolves via DI.
- **`GetProductMarginSummaryHandler`** receives `TimeWindowParser` via constructor injection; static call replaced with instance call.
- **`GetProductMarginSummaryHandlerTests`** updated to construct `TimeWindowParser` with `FakeTimeProvider` frozen at `2026-01-15 12:00:00 UTC`; all `DateTime.Today` references eliminated; new test `ParseTimeWindow_UnknownValue_ThrowsArgumentException` added. 8/8 tests pass deterministically.

## Artifacts

Brief, spec, arch-review, task plan, impl, review, and whole-branch code-review markdown are committed under `artifacts/feat-3334/` on this branch.

## Code review

All five functional requirements met. Review result: **CLEAN**. One advisory note: the `_ =>` arm in `Handle_DifferentTimeWindows_ParsesCorrectly`'s local `expectedDates` switch is unreachable dead code (not blocking).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012NT7VQ42KJNmUhGnm82mU8)_