### PR TITLE
fix: make Baleni Zásilky grid full width

### DIFF
--- a/frontend/src/components/baleni/BaleniLayout.tsx
+++ b/frontend/src/components/baleni/BaleniLayout.tsx
@@ -12,6 +12,7 @@ const BaleniLayout: React.FC = () => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const isHome = pathname === BALENI_ROOT || pathname === `${BALENI_ROOT}/`;
+  const isWide = pathname === `${BALENI_ROOT}/zasilky`;
 
   useEffect(() => {
     const link = document.querySelector<HTMLLinkElement>('link[rel="manifest"]');
@@ -42,7 +43,7 @@ const BaleniLayout: React.FC = () => {
         </header>
 
         <main className="flex-1 overflow-y-auto p-4">
-          <div className="max-w-5xl mx-auto w-full">
+          <div className={isWide ? 'w-full' : 'max-w-5xl mx-auto w-full'}>
             <Outlet />
           </div>
         </main>


### PR DESCRIPTION
The shared `BaleniLayout` wrapped every Baleni subpage in a `max-w-5xl` container, leaving the Zásilky data grid with a large empty gutter on the right instead of using the full screen width. This applies the width cap conditionally so the `/baleni/zasilky` route stretches full width while the Home, Packing, and Statistiky screens keep their intentionally centered narrow layout. Verified with `npm run build` (passes) and lint on the changed file (clean); a visual check of the four Baleni routes is still recommended.