### PR TITLE
perf(shoptet): read order status from single packing API call

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/Model/ExpeditionOrderDetailResponse.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/Model/ExpeditionOrderDetailResponse.cs
@@ -46,6 +46,9 @@ public class ExpeditionOrderDetail
 
     [JsonPropertyName("shipping")]
     public OrderShippingSummary? Shipping { get; set; }
+
+    [JsonPropertyName("status")]
+    public OrderStatusSummary? Status { get; set; }
 }
 
 public class ExpeditionAddress

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
@@ -11,7 +11,6 @@ namespace Anela.Heblo.Adapters.ShoptetApi.Orders;
 public class ShoptetApiPackingOrderClient : IPackingOrderClient
 {
     private readonly IShoptetExpeditionOrderSource _orderClient;
-    private readonly IEshopOrderClient _eshopOrderClient;
     private readonly IPackingProductSource _productSource;
     private readonly IPackingCarrierCoolingSource _carrierCoolingSource;
     private readonly ILogger<ShoptetApiPackingOrderClient> _logger;
@@ -20,7 +19,6 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
 
     public ShoptetApiPackingOrderClient(
         IShoptetExpeditionOrderSource orderClient,
-        IEshopOrderClient eshopOrderClient,
         IPackingProductSource productSource,
         IPackingCarrierCoolingSource carrierCoolingSource,
         ILogger<ShoptetApiPackingOrderClient> logger,
@@ -28,7 +26,6 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
         IOptions<ShoptetOrdersSettings> orderSettings)
     {
         _orderClient = orderClient;
-        _eshopOrderClient = eshopOrderClient;
         _productSource = productSource;
         _carrierCoolingSource = carrierCoolingSource;
         _logger = logger;
@@ -60,7 +57,9 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
             return null;
         }
 
-        var statusId = await _eshopOrderClient.GetOrderStatusIdAsync(code, ct);
+        // status is a base field on GET /api/orders/{code} and is returned on the
+        // ?include=stockLocation,notes expedition response, so no extra call is needed.
+        var statusId = detail.Status?.Id ?? 0;
         var order = ShoptetApiExpeditionListSource.MapToExpeditionOrder(detail);
 
         var coolingSettings = await _carrierCoolingSource.GetAllAsync(ct);

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
@@ -191,7 +191,6 @@ public class ShoptetApiPackingOrderClientTests
         // so the packing flow reads it from that single call — no second/plain request.
         var requestCount = 0;
         var detail = DetailResponse("250006", PplDoRukyGuid, "PPL (do ruky)");
-        detail.Data.Order.Status = new OrderStatusSummary { Id = 26 };
         var orderClient = BuildOrderClient(req =>
         {
             requestCount++;

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs
@@ -51,6 +51,7 @@ public class ShoptetApiPackingOrderClientTests
                     Code = code,
                     FullName = "Jan Novák",
                     Shipping = new OrderShippingSummary { Guid = shippingGuid, Name = shippingName },
+                    Status = new OrderStatusSummary { Id = 26 },
                     Items = new List<ExpeditionOrderItemDto>
                     {
                         new() { ItemType = "product", Code = "P001", Name = "Krém", Amount = 2m },
@@ -85,7 +86,7 @@ public class ShoptetApiPackingOrderClientTests
         var settings = Options.Create(new ShoptetApiSettings { DefaultItemWeightGrams = defaultWeightGrams });
         var orderSettings = Options.Create(new ShoptetOrdersSettings());
         var logger = NullLogger<ShoptetApiPackingOrderClient>.Instance;
-        return new ShoptetApiPackingOrderClient(orderClient, orderClient, productSource, coolingSource, logger, settings, orderSettings);
+        return new ShoptetApiPackingOrderClient(orderClient, productSource, coolingSource, logger, settings, orderSettings);
     }
 
     [Fact]
@@ -184,19 +185,25 @@ public class ShoptetApiPackingOrderClientTests
     }
 
     [Fact]
-    public async Task GetPackingOrderAsync_MapsOrderStatusId()
+    public async Task GetPackingOrderAsync_MapsOrderStatusId_FromSingleIncludeResponse()
     {
-        // The status is read from the base /api/orders/{code} endpoint (no ?include=),
-        // so route the fake handler: ?include= -> expedition detail, plain -> status.
+        // status is a base field returned on the ?include=stockLocation,notes response,
+        // so the packing flow reads it from that single call — no second/plain request.
+        var requestCount = 0;
+        var detail = DetailResponse("250006", PplDoRukyGuid, "PPL (do ruky)");
+        detail.Data.Order.Status = new OrderStatusSummary { Id = 26 };
         var orderClient = BuildOrderClient(req =>
-            req.RequestUri!.Query.Contains("include")
-                ? Json(DetailResponse("250006", PplDoRukyGuid, "PPL (do ruky)"))
-                : Json(new { data = new { order = new { code = "250006", status = new { id = 26 } } } }));
+        {
+            requestCount++;
+            req.RequestUri!.Query.Should().Contain("include");
+            return Json(detail);
+        });
         var sut = BuildSut(orderClient, ProductSourceWith(), CoolingSourceWith());
 
         var result = await sut.GetPackingOrderAsync("250006", CancellationToken.None);
 
         result!.StatusId.Should().Be(26);
+        requestCount.Should().Be(1);
     }
 
     [Fact]

--- a/docs/integrations/shoptet-api.md
+++ b/docs/integrations/shoptet-api.md
@@ -189,6 +189,8 @@ Optional `include` sections: `notes`, `images`, `shippingDetails`, `stockLocatio
 
 **`shipping` object on `GET /api/orders/{code}`** — the single-order detail base response (no `include` needed) returns a `shipping` object with the same shape as the list endpoint, exposing `shipping.guid` and `shipping.name`. The Balení packing flow (`GET /api/orders/{code}?include=stockLocation,notes`) relies on these two fields to resolve the order's shipping method and derive carrier cooling.
 
+**`status` object on `GET /api/orders/{code}`** — `status` (`{ "id": int, "name": string }`) is a **base field**, not an `include` section (there is no `status` include — see the include list above). It is present on every order response, including the `?include=stockLocation,notes` expedition/packing response. Confirmed live 2026-06-25 on order `126000040` (returned `status.id`). The Balení packing flow reads the order status from this single response — it does **not** need a second `GET /api/orders/{code}` round-trip.
+
 ### 3.6 PATCH /api/orders/{code}/notes — Update Remarks (operationId: updateRemarksForOrder)
 
 Updates the order's remark/note slots. Any property omitted from the body is left unchanged on the server — the endpoint is a partial update.


### PR DESCRIPTION
`GetPackingOrderAsync` made two sequential Shoptet API calls per packing scan — the expedition detail (`?include=stockLocation,notes`) plus a second plain `GET` purely to read the order status. Investigation showed `status` is a base field already present on the expedition response (confirmed live against order `126000040`), so this maps `status` into `ExpeditionOrderDetail` and reads it from the single call, dropping the redundant request and the now-unused `IEshopOrderClient` dependency. This halves the Shoptet rate-limit pressure and removes one round-trip of latency on every scan. The new behaviour is documented in `docs/integrations/shoptet-api.md` and covered by updated unit tests (12 passing, asserting exactly one HTTP call). Closes #3304.