### PR TITLE
#3404: Delete dead commented-out RegisterRefreshTask blocks from CatalogModule

### DIFF
--- a/artifacts/feat-3404/arch-review.r1.md
+++ b/artifacts/feat-3404/arch-review.r1.md
@@ -1,0 +1,14 @@
+# Arch Review — feat-3404
+
+## Assessment
+This is a pure dead-code removal with no architectural implications:
+- The two removed blocks were already completely inert (commented out).
+- The interfaces they referenced (`ISalesCostCalculationService`, `IManufactureCostCalculationService`) are no longer registered or used anywhere in the codebase — removing the comments does not alter the DI graph.
+- No downstream modules depend on these registration entries.
+- No migration, schema, or API surface change is involved.
+
+## Risks
+None. The change reduces file size and cognitive overhead with zero runtime impact.
+
+## Decision
+Proceed with deletion.

--- a/artifacts/feat-3404/brief.md
+++ b/artifacts/feat-3404/brief.md
@@ -1,0 +1,31 @@
+## Module
+Catalog
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` lines 244–270 contain two large commented-out `RegisterRefreshTask` blocks for `ISalesCostCalculationService` and `IManufactureCostCalculationService` that were replaced by the new cost-source architecture:
+
+```csharp
+// COMMENTED OUT - Old services replaced by new cost source architecture
+// services.RegisterRefreshTask(
+//     ...  (25 lines)
+// );
+
+// COMMENTED OUT - Old services replaced by new cost source architecture
+// services.RegisterRefreshTask(
+//     ...  (15 lines)
+// );
+```
+
+The comment itself states these are dead — &#34;replaced by new cost source architecture.&#34;
+
+## Why it matters
+`CatalogModule.cs` is already a dense 321-line registration file with 18+ `RegisterRefreshTask` calls and 30+ `AddScoped`/`AddTransient` registrations. Forty lines of commented-out dead code in the middle of this file:
+- Increases the cognitive load when reading or modifying the registration sequence.
+- References removed interfaces (`ISalesCostCalculationService`, `IManufactureCostCalculationService`) that no longer exist, which confuses readers about what services are actually active.
+- If git history is the source of truth for &#34;what was here before,&#34; comments are redundant; the diff already records the removal.
+
+## Suggested fix
+Delete lines 244–270. The git history preserves the old registration code if it ever needs to be referenced. No test or runtime change is needed — the code is already unreachable.
+
+---
+_Filed by daily arch-review routine on 2026-06-28._

--- a/artifacts/feat-3404/code-review.r1.md
+++ b/artifacts/feat-3404/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking
+- None
+
+### Advisory
+- None

--- a/artifacts/feat-3404/design.r1.md
+++ b/artifacts/feat-3404/design.r1.md
@@ -1,0 +1,10 @@
+# Design — feat-3404
+
+## Approach
+Single surgical edit: remove the two commented-out `RegisterRefreshTask` blocks (lines 244–270) and the surrounding blank lines, leaving the active cost-source refresh tasks below intact.
+
+## Change
+- **File:** `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+- **Delete:** lines 244–270 (the blank line before the first comment block through the blank line after the second `);`)
+
+No new files, no renaming, no interface changes.

--- a/artifacts/feat-3404/impl/delete-dead-comments.r1.md
+++ b/artifacts/feat-3404/impl/delete-dead-comments.r1.md
@@ -1,0 +1,7 @@
+# Implementation — delete-dead-comments r1
+
+## Change made
+Deleted lines 244–270 from `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`: two commented-out `RegisterRefreshTask` blocks for `ISalesCostCalculationService` and `IManufactureCostCalculationService`, along with their surrounding blank lines.
+
+## Verification
+`dotnet build backend/src/Anela.Heblo.Application/` — 0 errors, 15 warnings (all pre-existing nullable warnings unrelated to this change).

--- a/artifacts/feat-3404/review/delete-dead-comments.r1.md
+++ b/artifacts/feat-3404/review/delete-dead-comments.r1.md
@@ -1,0 +1,9 @@
+# Review — delete-dead-comments r1
+
+## Assessment
+The change exactly matches the task specification: both commented-out `RegisterRefreshTask` blocks (lines 244–270) have been removed from `CatalogModule.cs`. No unrelated code was touched. The surrounding active code (active `RegisterRefreshTask` calls above and below) is unaffected. Build passes with 0 errors.
+
+## Findings
+None.
+
+**Status:** PASS

--- a/artifacts/feat-3404/spec.r1.md
+++ b/artifacts/feat-3404/spec.r1.md
@@ -1,0 +1,18 @@
+# Spec — feat-3404: Delete dead commented-out code in CatalogModule
+
+## Problem
+`CatalogModule.cs` (backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs) contains two large commented-out `RegisterRefreshTask` blocks at lines 244–270 for `ISalesCostCalculationService` and `IManufactureCostCalculationService`. Both blocks carry explicit comments stating they were replaced by the new cost-source architecture. These 27 lines of dead commented-out code:
+- Add cognitive noise to a dense 321-line DI registration file.
+- Reference interfaces that no longer exist (`ISalesCostCalculationService`, `IManufactureCostCalculationService`), which confuses readers about which services are active.
+- Are redundant given git history preserves the removal.
+
+## Scope
+- **File:** `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+- **Lines to delete:** 244–270 (the two commented-out `RegisterRefreshTask` blocks and their surrounding blank lines)
+- **No other files** need to be changed.
+- **No tests** need to be added or modified — the commented-out code is already unreachable and was never exercised.
+
+## Success criteria
+1. Lines 244–270 are deleted from `CatalogModule.cs`.
+2. `dotnet build` passes with zero errors or warnings introduced by this change.
+3. All existing tests still pass.

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3404",
+  "issue_number": 3404,
+  "created_at": "2026-06-29T07:14:52.154574Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T07:16:03.348386Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-06-29T07:16:03.348386Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T07:16:16.300861Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-06-29T07:16:29.823346Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T07:16:49.184791Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "delete-dead-comments",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-06-29T07:19:49.555643Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T07:19:57.943563Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T07:20:55.948381Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-06-29T07:16:16.300861Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T07:16:29.823346Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -21,16 +21,20 @@
       "updated_at": "2026-06-29T07:16:49.184791Z"
     },
     "developing": {
+      "status": "completed",
+      "updated_at": "2026-06-29T07:19:49.555643Z"
+    },
+    "code-review": {
       "status": "in_progress",
-      "updated_at": "2026-06-29T07:16:53.591986Z"
+      "updated_at": "2026-06-29T07:19:57.943563Z"
     }
   },
   "tasks": [
     {
       "name": "delete-dead-comments",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-29T07:16:53.929968Z"
+      "updated_at": "2026-06-29T07:19:49.319385Z"
     }
   ]
 }

--- a/artifacts/feat-3404/state.json
+++ b/artifacts/feat-3404/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-29T07:16:49.184791Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T07:16:53.591986Z"
     }
   },
   "tasks": [
     {
       "name": "delete-dead-comments",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-29T07:16:53.929968Z"
     }
   ]
 }

--- a/artifacts/feat-3404/task-context/delete-dead-comments.md
+++ b/artifacts/feat-3404/task-context/delete-dead-comments.md
@@ -1,0 +1,39 @@
+# Task Plan — feat-3404
+
+### task: delete-dead-comments
+
+**Goal:** Delete the two commented-out `RegisterRefreshTask` blocks from `CatalogModule.cs`.
+
+**File:** `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+
+**Change:** Remove lines 244–270:
+```
+        // COMMENTED OUT - Old services replaced by new cost source architecture
+        // services.RegisterRefreshTask<ISalesCostCalculationService>(
+        //     nameof(ISalesCostCalculationService.Reload),
+        //     async (serviceProvider, ct) =>
+        //     {
+        //         var catalogRepository = serviceProvider.GetRequiredService<ICatalogRepository>();
+        //         var costService = serviceProvider.GetRequiredService<ISalesCostCalculationService>();
+        //
+        //         await catalogRepository.WaitForCurrentMergeAsync(ct);
+        //         await costService.Reload();
+        //     }
+        // );
+
+        // COMMENTED OUT - Old services replaced by new cost source architecture
+        // services.RegisterRefreshTask<IManufactureCostCalculationService>(
+        //     nameof(IManufactureCostCalculationService.Reload),
+        //     async (serviceProvider, ct) =>
+        //     {
+        //         var catalogRepository = serviceProvider.GetRequiredService<ICatalogRepository>();
+        //         var manufactureCostService = serviceProvider.GetRequiredService<IManufactureCostCalculationService>();
+        //
+        //         await catalogRepository.WaitForCurrentMergeAsync(ct);
+        //         var catalogData = await catalogRepository.GetAllAsync(ct);
+        //         await manufactureCostService.Reload(catalogData.ToList());
+        //     }
+        // );
+```
+
+**Verify:** `dotnet build backend/src/Anela.Heblo.Application/` succeeds.

--- a/artifacts/feat-3404/task-plan.r1.md
+++ b/artifacts/feat-3404/task-plan.r1.md
@@ -1,0 +1,39 @@
+# Task Plan — feat-3404
+
+### task: delete-dead-comments
+
+**Goal:** Delete the two commented-out `RegisterRefreshTask` blocks from `CatalogModule.cs`.
+
+**File:** `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+
+**Change:** Remove lines 244–270:
+```
+        // COMMENTED OUT - Old services replaced by new cost source architecture
+        // services.RegisterRefreshTask<ISalesCostCalculationService>(
+        //     nameof(ISalesCostCalculationService.Reload),
+        //     async (serviceProvider, ct) =>
+        //     {
+        //         var catalogRepository = serviceProvider.GetRequiredService<ICatalogRepository>();
+        //         var costService = serviceProvider.GetRequiredService<ISalesCostCalculationService>();
+        //
+        //         await catalogRepository.WaitForCurrentMergeAsync(ct);
+        //         await costService.Reload();
+        //     }
+        // );
+
+        // COMMENTED OUT - Old services replaced by new cost source architecture
+        // services.RegisterRefreshTask<IManufactureCostCalculationService>(
+        //     nameof(IManufactureCostCalculationService.Reload),
+        //     async (serviceProvider, ct) =>
+        //     {
+        //         var catalogRepository = serviceProvider.GetRequiredService<ICatalogRepository>();
+        //         var manufactureCostService = serviceProvider.GetRequiredService<IManufactureCostCalculationService>();
+        //
+        //         await catalogRepository.WaitForCurrentMergeAsync(ct);
+        //         var catalogData = await catalogRepository.GetAllAsync(ct);
+        //         await manufactureCostService.Reload(catalogData.ToList());
+        //     }
+        // );
+```
+
+**Verify:** `dotnet build backend/src/Anela.Heblo.Application/` succeeds.

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -241,33 +241,6 @@ public static class CatalogModule
             (r, ct) => r.RefreshManufactureDifficultySettingsData(null, ct)
         );
 
-        // COMMENTED OUT - Old services replaced by new cost source architecture
-        // services.RegisterRefreshTask<ISalesCostCalculationService>(
-        //     nameof(ISalesCostCalculationService.Reload),
-        //     async (serviceProvider, ct) =>
-        //     {
-        //         var catalogRepository = serviceProvider.GetRequiredService<ICatalogRepository>();
-        //         var costService = serviceProvider.GetRequiredService<ISalesCostCalculationService>();
-        //
-        //         await catalogRepository.WaitForCurrentMergeAsync(ct);
-        //         await costService.Reload();
-        //     }
-        // );
-
-        // COMMENTED OUT - Old services replaced by new cost source architecture
-        // services.RegisterRefreshTask<IManufactureCostCalculationService>(
-        //     nameof(IManufactureCostCalculationService.Reload),
-        //     async (serviceProvider, ct) =>
-        //     {
-        //         var catalogRepository = serviceProvider.GetRequiredService<ICatalogRepository>();
-        //         var manufactureCostService = serviceProvider.GetRequiredService<IManufactureCostCalculationService>();
-        //
-        //         await catalogRepository.WaitForCurrentMergeAsync(ct);
-        //         var catalogData = await catalogRepository.GetAllAsync(ct);
-        //         await manufactureCostService.Reload(catalogData.ToList());
-        //     }
-        // );
-
         // Cost source refresh tasks (Tier 2 - after catalog refresh)
         // Sources compute costs and populate cache
         services.RegisterRefreshTask<IMaterialCostProvider>(


### PR DESCRIPTION
Closes #3404

## What the issue was
`CatalogModule.cs` (the Catalog module's DI registration file) contained two large commented-out `RegisterRefreshTask` blocks for `ISalesCostCalculationService` and `IManufactureCostCalculationService`. Both blocks carried explicit comments stating they were replaced by the new cost-source architecture. These 27 lines of dead commented-out code added cognitive noise to an already dense 321-line registration file and referenced interfaces that no longer exist in the codebase.

## How it was fixed / handled
Deleted lines 244–270 from `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — the two commented-out blocks and their surrounding blank lines. All active `RegisterRefreshTask` calls above and below the deletion site are untouched. The new cost-source architecture registrations that replaced these remain in place. Build verified: 0 errors.

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3404/`.

## Code review

## Review Result: CLEAN

### Blocking
- None

### Advisory
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01JesdCQniwD4gKQf7kxf9sK)_