### PR TITLE
feat(mcp): add read-only meeting notes MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Read the relevant doc **before** implementation work touches that area. No archi
 - `docs/testing/e2e-module-guide.md` — module boundaries for parallel E2E execution
 
 **Integrations**
-- `docs/integrations/mcp-server.md` — MCP tools, endpoints, client config (16 tools)
+- `docs/integrations/mcp-server.md` — MCP tools, endpoints, client config (20 tools)
 - `docs/integrations/shoptet-api.md` — Shoptet REST API findings
 
 **Features** — `docs/features/` has per-feature specs.

--- a/backend/src/Anela.Heblo.API/MCP/McpModule.cs
+++ b/backend/src/Anela.Heblo.API/MCP/McpModule.cs
@@ -19,7 +19,8 @@ public static class McpModule
             .WithTools<ManufactureBatchMcpTools>()
             .WithTools<KnowledgeBaseTools>()
             .WithTools<LeafletTools>()
-            .WithTools<UserManagementMcpTools>();
+            .WithTools<UserManagementMcpTools>()
+            .WithTools<MeetingTasksMcpTools>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.API/MCP/Tools/MeetingTasksMcpTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/MeetingTasksMcpTools.cs
@@ -1,0 +1,205 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.GetTranscriptDetail;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.GetTranscriptList;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace Anela.Heblo.API.MCP.Tools;
+
+/// <summary>
+/// Read-only MCP tools for Meeting Notes (MeetingTasks feature).
+/// Thin wrappers around existing MediatR read handlers. Per-meeting visibility is enforced
+/// inside the handlers via ICurrentUserService / IMeetingAccessGuard; these tools add an
+/// explicit anela.meetings.read gate mirroring the controller's [FeatureAuthorize].
+/// </summary>
+[McpServerToolType]
+public class MeetingTasksMcpTools
+{
+    private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<MeetingTasksMcpTools> _logger;
+
+    public MeetingTasksMcpTools(
+        IMediator mediator,
+        ICurrentUserService currentUserService,
+        ILogger<MeetingTasksMcpTools> logger)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    [McpServerTool]
+    [Description("List meeting notes (summary level: subject, summary, status, task counts; no raw transcript or task detail). Supports search, status filter, and pagination. Returns only meetings the caller is allowed to see.")]
+    public async Task<string> ListMeetings(
+        [Description("Search term matched against subject and summary")]
+        string? searchText = null,
+        [Description("Filter by status: PendingReview, Approved, or PartiallyApproved")]
+        string? statusFilter = null,
+        [Description("Also search inside the raw transcript text (default: false)")]
+        bool searchInTranscript = false,
+        [Description("Page number for pagination (default: 1)")]
+        int pageNumber = 1,
+        [Description("Page size for pagination (default: 20)")]
+        int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureReadAccess();
+
+        try
+        {
+            var request = new GetTranscriptListRequest
+            {
+                SearchText = searchText,
+                StatusFilter = statusFilter,
+                SearchInTranscript = searchInTranscript,
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            };
+
+            var response = await _mediator.Send(request, cancellationToken);
+            return JsonSerializer.Serialize(response);
+        }
+        catch (McpException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MCP ListMeetings failed");
+            throw new McpException($"Failed to list meetings: {ex.Message}");
+        }
+    }
+
+    [McpServerTool]
+    [Description("Get the summary and metadata of a single meeting (no raw transcript, no task detail). Use GetMeetingTranscript or GetMeetingTasks for those.")]
+    public async Task<string> GetMeetingSummary(
+        [Description("Meeting id (GUID)")] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureReadAccess();
+
+        try
+        {
+            var transcript = await GetTranscriptOrThrow(id, cancellationToken);
+
+            return JsonSerializer.Serialize(new
+            {
+                transcript.Id,
+                transcript.Subject,
+                transcript.Summary,
+                transcript.Status,
+                transcript.PlaudCreatedAt,
+                transcript.ReceivedAt,
+                transcript.ReviewedAt,
+                transcript.ReviewedByUser,
+                transcript.TaskCount,
+                transcript.ApprovedTaskCount,
+                transcript.RejectedTaskCount,
+                transcript.AccessLevel
+            });
+        }
+        catch (McpException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MCP GetMeetingSummary failed for meeting {MeetingId}", id);
+            throw new McpException($"Failed to get meeting summary: {ex.Message}");
+        }
+    }
+
+    [McpServerTool]
+    [Description("Get the full raw transcript text of a single meeting. May be large.")]
+    public async Task<string> GetMeetingTranscript(
+        [Description("Meeting id (GUID)")] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureReadAccess();
+
+        try
+        {
+            var transcript = await GetTranscriptOrThrow(id, cancellationToken);
+
+            return JsonSerializer.Serialize(new
+            {
+                transcript.Id,
+                transcript.Subject,
+                transcript.RawTranscript
+            });
+        }
+        catch (McpException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MCP GetMeetingTranscript failed for meeting {MeetingId}", id);
+            throw new McpException($"Failed to get meeting transcript: {ex.Message}");
+        }
+    }
+
+    [McpServerTool]
+    [Description("Get the proposed task list extracted from a single meeting.")]
+    public async Task<string> GetMeetingTasks(
+        [Description("Meeting id (GUID)")] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureReadAccess();
+
+        try
+        {
+            var transcript = await GetTranscriptOrThrow(id, cancellationToken);
+
+            return JsonSerializer.Serialize(new
+            {
+                transcript.Id,
+                transcript.Subject,
+                transcript.Tasks
+            });
+        }
+        catch (McpException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MCP GetMeetingTasks failed for meeting {MeetingId}", id);
+            throw new McpException($"Failed to get meeting tasks: {ex.Message}");
+        }
+    }
+
+    private void EnsureReadAccess()
+    {
+        var role = AccessRoles.For(Feature.Anela_Meetings, AccessLevel.Read);
+        if (!_currentUserService.IsInRole(role))
+        {
+            throw new McpException(
+                $"[FORBIDDEN] You do not have permission to access Meeting Notes (requires {role}).");
+        }
+    }
+
+    private async Task<Application.Features.MeetingTasks.Contracts.MeetingTranscriptDto> GetTranscriptOrThrow(
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var response = await _mediator.Send(new GetTranscriptDetailRequest { Id = id }, cancellationToken);
+
+        if (!response.Success)
+        {
+            var code = response.ErrorCode?.ToString() ?? "UNKNOWN_ERROR";
+            // FullError() dereferences Params, which is null when the handler reports an error
+            // without parameters (e.g. ResourceNotFound) — only use it when params are present.
+            var detail = response.Params is { Count: > 0 } ? response.FullError() : code;
+            throw new McpException($"[{code}] {detail}");
+        }
+
+        return response.Transcript;
+    }
+}

--- a/backend/src/Anela.Heblo.API/MCP/Tools/MeetingTasksMcpTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/MeetingTasksMcpTools.cs
@@ -63,7 +63,13 @@ public class MeetingTasksMcpTools
             };
 
             var response = await _mediator.Send(request, cancellationToken);
-            return JsonSerializer.Serialize(response);
+            return JsonSerializer.Serialize(new
+            {
+                response.Items,
+                response.TotalCount,
+                response.PageNumber,
+                response.PageSize
+            });
         }
         catch (McpException)
         {

--- a/backend/test/Anela.Heblo.Tests/MCP/Tools/MeetingTasksMcpToolsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/MCP/Tools/MeetingTasksMcpToolsTests.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using Anela.Heblo.API.MCP.Tools;
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.GetTranscriptDetail;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.GetTranscriptList;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.MCP.Tools;
+
+public class MeetingTasksMcpToolsTests
+{
+    private static readonly string ReadRole = AccessRoles.For(Feature.Anela_Meetings, AccessLevel.Read);
+
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+    private readonly MeetingTasksMcpTools _tools;
+
+    public MeetingTasksMcpToolsTests()
+    {
+        // Default: caller has read access. FORBIDDEN tests override this to false.
+        _currentUserServiceMock.Setup(s => s.IsInRole(ReadRole)).Returns(true);
+        _tools = new MeetingTasksMcpTools(
+            _mediatorMock.Object,
+            _currentUserServiceMock.Object,
+            Mock.Of<ILogger<MeetingTasksMcpTools>>());
+    }
+
+    private static MeetingTranscriptDto BuildTranscript(Guid id) => new()
+    {
+        Id = id,
+        PlaudRecordingId = "plaud-1",
+        Subject = "Weekly sync",
+        Summary = "We discussed the roadmap.",
+        RawTranscript = "Alice: hello. Bob: hi.",
+        Status = "Approved",
+        TaskCount = 1,
+        ApprovedTaskCount = 1,
+        AccessLevel = "Public",
+        Tasks = new List<ProposedTaskDto>
+        {
+            new() { Id = Guid.NewGuid(), Title = "Ship it", Description = "Ship the feature", Assignee = "Alice", Status = "Approved" }
+        }
+    };
+
+    [Fact]
+    public async Task ListMeetings_MapsParametersOntoRequest()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetTranscriptListRequest>(), default))
+            .ReturnsAsync(new GetTranscriptListResponse { Items = new(), TotalCount = 0, PageNumber = 2, PageSize = 10 });
+
+        // Act
+        var json = await _tools.ListMeetings(
+            searchText: "roadmap",
+            statusFilter: "Approved",
+            searchInTranscript: true,
+            pageNumber: 2,
+            pageSize: 10);
+
+        // Assert
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<GetTranscriptListRequest>(req =>
+                req.SearchText == "roadmap" &&
+                req.StatusFilter == "Approved" &&
+                req.SearchInTranscript == true &&
+                req.PageNumber == 2 &&
+                req.PageSize == 10),
+            default), Times.Once);
+
+        var deserialized = JsonSerializer.Deserialize<GetTranscriptListResponse>(json);
+        Assert.NotNull(deserialized);
+        Assert.Equal(2, deserialized!.PageNumber);
+    }
+
+    [Fact]
+    public async Task GetMeetingSummary_SendsDetailRequest_AndOmitsTranscriptAndTasks()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetTranscriptDetailRequest>(), default))
+            .ReturnsAsync(new GetTranscriptDetailResponse { Transcript = BuildTranscript(id) });
+
+        // Act
+        var json = await _tools.GetMeetingSummary(id);
+
+        // Assert
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<GetTranscriptDetailRequest>(req => req.Id == id), default), Times.Once);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("We discussed the roadmap.", root.GetProperty("Summary").GetString());
+        Assert.False(root.TryGetProperty("RawTranscript", out _));
+        Assert.False(root.TryGetProperty("Tasks", out _));
+    }
+
+    [Fact]
+    public async Task GetMeetingTranscript_ReturnsRawTranscriptOnly()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetTranscriptDetailRequest>(), default))
+            .ReturnsAsync(new GetTranscriptDetailResponse { Transcript = BuildTranscript(id) });
+
+        // Act
+        var json = await _tools.GetMeetingTranscript(id);
+
+        // Assert
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("Alice: hello. Bob: hi.", root.GetProperty("RawTranscript").GetString());
+        Assert.False(root.TryGetProperty("Summary", out _));
+        Assert.False(root.TryGetProperty("Tasks", out _));
+    }
+
+    [Fact]
+    public async Task GetMeetingTasks_ReturnsTaskList()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetTranscriptDetailRequest>(), default))
+            .ReturnsAsync(new GetTranscriptDetailResponse { Transcript = BuildTranscript(id) });
+
+        // Act
+        var json = await _tools.GetMeetingTasks(id);
+
+        // Assert
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var tasks = root.GetProperty("Tasks");
+        Assert.Equal(1, tasks.GetArrayLength());
+        Assert.Equal("Ship it", tasks[0].GetProperty("Title").GetString());
+        Assert.False(root.TryGetProperty("RawTranscript", out _));
+    }
+
+    [Theory]
+    [InlineData("ListMeetings")]
+    [InlineData("GetMeetingSummary")]
+    [InlineData("GetMeetingTranscript")]
+    [InlineData("GetMeetingTasks")]
+    public async Task Tools_ThrowForbidden_AndSkipMediator_WhenUserLacksReadRole(string tool)
+    {
+        // Arrange
+        _currentUserServiceMock.Setup(s => s.IsInRole(ReadRole)).Returns(false);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<McpException>(() => tool switch
+        {
+            "ListMeetings" => _tools.ListMeetings(),
+            "GetMeetingSummary" => _tools.GetMeetingSummary(Guid.NewGuid()),
+            "GetMeetingTranscript" => _tools.GetMeetingTranscript(Guid.NewGuid()),
+            _ => _tools.GetMeetingTasks(Guid.NewGuid())
+        });
+
+        // Assert
+        Assert.Contains("FORBIDDEN", exception.Message);
+        Assert.Contains(ReadRole, exception.Message);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<IRequest<GetTranscriptListResponse>>(), default), Times.Never);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<IRequest<GetTranscriptDetailResponse>>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetMeetingSummary_ThrowsMcpException_WhenHandlerReportsNotFound()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetTranscriptDetailRequest>(), default))
+            .ReturnsAsync(new GetTranscriptDetailResponse(ErrorCodes.ResourceNotFound));
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<McpException>(() => _tools.GetMeetingSummary(Guid.NewGuid()));
+        Assert.Contains("ResourceNotFound", exception.Message);
+    }
+}

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-The application exposes MCP tools for AI assistants to query catalog data, manufacturing orders, perform batch calculations, and user-directory lookups.
+The application exposes MCP tools for AI assistants to query catalog data, manufacturing orders, perform batch calculations, user-directory lookups, and meeting notes.
 
 ## Available Tools
 
@@ -31,6 +31,12 @@ The application exposes MCP tools for AI assistants to query catalog data, manuf
 **Knowledge Base (2)**
 - `SearchKnowledgeBase` — semantic search over ingested documents, returns ranked chunks with source references
 - `AskKnowledgeBase` — AI-generated answer grounded in company documents, returns prose answer with cited sources
+
+**Meeting Notes (4)** — read-only; all require the `anela.meetings.read` permission. Per-meeting visibility (Public / Private / Restricted) is enforced per caller, same as the web UI.
+- `ListMeetings` — list meetings (summary level: subject, summary, status, task counts; no raw transcript) with search, status filter, and pagination
+- `GetMeetingSummary` — summary and metadata of a single meeting (no raw transcript, no task detail)
+- `GetMeetingTranscript` — full raw transcript text of a single meeting
+- `GetMeetingTasks` — proposed task list extracted from a single meeting
 
 ## Implementation
 


### PR DESCRIPTION
Exposes the existing MeetingTasks feature to MCP clients via four read-only tools: `ListMeetings`, `GetMeetingSummary`, `GetMeetingTranscript`, and `GetMeetingTasks` — split fine-grained so a client can fetch the summary or task list without pulling the (often large) raw transcript. Each is a thin wrapper over the existing `GetTranscriptList`/`GetTranscriptDetail` MediatR handlers, so per-meeting visibility (Public/Private/Restricted) is enforced by the existing access guard, plus an explicit `anela.meetings.read` permission gate on every tool. No new handlers, repositories, or DB changes. Adds unit tests (param mapping, projection field inclusion/exclusion, FORBIDDEN gating, not-found handling) and updates the MCP server docs.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet format` — clean
- [x] MCP test suite — 81/81 pass (9 new)
- [ ] Manual smoke: call `/mcp` with a valid Entra token; confirm visibility filtering and that a user without `anela.meetings.read` gets FORBIDDEN