### PR TITLE
#3370: fix Authorization→UserManagement module boundary violation

### DIFF
--- a/artifacts/feat-3370/arch-review.r1.md
+++ b/artifacts/feat-3370/arch-review.r1.md
@@ -1,0 +1,172 @@
+# Architecture Review: Authorization–UserManagement Module Boundary Fix
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The violation is real and unambiguous. `GetEntraAccessUsersHandler` carries a `using Anela.Heblo.Application.Features.UserManagement.Services` import, directly referencing the internal `IGraphService` interface. This is the only Authorization handler with a cross-module import of this kind; all other Authorization handlers depend only on `IAuthorizationRepository`, `IPermissionResolver`, and domain types.
+
+The established remedy pattern (`IArticleUserResolver` / `GraphArticleUserResolver`) is a clean fit here. The Article module's shape is exactly analogous: a consuming module defines a narrow contract in its own `Contracts/` directory, the UserManagement module implements an `internal sealed` adapter in its `Infrastructure/` directory that delegates to `IGraphService`, and `UserManagementModule.cs` owns the DI binding. The spec's proposed structure follows this pattern faithfully.
+
+One meaningful difference from the Article pattern: `GraphArticleUserResolver` wraps two exception types (`MsalException`, `ODataError`) because `BackfillArticleRequestedByHandler` explicitly catches them. The current `GetEntraAccessUsersHandler` propagates all exceptions from `IGraphService` without catching. The adapter must not add exception translation unless required by the handler; it should not import the Article error-wrapping precedent.
+
+The existing unit test (`GetEntraAccessUsersHandlerTests`) mocks `IGraphService` directly. That test must be rewritten to mock `IEntraAccessUserSource` instead — the spec omits this but it is a required change for the tests to compile.
+
+The `Authorization/Contracts/` directory does not yet exist. It must be created.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Authorization module
+  UseCases/GetEntraAccessUsers/
+    GetEntraAccessUsersHandler   -- injects IEntraAccessUserSource (was IGraphService)
+  Contracts/
+    IEntraAccessUserSource       -- NEW: consumer-owned contract
+      GetBaseMembersAsync(CancellationToken) -> Task<List<EntraAccessUserRecord>>
+    EntraAccessUserRecord        -- NEW: Authorization-owned value type (sealed record)
+
+UserManagement module
+  Infrastructure/
+    GraphArticleUserResolver     -- existing, unchanged
+    EntraAccessUserSourceAdapter -- NEW: internal sealed, implements IEntraAccessUserSource
+  UserManagementModule.cs        -- adds one AddScoped line
+
+Domain (unchanged)
+  AccessRoles.Base               -- passed to IGraphService by the adapter
+```
+
+### Key Design Decisions
+
+#### Decision 1: Contract file placement — interface and record in a single file
+
+**Options considered:**
+- One file per type (`IEntraAccessUserSource.cs` + `EntraAccessUserRecord.cs`)
+- Combined in `IEntraAccessUserSource.cs`
+
+**Chosen approach:** Single file, matching the `IArticleUserResolver.cs` precedent which co-locates `ArticleUserMatch` alongside the interface in one file.
+
+**Rationale:** The record is a value type that only exists to satisfy the interface's return type. Splitting it adds file count with no navigability benefit. The pattern is already established in the codebase.
+
+#### Decision 2: No exception translation in the adapter
+
+**Options considered:**
+- Wrap `MsalException` / `ODataError` (matching the Article adapter)
+- Let exceptions propagate as-is from `IGraphService`
+
+**Chosen approach:** No exception wrapping. The adapter delegates and maps; it does not catch.
+
+**Rationale:** `GetEntraAccessUsersHandler` currently lets all exceptions from `IGraphService` propagate unhandled. The API layer or global exception middleware handles them. Adding exception translation in the adapter would change observable behavior (NFR-1). The Article adapter wraps because its consumer explicitly catches; the Authorization handler does not. Follow what the consumer requires, not what the reference implementation does.
+
+#### Decision 3: Test rewrite scope
+
+**Options considered:**
+- Keep existing `GetEntraAccessUsersHandlerTests` structure, swap mock type only
+- Write a new test class
+
+**Chosen approach:** Rewrite the existing test class in-place. Replace `Mock<IGraphService>` with `Mock<IEntraAccessUserSource>`, replace `UserDto` list construction with `EntraAccessUserRecord` list construction, remove the `using` imports for `UserManagement.Contracts` and `UserManagement.Services`.
+
+**Rationale:** The test assertions (ordering, field mapping, empty list) remain valid. Rewriting in-place keeps the test count identical and avoids dead test classes.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Files to create:
+
+```
+backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/
+  IEntraAccessUserSource.cs                   (new)
+
+backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/
+  EntraAccessUserSourceAdapter.cs             (new)
+```
+
+Files to modify:
+
+```
+backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/
+  GetEntraAccessUsersHandler.cs               (swap dependency)
+
+backend/src/Anela.Heblo.Application/Features/UserManagement/
+  UserManagementModule.cs                     (add one AddScoped line)
+
+backend/test/Anela.Heblo.Tests/Authorization/
+  GetEntraAccessUsersHandlerTests.cs          (rewrite mocked dependency)
+```
+
+No other files need to change.
+
+### Interfaces and Contracts
+
+`IEntraAccessUserSource.cs` — place in namespace `Anela.Heblo.Application.Features.Authorization.Contracts`. No `using` statements that reference any `UserManagement.*` namespace.
+
+```csharp
+namespace Anela.Heblo.Application.Features.Authorization.Contracts;
+
+public interface IEntraAccessUserSource
+{
+    Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct);
+}
+
+public sealed record EntraAccessUserRecord(string Id, string Email, string DisplayName);
+```
+
+`EntraAccessUserSourceAdapter.cs` — place in namespace `Anela.Heblo.Application.Features.UserManagement.Infrastructure`. Class is `internal sealed`. The only `using` additions needed are `Authorization.Contracts` (to satisfy the interface) and `Domain.Features.Authorization` (for `AccessRoles.Base`). `UserManagement.Services` is already in scope via the existing infrastructure namespace.
+
+The mapping: `UserDto.Id` → `EntraAccessUserRecord.Id`, `UserDto.Email` → `.Email`, `UserDto.DisplayName` → `.DisplayName`. All three fields are present on `UserDto` (confirmed in `UserManagement/Contracts/UserDto.cs`).
+
+`UserManagementModule.cs` registration goes after the existing `IArticleUserResolver` line:
+
+```csharp
+services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>();
+```
+
+`GetEntraAccessUsersHandler.cs` — after the change, its only non-system `using` is:
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.Contracts;
+using Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+using MediatR;
+```
+
+The `using Anela.Heblo.Domain.Features.Authorization` import (`AccessRoles`) is removed because the handler no longer calls any method that requires it — `AccessRoles.Base` moves into the adapter. The handler maps `EntraAccessUserRecord` → `EntraUserDto` using `.Id`, `.Email`, `.DisplayName`.
+
+### Data Flow
+
+```
+HTTP GET /api/authorization/entra-access-users
+  -> MediatR dispatches GetEntraAccessUsersRequest
+  -> GetEntraAccessUsersHandler.Handle()
+       calls IEntraAccessUserSource.GetBaseMembersAsync(ct)
+       -> EntraAccessUserSourceAdapter.GetBaseMembersAsync(ct)
+            calls IGraphService.GetAppRoleMembersAsync(AccessRoles.Base, ct)
+            -> GraphService (Microsoft Graph)
+            returns List<UserDto>
+            maps each UserDto to EntraAccessUserRecord
+            returns List<EntraAccessUserRecord>
+       handler maps EntraAccessUserRecord -> EntraUserDto
+       sorts by DisplayName
+       returns GetEntraAccessUsersResponse
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Test file still imports `UserManagement.*` after handler is updated — build passes but boundary grep fails | Medium | Treat test rewrite as a required step, not optional. Verify `grep -r "UserManagement.Services" backend/` after all changes. |
+| `EntraAccessUserRecord` property names diverge from `UserDto` (`Id` vs something else) | Low | Confirmed via source: `UserDto` has `Id`, `Email`, `DisplayName` — all match the record's positional parameters. |
+| Second developer adds a method to `IEntraAccessUserSource` for a future Authorization use case without noticing FR-5 | Low | The interface comment (on `IArticleUserResolver` as precedent) already documents the single-consumer intent. A code comment in the interface reinforces this. |
+| `AuthorizationModule.cs` is incorrectly assumed to need a registration | None | Confirmed: `AuthorizationModule.cs` must NOT register `IEntraAccessUserSource`. Only `UserManagementModule.cs` owns this binding, exactly as it owns `IArticleUserResolver`. |
+
+## Specification Amendments
+
+**Amendment 1 — Test file is a required deliverable.** The spec lists no test changes under FR-4. However `GetEntraAccessUsersHandlerTests.cs` will fail to compile after the handler is updated because it constructs `new GetEntraAccessUsersHandler(mock.Object)` where `mock` is `Mock<IGraphService>`. The test must be updated as part of this task. Add it to FR-4's acceptance criteria: "Existing unit tests compile and pass against `Mock<IEntraAccessUserSource>`."
+
+**Amendment 2 — Handler no longer needs `using Anela.Heblo.Domain.Features.Authorization`.** The spec does not explicitly say to remove this import; it was present only because the handler called `AccessRoles.Base`. After the change, `AccessRoles.Base` is referenced only inside `EntraAccessUserSourceAdapter`. Remove the import from the handler to keep the file clean and avoid a `dotnet format` warning about unused usings.
+
+## Prerequisites
+
+None. All required types (`IGraphService`, `AccessRoles`, `UserDto`, `UserManagementModule`) already exist. No migrations, no configuration changes, no infrastructure work required before implementation can begin.

--- a/artifacts/feat-3370/brief.md
+++ b/artifacts/feat-3370/brief.md
@@ -1,0 +1,45 @@
+## Module
+UserManagement
+
+## Finding
+`GetEntraAccessUsersHandler` in the `Authorization` module directly injects and uses `IGraphService` from the `UserManagement` module's `Services` namespace:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs
+using Anela.Heblo.Application.Features.UserManagement.Services;  // line 1 — cross-module import
+
+public class GetEntraAccessUsersHandler : IRequestHandler<...>
+{
+    private readonly IGraphService _graphService;  // line 9 — UserManagement-internal service
+
+    public GetEntraAccessUsersHandler(IGraphService graphService) => _graphService = graphService;
+
+    public async Task<...> Handle(..., CancellationToken ct)
+    {
+        var users = await _graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct);  // line 15
+```
+
+`IGraphService` is a UserManagement-internal service interface (`UserManagement/Services/IGraphService.cs`). The Authorization module consuming it directly violates module isolation.
+
+The correct pattern is already established in this codebase for the identical scenario: the `IArticleUserResolver` contract lives in `Article/Contracts/` (consumer-owned), `GraphArticleUserResolver` in `UserManagement/Infrastructure/` implements it (provider adapter), and `UserManagementModule` registers the binding. Authorization should follow the same shape.
+
+## Why it matters
+`development_guidelines.md` forbids direct cross-module service access: "Communication between modules **exclusively through `contracts/`**." By injecting `IGraphService` directly, `Authorization` is coupled to UserManagement's internal abstraction. Any rename, split, or evolution of `IGraphService` (adding a method, changing its return type) becomes a breaking change for the Authorization module, and the isolation guarantee that lets each module evolve independently is broken.
+
+## Suggested fix
+Minimal two-step fix:
+
+1. Add a consumer-owned contract in `Authorization/Contracts/IEntraAccessUserSource.cs`:
+   ```csharp
+   public interface IEntraAccessUserSource
+   {
+       Task<List<UserManagement.Dtos.EntraUserDto>> GetBaseMembersAsync(CancellationToken ct);
+   }
+   ```
+
+2. Add an adapter in `UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs` that delegates to `IGraphService`, and register it in `UserManagementModule`. `GetEntraAccessUsersHandler` injects `IEntraAccessUserSource` instead.
+
+This mirrors exactly how `IArticleUserResolver` / `GraphArticleUserResolver` is structured.
+
+---
+_Filed by daily arch-review routine on 2026-06-26._

--- a/artifacts/feat-3370/code-review.r1.md
+++ b/artifacts/feat-3370/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — No `Authorization -> UserManagement` boundary rule is registered in `ModuleBoundariesTests`. The refactor eliminates the direct dependency at the handler level, but there is no reflection-based regression guard to prevent `Authorization` types from re-acquiring a `UserManagement` namespace reference in the future. The pattern established for `Leaflet -> KnowledgeBase` (a `ModuleBoundaryRule` entry with an empty allowlist) would lock in the new boundary at CI level. Consider adding a rule with `InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Authorization"` and `ForbiddenNamespacePrefixes: ["Anela.Heblo.Application.Features.UserManagement", "Anela.Heblo.Domain.Features.UserManagement"]`.

--- a/artifacts/feat-3370/impl/create-authorization-contract.r1.md
+++ b/artifacts/feat-3370/impl/create-authorization-contract.r1.md
@@ -1,0 +1,19 @@
+# Implementation: create-authorization-contract
+
+## What was implemented
+Created the `Contracts/` directory under the Authorization feature module and added the `IEntraAccessUserSource` interface along with the `EntraAccessUserRecord` sealed record as a single file. This contract defines how the Authorization module retrieves Entra (Azure AD) base members.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/IEntraAccessUserSource.cs` — defines `IEntraAccessUserSource` interface with `GetBaseMembersAsync` and the `EntraAccessUserRecord(string Id, string Email, string DisplayName)` sealed record
+
+## Tests
+None required for this task.
+
+## How to verify
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+
+## Notes
+Build completed with 0 errors (139 pre-existing warnings, unrelated to this change). The sealed record is used as internal domain transport; both the interface and the record live in the same namespace so no OpenAPI generator can see the record.
+
+## Status
+DONE

--- a/artifacts/feat-3370/impl/create-usermanagement-adapter.r1.md
+++ b/artifacts/feat-3370/impl/create-usermanagement-adapter.r1.md
@@ -1,0 +1,19 @@
+# Implementation: create-usermanagement-adapter
+
+## What was implemented
+Created `EntraAccessUserSourceAdapter`, an `internal sealed` class implementing `IEntraAccessUserSource`. It injects `IGraphService` and maps `UserDto` results from `GetAppRoleMembersAsync(AccessRoles.Base, ct)` into `EntraAccessUserRecord` values using the `(Id, Email, DisplayName)` constructor.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs` — adapter implementing `IEntraAccessUserSource` via `IGraphService`
+
+## Tests
+None required for this task.
+
+## How to verify
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+
+## Notes
+Field names (`Id`, `Email`, `DisplayName`) on `UserDto` and the `EntraAccessUserRecord` record constructor parameter order (`Id`, `Email`, `DisplayName`) were verified against source before implementation. No deviations from the task template.
+
+## Status
+DONE

--- a/artifacts/feat-3370/impl/register-adapter-in-di.r1.md
+++ b/artifacts/feat-3370/impl/register-adapter-in-di.r1.md
@@ -1,0 +1,19 @@
+# Implementation: register-adapter-in-di
+
+## What was implemented
+Added `IEntraAccessUserSource` → `EntraAccessUserSourceAdapter` DI registration to `UserManagementModule`, alongside its required `using` directive for `Anela.Heblo.Application.Features.Authorization.Contracts`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — added `using Anela.Heblo.Application.Features.Authorization.Contracts;` (alphabetically positioned) and `services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>();` after the existing `IArticleUserResolver` registration.
+
+## Tests
+None required for this task.
+
+## How to verify
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+
+## Notes
+Build completed with 0 errors (139 pre-existing warnings, none introduced by this change).
+
+## Status
+DONE

--- a/artifacts/feat-3370/impl/update-handler-tests.r1.md
+++ b/artifacts/feat-3370/impl/update-handler-tests.r1.md
@@ -1,0 +1,21 @@
+# Implementation: update-handler-tests
+
+## What was implemented
+Rewrote `GetEntraAccessUsersHandlerTests` to mock `IEntraAccessUserSource` instead of `IGraphService`. Removed the three old usings (`UserManagement.Contracts`, `UserManagement.Services`, `Domain.Features.Authorization`) and added `Authorization.Contracts`. Updated both tests to use `Mock<IEntraAccessUserSource>`, the new `GetBaseMembersAsync` method, and `EntraAccessUserRecord` positional constructor `(Id, Email, DisplayName)`.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Authorization/GetEntraAccessUsersHandlerTests.cs` — replaced IGraphService mock with IEntraAccessUserSource mock; updated test data from UserDto object initializers to EntraAccessUserRecord positional constructors; renamed empty-list test from `WhenGraphReturnsEmpty` to `WhenSourceReturnsEmpty` and used `It.IsAny<CancellationToken>()` for robustness
+
+## Tests
+- Test: GetEntraAccessUsersHandlerTests — 2 tests pass (125 total Authorization tests pass, 1 skipped integration test)
+
+## How to verify
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Authorization"
+```
+
+## Notes
+No deviations from the task spec. The AccessMatrixGen tool error seen during full `dotnet test` builds is pre-existing and unrelated to this change.
+
+## Status
+DONE

--- a/artifacts/feat-3370/impl/update-handler.r1.md
+++ b/artifacts/feat-3370/impl/update-handler.r1.md
@@ -1,0 +1,19 @@
+# Implementation: update-handler
+
+## What was implemented
+Updated `GetEntraAccessUsersHandler` to inject `IEntraAccessUserSource` instead of `IGraphService`. Removed the cross-module using directive (`UserManagement.Services`) and the domain reference (`Domain.Features.Authorization`). The call site was updated from `_graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct)` to `_source.GetBaseMembersAsync(ct)`. The response mapping (Id, Email, DisplayName) and ordering by DisplayName are unchanged.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs` — replaced IGraphService dependency with IEntraAccessUserSource, removed cross-module usings, updated field name and call site
+
+## Tests
+N/A for this task (test update is a separate task).
+
+## How to verify
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+
+## Notes
+Build succeeded with 0 errors (139 pre-existing nullable warnings, none introduced by this change).
+
+## Status
+DONE

--- a/artifacts/feat-3370/impl/verify.r1.md
+++ b/artifacts/feat-3370/impl/verify.r1.md
@@ -1,0 +1,25 @@
+# Implementation: verify
+
+## What was implemented
+Ran all verification steps confirming the refactor is complete and correct.
+
+## Files created/modified
+None — verification only.
+
+## Tests
+- `dotnet test --filter FullyQualifiedName~Authorization`: 125 passed, 1 skipped (pre-existing integration test), 0 failed.
+
+## How to verify
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Authorization"
+grep -r "UserManagement.Services" backend/src/Anela.Heblo.Application/Features/Authorization/ || echo "CLEAN"
+```
+
+## Notes
+- Build: 0 errors, 139 pre-existing warnings (none new)
+- Authorization tests: 125 passed, 1 skipped (pre-existing integration test skip), 0 failed
+- Module boundary grep: CLEAN — no `UserManagement.Services` references in Authorization
+
+## Status
+DONE

--- a/artifacts/feat-3370/review/create-authorization-contract.r1.md
+++ b/artifacts/feat-3370/review/create-authorization-contract.r1.md
@@ -1,0 +1,14 @@
+# Code Review: create-authorization-contract
+
+## Summary
+The implementation is a verbatim match of the specification. The file was created at the correct path, the namespace is correct, no extraneous `using` statements are present, the interface exposes exactly one method with the correct signature, and the `EntraAccessUserRecord` sealed record has the correct positional parameters.
+
+## Review Result: PASS
+
+### task: create-authorization-contract
+**Status:** PASS
+
+## Overall Notes
+No issues. The file is minimal and correct — zero `using` directives, no references to any `UserManagement.*` namespace, and the record is `sealed` as required. Build confirmation (0 errors) is consistent with a clean, compilable file.
+
+**Status:** PASS

--- a/artifacts/feat-3370/review/create-usermanagement-adapter.r1.md
+++ b/artifacts/feat-3370/review/create-usermanagement-adapter.r1.md
@@ -1,0 +1,18 @@
+# Code Review: create-usermanagement-adapter
+
+## Summary
+The adapter is a clean, minimal implementation that correctly satisfies all acceptance criteria. It is `internal sealed`, implements `IEntraAccessUserSource` with only `IGraphService` injected, calls the correct method with `AccessRoles.Base`, maps all three `UserDto` fields to `EntraAccessUserRecord`, and lets exceptions propagate without any wrapping. No leakage of internal types through the public surface.
+
+## Review Result: PASS
+
+### task: create-usermanagement-adapter
+**Status:** PASS
+
+## Overall Notes
+- Class declaration (`internal sealed class EntraAccessUserSourceAdapter : IEntraAccessUserSource`) meets the spec exactly.
+- Constructor injects only `IGraphService` — no other dependencies.
+- `GetBaseMembersAsync` calls `_graph.GetAppRoleMembersAsync(AccessRoles.Base, ct)`, matching the spec precisely. `AccessRoles.Base` resolves to the `"heblo_user"` app-role value from the domain layer.
+- The LINQ projection maps `UserDto.Id`, `UserDto.Email`, `UserDto.DisplayName` to the `EntraAccessUserRecord` positional constructor — all three fields confirmed present on both types.
+- No try/catch blocks; exceptions propagate to callers as required.
+- `IGraphService` is consumed only as a private field. The class's only public surface is the `GetBaseMembersAsync` method declared on `IEntraAccessUserSource`, which returns types from the `Authorization.Contracts` namespace, not from `UserManagement.Services.*`. The criterion is fully satisfied.
+- The `using Anela.Heblo.Application.Features.UserManagement.Services;` import is an implementation detail of the `internal sealed` class and does not expose that namespace externally.

--- a/artifacts/feat-3370/review/register-adapter-in-di.r1.md
+++ b/artifacts/feat-3370/review/register-adapter-in-di.r1.md
@@ -1,0 +1,16 @@
+# Code Review: register-adapter-in-di
+
+## Summary
+The implementation correctly registers `EntraAccessUserSourceAdapter` as the `IEntraAccessUserSource` binding in `UserManagementModule.cs`. The required using directive is present, the `AddScoped` line is placed logically alongside the other cross-module registration (`IArticleUserResolver`), and no other module registers this binding. Build is confirmed clean.
+
+## Review Result: PASS
+
+### task: register-adapter-in-di
+**Status:** PASS
+
+## Overall Notes
+- `using Anela.Heblo.Application.Features.Authorization.Contracts;` is present at line 3. ✓
+- `services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>();` is present at line 22. ✓
+- A codebase-wide search for `IEntraAccessUserSource` found only three references: the interface definition, the adapter implementation, and this single registration — no duplicate registrations elsewhere. ✓
+- The registration is grouped with the other infrastructure-level scoped service (`IArticleUserResolver`), which is consistent with the existing style in the module.
+- `EntraAccessUserSourceAdapter` is declared `internal sealed`, which is appropriate for an adapter living in the same assembly as the module that registers it.

--- a/artifacts/feat-3370/review/update-handler-tests.r1.md
+++ b/artifacts/feat-3370/review/update-handler-tests.r1.md
@@ -1,0 +1,18 @@
+# Code Review: update-handler-tests
+
+## Summary
+The test file is clean and correct. All five acceptance criteria are met: cross-module usings have been removed, the right mock type is used, test data uses the positional constructor with the correct field order, the setup targets the right method, and the assertions are intact.
+
+## Review Result: PASS
+
+### task: update-handler-tests
+**Status:** PASS
+
+## Overall Notes
+- `using` statements (lines 1–5) reference only `Authorization.Contracts`, `Authorization.UseCases.GetEntraAccessUsers`, `FluentAssertions`, `Moq`, and `Xunit`. No `UserManagement.Services`, `UserManagement.Contracts`, or `Domain.Features.Authorization` imports are present.
+- Both tests create `Mock<IEntraAccessUserSource>` — the correct abstraction.
+- Test records use the positional constructor `new("id", "email", "name")` matching the `(Id, Email, DisplayName)` order.
+- Setup wires `GetBaseMembersAsync` in both tests (`default` in the first, `It.IsAny<CancellationToken>()` in the second — both are valid).
+- Assertions verify ordering by `DisplayName` and field mapping to `EntraUserDto` (`DisplayName`, `EntraObjectId`) — unchanged from the original intent.
+- The two-test structure covers the happy path with ordering and the empty-source edge case.
+- No dead code, no leftover references to `IGraphService` or `GetAppRoleMembersAsync`.

--- a/artifacts/feat-3370/review/update-handler.r1.md
+++ b/artifacts/feat-3370/review/update-handler.r1.md
@@ -1,0 +1,19 @@
+# Code Review: update-handler
+
+## Summary
+The handler was correctly refactored. All cross-module dependencies have been removed, the injected abstraction has been swapped to `IEntraAccessUserSource`, and the field mapping is correct and functionally identical to the prior implementation.
+
+## Review Result: PASS
+
+### task: update-handler
+**Status:** PASS
+
+## Overall Notes
+- No `using` statements referencing `UserManagement.Services` or `UserManagement.Contracts` — only `Authorization.Contracts` and `MediatR` are present.
+- Constructor injects `IEntraAccessUserSource` (named `_source`); `IGraphService` is gone.
+- `GetBaseMembersAsync(ct)` is called on the source, matching the intended call site.
+- `EntraUserDto` is built from `EntraAccessUserRecord` fields: `Id → EntraObjectId`, `Email → Email`, `DisplayName → DisplayName` — all three fields mapped correctly.
+- `OrderBy(u => u.DisplayName)` is preserved, maintaining sort behaviour identical to the previous implementation.
+- Build reported 0 errors.
+
+**Status:** PASS

--- a/artifacts/feat-3370/review/verify.r1.md
+++ b/artifacts/feat-3370/review/verify.r1.md
@@ -1,0 +1,19 @@
+# Code Review: verify
+
+## Summary
+
+All three verification checks from the task spec passed cleanly. The build is error-free, the Authorization-scoped tests ran with zero failures, and the module boundary grep confirms no cross-module leakage from `UserManagement.Services` into the Authorization layer.
+
+## Review Result: PASS
+
+### task: verify
+**Status:** PASS
+
+## Overall Notes
+
+- The build produced 139 warnings, all described as pre-existing. No new warnings were introduced by this change, which is the correct baseline.
+- The test run executed 125 tests, not just 2. The spec's "expect 2 tests pass" was a floor (the two new Authorization tests), not a ceiling. Running the broader suite and seeing 125 pass with 1 pre-existing skip gives higher confidence than running a narrower filter would.
+- The 1 skipped test is a pre-existing integration test, not related to this task. No action required.
+- The `CLEAN` result on the module boundary grep is the critical architectural signal: the Authorization module has no direct import of `UserManagement.Services`, confirming the dependency inversion is correctly in place.
+
+**Status:** PASS

--- a/artifacts/feat-3370/spec.r1.md
+++ b/artifacts/feat-3370/spec.r1.md
@@ -1,0 +1,182 @@
+# Specification: Authorization–UserManagement Module Boundary Fix
+
+## Summary
+
+`GetEntraAccessUsersHandler` in the `Authorization` module directly injects `IGraphService`, an internal service interface belonging to the `UserManagement` module, violating the project rule that cross-module communication must go exclusively through `contracts/` directories. This refactor introduces a consumer-owned contract in `Authorization/Contracts/` and a provider-side adapter in `UserManagement/Infrastructure/`, mirroring the existing `IArticleUserResolver` / `GraphArticleUserResolver` pattern, thereby restoring module isolation with no functional change.
+
+## Background
+
+`development_guidelines.md` mandates that modules communicate exclusively through contracts: "Communication between modules **exclusively through `contracts/`**." The violation was identified by the daily arch-review routine on 2026-06-26.
+
+`IGraphService` (`UserManagement/Services/IGraphService.cs`) is a UserManagement-internal abstraction that wraps Microsoft Graph calls. `GetEntraAccessUsersHandler` (`Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs`) imports it directly via `using Anela.Heblo.Application.Features.UserManagement.Services`, coupling Authorization to UserManagement's internal implementation shape.
+
+The correct pattern is established by `IArticleUserResolver` / `GraphArticleUserResolver`:
+- The consuming module (Article) defines a narrow contract in `Article/Contracts/IArticleUserResolver.cs` with only the methods it needs.
+- The providing module (UserManagement) implements `GraphArticleUserResolver` in `UserManagement/Infrastructure/` as an `internal sealed` adapter, delegating to `IGraphService`.
+- `UserManagementModule.cs` registers the binding: `services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>()`.
+
+Authorization must follow the same shape.
+
+## Functional Requirements
+
+### FR-1: Consumer-owned contract in Authorization
+
+A new interface `IEntraAccessUserSource` must be created at `backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/IEntraAccessUserSource.cs`.
+
+The interface must expose exactly one method that satisfies `GetEntraAccessUsersHandler`'s current need: retrieving the list of users assigned the base app role.
+
+```csharp
+namespace Anela.Heblo.Application.Features.Authorization.Contracts;
+
+public interface IEntraAccessUserSource
+{
+    Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct);
+}
+
+public sealed record EntraAccessUserRecord(string Id, string Email, string DisplayName);
+```
+
+The `EntraAccessUserRecord` value type is Authorization-owned. It must NOT reference any type from the `UserManagement` namespace (no `UserDto`, no `IGraphService`).
+
+**Acceptance criteria:**
+- File exists at `Authorization/Contracts/IEntraAccessUserSource.cs`.
+- The interface and its supporting record type live in namespace `Anela.Heblo.Application.Features.Authorization.Contracts`.
+- The interface has no `using` statements referencing any `UserManagement.*` namespace.
+- The interface exposes exactly one method: `GetBaseMembersAsync(CancellationToken)` returning `Task<List<EntraAccessUserRecord>>`.
+
+### FR-2: Provider-side adapter in UserManagement
+
+A new class `EntraAccessUserSourceAdapter` must be created at `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs`.
+
+- It is `internal sealed` (consistent with `GraphArticleUserResolver`).
+- It implements `IEntraAccessUserSource` (from `Authorization.Contracts`).
+- It depends on `IGraphService` via constructor injection.
+- Its `GetBaseMembersAsync` delegates to `_graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct)` and maps `UserDto` → `EntraAccessUserRecord`.
+
+```csharp
+using Anela.Heblo.Application.Features.Authorization.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Services;
+using Anela.Heblo.Domain.Features.Authorization;
+
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class EntraAccessUserSourceAdapter : IEntraAccessUserSource
+{
+    private readonly IGraphService _graph;
+
+    public EntraAccessUserSourceAdapter(IGraphService graph) => _graph = graph;
+
+    public async Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct)
+    {
+        var users = await _graph.GetAppRoleMembersAsync(AccessRoles.Base, ct);
+        return users
+            .Select(u => new EntraAccessUserRecord(u.Id, u.Email, u.DisplayName))
+            .ToList();
+    }
+}
+```
+
+**Acceptance criteria:**
+- File exists at `UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs`.
+- Class is `internal sealed`.
+- Class implements `IEntraAccessUserSource` and injects only `IGraphService`.
+- The adapter does not expose `IGraphService` or any `UserManagement.Services.*` type in its public surface.
+
+### FR-3: DI registration in UserManagementModule
+
+`UserManagementModule.AddUserManagement()` must register the new adapter:
+
+```csharp
+services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>();
+```
+
+This registration sits alongside the existing `IArticleUserResolver` registration.
+
+**Acceptance criteria:**
+- `UserManagementModule.cs` contains `services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>()`.
+- No other module registers this binding.
+
+### FR-4: Handler updated to inject IEntraAccessUserSource
+
+`GetEntraAccessUsersHandler` must be updated to:
+- Remove `using Anela.Heblo.Application.Features.UserManagement.Services;`
+- Add `using Anela.Heblo.Application.Features.Authorization.Contracts;`
+- Replace the `IGraphService _graphService` field with `IEntraAccessUserSource _entraSource`
+- Replace the `GetAppRoleMembersAsync` call with `GetBaseMembersAsync`
+- Map from `EntraAccessUserRecord` instead of `UserDto`
+
+**Acceptance criteria:**
+- `GetEntraAccessUsersHandler.cs` contains no `using` statement referencing `UserManagement.Services` or `UserManagement.Contracts`.
+- The handler injects `IEntraAccessUserSource`, not `IGraphService`.
+- The handler builds `EntraUserDto` from `EntraAccessUserRecord` fields (`Id`, `Email`, `DisplayName`).
+- The handler's behavior (field mapping, `OrderBy(u => u.DisplayName)`) is functionally identical to the current implementation.
+
+### FR-5: No other Authorization use cases added to IEntraAccessUserSource
+
+The new contract must be scoped only to what `GetEntraAccessUsersHandler` needs. No additional `IGraphService` methods (e.g., `SearchUsersAsync`, `GetGroupMembersAsync`) may be added to `IEntraAccessUserSource` as part of this change.
+
+**Acceptance criteria:**
+- `IEntraAccessUserSource` declares exactly one method.
+
+## Non-Functional Requirements
+
+### NFR-1: No behavioral change
+
+This is a pure structural refactor. The response payload of `GET /api/authorization/entra-access-users` (or equivalent) must remain identical before and after the change: same fields, same ordering, same data source.
+
+**Acceptance criteria:**
+- Existing unit or integration tests for `GetEntraAccessUsersHandler` pass without modification to their assertions.
+- If no unit tests exist for this handler, a unit test must be added that verifies the handler maps `EntraAccessUserRecord` fields correctly and returns users ordered by `DisplayName`.
+
+### NFR-2: Module boundary enforced
+
+After the change, the `Authorization` feature directory must contain zero `using` statements referencing `UserManagement.Services.*`.
+
+**Acceptance criteria:**
+- `grep -r "UserManagement.Services" backend/src/Anela.Heblo.Application/Features/Authorization/` returns no results.
+
+### NFR-3: Build passes
+
+`dotnet build` and `dotnet format` must succeed after the change with no new warnings.
+
+## Data Model
+
+No data model changes. This refactor is entirely in the application/service layer. No database entities, migrations, or persistence changes are involved.
+
+The data flow remains:
+
+```
+GetEntraAccessUsersHandler
+  → IEntraAccessUserSource.GetBaseMembersAsync()          [Authorization contract]
+    → EntraAccessUserSourceAdapter                         [UserManagement adapter]
+      → IGraphService.GetAppRoleMembersAsync(AccessRoles.Base)
+        → Microsoft Graph API
+```
+
+## API / Interface Design
+
+No API changes. The existing MediatR request/response types (`GetEntraAccessUsersRequest`, `GetEntraAccessUsersResponse`, `EntraUserDto`) remain unchanged and in their current location (`Authorization/UseCases/GetEntraAccessUsers/`).
+
+The new `EntraAccessUserRecord` is an internal intermediary type; it is not exposed via HTTP.
+
+## Dependencies
+
+- `IGraphService` — existing UserManagement-internal service; the adapter depends on it. No changes to `IGraphService` itself.
+- `AccessRoles.Base` — existing constant in `Anela.Heblo.Domain.Features.Authorization`; the adapter references it directly (it is a domain constant, not a UserManagement-internal type, so this is acceptable).
+- `UserManagementModule.cs` — requires one new `AddScoped` line.
+- No new NuGet packages.
+
+## Out of Scope
+
+- Changes to `IGraphService` (adding, removing, or renaming methods).
+- Refactoring other handlers in `Authorization` that may have separate issues.
+- Changes to `UserManagement`-internal use cases that consume `IGraphService` directly (those are intra-module and do not violate the boundary rule).
+- Frontend changes.
+- E2E test changes.
+- Any unrelated cleanup in `GetEntraAccessUsersHandler` (e.g., extracting mapping logic).
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "create-authorization-contract",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-26T09:24:49.908495Z"
+      "updated_at": "2026-06-26T09:28:05.028559Z"
     },
     {
       "name": "create-usermanagement-adapter",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-26T09:28:08.492626Z"
     },
     {
       "name": "register-adapter-in-di",

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -46,15 +46,15 @@
     },
     {
       "name": "update-handler",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-26T09:33:20.116825Z"
+      "updated_at": "2026-06-26T09:35:17.162630Z"
     },
     {
       "name": "update-handler-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-26T09:35:17.359262Z"
     },
     {
       "name": "verify",

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-26T09:24:14.554826Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-26T09:24:46.393124Z"
     }
   },
   "tasks": [
     {
       "name": "create-authorization-contract",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-26T09:24:49.908495Z"
     },
     {
       "name": "create-usermanagement-adapter",

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -17,13 +17,50 @@
       "updated_at": "2026-06-26T09:20:58.551798Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-26T09:21:10.268122Z"
+      "status": "completed",
+      "updated_at": "2026-06-26T09:24:14.554826Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "create-authorization-contract",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "create-usermanagement-adapter",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "register-adapter-in-di",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "update-handler",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "update-handler-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "verify",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-26T09:15:34.482659Z"
+      "status": "completed",
+      "updated_at": "2026-06-26T09:17:41.966279Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-26T09:17:53.812135Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "create-usermanagement-adapter",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-26T09:28:08.492626Z"
+      "updated_at": "2026-06-26T09:30:59.605275Z"
     },
     {
       "name": "register-adapter-in-di",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-26T09:30:59.843670Z"
     },
     {
       "name": "update-handler",

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-06-26T09:24:14.554826Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-26T09:24:46.393124Z"
+      "status": "completed",
+      "updated_at": "2026-06-26T10:05:10.673889Z"
     }
   },
   "tasks": [
@@ -58,9 +58,9 @@
     },
     {
       "name": "verify",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-26T09:47:50.391320Z"
+      "updated_at": "2026-06-26T10:05:10.479883Z"
     }
   ]
 }

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-06-26T10:05:10.673889Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-26T10:05:18.573902Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3370",
+  "issue_number": 3370,
+  "created_at": "2026-06-26T09:15:29.609167Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-26T09:15:34.482659Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-06-26T09:17:41.966279Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-26T09:17:53.812135Z"
+      "status": "completed",
+      "updated_at": "2026-06-26T09:20:46.350448Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-26T09:20:58.551798Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-26T09:21:10.268122Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -40,15 +40,15 @@
     },
     {
       "name": "register-adapter-in-di",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-26T09:30:59.843670Z"
+      "updated_at": "2026-06-26T09:33:19.910267Z"
     },
     {
       "name": "update-handler",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-26T09:33:20.116825Z"
     },
     {
       "name": "update-handler-tests",

--- a/artifacts/feat-3370/state.json
+++ b/artifacts/feat-3370/state.json
@@ -52,15 +52,15 @@
     },
     {
       "name": "update-handler-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-26T09:35:17.359262Z"
+      "updated_at": "2026-06-26T09:47:50.196946Z"
     },
     {
       "name": "verify",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-26T09:47:50.391320Z"
     }
   ]
 }

--- a/artifacts/feat-3370/task-context/create-authorization-contract.md
+++ b/artifacts/feat-3370/task-context/create-authorization-contract.md
@@ -1,0 +1,31 @@
+### task: create-authorization-contract
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/IEntraAccessUserSource.cs`
+
+- [ ] **Step 1: Create the `Contracts/` directory and the interface file.**
+
+  The `Contracts/` folder for the Authorization module does not yet exist — create both the
+  directory and the file. The interface has exactly one method. The record is a `sealed record`
+  (internal domain transport — Authorization module owns both, so no OpenAPI generator sees it).
+
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Authorization.Contracts;
+
+  public interface IEntraAccessUserSource
+  {
+      Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct);
+  }
+
+  public sealed record EntraAccessUserRecord(string Id, string Email, string DisplayName);
+  ```
+
+- [ ] **Step 2: Verify the file compiles in isolation.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds (new file adds no dependencies).
+
+---

--- a/artifacts/feat-3370/task-context/create-usermanagement-adapter.md
+++ b/artifacts/feat-3370/task-context/create-usermanagement-adapter.md
@@ -1,0 +1,49 @@
+### task: create-usermanagement-adapter
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs`
+
+- [ ] **Step 1: Create the adapter.**
+
+  The adapter is `internal sealed` — it must NOT be `public`. It lives in the `Infrastructure/`
+  folder alongside `GraphArticleUserResolver`. It injects `IGraphService` (UserManagement's own
+  interface) and maps the result to `EntraAccessUserRecord` (Authorization's contract type).
+  No exception wrapping — see architecture decision in spec.
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Services;
+  using Anela.Heblo.Domain.Features.Authorization;
+
+  namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+  internal sealed class EntraAccessUserSourceAdapter : IEntraAccessUserSource
+  {
+      private readonly IGraphService _graph;
+
+      public EntraAccessUserSourceAdapter(IGraphService graph) => _graph = graph;
+
+      public async Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct)
+      {
+          var users = await _graph.GetAppRoleMembersAsync(AccessRoles.Base, ct);
+          return users
+              .Select(u => new EntraAccessUserRecord(u.Id, u.Email, u.DisplayName))
+              .ToList();
+      }
+  }
+  ```
+
+  Note on `AccessRoles.Base`: `AccessRoles` is a generated static class at
+  `backend/src/Anela.Heblo.Domain/Features/Authorization/AccessRoles.generated.cs` in the
+  `Anela.Heblo.Domain.Features.Authorization` namespace. The value `Base` was previously used
+  directly in the handler — copy it here verbatim.
+
+- [ ] **Step 2: Verify the file compiles.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds.
+
+---

--- a/artifacts/feat-3370/task-context/register-adapter-in-di.md
+++ b/artifacts/feat-3370/task-context/register-adapter-in-di.md
@@ -1,0 +1,90 @@
+### task: register-adapter-in-di
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`
+
+- [ ] **Step 1: Add one `AddScoped` line after the existing `IArticleUserResolver` registration.**
+
+  Current file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Common.Behaviors;
+  using Anela.Heblo.Application.Features.Article.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+  using Anela.Heblo.Application.Features.UserManagement.UseCases.GetGroupMembers;
+  using Anela.Heblo.Application.Features.UserManagement.Validators;
+  using FluentValidation;
+  using MediatR;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.UserManagement;
+
+  public static class UserManagementModule
+  {
+      public static IServiceCollection AddUserManagement(this IServiceCollection services, IConfiguration configuration)
+      {
+          // IGraphService is registered by the adapter layer via AddMicrosoft365Adapter(), not here.
+
+          // Cross-module: IArticleUserResolver delegates to IGraphService (Mock or real) from adapter layer.
+          services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+
+          services.AddScoped<IValidator<GetGroupMembersRequest>, GetGroupMembersRequestValidator>();
+          services.AddScoped<
+              IPipelineBehavior<GetGroupMembersRequest, GetGroupMembersResponse>,
+              ValidationBehavior<GetGroupMembersRequest, GetGroupMembersResponse>>();
+
+          // Note: HttpContextAccessor must be registered in the API layer
+
+          return services;
+      }
+  }
+  ```
+
+  Updated file content — add one using and one `AddScoped` line:
+
+  ```csharp
+  using Anela.Heblo.Application.Common.Behaviors;
+  using Anela.Heblo.Application.Features.Article.Contracts;
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+  using Anela.Heblo.Application.Features.UserManagement.UseCases.GetGroupMembers;
+  using Anela.Heblo.Application.Features.UserManagement.Validators;
+  using FluentValidation;
+  using MediatR;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.UserManagement;
+
+  public static class UserManagementModule
+  {
+      public static IServiceCollection AddUserManagement(this IServiceCollection services, IConfiguration configuration)
+      {
+          // IGraphService is registered by the adapter layer via AddMicrosoft365Adapter(), not here.
+
+          // Cross-module: IArticleUserResolver delegates to IGraphService (Mock or real) from adapter layer.
+          services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+          services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>();
+
+          services.AddScoped<IValidator<GetGroupMembersRequest>, GetGroupMembersRequestValidator>();
+          services.AddScoped<
+              IPipelineBehavior<GetGroupMembersRequest, GetGroupMembersResponse>,
+              ValidationBehavior<GetGroupMembersRequest, GetGroupMembersResponse>>();
+
+          // Note: HttpContextAccessor must be registered in the API layer
+
+          return services;
+      }
+  }
+  ```
+
+- [ ] **Step 2: Verify the file compiles.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds.
+
+---

--- a/artifacts/feat-3370/task-context/update-handler-tests.md
+++ b/artifacts/feat-3370/task-context/update-handler-tests.md
@@ -1,0 +1,131 @@
+### task: update-handler-tests
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/GetEntraAccessUsersHandlerTests.cs`
+
+- [ ] **Step 1: Rewrite the test file to mock `IEntraAccessUserSource` instead of `IGraphService`.**
+
+  Current file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+  using Anela.Heblo.Application.Features.UserManagement.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Services;
+  using Anela.Heblo.Domain.Features.Authorization;
+  using FluentAssertions;
+  using Moq;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Authorization;
+
+  public class GetEntraAccessUsersHandlerTests
+  {
+      private static GetEntraAccessUsersHandler NewHandler(IGraphService graphService)
+          => new(graphService);
+
+      [Fact]
+      public async Task Handle_ReturnsEntraUsersOrderedByDisplayName()
+      {
+          var mock = new Mock<IGraphService>();
+          mock.Setup(g => g.GetAppRoleMembersAsync(AccessRoles.Base, default))
+              .ReturnsAsync(new List<UserDto>
+              {
+                  new() { Id = "obj-2", DisplayName = "Zdenek Novak", Email = "z@x.cz" },
+                  new() { Id = "obj-1", DisplayName = "Anna Novak", Email = "a@x.cz" },
+              });
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().HaveCount(2);
+          result.Users[0].DisplayName.Should().Be("Anna Novak");
+          result.Users[0].EntraObjectId.Should().Be("obj-1");
+          result.Users[1].DisplayName.Should().Be("Zdenek Novak");
+      }
+
+      [Fact]
+      public async Task Handle_WhenGraphReturnsEmpty_ReturnsEmptyList()
+      {
+          var mock = new Mock<IGraphService>();
+          mock.Setup(g => g.GetAppRoleMembersAsync(It.IsAny<string>(), default))
+              .ReturnsAsync(new List<UserDto>());
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().BeEmpty();
+      }
+  }
+  ```
+
+  Updated file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+  using FluentAssertions;
+  using Moq;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Authorization;
+
+  public class GetEntraAccessUsersHandlerTests
+  {
+      private static GetEntraAccessUsersHandler NewHandler(IEntraAccessUserSource source)
+          => new(source);
+
+      [Fact]
+      public async Task Handle_ReturnsEntraUsersOrderedByDisplayName()
+      {
+          var mock = new Mock<IEntraAccessUserSource>();
+          mock.Setup(s => s.GetBaseMembersAsync(default))
+              .ReturnsAsync(new List<EntraAccessUserRecord>
+              {
+                  new("obj-2", "z@x.cz", "Zdenek Novak"),
+                  new("obj-1", "a@x.cz", "Anna Novak"),
+              });
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().HaveCount(2);
+          result.Users[0].DisplayName.Should().Be("Anna Novak");
+          result.Users[0].EntraObjectId.Should().Be("obj-1");
+          result.Users[1].DisplayName.Should().Be("Zdenek Novak");
+      }
+
+      [Fact]
+      public async Task Handle_WhenSourceReturnsEmpty_ReturnsEmptyList()
+      {
+          var mock = new Mock<IEntraAccessUserSource>();
+          mock.Setup(s => s.GetBaseMembersAsync(It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<EntraAccessUserRecord>());
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().BeEmpty();
+      }
+  }
+  ```
+
+  Key changes:
+  - Remove usings for `UserManagement.Contracts`, `UserManagement.Services`, `Domain.Features.Authorization`
+  - Add using for `Authorization.Contracts`
+  - `NewHandler` parameter type: `IGraphService` → `IEntraAccessUserSource`
+  - `Mock<IGraphService>` → `Mock<IEntraAccessUserSource>`
+  - Setup method: `g.GetAppRoleMembersAsync(AccessRoles.Base, default)` → `s.GetBaseMembersAsync(default)`
+  - Test data: `List<UserDto> { new() { ... } }` → `List<EntraAccessUserRecord> { new("id", "email", "name") }`
+    - `EntraAccessUserRecord` constructor parameter order is `(Id, Email, DisplayName)` — match the record declaration exactly
+  - Empty-list test: `It.IsAny<string>()` arg removed (method takes only `CancellationToken`); use `It.IsAny<CancellationToken>()` for robustness
+  - Assertions are unchanged — they test handler output (`EntraUserDto`), not mock input
+
+- [ ] **Step 2: Run the Authorization tests.**
+
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "Authorization"
+  ```
+
+  Expected: 2 tests pass, 0 fail.
+
+---

--- a/artifacts/feat-3370/task-context/update-handler.md
+++ b/artifacts/feat-3370/task-context/update-handler.md
@@ -1,0 +1,84 @@
+### task: update-handler
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs`
+
+- [ ] **Step 1: Replace the handler's dependency from `IGraphService` to `IEntraAccessUserSource`.**
+
+  Current file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.UserManagement.Services;
+  using Anela.Heblo.Domain.Features.Authorization;
+  using MediatR;
+
+  namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+
+  public class GetEntraAccessUsersHandler : IRequestHandler<GetEntraAccessUsersRequest, GetEntraAccessUsersResponse>
+  {
+      private readonly IGraphService _graphService;
+
+      public GetEntraAccessUsersHandler(IGraphService graphService) => _graphService = graphService;
+
+      public async Task<GetEntraAccessUsersResponse> Handle(GetEntraAccessUsersRequest request, CancellationToken ct)
+      {
+          var users = await _graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct);
+          return new GetEntraAccessUsersResponse
+          {
+              Users = users.Select(u => new EntraUserDto
+              {
+                  EntraObjectId = u.Id,
+                  Email = u.Email,
+                  DisplayName = u.DisplayName,
+              }).OrderBy(u => u.DisplayName).ToList(),
+          };
+      }
+  }
+  ```
+
+  Updated file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using MediatR;
+
+  namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+
+  public class GetEntraAccessUsersHandler : IRequestHandler<GetEntraAccessUsersRequest, GetEntraAccessUsersResponse>
+  {
+      private readonly IEntraAccessUserSource _source;
+
+      public GetEntraAccessUsersHandler(IEntraAccessUserSource source) => _source = source;
+
+      public async Task<GetEntraAccessUsersResponse> Handle(GetEntraAccessUsersRequest request, CancellationToken ct)
+      {
+          var users = await _source.GetBaseMembersAsync(ct);
+          return new GetEntraAccessUsersResponse
+          {
+              Users = users.Select(u => new EntraUserDto
+              {
+                  EntraObjectId = u.Id,
+                  Email = u.Email,
+                  DisplayName = u.DisplayName,
+              }).OrderBy(u => u.DisplayName).ToList(),
+          };
+      }
+  }
+  ```
+
+  Key changes:
+  - Remove `using Anela.Heblo.Application.Features.UserManagement.Services;` (eliminates the cross-module violation)
+  - Remove `using Anela.Heblo.Domain.Features.Authorization;` (`AccessRoles.Base` is now only used inside the adapter)
+  - Field renamed `_graphService` → `_source` for accuracy
+  - Call site: `_graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct)` → `_source.GetBaseMembersAsync(ct)`
+  - The mapping of `Id`, `Email`, `DisplayName` is unchanged; the ordering by `DisplayName` is unchanged
+
+- [ ] **Step 2: Verify the file compiles.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds with no warnings about missing usings.
+
+---

--- a/artifacts/feat-3370/task-context/verify.md
+++ b/artifacts/feat-3370/task-context/verify.md
@@ -1,0 +1,27 @@
+### task: verify
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Full build.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: `Build succeeded.` with 0 errors.
+
+- [ ] **Step 2: Authorization tests.**
+
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "Authorization"
+  ```
+
+  Expected: `Passed! - Failed: 0, Passed: 2, Skipped: 0`.
+
+- [ ] **Step 3: Confirm module boundary is clean.**
+
+  ```bash
+  grep -r "UserManagement.Services" backend/src/Anela.Heblo.Application/Features/Authorization/ || echo "CLEAN"
+  ```
+
+  Expected output: `CLEAN` (no matches — the violation is gone).

--- a/artifacts/feat-3370/task-plan.r1.md
+++ b/artifacts/feat-3370/task-plan.r1.md
@@ -1,0 +1,439 @@
+# Implementation Plan: Authorization–UserManagement Module Boundary Fix
+
+## Context
+
+`GetEntraAccessUsersHandler` (Authorization module) currently injects `IGraphService`, an interface
+that belongs to the UserManagement module. Cross-module communication must go exclusively through
+`contracts/` directories. This plan introduces a consumer-owned contract in `Authorization/Contracts/`
+and a provider-side adapter in `UserManagement/Infrastructure/`, mirroring the existing
+`IArticleUserResolver` / `GraphArticleUserResolver` pattern. No functional change.
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| **Create** | `backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/IEntraAccessUserSource.cs` | Consumer-owned interface + record that the Authorization module depends on |
+| **Create** | `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs` | Provider-side adapter: wraps `IGraphService`, implements `IEntraAccessUserSource` |
+| **Modify** | `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` | Register the adapter for DI |
+| **Modify** | `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs` | Swap `IGraphService` injection for `IEntraAccessUserSource` |
+| **Modify** | `backend/test/Anela.Heblo.Tests/Authorization/GetEntraAccessUsersHandlerTests.cs` | Rewrite mocked dependency to use `IEntraAccessUserSource` / `EntraAccessUserRecord` |
+
+---
+
+### task: create-authorization-contract
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/IEntraAccessUserSource.cs`
+
+- [ ] **Step 1: Create the `Contracts/` directory and the interface file.**
+
+  The `Contracts/` folder for the Authorization module does not yet exist — create both the
+  directory and the file. The interface has exactly one method. The record is a `sealed record`
+  (internal domain transport — Authorization module owns both, so no OpenAPI generator sees it).
+
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Authorization.Contracts;
+
+  public interface IEntraAccessUserSource
+  {
+      Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct);
+  }
+
+  public sealed record EntraAccessUserRecord(string Id, string Email, string DisplayName);
+  ```
+
+- [ ] **Step 2: Verify the file compiles in isolation.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds (new file adds no dependencies).
+
+---
+
+### task: create-usermanagement-adapter
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs`
+
+- [ ] **Step 1: Create the adapter.**
+
+  The adapter is `internal sealed` — it must NOT be `public`. It lives in the `Infrastructure/`
+  folder alongside `GraphArticleUserResolver`. It injects `IGraphService` (UserManagement's own
+  interface) and maps the result to `EntraAccessUserRecord` (Authorization's contract type).
+  No exception wrapping — see architecture decision in spec.
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Services;
+  using Anela.Heblo.Domain.Features.Authorization;
+
+  namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+  internal sealed class EntraAccessUserSourceAdapter : IEntraAccessUserSource
+  {
+      private readonly IGraphService _graph;
+
+      public EntraAccessUserSourceAdapter(IGraphService graph) => _graph = graph;
+
+      public async Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct)
+      {
+          var users = await _graph.GetAppRoleMembersAsync(AccessRoles.Base, ct);
+          return users
+              .Select(u => new EntraAccessUserRecord(u.Id, u.Email, u.DisplayName))
+              .ToList();
+      }
+  }
+  ```
+
+  Note on `AccessRoles.Base`: `AccessRoles` is a generated static class at
+  `backend/src/Anela.Heblo.Domain/Features/Authorization/AccessRoles.generated.cs` in the
+  `Anela.Heblo.Domain.Features.Authorization` namespace. The value `Base` was previously used
+  directly in the handler — copy it here verbatim.
+
+- [ ] **Step 2: Verify the file compiles.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds.
+
+---
+
+### task: register-adapter-in-di
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`
+
+- [ ] **Step 1: Add one `AddScoped` line after the existing `IArticleUserResolver` registration.**
+
+  Current file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Common.Behaviors;
+  using Anela.Heblo.Application.Features.Article.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+  using Anela.Heblo.Application.Features.UserManagement.UseCases.GetGroupMembers;
+  using Anela.Heblo.Application.Features.UserManagement.Validators;
+  using FluentValidation;
+  using MediatR;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.UserManagement;
+
+  public static class UserManagementModule
+  {
+      public static IServiceCollection AddUserManagement(this IServiceCollection services, IConfiguration configuration)
+      {
+          // IGraphService is registered by the adapter layer via AddMicrosoft365Adapter(), not here.
+
+          // Cross-module: IArticleUserResolver delegates to IGraphService (Mock or real) from adapter layer.
+          services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+
+          services.AddScoped<IValidator<GetGroupMembersRequest>, GetGroupMembersRequestValidator>();
+          services.AddScoped<
+              IPipelineBehavior<GetGroupMembersRequest, GetGroupMembersResponse>,
+              ValidationBehavior<GetGroupMembersRequest, GetGroupMembersResponse>>();
+
+          // Note: HttpContextAccessor must be registered in the API layer
+
+          return services;
+      }
+  }
+  ```
+
+  Updated file content — add one using and one `AddScoped` line:
+
+  ```csharp
+  using Anela.Heblo.Application.Common.Behaviors;
+  using Anela.Heblo.Application.Features.Article.Contracts;
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+  using Anela.Heblo.Application.Features.UserManagement.UseCases.GetGroupMembers;
+  using Anela.Heblo.Application.Features.UserManagement.Validators;
+  using FluentValidation;
+  using MediatR;
+  using Microsoft.Extensions.Configuration;
+  using Microsoft.Extensions.DependencyInjection;
+
+  namespace Anela.Heblo.Application.Features.UserManagement;
+
+  public static class UserManagementModule
+  {
+      public static IServiceCollection AddUserManagement(this IServiceCollection services, IConfiguration configuration)
+      {
+          // IGraphService is registered by the adapter layer via AddMicrosoft365Adapter(), not here.
+
+          // Cross-module: IArticleUserResolver delegates to IGraphService (Mock or real) from adapter layer.
+          services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+          services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>();
+
+          services.AddScoped<IValidator<GetGroupMembersRequest>, GetGroupMembersRequestValidator>();
+          services.AddScoped<
+              IPipelineBehavior<GetGroupMembersRequest, GetGroupMembersResponse>,
+              ValidationBehavior<GetGroupMembersRequest, GetGroupMembersResponse>>();
+
+          // Note: HttpContextAccessor must be registered in the API layer
+
+          return services;
+      }
+  }
+  ```
+
+- [ ] **Step 2: Verify the file compiles.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds.
+
+---
+
+### task: update-handler
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs`
+
+- [ ] **Step 1: Replace the handler's dependency from `IGraphService` to `IEntraAccessUserSource`.**
+
+  Current file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.UserManagement.Services;
+  using Anela.Heblo.Domain.Features.Authorization;
+  using MediatR;
+
+  namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+
+  public class GetEntraAccessUsersHandler : IRequestHandler<GetEntraAccessUsersRequest, GetEntraAccessUsersResponse>
+  {
+      private readonly IGraphService _graphService;
+
+      public GetEntraAccessUsersHandler(IGraphService graphService) => _graphService = graphService;
+
+      public async Task<GetEntraAccessUsersResponse> Handle(GetEntraAccessUsersRequest request, CancellationToken ct)
+      {
+          var users = await _graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct);
+          return new GetEntraAccessUsersResponse
+          {
+              Users = users.Select(u => new EntraUserDto
+              {
+                  EntraObjectId = u.Id,
+                  Email = u.Email,
+                  DisplayName = u.DisplayName,
+              }).OrderBy(u => u.DisplayName).ToList(),
+          };
+      }
+  }
+  ```
+
+  Updated file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using MediatR;
+
+  namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+
+  public class GetEntraAccessUsersHandler : IRequestHandler<GetEntraAccessUsersRequest, GetEntraAccessUsersResponse>
+  {
+      private readonly IEntraAccessUserSource _source;
+
+      public GetEntraAccessUsersHandler(IEntraAccessUserSource source) => _source = source;
+
+      public async Task<GetEntraAccessUsersResponse> Handle(GetEntraAccessUsersRequest request, CancellationToken ct)
+      {
+          var users = await _source.GetBaseMembersAsync(ct);
+          return new GetEntraAccessUsersResponse
+          {
+              Users = users.Select(u => new EntraUserDto
+              {
+                  EntraObjectId = u.Id,
+                  Email = u.Email,
+                  DisplayName = u.DisplayName,
+              }).OrderBy(u => u.DisplayName).ToList(),
+          };
+      }
+  }
+  ```
+
+  Key changes:
+  - Remove `using Anela.Heblo.Application.Features.UserManagement.Services;` (eliminates the cross-module violation)
+  - Remove `using Anela.Heblo.Domain.Features.Authorization;` (`AccessRoles.Base` is now only used inside the adapter)
+  - Field renamed `_graphService` → `_source` for accuracy
+  - Call site: `_graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct)` → `_source.GetBaseMembersAsync(ct)`
+  - The mapping of `Id`, `Email`, `DisplayName` is unchanged; the ordering by `DisplayName` is unchanged
+
+- [ ] **Step 2: Verify the file compiles.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: build succeeds with no warnings about missing usings.
+
+---
+
+### task: update-handler-tests
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Authorization/GetEntraAccessUsersHandlerTests.cs`
+
+- [ ] **Step 1: Rewrite the test file to mock `IEntraAccessUserSource` instead of `IGraphService`.**
+
+  Current file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+  using Anela.Heblo.Application.Features.UserManagement.Contracts;
+  using Anela.Heblo.Application.Features.UserManagement.Services;
+  using Anela.Heblo.Domain.Features.Authorization;
+  using FluentAssertions;
+  using Moq;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Authorization;
+
+  public class GetEntraAccessUsersHandlerTests
+  {
+      private static GetEntraAccessUsersHandler NewHandler(IGraphService graphService)
+          => new(graphService);
+
+      [Fact]
+      public async Task Handle_ReturnsEntraUsersOrderedByDisplayName()
+      {
+          var mock = new Mock<IGraphService>();
+          mock.Setup(g => g.GetAppRoleMembersAsync(AccessRoles.Base, default))
+              .ReturnsAsync(new List<UserDto>
+              {
+                  new() { Id = "obj-2", DisplayName = "Zdenek Novak", Email = "z@x.cz" },
+                  new() { Id = "obj-1", DisplayName = "Anna Novak", Email = "a@x.cz" },
+              });
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().HaveCount(2);
+          result.Users[0].DisplayName.Should().Be("Anna Novak");
+          result.Users[0].EntraObjectId.Should().Be("obj-1");
+          result.Users[1].DisplayName.Should().Be("Zdenek Novak");
+      }
+
+      [Fact]
+      public async Task Handle_WhenGraphReturnsEmpty_ReturnsEmptyList()
+      {
+          var mock = new Mock<IGraphService>();
+          mock.Setup(g => g.GetAppRoleMembersAsync(It.IsAny<string>(), default))
+              .ReturnsAsync(new List<UserDto>());
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().BeEmpty();
+      }
+  }
+  ```
+
+  Updated file content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Authorization.Contracts;
+  using Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
+  using FluentAssertions;
+  using Moq;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Authorization;
+
+  public class GetEntraAccessUsersHandlerTests
+  {
+      private static GetEntraAccessUsersHandler NewHandler(IEntraAccessUserSource source)
+          => new(source);
+
+      [Fact]
+      public async Task Handle_ReturnsEntraUsersOrderedByDisplayName()
+      {
+          var mock = new Mock<IEntraAccessUserSource>();
+          mock.Setup(s => s.GetBaseMembersAsync(default))
+              .ReturnsAsync(new List<EntraAccessUserRecord>
+              {
+                  new("obj-2", "z@x.cz", "Zdenek Novak"),
+                  new("obj-1", "a@x.cz", "Anna Novak"),
+              });
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().HaveCount(2);
+          result.Users[0].DisplayName.Should().Be("Anna Novak");
+          result.Users[0].EntraObjectId.Should().Be("obj-1");
+          result.Users[1].DisplayName.Should().Be("Zdenek Novak");
+      }
+
+      [Fact]
+      public async Task Handle_WhenSourceReturnsEmpty_ReturnsEmptyList()
+      {
+          var mock = new Mock<IEntraAccessUserSource>();
+          mock.Setup(s => s.GetBaseMembersAsync(It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<EntraAccessUserRecord>());
+
+          var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
+
+          result.Success.Should().BeTrue();
+          result.Users.Should().BeEmpty();
+      }
+  }
+  ```
+
+  Key changes:
+  - Remove usings for `UserManagement.Contracts`, `UserManagement.Services`, `Domain.Features.Authorization`
+  - Add using for `Authorization.Contracts`
+  - `NewHandler` parameter type: `IGraphService` → `IEntraAccessUserSource`
+  - `Mock<IGraphService>` → `Mock<IEntraAccessUserSource>`
+  - Setup method: `g.GetAppRoleMembersAsync(AccessRoles.Base, default)` → `s.GetBaseMembersAsync(default)`
+  - Test data: `List<UserDto> { new() { ... } }` → `List<EntraAccessUserRecord> { new("id", "email", "name") }`
+    - `EntraAccessUserRecord` constructor parameter order is `(Id, Email, DisplayName)` — match the record declaration exactly
+  - Empty-list test: `It.IsAny<string>()` arg removed (method takes only `CancellationToken`); use `It.IsAny<CancellationToken>()` for robustness
+  - Assertions are unchanged — they test handler output (`EntraUserDto`), not mock input
+
+- [ ] **Step 2: Run the Authorization tests.**
+
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "Authorization"
+  ```
+
+  Expected: 2 tests pass, 0 fail.
+
+---
+
+### task: verify
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Full build.**
+
+  ```bash
+  dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+  ```
+
+  Expected: `Build succeeded.` with 0 errors.
+
+- [ ] **Step 2: Authorization tests.**
+
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "Authorization"
+  ```
+
+  Expected: `Passed! - Failed: 0, Passed: 2, Skipped: 0`.
+
+- [ ] **Step 3: Confirm module boundary is clean.**
+
+  ```bash
+  grep -r "UserManagement.Services" backend/src/Anela.Heblo.Application/Features/Authorization/ || echo "CLEAN"
+  ```
+
+  Expected output: `CLEAN` (no matches — the violation is gone).

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/IEntraAccessUserSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/Contracts/IEntraAccessUserSource.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Authorization.Contracts;
+
+public interface IEntraAccessUserSource
+{
+    Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct);
+}
+
+public sealed record EntraAccessUserRecord(string Id, string Email, string DisplayName);

--- a/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetEntraAccessUsers/GetEntraAccessUsersHandler.cs
@@ -1,18 +1,17 @@
-using Anela.Heblo.Application.Features.UserManagement.Services;
-using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Application.Features.Authorization.Contracts;
 using MediatR;
 
 namespace Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
 
 public class GetEntraAccessUsersHandler : IRequestHandler<GetEntraAccessUsersRequest, GetEntraAccessUsersResponse>
 {
-    private readonly IGraphService _graphService;
+    private readonly IEntraAccessUserSource _source;
 
-    public GetEntraAccessUsersHandler(IGraphService graphService) => _graphService = graphService;
+    public GetEntraAccessUsersHandler(IEntraAccessUserSource source) => _source = source;
 
     public async Task<GetEntraAccessUsersResponse> Handle(GetEntraAccessUsersRequest request, CancellationToken ct)
     {
-        var users = await _graphService.GetAppRoleMembersAsync(AccessRoles.Base, ct);
+        var users = await _source.GetBaseMembersAsync(ct);
         return new GetEntraAccessUsersResponse
         {
             Users = users.Select(u => new EntraUserDto

--- a/backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs
@@ -1,0 +1,20 @@
+using Anela.Heblo.Application.Features.Authorization.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Services;
+using Anela.Heblo.Domain.Features.Authorization;
+
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class EntraAccessUserSourceAdapter : IEntraAccessUserSource
+{
+    private readonly IGraphService _graph;
+
+    public EntraAccessUserSourceAdapter(IGraphService graph) => _graph = graph;
+
+    public async Task<List<EntraAccessUserRecord>> GetBaseMembersAsync(CancellationToken ct)
+    {
+        var users = await _graph.GetAppRoleMembersAsync(AccessRoles.Base, ct);
+        return users
+            .Select(u => new EntraAccessUserRecord(u.Id, u.Email, u.DisplayName))
+            .ToList();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Common.Behaviors;
 using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.Authorization.Contracts;
 using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
 using Anela.Heblo.Application.Features.UserManagement.UseCases.GetGroupMembers;
 using Anela.Heblo.Application.Features.UserManagement.Validators;
@@ -18,6 +19,7 @@ public static class UserManagementModule
 
         // Cross-module: IArticleUserResolver delegates to IGraphService (Mock or real) from adapter layer.
         services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+        services.AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>();
 
         services.AddScoped<IValidator<GetGroupMembersRequest>, GetGroupMembersRequestValidator>();
         services.AddScoped<

--- a/backend/test/Anela.Heblo.Tests/Authorization/GetEntraAccessUsersHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/GetEntraAccessUsersHandlerTests.cs
@@ -1,7 +1,5 @@
+using Anela.Heblo.Application.Features.Authorization.Contracts;
 using Anela.Heblo.Application.Features.Authorization.UseCases.GetEntraAccessUsers;
-using Anela.Heblo.Application.Features.UserManagement.Contracts;
-using Anela.Heblo.Application.Features.UserManagement.Services;
-using Anela.Heblo.Domain.Features.Authorization;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -10,18 +8,18 @@ namespace Anela.Heblo.Tests.Authorization;
 
 public class GetEntraAccessUsersHandlerTests
 {
-    private static GetEntraAccessUsersHandler NewHandler(IGraphService graphService)
-        => new(graphService);
+    private static GetEntraAccessUsersHandler NewHandler(IEntraAccessUserSource source)
+        => new(source);
 
     [Fact]
     public async Task Handle_ReturnsEntraUsersOrderedByDisplayName()
     {
-        var mock = new Mock<IGraphService>();
-        mock.Setup(g => g.GetAppRoleMembersAsync(AccessRoles.Base, default))
-            .ReturnsAsync(new List<UserDto>
+        var mock = new Mock<IEntraAccessUserSource>();
+        mock.Setup(s => s.GetBaseMembersAsync(default))
+            .ReturnsAsync(new List<EntraAccessUserRecord>
             {
-                new() { Id = "obj-2", DisplayName = "Zdenek Novak", Email = "z@x.cz" },
-                new() { Id = "obj-1", DisplayName = "Anna Novak", Email = "a@x.cz" },
+                new("obj-2", "z@x.cz", "Zdenek Novak"),
+                new("obj-1", "a@x.cz", "Anna Novak"),
             });
 
         var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
@@ -34,11 +32,11 @@ public class GetEntraAccessUsersHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenGraphReturnsEmpty_ReturnsEmptyList()
+    public async Task Handle_WhenSourceReturnsEmpty_ReturnsEmptyList()
     {
-        var mock = new Mock<IGraphService>();
-        mock.Setup(g => g.GetAppRoleMembersAsync(It.IsAny<string>(), default))
-            .ReturnsAsync(new List<UserDto>());
+        var mock = new Mock<IEntraAccessUserSource>();
+        mock.Setup(s => s.GetBaseMembersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<EntraAccessUserRecord>());
 
         var result = await NewHandler(mock.Object).Handle(new GetEntraAccessUsersRequest(), default);
 


### PR DESCRIPTION
Closes #3370

## What the issue was

`GetEntraAccessUsersHandler` in the `Authorization` module was directly injecting `IGraphService`, an internal service interface belonging to the `UserManagement` module, via `using Anela.Heblo.Application.Features.UserManagement.Services`. This violated the project rule that cross-module communication must go exclusively through `contracts/` directories (`development_guidelines.md`), coupling Authorization to UserManagement's internal abstraction.

## How it was fixed

Introduced the consumer-owned contract pattern already established by `IArticleUserResolver` / `GraphArticleUserResolver`:

1. **New** `Authorization/Contracts/IEntraAccessUserSource.cs` — consumer-owned interface with one method (`GetBaseMembersAsync`) and an Authorization-owned transfer record (`EntraAccessUserRecord`). No `UserManagement.*` references.
2. **New** `UserManagement/Infrastructure/EntraAccessUserSourceAdapter.cs` — `internal sealed` adapter implementing `IEntraAccessUserSource`, delegating to `IGraphService` and mapping `UserDto → EntraAccessUserRecord`. No exception wrapping (handler lets exceptions propagate).
3. **Updated** `UserManagementModule.cs` — one new `AddScoped<IEntraAccessUserSource, EntraAccessUserSourceAdapter>()` line after the existing `IArticleUserResolver` binding.
4. **Updated** `GetEntraAccessUsersHandler.cs` — injects `IEntraAccessUserSource` instead of `IGraphService`; removed cross-module `using` statements. Field mapping and `OrderBy(DisplayName)` are unchanged.
5. **Updated** `GetEntraAccessUsersHandlerTests.cs` — mocks `IEntraAccessUserSource` instead of `IGraphService`; uses `EntraAccessUserRecord` positional constructor.

After the change: `grep -r "UserManagement.Services" .../Features/Authorization/` → CLEAN.

## Artifacts

Brief, spec, arch-review, task plan, impl and review markdown are committed in this branch under `artifacts/feat-3370/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — No `Authorization → UserManagement` boundary rule is registered. Consider adding a `ModuleBoundaryRule` entry (mirroring the `Leaflet → KnowledgeBase` pattern) with `InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Authorization"` and `ForbiddenNamespacePrefixes: ["Anela.Heblo.Application.Features.UserManagement", "Anela.Heblo.Domain.Features.UserManagement"]` to lock in the boundary at CI level.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJoJXX61FbfcKPD4t9PABL)_