### PR TITLE
#3394: Move BankStatementsController exception handling to global middleware

### DIFF
--- a/artifacts/feat-3394/arch-review.r1.md
+++ b/artifacts/feat-3394/arch-review.r1.md
@@ -1,0 +1,119 @@
+# Architecture Review: Remove Inline Exception Handling from BankStatementsController
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a pure refactoring within an already-established pattern. The codebase already has `IExceptionHandler`, `AddExceptionHandler<T>()`, `AddProblemDetails()`, and `app.UseExceptionHandler()` fully wired. The existing `UnauthorizedAccessExceptionHandler` provides a direct template for both new handlers. No new concepts are introduced; this is mechanical extraction.
+
+The spec is correct and complete. The two exception types (`ArgumentException`, `FluentValidation.ValidationException`) are genuinely cross-cutting concerns and do not belong in the controller.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Infrastructure/ExceptionHandling/
+├── UnauthorizedAccessExceptionHandler.cs   (existing)
+├── ArgumentExceptionHandler.cs             (new)
+└── ValidationExceptionHandler.cs           (new)
+```
+
+Both new handlers follow the identical shape of `UnauthorizedAccessExceptionHandler`: implement `IExceptionHandler`, inject `ILogger<T>`, write a ProblemDetails response via `httpContext.Response.WriteAsJsonAsync(...)`, return `true`.
+
+### Key Design Decisions
+
+**Registration order matters.** ASP.NET Core tries handlers in registration order and stops at the first that returns `true`. `ArgumentException` and `ValidationException` must come after `UnauthorizedAccessExceptionHandler`. None of these exception types share an inheritance relationship, so their relative order is immaterial, but `ValidationExceptionHandler` is registered before `ArgumentExceptionHandler` for clarity.
+
+**ValidationException error shape.** Populated from `ValidationException.Errors` (`IEnumerable<ValidationFailure>`). Map to an anonymous type — records are acceptable for internal domain use since this is not a DTO crossing the OpenAPI boundary.
+
+**ArgumentExceptionHandler scope.** `ArgumentException` is a broad base type — `ArgumentNullException`, `ArgumentOutOfRangeException` etc. all derive from it. This is intentional and appropriate for the current use case. Subclass handlers can be inserted ahead of `ArgumentExceptionHandler` in the chain if tighter scoping is ever needed.
+
+**Logging level.** Both handlers log at Warning. This aligns with `UnauthorizedAccessExceptionHandler` — client-induced errors warrant Warning, not Error, since they reflect bad input rather than system faults.
+
+**No status code override on ValidationException.** Map to 400 (not 422), consistent with existing project convention.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New files:
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs`
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ValidationExceptionHandler.cs`
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs`
+
+Modified files:
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+### Interfaces and Contracts
+
+Both handlers implement `Microsoft.AspNetCore.Diagnostics.IExceptionHandler` (same interface as `UnauthorizedAccessExceptionHandler`).
+
+`ArgumentExceptionHandler` response shape:
+```json
+{
+  "status": 400,
+  "title": "Bad Request",
+  "detail": "<exception.Message>",
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1"
+}
+```
+
+`ValidationExceptionHandler` response shape:
+```json
+{
+  "status": 400,
+  "title": "Validation Failed",
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "extensions": {
+    "errors": [
+      { "propertyName": "Amount", "errorMessage": "Must be greater than zero." }
+    ]
+  }
+}
+```
+
+Use `Microsoft.AspNetCore.Mvc.ProblemDetails` to construct responses.
+
+### Data Flow
+
+```
+Request → Controller (dispatches MediatR, no try/catch)
+              ↓ exception thrown
+         UseExceptionHandler middleware
+              ↓
+         UnauthorizedAccessExceptionHandler  → handled if UnauthorizedAccessException
+              ↓ not handled
+         ValidationExceptionHandler          → handled if ValidationException
+              ↓ not handled
+         ArgumentExceptionHandler            → handled if ArgumentException
+              ↓ not handled
+         ASP.NET Core default problem details response (500)
+```
+
+### Test Pattern
+
+Follow `UnauthorizedAccessExceptionHandlerTests.cs` exactly:
+- Arrange: `DefaultHttpContext` with `MemoryStream` on `Response.Body`
+- Act: call `TryHandleAsync(...)` with a constructed exception instance
+- Assert: `result == true`, deserialize body JSON, verify status code and field values
+
+For `ValidationExceptionHandler` tests, construct `ValidationException` with a list of `ValidationFailure` objects and assert the `errors` array in the response body. Also test the empty-errors case.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `ArgumentException` is too broad — catches exceptions that should propagate | Low | Current usage in `ImportStatements` is intentional. Register a more specific handler before `ArgumentExceptionHandler` if needed. |
+| Registration order silently broken by future insertions | Low | Add a comment in `ServiceCollectionExtensions.cs` noting that handler order is significant. |
+| `ValidationException.Errors` is null or empty in edge cases | Low | Guard with null-coalescing to empty array; test the empty-errors case explicitly. |
+
+## Specification Amendments
+
+None. The spec is self-consistent and complete. No additions or changes are needed.
+
+## Prerequisites
+
+None. All infrastructure (`IExceptionHandler`, `AddProblemDetails`, `UseExceptionHandler`) is already in place. Implementation can begin immediately.

--- a/artifacts/feat-3394/brief.md
+++ b/artifacts/feat-3394/brief.md
@@ -1,0 +1,25 @@
+## Module
+Bank
+
+## Finding
+`BankStatementsController` in `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` contains try/catch blocks in two of its three action methods:
+
+- `ImportStatements` (lines 44–69): catches `ArgumentException` → `BadRequest(new { message })`, catches `Exception` → `StatusCode(500, new { message })`.
+- `GetBankStatements` (lines 102–134): catches `FluentValidation.ValidationException` → `BadRequest(new { message, errors })`, catches `Exception` → `StatusCode(500, new { message })`.
+
+The third action, `GetBankStatement` (lines 143–150), has no try/catch at all — an inconsistency within the same controller.
+
+The project rule is "Business logic must be in MediatR handlers, NOT in controllers". Mapping exceptions to HTTP response shapes is exception-to-HTTP translation that controllers should not own. It causes two concrete problems here:
+1. The `ArgumentException` for an unknown account name is a domain signal; catching it in the controller means the response shape is controller-specific rather than consistent across the API.
+2. The `FluentValidation.ValidationException` catch in `GetBankStatements` duplicates logic that a shared problem-details filter would handle uniformly for every endpoint.
+
+## Why it matters
+- Inconsistency: one action handles errors; another doesn't. A future developer adding error handling to `GetBankStatement` will pick a different style.
+- Fragility: the anonymous `{ message }` and `{ message, errors }` response shapes are invisible to the OpenAPI spec and the generated TypeScript client.
+- Duplication: every controller that catches exceptions inline re-implements the same mapping — already seen across multiple modules.
+
+## Suggested fix
+Remove the try/catch blocks from the controller actions. Register a global exception handler (e.g. `app.UseExceptionHandler` with `IProblemDetailsService`, or an `IExceptionFilter`) that maps `ArgumentException` → 400 and unhandled exceptions → 500 using `ProblemDetails`. The `FluentValidation.ValidationException` path is already handled by the `ValidationBehavior` MediatR pipeline — the catch in the controller is redundant if a global handler exists.
+
+---
+_Filed by daily arch-review routine on 2026-06-27._

--- a/artifacts/feat-3394/code-review.r1.md
+++ b/artifacts/feat-3394/code-review.r1.md
@@ -1,0 +1,15 @@
+# Code Review: feat-3394 — Remove Inline Exception Handling from BankStatementsController
+
+## Summary
+The implementation correctly moves exception-to-HTTP translation out of the controller and into global `IExceptionHandler` implementations. The pattern is well-applied. One blocking security finding: `ArgumentExceptionHandler` accepts `ArgumentNullException` subclasses whose message text reveals internal parameter names (e.g. `"Value cannot be null. (Parameter 'mediator')`).
+
+## Review Result: CHANGES_REQUESTED
+
+### Blocking
+
+- **ArgumentExceptionHandler accepts ArgumentNullException** — `ArgumentNullException` is a subclass of `ArgumentException`. Its `.Message` typically contains internal parameter names (e.g. the constructor guard `throw new ArgumentNullException(nameof(mediator))` produces `"Value cannot be null. (Parameter 'mediator')"`) which must never be surfaced to API clients in the `detail` field. The handler must exclude `ArgumentNullException` so that class falls through to the default 500 handler. Fix: add `|| exception is ArgumentNullException` to the early-return guard.
+
+### Advisory
+
+- **Validation error property casing**: The old controller emitted `PropertyName`/`ErrorMessage` directly from `ValidationFailure` members. Whether ASP.NET Core serialized these as PascalCase or camelCase depends on the global `JsonSerializerOptions`. The new handler explicitly emits camelCase (`propertyName`/`errorMessage`) via an anonymous type with lowercase-named properties. This is consistent with the project's camelCase convention and is the correct behavior. No change needed; noted for awareness.
+- **Test file stubs in diff**: The diff submission truncated the test files to comments. Actual test files exist with full `[Fact]` methods (verified: all 9 ExceptionHandling tests pass).

--- a/artifacts/feat-3394/code-review.r2.md
+++ b/artifacts/feat-3394/code-review.r2.md
@@ -1,0 +1,13 @@
+# Code Review: feat-3394 (Round 2)
+
+## Summary
+Security fix from round 1 has been applied and committed. `ArgumentExceptionHandler` now correctly excludes `ArgumentNullException` via `|| exception is ArgumentNullException` guard. Test updated to verify `ArgumentNullException` falls through (returns false, writes no body). All 9 ExceptionHandling tests pass. Build clean.
+
+## Review Result: CLEAN
+
+No blocking findings remain. The implementation is ready for merge.
+
+### Advisory
+
+- Validation error JSON casing: The new handler explicitly emits `propertyName`/`errorMessage` (camelCase) via anonymous type. The old controller also produced camelCase via ASP.NET Core's `JsonSerializerOptions`. No regression.
+- All uncommitted changes (handler fix + test fix) were committed in `f27a0a2` before this round.

--- a/artifacts/feat-3394/impl/implement-controller-cleanup.r1.md
+++ b/artifacts/feat-3394/impl/implement-controller-cleanup.r1.md
@@ -1,0 +1,16 @@
+# Implementation: implement-controller-cleanup
+
+## What was implemented
+Removed inline try/catch blocks from `ImportStatements` and `GetBankStatements` in `BankStatementsController`. Exception handling now delegates to the global `ArgumentExceptionHandler` and `ValidationExceptionHandler`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` — Removed `try/catch (ArgumentException)/catch (Exception)` from `ImportStatements`; removed `try/catch (FluentValidation.ValidationException)/catch (Exception)` from `GetBankStatements`. Retained `_logger.LogInformation(...)` calls in both methods.
+
+## How to verify
+- `BankStatementsController` contains no `catch` blocks
+- `_logger.LogInformation(...)` still present in `ImportStatements` and `GetBankStatements`
+- `dotnet build` succeeds (verified: 0 errors)
+- `dotnet format --verify-no-changes` passes (verified: exit code 0)
+
+## Status
+DONE

--- a/artifacts/feat-3394/impl/implement-exception-handlers.r1.md
+++ b/artifacts/feat-3394/impl/implement-exception-handlers.r1.md
@@ -1,0 +1,22 @@
+# Implementation: implement-exception-handlers
+
+## What was implemented
+Created `ArgumentExceptionHandler` and `ValidationExceptionHandler` following the established `UnauthorizedAccessExceptionHandler` pattern, and registered both in `AddCrossCuttingServices()`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs` — Maps `ArgumentException` → 400 ProblemDetails with `detail: ex.Message`
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ValidationExceptionHandler.cs` — Maps `FluentValidation.ValidationException` → 400 ProblemDetails with `extensions.errors` array
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — Registered both handlers in correct order after `UnauthorizedAccessExceptionHandler`
+
+## Tests
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs`
+
+## How to verify
+```
+dotnet test --filter "FullyQualifiedName~ExceptionHandling"
+```
+All 9 ExceptionHandling tests pass.
+
+## Status
+DONE

--- a/artifacts/feat-3394/impl/implement-tests.r1.md
+++ b/artifacts/feat-3394/impl/implement-tests.r1.md
@@ -1,0 +1,17 @@
+# Implementation: implement-tests
+
+## What was implemented
+Created unit tests for `ArgumentExceptionHandler` and `ValidationExceptionHandler` following the exact pattern from `UnauthorizedAccessExceptionHandlerTests.cs`.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs` — 3 tests: Returns400WithProblemDetails (verifies status 400, title, detail), WhenArgumentNullException_Returns400 (subclass handling), WhenOtherException_ReturnsFalseAndDoesNotWriteBody
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs` — 3 tests: Returns400WithProblemDetails (verifies status 400, title), ExposesErrorsInExtensions (verifies errors array with propertyName+errorMessage), WhenOtherException_ReturnsFalseAndDoesNotWriteBody
+
+## How to verify
+```
+dotnet test --filter "FullyQualifiedName~ExceptionHandling"
+```
+All 9 ExceptionHandling tests pass (6 new + 3 existing).
+
+## Status
+DONE

--- a/artifacts/feat-3394/review/implement-controller-cleanup.r1.md
+++ b/artifacts/feat-3394/review/implement-controller-cleanup.r1.md
@@ -1,0 +1,16 @@
+# Code Review: implement-controller-cleanup
+
+## Summary
+The `BankStatementsController` cleanup is correct and complete. Both try/catch blocks have been removed, the `_logger.LogInformation(...)` calls are retained in both methods, and the controller now delegates all exception handling to the global middleware. No catch blocks remain.
+
+## Review Result: PASS
+
+### task: implement-controller-cleanup
+**Status:** PASS
+
+## Overall Notes
+- `ImportStatements`: try/catch removed, LogInformation retained, method is now a clean dispatch.
+- `GetBankStatements`: try/catch removed, LogInformation retained, method is now a clean dispatch.
+- `GetBankStatement`: unchanged (was already correct).
+- No unused imports remain.
+- `dotnet build`: 0 errors. `dotnet format --verify-no-changes`: exit code 0.

--- a/artifacts/feat-3394/review/implement-exception-handlers.r1.md
+++ b/artifacts/feat-3394/review/implement-exception-handlers.r1.md
@@ -1,0 +1,15 @@
+# Code Review: implement-exception-handlers
+
+## Summary
+The implementation correctly creates `ArgumentExceptionHandler` and `ValidationExceptionHandler` following the established `UnauthorizedAccessExceptionHandler` pattern. Both handlers implement `IExceptionHandler`, log at Warning level, write ProblemDetails responses, and are registered in the correct order. All acceptance criteria are met.
+
+## Review Result: PASS
+
+### task: implement-exception-handlers
+**Status:** PASS
+
+## Overall Notes
+- `ArgumentExceptionHandler` correctly includes `Detail = ex.Message` to preserve the user-facing error message, which the original controller also exposed.
+- `ValidationExceptionHandler` correctly populates `Extensions["errors"]` with `propertyName`/`errorMessage` objects.
+- Registration order (Unauthorized → Validation → Argument) is documented with a comment.
+- `dotnet build`: 0 errors. `dotnet format --verify-no-changes`: exit code 0. All 9 ExceptionHandling tests pass.

--- a/artifacts/feat-3394/review/implement-tests.r1.md
+++ b/artifacts/feat-3394/review/implement-tests.r1.md
@@ -1,0 +1,15 @@
+# Code Review: implement-tests
+
+## Summary
+Unit tests for both new handlers are complete and follow the `UnauthorizedAccessExceptionHandlerTests` pattern exactly. All 6 new tests are meaningful and cover the required scenarios. All 9 ExceptionHandling tests pass.
+
+## Review Result: PASS
+
+### task: implement-tests
+**Status:** PASS
+
+## Overall Notes
+- `ArgumentExceptionHandlerTests`: Tests for 400 with correct ProblemDetails shape, ArgumentNullException subclass handling, and non-matching exception.
+- `ValidationExceptionHandlerTests`: Tests for 400 with correct ProblemDetails shape, errors extension array with propertyName/errorMessage fields, and non-matching exception.
+- No tests use `Skip` or `[Ignore]`.
+- All 9 ExceptionHandling tests pass.

--- a/artifacts/feat-3394/spec.r1.md
+++ b/artifacts/feat-3394/spec.r1.md
@@ -1,0 +1,157 @@
+# Specification: Remove Inline Exception Handling from BankStatementsController
+
+## Summary
+
+Two of the three action methods in `BankStatementsController` contain inline try/catch blocks that perform exception-to-HTTP translation, duplicating logic that belongs in the global exception-handling infrastructure. This specification covers adding two new `IExceptionHandler` implementations — one for `ArgumentException` and one for `FluentValidation.ValidationException` — and removing the redundant try/catch blocks from the controller, leaving the controller responsible only for dispatching MediatR requests and returning their results.
+
+## Background
+
+The project rule is that business logic must live in MediatR handlers, not in controllers. Exception-to-HTTP mapping is a cross-cutting infrastructure concern and is already partially solved: `UnauthorizedAccessExceptionHandler` demonstrates the established pattern, `app.UseExceptionHandler()` is already wired into the pipeline, and `services.AddProblemDetails()` is already called.
+
+The current state in `BankStatementsController` has three concrete problems:
+
+1. `ImportStatements` (lines 44–69) catches `ArgumentException` and returns `BadRequest(new { message })` — an anonymous shape invisible to OpenAPI and the generated TypeScript client.
+2. `GetBankStatements` (lines 102–134) catches `FluentValidation.ValidationException` and returns `BadRequest(new { message, errors })` — also an anonymous shape, and redundant because `ValidationBehavior` in the MediatR pipeline already throws this exception; a global handler already handles it correctly everywhere else.
+3. `GetBankStatement` (lines 143–150) has no try/catch at all, creating an inconsistency within the same controller.
+
+## Functional Requirements
+
+### FR-1: ArgumentExceptionHandler — global mapping of ArgumentException to 400 ProblemDetails
+
+Add a new `IExceptionHandler` class `ArgumentExceptionHandler` in `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/` that:
+
+- Matches `ArgumentException` (and subclasses, e.g. `ArgumentNullException`, `ArgumentOutOfRangeException`).
+- Sets the HTTP status code to 400 Bad Request.
+- Writes a `ProblemDetails` response body with:
+  - `Status`: 400
+  - `Title`: `"Bad Request"`
+  - `Detail`: the exception's `Message` property
+  - `Type`: `"https://tools.ietf.org/html/rfc7231#section-6.5.1"`
+- Logs the exception at `Warning` level using the injected `ILogger<ArgumentExceptionHandler>`.
+- Returns `true` to signal that the exception has been handled.
+
+**Acceptance criteria:**
+- A request to `POST /api/bank-statements/import` with an unknown account name results in HTTP 400 with `Content-Type: application/problem+json` and `status: 400` in the body.
+- The server log contains a `Warning`-level entry with the exception details.
+
+### FR-2: ValidationExceptionHandler — global mapping of FluentValidation.ValidationException to 400 ProblemDetails
+
+Add a new `IExceptionHandler` class `ValidationExceptionHandler` in `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/` that:
+
+- Matches `FluentValidation.ValidationException` exactly.
+- Sets the HTTP status code to 400 Bad Request.
+- Writes a `ProblemDetails` response body with:
+  - `Status`: 400
+  - `Title`: `"Validation Failed"`
+  - `Type`: `"https://tools.ietf.org/html/rfc7231#section-6.5.1"`
+  - An `Extensions` entry keyed `"errors"` containing a list of objects with `propertyName` and `errorMessage` fields derived from `exception.Errors`.
+- Logs the exception at `Warning` level using the injected `ILogger<ValidationExceptionHandler>`.
+- Returns `true` to signal that the exception has been handled.
+
+**Acceptance criteria:**
+- A request to `GET /api/bank-statements` with invalid query parameters results in HTTP 400 with `Content-Type: application/problem+json` and an `errors` extension array.
+
+### FR-3: Register the new handlers in the correct order
+
+In `ServiceCollectionExtensions.AddCrossCuttingServices()`, register after existing `UnauthorizedAccessExceptionHandler`:
+
+```
+services.AddExceptionHandler<UnauthorizedAccessExceptionHandler>();  // existing — 401
+services.AddExceptionHandler<ValidationExceptionHandler>();           // new — FluentValidation 400
+services.AddExceptionHandler<ArgumentExceptionHandler>();             // new — ArgumentException 400
+services.AddProblemDetails();                                         // existing
+```
+
+**Acceptance criteria:**
+- `dotnet build` succeeds without errors.
+
+### FR-4: Remove try/catch blocks from BankStatementsController
+
+In `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`:
+
+**`ImportStatements`:** Remove the outer `try/catch (ArgumentException)/catch (Exception)` wrapper. Retain the `_logger.LogInformation(…)` call. Method becomes a straight-line dispatch.
+
+**`GetBankStatements`:** Remove the outer `try/catch (FluentValidation.ValidationException)/catch (Exception)` wrapper. Retain the `_logger.LogInformation(…)` call.
+
+**`GetBankStatement`:** No change required.
+
+The `_logger` field remains and is used for the retained `LogInformation` calls.
+
+**Acceptance criteria:**
+- `BankStatementsController` contains no `catch` blocks.
+- `dotnet build` succeeds.
+- `dotnet format` produces no diff.
+
+## Non-Functional Requirements
+
+### NFR-1: Consistency
+After this change, all three action methods handle errors identically: by not catching them at the controller level.
+
+### NFR-2: Logging parity
+- `ArgumentExceptionHandler`: `Warning` with exception (preserves removed `LogWarning` in `ImportStatements`).
+- `ValidationExceptionHandler`: `Warning` with exception (preserves removed `LogWarning` in `GetBankStatements`).
+- Generic catch (Exception) → 500: ASP.NET's built-in fallback inside `UseExceptionHandler()` already logs at `Error` level.
+
+### NFR-3: No new NuGet packages
+All required types (`IExceptionHandler`, `ProblemDetails`, `ValidationException`) are already project dependencies.
+
+## Data Model
+
+No database schema changes.
+
+ProblemDetails shape used by both handlers (RFC 7807):
+```
+{
+  type:     string,
+  title:    string,
+  status:   int,
+  detail:   string?,    // ArgumentExceptionHandler: exception.Message; ValidationExceptionHandler: omitted
+  extensions: {
+    errors: [{ propertyName: string, errorMessage: string }]  // ValidationExceptionHandler only
+  }
+}
+```
+
+## API / Interface Design
+
+No new endpoints. Error response shape changes for existing endpoints:
+
+| Endpoint | Before | After |
+|---|---|---|
+| `POST /api/bank-statements/import` (ArgumentException) | `{ "message": "..." }` | ProblemDetails 400 with `detail` |
+| `GET /api/bank-statements` (ValidationException) | `{ "message": "Invalid request", "errors": [...] }` | ProblemDetails 400 with `extensions.errors` |
+
+New files:
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs`
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ValidationExceptionHandler.cs`
+
+Modified files:
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+Test files to add:
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs`
+
+## Dependencies
+
+- `Microsoft.AspNetCore.Diagnostics` — `IExceptionHandler` (already used)
+- `Microsoft.AspNetCore.Mvc` — `ProblemDetails` (already registered)
+- `FluentValidation` — `ValidationException` (already a project dependency)
+- No new NuGet packages required.
+
+## Out of Scope
+
+- Removing try/catch blocks from other controllers (future follow-up).
+- Adding `[ProducesResponseType]` attributes to action methods.
+- Replacing `ArgumentException` in `ImportBankStatementHandler` with a domain exception type.
+- Frontend error-handling changes beyond ensuring `npm run build` succeeds.
+
+## Open Questions
+
+None. Assumptions made:
+1. `[ProducesResponseType]` decoration is out of scope per brief.
+2. `ArgumentNullException` from DI constructor guards fires at DI resolution time, before the request pipeline; it will never reach `UseExceptionHandler`. The handler correctly catches argument exceptions from MediatR handlers only.
+3. Frontend `useBankStatements.ts` uses `as any` casts and manual DTO types (issue #3395); the error shape change is acceptable. The frontend currently does not strongly type error responses from these endpoints.
+
+## Status: COMPLETE

--- a/artifacts/feat-3394/state.json
+++ b/artifacts/feat-3394/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-06-28T06:35:24.501388Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-28T06:35:44.850957Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3394/state.json
+++ b/artifacts/feat-3394/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-28T06:16:11.504792Z"
+      "status": "completed",
+      "updated_at": "2026-06-28T06:19:11.957787Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-28T06:19:18.189046Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3394/state.json
+++ b/artifacts/feat-3394/state.json
@@ -21,28 +21,28 @@
       "updated_at": "2026-06-28T06:23:06.377500Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-28T06:23:55.519109Z"
+      "status": "completed",
+      "updated_at": "2026-06-28T06:35:24.501388Z"
     }
   },
   "tasks": [
     {
       "name": "implement-exception-handlers",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-28T06:23:55.748505Z"
+      "updated_at": "2026-06-28T06:35:23.372863Z"
     },
     {
       "name": "implement-controller-cleanup",
-      "status": "pending",
+      "status": "completed",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-28T06:35:23.826577Z"
     },
     {
       "name": "implement-tests",
-      "status": "pending",
+      "status": "completed",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-28T06:35:24.281717Z"
     }
   ]
 }

--- a/artifacts/feat-3394/state.json
+++ b/artifacts/feat-3394/state.json
@@ -17,13 +17,32 @@
       "updated_at": "2026-06-28T06:20:44.944985Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-28T06:20:45.232740Z"
+      "status": "completed",
+      "updated_at": "2026-06-28T06:23:06.377500Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "implement-exception-handlers",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "implement-controller-cleanup",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "implement-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3394/state.json
+++ b/artifacts/feat-3394/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-28T06:23:06.377500Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-28T06:23:55.519109Z"
     }
   },
   "tasks": [
     {
       "name": "implement-exception-handlers",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-28T06:23:55.748505Z"
     },
     {
       "name": "implement-controller-cleanup",

--- a/artifacts/feat-3394/state.json
+++ b/artifacts/feat-3394/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3394",
+  "issue_number": 3394,
+  "created_at": "2026-06-28T06:15:18.200369Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-28T06:16:11.504792Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3394/state.json
+++ b/artifacts/feat-3394/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-06-28T06:19:11.957787Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-28T06:19:18.189046Z"
+      "status": "completed",
+      "updated_at": "2026-06-28T06:20:37.578758Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-28T06:20:44.944985Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-28T06:20:45.232740Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3394/task-context/implement-controller-cleanup.md
+++ b/artifacts/feat-3394/task-context/implement-controller-cleanup.md
@@ -1,0 +1,25 @@
+### task: implement-controller-cleanup
+
+**Goal:** Remove the try/catch blocks from `ImportStatements` and `GetBankStatements` in `BankStatementsController`, retaining only the `_logger.LogInformation(...)` calls and the happy-path logic.
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`
+
+**Implementation notes:**
+
+`ImportStatements`:
+- Keep `_logger.LogInformation("Importing bank statements for account {AccountName} from {DateFrom} to {DateTo}", ...)` at the top of the method body
+- Remove the `try { ... } catch (ArgumentException ...) { ... } catch (Exception ...) { ... }` wrapper entirely
+- The method body becomes: log → build `importRequest` → `await _mediator.Send(importRequest)` → build `result` → return `Ok(result)`
+
+`GetBankStatements`:
+- Keep `_logger.LogInformation("Getting bank statements with Skip={Skip}, Take={Take}", skip, take)` at the top of the method body
+- Remove the `try { ... } catch (FluentValidation.ValidationException ...) { ... } catch (Exception ...) { ... }` wrapper entirely
+- The method body becomes: log → build `request` → `await _mediator.Send(request)` → return `Ok(response)`
+- Remove the `using FluentValidation;` using if it becomes unused (verify — no explicit FluentValidation using exists at the top of the controller file, only a catch-block reference)
+
+**Success criteria:**
+- Neither method contains `try`, `catch`, `return BadRequest(...)`, or `return StatusCode(500, ...)`
+- `_logger.LogInformation(...)` is still present in both methods
+- `dotnet build` succeeds
+- `dotnet format` reports no changes

--- a/artifacts/feat-3394/task-context/implement-exception-handlers.md
+++ b/artifacts/feat-3394/task-context/implement-exception-handlers.md
@@ -1,0 +1,47 @@
+### task: implement-exception-handlers
+
+**Goal:** Create `ArgumentExceptionHandler` and `ValidationExceptionHandler` following the `UnauthorizedAccessExceptionHandler` pattern, and register both in the DI pipeline.
+
+**Files to create:**
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs`
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ValidationExceptionHandler.cs`
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+**Implementation notes:**
+
+`ArgumentExceptionHandler.cs`:
+- Namespace: `Anela.Heblo.API.Infrastructure.ExceptionHandling`
+- `sealed class ArgumentExceptionHandler : IExceptionHandler`
+- Constructor takes `ILogger<ArgumentExceptionHandler>`
+- `TryHandleAsync`: return `false` if `exception is not ArgumentException`; otherwise log `LogWarning(ex, "Invalid argument: {Message}", ex.Message)`, set `StatusCodes.Status400BadRequest`, write `ProblemDetails { Status = 400, Title = "Bad Request", Detail = ex.Message, Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1" }`, return `true`
+- Include `Detail` set to `ex.Message` — this is a user-facing error (bad input) and preserves the original `{ "message": ex.Message }` contract, now typed as standard ProblemDetails
+
+`ValidationExceptionHandler.cs`:
+- Namespace: `Anela.Heblo.API.Infrastructure.ExceptionHandling`
+- `sealed class ValidationExceptionHandler : IExceptionHandler`
+- Constructor takes `ILogger<ValidationExceptionHandler>`
+- `TryHandleAsync`: return `false` if `exception is not FluentValidation.ValidationException`; otherwise log `LogWarning(ex, "Validation failed")`, set `StatusCodes.Status400BadRequest`
+- Write `ProblemDetails` with `Status = 400`, `Title = "Validation Failed"`, `Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1"`, and add `Extensions["errors"]` containing a list of `{ propertyName, errorMessage }` objects derived from `exception.Errors` (null-coalesce to empty array if `Errors` is null)
+- Use `WriteAsJsonAsync` like the existing handler
+- Requires `using FluentValidation;`
+
+`ServiceCollectionExtensions.cs` — inside `AddCrossCuttingServices()`, replace:
+```csharp
+services.AddExceptionHandler<UnauthorizedAccessExceptionHandler>();
+services.AddProblemDetails();
+```
+with:
+```csharp
+// Handler order is significant — first match wins.
+services.AddExceptionHandler<UnauthorizedAccessExceptionHandler>();
+services.AddExceptionHandler<ValidationExceptionHandler>();
+services.AddExceptionHandler<ArgumentExceptionHandler>();
+services.AddProblemDetails();
+```
+
+**Success criteria:**
+- Both new handler classes compile with `dotnet build`
+- `dotnet format` reports no changes
+- Registration order in `ServiceCollectionExtensions.cs`: Unauthorized → Validation → Argument → ProblemDetails

--- a/artifacts/feat-3394/task-context/implement-tests.md
+++ b/artifacts/feat-3394/task-context/implement-tests.md
@@ -1,0 +1,31 @@
+### task: implement-tests
+
+**Goal:** Add unit tests for `ArgumentExceptionHandler` and `ValidationExceptionHandler` following the exact pattern from `UnauthorizedAccessExceptionHandlerTests.cs`.
+
+**Files to create:**
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs`
+
+**Implementation notes:**
+
+Both test files use:
+- Namespace: `Anela.Heblo.Tests.Infrastructure.ExceptionHandling`
+- Usings: `System.Text.Json`, `Anela.Heblo.API.Infrastructure.ExceptionHandling`, `FluentAssertions`, `Microsoft.AspNetCore.Http`, `Microsoft.Extensions.Logging.Abstractions`, `Xunit`
+- A `private static CreateSut()` helper that constructs the handler with `NullLogger<T>.Instance`, a `MemoryStream` body, and a `DefaultHttpContext` with that body wired to `context.Response.Body`
+
+`ArgumentExceptionHandlerTests` — three tests:
+1. `TryHandleAsync_WhenArgumentException_Returns400WithProblemDetails` — pass `new ArgumentException("Unknown account name: TestAccount")`, assert `handled == true`, `StatusCode == 400`, JSON body has `status == 400`, `title == "Bad Request"`, `detail == "Unknown account name: TestAccount"`
+2. `TryHandleAsync_WhenArgumentNullException_Returns400` — pass `new ArgumentNullException("param")`, assert `handled == true`, `StatusCode == 400` (validates subclass handling)
+3. `TryHandleAsync_WhenOtherException_ReturnsFalseAndDoesNotWriteBody` — pass `new InvalidOperationException("unrelated")`, assert `handled == false`, `body.Length == 0`, `StatusCode == 200` (unchanged)
+
+`ValidationExceptionHandlerTests` — three tests:
+1. `TryHandleAsync_WhenValidationException_Returns400WithProblemDetails` — pass `new ValidationException(new[] { new ValidationFailure("Amount", "Must be greater than zero") })`, assert `handled == true`, `StatusCode == 400`, JSON body has `status == 400`, `title == "Validation Failed"`
+2. `TryHandleAsync_WhenValidationException_ExposesErrorsInExtensions` — same setup, assert JSON body has `errors` array with one entry where `propertyName == "Amount"` and `errorMessage == "Must be greater than zero"`
+3. `TryHandleAsync_WhenOtherException_ReturnsFalseAndDoesNotWriteBody` — pass `new InvalidOperationException("unrelated")`, assert `handled == false`, `body.Length == 0`, `StatusCode == 200` (unchanged)
+
+For `ValidationException` construction: `FluentValidation.ValidationException` has a constructor that accepts `IEnumerable<ValidationFailure>`. Use `new ValidationException(new[] { new ValidationFailure("Amount", "Must be greater than zero") })`.
+
+**Success criteria:**
+- `dotnet build` succeeds for the test project
+- All six new tests pass (`dotnet test --filter "FullyQualifiedName~ExceptionHandling"`)
+- No test uses `Skip` or `[Ignore]`

--- a/artifacts/feat-3394/task-plan.r1.md
+++ b/artifacts/feat-3394/task-plan.r1.md
@@ -1,0 +1,116 @@
+# Task Plan: feat-3394
+
+## Overview
+Replace inline try/catch blocks in `BankStatementsController` with two new global `IExceptionHandler` implementations (`ArgumentExceptionHandler` and `ValidationExceptionHandler`), registered in the DI pipeline after the existing `UnauthorizedAccessExceptionHandler`. Unit tests mirror the pattern established by `UnauthorizedAccessExceptionHandlerTests`.
+
+---
+
+### task: implement-exception-handlers
+
+**Goal:** Create `ArgumentExceptionHandler` and `ValidationExceptionHandler` following the `UnauthorizedAccessExceptionHandler` pattern, and register both in the DI pipeline.
+
+**Files to create:**
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs`
+- `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ValidationExceptionHandler.cs`
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+**Implementation notes:**
+
+`ArgumentExceptionHandler.cs`:
+- Namespace: `Anela.Heblo.API.Infrastructure.ExceptionHandling`
+- `sealed class ArgumentExceptionHandler : IExceptionHandler`
+- Constructor takes `ILogger<ArgumentExceptionHandler>`
+- `TryHandleAsync`: return `false` if `exception is not ArgumentException`; otherwise log `LogWarning(ex, "Invalid argument: {Message}", ex.Message)`, set `StatusCodes.Status400BadRequest`, write `ProblemDetails { Status = 400, Title = "Bad Request", Detail = ex.Message, Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1" }`, return `true`
+- Include `Detail` set to `ex.Message` — this is a user-facing error (bad input) and preserves the original `{ "message": ex.Message }` contract, now typed as standard ProblemDetails
+
+`ValidationExceptionHandler.cs`:
+- Namespace: `Anela.Heblo.API.Infrastructure.ExceptionHandling`
+- `sealed class ValidationExceptionHandler : IExceptionHandler`
+- Constructor takes `ILogger<ValidationExceptionHandler>`
+- `TryHandleAsync`: return `false` if `exception is not FluentValidation.ValidationException`; otherwise log `LogWarning(ex, "Validation failed")`, set `StatusCodes.Status400BadRequest`
+- Write `ProblemDetails` with `Status = 400`, `Title = "Validation Failed"`, `Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1"`, and add `Extensions["errors"]` containing a list of `{ propertyName, errorMessage }` objects derived from `exception.Errors` (null-coalesce to empty array if `Errors` is null)
+- Use `WriteAsJsonAsync` like the existing handler
+- Requires `using FluentValidation;`
+
+`ServiceCollectionExtensions.cs` — inside `AddCrossCuttingServices()`, replace:
+```csharp
+services.AddExceptionHandler<UnauthorizedAccessExceptionHandler>();
+services.AddProblemDetails();
+```
+with:
+```csharp
+// Handler order is significant — first match wins.
+services.AddExceptionHandler<UnauthorizedAccessExceptionHandler>();
+services.AddExceptionHandler<ValidationExceptionHandler>();
+services.AddExceptionHandler<ArgumentExceptionHandler>();
+services.AddProblemDetails();
+```
+
+**Success criteria:**
+- Both new handler classes compile with `dotnet build`
+- `dotnet format` reports no changes
+- Registration order in `ServiceCollectionExtensions.cs`: Unauthorized → Validation → Argument → ProblemDetails
+
+---
+
+### task: implement-controller-cleanup
+
+**Goal:** Remove the try/catch blocks from `ImportStatements` and `GetBankStatements` in `BankStatementsController`, retaining only the `_logger.LogInformation(...)` calls and the happy-path logic.
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`
+
+**Implementation notes:**
+
+`ImportStatements`:
+- Keep `_logger.LogInformation("Importing bank statements for account {AccountName} from {DateFrom} to {DateTo}", ...)` at the top of the method body
+- Remove the `try { ... } catch (ArgumentException ...) { ... } catch (Exception ...) { ... }` wrapper entirely
+- The method body becomes: log → build `importRequest` → `await _mediator.Send(importRequest)` → build `result` → return `Ok(result)`
+
+`GetBankStatements`:
+- Keep `_logger.LogInformation("Getting bank statements with Skip={Skip}, Take={Take}", skip, take)` at the top of the method body
+- Remove the `try { ... } catch (FluentValidation.ValidationException ...) { ... } catch (Exception ...) { ... }` wrapper entirely
+- The method body becomes: log → build `request` → `await _mediator.Send(request)` → return `Ok(response)`
+- Remove the `using FluentValidation;` using if it becomes unused (verify — no explicit FluentValidation using exists at the top of the controller file, only a catch-block reference)
+
+**Success criteria:**
+- Neither method contains `try`, `catch`, `return BadRequest(...)`, or `return StatusCode(500, ...)`
+- `_logger.LogInformation(...)` is still present in both methods
+- `dotnet build` succeeds
+- `dotnet format` reports no changes
+
+---
+
+### task: implement-tests
+
+**Goal:** Add unit tests for `ArgumentExceptionHandler` and `ValidationExceptionHandler` following the exact pattern from `UnauthorizedAccessExceptionHandlerTests.cs`.
+
+**Files to create:**
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs`
+
+**Implementation notes:**
+
+Both test files use:
+- Namespace: `Anela.Heblo.Tests.Infrastructure.ExceptionHandling`
+- Usings: `System.Text.Json`, `Anela.Heblo.API.Infrastructure.ExceptionHandling`, `FluentAssertions`, `Microsoft.AspNetCore.Http`, `Microsoft.Extensions.Logging.Abstractions`, `Xunit`
+- A `private static CreateSut()` helper that constructs the handler with `NullLogger<T>.Instance`, a `MemoryStream` body, and a `DefaultHttpContext` with that body wired to `context.Response.Body`
+
+`ArgumentExceptionHandlerTests` — three tests:
+1. `TryHandleAsync_WhenArgumentException_Returns400WithProblemDetails` — pass `new ArgumentException("Unknown account name: TestAccount")`, assert `handled == true`, `StatusCode == 400`, JSON body has `status == 400`, `title == "Bad Request"`, `detail == "Unknown account name: TestAccount"`
+2. `TryHandleAsync_WhenArgumentNullException_Returns400` — pass `new ArgumentNullException("param")`, assert `handled == true`, `StatusCode == 400` (validates subclass handling)
+3. `TryHandleAsync_WhenOtherException_ReturnsFalseAndDoesNotWriteBody` — pass `new InvalidOperationException("unrelated")`, assert `handled == false`, `body.Length == 0`, `StatusCode == 200` (unchanged)
+
+`ValidationExceptionHandlerTests` — three tests:
+1. `TryHandleAsync_WhenValidationException_Returns400WithProblemDetails` — pass `new ValidationException(new[] { new ValidationFailure("Amount", "Must be greater than zero") })`, assert `handled == true`, `StatusCode == 400`, JSON body has `status == 400`, `title == "Validation Failed"`
+2. `TryHandleAsync_WhenValidationException_ExposesErrorsInExtensions` — same setup, assert JSON body has `errors` array with one entry where `propertyName == "Amount"` and `errorMessage == "Must be greater than zero"`
+3. `TryHandleAsync_WhenOtherException_ReturnsFalseAndDoesNotWriteBody` — pass `new InvalidOperationException("unrelated")`, assert `handled == false`, `body.Length == 0`, `StatusCode == 200` (unchanged)
+
+For `ValidationException` construction: `FluentValidation.ValidationException` has a constructor that accepts `IEnumerable<ValidationFailure>`. Use `new ValidationException(new[] { new ValidationFailure("Amount", "Must be greater than zero") })`.
+
+**Success criteria:**
+- `dotnet build` succeeds for the test project
+- All six new tests pass (`dotnet test --filter "FullyQualifiedName~ExceptionHandling"`)
+- No test uses `Skip` or `[Ignore]`

--- a/backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
@@ -41,31 +41,18 @@ public class BankStatementsController : BaseApiController
     [HttpPost("import")]
     public async Task<ActionResult<BankStatementImportResultDto>> ImportStatements([FromBody] BankImportRequestDto request)
     {
-        try
-        {
-            _logger.LogInformation("Importing bank statements for account {AccountName} from {DateFrom} to {DateTo}",
-                request.AccountName, request.DateFrom, request.DateTo);
+        _logger.LogInformation("Importing bank statements for account {AccountName} from {DateFrom} to {DateTo}",
+            request.AccountName, request.DateFrom, request.DateTo);
 
-            var importRequest = new ImportBankStatementRequest(request.AccountName, request.DateFrom, request.DateTo);
-            var response = await _mediator.Send(importRequest);
+        var importRequest = new ImportBankStatementRequest(request.AccountName, request.DateFrom, request.DateTo);
+        var response = await _mediator.Send(importRequest);
 
-            var result = new BankStatementImportResultDto
-            {
-                Statements = response.Statements
-            };
+        var result = new BankStatementImportResultDto
+        {
+            Statements = response.Statements
+        };
 
-            return Ok(result);
-        }
-        catch (ArgumentException ex)
-        {
-            _logger.LogWarning(ex, "Invalid request for bank statement import");
-            return BadRequest(new { message = ex.Message });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while importing bank statements");
-            return StatusCode(500, new { message = "An error occurred while importing bank statements" });
-        }
+        return Ok(result);
     }
 
     /// <summary>
@@ -99,39 +86,26 @@ public class BankStatementsController : BaseApiController
         [FromQuery] string? orderBy = "ImportDate",
         [FromQuery] bool ascending = false)
     {
-        try
-        {
-            _logger.LogInformation("Getting bank statements with Skip={Skip}, Take={Take}", skip, take);
+        _logger.LogInformation("Getting bank statements with Skip={Skip}, Take={Take}", skip, take);
 
-            var request = new GetBankStatementListRequest
-            {
-                Id = id,
-                TransferId = transferId,
-                Account = account,
-                StatementDate = statementDate,
-                ImportDate = importDate,
-                DateFrom = dateFrom,
-                DateTo = dateTo,
-                ErrorsOnly = errorsOnly,
-                Skip = skip,
-                Take = take,
-                OrderBy = orderBy,
-                Ascending = ascending
-            };
+        var request = new GetBankStatementListRequest
+        {
+            Id = id,
+            TransferId = transferId,
+            Account = account,
+            StatementDate = statementDate,
+            ImportDate = importDate,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+            ErrorsOnly = errorsOnly,
+            Skip = skip,
+            Take = take,
+            OrderBy = orderBy,
+            Ascending = ascending
+        };
 
-            var response = await _mediator.Send(request);
-            return Ok(response);
-        }
-        catch (FluentValidation.ValidationException ex)
-        {
-            _logger.LogWarning(ex, "Invalid request for bank statement list");
-            return BadRequest(new { message = "Invalid request", errors = ex.Errors.Select(e => new { e.PropertyName, e.ErrorMessage }) });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving bank statements");
-            return StatusCode(500, new { message = "An error occurred while retrieving bank statements" });
-        }
+        var response = await _mediator.Send(request);
+        return Ok(response);
     }
 
     /// <summary>

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -132,8 +132,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(TimeProvider.System);
 
         // Global exception → HTTP mapping for infrastructure exceptions.
+        // Handler order is significant — first match wins.
         // Business errors continue to flow through BaseApiController.HandleResponse.
         services.AddExceptionHandler<UnauthorizedAccessExceptionHandler>();
+        services.AddExceptionHandler<ValidationExceptionHandler>();
+        services.AddExceptionHandler<ArgumentExceptionHandler>();
         services.AddProblemDetails();
 
         // Register HttpClient for E2E testing middleware

--- a/backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs
@@ -24,7 +24,10 @@ public sealed class ArgumentExceptionHandler : IExceptionHandler
         Exception exception,
         CancellationToken cancellationToken)
     {
-        if (exception is not ArgumentException argumentException)
+        // Exclude ArgumentNullException — its message reveals internal parameter names
+        // (e.g. "Value cannot be null. (Parameter 'mediator')") and should not be
+        // surfaced to API clients. Let it fall through to the default 500 handler.
+        if (exception is not ArgumentException argumentException || exception is ArgumentNullException)
         {
             return false;
         }

--- a/backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ArgumentExceptionHandler.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.API.Infrastructure.ExceptionHandling;
+
+/// <summary>
+/// Maps <see cref="ArgumentException"/> (and subclasses) to a 400 Bad Request ProblemDetails response.
+/// The exception message is included in the <c>detail</c> field because argument exceptions represent
+/// user-facing validation failures (bad input), not internal system errors.
+/// </summary>
+public sealed class ArgumentExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<ArgumentExceptionHandler> _logger;
+
+    public ArgumentExceptionHandler(ILogger<ArgumentExceptionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not ArgumentException argumentException)
+        {
+            return false;
+        }
+
+        _logger.LogWarning(argumentException, "Invalid argument: {Message}", argumentException.Message);
+
+        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Bad Request",
+            Detail = argumentException.Message,
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1"
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ValidationExceptionHandler.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/ValidationExceptionHandler.cs
@@ -1,0 +1,52 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.API.Infrastructure.ExceptionHandling;
+
+/// <summary>
+/// Maps <see cref="ValidationException"/> to a 400 Bad Request ProblemDetails response.
+/// Validation failures are exposed in an <c>errors</c> extension array to preserve
+/// the per-property error detail that was previously returned by the controller.
+/// </summary>
+public sealed class ValidationExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<ValidationExceptionHandler> _logger;
+
+    public ValidationExceptionHandler(ILogger<ValidationExceptionHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (exception is not ValidationException validationException)
+        {
+            return false;
+        }
+
+        _logger.LogWarning(validationException, "Validation failed");
+
+        var errors = (validationException.Errors ?? [])
+            .Select(e => new { propertyName = e.PropertyName, errorMessage = e.ErrorMessage })
+            .ToList();
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Validation Failed",
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1"
+        };
+        problemDetails.Extensions["errors"] = errors;
+
+        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs
@@ -38,15 +38,17 @@ public class ArgumentExceptionHandlerTests
     }
 
     [Fact]
-    public async Task TryHandleAsync_WhenArgumentNullException_Returns400()
+    public async Task TryHandleAsync_WhenArgumentNullException_ReturnsFalseToPreventMessageLeak()
     {
+        // ArgumentNullException messages contain internal parameter names — must not be surfaced.
         var (handler, context, body) = CreateSut();
-        var exception = new ArgumentNullException("param");
+        var exception = new ArgumentNullException("mediator");
 
         var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
 
-        handled.Should().BeTrue();
-        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        handled.Should().BeFalse();
+        body.Length.Should().Be(0);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ArgumentExceptionHandlerTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Anela.Heblo.API.Infrastructure.ExceptionHandling;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Infrastructure.ExceptionHandling;
+
+public class ArgumentExceptionHandlerTests
+{
+    private static (ArgumentExceptionHandler Handler, DefaultHttpContext Context, MemoryStream Body) CreateSut()
+    {
+        var handler = new ArgumentExceptionHandler(
+            NullLogger<ArgumentExceptionHandler>.Instance);
+        var body = new MemoryStream();
+        var context = new DefaultHttpContext();
+        context.Response.Body = body;
+        return (handler, context, body);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WhenArgumentException_Returns400WithProblemDetails()
+    {
+        var (handler, context, body) = CreateSut();
+        var exception = new ArgumentException("Unknown account name: TestAccount");
+
+        var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        handled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        body.Position = 0;
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("status").GetInt32().Should().Be(400);
+        doc.RootElement.GetProperty("title").GetString().Should().Be("Bad Request");
+        doc.RootElement.GetProperty("detail").GetString().Should().Be("Unknown account name: TestAccount");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WhenArgumentNullException_Returns400()
+    {
+        var (handler, context, body) = CreateSut();
+        var exception = new ArgumentNullException("param");
+
+        var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        handled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WhenOtherException_ReturnsFalseAndDoesNotWriteBody()
+    {
+        var (handler, context, body) = CreateSut();
+        var exception = new InvalidOperationException("unrelated");
+
+        var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        handled.Should().BeFalse();
+        body.Length.Should().Be(0);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/ExceptionHandling/ValidationExceptionHandlerTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Anela.Heblo.API.Infrastructure.ExceptionHandling;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Infrastructure.ExceptionHandling;
+
+public class ValidationExceptionHandlerTests
+{
+    private static (ValidationExceptionHandler Handler, DefaultHttpContext Context, MemoryStream Body) CreateSut()
+    {
+        var handler = new ValidationExceptionHandler(
+            NullLogger<ValidationExceptionHandler>.Instance);
+        var body = new MemoryStream();
+        var context = new DefaultHttpContext();
+        context.Response.Body = body;
+        return (handler, context, body);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WhenValidationException_Returns400WithProblemDetails()
+    {
+        var (handler, context, body) = CreateSut();
+        var exception = new ValidationException(new[]
+        {
+            new ValidationFailure("Amount", "Must be greater than zero")
+        });
+
+        var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        handled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        body.Position = 0;
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("status").GetInt32().Should().Be(400);
+        doc.RootElement.GetProperty("title").GetString().Should().Be("Validation Failed");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WhenValidationException_ExposesErrorsInExtensions()
+    {
+        var (handler, context, body) = CreateSut();
+        var exception = new ValidationException(new[]
+        {
+            new ValidationFailure("Amount", "Must be greater than zero")
+        });
+
+        await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        body.Position = 0;
+        using var doc = JsonDocument.Parse(body);
+        var errors = doc.RootElement.GetProperty("errors");
+        errors.GetArrayLength().Should().Be(1);
+        errors[0].GetProperty("propertyName").GetString().Should().Be("Amount");
+        errors[0].GetProperty("errorMessage").GetString().Should().Be("Must be greater than zero");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WhenOtherException_ReturnsFalseAndDoesNotWriteBody()
+    {
+        var (handler, context, body) = CreateSut();
+        var exception = new InvalidOperationException("unrelated");
+
+        var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+        handled.Should().BeFalse();
+        body.Length.Should().Be(0);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+}


### PR DESCRIPTION
Closes #3394

## What the issue was

`BankStatementsController` had inline try/catch blocks in two of its three action methods, duplicating exception-to-HTTP translation logic that belongs in the global middleware layer. `ImportStatements` caught `ArgumentException` → 400 and `Exception` → 500; `GetBankStatements` caught `FluentValidation.ValidationException` → 400 and `Exception` → 500. `GetBankStatement` had no try/catch at all, creating an inconsistency. The anonymous `{ message }` / `{ message, errors }` response shapes were also invisible to the OpenAPI spec and the generated TypeScript client.

## How it was fixed / handled

Two new `IExceptionHandler` implementations were added following the established `UnauthorizedAccessExceptionHandler` pattern:

- **`ArgumentExceptionHandler`** — maps `ArgumentException` (excluding `ArgumentNullException` to prevent internal parameter-name leakage) to 400 ProblemDetails with `detail: ex.Message`
- **`ValidationExceptionHandler`** — maps `FluentValidation.ValidationException` to 400 ProblemDetails with an `extensions.errors` array preserving per-property error detail

Both handlers are registered in `AddCrossCuttingServices()` after the existing `UnauthorizedAccessExceptionHandler` (Unauthorized → Validation → Argument → default 500). The try/catch blocks were removed from `BankStatementsController`; the `_logger.LogInformation(...)` calls are retained. Unit tests follow the same pattern as `UnauthorizedAccessExceptionHandlerTests`.

## Artifacts
- Brief, spec, arch-review, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3394/`.

## Code review

Round 1 flagged that `ArgumentExceptionHandler` was accepting `ArgumentNullException` subclasses (whose messages contain internal parameter names). Fixed in `f27a0a2` by adding `|| exception is ArgumentNullException` to the early-return guard. Round 2: CLEAN — no blocking findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_016nrqCSeW9fGfR3vuoJMYrg)_