### PR TITLE
#3403: fix DateTime.Now → DateTime.UtcNow in catalog background refresh task

### DIFF
--- a/artifacts/feat-3403/arch-review.r1.md
+++ b/artifacts/feat-3403/arch-review.r1.md
@@ -1,0 +1,82 @@
+# Architecture Review: Fix DateTime.Now to DateTime.UtcNow in Catalog Background Refresh Task
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a two-line surgical fix to a latent timezone-correctness bug in the Catalog module's background refresh task. It aligns with an unambiguous, well-established codebase convention: every other date/time-sensitive path in the Catalog module uses `DateTime.UtcNow` or injects `TimeProvider`. The two offending lines in `CatalogModule.RegisterBackgroundRefreshTasks` (lines 310 and 313) are the sole exception.
+
+The fix has no integration points beyond the two changed lines. No API surface, data model, or module boundary is affected. Risk is minimal and well-contained.
+
+**Verified pattern inventory in the Catalog module:**
+
+| Pattern | Files |
+|---|---|
+| `DateTime.UtcNow` (direct) | `CostProviders/*.cs`, `Infrastructure/CatalogMergeScheduler.cs`, `Infrastructure/CatalogCacheStore.cs`, `Services/*.cs`, `DashboardTiles/InventorySummaryTileBase.cs`, handlers |
+| `TimeProvider` (injected) | `GetCatalogDetailHandler`, `GetProductMarginsHandler`, `CatalogMergeService`, `CatalogDataRefreshService`, `CatalogCacheStore`, `LowStockAlertTile`, `InventoryCountTileBase`, `EshopStockDomainService`, and others |
+| `DateTime.Now` | `CatalogModule.cs` lines 310 and 313 — **the two lines being fixed** |
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+CatalogModule.cs
+  └── RegisterBackgroundRefreshTasks()
+        └── RefreshMarginData lambda (anonymous hosted-service task)
+              ├── line 310: twoYearsAgo = DateOnly.FromDateTime(DateTime.Now.AddYears(-2))
+              │              → CHANGE TO: DateTime.UtcNow.AddYears(-2)
+              └── line 313: dateTo = DateOnly.FromDateTime(DateTime.Now).AddMonths(-1)
+                             → CHANGE TO: DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1)
+```
+
+No new components. No new abstractions. No new files.
+
+### Key Design Decisions
+
+#### Decision 1: `DateTime.UtcNow` over `TimeProvider` injection
+
+**Options considered:**
+1. Replace `DateTime.Now` with `DateTime.UtcNow` (two-character change per line).
+2. Introduce `TimeProvider` injection into the `RegisterBackgroundRefreshTasks` helper, resolve it from `IServiceProvider`, and call `timeProvider.GetUtcNow()`.
+
+**Chosen approach:** Replace with `DateTime.UtcNow`.
+
+**Rationale:** The spec explicitly marks `TimeProvider` injection as out of scope, and this is the correct call. The lambda in `RegisterBackgroundRefreshTasks` is a fire-and-forget background task wired up once at startup; it already resolves `ICatalogRepository` and `IMarginCalculationService` from the scoped `IServiceProvider` at execution time. Injecting `TimeProvider` at the module-registration level would require either adding a parameter to the helper or resolving `TimeProvider` from the root container, neither of which is necessary for the stated goal. `DateTime.UtcNow` is used directly in several analogous non-testable paths in the same module (e.g., `CatalogMergeScheduler`, `StockUpProcessingService`, `ProductWeightRecalculationService`) with no test coverage requirement. The fix is correct and consistent. `TimeProvider` injection can be added in a follow-up if and when this task acquires test coverage.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Only one file changes:
+
+```
+backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+  lines 310, 313
+```
+
+No new files. No new directories.
+
+### Interfaces and Contracts
+
+None. This fix touches no public interface, no contract DTO, and no API endpoint.
+
+### Data Flow
+
+The data flow is unchanged. The fix only alters the `DateOnly` values passed to `marginService.GetMarginAsync(product, dateFrom, dateTo, ct)`. After the fix those values are derived from UTC rather than local server time, which is the intended semantic.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Behavioral change if host runs in a non-UTC timezone | Low | This is the desired correction. On UTC hosts (current Azure default) the output is identical. On non-UTC hosts the corrected output is more accurate. |
+| Accidentally touching surrounding logic | Low | Change is limited to the two `DateTime.Now` tokens; surrounding variables (`minDate`, `dateFrom`, loop body) are untouched. |
+| Build regression | Negligible | `DateTime.UtcNow` is the same type (`DateTime`) as `DateTime.Now`; the call site is identical. `dotnet build` will pass. |
+
+## Specification Amendments
+
+None required. The spec is complete and accurate. The implementation is a direct literal substitution with no ambiguity.
+
+## Prerequisites
+
+None. The change is self-contained and requires no migration, config update, infrastructure change, or dependency addition.

--- a/artifacts/feat-3403/brief.md
+++ b/artifacts/feat-3403/brief.md
@@ -1,0 +1,35 @@
+## Module
+Catalog
+
+## Finding
+`CatalogModule.cs` in the `RegisterBackgroundRefreshTasks` helper (lines 310 and 313) uses `DateTime.Now` (local server time) when computing the date bounds passed to the margin calculation:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs — lines 310, 313
+var twoYearsAgo = DateOnly.FromDateTime(DateTime.Now.AddYears(-2));
+// ...
+var dateTo = DateOnly.FromDateTime(DateTime.Now).AddMonths(-1);
+```
+
+Every other time-based computation in the Catalog module uses `DateTime.UtcNow` (CostProviders, Services) or injects `TimeProvider` (handlers). This is the only place using `DateTime.Now`.
+
+## Why it matters
+`DateTime.Now` returns the server's local clock, which varies with the host OS timezone and DST rules. Azure Web App containers default to UTC, but the config can be changed, and the discrepancy between local and UTC can shift a `DateOnly` boundary by one calendar day at end-of-day. Concretely:
+
+- `dateTo = DateOnly.FromDateTime(DateTime.Now).AddMonths(-1)` is intended to exclude the current (incomplete) month from margin calculation. In a UTC+2 timezone the day rolls over 2 hours earlier than the intended UTC boundary, occasionally including a partial first day of the current month in the `dateTo` window.
+- Inconsistency with the rest of the codebase makes future readers question whether local time is intentional.
+
+The background task also cannot be tested with fake time because `DateTime.Now` is a static call with no injection point.
+
+## Suggested fix
+Replace both occurrences with `DateTime.UtcNow`:
+
+```csharp
+var twoYearsAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-2));
+var dateTo = DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1);
+```
+
+This makes the margin recalculation consistent with all other cost/date computations in the module and eliminates the timezone-dependency risk.
+
+---
+_Filed by daily arch-review routine on 2026-06-28._

--- a/artifacts/feat-3403/code-review.r1.md
+++ b/artifacts/feat-3403/code-review.r1.md
@@ -1,0 +1,18 @@
+## Review Result: CLEAN
+
+## Blocking
+- None
+
+## Advisory
+- The background refresh task constructs `DateTime.UtcNow` twice independently (lines 310 and 313). If the task ever runs at a month boundary (e.g., 23:59:59 UTC on the last day of a month), the two calls could theoretically resolve to different calendar dates. Capturing `var now = DateTime.UtcNow;` once and deriving both values from it would eliminate that race entirely. The risk is negligible in practice for a date-granularity calculation, but the pattern is worth noting for future robustness. This is a pre-existing pattern, not introduced by this PR.
+- The adjacent handler `GetProductMarginsHandler.cs` already uses `_timeProvider.GetUtcNow()` (an abstracted `TimeProvider`), which is testable and avoids direct `DateTime.UtcNow` calls. Aligning the background task to the same abstraction would be ideal longer-term, but is out of scope for this surgical fix.
+
+---
+
+### Review notes
+
+**Scope:** The diff contains exactly two token substitutions (`DateTime.Now` → `DateTime.UtcNow`) on lines 310 and 313 of `CatalogModule.cs`, matching the stated intent precisely. No other lines were modified.
+
+**Correctness:** Both changed sites compute `DateOnly` values used to bound a margin calculation window. `DateOnly.FromDateTime` strips the time component, so the UTC vs. local difference only matters when the local clock and UTC straddle a calendar day boundary. Switching to `DateTime.UtcNow` aligns with the rest of the Catalog feature, which uses `DateTime.UtcNow` (e.g., `SalesCostProvider.GetDateRange`) and `_timeProvider.GetUtcNow()` (`GetProductMarginsHandler`).
+
+**No regressions:** No other `DateTime.Now` usages remain in the Catalog feature directory. The change does not affect public API contracts, database schema, or test fixtures.

--- a/artifacts/feat-3403/impl/fix-datetime-utcnow.r1.md
+++ b/artifacts/feat-3403/impl/fix-datetime-utcnow.r1.md
@@ -1,0 +1,27 @@
+# Implementation: fix-datetime-utcnow
+
+## What was implemented
+Replaced two occurrences of `DateTime.Now` with `DateTime.UtcNow` in the `RegisterBackgroundRefreshTasks` method of `CatalogModule.cs`. This ensures the date boundary calculations for margin windows are timezone-independent, preventing off-by-one-day errors on hosts where the local timezone differs from UTC.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — line 310: `DateTime.Now.AddYears(-2)` → `DateTime.UtcNow.AddYears(-2)`; line 313: `DateTime.Now` → `DateTime.UtcNow` (inline comment preserved as-is)
+
+## Tests
+None — out of scope per spec
+
+## How to verify
+1. Run `git show HEAD` on the feature branch to confirm exactly two token changes in `CatalogModule.cs`.
+2. Run `dotnet build Anela.Heblo.sln` — must produce 0 errors (pre-existing warnings are unrelated).
+3. Inspect lines 310 and 313 in `CatalogModule.cs` for `DateTime.UtcNow`.
+
+## Notes
+No deviations. The solution file is at the worktree root (`Anela.Heblo.sln`), not under `backend/` as the task spec suggested — the build was run from the correct path.
+
+## PR Summary
+Fixes timezone-sensitive date boundary calculations in the catalog background refresh task. `DateTime.Now` returns local server time, which can differ from UTC by hours, causing the `twoYearsAgo` and `dateTo` date boundaries to land on the wrong calendar day depending on where the app is hosted. Switching to `DateTime.UtcNow` makes the calculation deterministic and consistent across environments (local dev, staging, production on Azure).
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — replaced `DateTime.Now` with `DateTime.UtcNow` on lines 310 and 313
+
+## Status
+DONE

--- a/artifacts/feat-3403/review/fix-datetime-utcnow.r1.md
+++ b/artifacts/feat-3403/review/fix-datetime-utcnow.r1.md
@@ -1,0 +1,19 @@
+# Code Review: Fix DateTime.Now to DateTime.UtcNow in Catalog Background Refresh Task
+
+## Summary
+The implementation correctly replaces both `DateTime.Now` occurrences with `DateTime.UtcNow` on lines 310 and 313 of `CatalogModule.cs`. The change is surgical — exactly two tokens were substituted, the inline comment on line 313 is preserved verbatim, and no surrounding code was touched. The implementation fully satisfies every acceptance criterion in the spec.
+
+## Review Result: PASS
+
+### task: fix-datetime-utcnow
+**Status:** PASS
+
+## Overall Notes
+Verified directly against the file at `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` lines 310 and 313:
+
+- Line 310: `var twoYearsAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-2));` — correct.
+- Line 313: `var dateTo = DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1); // Current month is not accurate` — correct, comment preserved exactly.
+
+The developer's note that the solution file lives at the worktree root rather than under `backend/` (as the task spec suggested) is a non-issue; the build target is equivalent and the spec's acceptance criterion is a passing `dotnet build`, not the exact invocation path.
+
+No documentation updates are required for a fix of this scope.

--- a/artifacts/feat-3403/spec.r1.md
+++ b/artifacts/feat-3403/spec.r1.md
@@ -1,0 +1,105 @@
+# Specification: Fix DateTime.Now to DateTime.UtcNow in Catalog Background Refresh Task
+
+## Summary
+
+Two occurrences of `DateTime.Now` in `CatalogModule.RegisterBackgroundRefreshTasks` use the server's local clock instead of UTC, creating a timezone-dependent date boundary that can silently corrupt margin calculation windows by one calendar day. Replacing both with `DateTime.UtcNow` eliminates this risk, restores consistency with every other time-based computation in the Catalog module, and makes the background task testable with injected fake time.
+
+## Background
+
+The Catalog module runs a background task (`RefreshMarginData`) that recalculates product margins over a rolling historical window: from two years ago (or 2025-01-01, whichever is later) up to the end of the previous complete month. The intent of setting `dateTo` to "last month" is to exclude the current, still-incomplete month from margin calculations.
+
+Every other date/time-sensitive path in the module — cost providers, margin services, and MediatR handlers — uses either `DateTime.UtcNow` or an injected `TimeProvider`. The two lines in `RegisterBackgroundRefreshTasks` are the only exception, a leftover inconsistency likely introduced before the UTC convention was established.
+
+On Azure Web App for Containers the default OS timezone is UTC, so the bug is currently latent. It would become active if the container's timezone is ever changed, if the app is moved to a host with a non-UTC timezone, or if a developer runs a local test environment in a UTC+ offset: the `DateOnly` boundary can shift by a full calendar day, meaning the "incomplete current month" guard either includes a partial month's data or clips the last day of the previous month.
+
+Because `DateTime.Now` is a static call with no injection point, the task also cannot be driven by a fake clock in automated tests.
+
+## Functional Requirements
+
+### FR-1: Replace DateTime.Now with DateTime.UtcNow on line 310
+
+Replace the `twoYearsAgo` computation so it uses UTC time.
+
+**Before:**
+```csharp
+var twoYearsAgo = DateOnly.FromDateTime(DateTime.Now.AddYears(-2));
+```
+**After:**
+```csharp
+var twoYearsAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-2));
+```
+
+**Acceptance criteria:**
+- `DateTime.Now` no longer appears in `CatalogModule.cs`.
+- `twoYearsAgo` is derived from `DateTime.UtcNow`.
+- `dotnet build` passes with no warnings introduced.
+
+### FR-2: Replace DateTime.Now with DateTime.UtcNow on line 313
+
+Replace the `dateTo` computation so it uses UTC time.
+
+**Before:**
+```csharp
+var dateTo = DateOnly.FromDateTime(DateTime.Now).AddMonths(-1); // Current month is not accurate
+```
+**After:**
+```csharp
+var dateTo = DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1); // Current month is not accurate
+```
+
+**Acceptance criteria:**
+- `dateTo` is derived from `DateTime.UtcNow`.
+- The existing inline comment is preserved unchanged.
+- No other logic in the method is altered.
+
+### FR-3: No other changes in scope
+
+The fix is limited to the two literal substitutions described in FR-1 and FR-2. No refactoring of surrounding code, no introduction of `TimeProvider` injection into this helper, and no changes to any other file.
+
+**Acceptance criteria:**
+- `git diff` for this change shows only the two `DateTime.Now` → `DateTime.UtcNow` substitutions in `CatalogModule.cs`.
+- All existing unit and integration tests that were passing before the change continue to pass.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+No performance impact. The change is a direct substitution of one static clock call for another; both are O(1) and sub-microsecond.
+
+### NFR-2: Correctness / Timezone safety
+
+After the fix, date boundary computation in `RegisterBackgroundRefreshTasks` is timezone-invariant. The `dateTo` guard correctly excludes the current calendar month under UTC regardless of host OS timezone setting.
+
+### NFR-3: Consistency
+
+After the fix, `DateTime.Now` has zero occurrences in the Catalog module. All time references in the module use `DateTime.UtcNow` or `TimeProvider`.
+
+### NFR-4: Testability
+
+This change is a prerequisite for any future test that needs to control the clock in `RegisterBackgroundRefreshTasks`. Replacing the static call is the minimum step; actual `TimeProvider` injection is out of scope for this fix (see Out of Scope).
+
+## Data Model
+
+No data model changes. The `Margins` property on `Product` entities is populated identically to before; only the date window passed to `GetMarginAsync` is guaranteed to be UTC-consistent.
+
+## API / Interface Design
+
+No API or UI changes. This is an internal background task computation.
+
+## Dependencies
+
+- `CatalogModule.cs` — `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`, lines 310 and 313.
+- No new dependencies are introduced.
+
+## Out of Scope
+
+- Introducing `TimeProvider` injection into `RegisterBackgroundRefreshTasks` or `RegisterRefreshTask`. That refactor would improve testability further but is a separate, larger change.
+- Writing new unit tests for the background task clock behaviour. That is desirable but depends on `TimeProvider` injection which is excluded above.
+- Auditing other modules for `DateTime.Now` usage. This fix addresses only the Catalog module finding.
+- Any change to how `dateFrom` / `dateTo` are consumed by `GetMarginAsync` or stored in the database.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3403/state.json
+++ b/artifacts/feat-3403/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-06-29T06:17:40.788112Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T06:19:52.231008Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3403/state.json
+++ b/artifacts/feat-3403/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-datetime-utcnow",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3403/state.json
+++ b/artifacts/feat-3403/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-06-29T06:26:42.624691Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-29T06:26:57.164551Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3403/state.json
+++ b/artifacts/feat-3403/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-06-29T06:19:52.231008Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T06:20:01.275361Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T06:21:28.668449Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3403/state.json
+++ b/artifacts/feat-3403/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3403",
+  "issue_number": 3403,
+  "created_at": "2026-06-29T06:15:49.143776Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-29T06:17:40.788112Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3403/state.json
+++ b/artifacts/feat-3403/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-29T06:21:28.668449Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T06:21:53.504369Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T06:26:42.624691Z"
     }
   },
   "tasks": [
     {
       "name": "fix-datetime-utcnow",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-29T06:21:53.734764Z"
+      "updated_at": "2026-06-29T06:26:42.385469Z"
     }
   ]
 }

--- a/artifacts/feat-3403/state.json
+++ b/artifacts/feat-3403/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-29T06:21:28.668449Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T06:21:53.504369Z"
     }
   },
   "tasks": [
     {
       "name": "fix-datetime-utcnow",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-29T06:21:53.734764Z"
     }
   ]
 }

--- a/artifacts/feat-3403/task-context/fix-datetime-utcnow.md
+++ b/artifacts/feat-3403/task-context/fix-datetime-utcnow.md
@@ -1,0 +1,78 @@
+### task: fix-datetime-utcnow
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:310,313`
+
+- [ ] **Step 1: Apply the change on line 310**
+
+  Open `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`.
+
+  Find line 310 (inside `RegisterBackgroundRefreshTasks`):
+
+  ```csharp
+  // Before
+  var twoYearsAgo = DateOnly.FromDateTime(DateTime.Now.AddYears(-2));
+  ```
+
+  Replace with:
+
+  ```csharp
+  // After
+  var twoYearsAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-2));
+  ```
+
+- [ ] **Step 2: Apply the change on line 313**
+
+  On line 313, immediately below:
+
+  ```csharp
+  // Before
+  var dateTo = DateOnly.FromDateTime(DateTime.Now).AddMonths(-1); // Current month is not accurate
+  ```
+
+  Replace with:
+
+  ```csharp
+  // After
+  var dateTo = DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1); // Current month is not accurate
+  ```
+
+  The trailing inline comment `// Current month is not accurate` must be preserved exactly as-is.
+
+- [ ] **Step 3: Verify the diff is surgical**
+
+  Run from the project root:
+
+  ```bash
+  git diff
+  ```
+
+  Expected: exactly two changed tokens (`DateTime.Now` → `DateTime.UtcNow`), both in `CatalogModule.cs`, nothing else. If any other file or line appears in the diff, something went wrong — revert and start again.
+
+- [ ] **Step 4: Build**
+
+  From the project root:
+
+  ```bash
+  dotnet build backend/Anela.Heblo.sln
+  ```
+
+  Expected: build succeeds with zero errors and zero new warnings. If any warning is introduced, investigate before proceeding.
+
+- [ ] **Step 5: Commit**
+
+  Stage only the modified file:
+
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+  ```
+
+  Commit:
+
+  ```bash
+  git commit -m "fix: use DateTime.UtcNow in catalog background refresh task
+
+  Replace DateTime.Now with DateTime.UtcNow on lines 310 and 313 of
+  CatalogModule.cs to avoid timezone-dependent date boundaries that
+  could corrupt margin calculation windows by one calendar day."
+  ```

--- a/artifacts/feat-3403/task-plan.r1.md
+++ b/artifacts/feat-3403/task-plan.r1.md
@@ -1,0 +1,90 @@
+# Task Plan: Fix DateTime.Now to DateTime.UtcNow in Catalog Background Refresh Task
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Modify | `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` | Replace two `DateTime.Now` calls with `DateTime.UtcNow` at lines 310 and 313 |
+
+No files are created. No files are deleted.
+
+---
+
+### task: fix-datetime-utcnow
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:310,313`
+
+- [ ] **Step 1: Apply the change on line 310**
+
+  Open `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`.
+
+  Find line 310 (inside `RegisterBackgroundRefreshTasks`):
+
+  ```csharp
+  // Before
+  var twoYearsAgo = DateOnly.FromDateTime(DateTime.Now.AddYears(-2));
+  ```
+
+  Replace with:
+
+  ```csharp
+  // After
+  var twoYearsAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-2));
+  ```
+
+- [ ] **Step 2: Apply the change on line 313**
+
+  On line 313, immediately below:
+
+  ```csharp
+  // Before
+  var dateTo = DateOnly.FromDateTime(DateTime.Now).AddMonths(-1); // Current month is not accurate
+  ```
+
+  Replace with:
+
+  ```csharp
+  // After
+  var dateTo = DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1); // Current month is not accurate
+  ```
+
+  The trailing inline comment `// Current month is not accurate` must be preserved exactly as-is.
+
+- [ ] **Step 3: Verify the diff is surgical**
+
+  Run from the project root:
+
+  ```bash
+  git diff
+  ```
+
+  Expected: exactly two changed tokens (`DateTime.Now` → `DateTime.UtcNow`), both in `CatalogModule.cs`, nothing else. If any other file or line appears in the diff, something went wrong — revert and start again.
+
+- [ ] **Step 4: Build**
+
+  From the project root:
+
+  ```bash
+  dotnet build backend/Anela.Heblo.sln
+  ```
+
+  Expected: build succeeds with zero errors and zero new warnings. If any warning is introduced, investigate before proceeding.
+
+- [ ] **Step 5: Commit**
+
+  Stage only the modified file:
+
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+  ```
+
+  Commit:
+
+  ```bash
+  git commit -m "fix: use DateTime.UtcNow in catalog background refresh task
+
+  Replace DateTime.Now with DateTime.UtcNow on lines 310 and 313 of
+  CatalogModule.cs to avoid timezone-dependent date boundaries that
+  could corrupt margin calculation windows by one calendar day."
+  ```

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -307,10 +307,10 @@ public static class CatalogModule
 
                 await catalogRepository.WaitForCurrentMergeAsync(ct);
                 var products = await catalogRepository.GetAllAsync(ct);
-                var twoYearsAgo = DateOnly.FromDateTime(DateTime.Now.AddYears(-2));
+                var twoYearsAgo = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-2));
                 var minDate = new DateOnly(2025, 1, 1); // No M2 margins available for older data
                 var dateFrom = twoYearsAgo > minDate ? twoYearsAgo : minDate;
-                var dateTo = DateOnly.FromDateTime(DateTime.Now).AddMonths(-1); // Current month is not accurate
+                var dateTo = DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1); // Current month is not accurate
 
                 foreach (var product in products)
                 {


### PR DESCRIPTION
Closes #3403

## What the issue was

`CatalogModule.RegisterBackgroundRefreshTasks` used `DateTime.Now` (local server time) on lines 310 and 313 to compute the date bounds passed to the margin calculation. Every other time-based computation in the Catalog module uses `DateTime.UtcNow` or an injected `TimeProvider`. The inconsistency meant the date boundary could shift by one calendar day when the container's local timezone differs from UTC, occasionally including a partial current month in the `dateTo` window or clipping the last day of the previous month.

## How it was fixed

Replaced both occurrences of `DateTime.Now` with `DateTime.UtcNow` in `CatalogModule.cs`:

- Line 310: `DateOnly.FromDateTime(DateTime.Now.AddYears(-2))` → `DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-2))`
- Line 313: `DateOnly.FromDateTime(DateTime.Now).AddMonths(-1)` → `DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1)` (inline comment preserved verbatim)

The diff is exactly two token substitutions in one file — no surrounding code was altered.

## Artifacts

Brief, spec, arch-review, task plan, impl, and review markdown are committed under `artifacts/feat-3403/` in this branch.

## Code review

## Review Result: CLEAN

## Blocking
- None

## Advisory
- The background refresh task constructs `DateTime.UtcNow` twice independently (lines 310 and 313). If the task ever runs at a month boundary, the two calls could theoretically resolve to different calendar dates. Capturing `var now = DateTime.UtcNow;` once would eliminate that race — the risk is negligible in practice for a date-granularity calculation, and this is a pre-existing pattern not introduced by this PR.
- The adjacent handler `GetProductMarginsHandler.cs` already uses `_timeProvider.GetUtcNow()`. Aligning the background task to `TimeProvider` would be ideal longer-term but is out of scope for this surgical fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2puxDkrbpwy9HCbiefBiy)_