### PR TITLE
fix(frontend): default theme to light instead of OS preference

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <script>
-      // Apply the saved theme before the bundle loads to avoid a flash of dark mode.
+      // Apply the saved theme before the bundle loads to avoid a flash of light mode.
       // Light is the default; dark is only applied when explicitly saved.
       (function () {
         try {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -12,14 +12,13 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <script>
-      // Apply the saved theme before the bundle loads to avoid a flash of light mode.
+      // Apply the saved theme before the bundle loads to avoid a flash of dark mode.
+      // Light is the default; dark is only applied when explicitly saved.
       (function () {
         try {
-          var t = localStorage.getItem('anela-theme');
-          if (t !== 'light' && t !== 'dark') {
-            t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          if (localStorage.getItem('anela-theme') === 'dark') {
+            document.documentElement.classList.add('dark');
           }
-          if (t === 'dark') document.documentElement.classList.add('dark');
         } catch (e) {}
       })();
     </script>

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -27,13 +27,7 @@ export const useTheme = () => {
 
 const getInitialTheme = (): Theme => {
   try {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved === "light" || saved === "dark") {
-      return saved;
-    }
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
+    return localStorage.getItem(STORAGE_KEY) === "dark" ? "dark" : "light";
   } catch {
     return "light";
   }

--- a/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -77,6 +77,7 @@ describe("ThemeContext", () => {
 
     expect(screen.getByTestId("theme")).toHaveTextContent("dark");
     expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
 
     act(() => {
       screen.getByText("toggle").click();
@@ -84,5 +85,6 @@ describe("ThemeContext", () => {
 
     expect(screen.getByTestId("theme")).toHaveTextContent("light");
     expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 });

--- a/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, act } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "../ThemeContext";
+
+const STORAGE_KEY = "anela-theme";
+
+// Mock window.matchMedia (always reports dark, to prove the OS preference is ignored)
+const createMatchMediaMock = (matches: boolean) => {
+  return (query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  });
+};
+
+const TestConsumer = () => {
+  const { theme, toggle } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={toggle}>toggle</button>
+    </div>
+  );
+};
+
+const renderWithProvider = () =>
+  render(
+    <ThemeProvider>
+      <TestConsumer />
+    </ThemeProvider>,
+  );
+
+describe("ThemeContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: createMatchMediaMock(true),
+    });
+  });
+
+  it("defaults to light when there is no saved preference, even if the OS prefers dark", () => {
+    renderWithProvider();
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("uses the saved dark preference", () => {
+    localStorage.setItem(STORAGE_KEY, "dark");
+
+    renderWithProvider();
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("uses the saved light preference", () => {
+    localStorage.setItem(STORAGE_KEY, "light");
+
+    renderWithProvider();
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+  });
+
+  it("persists the new theme to localStorage when toggled", () => {
+    renderWithProvider();
+
+    act(() => {
+      screen.getByText("toggle").click();
+    });
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+
+    act(() => {
+      screen.getByText("toggle").click();
+    });
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+  });
+});


### PR DESCRIPTION
After the dark mode rollout, users with no saved preference followed their OS `prefers-color-scheme` setting, unexpectedly flipping dark-mode-OS users into dark mode. This changes the default to light, applying dark only when explicitly saved by the user, so there is no change for existing users. The same logic is mirrored in the no-flash boot script in `index.html` to keep boot and React in sync, and persistence of the last-used theme is unchanged. Adds `ThemeContext` test coverage (light default even when the OS prefers dark, saved-dark/light, and toggle persistence).