### PR TITLE
ci: deploy current main to staging before nightly E2E tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,11 +63,12 @@ This directory contains the CI/CD workflows for the Anela Heblo project.
 │  ┌──────────────────────────┐     │
 │  │ e2e-nightly-regression.yml │    │
 │  │                          │     │
-│  │  1. Health Checks        │     │
-│  │  2. Run E2E Tests        │     │
-│  │  3. Upload Artifacts     │     │
-│  │  4. Create/Close Issue   │     │
-│  │  5. Teams Notification   │     │
+│  │  1. Deploy main → Staging │    │
+│  │  2. Health Checks        │     │
+│  │  3. Run E2E Tests        │     │
+│  │  4. Upload Artifacts     │     │
+│  │  5. Create/Close Issue   │     │
+│  │  6. Teams Notification   │     │
 │  └──────────────────────────┘     │
 │                                     │
 │  Runs daily at 2:00 AM CET         │
@@ -152,14 +153,16 @@ This directory contains the CI/CD workflows for the Anela Heblo project.
 - **Manual:** Via `workflow_dispatch` with optional test pattern filter
 
 **What it does:**
-1. **Health Checks** - Validate staging endpoints (`/health/live`, `/health/ready`)
-2. **Run E2E Tests** - Full Playwright test suite against staging
-3. **Upload Artifacts** - HTML report, screenshots, test logs (30 day retention)
-4. **Create/Update Issue** - GitHub issue on failure (auto-closes on success)
-5. **Teams Notification** - Optional webhook notification
+1. **Deploy main → Staging** - Push the current `main` (`latest` image) to the `heblo-test` web app so tests run against fresh code, then wait for `/health/ready`
+2. **Health Checks** - Validate staging endpoints (`/health/live`, `/health/ready`)
+3. **Run E2E Tests** - Full Playwright test suite against staging
+4. **Upload Artifacts** - HTML report, screenshots, test logs (30 day retention)
+5. **Create/Update Issue** - GitHub issue on failure (auto-closes on success)
+6. **Teams Notification** - Optional webhook notification
 
 **Key Features:**
 - ✅ Nightly execution (results ready in morning)
+- ✅ Auto-deploys current main to staging before testing (no more stale-deployment gap)
 - ✅ Full E2E coverage
 - ✅ Health pre-checks
 - ✅ Automatic issue tracking
@@ -182,6 +185,9 @@ gh workflow run e2e-nightly-regression.yml -f test_pattern=catalog
 
 # Run with different browser
 gh workflow run e2e-nightly-regression.yml -f browser=firefox
+
+# Skip the staging deploy and test whatever is already deployed
+gh workflow run e2e-nightly-regression.yml -f deploy_staging=false
 ```
 
 ## How to...

--- a/.github/workflows/e2e-nightly-regression.yml
+++ b/.github/workflows/e2e-nightly-regression.yml
@@ -28,10 +28,19 @@ on:
         required: false
         default: false
         type: boolean
+      deploy_staging:
+        description: 'Deploy current main to staging before running tests (disable to test a pre-deployed build)'
+        required: false
+        default: true
+        type: boolean
 
 env:
   STAGING_URL: https://heblo.stg.anela.cz
   NODE_VERSION: '18'
+  REGISTRY: docker.io
+  IMAGE_NAME: heblo
+  # Image tag deployed to staging — 'latest' always points to the most recent main build
+  IMAGE_TAG: latest
 
 # Required permissions for test reporter to create check runs
 permissions:
@@ -39,10 +48,114 @@ permissions:
   contents: read     # Allow reading repository contents
 
 jobs:
+  # Deploy current main to staging so E2E tests run against fresh code, not stale deployments
+  deploy-staging:
+    name: 🚀 Deploy main to Staging
+    runs-on: ubuntu-latest
+    # Always deploy on the nightly schedule; on manual runs honor the deploy_staging toggle (default true)
+    if: github.event_name == 'schedule' || github.event.inputs.deploy_staging != 'false'
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔖 Capture deployed commit
+        id: commit
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "📌 Deploying main @ $SHORT_SHA (image tag: ${{ env.IMAGE_TAG }})"
+
+      - name: 🔐 Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS_TEST }}
+
+      - name: 🚀 Deploy to Azure Web App (Staging)
+        run: |
+          WEBAPP_NAME="heblo-test"
+          DOCKER_IMAGE="${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
+
+          echo "🎯 Deploying to: $WEBAPP_NAME"
+          echo "🐳 Image: $DOCKER_IMAGE"
+
+          az webapp config set \
+            --name $WEBAPP_NAME \
+            --resource-group rgHeblo \
+            --linux-fx-version "DOCKER|$DOCKER_IMAGE" \
+            --output none
+
+          az webapp config container set \
+            --name $WEBAPP_NAME \
+            --resource-group rgHeblo \
+            --container-image-name "$DOCKER_IMAGE" \
+            --container-registry-url https://index.docker.io/v1/ \
+            --output none
+
+          az webapp restart \
+            --name $WEBAPP_NAME \
+            --resource-group rgHeblo \
+            --output none
+
+          echo "WEBAPP_NAME=$WEBAPP_NAME" >> $GITHUB_ENV
+
+      - name: 🔧 Configure App Settings
+        run: |
+          az webapp config appsettings set \
+            --resource-group rgHeblo \
+            --name $WEBAPP_NAME \
+            --settings \
+              ASPNETCORE_ENVIRONMENT=Staging \
+              WEBSITES_PORT=8080 \
+              WEBSITES_ENABLE_APP_SERVICE_STORAGE=false \
+              DOCKER_REGISTRY_SERVER_URL=https://index.docker.io \
+              SCM_DO_BUILD_DURING_DEPLOYMENT=false \
+              APP_VERSION="staging-main-${{ steps.commit.outputs.short_sha }}" \
+              DEPLOYMENT_SOURCE="E2E-Nightly-Main" \
+            --output none
+
+      - name: ⏳ Wait for staging to be ready
+        run: |
+          echo "⏳ Waiting for staging deployment to become ready..."
+          # Initial wait for image pull + container startup
+          sleep 60
+
+          MAX_ATTEMPTS=20
+          ATTEMPT=1
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "🔍 Readiness check attempt $ATTEMPT/$MAX_ATTEMPTS..."
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${{ env.STAGING_URL }}/health/ready" || echo "000")
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✅ Staging is ready! (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+              break
+            fi
+
+            if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+              echo "❌ Staging failed to become ready after $MAX_ATTEMPTS attempts (last HTTP $HTTP_CODE)"
+              exit 1
+            fi
+
+            echo "⏳ Not ready yet (HTTP $HTTP_CODE), waiting 15s..."
+            sleep 15
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+      - name: 📝 Deployment Summary
+        run: |
+          echo "## 🚀 Staging Deployment (Pre-E2E)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Source**: main @ \`${{ steps.commit.outputs.short_sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image**: \`${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL**: ${{ env.STAGING_URL }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Deployed at**: $(date)" >> $GITHUB_STEP_SUMMARY
+
   # Validate staging health before running tests
   validate-staging-health:
     name: 🏥 Validate Staging Health
     runs-on: ubuntu-latest
+    needs: deploy-staging
+    # Run after a successful deploy, or when the deploy was intentionally skipped (manual run, deploy_staging=false)
+    if: always() && needs.deploy-staging.result != 'failure' && needs.deploy-staging.result != 'cancelled'
 
     steps:
       - name: 📊 Check Liveness Endpoint


### PR DESCRIPTION
## Problem

The nightly E2E regression suite runs against staging (`https://heblo.stg.anela.cz`), but staging is only ever deployed via the manual `deploy-staging-manual.yml` workflow — so the suite was testing stale code rather than current `main`.

## Change

Adds a `deploy-staging` job to `e2e-nightly-regression.yml` that runs before the health checks and E2E tests: it deploys the `latest` image (current main) to the `heblo-test` web app — mirroring the proven steps from the manual deploy workflow — then waits for `/health/ready`. The job is gated by a new `deploy_staging` input (default `true`) so a manual run can pass `-f deploy_staging=false` to test a pre-deployed build, and `validate-staging-health`/`run-e2e-tests` are wired with `needs` + `always()` guards so the suite is blocked on a failed deploy but still runs when the deploy is intentionally skipped. The workflows README is updated to document the new step and toggle.

This reuses the existing `AZURE_CREDENTIALS_TEST` and `DOCKER_USERNAME` secrets, so no new secrets are required.