### PR TITLE
feat: add packing statistics overview to Baleni module

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
@@ -5,6 +5,7 @@ using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumber
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetOrderTrackingNumbers;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackageLabelPdf;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingDashboard;
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingStatistics;
 using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackages;
 using Anela.Heblo.Application.Features.Packaging.UseCases.ResetOrderShipment;
 using Anela.Heblo.Application.Features.Packaging.UseCases.ScanPackingOrder;
@@ -136,6 +137,19 @@ public class PackagingController : BaseApiController
     public async Task<ActionResult<GetPackingDashboardResponse>> GetDashboard(CancellationToken ct)
     {
         var response = await _mediator.Send(new GetPackingDashboardRequest(), ct);
+        return HandleResponse(response);
+    }
+
+    /// <summary>
+    /// Aggregated packing statistics over a local-day window (defaults to the last 30 days).
+    /// Read-only, derived solely from persisted package rows.
+    /// </summary>
+    [HttpGet("statistics")]
+    public async Task<ActionResult<GetPackingStatisticsResponse>> GetStatistics(
+        [FromQuery] GetPackingStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var response = await _mediator.Send(request, cancellationToken);
         return HandleResponse(response);
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsHandler.cs
@@ -1,0 +1,117 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Packaging;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingStatistics;
+
+public class GetPackingStatisticsHandler
+    : IRequestHandler<GetPackingStatisticsRequest, GetPackingStatisticsResponse>
+{
+    private const int DefaultRangeDays = 30;
+
+    private readonly IPackageRepository _repo;
+    private readonly TimeProvider _timeProvider;
+
+    public GetPackingStatisticsHandler(IPackageRepository repo, TimeProvider timeProvider)
+    {
+        _repo = repo;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<GetPackingStatisticsResponse> Handle(
+        GetPackingStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var localZone = TimeZoneInfo.Local;
+        var today = DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date);
+
+        var toDate = request.ToDate.HasValue ? DateOnly.FromDateTime(request.ToDate.Value) : today;
+        var fromDate = request.FromDate.HasValue
+            ? DateOnly.FromDateTime(request.FromDate.Value)
+            : toDate.AddDays(-(DefaultRangeDays - 1));
+
+        if (fromDate > toDate)
+        {
+            return new GetPackingStatisticsResponse(ErrorCodes.InvalidDateRange);
+        }
+
+        // Half-open UTC window covering the local days [fromDate, toDate].
+        var fromUtc = ToLocalDayStart(fromDate, localZone);
+        var toUtc = ToLocalDayStart(toDate.AddDays(1), localZone);
+
+        var stats = await _repo.GetPackingStatisticsAsync(fromUtc, toUtc, localZone, cancellationToken);
+
+        return Map(stats, fromDate, toDate);
+    }
+
+    private static DateTimeOffset ToLocalDayStart(DateOnly day, TimeZoneInfo zone)
+    {
+        var dayStart = day.ToDateTime(TimeOnly.MinValue);
+        return new DateTimeOffset(dayStart, zone.GetUtcOffset(dayStart));
+    }
+
+    private static GetPackingStatisticsResponse Map(PackingStatistics stats, DateOnly fromDate, DateOnly toDate)
+    {
+        var busiestDay = stats.ThroughputDaily
+            .OrderByDescending(d => d.PackageCount)
+            .FirstOrDefault();
+        var busiestHour = stats.HourHeatmap
+            .OrderByDescending(h => h.PackageCount)
+            .FirstOrDefault();
+
+        return new GetPackingStatisticsResponse
+        {
+            FromDate = fromDate.ToDateTime(TimeOnly.MinValue),
+            ToDate = toDate.ToDateTime(TimeOnly.MinValue),
+            PackerAttributionSince = stats.PackerAttributionSince?.ToDateTime(TimeOnly.MinValue),
+            Summary = new PackingStatisticsSummaryDto
+            {
+                TotalPackages = stats.TotalPackages,
+                TotalOrders = stats.TotalOrders,
+                DistinctPackers = stats.ByPacker.Count,
+                AveragePackagesPerOrder = stats.TotalOrders == 0
+                    ? 0
+                    : Math.Round((double)stats.TotalPackages / stats.TotalOrders, 2),
+                TrackingCoveragePercent = stats.TotalPackages == 0
+                    ? 0
+                    : Math.Round(100.0 * stats.PackagesWithTracking / stats.TotalPackages, 1),
+                BusiestDay = busiestDay is null ? null : MapDaily(busiestDay),
+                BusiestHour = busiestHour is null ? null : MapHour(busiestHour),
+            },
+            ThroughputDaily = stats.ThroughputDaily.Select(MapDaily).ToList(),
+            HourHeatmap = stats.HourHeatmap.Select(MapHour).ToList(),
+            ByPacker = stats.ByPacker.Select(p => new PackerThroughputDto
+            {
+                PackerId = p.PackerId,
+                PackerName = p.PackerName ?? "Neznámý",
+                OrderCount = p.OrderCount,
+                PackageCount = p.PackageCount,
+            }).ToList(),
+            ByCarrier = stats.ByCarrier.Select(c => new CarrierMixDto
+            {
+                Code = c.Code,
+                Name = c.Name ?? c.Code,
+                PackageCount = c.PackageCount,
+            }).ToList(),
+            PackagesPerOrder = stats.PackagesPerOrder.Select(b => new PackagesPerOrderBucketDto
+            {
+                PackageCount = b.PackageCount,
+                OrderCount = b.OrderCount,
+            }).ToList(),
+        };
+    }
+
+    private static DailyThroughputDto MapDaily(DailyThroughput d) => new()
+    {
+        Date = d.Date.ToDateTime(TimeOnly.MinValue),
+        OrderCount = d.OrderCount,
+        PackageCount = d.PackageCount,
+    };
+
+    private static HourBucketDto MapHour(HourBucket h) => new()
+    {
+        DayOfWeek = h.DayOfWeek,
+        Hour = h.Hour,
+        PackageCount = h.PackageCount,
+    };
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsHandler.cs
@@ -22,7 +22,7 @@ public class GetPackingStatisticsHandler
         GetPackingStatisticsRequest request,
         CancellationToken cancellationToken)
     {
-        var localZone = TimeZoneInfo.Local;
+        var localZone = _timeProvider.LocalTimeZone;
         var today = DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date);
 
         var toDate = request.ToDate.HasValue ? DateOnly.FromDateTime(request.ToDate.Value) : today;

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsRequest.cs
@@ -1,0 +1,12 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingStatistics;
+
+public class GetPackingStatisticsRequest : IRequest<GetPackingStatisticsResponse>
+{
+    /// <summary>Inclusive start of the local-day window. Defaults to 29 days before <see cref="ToDate"/>.</summary>
+    public DateTime? FromDate { get; set; }
+
+    /// <summary>Inclusive end of the local-day window. Defaults to today (local).</summary>
+    public DateTime? ToDate { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackingStatistics/GetPackingStatisticsResponse.cs
@@ -1,0 +1,80 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingStatistics;
+
+public class GetPackingStatisticsResponse : BaseResponse
+{
+    /// <summary>Start of the resolved local-day window (echoed so the client can render the range).</summary>
+    public DateTime FromDate { get; set; }
+
+    /// <summary>End of the resolved local-day window (inclusive).</summary>
+    public DateTime ToDate { get; set; }
+
+    /// <summary>
+    /// Earliest local day with packer attribution. When later than <see cref="FromDate"/>,
+    /// the packer panel only reflects part of the window — the client shows a hint.
+    /// </summary>
+    public DateTime? PackerAttributionSince { get; set; }
+
+    public PackingStatisticsSummaryDto Summary { get; set; } = new();
+    public List<DailyThroughputDto> ThroughputDaily { get; set; } = new();
+    public List<HourBucketDto> HourHeatmap { get; set; } = new();
+    public List<PackerThroughputDto> ByPacker { get; set; } = new();
+    public List<CarrierMixDto> ByCarrier { get; set; } = new();
+    public List<PackagesPerOrderBucketDto> PackagesPerOrder { get; set; } = new();
+
+    public GetPackingStatisticsResponse() { }
+    public GetPackingStatisticsResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+
+public class PackingStatisticsSummaryDto
+{
+    public int TotalPackages { get; set; }
+    public int TotalOrders { get; set; }
+    public int DistinctPackers { get; set; }
+    public double AveragePackagesPerOrder { get; set; }
+    public double TrackingCoveragePercent { get; set; }
+
+    /// <summary>Local day with the most packages, if any.</summary>
+    public DailyThroughputDto? BusiestDay { get; set; }
+
+    /// <summary>Weekday/hour cell with the most packages, if any.</summary>
+    public HourBucketDto? BusiestHour { get; set; }
+}
+
+public class DailyThroughputDto
+{
+    public DateTime Date { get; set; }
+    public int OrderCount { get; set; }
+    public int PackageCount { get; set; }
+}
+
+public class HourBucketDto
+{
+    /// <summary>ISO weekday: 1 = Monday .. 7 = Sunday.</summary>
+    public int DayOfWeek { get; set; }
+    public int Hour { get; set; }
+    public int PackageCount { get; set; }
+}
+
+public class PackerThroughputDto
+{
+    public Guid? PackerId { get; set; }
+    public string PackerName { get; set; } = string.Empty;
+    public int OrderCount { get; set; }
+    public int PackageCount { get; set; }
+}
+
+public class CarrierMixDto
+{
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int PackageCount { get; set; }
+}
+
+public class PackagesPerOrderBucketDto
+{
+    /// <summary>Number of packages per order; 3 means "3 or more".</summary>
+    public int PackageCount { get; set; }
+    public int OrderCount { get; set; }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/IPackageRepository.cs
@@ -57,4 +57,15 @@ public interface IPackageRepository
 
     Task<(int TotalDistinctOrders, IReadOnlyList<PackerPackingSummary> ByPacker)>
         GetPackedTodayByPackerAsync(DateTimeOffset fromUtc, DateTimeOffset toUtc, CancellationToken ct = default);
+
+    /// <summary>
+    /// Aggregates packing activity in the half-open window [fromUtc, toUtc) into a
+    /// <see cref="PackingStatistics"/>. Day-of-week and hour-of-day buckets are computed
+    /// in <paramref name="localZone"/> so they reflect the warehouse's local working hours.
+    /// </summary>
+    Task<PackingStatistics> GetPackingStatisticsAsync(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        TimeZoneInfo localZone,
+        CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Packaging/PackingStatistics.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Packaging/PackingStatistics.cs
@@ -1,0 +1,32 @@
+namespace Anela.Heblo.Domain.Features.Packaging;
+
+/// <summary>
+/// Aggregated, read-only view of packing activity over a date window, derived
+/// solely from persisted <see cref="Package"/> rows. All day/hour grouping is in
+/// the local timezone passed to the aggregation so peaks line up with the workday.
+/// </summary>
+public sealed record PackingStatistics(
+    int TotalPackages,
+    int TotalOrders,
+    int PackagesWithTracking,
+    DateOnly? PackerAttributionSince,
+    IReadOnlyList<DailyThroughput> ThroughputDaily,
+    IReadOnlyList<HourBucket> HourHeatmap,
+    IReadOnlyList<PackerThroughput> ByPacker,
+    IReadOnlyList<CarrierThroughput> ByCarrier,
+    IReadOnlyList<PackagesPerOrderBucket> PackagesPerOrder);
+
+/// <summary>Orders and packages packed on a given local calendar day.</summary>
+public sealed record DailyThroughput(DateOnly Date, int OrderCount, int PackageCount);
+
+/// <summary>Packages packed in a given local weekday/hour cell. <paramref name="DayOfWeek"/> is ISO (1=Mon..7=Sun).</summary>
+public sealed record HourBucket(int DayOfWeek, int Hour, int PackageCount);
+
+/// <summary>Distinct orders and packages attributed to a packer. Null packer id means the row predates attribution.</summary>
+public sealed record PackerThroughput(Guid? PackerId, string? PackerName, int OrderCount, int PackageCount);
+
+/// <summary>Packages handled by a shipping provider.</summary>
+public sealed record CarrierThroughput(string Code, string? Name, int PackageCount);
+
+/// <summary>How many orders shipped in N packages. <paramref name="PackageCount"/> is capped at 3 (meaning "3 or more").</summary>
+public sealed record PackagesPerOrderBucket(int PackageCount, int OrderCount);

--- a/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Repositories/Packaging/PackageRepository.cs
@@ -185,6 +185,117 @@ public class PackageRepository : IPackageRepository
         return (total, byPacker);
     }
 
+    public async Task<PackingStatistics> GetPackingStatisticsAsync(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        TimeZoneInfo localZone,
+        CancellationToken ct = default)
+    {
+        // Npgsql requires UTC DateTimeOffset values for timestamptz comparisons.
+        var from = fromUtc.ToUniversalTime();
+        var to = toUtc.ToUniversalTime();
+
+        // Project the minimal columns for the window, then aggregate in memory. The
+        // window is bounded (default 30 days), so the row count stays small and we
+        // avoid provider-specific local-time GroupBy translation.
+        var rows = await _db.Packages
+            .AsNoTracking()
+            .Where(p => p.PackedAt >= from && p.PackedAt < to)
+            .Select(p => new StatRow(
+                p.PackedAt,
+                p.OrderCode,
+                p.PackageNumber,
+                p.ShippingProviderCode,
+                p.ShippingProviderName,
+                p.PackedByUserId,
+                p.PackedBy,
+                p.TrackingNumber != null))
+            .ToListAsync(ct);
+
+        return Aggregate(rows, localZone);
+    }
+
+    private sealed record StatRow(
+        DateTimeOffset PackedAt,
+        string OrderCode,
+        string PackageNumber,
+        string ShippingProviderCode,
+        string? ShippingProviderName,
+        Guid? PackedByUserId,
+        string? PackedBy,
+        bool HasTracking);
+
+    private static PackingStatistics Aggregate(IReadOnlyList<StatRow> rows, TimeZoneInfo localZone)
+    {
+        // Pre-compute each row's local timestamp once so all groupings stay consistent.
+        var local = rows
+            .Select(r => new { Row = r, Local = TimeZoneInfo.ConvertTime(r.PackedAt, localZone) })
+            .ToList();
+
+        var throughputDaily = local
+            .GroupBy(x => DateOnly.FromDateTime(x.Local.DateTime))
+            .Select(g => new DailyThroughput(
+                g.Key,
+                g.Select(x => x.Row.OrderCode).Distinct().Count(),
+                g.Count()))
+            .OrderBy(d => d.Date)
+            .ToList();
+
+        var hourHeatmap = local
+            .GroupBy(x => new { Day = IsoDayOfWeek(x.Local.DayOfWeek), x.Local.Hour })
+            .Select(g => new HourBucket(g.Key.Day, g.Key.Hour, g.Count()))
+            .OrderBy(h => h.DayOfWeek).ThenBy(h => h.Hour)
+            .ToList();
+
+        var byPacker = local
+            .Where(x => x.Row.PackedByUserId != null)
+            .GroupBy(x => x.Row.PackedByUserId)
+            .Select(g => new PackerThroughput(
+                g.Key,
+                g.Select(x => x.Row.PackedBy).FirstOrDefault(n => n != null),
+                g.Select(x => x.Row.OrderCode).Distinct().Count(),
+                g.Count()))
+            .OrderByDescending(p => p.OrderCount)
+            .ToList();
+
+        var byCarrier = local
+            .GroupBy(x => x.Row.ShippingProviderCode)
+            .Select(g => new CarrierThroughput(
+                g.Key,
+                g.Select(x => x.Row.ShippingProviderName).FirstOrDefault(n => n != null),
+                g.Count()))
+            .OrderByDescending(c => c.PackageCount)
+            .ToList();
+
+        var packagesPerOrder = rows
+            .GroupBy(r => r.OrderCode)
+            .Select(g => Math.Min(3, g.Select(r => r.PackageNumber).Distinct().Count()))
+            .GroupBy(bucket => bucket)
+            .Select(g => new PackagesPerOrderBucket(g.Key, g.Count()))
+            .OrderBy(b => b.PackageCount)
+            .ToList();
+
+        var attributedDays = local
+            .Where(x => x.Row.PackedByUserId != null)
+            .Select(x => DateOnly.FromDateTime(x.Local.DateTime))
+            .ToList();
+        var attributionSince = attributedDays.Count == 0 ? (DateOnly?)null : attributedDays.Min();
+
+        return new PackingStatistics(
+            TotalPackages: rows.Count,
+            TotalOrders: rows.Select(r => r.OrderCode).Distinct().Count(),
+            PackagesWithTracking: rows.Count(r => r.HasTracking),
+            PackerAttributionSince: attributionSince,
+            ThroughputDaily: throughputDaily,
+            HourHeatmap: hourHeatmap,
+            ByPacker: byPacker,
+            ByCarrier: byCarrier,
+            PackagesPerOrder: packagesPerOrder);
+    }
+
+    // .NET DayOfWeek has Sunday = 0; convert to ISO where Monday = 1 .. Sunday = 7.
+    private static int IsoDayOfWeek(DayOfWeek day) => day == DayOfWeek.Sunday ? 7 : (int)day;
+
     private static string EscapeLike(string value) =>
         value.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingStatisticsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/GetPackingStatisticsHandlerTests.cs
@@ -1,0 +1,129 @@
+using Anela.Heblo.Application.Features.Packaging.UseCases.GetPackingStatistics;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Packaging;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Packaging;
+
+public class GetPackingStatisticsHandlerTests
+{
+    private static readonly DateTimeOffset PragueNow =
+        new(2026, 6, 25, 14, 30, 0, TimeSpan.FromHours(2));
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _localNow;
+        private readonly TimeZoneInfo _zone;
+
+        public FakeTimeProvider(DateTimeOffset localNow)
+        {
+            _localNow = localNow;
+            _zone = TimeZoneInfo.CreateCustomTimeZone("FakeZone", localNow.Offset, "FakeZone", "FakeZone");
+        }
+
+        public override DateTimeOffset GetUtcNow() => _localNow.ToUniversalTime();
+        public override TimeZoneInfo LocalTimeZone => _zone;
+    }
+
+    private static PackingStatistics EmptyStats() => new(
+        TotalPackages: 0,
+        TotalOrders: 0,
+        PackagesWithTracking: 0,
+        PackerAttributionSince: null,
+        ThroughputDaily: new List<DailyThroughput>(),
+        HourHeatmap: new List<HourBucket>(),
+        ByPacker: new List<PackerThroughput>(),
+        ByCarrier: new List<CarrierThroughput>(),
+        PackagesPerOrder: new List<PackagesPerOrderBucket>());
+
+    private static GetPackingStatisticsHandler MakeSut(out Mock<IPackageRepository> repo, PackingStatistics result)
+    {
+        repo = new Mock<IPackageRepository>();
+        repo.Setup(r => r.GetPackingStatisticsAsync(
+                It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(),
+                It.IsAny<TimeZoneInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return new GetPackingStatisticsHandler(repo.Object, new FakeTimeProvider(PragueNow));
+    }
+
+    [Fact]
+    public async Task DefaultsToTrailing30DayWindowEndingToday()
+    {
+        var sut = MakeSut(out _, EmptyStats());
+
+        var response = await sut.Handle(new GetPackingStatisticsRequest(), CancellationToken.None);
+
+        response.Success.Should().BeTrue();
+        response.ToDate.Date.Should().Be(new DateTime(2026, 6, 25));
+        response.FromDate.Date.Should().Be(new DateTime(2026, 5, 27)); // 30-day inclusive window
+    }
+
+    [Fact]
+    public async Task ReturnsInvalidDateRange_WhenFromAfterTo()
+    {
+        var sut = MakeSut(out _, EmptyStats());
+
+        var response = await sut.Handle(
+            new GetPackingStatisticsRequest { FromDate = new DateTime(2026, 6, 20), ToDate = new DateTime(2026, 6, 1) },
+            CancellationToken.None);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.InvalidDateRange);
+    }
+
+    [Fact]
+    public async Task ComputesSummaryDerivations()
+    {
+        var stats = new PackingStatistics(
+            TotalPackages: 10,
+            TotalOrders: 4,
+            PackagesWithTracking: 9,
+            PackerAttributionSince: new DateOnly(2026, 6, 9),
+            ThroughputDaily: new List<DailyThroughput>
+            {
+                new(new DateOnly(2026, 6, 10), 1, 3),
+                new(new DateOnly(2026, 6, 11), 3, 7),
+            },
+            HourHeatmap: new List<HourBucket>
+            {
+                new(3, 9, 2),
+                new(3, 10, 8),
+            },
+            ByPacker: new List<PackerThroughput>
+            {
+                new(Guid.NewGuid(), "Alice", 3, 7),
+                new(Guid.NewGuid(), null, 1, 3),
+            },
+            ByCarrier: new List<CarrierThroughput> { new("DPD", "DPD", 10) },
+            PackagesPerOrder: new List<PackagesPerOrderBucket> { new(1, 2), new(2, 2) });
+
+        var sut = MakeSut(out _, stats);
+
+        var response = await sut.Handle(new GetPackingStatisticsRequest(), CancellationToken.None);
+
+        response.Summary.TotalPackages.Should().Be(10);
+        response.Summary.TotalOrders.Should().Be(4);
+        response.Summary.DistinctPackers.Should().Be(2);
+        response.Summary.AveragePackagesPerOrder.Should().Be(2.5);
+        response.Summary.TrackingCoveragePercent.Should().Be(90.0);
+        response.Summary.BusiestDay!.PackageCount.Should().Be(7);
+        response.Summary.BusiestHour!.Hour.Should().Be(10);
+        response.PackerAttributionSince.Should().Be(new DateTime(2026, 6, 9));
+        // Unattributed packer name falls back to a placeholder.
+        response.ByPacker.Should().Contain(p => p.PackerName == "Neznámý");
+    }
+
+    [Fact]
+    public async Task ZeroOrders_DoesNotDivideByZero()
+    {
+        var sut = MakeSut(out _, EmptyStats());
+
+        var response = await sut.Handle(new GetPackingStatisticsRequest(), CancellationToken.None);
+
+        response.Summary.AveragePackagesPerOrder.Should().Be(0);
+        response.Summary.TrackingCoveragePercent.Should().Be(0);
+        response.Summary.BusiestDay.Should().BeNull();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/PackageRepositoryStatisticsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/PackageRepositoryStatisticsTests.cs
@@ -1,0 +1,217 @@
+using Anela.Heblo.Domain.Features.Packaging;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Repositories.Packaging;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Packaging;
+
+public class PackageRepositoryStatisticsTests : IDisposable
+{
+    private readonly ApplicationDbContext _db;
+    private readonly PackageRepository _repo;
+
+    // Fixed Prague zone so day/hour bucketing is deterministic regardless of host TZ.
+    private static readonly TimeZoneInfo Prague = TimeZoneInfo.FindSystemTimeZoneById("Europe/Prague");
+    private static readonly TimeSpan Offset = TimeSpan.FromHours(2); // CEST (summer)
+    private static readonly DateTimeOffset WindowStart = new(2026, 6, 1, 0, 0, 0, Offset);
+    private static readonly DateTimeOffset WindowEnd = new(2026, 6, 30, 0, 0, 0, Offset);
+
+    public PackageRepositoryStatisticsTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"PackingStats_{Guid.NewGuid()}")
+            .Options;
+        _db = new ApplicationDbContext(options);
+        _repo = new PackageRepository(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static Package MakePackage(
+        string orderCode,
+        string packageNumber,
+        DateTimeOffset packedAt,
+        string carrierCode = "DPD",
+        string? carrierName = "DPD",
+        string? packedBy = null,
+        Guid? packedByUserId = null,
+        string? trackingNumber = "TRACK")
+        => new()
+        {
+            OrderCode = orderCode,
+            CustomerName = "Test",
+            PackageNumber = packageNumber,
+            ShippingProviderCode = carrierCode,
+            ShippingProviderName = carrierName,
+            ShipmentGuid = Guid.NewGuid(),
+            PackedAt = packedAt,
+            CreatedAt = packedAt,
+            PackedBy = packedBy,
+            PackedByUserId = packedByUserId,
+            TrackingNumber = trackingNumber,
+        };
+
+    private Task<PackingStatistics> Aggregate() =>
+        _repo.GetPackingStatisticsAsync(WindowStart, WindowEnd, Prague);
+
+    [Fact]
+    public async Task TotalsCountPackagesAndDistinctOrders()
+    {
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-1", "1", WindowStart.AddDays(2)),
+            MakePackage("ORD-1", "2", WindowStart.AddDays(2)),
+            MakePackage("ORD-2", "1", WindowStart.AddDays(3)));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        stats.TotalPackages.Should().Be(3);
+        stats.TotalOrders.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ExcludesRowsOutsideWindow()
+    {
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-BEFORE", "1", WindowStart.AddSeconds(-1)),
+            MakePackage("ORD-AFTER", "1", WindowEnd),
+            MakePackage("ORD-IN", "1", WindowStart.AddDays(1)));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        stats.TotalPackages.Should().Be(1);
+        stats.TotalOrders.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DailyThroughputGroupsByLocalDay()
+    {
+        // Two packages on Jun 3 (one order), one on Jun 5.
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-A", "1", new DateTimeOffset(2026, 6, 3, 9, 0, 0, Offset)),
+            MakePackage("ORD-A", "2", new DateTimeOffset(2026, 6, 3, 9, 5, 0, Offset)),
+            MakePackage("ORD-B", "1", new DateTimeOffset(2026, 6, 5, 14, 0, 0, Offset)));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        var jun3 = stats.ThroughputDaily.Single(d => d.Date == new DateOnly(2026, 6, 3));
+        jun3.PackageCount.Should().Be(2);
+        jun3.OrderCount.Should().Be(1);
+        stats.ThroughputDaily.Single(d => d.Date == new DateOnly(2026, 6, 5)).PackageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HourHeatmapUsesLocalWeekdayAndHour()
+    {
+        // 2026-06-03 is a Wednesday (ISO day 3). 09:30 local.
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-A", "1", new DateTimeOffset(2026, 6, 3, 9, 30, 0, Offset)));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        var cell = stats.HourHeatmap.Single();
+        cell.DayOfWeek.Should().Be(3); // Wednesday, ISO
+        cell.Hour.Should().Be(9);
+        cell.PackageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ByPackerCountsDistinctOrdersAndExcludesUnattributed()
+    {
+        var alice = Guid.NewGuid();
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-1", "1", WindowStart.AddDays(10), packedBy: "Alice", packedByUserId: alice),
+            MakePackage("ORD-2", "1", WindowStart.AddDays(10), packedBy: "Alice", packedByUserId: alice),
+            MakePackage("ORD-3", "1", WindowStart.AddDays(1), packedBy: null, packedByUserId: null));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        stats.ByPacker.Should().ContainSingle();
+        var packer = stats.ByPacker.Single();
+        packer.PackerId.Should().Be(alice);
+        packer.OrderCount.Should().Be(2);
+        packer.PackageCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task PackerAttributionSinceIsEarliestAttributedLocalDay()
+    {
+        var alice = Guid.NewGuid();
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-OLD", "1", WindowStart.AddDays(1), packedBy: null, packedByUserId: null),
+            MakePackage("ORD-NEW", "1", new DateTimeOffset(2026, 6, 9, 8, 0, 0, Offset), packedBy: "Alice", packedByUserId: alice));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        stats.PackerAttributionSince.Should().Be(new DateOnly(2026, 6, 9));
+    }
+
+    [Fact]
+    public async Task ByCarrierCountsPackagesPerProvider()
+    {
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-1", "1", WindowStart.AddDays(1), carrierCode: "DPD", carrierName: "DPD"),
+            MakePackage("ORD-2", "1", WindowStart.AddDays(1), carrierCode: "DPD", carrierName: "DPD"),
+            MakePackage("ORD-3", "1", WindowStart.AddDays(1), carrierCode: "GLS", carrierName: "GLS"));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        stats.ByCarrier.Single(c => c.Code == "DPD").PackageCount.Should().Be(2);
+        stats.ByCarrier.Single(c => c.Code == "GLS").PackageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PackagesPerOrderBucketsCapAtThreePlus()
+    {
+        // ORD-1: 1 package, ORD-2: 2 packages, ORD-3: 4 packages → bucket 3+ .
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-1", "1", WindowStart.AddDays(1)),
+            MakePackage("ORD-2", "1", WindowStart.AddDays(1)),
+            MakePackage("ORD-2", "2", WindowStart.AddDays(1)),
+            MakePackage("ORD-3", "1", WindowStart.AddDays(1)),
+            MakePackage("ORD-3", "2", WindowStart.AddDays(1)),
+            MakePackage("ORD-3", "3", WindowStart.AddDays(1)),
+            MakePackage("ORD-3", "4", WindowStart.AddDays(1)));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        stats.PackagesPerOrder.Single(b => b.PackageCount == 1).OrderCount.Should().Be(1);
+        stats.PackagesPerOrder.Single(b => b.PackageCount == 2).OrderCount.Should().Be(1);
+        stats.PackagesPerOrder.Single(b => b.PackageCount == 3).OrderCount.Should().Be(1); // 3 means "3+"
+    }
+
+    [Fact]
+    public async Task TrackingCoverageCountsNonNullTrackingNumbers()
+    {
+        await _db.Packages.AddRangeAsync(
+            MakePackage("ORD-1", "1", WindowStart.AddDays(1), trackingNumber: "T1"),
+            MakePackage("ORD-2", "1", WindowStart.AddDays(1), trackingNumber: null));
+        await _db.SaveChangesAsync();
+
+        var stats = await Aggregate();
+
+        stats.TotalPackages.Should().Be(2);
+        stats.PackagesWithTracking.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task EmptyWindowReturnsEmptySeries()
+    {
+        var stats = await Aggregate();
+
+        stats.TotalPackages.Should().Be(0);
+        stats.TotalOrders.Should().Be(0);
+        stats.ThroughputDaily.Should().BeEmpty();
+        stats.ByPacker.Should().BeEmpty();
+        stats.PackerAttributionSince.Should().BeNull();
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,7 +91,7 @@ import FinishPoStep from "./components/terminal/lot-identification/FinishPoStep"
 import FreeformMaterialStep from "./components/terminal/lot-identification/FreeformMaterialStep";
 import BaleniLayout from "./components/baleni/BaleniLayout";
 import BaleniHome from "./components/baleni/BaleniHome";
-import BaleniPlaceholder from "./components/baleni/BaleniPlaceholder";
+import BaleniStatistics from "./components/baleni/statistics/BaleniStatistics";
 import BaleniPacking from "./components/baleni/BaleniPacking";
 import { ZasilkyPage } from "./components/baleni/zasilky/ZasilkyPage";
 import "./i18n";
@@ -399,7 +399,7 @@ function App() {
                         <Route index element={<BaleniHome />} />
                         <Route path="baleni" element={<BaleniPacking />} />
                         <Route path="zasilky" element={<ZasilkyPage />} />
-                        <Route path="statistiky" element={<BaleniPlaceholder title="Statistiky" />} />
+                        <Route path="statistiky" element={<BaleniStatistics />} />
                       </Route>
 
                       {/* Desktop app — full Layout with sidebar (pathless layout route) */}

--- a/frontend/src/api/hooks/usePackingStatistics.ts
+++ b/frontend/src/api/hooks/usePackingStatistics.ts
@@ -1,0 +1,93 @@
+import { useQuery } from "@tanstack/react-query";
+import { getApiBaseUrl, getAuthenticatedFetch } from "../client";
+
+export interface PackingStatisticsSummary {
+  totalPackages: number;
+  totalOrders: number;
+  distinctPackers: number;
+  averagePackagesPerOrder: number;
+  trackingCoveragePercent: number;
+  busiestDay: DailyThroughput | null;
+  busiestHour: HourBucket | null;
+}
+
+export interface DailyThroughput {
+  date: string;
+  orderCount: number;
+  packageCount: number;
+}
+
+export interface HourBucket {
+  /** ISO weekday: 1 = Monday .. 7 = Sunday. */
+  dayOfWeek: number;
+  hour: number;
+  packageCount: number;
+}
+
+export interface PackerThroughput {
+  packerId: string | null;
+  packerName: string;
+  orderCount: number;
+  packageCount: number;
+}
+
+export interface CarrierMix {
+  code: string;
+  name: string;
+  packageCount: number;
+}
+
+export interface PackagesPerOrderBucket {
+  /** Packages per order; 3 means "3 or more". */
+  packageCount: number;
+  orderCount: number;
+}
+
+export interface PackingStatisticsResponse {
+  fromDate: string;
+  toDate: string;
+  packerAttributionSince: string | null;
+  summary: PackingStatisticsSummary;
+  throughputDaily: DailyThroughput[];
+  hourHeatmap: HourBucket[];
+  byPacker: PackerThroughput[];
+  byCarrier: CarrierMix[];
+  packagesPerOrder: PackagesPerOrderBucket[];
+}
+
+export interface PackingStatisticsParams {
+  /** Inclusive start of the local-day window (YYYY-MM-DD). */
+  fromDate?: string;
+  /** Inclusive end of the local-day window (YYYY-MM-DD). */
+  toDate?: string;
+}
+
+export const packingStatisticsKeys = {
+  all: ["packingStatistics"] as const,
+  detail: (params: PackingStatisticsParams) =>
+    [...packingStatisticsKeys.all, params] as const,
+};
+
+export const usePackingStatistics = (params: PackingStatisticsParams = {}) =>
+  useQuery({
+    queryKey: packingStatisticsKeys.detail(params),
+    queryFn: async (): Promise<PackingStatisticsResponse> => {
+      const query = new URLSearchParams();
+      if (params.fromDate) query.set("fromDate", params.fromDate);
+      if (params.toDate) query.set("toDate", params.toDate);
+      const suffix = query.toString() ? `?${query.toString()}` : "";
+
+      const url = `${getApiBaseUrl()}/api/packaging/statistics${suffix}`;
+      const response = await getAuthenticatedFetch()(url, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return response.json() as Promise<PackingStatisticsResponse>;
+    },
+    staleTime: 5 * 60_000,
+  });

--- a/frontend/src/components/baleni/statistics/BaleniStatistics.tsx
+++ b/frontend/src/components/baleni/statistics/BaleniStatistics.tsx
@@ -1,0 +1,211 @@
+import React from "react";
+import { AlertCircle, BarChart3, RefreshCw } from "lucide-react";
+import { format, parseISO, subDays } from "date-fns";
+import { cs } from "date-fns/locale";
+import { useScreenView } from "../../../telemetry/useScreenView";
+import {
+  PackingStatisticsResponse,
+  usePackingStatistics,
+} from "../../../api/hooks/usePackingStatistics";
+import PackingHourHeatmap from "./PackingHourHeatmap";
+import {
+  CarrierMixChart,
+  PackagesPerOrderChart,
+  PackerLeaderboard,
+  ThroughputChart,
+} from "./PackingCharts";
+
+const RANGE_PRESETS = [
+  { id: "7", label: "7 dní", days: 7 },
+  { id: "30", label: "30 dní", days: 30 },
+  { id: "90", label: "90 dní", days: 90 },
+] as const;
+
+const DEFAULT_RANGE_DAYS = 30;
+const ISO_DATE = "yyyy-MM-dd";
+
+const Panel: React.FC<{ title: string; children: React.ReactNode; subtitle?: React.ReactNode }> = ({
+  title,
+  subtitle,
+  children,
+}) => (
+  <div className="bg-white border border-border-light rounded-xl p-6 shadow-soft">
+    <div className="mb-4">
+      <h3 className="text-sm font-semibold text-neutral-slate">{title}</h3>
+      {subtitle && <p className="text-xs text-neutral-gray mt-1">{subtitle}</p>}
+    </div>
+    {children}
+  </div>
+);
+
+const KpiCard: React.FC<{ label: string; value: React.ReactNode; loading: boolean }> = ({
+  label,
+  value,
+  loading,
+}) => (
+  <div className="bg-white border border-border-light rounded-xl p-5 shadow-soft">
+    <p className="text-sm text-neutral-gray mb-2">{label}</p>
+    {loading ? (
+      <div className="h-8 w-20 bg-secondary-blue-pale rounded animate-pulse" />
+    ) : (
+      <p className="text-3xl font-bold text-primary-blue">{value}</p>
+    )}
+  </div>
+);
+
+const formatDay = (iso: string): string => format(parseISO(iso), "d. M. yyyy", { locale: cs });
+
+const packerAttributionHint = (data: PackingStatisticsResponse): string | null => {
+  if (!data.packerAttributionSince) return null;
+  if (parseISO(data.packerAttributionSince) <= parseISO(data.fromDate)) return null;
+  return `Evidence baličů je dostupná až od ${formatDay(data.packerAttributionSince)}.`;
+};
+
+const BaleniStatistics: React.FC = () => {
+  useScreenView("Baleni", "Statistics");
+  const [rangeDays, setRangeDays] = React.useState<number>(DEFAULT_RANGE_DAYS);
+
+  const params = React.useMemo(() => {
+    const today = new Date();
+    return {
+      fromDate: format(subDays(today, rangeDays - 1), ISO_DATE),
+      toDate: format(today, ISO_DATE),
+    };
+  }, [rangeDays]);
+
+  const { data, isLoading, error, refetch, isFetching } = usePackingStatistics(params);
+
+  if (error) {
+    return (
+      <div className="py-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center gap-3">
+            <AlertCircle className="h-5 w-5 text-red-600" />
+            <div>
+              <h3 className="text-sm font-medium text-red-800">Chyba při načítání statistik</h3>
+              <p className="text-sm text-red-700 mt-1">
+                {error instanceof Error ? error.message : "Neočekávaná chyba"}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => refetch()}
+            className="mt-3 px-3 py-1 text-sm bg-red-100 text-red-800 rounded hover:bg-red-200 transition-colors"
+          >
+            Zkusit znovu
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const summary = data?.summary;
+  const attributionHint = data ? packerAttributionHint(data) : null;
+
+  return (
+    <div className="pt-4 space-y-6" data-testid="baleni-statistics">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-slate flex items-center gap-3">
+            <BarChart3 className="h-6 w-6 text-primary-blue" />
+            Statistiky balicí stanice
+          </h1>
+          {data && (
+            <p className="text-sm text-neutral-gray mt-1">
+              {formatDay(data.fromDate)} – {formatDay(data.toDate)}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {RANGE_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              onClick={() => setRangeDays(preset.days)}
+              className={`px-3 py-2 rounded-lg border text-sm transition-colors ${
+                rangeDays === preset.days
+                  ? "bg-secondary-blue-pale border-primary-blue text-primary-blue"
+                  : "bg-white border-border-light text-neutral-gray hover:bg-secondary-blue-pale"
+              }`}
+            >
+              {preset.label}
+            </button>
+          ))}
+          <button
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border-light text-neutral-gray hover:bg-secondary-blue-pale transition-colors disabled:opacity-50"
+            aria-label="Obnovit"
+          >
+            <RefreshCw className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+          </button>
+        </div>
+      </div>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-4">
+        <KpiCard label="Balíků" value={summary?.totalPackages ?? "—"} loading={isLoading} />
+        <KpiCard label="Objednávek" value={summary?.totalOrders ?? "—"} loading={isLoading} />
+        <KpiCard
+          label="Ø balíků / obj."
+          value={summary ? summary.averagePackagesPerOrder.toFixed(2) : "—"}
+          loading={isLoading}
+        />
+        <KpiCard
+          label="Pokrytí trackingu"
+          value={summary ? `${summary.trackingCoveragePercent} %` : "—"}
+          loading={isLoading}
+        />
+        <KpiCard label="Baličů" value={summary?.distinctPackers ?? "—"} loading={isLoading} />
+        <KpiCard
+          label="Nejvytíženější den"
+          value={
+            summary?.busiestDay
+              ? format(parseISO(summary.busiestDay.date), "d. M.", { locale: cs })
+              : "—"
+          }
+          loading={isLoading}
+        />
+      </div>
+
+      {isLoading || !data ? (
+        <div className="flex items-center justify-center h-72 bg-white border border-border-light rounded-xl shadow-soft">
+          <div className="text-center">
+            <RefreshCw className="h-8 w-8 text-primary-blue animate-spin mx-auto mb-4" />
+            <p className="text-neutral-gray">Načítání dat...</p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <Panel title="Průběh balení v čase" subtitle="Počet zabalených balíků a objednávek po dnech">
+            <ThroughputChart data={data.throughputDaily} />
+          </Panel>
+
+          <Panel
+            title="Vytížení podle hodin"
+            subtitle="Počet zabalených balíků podle dne v týdnu a hodiny (místní čas)"
+          >
+            <PackingHourHeatmap data={data.hourHeatmap} />
+          </Panel>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <Panel title="Baliči" subtitle={attributionHint ?? "Počet zabalených objednávek na baliče"}>
+              <PackerLeaderboard data={data.byPacker} />
+            </Panel>
+
+            <Panel title="Dopravci" subtitle="Podíl balíků podle dopravce">
+              <CarrierMixChart data={data.byCarrier} />
+            </Panel>
+          </div>
+
+          <Panel title="Balíků na objednávku" subtitle="Rozložení objednávek podle počtu balíků">
+            <PackagesPerOrderChart data={data.packagesPerOrder} />
+          </Panel>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default BaleniStatistics;

--- a/frontend/src/components/baleni/statistics/PackingCharts.tsx
+++ b/frontend/src/components/baleni/statistics/PackingCharts.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { format, parseISO } from "date-fns";
+import { cs } from "date-fns/locale";
+import {
+  CarrierMix,
+  DailyThroughput,
+  PackagesPerOrderBucket,
+  PackerThroughput,
+} from "../../../api/hooks/usePackingStatistics";
+
+const CARRIER_COLORS = ["#2563eb", "#0ea5e9", "#14b8a6", "#f59e0b", "#a855f7", "#ec4899", "#64748b"];
+const EmptyState: React.FC = () => (
+  <p className="text-sm text-neutral-gray italic">Žádná data k zobrazení.</p>
+);
+
+export const ThroughputChart: React.FC<{ data: DailyThroughput[] }> = ({ data }) => {
+  if (data.length === 0) return <EmptyState />;
+  const chartData = data.map((d) => ({
+    ...d,
+    label: format(parseISO(d.date), "dd.MM.", { locale: cs }),
+  }));
+  return (
+    <div className="h-72 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData} margin={{ top: 10, right: 20, left: 0, bottom: 10 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} stroke="#6b7280" />
+          <YAxis tick={{ fontSize: 11 }} stroke="#6b7280" allowDecimals={false} />
+          <Tooltip
+            formatter={(value, name) => [
+              value,
+              name === "packageCount" ? "Balíků" : "Objednávek",
+            ]}
+            labelFormatter={(label) => `Den ${label}`}
+          />
+          <Legend
+            formatter={(value) => (value === "packageCount" ? "Balíků" : "Objednávek")}
+          />
+          <Bar dataKey="packageCount" fill="#2563eb" radius={[2, 2, 0, 0]} />
+          <Bar dataKey="orderCount" fill="#93c5fd" radius={[2, 2, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export const CarrierMixChart: React.FC<{ data: CarrierMix[] }> = ({ data }) => {
+  if (data.length === 0) return <EmptyState />;
+  return (
+    <div className="h-72 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="packageCount"
+            nameKey="name"
+            cx="50%"
+            cy="50%"
+            innerRadius={55}
+            outerRadius={90}
+            paddingAngle={2}
+          >
+            {data.map((entry, index) => (
+              <Cell key={entry.code} fill={CARRIER_COLORS[index % CARRIER_COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip formatter={(value) => [value, "Balíků"]} />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export const PackerLeaderboard: React.FC<{ data: PackerThroughput[] }> = ({ data }) => {
+  if (data.length === 0) return <EmptyState />;
+  return (
+    <div className="w-full" style={{ height: Math.max(160, data.length * 44) }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          layout="vertical"
+          data={data}
+          margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
+          <XAxis type="number" tick={{ fontSize: 11 }} stroke="#6b7280" allowDecimals={false} />
+          <YAxis
+            type="category"
+            dataKey="packerName"
+            width={120}
+            tick={{ fontSize: 12 }}
+            stroke="#6b7280"
+          />
+          <Tooltip formatter={(value) => [value, "Objednávek"]} />
+          <Bar dataKey="orderCount" fill="#2563eb" radius={[0, 4, 4, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export const PackagesPerOrderChart: React.FC<{ data: PackagesPerOrderBucket[] }> = ({ data }) => {
+  if (data.length === 0) return <EmptyState />;
+  const chartData = data.map((b) => ({
+    ...b,
+    label: b.packageCount >= 3 ? "3+" : String(b.packageCount),
+  }));
+  return (
+    <div className="h-60 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData} margin={{ top: 10, right: 20, left: 0, bottom: 10 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 12 }}
+            stroke="#6b7280"
+            label={{ value: "Balíků v objednávce", position: "insideBottom", offset: -5, fontSize: 11 }}
+          />
+          <YAxis tick={{ fontSize: 11 }} stroke="#6b7280" allowDecimals={false} />
+          <Tooltip formatter={(value) => [value, "Objednávek"]} />
+          <Bar dataKey="orderCount" fill="#0ea5e9" radius={[2, 2, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/frontend/src/components/baleni/statistics/PackingHourHeatmap.tsx
+++ b/frontend/src/components/baleni/statistics/PackingHourHeatmap.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { HourBucket } from "../../../api/hooks/usePackingStatistics";
+
+interface PackingHourHeatmapProps {
+  data: HourBucket[];
+}
+
+const WEEKDAY_LABELS = ["Po", "Út", "St", "Čt", "Pá", "So", "Ne"]; // ISO order: Mon..Sun
+const DEFAULT_FROM_HOUR = 6;
+const DEFAULT_TO_HOUR = 20;
+
+const cellKey = (dayOfWeek: number, hour: number): string => `${dayOfWeek}-${hour}`;
+
+/**
+ * Local weekday × hour heatmap of package counts. recharts has no native heatmap,
+ * so this is a simple CSS grid with opacity scaled to each cell's share of the max.
+ */
+const PackingHourHeatmap: React.FC<PackingHourHeatmapProps> = ({ data }) => {
+  const counts = React.useMemo(() => {
+    const map = new Map<string, number>();
+    for (const bucket of data) {
+      map.set(cellKey(bucket.dayOfWeek, bucket.hour), bucket.packageCount);
+    }
+    return map;
+  }, [data]);
+
+  const maxCount = React.useMemo(
+    () => data.reduce((max, b) => Math.max(max, b.packageCount), 0),
+    [data],
+  );
+
+  // Render the hour span that actually contains activity, falling back to working hours.
+  const { fromHour, toHour } = React.useMemo(() => {
+    if (data.length === 0) {
+      return { fromHour: DEFAULT_FROM_HOUR, toHour: DEFAULT_TO_HOUR };
+    }
+    const hours = data.map((b) => b.hour);
+    return { fromHour: Math.min(...hours), toHour: Math.max(...hours) };
+  }, [data]);
+
+  const hours = React.useMemo(() => {
+    const result: number[] = [];
+    for (let h = fromHour; h <= toHour; h++) result.push(h);
+    return result;
+  }, [fromHour, toHour]);
+
+  if (data.length === 0) {
+    return (
+      <p className="text-sm text-neutral-gray italic">Žádná data k zobrazení.</p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="border-separate border-spacing-1" data-testid="packing-hour-heatmap">
+        <thead>
+          <tr>
+            <th className="w-8" />
+            {hours.map((hour) => (
+              <th key={hour} className="text-xs font-normal text-neutral-gray text-center w-7">
+                {hour}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {WEEKDAY_LABELS.map((label, index) => {
+            const dayOfWeek = index + 1; // ISO 1..7
+            return (
+              <tr key={dayOfWeek}>
+                <td className="text-xs text-neutral-gray pr-1 text-right">{label}</td>
+                {hours.map((hour) => {
+                  const count = counts.get(cellKey(dayOfWeek, hour)) ?? 0;
+                  const intensity = maxCount > 0 ? count / maxCount : 0;
+                  return (
+                    <td
+                      key={hour}
+                      className="h-7 w-7 rounded"
+                      title={`${label} ${hour}:00 — ${count} balíků`}
+                      style={{
+                        backgroundColor:
+                          count === 0
+                            ? "var(--heatmap-empty, #f1f5f9)"
+                            : `rgba(37, 99, 235, ${0.15 + intensity * 0.85})`,
+                      }}
+                    />
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PackingHourHeatmap;

--- a/frontend/src/components/baleni/statistics/__tests__/BaleniStatistics.test.tsx
+++ b/frontend/src/components/baleni/statistics/__tests__/BaleniStatistics.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { PackingStatisticsResponse } from "../../../../api/hooks/usePackingStatistics";
+import BaleniStatistics from "../BaleniStatistics";
+
+jest.mock("../../../../telemetry/useScreenView", () => ({
+  useScreenView: jest.fn(),
+}));
+
+const mockUsePackingStatistics = jest.fn();
+jest.mock("../../../../api/hooks/usePackingStatistics", () => ({
+  ...jest.requireActual("../../../../api/hooks/usePackingStatistics"),
+  usePackingStatistics: (params: unknown) => mockUsePackingStatistics(params),
+}));
+
+const sampleData: PackingStatisticsResponse = {
+  fromDate: "2026-05-27",
+  toDate: "2026-06-25",
+  packerAttributionSince: "2026-06-09",
+  summary: {
+    totalPackages: 120,
+    totalOrders: 80,
+    distinctPackers: 3,
+    averagePackagesPerOrder: 1.5,
+    trackingCoveragePercent: 92.5,
+    busiestDay: { date: "2026-06-10", orderCount: 12, packageCount: 18 },
+    busiestHour: { dayOfWeek: 3, hour: 10, packageCount: 9 },
+  },
+  throughputDaily: [{ date: "2026-06-10", orderCount: 12, packageCount: 18 }],
+  hourHeatmap: [{ dayOfWeek: 3, hour: 10, packageCount: 9 }],
+  byPacker: [{ packerId: "p1", packerName: "Alice", orderCount: 40, packageCount: 60 }],
+  byCarrier: [{ code: "DPD", name: "DPD", packageCount: 120 }],
+  packagesPerOrder: [{ packageCount: 1, orderCount: 50 }],
+};
+
+const setHookResult = (overrides: Record<string, unknown>) => {
+  mockUsePackingStatistics.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    isFetching: false,
+    ...overrides,
+  });
+};
+
+describe("BaleniStatistics", () => {
+  beforeEach(() => mockUsePackingStatistics.mockReset());
+
+  it("shows a loading state while fetching", () => {
+    setHookResult({ isLoading: true });
+    render(<BaleniStatistics />);
+    expect(screen.getByText("Načítání dat...")).toBeInTheDocument();
+  });
+
+  it("shows an error state with a retry button", () => {
+    setHookResult({ error: new Error("boom") });
+    render(<BaleniStatistics />);
+    expect(screen.getByText("Chyba při načítání statistik")).toBeInTheDocument();
+    expect(screen.getByText("Zkusit znovu")).toBeInTheDocument();
+  });
+
+  it("renders KPI values and all panels when data is present", () => {
+    setHookResult({ data: sampleData });
+    render(<BaleniStatistics />);
+
+    expect(screen.getByTestId("baleni-statistics")).toBeInTheDocument();
+    expect(screen.getByText("120")).toBeInTheDocument(); // total packages
+    expect(screen.getByText("80")).toBeInTheDocument(); // total orders
+    expect(screen.getByText("92.5 %")).toBeInTheDocument(); // tracking coverage
+    expect(screen.getByText("Průběh balení v čase")).toBeInTheDocument();
+    expect(screen.getByText("Vytížení podle hodin")).toBeInTheDocument();
+    expect(screen.getByTestId("packing-hour-heatmap")).toBeInTheDocument();
+    expect(screen.getByText("Dopravci")).toBeInTheDocument();
+  });
+
+  it("shows the packer attribution hint when attribution starts after the window", () => {
+    setHookResult({ data: sampleData });
+    render(<BaleniStatistics />);
+    expect(screen.getByText(/Evidence baličů je dostupná až od/)).toBeInTheDocument();
+  });
+
+  it("omits the attribution hint when attribution covers the whole window", () => {
+    setHookResult({
+      data: { ...sampleData, packerAttributionSince: "2026-05-20" },
+    });
+    render(<BaleniStatistics />);
+    expect(screen.queryByText(/Evidence baličů je dostupná až od/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Replaces the `/baleni/statistiky` placeholder with a read-only statistics page backed by a new `GET /api/packaging/statistics` endpoint that aggregates the `Packages` table over a selectable local-day window (30-day default, 7/30/90-day presets). The page surfaces summary KPIs, throughput-over-time, a peak-hours heatmap, a packer leaderboard, carrier mix, and packages-per-order — all derived solely from data we already persist, with no external/Shoptet calls. Day/hour bucketing is computed in Europe/Prague local time so peaks align with the workday, and the packer panel shows a "data since" hint because packer attribution only began ~9 Jun. Adds `useScreenView('Baleni','Statistics')`, closing the telemetry gap noted in the usage-analytics docs. Covered by 14 backend tests (repository aggregations + handler) and 5 frontend component tests; full Packaging/Contract/Architecture suite (138) green, FE build clean.