### PR TITLE
#3408: Fix SaveChangesAsync exception swallowing in MarketingInvoiceImportService

### DIFF
--- a/artifacts/feat-3408/arch-review.r1.md
+++ b/artifacts/feat-3408/arch-review.r1.md
@@ -1,0 +1,130 @@
+# Architecture Review: Fix SaveChangesAsync Exception Swallowing in MarketingInvoiceImportService
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a pure bug fix that restores an invariant the codebase already documents. The comment at `ImportMarketingInvoicesHandler` lines 50–52 explicitly states that import-time exceptions must not be caught at the handler level so Hangfire can retry. The both job classes (`MetaAdsInvoiceImportJob`, `GoogleAdsInvoiceImportJob`) already have a correct catch-log-rethrow block. The missing link is the single swallowed `throw;` inside `MarketingInvoiceImportService`.
+
+The call chain is:
+
+```
+HangfireJob.ExecuteAsync
+  └─ IMediator.Send(ImportMarketingInvoicesRequest)
+       └─ ImportMarketingInvoicesHandler.Handle        ← no catch, by design
+            └─ IMarketingInvoiceImportService.ImportAsync
+                 └─ IImportedMarketingTransactionRepository.SaveChangesAsync  ← exception swallowed here
+```
+
+Every layer above the service correctly lets exceptions propagate. Only the batch-flush catch block breaks the chain. The fix is fully contained within that one service; no layer above or below it changes.
+
+The existing test suite (`MarketingInvoiceImportServiceTests`) is well-structured: one test per behaviour, Moq-based, no integration infrastructure. The test that currently asserts the swallowing behaviour (`ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow`) must be corrected in place, not replaced with a parallel test, to avoid leaving a contradicting assertion in the file.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. The fix touches exactly two files:
+
+```
+MarketingInvoiceImportService          (src — one-line change)
+MarketingInvoiceImportServiceTests     (test — rename + rewrite one test, add one test)
+```
+
+The propagation path after the fix:
+
+```
+SaveChangesAsync throws
+  → catch block: LogError, result.Failed += stagedCount, throw;   ← add throw;
+  → ImportAsync propagates exception
+  → ImportMarketingInvoicesHandler propagates exception (already correct)
+  → MetaAdsInvoiceImportJob / GoogleAdsInvoiceImportJob catch block: LogError, rethrow
+  → Hangfire records failure and schedules retry
+```
+
+The success-path logging line (`LogInformation` at line 111) is skipped because the exception propagates past it. This is the correct behaviour — a completion log must not be emitted when persistence failed.
+
+### Key Design Decisions
+
+#### Decision 1: Placement of `throw;` relative to the existing log and counter
+
+**Options considered:**
+- Add `throw;` before `result.Failed += stagedCount` (loses the accurate failed count in any observer that catches further up).
+- Add `throw;` after `result.Failed += stagedCount` (preserves the count; the result object is accessible to any future catch handler higher in the stack, even though today nothing inspects it after a rethrow).
+- Remove the catch block entirely (discards the `LogError` call, which has operational value for diagnosing transient DB failures in logs before the Hangfire failure record appears).
+
+**Chosen approach:** Add `throw;` as the final statement of the catch block, after `result.Failed += stagedCount`, exactly as the spec prescribes.
+
+**Rationale:** The log and the counter both have value and exist today. Adding `throw;` as the last statement preserves them and is the minimal diff that closes the propagation gap. The spec's out-of-scope statement explicitly excludes the jobs and the handler; no other change is needed.
+
+#### Decision 2: Test strategy for the rethrow contract
+
+**Options considered:**
+- Keep the renamed/fixed test as the only test; rely on the type assertion to implicitly cover preservation.
+- Add a second dedicated test (`ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved`) that makes the type-preservation contract explicit.
+
+**Chosen approach:** Two tests as specified — the renamed test verifies that the exception propagates at all (`ThrowsAsync`), and the new test makes the type identity explicit.
+
+**Rationale:** `ThrowsAsync<InvalidOperationException>` already asserts both propagation and type. A second test with a different name documents the *intent* of type preservation for future readers. The cost is negligible; the documentation value is real. Both tests assert the `SaveChangesAsync` mock was called `Times.Once`, confirming the flush was attempted.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. No directory changes. Modify exactly:
+
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+### Interfaces and Contracts
+
+`IMarketingInvoiceImportService.ImportAsync` contract changes in one respect: previously it was guaranteed not to throw when `SaveChangesAsync` failed. After the fix, it throws whatever exception `SaveChangesAsync` threw. The exception is not wrapped — `throw;` preserves the original stack trace and type. Callers already handle this: the handler does not catch, the jobs catch and rethrow.
+
+No interface signature changes. No new types.
+
+### Data Flow
+
+**Before fix (broken):**
+```
+SaveChangesAsync throws InvalidOperationException
+  → catch: log, result.Failed += stagedCount
+  → ImportAsync returns result (Imported=0, Failed=N)
+  → handler returns ImportMarketingInvoicesResponse(Failed=N)
+  → job logs "completed", Hangfire records success  ← silent data loss
+```
+
+**After fix (correct):**
+```
+SaveChangesAsync throws InvalidOperationException
+  → catch: log, result.Failed += stagedCount, throw;
+  → ImportAsync propagates InvalidOperationException
+  → handler propagates (no catch)
+  → job catch block: log error, rethrow
+  → Hangfire records failure, schedules retry  ← correct
+```
+
+The success-path completion log at `ImportAsync` line 111 is bypassed because the exception propagates before reaching it. The job-level error log from the job's catch block fires instead.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| The completion log at line 111 of `ImportAsync` is not emitted on flush failure, which changes existing log-based alerting or dashboards | Low | No evidence of log-based alerting in scope; the Hangfire failure record is the primary observability mechanism. If log analysis depends on the completion line being emitted, add a `finally` block to always log completion — but this is outside the spec and should not be added speculatively. |
+| Future callers of `ImportAsync` do not expect it to throw on flush failure | Low | The contract is now documented by the corrected tests. `IMarketingInvoiceImportService` has exactly two callers in the codebase (via the handler), both of which already handle exceptions correctly. |
+| The `stagedCount` variable captures the count of staged-but-unpersisted transactions, and incrementing `result.Failed` by it before rethrowing could mislead a future handler that inspects the result | Very Low | No caller today inspects `result` after a rethrow. The spec preserves this behaviour. If the result object ever becomes observable again, the `Failed` count will be semantically accurate (those transactions were staged but not committed). |
+
+## Specification Amendments
+
+None required. The spec is complete and internally consistent. The implementation is a strict subset of what the spec prescribes.
+
+One clarification for implementors: the `result.Imported` stays 0 after the rethrow, and `result.Skipped` stays at whatever it accumulated during the per-transaction loop. The spec's test assertions (removing `result.Failed == 2`, `result.Imported == 0`, `result.Skipped == 0`) are correct because none of those values matter once the exception is propagating — the result object is unreachable to any caller.
+
+## Prerequisites
+
+None. This is a self-contained source change with no migration, infrastructure, or configuration dependency.
+
+Build validation before merging:
+- `dotnet build` must pass.
+- `dotnet format` must produce no diff.
+- All tests in `MarketingInvoiceImportServiceTests` must pass, including the two changed/added tests.
+- The remaining eight tests in the file must continue to pass without modification.

--- a/artifacts/feat-3408/brief.md
+++ b/artifacts/feat-3408/brief.md
@@ -1,0 +1,58 @@
+## Module
+MarketingInvoices
+
+## Finding
+There is a contradiction between the handler's stated intent and the service's actual behavior when a batch-level DB flush fails.
+
+**Handler comment** (`backend/src/Anela.Heblo.Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs`, lines 50–52):
+```csharp
+// Import-time exceptions are intentionally NOT caught here — they must
+// propagate to the job's catch-log-rethrow so Hangfire can retry.
+var result = await _importService.ImportAsync(source, request.From, request.To, cancellationToken);
+```
+
+**Service behavior** (`backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`, lines 93–109):
+```csharp
+try
+{
+    await _repository.SaveChangesAsync(ct);
+    result.Imported = stagedCount;
+}
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Failed to persist {Count} marketing transactions for {Platform}", ...);
+    result.Failed += stagedCount;
+    // result.Imported intentionally stays 0 — nothing was committed.
+}
+```
+
+The service catches `SaveChangesAsync` exceptions (transient DB connectivity, deadlock, constraint violation) and swallows them. It returns a `MarketingImportResult` with `Imported=0` and `Failed=N` instead of rethrowing.
+
+Consequence: the handler never sees an exception, so the Hangfire job (`MetaAdsInvoiceImportJob` / `GoogleAdsInvoiceImportJob`) logs `"completed. Imported=0, Skipped=0, Failed=N"` at `Information` level and exits normally — Hangfire records a **success** and schedules no retry.
+
+The per-transaction catch (lines 82–90, swallowing individual `AddAsync` errors) is intentional — partial failure should not abort the run. But a `SaveChangesAsync` failure is categorically different: it means **no** staged transaction was persisted and the failure is likely transient (DB blip, connection reset). This is exactly the case the handler comment says should trigger a Hangfire retry.
+
+## Why it matters
+- A transient DB failure during flush silently drops all transactions staged in that run. They will only be re-imported on the next scheduled run (up to 12 hours later for the twice-daily jobs).
+- Hangfire's job history shows a successful execution with `Failed=N`, obscuring the fact that a system-level error occurred.
+- The architectural intent (comment in handler) and the runtime behaviour are directly contradictory, making the failure mode invisible to operators.
+
+## Suggested fix
+Rethrow in the `SaveChangesAsync` catch block after logging:
+
+```csharp
+catch (Exception ex)
+{
+    _logger.LogError(
+        ex,
+        "Failed to persist {Count} marketing transactions for {Platform}",
+        stagedCount, source.Platform);
+    result.Failed += stagedCount;
+    throw; // propagate so the job can catch-log-rethrow and Hangfire schedules a retry
+}
+```
+
+This ensures a DB flush failure produces a Hangfire job failure, surfaces properly in monitoring, and triggers automatic retry — which is exactly what the handler comment documents as the intended design.
+
+---
+_Filed by daily arch-review routine on 2026-06-29._

--- a/artifacts/feat-3408/code-review.r1.md
+++ b/artifacts/feat-3408/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs:407` — `Assert.IsType<InvalidOperationException>(ex)` in `_ExceptionTypeIsPreserved` is redundant: `Assert.ThrowsAsync<InvalidOperationException>` already guarantees the type. The message-equality assertion (`Assert.Equal("flush failed", ex.Message)`) is the only value-adding check in that test; the `IsType` line can be removed without losing coverage.

--- a/artifacts/feat-3408/impl/fix-service.r1.md
+++ b/artifacts/feat-3408/impl/fix-service.r1.md
@@ -1,0 +1,37 @@
+# Implementation: fix-service
+
+## What was implemented
+
+Added `throw;` as the final statement in the `SaveChangesAsync` catch block inside `MarketingInvoiceImportService.ImportAsync`. Previously, DB flush exceptions were silently swallowed — the error was logged and `result.Failed` was incremented, but the exception never propagated. This meant the Hangfire job layer would see a successful return and never know the batch write failed. The fix ensures the exception propagates so Hangfire can retry the job correctly.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — added `throw;` after `result.Failed += stagedCount;` in the batch-flush catch block (line 107, inside the `if (stagedCount > 0)` try/catch)
+
+## Tests
+
+N/A for this task — test changes are in fix-tests task.
+
+## How to verify
+
+1. Build: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — must produce 0 errors.
+2. Confirm the per-transaction catch block (around `AddAsync`) is unchanged — that one intentionally swallows exceptions to allow other transactions to continue.
+3. To observe at runtime: simulate a `SaveChangesAsync` failure (e.g., DB constraint violation) — the Hangfire job should now surface the exception and schedule a retry rather than recording a silent success.
+
+## Notes
+
+- Only the batch-flush catch block was modified; the per-transaction catch block was intentionally left untouched.
+- The `throw;` form (not `throw ex;`) is used to preserve the original stack trace.
+- Build produced 139 pre-existing nullable warnings and 0 errors — all warnings are unrelated to this change.
+
+## PR Summary
+
+DB flush exceptions in `MarketingInvoiceImportService.ImportAsync` were silently swallowed: the error was logged and the failed count was updated, but the exception never propagated to the Hangfire job layer. This meant jobs would complete "successfully" even when the entire staged batch was lost. Adding `throw;` after the failed-count update ensures the exception surfaces so Hangfire can retry the job.
+
+### Changes
+
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — added `throw;` in the `SaveChangesAsync` catch block to propagate DB flush exceptions to the job layer
+
+## Status
+
+DONE

--- a/artifacts/feat-3408/impl/fix-tests.r1.md
+++ b/artifacts/feat-3408/impl/fix-tests.r1.md
@@ -1,0 +1,32 @@
+# Implementation: fix-tests
+
+## What was implemented
+Updated `MarketingInvoiceImportServiceTests` to reflect the correct behavior of `SaveChangesAsync` failure: the service should rethrow the exception rather than swallowing it and reporting staged records as failed. The old test `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow` encoded the wrong/buggy behavior. It was replaced and a second test was added to verify exception type preservation.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — renamed bug-encoding test to `ImportAsync_FinalSaveChangesThrows_Rethrows` and rewrote it to assert `ThrowsAsync<InvalidOperationException>`; added new `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` test.
+
+## Tests
+- `ImportAsync_FinalSaveChangesThrows_Rethrows` — verifies that when the single post-loop `SaveChangesAsync` call throws, the exception propagates out of `ImportAsync` (not swallowed), and `SaveChangesAsync` is called exactly once.
+- `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` — verifies that the exception type (`InvalidOperationException`) and message (`"flush failed"`) are preserved unchanged, proving `throw;` semantics rather than `throw ex;`.
+
+All 10 tests in the class pass.
+
+## How to verify
+```bash
+cd /home/user/worktrees/feature-3408-Arch-Review-Marketinginvoices-Savechangesasync-Fai
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+```
+Expected: Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10
+
+## Notes
+No deviations from the task spec. The test file compiled and all tests passed on first run, confirming the production implementation (from the earlier fix-service step) already uses `throw;` correctly.
+
+## PR Summary
+Update `MarketingInvoiceImportServiceTests` to assert the correct rethrow behavior when `SaveChangesAsync` fails. The previous test `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow` encoded the wrong behavior (swallowing exceptions and reporting failures). It is replaced by two tests that verify: (1) the exception propagates out of `ImportAsync`, and (2) exception type and message are preserved.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — renamed and rewrote `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow` → `ImportAsync_FinalSaveChangesThrows_Rethrows`; added `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved`.
+
+## Status
+DONE

--- a/artifacts/feat-3408/review/fix-service.r1.md
+++ b/artifacts/feat-3408/review/fix-service.r1.md
@@ -1,0 +1,16 @@
+# Code Review: fix-service
+
+## Summary
+
+The `throw;` statement was correctly added at line 108 of `MarketingInvoiceImportService.cs` in the worktree. The batch-flush catch block now rethrowing after logging and incrementing `result.Failed`. The per-transaction catch block is untouched. Build passes with 0 errors. All acceptance criteria met.
+
+Note: The automated reviewer incorrectly checked the main checkout path (`/home/user/Anela.Heblo`) rather than the worktree path — the fix is present and verified in the worktree at line 108.
+
+## Review Result: PASS
+
+### task: fix-service
+**Status:** PASS
+
+## Overall Notes
+
+Single-line change correctly applied. Bare `throw;` used (not `throw ex;`), preserving the original stack trace. The implementation matches the specification exactly.

--- a/artifacts/feat-3408/review/fix-tests.r1.md
+++ b/artifacts/feat-3408/review/fix-tests.r1.md
@@ -1,0 +1,21 @@
+# Code Review: fix-tests
+
+## Summary
+
+The implementation correctly replaces the old bug-encoding test and adds the second verification test. All five acceptance criteria are verifiable directly in the file. The `SaveChangesAsync` mock verification (`Times.Once`) is present in `ImportAsync_FinalSaveChangesThrows_Rethrows`. The second test (`ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved`) asserts both `IsType<InvalidOperationException>` and `ex.Message == "flush failed"`. No result assertions remain after the throw path in either test.
+
+## Review Result: PASS
+
+### task: fix-tests
+**Status:** PASS
+
+## Overall Notes
+
+All acceptance criteria are met exactly:
+
+- Test renamed to `ImportAsync_FinalSaveChangesThrows_Rethrows`. ✓
+- Uses `await Assert.ThrowsAsync<InvalidOperationException>(...)`. ✓
+- No result assertions after the throw — the old `result.Imported / result.Failed` checks are gone. ✓
+- `SaveChangesAsync` mock verification `Times.Once` preserved. ✓
+- New test `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` added, asserting `IsType<InvalidOperationException>` and `ex.Message == "flush failed"`. ✓
+- The 8 pre-existing tests are structurally unchanged; total is 10 tests. ✓

--- a/artifacts/feat-3408/spec.r1.md
+++ b/artifacts/feat-3408/spec.r1.md
@@ -1,0 +1,109 @@
+# Specification: Fix SaveChangesAsync Exception Swallowing in MarketingInvoiceImportService
+
+## Summary
+
+`MarketingInvoiceImportService.ImportAsync` silently swallows exceptions thrown by `SaveChangesAsync`, causing a batch-level DB flush failure to be reported as a successful Hangfire job execution with `Failed=N`. This directly contradicts the documented architectural intent in `ImportMarketingInvoicesHandler`, which states that import-time exceptions must propagate so Hangfire can schedule a retry. The fix is a one-line `throw;` addition in the `SaveChangesAsync` catch block, accompanied by a test update to reflect the corrected contract.
+
+## Background
+
+The MarketingInvoices module runs two Hangfire recurring jobs — `MetaAdsInvoiceImportJob` (cron `0 6,18 * * *`) and `GoogleAdsInvoiceImportJob` (cron `15 6,18 * * *`) — that each dispatch an `ImportMarketingInvoicesRequest` via MediatR. The handler routes to `MarketingInvoiceImportService.ImportAsync`, which fetches transactions from a platform source, stages them via `IImportedMarketingTransactionRepository.AddAsync`, and flushes the unit of work with a single `SaveChangesAsync` call after the loop.
+
+The service uses two distinct catch boundaries:
+
+1. **Per-transaction catch** (lines 83–90): Catches `AddAsync` failures on individual transactions. This is intentional — a bad row should not abort the entire run. Affected transactions are counted as `Failed` and the loop continues.
+2. **Batch flush catch** (lines 100–108): Catches `SaveChangesAsync` failures after all transactions have been staged. This is the bug. A flush failure means **no** transaction from the run was persisted, and the failure is typically transient (DB connectivity blip, connection pool exhaustion, deadlock). The current code logs the error and returns a result object with `Failed=N`, `Imported=0` — the exception is not rethrown.
+
+Because the exception is swallowed, `ImportMarketingInvoicesHandler` never sees it, the job logs a completion message at `Information` level, and Hangfire records a success. The architectural comment at handler lines 50–52 explicitly documents that this propagation path must work; it does not.
+
+A transient flush failure silently drops up to the entire 7-day lookback window of transactions for a run. The next opportunity to recover them is the subsequent scheduled execution — up to 12 hours later. There is no alert, no Hangfire failure record, and no operator visibility.
+
+## Functional Requirements
+
+### FR-1: Rethrow SaveChangesAsync exceptions after logging
+
+When `SaveChangesAsync` throws, `MarketingInvoiceImportService.ImportAsync` must:
+1. Log the error at `Error` level (already done — no change needed here).
+2. Increment `result.Failed` by `stagedCount` (already done — no change needed here).
+3. Rethrow the original exception using `throw;` so the exception propagates to `ImportMarketingInvoicesHandler` and from there to the Hangfire job's catch block.
+
+**Acceptance criteria:**
+- When `SaveChangesAsync` throws any exception, `ImportAsync` rethrows it (the exception propagates out of `ImportAsync`).
+- The `LogError` call for the flush failure still executes before the rethrow.
+- The per-transaction catch boundary (lines 83–90) is unaffected — `AddAsync` failures still do not abort the run.
+- `MetaAdsInvoiceImportJob.ExecuteAsync` and `GoogleAdsInvoiceImportJob.ExecuteAsync` receive the propagated exception in their existing `catch (Exception ex)` blocks, log it at `Error` level, and rethrow it so Hangfire records a failure and schedules a retry.
+
+### FR-2: Update the existing test that asserts the swallowing behavior
+
+The test `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow` in `MarketingInvoiceImportServiceTests` currently asserts `DoesNotThrow`. This assertion encodes the buggy behavior. It must be replaced with a test that asserts the exception is propagated.
+
+**Acceptance criteria:**
+- The test is renamed to `ImportAsync_FinalSaveChangesThrows_Rethrows` (or equivalent that communicates the correct contract).
+- The test body uses `await Assert.ThrowsAsync<InvalidOperationException>(...)` (matching the mock's thrown type) instead of a plain `await _service.ImportAsync(...)`.
+- The `result.Failed == 2` assertion is removed (the exception propagates before a result is returned; there is no return value to assert on).
+- The `result.Imported == 0` and `result.Skipped == 0` assertions are removed for the same reason.
+- The `SaveChangesAsync` mock verification (`Times.Once`) is preserved.
+- All other existing tests in `MarketingInvoiceImportServiceTests` continue to pass without modification.
+
+### FR-3: Add a service-level test for the rethrow behavior
+
+A new test must explicitly document that the exception type is preserved through the rethrow (i.e., `throw;` is used, not `throw ex;`).
+
+**Acceptance criteria:**
+- A test named `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` (or equivalent) sets up `SaveChangesAsync` to throw a specific typed exception (e.g., `InvalidOperationException` with a known message).
+- `Assert.ThrowsAsync<InvalidOperationException>` confirms the exact type propagates.
+- This test is in `MarketingInvoiceImportServiceTests`.
+
+## Non-Functional Requirements
+
+### NFR-1: No behavior change for the happy path
+
+The fix must not alter any code path that does not involve a `SaveChangesAsync` exception. Specifically: normal import, per-transaction failures, empty input, duplicate detection, and missing-currency handling must all behave identically to before.
+
+### NFR-2: Minimal diff
+
+The production code change is a single line (`throw;`) inside the existing catch block. No refactoring of surrounding logic, no new abstractions, no changes to logging format, no changes to `MarketingImportResult`.
+
+### NFR-3: Build must pass
+
+`dotnet build` must succeed after the change. `dotnet format` must report no violations.
+
+### NFR-4: All tests must pass
+
+All tests in the solution must pass after the change, including the updated and new tests in `MarketingInvoiceImportServiceTests`.
+
+## Data Model
+
+No data model changes. `MarketingImportResult` (`Imported`, `Skipped`, `Failed`) is unchanged.
+
+## API / Interface Design
+
+No API or interface changes. `IMarketingInvoiceImportService.ImportAsync` signature is unchanged. The behavioral contract changes: callers must now handle (or propagate) exceptions from `ImportAsync` when `SaveChangesAsync` fails. The existing job catch-rethrow pattern already handles this correctly — no job-level code changes are needed.
+
+## Dependencies
+
+- `MarketingInvoiceImportService` — production fix (`throw;` in `SaveChangesAsync` catch).
+- `MarketingInvoiceImportServiceTests` — test update (rename + fix one test, add one test).
+- No other files require changes.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` | Add `throw;` at line 108, after `result.Failed += stagedCount;` |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Rename and fix `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow`; add `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` |
+
+## Out of Scope
+
+- Changes to `MetaAdsInvoiceImportJob` or `GoogleAdsInvoiceImportJob` — they already rethrow correctly.
+- Changes to `ImportMarketingInvoicesHandler` — it already intentionally does not catch.
+- Alerting, monitoring dashboards, or Hangfire dashboard configuration.
+- Retry policy configuration (Hangfire defaults apply).
+- Any changes to the per-transaction catch block (lines 83–90) — that behavior is intentional and correct.
+- Adding a `stagedCount == 0` fast-exit path — not requested and out of scope.
+- Changes to any other module or service.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T10:15:54.931947Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3408",
+  "issue_number": 3408,
+  "created_at": "2026-06-29T10:15:21.994633Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-06-29T10:18:12.388234Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T10:18:12.667756Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T10:20:45.315583Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T10:20:45.595201Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T10:20:45.798877Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T10:15:54.931947Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T10:18:12.388234Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T10:18:12.667756Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-06-29T10:35:31.320961Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-06-29T10:35:48.726954Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-29T10:22:47.770007Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T10:23:03.951797Z"
     }
   },
   "tasks": [
     {
       "name": "fix-service",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-29T10:23:04.164327Z"
     },
     {
       "name": "fix-tests",

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -17,13 +17,26 @@
       "updated_at": "2026-06-29T10:20:45.595201Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T10:20:45.798877Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T10:22:47.770007Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-service",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "fix-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-06-29T10:22:47.770007Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T10:23:03.951797Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T10:35:31.320961Z"
     }
   },
   "tasks": [
@@ -34,9 +34,9 @@
     },
     {
       "name": "fix-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-29T10:26:41.291000Z"
+      "updated_at": "2026-06-29T10:35:31.103457Z"
     }
   ]
 }

--- a/artifacts/feat-3408/state.json
+++ b/artifacts/feat-3408/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "fix-service",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-29T10:23:04.164327Z"
+      "updated_at": "2026-06-29T10:26:36.889329Z"
     },
     {
       "name": "fix-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-29T10:26:41.291000Z"
     }
   ]
 }

--- a/artifacts/feat-3408/task-context/fix-service.md
+++ b/artifacts/feat-3408/task-context/fix-service.md
@@ -1,0 +1,84 @@
+### task: fix-service
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+- [ ] **Step 1: Locate the SaveChangesAsync catch block**
+
+  Open the service file. The batch-flush block runs from line 93 to line 109. The catch block looks like this (lines 100–108):
+
+  ```csharp
+          catch (Exception ex)
+          {
+              _logger.LogError(
+                  ex,
+                  "Failed to persist {Count} marketing transactions for {Platform}",
+                  stagedCount, source.Platform);
+              result.Failed += stagedCount;
+              // result.Imported intentionally stays 0 — nothing was committed.
+          }
+  ```
+
+- [ ] **Step 2: Add `throw;` after `result.Failed += stagedCount;`**
+
+  Replace the catch block so it reads:
+
+  ```csharp
+          catch (Exception ex)
+          {
+              _logger.LogError(
+                  ex,
+                  "Failed to persist {Count} marketing transactions for {Platform}",
+                  stagedCount, source.Platform);
+              result.Failed += stagedCount;
+              // result.Imported intentionally stays 0 — nothing was committed.
+              throw;
+          }
+  ```
+
+  The exact edit is: after line 106 (`result.Failed += stagedCount;`), before the closing `}` of the catch block, insert `throw;`. Use `throw;` (bare rethrow), not `throw ex;` — bare rethrow preserves the original stack trace.
+
+- [ ] **Step 3: Verify the surrounding context is untouched**
+
+  After the edit the full `if (stagedCount > 0)` block should look like this:
+
+  ```csharp
+      if (stagedCount > 0)
+      {
+          try
+          {
+              await _repository.SaveChangesAsync(ct);
+              result.Imported = stagedCount;
+          }
+          catch (Exception ex)
+          {
+              _logger.LogError(
+                  ex,
+                  "Failed to persist {Count} marketing transactions for {Platform}",
+                  stagedCount, source.Platform);
+              result.Failed += stagedCount;
+              // result.Imported intentionally stays 0 — nothing was committed.
+              throw;
+          }
+      }
+  ```
+
+  The per-transaction catch block (lines 83–91) must remain unchanged — it intentionally swallows to keep the run going.
+
+- [ ] **Step 4: Build**
+
+  ```
+  cd backend
+  dotnet build
+  ```
+
+  Expected: build succeeds with no errors. The `throw;` statement in a catch block with a declared return type is valid because control never reaches `return result;` when the exception propagates — the compiler accepts this.
+
+- [ ] **Step 5: Commit**
+
+  ```
+  git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+  git commit -m "fix: rethrow SaveChangesAsync exception in MarketingInvoiceImportService"
+  ```
+
+---

--- a/artifacts/feat-3408/task-context/fix-tests.md
+++ b/artifacts/feat-3408/task-context/fix-tests.md
@@ -1,0 +1,176 @@
+### task: fix-tests
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+- [ ] **Step 1: Rename and rewrite the bug-encoding test**
+
+  The current test at line 130–164 is named `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow`. It asserts `DoesNotThrow` (by simply awaiting without any throw assertion) — this is the bug encoded in the tests. It must be replaced entirely.
+
+  **Current test (lines 130–164):**
+
+  ```csharp
+  [Fact]
+  public async Task ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow()
+  {
+      // Arrange
+      var from = new DateTime(2026, 4, 1);
+      var to = new DateTime(2026, 4, 2);
+
+      var transactions = new List<MarketingTransaction>
+      {
+          new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+          new() { TransactionId = "TX-002", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+      };
+
+      _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(transactions);
+
+      _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(false);
+
+      _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync((ImportedMarketingTransaction e, CancellationToken _) => e);
+
+      // The single post-loop flush fails — none of the staged records are persisted
+      _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+      // Act
+      var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+      // Assert
+      Assert.Equal(0, result.Imported);
+      Assert.Equal(0, result.Skipped);
+      Assert.Equal(2, result.Failed);
+      _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+  ```
+
+  **Replace with:**
+
+  ```csharp
+  [Fact]
+  public async Task ImportAsync_FinalSaveChangesThrows_Rethrows()
+  {
+      // Arrange
+      var from = new DateTime(2026, 4, 1);
+      var to = new DateTime(2026, 4, 2);
+
+      var transactions = new List<MarketingTransaction>
+      {
+          new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+          new() { TransactionId = "TX-002", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+      };
+
+      _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(transactions);
+
+      _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(false);
+
+      _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync((ImportedMarketingTransaction e, CancellationToken _) => e);
+
+      // The single post-loop flush fails — none of the staged records are persisted
+      _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+      // Act & Assert
+      await Assert.ThrowsAsync<InvalidOperationException>(
+          () => _service.ImportAsync(_mockSource.Object, from, to));
+
+      _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+  ```
+
+  Note: the result assertions (`Assert.Equal(0, result.Imported)` etc.) are removed because `ImportAsync` throws — there is no return value to assert on.
+
+- [ ] **Step 2: Add the exception-type-preservation test**
+
+  After the renamed test, add a new `[Fact]` that proves `throw;` (not `throw ex;`) is in use. Add it as a new method at the end of the class, before the closing `}`:
+
+  ```csharp
+  [Fact]
+  public async Task ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved()
+  {
+      // Arrange
+      var from = new DateTime(2026, 4, 1);
+      var to = new DateTime(2026, 4, 2);
+
+      var transactions = new List<MarketingTransaction>
+      {
+          new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+      };
+
+      _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(transactions);
+
+      _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(false);
+
+      _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync((ImportedMarketingTransaction e, CancellationToken _) => e);
+
+      _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+      // Act
+      var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+          () => _service.ImportAsync(_mockSource.Object, from, to));
+
+      // Assert — exception type propagates unchanged (proves `throw;` not `throw ex;`)
+      Assert.IsType<InvalidOperationException>(ex);
+      Assert.Equal("flush failed", ex.Message);
+  }
+  ```
+
+  This test verifies:
+  1. `InvalidOperationException` propagates (the exception is not wrapped or swallowed).
+  2. The message is unchanged (the original exception object, not a re-thrown copy).
+
+- [ ] **Step 3: Run only the marketing invoice tests**
+
+  ```
+  cd backend
+  dotnet test --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+  ```
+
+  Expected output: all tests in the class pass. Specifically:
+  - `ImportAsync_FinalSaveChangesThrows_Rethrows` — passes (throws as expected)
+  - `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` — passes
+  - All other existing tests — still pass (per-transaction catch is unaffected)
+
+- [ ] **Step 4: Run the full test suite**
+
+  ```
+  cd backend
+  dotnet test
+  ```
+
+  Expected: all tests pass. No regressions.
+
+- [ ] **Step 5: Format and commit**
+
+  ```
+  cd backend
+  dotnet format
+  git add backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+  git commit -m "test: update MarketingInvoiceImportServiceTests to assert rethrow behavior"
+  ```
+
+---
+
+## Self-Review: Spec Coverage Check
+
+| Requirement | Covered |
+|---|---|
+| FR-1: `throw;` added after `result.Failed += stagedCount;` | task: fix-service, Step 2 |
+| FR-1: `LogError` still executes before rethrow | task: fix-service, Step 3 (block shown in full; LogError precedes throw) |
+| FR-1: Per-transaction catch unaffected | task: fix-service, Step 3 (explicitly called out) |
+| FR-2: Test renamed to `ImportAsync_FinalSaveChangesThrows_Rethrows` | task: fix-tests, Step 1 |
+| FR-2: Uses `await Assert.ThrowsAsync<InvalidOperationException>(...)` | task: fix-tests, Step 1 |
+| FR-2: Result assertions removed | task: fix-tests, Step 1 |
+| FR-2: `SaveChangesAsync` mock verification `Times.Once` preserved | task: fix-tests, Step 1 |
+| FR-3: Test named `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` | task: fix-tests, Step 2 |
+| FR-3: Verifies `InvalidOperationException` type propagates | task: fix-tests, Step 2 |

--- a/artifacts/feat-3408/task-plan.r1.md
+++ b/artifacts/feat-3408/task-plan.r1.md
@@ -1,0 +1,278 @@
+# Task Plan: Fix SaveChangesAsync Exception Swallowing in MarketingInvoiceImportService
+
+## Overview
+
+`MarketingInvoiceImportService.ImportAsync` silently swallows exceptions thrown by `SaveChangesAsync`. A batch-level DB flush failure is logged and counted as `Failed`, but the exception is consumed — so the calling Hangfire job sees success. The fix is a one-line `throw;` addition and a corresponding test update.
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` | Modify | Production service — add `throw;` at end of SaveChangesAsync catch block (line 107) |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Modify | Rename one test that encodes the bug; add one test proving exception type is preserved |
+
+---
+
+## Tasks
+
+### task: fix-service
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+- [ ] **Step 1: Locate the SaveChangesAsync catch block**
+
+  Open the service file. The batch-flush block runs from line 93 to line 109. The catch block looks like this (lines 100–108):
+
+  ```csharp
+          catch (Exception ex)
+          {
+              _logger.LogError(
+                  ex,
+                  "Failed to persist {Count} marketing transactions for {Platform}",
+                  stagedCount, source.Platform);
+              result.Failed += stagedCount;
+              // result.Imported intentionally stays 0 — nothing was committed.
+          }
+  ```
+
+- [ ] **Step 2: Add `throw;` after `result.Failed += stagedCount;`**
+
+  Replace the catch block so it reads:
+
+  ```csharp
+          catch (Exception ex)
+          {
+              _logger.LogError(
+                  ex,
+                  "Failed to persist {Count} marketing transactions for {Platform}",
+                  stagedCount, source.Platform);
+              result.Failed += stagedCount;
+              // result.Imported intentionally stays 0 — nothing was committed.
+              throw;
+          }
+  ```
+
+  The exact edit is: after line 106 (`result.Failed += stagedCount;`), before the closing `}` of the catch block, insert `throw;`. Use `throw;` (bare rethrow), not `throw ex;` — bare rethrow preserves the original stack trace.
+
+- [ ] **Step 3: Verify the surrounding context is untouched**
+
+  After the edit the full `if (stagedCount > 0)` block should look like this:
+
+  ```csharp
+      if (stagedCount > 0)
+      {
+          try
+          {
+              await _repository.SaveChangesAsync(ct);
+              result.Imported = stagedCount;
+          }
+          catch (Exception ex)
+          {
+              _logger.LogError(
+                  ex,
+                  "Failed to persist {Count} marketing transactions for {Platform}",
+                  stagedCount, source.Platform);
+              result.Failed += stagedCount;
+              // result.Imported intentionally stays 0 — nothing was committed.
+              throw;
+          }
+      }
+  ```
+
+  The per-transaction catch block (lines 83–91) must remain unchanged — it intentionally swallows to keep the run going.
+
+- [ ] **Step 4: Build**
+
+  ```
+  cd backend
+  dotnet build
+  ```
+
+  Expected: build succeeds with no errors. The `throw;` statement in a catch block with a declared return type is valid because control never reaches `return result;` when the exception propagates — the compiler accepts this.
+
+- [ ] **Step 5: Commit**
+
+  ```
+  git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+  git commit -m "fix: rethrow SaveChangesAsync exception in MarketingInvoiceImportService"
+  ```
+
+---
+
+### task: fix-tests
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+- [ ] **Step 1: Rename and rewrite the bug-encoding test**
+
+  The current test at line 130–164 is named `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow`. It asserts `DoesNotThrow` (by simply awaiting without any throw assertion) — this is the bug encoded in the tests. It must be replaced entirely.
+
+  **Current test (lines 130–164):**
+
+  ```csharp
+  [Fact]
+  public async Task ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow()
+  {
+      // Arrange
+      var from = new DateTime(2026, 4, 1);
+      var to = new DateTime(2026, 4, 2);
+
+      var transactions = new List<MarketingTransaction>
+      {
+          new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+          new() { TransactionId = "TX-002", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+      };
+
+      _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(transactions);
+
+      _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(false);
+
+      _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync((ImportedMarketingTransaction e, CancellationToken _) => e);
+
+      // The single post-loop flush fails — none of the staged records are persisted
+      _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+      // Act
+      var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+      // Assert
+      Assert.Equal(0, result.Imported);
+      Assert.Equal(0, result.Skipped);
+      Assert.Equal(2, result.Failed);
+      _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+  ```
+
+  **Replace with:**
+
+  ```csharp
+  [Fact]
+  public async Task ImportAsync_FinalSaveChangesThrows_Rethrows()
+  {
+      // Arrange
+      var from = new DateTime(2026, 4, 1);
+      var to = new DateTime(2026, 4, 2);
+
+      var transactions = new List<MarketingTransaction>
+      {
+          new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+          new() { TransactionId = "TX-002", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+      };
+
+      _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(transactions);
+
+      _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(false);
+
+      _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync((ImportedMarketingTransaction e, CancellationToken _) => e);
+
+      // The single post-loop flush fails — none of the staged records are persisted
+      _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+      // Act & Assert
+      await Assert.ThrowsAsync<InvalidOperationException>(
+          () => _service.ImportAsync(_mockSource.Object, from, to));
+
+      _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+  ```
+
+  Note: the result assertions (`Assert.Equal(0, result.Imported)` etc.) are removed because `ImportAsync` throws — there is no return value to assert on.
+
+- [ ] **Step 2: Add the exception-type-preservation test**
+
+  After the renamed test, add a new `[Fact]` that proves `throw;` (not `throw ex;`) is in use. Add it as a new method at the end of the class, before the closing `}`:
+
+  ```csharp
+  [Fact]
+  public async Task ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved()
+  {
+      // Arrange
+      var from = new DateTime(2026, 4, 1);
+      var to = new DateTime(2026, 4, 2);
+
+      var transactions = new List<MarketingTransaction>
+      {
+          new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+      };
+
+      _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(transactions);
+
+      _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync(false);
+
+      _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+          .ReturnsAsync((ImportedMarketingTransaction e, CancellationToken _) => e);
+
+      _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+      // Act
+      var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+          () => _service.ImportAsync(_mockSource.Object, from, to));
+
+      // Assert — exception type propagates unchanged (proves `throw;` not `throw ex;`)
+      Assert.IsType<InvalidOperationException>(ex);
+      Assert.Equal("flush failed", ex.Message);
+  }
+  ```
+
+  This test verifies:
+  1. `InvalidOperationException` propagates (the exception is not wrapped or swallowed).
+  2. The message is unchanged (the original exception object, not a re-thrown copy).
+
+- [ ] **Step 3: Run only the marketing invoice tests**
+
+  ```
+  cd backend
+  dotnet test --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+  ```
+
+  Expected output: all tests in the class pass. Specifically:
+  - `ImportAsync_FinalSaveChangesThrows_Rethrows` — passes (throws as expected)
+  - `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` — passes
+  - All other existing tests — still pass (per-transaction catch is unaffected)
+
+- [ ] **Step 4: Run the full test suite**
+
+  ```
+  cd backend
+  dotnet test
+  ```
+
+  Expected: all tests pass. No regressions.
+
+- [ ] **Step 5: Format and commit**
+
+  ```
+  cd backend
+  dotnet format
+  git add backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+  git commit -m "test: update MarketingInvoiceImportServiceTests to assert rethrow behavior"
+  ```
+
+---
+
+## Self-Review: Spec Coverage Check
+
+| Requirement | Covered |
+|---|---|
+| FR-1: `throw;` added after `result.Failed += stagedCount;` | task: fix-service, Step 2 |
+| FR-1: `LogError` still executes before rethrow | task: fix-service, Step 3 (block shown in full; LogError precedes throw) |
+| FR-1: Per-transaction catch unaffected | task: fix-service, Step 3 (explicitly called out) |
+| FR-2: Test renamed to `ImportAsync_FinalSaveChangesThrows_Rethrows` | task: fix-tests, Step 1 |
+| FR-2: Uses `await Assert.ThrowsAsync<InvalidOperationException>(...)` | task: fix-tests, Step 1 |
+| FR-2: Result assertions removed | task: fix-tests, Step 1 |
+| FR-2: `SaveChangesAsync` mock verification `Times.Once` preserved | task: fix-tests, Step 1 |
+| FR-3: Test named `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` | task: fix-tests, Step 2 |
+| FR-3: Verifies `InvalidOperationException` type propagates | task: fix-tests, Step 2 |

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
@@ -105,6 +105,7 @@ public class MarketingInvoiceImportService : IMarketingInvoiceImportService
                     stagedCount, source.Platform);
                 result.Failed += stagedCount;
                 // result.Imported intentionally stays 0 — nothing was committed.
+                throw;
             }
         }
 

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -128,7 +128,7 @@ public class MarketingInvoiceImportServiceTests
     }
 
     [Fact]
-    public async Task ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow()
+    public async Task ImportAsync_FinalSaveChangesThrows_Rethrows()
     {
         // Arrange
         var from = new DateTime(2026, 4, 1);
@@ -153,13 +153,10 @@ public class MarketingInvoiceImportServiceTests
         _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("flush failed"));
 
-        // Act
-        var result = await _service.ImportAsync(_mockSource.Object, from, to);
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.ImportAsync(_mockSource.Object, from, to));
 
-        // Assert
-        Assert.Equal(0, result.Imported);
-        Assert.Equal(0, result.Skipped);
-        Assert.Equal(2, result.Failed);
         _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -374,5 +371,38 @@ public class MarketingInvoiceImportServiceTests
                 null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ImportedMarketingTransaction e, CancellationToken _) => e);
+
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+        // Act
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.ImportAsync(_mockSource.Object, from, to));
+
+        // Assert — exception type propagates unchanged (proves `throw;` not `throw ex;`)
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Equal("flush failed", ex.Message);
     }
 }


### PR DESCRIPTION
Closes #3408

## What the issue was

`MarketingInvoiceImportService.ImportAsync` silently swallowed exceptions thrown by `SaveChangesAsync`. When a batch-level DB flush failed (transient connectivity blip, deadlock, connection pool exhaustion), the service logged the error and returned `MarketingImportResult` with `Failed=N, Imported=0` — the exception was never rethrown. This contradicted the explicit comment in `ImportMarketingInvoicesHandler` (lines 50–52) stating that import-time exceptions must propagate so Hangfire can retry. The result: Hangfire recorded a success, operators saw a misleading `Information`-level log, and all transactions from the run were silently dropped until the next scheduled execution (up to 12 hours later).

## How it was fixed

Added a single `throw;` as the final statement in the `SaveChangesAsync` catch block in `MarketingInvoiceImportService`, after the existing `LogError` and `result.Failed += stagedCount` lines. The bare rethrow preserves the original stack trace and lets the exception propagate to `ImportMarketingInvoicesHandler` and from there to the Hangfire job's catch-log-rethrow block, which correctly records a job failure and triggers retry.

The per-transaction catch block (swallowing individual `AddAsync` failures) is intentionally left unchanged — partial row failures should not abort the run.

Tests updated: the existing test `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow` (which encoded the buggy behavior) was renamed to `ImportAsync_FinalSaveChangesThrows_Rethrows` and rewritten to use `Assert.ThrowsAsync<InvalidOperationException>`. A second new test `ImportAsync_FinalSaveChangesThrows_ExceptionTypeIsPreserved` was added to verify the exact exception type and message propagate unchanged.

## Artifacts

Brief, spec, arch-review, task-plan, impl, and review markdown are committed in this branch under `artifacts/feat-3408/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs:407` — `Assert.IsType<InvalidOperationException>(ex)` in `_ExceptionTypeIsPreserved` is redundant: `Assert.ThrowsAsync<InvalidOperationException>` already guarantees the type. The `Assert.Equal("flush failed", ex.Message)` is the only value-adding assertion; the `IsType` line can be dropped without losing coverage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqFgFApkDpDFkADspBRr7v)_