### PR TITLE
#3366: extract article status constants to shared config

### DIFF
--- a/frontend/src/features/articles/ArticleDetail.tsx
+++ b/frontend/src/features/articles/ArticleDetail.tsx
@@ -4,26 +4,11 @@ import { ArticleStatus } from '../../api/generated/api-client';
 import ArticleSourceList from './ArticleSourceList';
 import ArticleFeedbackSection from './ArticleFeedbackSection';
 import ArticleDebugPanel from './ArticleDebugPanel';
+import { ARTICLE_STATUS_LABELS, ARTICLE_STATUS_COLORS } from './articleStatusConfig';
 
 interface ArticleDetailProps {
   articleId: string;
 }
-
-const STATUS_LABELS: Record<ArticleStatus, string> = {
-  [ArticleStatus.Queued]: 'Ve frontě',
-  [ArticleStatus.Researching]: 'Výzkum — shromažďuji fakta…',
-  [ArticleStatus.Writing]: 'Psaní — generuji obsah…',
-  [ArticleStatus.Generated]: 'Vygenerováno',
-  [ArticleStatus.Failed]: 'Generování selhalo',
-};
-
-const STATUS_COLORS: Record<ArticleStatus, string> = {
-  [ArticleStatus.Queued]: 'bg-gray-100 text-gray-700',
-  [ArticleStatus.Researching]: 'bg-blue-100 text-blue-700',
-  [ArticleStatus.Writing]: 'bg-purple-100 text-purple-700',
-  [ArticleStatus.Generated]: 'bg-green-100 text-green-700',
-  [ArticleStatus.Failed]: 'bg-red-100 text-red-700',
-};
 
 function HtmlContent({ html }: { html: string }) {
   const srcdoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
@@ -54,7 +39,7 @@ function InProgressView({ article }: { article: ArticleDetailType }) {
   return (
     <div className="flex flex-col items-center justify-center py-16 gap-4 text-gray-500">
       <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
-      <p className="text-sm">{STATUS_LABELS[article.status]}</p>
+      <p className="text-sm">{ARTICLE_STATUS_LABELS[article.status]}</p>
     </div>
   );
 }
@@ -102,12 +87,12 @@ export default function ArticleDetail({ articleId }: ArticleDetailProps) {
     <div>
       <div className="flex items-center gap-2 mb-4">
         <span
-          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[article.status]}`}
+          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${ARTICLE_STATUS_COLORS[article.status]}`}
         >
           {IN_PROGRESS_STATUSES.has(article.status) && (
             <Loader2 className="w-3 h-3 animate-spin" />
           )}
-          {STATUS_LABELS[article.status]}
+          {ARTICLE_STATUS_LABELS[article.status]}
         </span>
       </div>
 

--- a/frontend/src/features/articles/ArticleList.tsx
+++ b/frontend/src/features/articles/ArticleList.tsx
@@ -1,6 +1,6 @@
 import { Loader2 } from 'lucide-react';
 import { ArticleListItem, IN_PROGRESS_STATUSES } from '../../api/hooks/useArticles';
-import { ArticleStatus } from '../../api/generated/api-client';
+import { ARTICLE_STATUS_LABELS, ARTICLE_STATUS_COLORS } from './articleStatusConfig';
 
 interface ArticleListProps {
   items: ArticleListItem[];
@@ -8,22 +8,6 @@ interface ArticleListProps {
   selectedId: string | null;
   onSelect: (id: string) => void;
 }
-
-const STATUS_LABELS: Record<ArticleStatus, string> = {
-  [ArticleStatus.Queued]: 'Ve frontě',
-  [ArticleStatus.Researching]: 'Výzkum',
-  [ArticleStatus.Writing]: 'Psaní',
-  [ArticleStatus.Generated]: 'Vygenerováno',
-  [ArticleStatus.Failed]: 'Chyba',
-};
-
-const STATUS_COLORS: Record<ArticleStatus, string> = {
-  [ArticleStatus.Queued]: 'bg-gray-100 text-gray-700',
-  [ArticleStatus.Researching]: 'bg-blue-100 text-blue-700',
-  [ArticleStatus.Writing]: 'bg-purple-100 text-purple-700',
-  [ArticleStatus.Generated]: 'bg-green-100 text-green-700',
-  [ArticleStatus.Failed]: 'bg-red-100 text-red-700',
-};
 
 const DATE_FORMATTER = new Intl.DateTimeFormat('cs-CZ', {
   day: '2-digit',
@@ -75,12 +59,12 @@ export default function ArticleList({ items, isLoading, selectedId, onSelect }: 
                 <p className="text-xs text-gray-400 mt-1">{formatDate(item.createdAt)}</p>
               </div>
               <span
-                className={`shrink-0 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[item.status]}`}
+                className={`shrink-0 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${ARTICLE_STATUS_COLORS[item.status]}`}
               >
                 {IN_PROGRESS_STATUSES.has(item.status) && (
                   <Loader2 className="w-3 h-3 animate-spin" />
                 )}
-                {STATUS_LABELS[item.status]}
+                {ARTICLE_STATUS_LABELS[item.status]}
               </span>
             </div>
           </button>

--- a/frontend/src/features/articles/articleStatusConfig.ts
+++ b/frontend/src/features/articles/articleStatusConfig.ts
@@ -1,0 +1,17 @@
+import { ArticleStatus } from '../../api/generated/api-client';
+
+export const ARTICLE_STATUS_LABELS: Record<ArticleStatus, string> = {
+  [ArticleStatus.Queued]: 'Ve frontě',
+  [ArticleStatus.Researching]: 'Výzkum — shromažďuji fakta…',
+  [ArticleStatus.Writing]: 'Psaní — generuji obsah…',
+  [ArticleStatus.Generated]: 'Vygenerováno',
+  [ArticleStatus.Failed]: 'Generování selhalo',
+};
+
+export const ARTICLE_STATUS_COLORS: Record<ArticleStatus, string> = {
+  [ArticleStatus.Queued]: 'bg-gray-100 text-gray-700',
+  [ArticleStatus.Researching]: 'bg-blue-100 text-blue-700',
+  [ArticleStatus.Writing]: 'bg-purple-100 text-purple-700',
+  [ArticleStatus.Generated]: 'bg-green-100 text-green-700',
+  [ArticleStatus.Failed]: 'bg-red-100 text-red-700',
+};


### PR DESCRIPTION
Closes #3366

## What the issue was
`STATUS_COLORS` and `STATUS_LABELS` were defined identically in `ArticleDetail.tsx` and `ArticleList.tsx`, with label text that had already diverged (`'Výzkum'` vs `'Výzkum — shromažďuji fakta…'`, `'Chyba'` vs `'Generování selhalo'`). Adding a new `ArticleStatus` value or changing colors required editing two files.

## How it was fixed
Extracted both constants to `frontend/src/features/articles/articleStatusConfig.ts` as `ARTICLE_STATUS_LABELS` and `ARTICLE_STATUS_COLORS`. Both `ArticleDetail.tsx` and `ArticleList.tsx` now import from this single source of truth. The verbose label text from `ArticleDetail` was chosen as the canonical form.

## Artifacts
- 3 files changed: new `articleStatusConfig.ts`, updated `ArticleDetail.tsx`, updated `ArticleList.tsx`
- Build: `Compiled successfully`
- Lint: 0 errors in changed files
- Tests: 13/13 passed (`features/articles`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M4V5biWTBywsY8b27MjZrR)_