### PR TITLE
fix(baleni): collapse overloaded carrier mix chart legend

### DIFF
--- a/frontend/src/components/baleni/statistics/PackingCharts.tsx
+++ b/frontend/src/components/baleni/statistics/PackingCharts.tsx
@@ -28,6 +28,7 @@ const EmptyState: React.FC = () => (
 
 export const MAX_CARRIERS = 6;
 export const OTHER_LABEL = "Ostatní";
+export const OTHER_KEY = "__ostalni_bucket__"; // sentinel React key; never equals a real carrier name
 const OTHER_COLOR = "#64748b"; // neutral slate for the "Ostatní" bucket
 
 export interface CarrierSlice {
@@ -71,11 +72,11 @@ export function buildCarrierSlices(data: readonly CarrierMix[]): CarrierSlice[] 
   }
 
   const otherTotal = rest.reduce((sum, s) => sum + s.packageCount, 0);
-  return [...top, { key: OTHER_LABEL, name: OTHER_LABEL, packageCount: otherTotal }];
+  return [...top, { key: OTHER_KEY, name: OTHER_LABEL, packageCount: otherTotal }];
 }
 
 function sliceColor(slice: CarrierSlice, index: number): string {
-  if (slice.key === OTHER_LABEL) return OTHER_COLOR;
+  if (slice.key === OTHER_KEY) return OTHER_COLOR;
   return CARRIER_COLORS[index % CARRIER_COLORS.length];
 }
 

--- a/frontend/src/components/baleni/statistics/PackingCharts.tsx
+++ b/frontend/src/components/baleni/statistics/PackingCharts.tsx
@@ -26,6 +26,59 @@ const EmptyState: React.FC = () => (
   <p className="text-sm text-neutral-gray italic">Žádná data k zobrazení.</p>
 );
 
+export const MAX_CARRIERS = 6;
+export const OTHER_LABEL = "Ostatní";
+const OTHER_COLOR = "#64748b"; // neutral slate for the "Ostatní" bucket
+
+export interface CarrierSlice {
+  /** Stable key for the React Cell + legend payload (slices are unique by name). */
+  key: string;
+  name: string;
+  packageCount: number;
+}
+
+/**
+ * Collapses raw CarrierMix rows into a bounded set of pie slices:
+ * 1. merge entries sharing the same display `name` (sum packageCount),
+ * 2. sort descending by packageCount,
+ * 3. keep the top MAX_CARRIERS, rolling any remainder into a single
+ *    "Ostatní" bucket (added only when >= 1 carrier remains).
+ * Pure: does not mutate the input array or its elements.
+ */
+export function buildCarrierSlices(data: readonly CarrierMix[]): CarrierSlice[] {
+  const mergedByName = new Map<string, CarrierSlice>();
+  for (const { name, packageCount } of data) {
+    const existing = mergedByName.get(name);
+    if (existing) {
+      mergedByName.set(name, {
+        ...existing,
+        packageCount: existing.packageCount + packageCount,
+      });
+    } else {
+      mergedByName.set(name, { key: name, name, packageCount });
+    }
+  }
+
+  const sorted = Array.from(mergedByName.values()).sort(
+    (a, b) => b.packageCount - a.packageCount,
+  );
+
+  const top = sorted.slice(0, MAX_CARRIERS);
+  const rest = sorted.slice(MAX_CARRIERS);
+
+  if (rest.length === 0) {
+    return top;
+  }
+
+  const otherTotal = rest.reduce((sum, s) => sum + s.packageCount, 0);
+  return [...top, { key: OTHER_LABEL, name: OTHER_LABEL, packageCount: otherTotal }];
+}
+
+function sliceColor(slice: CarrierSlice, index: number): string {
+  if (slice.key === OTHER_LABEL) return OTHER_COLOR;
+  return CARRIER_COLORS[index % CARRIER_COLORS.length];
+}
+
 export const ThroughputChart: React.FC<{ data: DailyThroughput[] }> = ({ data }) => {
   if (data.length === 0) return <EmptyState />;
   const chartData = data.map((d) => ({
@@ -59,26 +112,39 @@ export const ThroughputChart: React.FC<{ data: DailyThroughput[] }> = ({ data })
 
 export const CarrierMixChart: React.FC<{ data: CarrierMix[] }> = ({ data }) => {
   if (data.length === 0) return <EmptyState />;
+  const slices = buildCarrierSlices(data);
   return (
     <div className="h-72 w-full">
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Pie
-            data={data}
+            data={slices}
             dataKey="packageCount"
             nameKey="name"
             cx="50%"
-            cy="50%"
-            innerRadius={55}
-            outerRadius={90}
+            cy="45%"
+            innerRadius={45}
+            outerRadius={75}
             paddingAngle={2}
           >
-            {data.map((entry, index) => (
-              <Cell key={entry.code} fill={CARRIER_COLORS[index % CARRIER_COLORS.length]} />
+            {slices.map((entry, index) => (
+              <Cell key={entry.key} fill={sliceColor(entry, index)} />
             ))}
           </Pie>
           <Tooltip formatter={(value) => [value, "Balíků"]} />
-          <Legend />
+          <Legend
+            layout="horizontal"
+            verticalAlign="bottom"
+            align="center"
+            iconSize={8}
+            wrapperStyle={{
+              fontSize: 11,
+              lineHeight: "16px",
+              maxHeight: 64,
+              overflowY: "hidden",
+              paddingTop: 4,
+            }}
+          />
         </PieChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/baleni/statistics/__tests__/PackingCharts.test.tsx
+++ b/frontend/src/components/baleni/statistics/__tests__/PackingCharts.test.tsx
@@ -1,0 +1,85 @@
+import { CarrierMix } from "../../../../api/hooks/usePackingStatistics";
+import { buildCarrierSlices, MAX_CARRIERS, OTHER_LABEL } from "../PackingCharts";
+
+const carrier = (code: string, name: string, packageCount: number): CarrierMix => ({
+  code,
+  name,
+  packageCount,
+});
+
+describe("buildCarrierSlices", () => {
+  it("returns an empty array for empty input", () => {
+    expect(buildCarrierSlices([])).toEqual([]);
+  });
+
+  it("merges entries that share the same display name", () => {
+    const result = buildCarrierSlices([
+      carrier("ZAS-BOX", "Zásilkovna", 10),
+      carrier("ZAS-PP", "Zásilkovna", 5),
+      carrier("DPD", "DPD", 3),
+    ]);
+
+    expect(result).toHaveLength(2);
+    const zasilkovna = result.find((s) => s.name === "Zásilkovna");
+    expect(zasilkovna?.packageCount).toBe(15);
+    expect(zasilkovna?.key).toBe("Zásilkovna");
+  });
+
+  it("does not mutate the input array or its elements", () => {
+    const input = [carrier("DPD", "DPD", 3)];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    buildCarrierSlices(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("sorts slices descending by packageCount", () => {
+    const result = buildCarrierSlices([
+      carrier("A", "A", 1),
+      carrier("B", "B", 9),
+      carrier("C", "C", 4),
+    ]);
+    expect(result.map((s) => s.name)).toEqual(["B", "C", "A"]);
+  });
+
+  it("keeps top MAX_CARRIERS and rolls the rest into an Ostatní bucket", () => {
+    // 8 distinct names (strictly descending) -> 6 kept + 1 bucket summing the last 2.
+    const input = Array.from({ length: 8 }, (_, i) =>
+      carrier(`C${i}`, `Carrier ${i}`, 100 - i),
+    );
+    const result = buildCarrierSlices(input);
+
+    expect(result).toHaveLength(MAX_CARRIERS + 1);
+    const bucket = result[result.length - 1];
+    expect(bucket.name).toBe(OTHER_LABEL);
+    expect(bucket.key).toBe(OTHER_LABEL);
+    // last two carriers: (100-6) + (100-7) = 94 + 93
+    expect(bucket.packageCount).toBe(187);
+  });
+
+  it("adds no bucket when there are MAX_CARRIERS or fewer distinct names", () => {
+    const input = Array.from({ length: MAX_CARRIERS }, (_, i) =>
+      carrier(`C${i}`, `Carrier ${i}`, 10 + i),
+    );
+    const result = buildCarrierSlices(input);
+
+    expect(result).toHaveLength(MAX_CARRIERS);
+    expect(result.some((s) => s.name === OTHER_LABEL)).toBe(false);
+  });
+
+  it("merges first, then buckets (dedup can drop below the threshold)", () => {
+    // 8 rows but only 6 distinct names -> no bucket.
+    const result = buildCarrierSlices([
+      carrier("A1", "A", 5),
+      carrier("A2", "A", 5),
+      carrier("B", "B", 4),
+      carrier("C", "C", 3),
+      carrier("D", "D", 2),
+      carrier("E", "E", 1),
+      carrier("F1", "F", 1),
+      carrier("F2", "F", 1),
+    ]);
+
+    expect(result).toHaveLength(6);
+    expect(result.some((s) => s.name === OTHER_LABEL)).toBe(false);
+  });
+});

--- a/frontend/src/components/baleni/statistics/__tests__/PackingCharts.test.tsx
+++ b/frontend/src/components/baleni/statistics/__tests__/PackingCharts.test.tsx
@@ -1,5 +1,5 @@
 import { CarrierMix } from "../../../../api/hooks/usePackingStatistics";
-import { buildCarrierSlices, MAX_CARRIERS, OTHER_LABEL } from "../PackingCharts";
+import { buildCarrierSlices, MAX_CARRIERS, OTHER_KEY, OTHER_LABEL } from "../PackingCharts";
 
 const carrier = (code: string, name: string, packageCount: number): CarrierMix => ({
   code,
@@ -51,7 +51,7 @@ describe("buildCarrierSlices", () => {
     expect(result).toHaveLength(MAX_CARRIERS + 1);
     const bucket = result[result.length - 1];
     expect(bucket.name).toBe(OTHER_LABEL);
-    expect(bucket.key).toBe(OTHER_LABEL);
+    expect(bucket.key).toBe(OTHER_KEY);
     // last two carriers: (100-6) + (100-7) = 94 + 93
     expect(bucket.packageCount).toBe(187);
   });
@@ -64,6 +64,20 @@ describe("buildCarrierSlices", () => {
 
     expect(result).toHaveLength(MAX_CARRIERS);
     expect(result.some((s) => s.name === OTHER_LABEL)).toBe(false);
+  });
+
+  it("uses a sentinel key for the bucket even when a carrier is named Ostatní", () => {
+    // A carrier named exactly OTHER_LABEL should never produce a key collision with the bucket.
+    const input = Array.from({ length: MAX_CARRIERS + 1 }, (_, i) =>
+      carrier(`C${i}`, i === 0 ? OTHER_LABEL : `Carrier ${i}`, 100 - i),
+    );
+    const result = buildCarrierSlices(input);
+
+    const keys = result.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length); // all keys are unique
+    const bucket = result[result.length - 1];
+    expect(bucket.key).toBe(OTHER_KEY);
+    expect(bucket.name).toBe(OTHER_LABEL);
   });
 
   it("merges first, then buckets (dedup can drop below the threshold)", () => {


### PR DESCRIPTION
## Problem
The **Dopravci** panel on the Baleni statistics page rendered a recharts pie with a bare `<Legend />`. The API groups packages by `ShippingProviderCode` with no limit, and many distinct codes share the same display name, so the legend exploded into a long repeating list that drowned the whole right column.

## Fix
Frontend-only: a new pure `buildCarrierSlices()` helper merges carrier entries by display name, keeps the top 6 by package count, and rolls the rest into a single "Ostatní" bucket; the pie now uses a compact, bounded bottom legend so it can no longer overflow the panel. Added 7 unit tests covering merge/sort/top-N/bucket behavior; backend and API are untouched.

## Verification
`npm run build` compiles, new + existing tests pass, and eslint is clean on the changed files.