### PR TITLE
#3343: fix stock-operations E2E navigation URL to /stock-up-operations

### DIFF
--- a/artifacts/feat-3343/arch-review.r1.md
+++ b/artifacts/feat-3343/arch-review.r1.md
@@ -1,0 +1,127 @@
+# Architecture Review: Fix Stock-Operations E2E Navigation URL
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is entirely within the E2E test layer. No application source files, API contracts, backend handlers, or React components are touched. The fix is a mechanical string substitution correcting a typo that has caused every test in the `stock-operations` Playwright module to fail since the suite was written.
+
+The application route `/stock-up-operations` is registered at `frontend/src/App.tsx:449` and linked from the sidebar at `frontend/src/components/Layout/Sidebar.tsx:345`. Both have always used the correct path. The test code was written with the truncated string `/stock-operations` and no redirect or catch-all exists to absorb the mismatch, so every navigation lands on a blank page.
+
+Integration points:
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` — the `navigateToStockOperations` function, which all spec `beforeEach` blocks call.
+- `frontend/test/e2e/stock-operations/*.spec.ts` — eight spec files, seven of which assert `page.url().toContain('/stock-operations')`. One (`navigation.spec.ts`) also contains a bare `page.goto` with the wrong path.
+- `frontend/test/e2e/helpers/stock-operations-test-helpers.ts` — no URL references; not changed.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+E2E test execution
+│
+├── beforeEach (all spec files)
+│   └── navigateToStockOperations()               [e2e-auth-helper.ts:262]
+│       └── page.goto(`${baseUrl}/stock-operations`)   ← WRONG, fix here
+│
+├── navigation.spec.ts
+│   ├── line 13  expect(page.url()).toContain('/stock-operations')   ← fix
+│   └── line 96  page.goto(`${baseUrl}/stock-operations`)           ← fix
+│
+└── URL assertions in 7 spec files
+    ├── badges.spec.ts:15     toContain('/stock-operations')         ← fix
+    ├── accept.spec.ts:13     toContain('/stock-operations')         ← fix
+    ├── state-filter.spec.ts:14   toContain('/stock-operations')     ← fix
+    ├── source-filter.spec.ts:13  toContain('/stock-operations')     ← fix
+    ├── sorting.spec.ts:14    toContain('/stock-operations')         ← fix
+    ├── retry.spec.ts:15      toContain('/stock-operations')         ← fix
+    └── panel.spec.ts:18      toContain('/stock-operations')         ← fix
+
+filters.spec.ts — no URL string references, no change required
+```
+
+### Key Design Decisions
+
+#### Decision 1: Correct the string at all callsites — do not add a redirect
+
+**Options considered:**
+1. Add a React Router `<Redirect from="/stock-operations" to="/stock-up-operations" />` in `App.tsx` and leave the test URLs alone.
+2. Fix only the `navigateToStockOperations` helper (centralised navigation path) and leave spec-level assertions.
+3. Fix every wrong string in test files; no application change.
+
+**Chosen approach:** Option 3 — fix only test files.
+
+**Rationale:** The spec explicitly rules out adding a redirect (Out of Scope). A redirect would paper over a broken test by making a non-existent path work in production, which is undesirable. The URL assertions in spec files serve as a sanity check that the browser landed on the right page; they must assert the real route (`/stock-up-operations`), not a redirect source. Option 2 would leave seven broken URL assertions still failing. The correct fix is surgical: update every wrong occurrence in the test layer only.
+
+#### Decision 2: Replace the full substring, not just the prefix
+
+**Options considered:**
+1. Change `/stock-operations` to `/stock-up-operations` everywhere (exact substring match).
+2. Use a regex assertion (`/stock.*operations/`) to be resilient to future renames.
+
+**Chosen approach:** Option 1 — exact string replacement.
+
+**Rationale:** The assertions must verify the precise route the app uses. A loose regex would survive a future route rename silently and defeat the purpose of URL assertions. Use the real path string throughout.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. No deleted files. Changes are confined to:
+
+```
+frontend/test/e2e/
+├── helpers/
+│   └── e2e-auth-helper.ts          (1 occurrence, line 270)
+└── stock-operations/
+    ├── navigation.spec.ts          (2 occurrences, lines 13 and 96)
+    ├── badges.spec.ts              (1 occurrence, line 15)
+    ├── accept.spec.ts              (1 occurrence, line 13)
+    ├── state-filter.spec.ts        (1 occurrence, line 14)
+    ├── source-filter.spec.ts       (1 occurrence, line 13)
+    ├── sorting.spec.ts             (1 occurrence, line 14)
+    ├── retry.spec.ts               (1 occurrence, line 15)
+    └── panel.spec.ts               (1 occurrence, line 18)
+```
+
+`filters.spec.ts` contains no URL string; confirmed by grep — no change required.
+
+### Interfaces and Contracts
+
+No interface or type changes. The public signature of `navigateToStockOperations` is unchanged; callers are unaffected.
+
+### Data Flow
+
+Before fix:
+```
+beforeEach → navigateToStockOperations → page.goto(.../stock-operations)
+           → React Router: no match → blank page
+           → waitForTableUpdate → timeout at 15 s → test failure
+```
+
+After fix:
+```
+beforeEach → navigateToStockOperations → page.goto(.../stock-up-operations)
+           → React Router: matches /stock-up-operations → StockOperationsPage renders
+           → waitForTableUpdate → tbody tr or "Žádné výsledky" visible → test continues
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A grep miss leaves a stray `/stock-operations` occurrence | Medium | After edits, run `grep -r '/stock-operations' frontend/test/e2e/` and confirm zero results |
+| `navigation.spec.ts` line 96 uses `PLAYWRIGHT_BASE_URL` instead of `PLAYWRIGHT_FRONTEND_URL` — environment variable mismatch could leave the URL blank | Low | Line 96 reads `process.env.PLAYWRIGHT_BASE_URL \|\| 'https://heblo.stg.anela.cz'`; the helper at line 270 reads `PLAYWRIGHT_FRONTEND_URL \|\| PLAYWRIGHT_BASE_URL \|\| 'https://heblo.stg.anela.cz'`. Make line 96 consistent with the helper's env-var fallback chain when fixing |
+| Staging data may be in a state that produces 0 rows, causing `waitForTableUpdate` to wait for `h3[Žádné výsledky]` — this is correct by design but requires staging to be reachable | Low | Verify staging is accessible before running the E2E suite |
+
+## Specification Amendments
+
+The spec lists the following spec files as containing URL assertions (FR-4): badges.spec.ts, accept.spec.ts, state-filter.spec.ts, source-filter.spec.ts, sorting.spec.ts, retry.spec.ts, panel.spec.ts. This is accurate. `filters.spec.ts` is correctly omitted — confirmed by grep.
+
+One clarification beyond the spec: `navigation.spec.ts` line 96 uses `process.env.PLAYWRIGHT_BASE_URL` as its primary env variable, while the `navigateToStockOperations` helper (line 270) prefers `PLAYWRIGHT_FRONTEND_URL` first. The fix for line 96 should align it with the helper's fallback chain (`PLAYWRIGHT_FRONTEND_URL || PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz'`) to avoid a silent environment-variable discrepancy in the same file.
+
+## Prerequisites
+
+- Staging environment reachable at `https://heblo.stg.anela.cz` with stock-operations test data present.
+- No migrations, config changes, or infrastructure work required.
+- `./scripts/run-playwright-tests.sh` must target staging (default) and be executable.

--- a/artifacts/feat-3343/brief.md
+++ b/artifacts/feat-3343/brief.md
@@ -1,0 +1,17 @@
+**Source:** Nightly E2E triage — run 28147951139 (2026-06-25). Clears **56** failures (entire stock-operations module).
+
+## Problem
+Every `stock-operations` E2E test fails in `waitForTableUpdate` (`frontend/test/e2e/helpers/stock-operations-test-helpers.ts:26`) because the page is blank — the failure screenshot shows no sidebar and no content.
+
+## Root cause (confirmed)
+Tests navigate to `/stock-operations`, which is **not a real route**. The app route is `/stock-up-operations` (`frontend/src/App.tsx:449`; the sidebar links to `/stock-up-operations` in `frontend/src/components/Layout/Sidebar.tsx:345`). No `/stock-operations` route or redirect exists, so navigation lands on a blank page and the table never renders.
+
+## Scope / files
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` — `navigateToStockOperations` `page.goto(...)` (~line 270): `/stock-operations` → `/stock-up-operations`.
+- `frontend/test/e2e/stock-operations/navigation.spec.ts` — `expect(page.url()).toContain('/stock-operations')` (line 13) and the direct `page.goto(.../stock-operations)` (line 96).
+- Grep `frontend/test/e2e/stock-operations/` for any other `/stock-operations` occurrences.
+
+## Acceptance criteria
+- Stock-operations specs navigate to `/stock-up-operations`.
+- The table (or the "Žádné výsledky" empty state) renders.
+- The stock-operations module passes against staging.

--- a/artifacts/feat-3343/code-review.r1.md
+++ b/artifacts/feat-3343/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/test/e2e/stock-operations/navigation.spec.ts:10` — The URL assertion in `beforeEach` is not awaited (`expect(page.url()).toContain(...)` is synchronous and runs immediately after `navigateToStockOperations`, before navigation may have fully settled). This pre-existed the change and is not introduced by this diff, but the diff touches that line — worth noting if flakiness is observed.

--- a/artifacts/feat-3343/impl/fix-auth-helper-url.r1.md
+++ b/artifacts/feat-3343/impl/fix-auth-helper-url.r1.md
@@ -1,0 +1,24 @@
+# Implementation: fix-auth-helper-url
+
+## What was implemented
+Single-character string fix in the `navigateToStockOperations` helper: the `page.goto` call was navigating to `/stock-operations` (the wrong route) and has been corrected to `/stock-up-operations` (the actual frontend route).
+
+## Files created/modified
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` — changed `/stock-operations` to `/stock-up-operations` in the `page.goto` template literal at line 270.
+
+## Tests
+N/A — this is a test file fix; no additional tests needed.
+
+## How to verify
+Run the E2E tests that exercise stock operations navigation (e.g. any spec that calls `navigateToStockOperations`). The browser should land on the `/stock-up-operations` page instead of a 404/redirect.
+
+## Notes
+No deviations from the task spec. The `baseUrl` env-var chain was already correct and was not touched.
+
+## PR Summary
+
+### Changes
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` — corrected navigateToStockOperations URL from `/stock-operations` to `/stock-up-operations`
+
+## Status
+DONE

--- a/artifacts/feat-3343/impl/fix-navigation-spec.r1.md
+++ b/artifacts/feat-3343/impl/fix-navigation-spec.r1.md
@@ -1,0 +1,41 @@
+# Implementation: fix-navigation-spec
+
+## What was implemented
+
+Two URL corrections in the stock-operations E2E navigation spec:
+
+1. Line 13: URL assertion updated from `/stock-operations` to `/stock-up-operations` to match the actual frontend route.
+2. Lines 95–96: Direct `page.goto` URL updated from `/stock-operations` to `/stock-up-operations`, and the `baseUrl` fallback chain extended to check `PLAYWRIGHT_FRONTEND_URL` first (before `PLAYWRIGHT_BASE_URL`), aligning it with the helper's env-var resolution order.
+
+## Files created/modified
+
+- `frontend/test/e2e/stock-operations/navigation.spec.ts` — fixed URL assertion on line 13 and direct goto URL + baseUrl fallback chain on lines 95–96
+
+## Tests
+
+N/A — this is a test file fix.
+
+## How to verify
+
+Run the navigation spec against staging:
+
+```bash
+./scripts/run-playwright-tests.sh --grep "should navigate to page via direct URL"
+./scripts/run-playwright-tests.sh --grep "should display error state on API failure"
+```
+
+Both tests should reach the correct `/stock-up-operations` route without a 404 redirect.
+
+## Notes
+
+No deviations from the task spec. The two surrounding lines were unchanged; only the route path and the `baseUrl` variable initializer were touched.
+
+## PR Summary
+
+### Changes
+
+- `frontend/test/e2e/stock-operations/navigation.spec.ts` — corrected `/stock-operations` → `/stock-up-operations` in the URL assertion (line 13) and in the direct `page.goto` call (line 96); added `PLAYWRIGHT_FRONTEND_URL` as the first fallback in the `baseUrl` resolution chain (line 95)
+
+## Status
+
+DONE

--- a/artifacts/feat-3343/impl/fix-spec-url-assertions.r1.md
+++ b/artifacts/feat-3343/impl/fix-spec-url-assertions.r1.md
@@ -1,0 +1,34 @@
+# Implementation: fix-spec-url-assertions
+
+## What was implemented
+Changed `.toContain('/stock-operations')` to `.toContain('/stock-up-operations')` in the `test.beforeEach` block of all 7 stock-operations E2E spec files, correcting the URL assertion to match the actual route.
+
+## Files created/modified
+- `frontend/test/e2e/stock-operations/badges.spec.ts` — line 15: /stock-operations → /stock-up-operations
+- `frontend/test/e2e/stock-operations/accept.spec.ts` — line 13: /stock-operations → /stock-up-operations
+- `frontend/test/e2e/stock-operations/state-filter.spec.ts` — line 14: /stock-operations → /stock-up-operations
+- `frontend/test/e2e/stock-operations/source-filter.spec.ts` — line 13: /stock-operations → /stock-up-operations
+- `frontend/test/e2e/stock-operations/sorting.spec.ts` — line 14: /stock-operations → /stock-up-operations
+- `frontend/test/e2e/stock-operations/retry.spec.ts` — line 15: /stock-operations → /stock-up-operations
+- `frontend/test/e2e/stock-operations/panel.spec.ts` — line 18: /stock-operations → /stock-up-operations
+
+## Tests
+N/A — these are test file fixes.
+
+## How to verify
+Run grep to confirm no `/stock-operations` remains in the stock-operations spec dir:
+```
+grep -r "toContain('/stock-operations')" frontend/test/e2e/stock-operations/
+```
+Should return no matches.
+
+## Notes
+No deviations. All edits were identical single-line changes in `beforeEach` blocks. Committed as a single atomic commit: `7ebdcda fix(e2e): correct URL assertions in stock-operations spec files`.
+
+## PR Summary
+
+### Changes
+- 7 spec files — corrected URL assertion from /stock-operations to /stock-up-operations
+
+## Status
+DONE

--- a/artifacts/feat-3343/impl/verify-no-remaining-occurrences.r1.md
+++ b/artifacts/feat-3343/impl/verify-no-remaining-occurrences.r1.md
@@ -1,0 +1,35 @@
+# Implementation: verify-no-remaining-occurrences
+
+## What was implemented
+Verification grep sweep confirming zero remaining `/stock-operations` navigation URL occurrences across all E2E test files. The E2E test suite cannot be run against staging from this environment (staging access required), so the grep verification was performed instead.
+
+## Files created/modified
+No files modified — verification only.
+
+## Tests
+N/A
+
+## How to verify
+
+Run from worktree root:
+```bash
+grep -r '/stock-operations' frontend/test/e2e/ | grep -v '/stock-up-operations'
+```
+
+Remaining occurrences are only module import identifiers (`stock-operations-test-helpers`) and historical documentation text in `FAILED_TESTS.md` — not navigation URLs. Zero URL string occurrences remain.
+
+All 9 expected `/stock-up-operations` occurrences confirmed:
+- `e2e-auth-helper.ts` — 1 (page.goto)
+- `navigation.spec.ts` — 3 (URL assertion, route mock, direct goto)
+- `badges.spec.ts`, `accept.spec.ts`, `state-filter.spec.ts`, `source-filter.spec.ts`, `sorting.spec.ts`, `retry.spec.ts`, `panel.spec.ts` — 1 each (URL assertions)
+
+## Notes
+The full E2E suite against staging (`./scripts/run-playwright-tests.sh`) must be run by the developer to confirm all 56 tests pass. This cannot be executed from the CI pipeline environment.
+
+## PR Summary
+
+### Changes
+- No code changes — verification pass only.
+
+## Status
+DONE

--- a/artifacts/feat-3343/review/fix-auth-helper-url.r1.md
+++ b/artifacts/feat-3343/review/fix-auth-helper-url.r1.md
@@ -1,0 +1,12 @@
+# Code Review: fix-auth-helper-url
+
+## Summary
+The implementation makes the single required change: the `page.goto` target in `navigateToStockOperations` was updated from `/stock-operations` to `/stock-up-operations`. The `baseUrl` env-var chain (`PLAYWRIGHT_FRONTEND_URL || PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz'`) was left untouched. No other lines were modified.
+
+## Review Result: PASS
+
+### task: fix-auth-helper-url
+**Status:** PASS
+
+## Overall Notes
+The fix is minimal and surgical — exactly one string segment changed, matching the task spec precisely. The acceptance criteria are satisfied: `navigateToStockOperations` now navigates to `{baseUrl}/stock-up-operations`, so `page.url()` will contain `/stock-up-operations` after the call.

--- a/artifacts/feat-3343/review/fix-navigation-spec.r1.md
+++ b/artifacts/feat-3343/review/fix-navigation-spec.r1.md
@@ -1,0 +1,12 @@
+# Code Review: fix-navigation-spec
+
+## Summary
+Both fixes are correctly applied in the worktree. Line 13 now reads `.toContain('/stock-up-operations')`, and lines 94–96 use the extended `baseUrl` chain with `PLAYWRIGHT_FRONTEND_URL || PLAYWRIGHT_BASE_URL || '...'` and navigate to `/stock-up-operations`. A prior reviewer check was made against the main checkout path instead of the worktree path and incorrectly reported changes as missing.
+
+## Review Result: PASS
+
+### task: fix-navigation-spec
+**Status:** PASS
+
+## Overall Notes
+All acceptance criteria from FR-2 and FR-3 are met. Verified in the worktree at `/home/user/worktrees/feature-3343-Test-E2e-Fix-Stock-Operations-Navigation-Url-To-St/frontend/test/e2e/stock-operations/navigation.spec.ts`. No application source files were modified.

--- a/artifacts/feat-3343/review/fix-spec-url-assertions.r1.md
+++ b/artifacts/feat-3343/review/fix-spec-url-assertions.r1.md
@@ -1,0 +1,28 @@
+# Code Review: fix-spec-url-assertions
+
+## Summary
+All 7 spec files have been updated with the correct URL assertion. Each `beforeEach` block now asserts `.toContain('/stock-up-operations')` instead of the previous `/stock-operations`. The changes are surgical and confined to exactly the lines specified in the task — no unrelated code was touched.
+
+## Review Result: PASS
+
+### task: fix-spec-url-assertions
+**Status:** PASS
+
+Verified file-by-file:
+
+| File | Line | Value |
+|------|------|-------|
+| `badges.spec.ts` | 15 | `'/stock-up-operations'` |
+| `accept.spec.ts` | 13 | `'/stock-up-operations'` |
+| `state-filter.spec.ts` | 14 | `'/stock-up-operations'` |
+| `source-filter.spec.ts` | 13 | `'/stock-up-operations'` |
+| `sorting.spec.ts` | 14 | `'/stock-up-operations'` |
+| `retry.spec.ts` | 15 | `'/stock-up-operations'` |
+| `panel.spec.ts` | 18 | `'/stock-up-operations'` |
+
+All 7 assertions match the required string exactly. No other lines were modified in any of the files.
+
+## Overall Notes
+No cross-cutting concerns. The fix is consistent across all files and aligns with the task specification.
+
+**Status:** PASS

--- a/artifacts/feat-3343/review/verify-no-remaining-occurrences.r1.md
+++ b/artifacts/feat-3343/review/verify-no-remaining-occurrences.r1.md
@@ -1,0 +1,27 @@
+# Code Review: verify-no-remaining-occurrences
+
+## Summary
+The grep sweep was independently reproduced and confirms the implementation output is accurate. All remaining `/stock-operations` hits (excluding `/stock-up-operations`) are non-URL strings: module import identifiers (`stock-operations-test-helpers`) in 8 spec files and incidental text in `FAILED_TESTS.md`. No navigation URL strings using the old `/stock-operations` path survive. All `/stock-up-operations` occurrences land exactly where expected.
+
+## Review Result: PASS
+
+### task: verify-no-remaining-occurrences
+**Status:** PASS
+
+**Check 1 — No remaining `/stock-operations` navigation URLs:**
+Confirmed. The only hits from `grep -r '/stock-operations' frontend/test/e2e/ | grep -v '/stock-up-operations'` are:
+- 8 TypeScript import statements importing from `'../helpers/stock-operations-test-helpers'` (module identifier, not a URL).
+- 2 lines in `FAILED_TESTS.md` referencing `stock-operations` in documentation prose (not navigation code).
+
+Zero navigation URL strings (`page.goto`, `page.route`, `expect(url).toContain`, etc.) use the old `/stock-operations` path.
+
+**Check 2 — `/stock-up-operations` present in expected files:**
+Confirmed. 11 occurrences found across:
+- `helpers/e2e-auth-helper.ts` — 1 occurrence (`page.goto(\`${baseUrl}/stock-up-operations\`)`), which is what `navigateToStockOperations()` delegates to.
+- `stock-operations/navigation.spec.ts` — 3 occurrences (URL assertion, route intercept pattern, and direct `page.goto`).
+- `stock-operations/badges.spec.ts`, `accept.spec.ts`, `state-filter.spec.ts`, `source-filter.spec.ts`, `sorting.spec.ts`, `retry.spec.ts`, `panel.spec.ts` — 1 URL assertion each (7 files).
+
+Note: `filters.spec.ts` contains no direct `/stock-up-operations` string — it navigates exclusively via `navigateToStockOperations(page)`, which resolves to the correct URL through `e2e-auth-helper.ts`. This is correct and intentional; the spec still exercises the right URL at runtime.
+
+## Overall Notes
+The implementation output correctly described all findings. The count of "9 `/stock-up-operations` occurrences" in the implementation summary is slightly low — the independent grep finds 11 raw line hits — but this is a counting artefact (navigation.spec.ts has 3 occurrences on its own). Coverage across all 8 spec files plus the auth helper is complete and correct. No concerns remain.

--- a/artifacts/feat-3343/spec.r1.md
+++ b/artifacts/feat-3343/spec.r1.md
@@ -1,0 +1,103 @@
+# Specification: Fix Stock-Operations E2E Navigation URL
+
+## Summary
+
+Every E2E test in the `stock-operations` module fails because test helpers and specs navigate to `/stock-operations`, which does not exist as a route. The real application route is `/stock-up-operations`. This specification covers the surgical URL corrections required across the test helper and spec files to restore the full 56-test module against staging.
+
+## Background
+
+A nightly E2E run (28147951139, 2026-06-25) reported 56 failures across the entire `stock-operations` module. All failures originate in `waitForTableUpdate` because the page is blank — the browser lands on an unmatched route, React renders nothing, and neither a `tbody tr` row nor a `h3[Žádné výsledky]` element ever appears.
+
+Root-cause analysis confirmed that `frontend/src/App.tsx:449` registers the page at `/stock-up-operations`, and `frontend/src/components/Layout/Sidebar.tsx:345` links to the same path. No alias, redirect, or catch-all exists for `/stock-operations`. The test code was written with a truncated path and has never matched the live application.
+
+## Functional Requirements
+
+### FR-1: Correct the navigation helper
+
+The `navigateToStockOperations` function in `frontend/test/e2e/helpers/e2e-auth-helper.ts` (line 270) calls `page.goto` with the path `/stock-operations`. This must be changed to `/stock-up-operations`.
+
+**Acceptance criteria:**
+- `navigateToStockOperations` navigates to `{baseUrl}/stock-up-operations`.
+- After navigation, `page.url()` contains `/stock-up-operations`.
+- The sidebar is visible and the stock-operations page content renders.
+
+### FR-2: Correct the direct `page.goto` in navigation.spec.ts
+
+`frontend/test/e2e/stock-operations/navigation.spec.ts` line 96 contains a bare `page.goto(`${baseUrl}/stock-operations`)` inside the "should display error state on API failure" test. This path must be changed to `/stock-up-operations`.
+
+**Acceptance criteria:**
+- The error-state test navigates to `{baseUrl}/stock-up-operations`.
+- The API interception route `**/api/stock-up-operations**` (already correct at line 90) continues to match correctly.
+
+### FR-3: Correct URL assertion in navigation.spec.ts
+
+`frontend/test/e2e/stock-operations/navigation.spec.ts` line 13 asserts `expect(page.url()).toContain('/stock-operations')`. Because `/stock-up-operations` still contains the substring `/stock-operations`, this assertion would not fail — but it is semantically misleading. The assertion must be tightened to `/stock-up-operations` for clarity and to prevent future false-positives if a misrouted URL somehow passes the substring check.
+
+**Acceptance criteria:**
+- The URL assertion reads `expect(page.url()).toContain('/stock-up-operations')`.
+
+### FR-4: Correct URL assertions in all remaining spec files
+
+The following files each contain `expect(page.url()).toContain('/stock-operations')` in their first `test` block. All must be updated to `/stock-up-operations` for the same reasons as FR-3.
+
+Files (one occurrence each, all in the first test/beforeEach navigation assertion):
+- `frontend/test/e2e/stock-operations/badges.spec.ts` — line 15
+- `frontend/test/e2e/stock-operations/accept.spec.ts` — line 13
+- `frontend/test/e2e/stock-operations/state-filter.spec.ts` — line 14
+- `frontend/test/e2e/stock-operations/source-filter.spec.ts` — line 13
+- `frontend/test/e2e/stock-operations/sorting.spec.ts` — line 14
+- `frontend/test/e2e/stock-operations/retry.spec.ts` — line 15
+- `frontend/test/e2e/stock-operations/panel.spec.ts` — line 18
+
+**Acceptance criteria:**
+- Every occurrence of `.toContain('/stock-operations')` in the stock-operations module is replaced with `.toContain('/stock-up-operations')`.
+- No other spec files outside this module are affected.
+
+### FR-5: Full grep sweep for remaining occurrences
+
+Before declaring the fix complete, grep `frontend/test/e2e/stock-operations/` for any remaining literal string `/stock-operations` (excluding `/stock-up-operations`) to catch occurrences not identified by line-number in the brief.
+
+**Acceptance criteria:**
+- `grep -r "'/stock-operations'" frontend/test/e2e/stock-operations/` returns zero matches.
+- `grep -r '"/stock-operations"' frontend/test/e2e/stock-operations/` returns zero matches.
+- The same grep against `frontend/test/e2e/helpers/e2e-auth-helper.ts` returns zero matches.
+
+## Non-Functional Requirements
+
+### NFR-1: Scope containment
+
+No application source files (`frontend/src/`, `backend/`) are to be modified. This is a pure test-file correction. The application route `/stock-up-operations` is correct and must not be renamed.
+
+### NFR-2: No collateral changes
+
+Each edited line must change only the URL string. Do not reformat, re-order imports, add comments, or alter any logic beyond the string replacement.
+
+### NFR-3: Verification
+
+The fix is verified by running the E2E suite against staging via `./scripts/run-playwright-tests.sh` targeting the `stock-operations` module. All 56 previously failing tests must pass or produce a legitimate test-data failure (not a blank-page navigation failure).
+
+## Data Model
+
+Not applicable. This change touches only test navigation strings; no data model is affected.
+
+## API / Interface Design
+
+Not applicable. The backend API path `**/api/stock-up-operations**` is already correct in the tests and is unchanged.
+
+## Dependencies
+
+- Staging environment `https://heblo.stg.anela.cz` must be reachable and have test data present for the stock-up-operations module.
+- No library changes or new dependencies.
+
+## Out of Scope
+
+- Adding a `/stock-operations` redirect in the React router. There is no user-facing need for the old path — it only existed as a test mistake.
+- Changes to any backend controllers, DTOs, or API routes.
+- Changes to E2E tests outside the `stock-operations/` module directory and the `navigateToStockOperations` helper.
+- Fixing any other pre-existing test failures unrelated to the blank-page navigation issue.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -40,15 +40,15 @@
     },
     {
       "name": "fix-spec-url-assertions",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T11:26:57.062186Z"
+      "updated_at": "2026-06-25T11:28:50.597679Z"
     },
     {
       "name": "verify-no-remaining-occurrences",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T11:28:55.605307Z"
     }
   ]
 }

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T11:15:25.421383Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T11:17:11.861419Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T11:17:21.124405Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "fix-navigation-spec",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T11:24:43.440122Z"
+      "updated_at": "2026-06-25T11:26:52.156109Z"
     },
     {
       "name": "fix-spec-url-assertions",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T11:26:57.062186Z"
     },
     {
       "name": "verify-no-remaining-occurrences",

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-06-25T11:30:22.912913Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-25T11:30:33.922168Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-06-25T11:17:11.861419Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T11:17:21.124405Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T11:19:45.172461Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-25T11:20:03.056402Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T11:20:16.014344Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3343",
+  "issue_number": 3343,
+  "created_at": "2026-06-25T11:14:50.468059Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-25T11:15:25.421383Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "fix-auth-helper-url",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T11:23:06.549524Z"
+      "updated_at": "2026-06-25T11:24:39.229642Z"
     },
     {
       "name": "fix-navigation-spec",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T11:24:43.440122Z"
     },
     {
       "name": "fix-spec-url-assertions",

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -17,13 +17,38 @@
       "updated_at": "2026-06-25T11:20:03.056402Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T11:20:16.014344Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T11:22:03.940432Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-auth-helper-url",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "fix-navigation-spec",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "fix-spec-url-assertions",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "verify-no-remaining-occurrences",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-06-25T11:22:03.940432Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T11:23:06.341103Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T11:30:22.912913Z"
     }
   },
   "tasks": [
@@ -46,9 +46,9 @@
     },
     {
       "name": "verify-no-remaining-occurrences",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T11:28:55.605307Z"
+      "updated_at": "2026-06-25T11:30:22.667999Z"
     }
   ]
 }

--- a/artifacts/feat-3343/state.json
+++ b/artifacts/feat-3343/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-25T11:22:03.940432Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T11:23:06.341103Z"
     }
   },
   "tasks": [
     {
       "name": "fix-auth-helper-url",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T11:23:06.549524Z"
     },
     {
       "name": "fix-navigation-spec",

--- a/artifacts/feat-3343/task-context/fix-auth-helper-url.md
+++ b/artifacts/feat-3343/task-context/fix-auth-helper-url.md
@@ -1,0 +1,30 @@
+### task: fix-auth-helper-url
+
+**Files:**
+- Modify: `frontend/test/e2e/helpers/e2e-auth-helper.ts`
+
+- [ ] **Step 1: Fix the `page.goto` URL in `navigateToStockOperations`**
+
+  File: `frontend/test/e2e/helpers/e2e-auth-helper.ts`, line 270.
+
+  Current code (lines 268–270):
+  ```typescript
+  // Direct navigation to stock operations
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-operations`);
+  ```
+
+  Replace with:
+  ```typescript
+  // Direct navigation to stock operations
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-up-operations`);
+  ```
+
+  Only the string `/stock-operations` inside the template literal changes to `/stock-up-operations`. The `baseUrl` env-var chain is already correct (`PLAYWRIGHT_FRONTEND_URL || PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz'`); do not alter it.
+
+- [ ] **Step 2: Commit**
+  ```bash
+  git add frontend/test/e2e/helpers/e2e-auth-helper.ts
+  git commit -m "fix(e2e): correct navigateToStockOperations URL to /stock-up-operations"
+  ```

--- a/artifacts/feat-3343/task-context/fix-navigation-spec.md
+++ b/artifacts/feat-3343/task-context/fix-navigation-spec.md
@@ -1,0 +1,38 @@
+### task: fix-navigation-spec
+
+**Files:**
+- Modify: `frontend/test/e2e/stock-operations/navigation.spec.ts`
+
+- [ ] **Step 1: Fix URL assertion on line 13**
+
+  Current (line 13):
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 2: Fix direct `page.goto` URL on line 96**
+
+  Current (lines 95–96):
+  ```typescript
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-operations`);
+  ```
+
+  Replace with:
+  ```typescript
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-up-operations`);
+  ```
+
+  Note: the `baseUrl` line gains `process.env.PLAYWRIGHT_FRONTEND_URL ||` at the front to align with the helper's env-var fallback chain (FR-2).
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add frontend/test/e2e/stock-operations/navigation.spec.ts
+  git commit -m "fix(e2e): correct URL assertion and direct goto in navigation.spec.ts"
+  ```

--- a/artifacts/feat-3343/task-context/fix-spec-url-assertions.md
+++ b/artifacts/feat-3343/task-context/fix-spec-url-assertions.md
@@ -1,0 +1,102 @@
+### task: fix-spec-url-assertions
+
+**Files:**
+- Modify: `frontend/test/e2e/stock-operations/badges.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/accept.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/state-filter.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/source-filter.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/sorting.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/retry.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/panel.spec.ts`
+
+Each of these files has a single `.toContain('/stock-operations')` assertion in its `test.beforeEach` block. The fix is identical in every file.
+
+- [ ] **Step 1: Fix `badges.spec.ts` line 15**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 2: Fix `accept.spec.ts` line 13**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 3: Fix `state-filter.spec.ts` line 14**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 4: Fix `source-filter.spec.ts` line 13**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 5: Fix `sorting.spec.ts` line 14**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 6: Fix `retry.spec.ts` line 15**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 7: Fix `panel.spec.ts` line 18**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 8: Commit**
+  ```bash
+  git add \
+    frontend/test/e2e/stock-operations/badges.spec.ts \
+    frontend/test/e2e/stock-operations/accept.spec.ts \
+    frontend/test/e2e/stock-operations/state-filter.spec.ts \
+    frontend/test/e2e/stock-operations/source-filter.spec.ts \
+    frontend/test/e2e/stock-operations/sorting.spec.ts \
+    frontend/test/e2e/stock-operations/retry.spec.ts \
+    frontend/test/e2e/stock-operations/panel.spec.ts
+  git commit -m "fix(e2e): correct URL assertions in stock-operations spec files"
+  ```

--- a/artifacts/feat-3343/task-context/verify-no-remaining-occurrences.md
+++ b/artifacts/feat-3343/task-context/verify-no-remaining-occurrences.md
@@ -1,0 +1,29 @@
+### task: verify-no-remaining-occurrences
+
+**Files:**
+- No changes — verification only.
+
+- [ ] **Step 1: Grep for any remaining `/stock-operations` occurrences (must exclude `/stock-up-operations`)**
+
+  Run from the project root:
+  ```bash
+  grep -r '/stock-operations' frontend/test/e2e/ | grep -v '/stock-up-operations'
+  ```
+
+  Expected result: **no output**. If any lines appear, fix them before proceeding.
+
+- [ ] **Step 2: Confirm `/stock-up-operations` is present in all expected files**
+
+  ```bash
+  grep -r '/stock-up-operations' frontend/test/e2e/
+  ```
+
+  Expected: occurrences in `e2e-auth-helper.ts` and all eight spec files (`navigation.spec.ts`, `badges.spec.ts`, `accept.spec.ts`, `state-filter.spec.ts`, `source-filter.spec.ts`, `sorting.spec.ts`, `retry.spec.ts`, `panel.spec.ts`).
+
+- [ ] **Step 3: Run the E2E suite against staging**
+
+  ```bash
+  ./scripts/run-playwright-tests.sh
+  ```
+
+  All 56 `stock-operations` tests should pass. No app source files should have been modified.

--- a/artifacts/feat-3343/task-plan.r1.md
+++ b/artifacts/feat-3343/task-plan.r1.md
@@ -1,0 +1,220 @@
+# Fix Stock-Operations E2E Navigation URL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all E2E test files in the `stock-operations` module that navigate to the non-existent `/stock-operations` route, replacing it with the real application route `/stock-up-operations`.
+
+**Architecture:** This is a pure test-file fix — no application source is touched. The shared navigation helper `navigateToStockOperations` in `e2e-auth-helper.ts` has the wrong `page.goto` URL, and every spec file has a corresponding URL assertion that must match. Correcting the helper plus fixing the assertions in all seven spec files restores all 56 tests.
+
+**Tech Stack:** Playwright E2E tests (TypeScript), running against staging via `./scripts/run-playwright-tests.sh`.
+
+---
+
+### task: fix-auth-helper-url
+
+**Files:**
+- Modify: `frontend/test/e2e/helpers/e2e-auth-helper.ts`
+
+- [ ] **Step 1: Fix the `page.goto` URL in `navigateToStockOperations`**
+
+  File: `frontend/test/e2e/helpers/e2e-auth-helper.ts`, line 270.
+
+  Current code (lines 268–270):
+  ```typescript
+  // Direct navigation to stock operations
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-operations`);
+  ```
+
+  Replace with:
+  ```typescript
+  // Direct navigation to stock operations
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-up-operations`);
+  ```
+
+  Only the string `/stock-operations` inside the template literal changes to `/stock-up-operations`. The `baseUrl` env-var chain is already correct (`PLAYWRIGHT_FRONTEND_URL || PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz'`); do not alter it.
+
+- [ ] **Step 2: Commit**
+  ```bash
+  git add frontend/test/e2e/helpers/e2e-auth-helper.ts
+  git commit -m "fix(e2e): correct navigateToStockOperations URL to /stock-up-operations"
+  ```
+
+---
+
+### task: fix-navigation-spec
+
+**Files:**
+- Modify: `frontend/test/e2e/stock-operations/navigation.spec.ts`
+
+- [ ] **Step 1: Fix URL assertion on line 13**
+
+  Current (line 13):
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 2: Fix direct `page.goto` URL on line 96**
+
+  Current (lines 95–96):
+  ```typescript
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-operations`);
+  ```
+
+  Replace with:
+  ```typescript
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/stock-up-operations`);
+  ```
+
+  Note: the `baseUrl` line gains `process.env.PLAYWRIGHT_FRONTEND_URL ||` at the front to align with the helper's env-var fallback chain (FR-2).
+
+- [ ] **Step 3: Commit**
+  ```bash
+  git add frontend/test/e2e/stock-operations/navigation.spec.ts
+  git commit -m "fix(e2e): correct URL assertion and direct goto in navigation.spec.ts"
+  ```
+
+---
+
+### task: fix-spec-url-assertions
+
+**Files:**
+- Modify: `frontend/test/e2e/stock-operations/badges.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/accept.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/state-filter.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/source-filter.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/sorting.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/retry.spec.ts`
+- Modify: `frontend/test/e2e/stock-operations/panel.spec.ts`
+
+Each of these files has a single `.toContain('/stock-operations')` assertion in its `test.beforeEach` block. The fix is identical in every file.
+
+- [ ] **Step 1: Fix `badges.spec.ts` line 15**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 2: Fix `accept.spec.ts` line 13**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 3: Fix `state-filter.spec.ts` line 14**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 4: Fix `source-filter.spec.ts` line 13**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 5: Fix `sorting.spec.ts` line 14**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 6: Fix `retry.spec.ts` line 15**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 7: Fix `panel.spec.ts` line 18**
+
+  Current:
+  ```typescript
+  expect(page.url()).toContain('/stock-operations');
+  ```
+  Replace with:
+  ```typescript
+  expect(page.url()).toContain('/stock-up-operations');
+  ```
+
+- [ ] **Step 8: Commit**
+  ```bash
+  git add \
+    frontend/test/e2e/stock-operations/badges.spec.ts \
+    frontend/test/e2e/stock-operations/accept.spec.ts \
+    frontend/test/e2e/stock-operations/state-filter.spec.ts \
+    frontend/test/e2e/stock-operations/source-filter.spec.ts \
+    frontend/test/e2e/stock-operations/sorting.spec.ts \
+    frontend/test/e2e/stock-operations/retry.spec.ts \
+    frontend/test/e2e/stock-operations/panel.spec.ts
+  git commit -m "fix(e2e): correct URL assertions in stock-operations spec files"
+  ```
+
+---
+
+### task: verify-no-remaining-occurrences
+
+**Files:**
+- No changes — verification only.
+
+- [ ] **Step 1: Grep for any remaining `/stock-operations` occurrences (must exclude `/stock-up-operations`)**
+
+  Run from the project root:
+  ```bash
+  grep -r '/stock-operations' frontend/test/e2e/ | grep -v '/stock-up-operations'
+  ```
+
+  Expected result: **no output**. If any lines appear, fix them before proceeding.
+
+- [ ] **Step 2: Confirm `/stock-up-operations` is present in all expected files**
+
+  ```bash
+  grep -r '/stock-up-operations' frontend/test/e2e/
+  ```
+
+  Expected: occurrences in `e2e-auth-helper.ts` and all eight spec files (`navigation.spec.ts`, `badges.spec.ts`, `accept.spec.ts`, `state-filter.spec.ts`, `source-filter.spec.ts`, `sorting.spec.ts`, `retry.spec.ts`, `panel.spec.ts`).
+
+- [ ] **Step 3: Run the E2E suite against staging**
+
+  ```bash
+  ./scripts/run-playwright-tests.sh
+  ```
+
+  All 56 `stock-operations` tests should pass. No app source files should have been modified.

--- a/frontend/test/e2e/helpers/e2e-auth-helper.ts
+++ b/frontend/test/e2e/helpers/e2e-auth-helper.ts
@@ -267,7 +267,7 @@ export async function navigateToStockOperations(page: any): Promise<void> {
 
   // Direct navigation to stock operations
   const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
-  await page.goto(`${baseUrl}/stock-operations`);
+  await page.goto(`${baseUrl}/stock-up-operations`);
   await page.waitForLoadState('domcontentloaded');
   await waitForLoadingComplete(page);
 

--- a/frontend/test/e2e/stock-operations/accept.spec.ts
+++ b/frontend/test/e2e/stock-operations/accept.spec.ts
@@ -10,7 +10,7 @@ test.describe('Stock Operations - Accept Failed Operations', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to stock operations with full authentication
     await navigateToStockOperations(page);
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
     await waitForTableUpdate(page);
   });
 

--- a/frontend/test/e2e/stock-operations/badges.spec.ts
+++ b/frontend/test/e2e/stock-operations/badges.spec.ts
@@ -12,7 +12,7 @@ test.describe('Stock Operations - State Badges & Stuck Detection', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to stock operations with full authentication
     await navigateToStockOperations(page);
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
     await waitForTableUpdate(page);
   });
 

--- a/frontend/test/e2e/stock-operations/navigation.spec.ts
+++ b/frontend/test/e2e/stock-operations/navigation.spec.ts
@@ -10,7 +10,7 @@ test.describe('Stock Operations - Navigation & Initial Load', () => {
     await navigateToStockOperations(page);
 
     // Verify URL
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
 
     // Verify page title
     const title = await page.locator('h1').textContent();
@@ -92,8 +92,8 @@ test.describe('Stock Operations - Navigation & Initial Load', () => {
     });
 
     // Navigate to stock operations page (will trigger failed API call)
-    const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
-    await page.goto(`${baseUrl}/stock-operations`);
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/stock-up-operations`);
     await page.waitForTimeout(3000);
 
     // Check for error message

--- a/frontend/test/e2e/stock-operations/panel.spec.ts
+++ b/frontend/test/e2e/stock-operations/panel.spec.ts
@@ -15,7 +15,7 @@ test.describe('Stock Operations - Panel Interactions', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to stock operations with full authentication
     await navigateToStockOperations(page);
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
     await waitForTableUpdate(page);
   });
 

--- a/frontend/test/e2e/stock-operations/retry.spec.ts
+++ b/frontend/test/e2e/stock-operations/retry.spec.ts
@@ -12,7 +12,7 @@ test.describe('Stock Operations - Retry Functionality', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to stock operations with full authentication
     await navigateToStockOperations(page);
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
     await waitForTableUpdate(page);
   });
 

--- a/frontend/test/e2e/stock-operations/sorting.spec.ts
+++ b/frontend/test/e2e/stock-operations/sorting.spec.ts
@@ -11,7 +11,7 @@ test.describe('Stock Operations - Column Sorting', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to stock operations with full authentication
     await navigateToStockOperations(page);
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
     await waitForTableUpdate(page);
   });
 

--- a/frontend/test/e2e/stock-operations/source-filter.spec.ts
+++ b/frontend/test/e2e/stock-operations/source-filter.spec.ts
@@ -10,7 +10,7 @@ test.describe('Stock Operations - Source Type Filter', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to stock operations with full authentication
     await navigateToStockOperations(page);
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
     await waitForTableUpdate(page);
   });
 

--- a/frontend/test/e2e/stock-operations/state-filter.spec.ts
+++ b/frontend/test/e2e/stock-operations/state-filter.spec.ts
@@ -11,7 +11,7 @@ test.describe('Stock Operations - State Filter', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to stock operations with full authentication
     await navigateToStockOperations(page);
-    expect(page.url()).toContain('/stock-operations');
+    expect(page.url()).toContain('/stock-up-operations');
     await waitForTableUpdate(page);
   });
 


### PR DESCRIPTION
Closes #3343

## What the issue was
Every E2E test in the `stock-operations` module (56 tests) was failing because the navigation helper and all spec files navigated to `/stock-operations`, which is not a real route. The app registers the page at `/stock-up-operations`; React rendered nothing on the wrong path, causing `waitForTableUpdate` to time out on every test.

## How it was fixed
Pure test-file corrections — no app source files were changed:

- `frontend/test/e2e/helpers/e2e-auth-helper.ts` — corrected `navigateToStockOperations` `page.goto` from `/stock-operations` to `/stock-up-operations`
- `frontend/test/e2e/stock-operations/navigation.spec.ts` — fixed the URL assertion (line 13) and the direct `page.goto` (line 96); also aligned the `baseUrl` env-var fallback chain on line 95 to match the helper (`PLAYWRIGHT_FRONTEND_URL || PLAYWRIGHT_BASE_URL || ...`)
- `frontend/test/e2e/stock-operations/badges.spec.ts`, `accept.spec.ts`, `state-filter.spec.ts`, `source-filter.spec.ts`, `sorting.spec.ts`, `retry.spec.ts`, `panel.spec.ts` — corrected the single URL assertion in each `beforeEach` block

## Artifacts
Brief, spec, arch-review, task-plan, impl, and review markdown are committed in this branch under `artifacts/feat-3343/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `frontend/test/e2e/stock-operations/navigation.spec.ts:10` — The URL assertion in `beforeEach` is synchronous (`expect(page.url()).toContain(...)` runs immediately after `navigateToStockOperations`). Pre-existing; not introduced by this diff. Worth monitoring if flakiness is observed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVB4gedVjxt2awrBqQsFK6)_