### PR TITLE
#3387: fix missing dark mode variants on RecurringJobsPage happy-path

### DIFF
--- a/artifacts/feat-3387/arch-review.r1.md
+++ b/artifacts/feat-3387/arch-review.r1.md
@@ -1,0 +1,93 @@
+# Architecture Review: Dark Mode Fix – RecurringJobsPage Happy-Path Render
+
+## Skip Design: true
+The fix adds two missing Tailwind `dark:` variants to existing elements. No new visual components, layouts, or design decisions are required — the correct tokens are already defined and used correctly on the sibling error and empty-state branches.
+
+## Architectural Fit Assessment
+
+This is a single-file, two-line correctness fix that aligns with ADR-006 (every color-bearing Tailwind class must carry a `dark:` counterpart). The pattern being applied — `text-gray-900 dark:text-graphite-text` for headings and `bg-white shadow dark:bg-graphite-surface dark:shadow-soft-dark` for content cards — is already established in the same file at lines 119 and 123 (error branch) and lines 151 and 155 (empty-state branch). The fix closes the parity gap on the happy-path branch at lines 169 and 173.
+
+All design tokens used (`graphite-text`, `graphite-surface`, `shadow-soft-dark`) are confirmed present in `frontend/tailwind.config.js`. No new tokens, no config changes, and no architectural changes are required.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+RecurringJobsPage.tsx
+  ├── Loading branch  (line 106)  — no color-bearing elements, no changes needed
+  ├── Error branch    (line 114)  — CORRECT: dark: variants present
+  ├── Empty branch    (line 146)  — CORRECT: dark: variants present
+  └── Happy branch    (line 165)  — BROKEN: missing dark: variants on two elements
+        ├── <h1> line 169        — fix: add dark:text-graphite-text
+        └── <div> line 173       — fix: add dark:bg-graphite-surface dark:shadow-soft-dark
+```
+
+### Key Design Decisions
+
+#### Decision 1: Apply tokens that already exist on sibling branches verbatim
+**Options considered:**
+- Add the same `dark:` classes already present on the error and empty-state branches.
+- Audit the file for any other missing variants before making changes.
+
+**Chosen approach:** Apply only the two missing variant pairs identified in the spec; no broader audit in this changeset.
+
+**Rationale:** The spec explicitly scopes this to two elements. An audit of other components or pages is out of scope and belongs in a separate ADR-006 compliance sweep. Surgical changes reduce review surface and risk.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Only one file requires modification:
+
+```
+frontend/src/pages/RecurringJobsPage.tsx
+```
+
+No new files. No directory changes.
+
+### Interfaces and Contracts
+
+No interfaces, types, or API contracts are affected. This is a pure presentational change.
+
+### Data Flow
+
+No data flow changes. The fix is limited to JSX class strings in the return statement of the happy-path render branch.
+
+**Exact changes required:**
+
+**Line 169** — replace:
+```tsx
+<h1 className="text-lg font-semibold text-gray-900">Správa Recurring Jobs</h1>
+```
+with:
+```tsx
+<h1 className="text-lg font-semibold text-gray-900 dark:text-graphite-text">Správa Recurring Jobs</h1>
+```
+
+**Line 173** — replace:
+```tsx
+<div className="flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0">
+```
+with:
+```tsx
+<div className="flex-1 bg-white dark:bg-graphite-surface shadow dark:shadow-soft-dark rounded-lg overflow-hidden flex flex-col min-h-0">
+```
+
+Both changes must match the class order already used on lines 123 and 155 exactly, so diffs stay readable and reviewable.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Typo in token name causing silent light-mode fallback | Low | Tokens `graphite-text`, `graphite-surface`, and `shadow-soft-dark` are all confirmed in `tailwind.config.js`; a typo produces no build error but is caught by visual review in dark mode |
+| Touching wrong branch (error/empty instead of happy-path) | Low | All three render branches share near-identical JSX structure; confirm the edit target is the `return` after line 165, not lines 114–142 or 146–163 |
+| Extraneous class changes invalidating "no other classes changed" acceptance criteria | Low | Limit diff to the two specified elements; do not reformat surrounding code |
+
+## Specification Amendments
+
+None required. The spec is precise and complete for the scope of this change.
+
+## Prerequisites
+
+None. All Tailwind tokens are already registered in `frontend/tailwind.config.js`. No migrations, config updates, or infrastructure changes are needed before implementation can start.

--- a/artifacts/feat-3387/brief.md
+++ b/artifacts/feat-3387/brief.md
@@ -1,0 +1,43 @@
+## Module
+BackgroundJobs (Frontend)
+
+## Finding
+`frontend/src/pages/RecurringJobsPage.tsx` has two elements in the normal (non-error, non-empty) render path that lack `dark:` Tailwind variants, violating ADR-006 which requires every color-bearing class to render correctly in both light and dark mode.
+
+**Line 169 — page heading:**
+```tsx
+<h1>Správa Recurring Jobs</h1>
+```
+Missing: `dark:text-graphite-text`
+
+**Line 173 — main content card:**
+```tsx
+
+```
+Missing: `dark:bg-graphite-surface dark:shadow-soft-dark`
+
+The error-state and empty-state branches for the exact same elements already include the correct variants (lines 119 and 122–123):
+```tsx
+// error state — correct
+<h1>
+
+```
+
+So dark mode works in error/empty but breaks in the happy path: the heading is unreadable and the card background stays white in the dark theme.
+
+## Why it matters
+ADR-006 (accepted 2026-06-25): every component that renders color must render correctly in both light and Graphite dark mode. The happy path is the most-used code path, so broken dark mode here is highly visible.
+
+## Suggested fix
+Apply the missing `dark:` variants to the happy-path heading and card, matching what the error and empty states already do:
+
+```tsx
+// line 169
+<h1>Správa Recurring Jobs</h1>
+
+// line 173
+
+```
+
+---
+_Filed by daily arch-review routine on 2026-06-26._

--- a/artifacts/feat-3387/code-review.r1.md
+++ b/artifacts/feat-3387/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3387/design.r1.md
+++ b/artifacts/feat-3387/design.r1.md
@@ -1,0 +1,50 @@
+# Design: Dark Mode Fix – RecurringJobsPage Happy-Path Render
+
+## UX/UI Design
+
+The fix closes a visual parity gap between the happy-path branch and the already-correct error/empty-state branches of `RecurringJobsPage.tsx`.
+
+**Before (broken)**
+
+```
+Light mode                       Dark mode
+─────────────────────────────    ─────────────────────────────
+[Správa Recurring Jobs]          [Správa Recurring Jobs]   ← gray-900 on dark bg (unreadable)
+┌──────────────────────────┐     ┌──────────────────────────┐
+│  bg-white / shadow       │     │  bg-white / shadow       │  ← white card visible on dark bg
+│  ...table content...     │     │  ...table content...     │
+└──────────────────────────┘     └──────────────────────────┘
+```
+
+**After (fixed)**
+
+```
+Light mode                       Dark mode
+─────────────────────────────    ─────────────────────────────
+[Správa Recurring Jobs]          [Správa Recurring Jobs]   ← graphite-text (readable)
+┌──────────────────────────┐     ┌──────────────────────────┐
+│  bg-white / shadow       │     │  bg-graphite-surface     │  ← surface token + soft-dark shadow
+│  ...table content...     │     │  ...table content...     │
+└──────────────────────────┘     └──────────────────────────┘
+```
+
+No interaction, layout, or spacing changes. The fix is purely additive Tailwind variant pairs.
+
+## Component Design
+
+Only one component is affected.
+
+**`RecurringJobsPage.tsx`** — `frontend/src/pages/RecurringJobsPage.tsx`
+
+The happy-path `return` block (line 165 onward) contains two elements that need dark-mode variants:
+
+| Element | Location | Change |
+|---------|----------|--------|
+| `<h1>` page heading | line 169 | add `dark:text-graphite-text` |
+| Main content `<div>` | line 173 | add `dark:bg-graphite-surface dark:shadow-soft-dark` |
+
+No new components, hooks, or props are introduced. No interface or contract changes.
+
+## Data Schemas
+
+Not applicable — this change is CSS-only with no data layer impact.

--- a/artifacts/feat-3387/impl/add-dark-mode-variants-recurringjobspage.r1.md
+++ b/artifacts/feat-3387/impl/add-dark-mode-variants-recurringjobspage.r1.md
@@ -1,0 +1,36 @@
+# Implementation: add-dark-mode-variants-recurringjobspage
+
+## What was implemented
+
+Added two missing `dark:` Tailwind variants to the happy-path render branch of `RecurringJobsPage.tsx`:
+1. `dark:text-graphite-text` added to the `<h1>` page heading at line 169.
+2. `dark:bg-graphite-surface dark:shadow-soft-dark` added to the main content card `<div>` at line 173.
+
+This brings the happy-path branch into full parity with the already-correct error (lines 119, 123) and empty-state (lines 151, 155) branches.
+
+## Files created/modified
+- `frontend/src/pages/RecurringJobsPage.tsx` — two className strings updated in the happy-path return block
+
+## Tests
+
+No new tests required — this is a pure CSS class fix with no logic changes. Covered by `npm run build` and `npm run lint`.
+
+## How to verify
+
+1. Run `npm run build` from the `frontend/` directory — must pass with no errors.
+2. Run `npm run lint` — must produce no new warnings.
+3. Enable Graphite dark mode in the browser, navigate to the RecurringJobs page with jobs present — the heading must render in `graphite-text` colour and the card background must be `graphite-surface`.
+
+## Notes
+
+Changes are exact mirrors of the error and empty-state branches. No other elements were touched.
+
+## PR Summary
+
+Fixed broken dark mode on the happy-path render branch of `RecurringJobsPage` by adding two missing `dark:` Tailwind variant pairs. The page heading and main content card were rendering with light-mode-only classes (`text-gray-900`, `bg-white shadow`) when jobs were present, making the page unreadable in the Graphite dark theme on its most-used code path.
+
+### Changes
+- `frontend/src/pages/RecurringJobsPage.tsx` — added `dark:text-graphite-text` to `<h1>` line 169 and `dark:bg-graphite-surface dark:shadow-soft-dark` to outer content `<div>` line 173
+
+## Status
+DONE

--- a/artifacts/feat-3387/review/add-dark-mode-variants-recurringjobspage.r1.md
+++ b/artifacts/feat-3387/review/add-dark-mode-variants-recurringjobspage.r1.md
@@ -1,0 +1,14 @@
+# Code Review: add-dark-mode-variants-recurringjobspage
+
+## Summary
+
+Both dark mode Tailwind variants are confirmed present in the worktree at the correct lines. Line 169 contains `dark:text-graphite-text` and line 173 contains `dark:bg-graphite-surface dark:shadow-soft-dark`. The changes match the error and empty-state branches exactly, satisfying ADR-006. All acceptance criteria are met.
+
+## Review Result: PASS
+
+### task: add-dark-mode-variants-recurringjobspage
+**Status:** PASS
+
+## Overall Notes
+
+The implementation is a minimal, surgical two-line fix. The tokens used (`graphite-text`, `graphite-surface`, `shadow-soft-dark`) are confirmed present in `tailwind.config.js`. No logic was changed; no tests are required.

--- a/artifacts/feat-3387/spec.r1.md
+++ b/artifacts/feat-3387/spec.r1.md
@@ -1,0 +1,71 @@
+# Specification: Dark Mode Fix – RecurringJobsPage Happy-Path Render
+
+## Summary
+
+The happy-path (normal, data-populated) render branch of `RecurringJobsPage.tsx` omits `dark:` Tailwind variants on the page heading and the main content card, causing a broken Graphite dark-mode experience on the most-used code path. This fix adds the two missing variant pairs to bring the happy-path branch into parity with the already-correct error and empty-state branches, satisfying ADR-006.
+
+## Background
+
+ADR-006 (accepted 2026-06-25) mandates that every color-bearing Tailwind class must have a corresponding `dark:` variant so the component renders correctly in both light mode and Graphite dark mode. The error-state and empty-state branches of `RecurringJobsPage` were written with full dark-mode support. The happy-path branch — introduced separately or overlooked during review — was not updated to match. Because the happy path is the default state for any user who has recurring jobs configured, the broken dark mode is prominently visible in normal production use.
+
+## Functional Requirements
+
+### FR-1: Happy-path heading renders correctly in dark mode
+
+The `<h1>` element on line 169 of `frontend/src/pages/RecurringJobsPage.tsx` must include `dark:text-graphite-text` alongside its existing `text-gray-900` class.
+
+**Acceptance criteria:**
+- In Graphite dark mode, the "Správa Recurring Jobs" heading is rendered in `graphite-text` colour (not the light-mode `gray-900` colour).
+- The fix matches exactly what the error-state heading on line 119 and the empty-state heading on line 151 already render.
+- No other classes on the element are changed.
+
+### FR-2: Happy-path content card renders correctly in dark mode
+
+The outer content `<div>` on line 173 must include `dark:bg-graphite-surface` and `dark:shadow-soft-dark` alongside its existing `bg-white` and `shadow` classes.
+
+**Acceptance criteria:**
+- In Graphite dark mode, the content card background is `graphite-surface` (not white).
+- In Graphite dark mode, the card shadow resolves to the `soft-dark` token.
+- The fix matches exactly what the error-state card on line 123 and the empty-state card on line 155 already render.
+- No other classes on the element are changed.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+No performance impact. The change is purely additive Tailwind class tokens; no runtime logic is modified.
+
+### NFR-2: Security
+
+No security implications. The change is limited to CSS utility classes.
+
+### NFR-3: Consistency
+
+The corrected classes must exactly mirror the tokens used in the error and empty-state branches of the same component. No new design tokens are introduced.
+
+## Data Model
+
+Not applicable. This change does not touch data, state, or API contracts.
+
+## API / Interface Design
+
+Not applicable. This is a pure styling fix with no API or interface changes.
+
+## Dependencies
+
+- Tailwind CSS with the project's custom Graphite design token configuration (already present; tokens `graphite-text`, `graphite-surface`, and `shadow-soft-dark` are defined and used elsewhere in the same file).
+- ADR-006 (dark mode policy).
+
+## Out of Scope
+
+- Dark-mode audit of any other component or page.
+- Changes to the error-state or empty-state branches (already correct).
+- Changes to any element inside the happy-path render other than the two identified elements (heading and outer content card).
+- Design-token changes or additions.
+- Any backend, test, or build changes.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-06-27T08:16:43.305947Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-27T08:16:46.317585Z"
+      "status": "completed",
+      "updated_at": "2026-06-27T08:18:06.500060Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-27T08:18:19.496357Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-06-27T08:18:06.500060Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-27T08:18:19.496357Z"
+      "status": "completed",
+      "updated_at": "2026-06-27T08:19:07.566958Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-27T08:19:10.410076Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-06-27T08:19:07.566958Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-27T08:19:10.410076Z"
+      "status": "completed",
+      "updated_at": "2026-06-27T08:19:46.140042Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-dark-mode-variants-recurringjobspage",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-27T08:19:46.140042Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-27T08:20:04.884744Z"
     }
   },
   "tasks": [
     {
       "name": "add-dark-mode-variants-recurringjobspage",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-27T08:20:05.169483Z"
     }
   ]
 }

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-27T08:15:32.947218Z"
+      "status": "completed",
+      "updated_at": "2026-06-27T08:16:43.305947Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-27T08:16:46.317585Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3387",
+  "issue_number": 3387,
+  "created_at": "2026-06-27T08:14:41.157006Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-27T08:15:32.947218Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-06-27T08:22:02.484490Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-27T08:22:07.046352Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3387/state.json
+++ b/artifacts/feat-3387/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-27T08:19:46.140042Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-27T08:20:04.884744Z"
+      "status": "completed",
+      "updated_at": "2026-06-27T08:22:02.484490Z"
     }
   },
   "tasks": [
     {
       "name": "add-dark-mode-variants-recurringjobspage",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-27T08:20:05.169483Z"
+      "updated_at": "2026-06-27T08:21:57.761336Z"
     }
   ]
 }

--- a/artifacts/feat-3387/task-context/add-dark-mode-variants-recurringjobspage.md
+++ b/artifacts/feat-3387/task-context/add-dark-mode-variants-recurringjobspage.md
@@ -1,0 +1,16 @@
+### task: add-dark-mode-variants-recurringjobspage
+
+**Goal:** Make the page heading and main content card respect dark mode on the happy-path render branch.
+
+**Files to change:**
+- `frontend/src/pages/RecurringJobsPage.tsx` — add two `dark:` Tailwind variants (lines 169 and 173)
+
+**Implementation steps:**
+1. On line 169, change the `<h1>` className from `"text-lg font-semibold text-gray-900"` to `"text-lg font-semibold text-gray-900 dark:text-graphite-text"`.
+2. On line 173, change the wrapping `<div>` className from `"flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0"` to `"flex-1 bg-white dark:bg-graphite-surface shadow dark:shadow-soft-dark rounded-lg overflow-hidden flex flex-col min-h-0"`.
+
+**Acceptance criteria:**
+- `frontend/src/pages/RecurringJobsPage.tsx` line 169 contains `dark:text-graphite-text`.
+- `frontend/src/pages/RecurringJobsPage.tsx` line 173 contains both `dark:bg-graphite-surface` and `dark:shadow-soft-dark`.
+- `npm run build` passes with no errors.
+- `npm run lint` passes with no warnings introduced by this change.

--- a/artifacts/feat-3387/task-plan.r1.md
+++ b/artifacts/feat-3387/task-plan.r1.md
@@ -1,0 +1,22 @@
+# Task Plan: Dark Mode Fix – RecurringJobsPage Happy-Path Render
+
+## Overview
+
+Two Tailwind `dark:` variants are missing from the happy-path render branch of `RecurringJobsPage.tsx`. The fix adds `dark:text-graphite-text` to the page heading and `dark:bg-graphite-surface dark:shadow-soft-dark` to the main content card. No new files, no structural changes.
+
+### task: add-dark-mode-variants-recurringjobspage
+
+**Goal:** Make the page heading and main content card respect dark mode on the happy-path render branch.
+
+**Files to change:**
+- `frontend/src/pages/RecurringJobsPage.tsx` — add two `dark:` Tailwind variants (lines 169 and 173)
+
+**Implementation steps:**
+1. On line 169, change the `<h1>` className from `"text-lg font-semibold text-gray-900"` to `"text-lg font-semibold text-gray-900 dark:text-graphite-text"`.
+2. On line 173, change the wrapping `<div>` className from `"flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0"` to `"flex-1 bg-white dark:bg-graphite-surface shadow dark:shadow-soft-dark rounded-lg overflow-hidden flex flex-col min-h-0"`.
+
+**Acceptance criteria:**
+- `frontend/src/pages/RecurringJobsPage.tsx` line 169 contains `dark:text-graphite-text`.
+- `frontend/src/pages/RecurringJobsPage.tsx` line 173 contains both `dark:bg-graphite-surface` and `dark:shadow-soft-dark`.
+- `npm run build` passes with no errors.
+- `npm run lint` passes with no warnings introduced by this change.

--- a/frontend/src/pages/RecurringJobsPage.tsx
+++ b/frontend/src/pages/RecurringJobsPage.tsx
@@ -166,11 +166,11 @@ const RecurringJobsPage: React.FC = () => {
     <div className="flex flex-col h-full w-full">
       {/* Header - Fixed, title only */}
       <div className="flex-shrink-0 mb-3">
-        <h1 className="text-lg font-semibold text-gray-900">Správa Recurring Jobs</h1>
+        <h1 className="text-lg font-semibold text-gray-900 dark:text-graphite-text">Správa Recurring Jobs</h1>
       </div>
 
       {/* Main Content - Scrollable */}
-      <div className="flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0">
+      <div className="flex-1 bg-white dark:bg-graphite-surface shadow dark:shadow-soft-dark rounded-lg overflow-hidden flex flex-col min-h-0">
         {/* Action bar inside content */}
         <div className="px-6 py-4 border-b border-gray-200 dark:border-graphite-border flex items-center justify-between">
           <div className="flex items-center">


### PR DESCRIPTION
Closes #3387

## What the issue was

The happy-path (data-populated) render branch of `RecurringJobsPage.tsx` was missing `dark:` Tailwind variants on the page heading and the main content card. In Graphite dark mode, the heading rendered as unreadable `gray-900` text and the card background stayed white — breaking dark mode on the most-used code path. The error and empty-state branches were already correct.

This violates ADR-006 (accepted 2026-06-25): every color-bearing Tailwind class must have a corresponding `dark:` variant.

## How it was fixed

Two surgical class-string edits to `frontend/src/pages/RecurringJobsPage.tsx`:

- **Line 169 `<h1>`** — added `dark:text-graphite-text` to match the error-state heading (line 119) and empty-state heading (line 151).
- **Line 173 `<div>`** — added `dark:bg-graphite-surface dark:shadow-soft-dark` to match the error-state card (line 123) and empty-state card (line 155).

No logic changes, no new tokens, no other files touched.

## Artifacts

Brief, spec, architecture review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3387/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2aj4a3UP41YPP2383SZNq)_