### PR TITLE
#3350: seed staging manufacture orders for protocol E2E tests

### DIFF
--- a/artifacts/feat-3350/arch-review.r1.md
+++ b/artifacts/feat-3350/arch-review.r1.md
@@ -1,0 +1,23 @@
+# Architecture Review: Seed Manufacture Orders for E2E
+
+## Summary
+
+The solution is a standalone shell script in `scripts/`. This is the correct placement per the existing project pattern (see `scripts/run-playwright-tests.sh`, `scripts/start-backend-dev.sh`, etc.). No backend or frontend code changes are needed.
+
+## Design decisions
+
+- **Shell script (not TypeScript):** The seeding is a one-time operational task, not part of the test runner. A bash script with curl calls is simpler and has no Node.js dependency.
+- **Uses same Azure AD creds as E2E tests:** Reuses `E2E_CLIENT_ID`, `E2E_CLIENT_SECRET`, `AZURE_TENANT_ID` — no new secrets needed.
+- **Creates new orders, not modifying existing:** New orders appear at the top of the `CreatedDate DESC` sorted list, satisfying the "near the top" requirement without touching existing data.
+- **SinglePhase orders:** Simplest state-transition path. Draft → Planned → Completed requires only two PATCH calls without `confirm-semi-product` or `confirm-products` intermediate steps. The PATCH /status endpoint allows direct transitions when required.
+- **No test code changes:** The protocol.spec.ts tests are correctly written and should not be modified.
+
+## Risk
+
+- Low. Script only creates data, does not delete or modify existing records.
+- Idempotent usage: running twice creates extra orders, but they're harmless (more Completed/Draft rows at the top).
+- The staging API must be accessible from where the script is run (developer machine or CI with VPN/network access).
+
+## Approved approach
+
+Single script: `scripts/seed-manufacture-orders-for-e2e.sh`

--- a/artifacts/feat-3350/brief.md
+++ b/artifacts/feat-3350/brief.md
@@ -1,0 +1,10 @@
+**Source:** Nightly E2E triage — run 28147951139 (2026-06-25). Clears **2** manufacturing failures (protocol).
+
+## Problem
+`frontend/test/e2e/manufacturing/protocol.spec.ts:34/57` throw by design — no **Completed** and no **Draft/Planned** manufacture order in the first 5 rows on staging.
+
+## Scope
+Seed staging (`Heblo_TST`) with at least one **Completed** and one **Draft/Planned** manufacture order so both appear near the top of the list. Per project rule these tests throw (not skip) when data is missing — the fixture data must exist.
+
+## Acceptance criteria
+- Both protocol tests find the required orders and pass against staging.

--- a/artifacts/feat-3350/code-review.r1.md
+++ b/artifacts/feat-3350/code-review.r1.md
@@ -1,0 +1,17 @@
+# Code Review: feat-3350
+
+## Review Result: CLEAN
+
+## Summary
+
+The diff adds a single new file: `scripts/seed-manufacture-orders-for-e2e.sh`. All other changed files are pipeline artifacts (`artifacts/feat-3350/**`). No production code was modified.
+
+## Blocking
+
+- None
+
+## Advisory
+
+- The `--fail-with-body` curl flag requires curl ≥ 7.76 (released 2021-03). On older Ubuntu LTS systems this flag is absent. If portability is needed, replace with `--fail` and capture errors via stderr redirection. Acceptable risk for a developer/CI utility script.
+- The script creates permanent data on staging on each invocation. Adding an early-exit guard (`GET /api/ManufactureOrder?state=5` to check if a Completed order already exists near the top) would make it idempotent. Nice-to-have, not blocking for this triage fix.
+- No test file for the script (shell scripts in `scripts/` are not unit-tested in this project). Consistent with the project pattern.

--- a/artifacts/feat-3350/design.r1.md
+++ b/artifacts/feat-3350/design.r1.md
@@ -1,0 +1,65 @@
+# Design: seed-manufacture-orders-for-e2e.sh
+
+## Script structure
+
+```
+scripts/seed-manufacture-orders-for-e2e.sh
+```
+
+### Step 1 — Acquire Azure AD token
+
+```bash
+TOKEN=$(curl -s -X POST \
+  "https://login.microsoftonline.com/${AZURE_TENANT_ID}/oauth2/v2.0/token" \
+  -d "grant_type=client_credentials&client_id=${E2E_CLIENT_ID}&client_secret=${E2E_CLIENT_SECRET}&scope=api://8b34be89-f86f-422f-af40-7dbcd30cb66a/.default" \
+  | jq -r '.access_token')
+```
+
+### Step 2 — Create Draft order (will stay as Draft)
+
+```bash
+DRAFT_ID=$(curl -s -X POST "${BASE_URL}/api/ManufactureOrder" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"productCode":"MAS001001M","productName":"Hedvábný pan Jasmín E2E Draft","originalBatchSize":5000,"newBatchSize":5000,"scaleFactor":1,"plannedDate":"2027-01-01","manufactureType":1}' \
+  | jq '.id')
+```
+
+### Step 3 — Create second order, transition to Completed
+
+```bash
+# Create (Draft)
+COMP_ID=$(curl -s -X POST "${BASE_URL}/api/ManufactureOrder" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"productCode":"MAS001001M","productName":"Hedvábný pan Jasmín E2E Completed","originalBatchSize":5000,"newBatchSize":5000,"scaleFactor":1,"plannedDate":"2027-01-01","manufactureType":1}' \
+  | jq '.id')
+
+# Draft → Planned
+curl -s -X PATCH "${BASE_URL}/api/ManufactureOrder/${COMP_ID}/status" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"id\":${COMP_ID},\"newState\":2}"
+
+# Planned → Completed
+curl -s -X PATCH "${BASE_URL}/api/ManufactureOrder/${COMP_ID}/status" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"id\":${COMP_ID},\"newState\":5}"
+```
+
+## Environment variables required
+
+| Variable | Source | Description |
+|---|---|---|
+| `E2E_CLIENT_ID` | Azure AD | Service principal client ID |
+| `E2E_CLIENT_SECRET` | Azure AD | Service principal secret |
+| `AZURE_TENANT_ID` | Azure AD | Tenant ID |
+| `PLAYWRIGHT_BASE_URL` | Optional | Override staging URL (default: `https://heblo.stg.anela.cz`) |
+
+## Error handling
+
+- Check that all required env vars are set; exit early with a clear message if any is missing
+- Check that the Azure AD token was successfully obtained (non-null/non-error response)
+- Check that each `curl` call returns a non-null `id` in the response
+- Print the created order numbers on success

--- a/artifacts/feat-3350/impl/create-seed-script.r1.md
+++ b/artifacts/feat-3350/impl/create-seed-script.r1.md
@@ -1,0 +1,18 @@
+# Implementation: create-seed-script (r1)
+
+## What was done
+
+Created `scripts/seed-manufacture-orders-for-e2e.sh` — a bash script that seeds the staging environment with the two manufacture orders required by `protocol.spec.ts`.
+
+## Key implementation details
+
+- Pre-flight validation: checks for required env vars (`E2E_CLIENT_ID`, `E2E_CLIENT_SECRET`, `AZURE_TENANT_ID`) and for `jq`/`curl` availability
+- Azure AD token: acquired via `client_credentials` flow, same scope as E2E tests
+- Creates Draft order: `POST /api/ManufactureOrder` with `manufactureType: 1` (SinglePhase) — stays in Draft
+- Creates Completed order: same POST, then two PATCH calls `Draft → Planned (newState=2) → Completed (newState=5)`
+- Error handling: each step checks the response and exits with a descriptive message on failure
+- Script is executable (`chmod +x`)
+
+## File changed
+
+- `scripts/seed-manufacture-orders-for-e2e.sh` — new file, 113 lines

--- a/artifacts/feat-3350/review/create-seed-script.r1.md
+++ b/artifacts/feat-3350/review/create-seed-script.r1.md
@@ -1,0 +1,24 @@
+# Review: create-seed-script (r1)
+
+## Correctness check
+
+- Pre-flight env var check: correct. All three required vars validated.
+- `jq`/`curl` availability check: correct.
+- Azure AD token acquisition: correct pattern (`client_credentials`, correct scope).
+- Token null check: correct (`jq -r '.access_token // empty'`).
+- Draft order creation: `manufactureType: 1` (SinglePhase) is correct for a simple order with no products.
+- Completed order transition: Draft(1) → Planned(2) → Completed(5). Valid state transitions per the domain model.
+- Error handling: each `patch_status` and `create_order` checks for success. Good.
+- `--fail-with-body` on curl ensures HTTP 4xx/5xx cause script to exit via `set -e`.
+
+## Issues
+
+- None blocking.
+
+## Advisory
+
+- The `--fail-with-body` flag requires curl ≥ 7.76. On older systems, use `--fail` instead (loses error body on failure). Acceptable trade-off for a dev/CI script.
+- The script produces permanent data on staging. Re-running is safe but creates extra rows. A future enhancement could check if sufficient orders already exist before creating new ones (out of scope for this fix).
+- `plannedDate: 2027-01-01` is a future date. This is intentional to avoid "past date" validation errors and mirrors the existing `draftHedvabnyPan` fixture pattern (`productionDate: '24. 1. 2029'`).
+
+**Status:** PASS

--- a/artifacts/feat-3350/spec.r1.md
+++ b/artifacts/feat-3350/spec.r1.md
@@ -1,0 +1,40 @@
+# Spec: Seed Staging Manufacture Orders for Protocol Tests
+
+## Problem Statement
+
+Two E2E tests in `frontend/test/e2e/manufacturing/protocol.spec.ts` are failing on the nightly staging run because the manufacture orders list does not have any Completed or Draft/Planned orders in the first 5 rows.
+
+- **Test 1 (line 34):** Searches for a "Completed|Dokončeno" order. Throws with "No completed manufacture order found in the first 5 rows."
+- **Test 2 (line 57):** Searches for a "Draft|Návrh|Planned|Plánováno" order. Throws with "No non-completed manufacture order found in the first 5 rows."
+
+## Root Cause
+
+The `findAndClickRowByState` helper scans `maxRows = 5` rows (rows 0–4) of the manufacture orders table. The list is ordered `CreatedDate DESC`, so only the 5 most recently created orders are checked. On staging, these top rows apparently do not include orders in the required states.
+
+## Solution
+
+Create a shell seeding script that uses the staging REST API to create the required manufacture orders. Because orders are sorted by `CreatedDate DESC`, newly created orders appear first, guaranteeing they land in the first 5 rows.
+
+**Script creates:**
+1. One **Draft** manufacture order (created, left in Draft state)
+2. One **Completed** manufacture order (created, then transitioned Draft → Planned → Completed)
+
+Both orders are created with the known staging semi-product `MAS001001M` (Hedvábný pan Jasmín).
+
+## Key Findings
+
+- API: `POST /api/ManufactureOrder` — creates in Draft state
+- API: `PATCH /api/ManufactureOrder/{id}/status` — transitions state (body: `{"Id": id, "NewState": <int>}`)
+  - Draft = 1, Planned = 2, Completed = 5
+  - Valid transition: Draft → Planned → Completed
+- Auth: Azure AD service principal, same creds as E2E tests (`E2E_CLIENT_ID`, `E2E_CLIENT_SECRET`, `AZURE_TENANT_ID`)
+- Scope: `api://8b34be89-f86f-422f-af40-7dbcd30cb66a/.default`
+- Staging base URL: `https://heblo.stg.anela.cz`
+
+## No Code Changes Required in Tests
+
+The protocol tests are correctly written — they expect data to exist. The fix is operational (seeding the data), not a test logic change.
+
+## Deliverable
+
+`scripts/seed-manufacture-orders-for-e2e.sh` — a shell script that can be run on-demand to create the required staging data.

--- a/artifacts/feat-3350/state.json
+++ b/artifacts/feat-3350/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-06-25T18:23:47.864992Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-06-25T18:23:57.886143Z"
+      "status": "completed",
+      "updated_at": "2026-06-25T18:24:18.880705Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3350/state.json
+++ b/artifacts/feat-3350/state.json
@@ -21,16 +21,20 @@
       "updated_at": "2026-06-25T18:22:25.723001Z"
     },
     "developing": {
+      "status": "completed",
+      "updated_at": "2026-06-25T18:23:47.864992Z"
+    },
+    "code-review": {
       "status": "in_progress",
-      "updated_at": "2026-06-25T18:22:40.471133Z"
+      "updated_at": "2026-06-25T18:23:57.886143Z"
     }
   },
   "tasks": [
     {
       "name": "create-seed-script",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-25T18:22:40.716029Z"
+      "updated_at": "2026-06-25T18:23:47.495075Z"
     }
   ]
 }

--- a/artifacts/feat-3350/state.json
+++ b/artifacts/feat-3350/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3350",
+  "issue_number": 3350,
+  "created_at": "2026-06-25T18:20:51.203800Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-25T18:21:25.762403Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3350/state.json
+++ b/artifacts/feat-3350/state.json
@@ -9,21 +9,28 @@
       "updated_at": "2026-06-25T18:21:25.762403Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-25T18:21:55.603202Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-25T18:22:13.712492Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-25T18:22:25.723001Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "create-seed-script",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3350/state.json
+++ b/artifacts/feat-3350/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-25T18:22:25.723001Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-25T18:22:40.471133Z"
     }
   },
   "tasks": [
     {
       "name": "create-seed-script",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-25T18:22:40.716029Z"
     }
   ]
 }

--- a/artifacts/feat-3350/task-context/create-seed-script.md
+++ b/artifacts/feat-3350/task-context/create-seed-script.md
@@ -1,0 +1,26 @@
+### task: create-seed-script
+
+**Goal:** Create `scripts/seed-manufacture-orders-for-e2e.sh` that seeds staging with the required manufacture orders for the protocol E2E tests.
+
+**Files to create:**
+- `scripts/seed-manufacture-orders-for-e2e.sh`
+
+**Implementation steps:**
+
+1. Write a bash script with:
+   - Shebang: `#!/usr/bin/env bash`
+   - `set -euo pipefail`
+   - Required env var validation (`E2E_CLIENT_ID`, `E2E_CLIENT_SECRET`, `AZURE_TENANT_ID`)
+   - Optional `PLAYWRIGHT_BASE_URL` env var (defaults to `https://heblo.stg.anela.cz`)
+   - `jq` availability check
+   - Azure AD token acquisition via client-credentials flow
+   - POST to `/api/ManufactureOrder` to create a **Draft** order
+   - POST to `/api/ManufactureOrder` to create a second order, then two PATCH /status calls to bring it to **Completed**
+   - Print created order numbers on success
+
+2. Make the script executable (`chmod +x scripts/seed-manufacture-orders-for-e2e.sh`)
+
+**Acceptance criteria:**
+- Script exits with code 0 when successful
+- Script exits with non-zero and clear error message when env vars missing or API call fails
+- After running against staging, `protocol.spec.ts` tests pass

--- a/artifacts/feat-3350/task-plan.r1.md
+++ b/artifacts/feat-3350/task-plan.r1.md
@@ -1,0 +1,34 @@
+# Task Plan: Seed Manufacture Orders for E2E Protocol Tests
+
+## Overview
+
+Single task: create the seeding script. No backend or frontend code changes.
+
+---
+
+### task: create-seed-script
+
+**Goal:** Create `scripts/seed-manufacture-orders-for-e2e.sh` that seeds staging with the required manufacture orders for the protocol E2E tests.
+
+**Files to create:**
+- `scripts/seed-manufacture-orders-for-e2e.sh`
+
+**Implementation steps:**
+
+1. Write a bash script with:
+   - Shebang: `#!/usr/bin/env bash`
+   - `set -euo pipefail`
+   - Required env var validation (`E2E_CLIENT_ID`, `E2E_CLIENT_SECRET`, `AZURE_TENANT_ID`)
+   - Optional `PLAYWRIGHT_BASE_URL` env var (defaults to `https://heblo.stg.anela.cz`)
+   - `jq` availability check
+   - Azure AD token acquisition via client-credentials flow
+   - POST to `/api/ManufactureOrder` to create a **Draft** order
+   - POST to `/api/ManufactureOrder` to create a second order, then two PATCH /status calls to bring it to **Completed**
+   - Print created order numbers on success
+
+2. Make the script executable (`chmod +x scripts/seed-manufacture-orders-for-e2e.sh`)
+
+**Acceptance criteria:**
+- Script exits with code 0 when successful
+- Script exits with non-zero and clear error message when env vars missing or API call fails
+- After running against staging, `protocol.spec.ts` tests pass

--- a/scripts/seed-manufacture-orders-for-e2e.sh
+++ b/scripts/seed-manufacture-orders-for-e2e.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Seed staging with the manufacture orders required by E2E protocol tests.
+#
+# Creates:
+#   - One Draft manufacture order
+#   - One Completed manufacture order (Draft → Planned → Completed)
+#
+# Both appear at the top of the list (CreatedDate DESC sort), satisfying
+# the protocol.spec.ts requirement to find them in the first 5 rows.
+#
+# Required env vars:
+#   E2E_CLIENT_ID      — Azure AD service principal client ID
+#   E2E_CLIENT_SECRET  — Azure AD service principal secret
+#   AZURE_TENANT_ID    — Azure AD tenant ID
+#
+# Optional env vars:
+#   PLAYWRIGHT_BASE_URL — Override staging URL (default: https://heblo.stg.anela.cz)
+
+BASE_URL="${PLAYWRIGHT_BASE_URL:-https://heblo.stg.anela.cz}"
+SCOPE="api://8b34be89-f86f-422f-af40-7dbcd30cb66a/.default"
+TODAY="$(date -u +%Y-%m-%d)"
+PLANNED_DATE="2027-01-01"
+
+# --- pre-flight checks ---
+
+missing_vars=()
+[[ -z "${E2E_CLIENT_ID:-}" ]] && missing_vars+=("E2E_CLIENT_ID")
+[[ -z "${E2E_CLIENT_SECRET:-}" ]] && missing_vars+=("E2E_CLIENT_SECRET")
+[[ -z "${AZURE_TENANT_ID:-}" ]] && missing_vars+=("AZURE_TENANT_ID")
+
+if [[ ${#missing_vars[@]} -gt 0 ]]; then
+  echo "ERROR: Missing required environment variables: ${missing_vars[*]}" >&2
+  echo "Set E2E_CLIENT_ID, E2E_CLIENT_SECRET, and AZURE_TENANT_ID before running." >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: 'jq' is required but not installed. Install it first (e.g. sudo apt-get install jq)." >&2
+  exit 1
+fi
+
+if ! command -v curl &>/dev/null; then
+  echo "ERROR: 'curl' is required but not installed." >&2
+  exit 1
+fi
+
+echo "Seeding staging manufacture orders for E2E protocol tests..."
+echo "  Target: ${BASE_URL}"
+
+# --- acquire Azure AD token ---
+
+echo ""
+echo "Acquiring Azure AD token..."
+
+token_response=$(curl -s --fail-with-body -X POST \
+  "https://login.microsoftonline.com/${AZURE_TENANT_ID}/oauth2/v2.0/token" \
+  -d "grant_type=client_credentials&client_id=${E2E_CLIENT_ID}&client_secret=${E2E_CLIENT_SECRET}&scope=${SCOPE}")
+
+TOKEN=$(echo "${token_response}" | jq -r '.access_token // empty')
+if [[ -z "${TOKEN}" ]]; then
+  echo "ERROR: Failed to obtain Azure AD token. Response:" >&2
+  echo "${token_response}" >&2
+  exit 1
+fi
+
+echo "  Token acquired."
+
+# --- helpers ---
+
+api_post() {
+  local path="$1"
+  local body="$2"
+  curl -s --fail-with-body -X POST \
+    "${BASE_URL}${path}" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${body}"
+}
+
+api_patch() {
+  local path="$1"
+  local body="$2"
+  curl -s --fail-with-body -X PATCH \
+    "${BASE_URL}${path}" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${body}"
+}
+
+create_order() {
+  local label="$1"
+  local body
+  body=$(printf '{"productCode":"MAS001001M","productName":"Hedvábný pan Jasmín E2E %s","originalBatchSize":5000,"newBatchSize":5000,"scaleFactor":1.0,"plannedDate":"%s","manufactureType":1}' "${label}" "${PLANNED_DATE}")
+
+  local response
+  response=$(api_post "/api/ManufactureOrder" "${body}")
+  local order_id
+  order_id=$(echo "${response}" | jq -r '.id // empty')
+
+  if [[ -z "${order_id}" || "${order_id}" == "null" ]]; then
+    echo "ERROR: Failed to create ${label} order. Response:" >&2
+    echo "${response}" >&2
+    exit 1
+  fi
+
+  echo "${order_id}"
+}
+
+patch_status() {
+  local order_id="$1"
+  local new_state="$2"
+  local label="$3"
+  local body
+  body=$(printf '{"id":%s,"newState":%s}' "${order_id}" "${new_state}")
+
+  local response
+  response=$(api_patch "/api/ManufactureOrder/${order_id}/status" "${body}")
+  local success
+  success=$(echo "${response}" | jq -r '.success // "false"')
+
+  if [[ "${success}" != "true" ]]; then
+    echo "ERROR: Failed to patch order ${order_id} to ${label}. Response:" >&2
+    echo "${response}" >&2
+    exit 1
+  fi
+}
+
+# --- create Draft order ---
+
+echo ""
+echo "Creating Draft manufacture order..."
+DRAFT_ID=$(create_order "Draft")
+echo "  Created Draft order ID: ${DRAFT_ID}"
+
+# --- create Completed order ---
+
+echo ""
+echo "Creating Completed manufacture order (Draft → Planned → Completed)..."
+COMP_ID=$(create_order "Completed")
+echo "  Created order ID: ${COMP_ID} (currently Draft)"
+
+echo "  Transitioning to Planned (state=2)..."
+patch_status "${COMP_ID}" "2" "Planned"
+
+echo "  Transitioning to Completed (state=5)..."
+patch_status "${COMP_ID}" "5" "Completed"
+
+echo "  Order ${COMP_ID} is now Completed."
+
+# --- done ---
+
+echo ""
+echo "Done. Staging now has:"
+echo "  Draft order:     ID ${DRAFT_ID}"
+echo "  Completed order: ID ${COMP_ID}"
+echo ""
+echo "Both will appear in the first rows of the manufacture orders list (sorted CreatedDate DESC)."
+echo "The E2E protocol tests should now pass against staging."


### PR DESCRIPTION
Closes #3350

## What the issue was

Two nightly E2E tests in `frontend/test/e2e/manufacturing/protocol.spec.ts` were throwing because the staging manufacture orders list had no **Completed** or **Draft/Planned** order in the first 5 rows. The list is sorted `CreatedDate DESC`, so older orders in those states had been pushed below the search window (`maxRows = 5`).

## How it was fixed / handled

Added `scripts/seed-manufacture-orders-for-e2e.sh` — a bash script that authenticates to the staging API using the same Azure AD service-principal credentials used by E2E tests and:

1. Creates one **Draft** manufacture order (stays Draft)
2. Creates a second order and transitions it **Draft → Planned → Completed** via `PATCH /api/ManufactureOrder/{id}/status`

Both new orders appear at the top of the list immediately after creation, satisfying the "first 5 rows" constraint. No production code or test logic was changed — the tests are correctly written and should throw when data is missing.

**To fix the staging environment, run once:**
```bash
export E2E_CLIENT_ID=...
export E2E_CLIENT_SECRET=...
export AZURE_TENANT_ID=...
./scripts/seed-manufacture-orders-for-e2e.sh
```

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3350/`.

## Code review

**Result: CLEAN**

No blocking findings. Advisory only:
- `--fail-with-body` requires curl ≥ 7.76 (2021). On older systems, replace with `--fail` if needed.
- Script is not idempotent — re-running adds extra rows, which is harmless. A future enhancement could check whether sufficient orders already exist before creating new ones.


---
_Generated by [Claude Code](https://claude.ai/code/session_0168poEwVKbtUeyX2BExxHWX)_