### PR TITLE
#3407: Remove test-only BuildTestPipeline() from MetaAdsTransactionSource

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
@@ -136,18 +136,6 @@ public class MetaAdsTransactionSource : IMarketingTransactionSource
             })
             .Build();
 
-    /// <summary>Zero-delay pipeline for unit tests.</summary>
-    internal static ResiliencePipeline BuildTestPipeline() =>
-        new ResiliencePipelineBuilder()
-            .AddRetry(new RetryStrategyOptions
-            {
-                ShouldHandle = new PredicateBuilder()
-                    .Handle<HttpRequestException>(ex => ex.StatusCode == HttpStatusCode.TooManyRequests),
-                MaxRetryAttempts = 3,
-                Delay = TimeSpan.Zero,
-            })
-            .Build();
-
     // ── Internal deserialization models ──────────────────────────────────────
 
     private sealed class MetaTransactionsResponse

--- a/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
@@ -4,6 +4,8 @@ using Anela.Heblo.Adapters.MetaAds;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Retry;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Adapters.MetaAds;
@@ -229,11 +231,21 @@ public class MetaAdsTransactionSourceTests
             BaseAddress = new Uri("https://graph.facebook.com/")
         };
 
+        var testPipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<HttpRequestException>(ex => ex.StatusCode == HttpStatusCode.TooManyRequests),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.Zero,
+            })
+            .Build();
+
         var source = new MetaAdsTransactionSource(
             httpClient,
             Options.Create(settings),
             NullLogger<MetaAdsTransactionSource>.Instance,
-            MetaAdsTransactionSource.BuildTestPipeline());
+            testPipeline);
 
         var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
         var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);


### PR DESCRIPTION
Closes #3407

## What the issue was

`MetaAdsTransactionSource` (production HTTP adapter for the Meta Ads Graph API) contained an `internal static BuildTestPipeline()` method whose sole purpose was providing a zero-delay `ResiliencePipeline` for unit tests. This gave the production class a second responsibility — serving test-harness needs — that does not belong in the production binary.

## How it was fixed

- **Removed** `BuildTestPipeline()` (lines 139–149) from `MetaAdsTransactionSource.cs` entirely.
- **Updated** `MetaAdsTransactionSourceTests.cs`: added `using Polly;` / `using Polly.Retry;` and replaced the `MetaAdsTransactionSource.BuildTestPipeline()` call-site with an inline `ResiliencePipelineBuilder` construction (identical settings: `MaxRetryAttempts = 3`, `Delay = TimeSpan.Zero`, same `ShouldHandle` predicate) scoped to the one test method that exercises retry behaviour.
- `BuildDefaultPipeline()` is untouched — it remains the production path used by the constructor default.

## Code review

## Review Result: CLEAN

Plan alignment perfect — all three deliverables met. The removal is surgical, the two new `using` directives are necessary and correct, and the inline pipeline is correctly scoped to the one test method that exercises retry behaviour. No blocking findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Do9JQ1XGoES5YcYAoEqWx)_