### PR TITLE
#3411: add missing unit tests for ImportBankStatementHandler coverage gaps

### DIFF
--- a/artifacts/feat-3411/arch-review.r1.md
+++ b/artifacts/feat-3411/arch-review.r1.md
@@ -1,0 +1,21 @@
+# Architecture Review: Bank ImportBankStatementHandler coverage gaps
+
+## Summary
+Test-only change. No production architecture is affected. All four test cases fit naturally into the existing `ImportBankStatementHandlerTests` class.
+
+## Findings
+
+### No architectural concerns
+Adding tests to an existing test class in the same namespace requires no new abstractions, no new dependencies, and no changes to production code. The existing mock setup (`_mockFactory`, `_mockBankClient`, `_mockImportService`, `_mockRepository`, `_mockStateRepository`, `_mockMapper`, `_mockLogger`) already supports all required scenarios.
+
+### Logger assertion pattern
+The existing `BackgroundRefreshSchedulerServiceTests` establishes the `It.Is<It.IsAnyType>` pattern for asserting ILogger calls. This pattern should be reused consistently rather than introduced differently.
+
+### Relative dates for watermark tests
+Using `DateTime.UtcNow.AddDays(-N)` instead of hardcoded absolute dates makes tests robust over time. The stale-watermark tests must use this approach; `Handle_UsesExistingWatermarkState_WhenAccountKnown` uses a hardcoded `2026-06-09` date which will eventually become ambiguous relative to the default StaleWarningDays.
+
+### UpsertExistingAsync fallback
+The null-check fallback in `UpsertExistingAsync` guards against a race condition (row deleted between the existence check and the fetch). The test must set up `GetByTransferIdAsync` to return `null` while `existingTransfers` still reports the statement as a retry.
+
+## Decision
+Proceed with the four tests as specified. No production code changes required.

--- a/artifacts/feat-3411/brief.md
+++ b/artifacts/feat-3411/brief.md
@@ -1,0 +1,28 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs`
+
+## Coverage
+Line coverage: 33.1% (filter threshold: 60%)
+11 existing tests; 1 integration test file also exists.
+
+## What's not tested
+
+**`ProcessStatementAsync` retry path (`isRetry = true`)**:
+- When a statement was previously imported with a non-Success result (it exists in `existingTransfers` with a failed status), the handler sets `isRetry = true` and calls `UpsertExistingAsync` instead of `InsertNewAsync`. No test exercises this path. A bug here (e.g. `UpsertExistingAsync` not updating the result status) means failed bank statements can never be corrected on re-import — they stay in a permanent error state.
+
+**Stale watermark warning path**:
+- When `state.LastValidImportDate` has a value and `daysBehind > _watermarkOptions.StaleWarningDays`, a warning is logged. While the warning is non-functional (import proceeds), it also means the `StaleWarningDays` setting itself has never been exercised — a misconfiguration that sets it to 0 would spam warnings on every import run.
+
+**`state.RecordFailure` path on exception**:
+- The outer `catch` block records a failure on the state object and upserts it even when the main try-block throws. No test verifies that a mid-import exception (e.g. bank client throws) results in the state being persisted as failed.
+
+## Why it matters
+The retry path is the mechanism for recovering from a failed bank import. If `UpsertExistingAsync` has a bug, every statement that fails once becomes permanently stuck, and the stale-check means drift goes undetected until it is manually spotted.
+
+## Suggested approach
+- Seed `mockStateRepository` with a `BankImportState` that has a `LastValidImportDate` older than `StaleWarningDays` and verify a warning is logged.
+- Pre-populate `existingTransfers` with a `StatementId → ImportStatus.UnknownError` entry and verify `UpsertExistingAsync` is called and the returned DTO reflects the updated result.
+- Throw from `_mockBankClient.GetStatementsAsync` and assert `_mockStateRepository.UpsertAsync` is still called with a failure state. ~0.5 day effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-29. Based on CI run #28295125598 (23c3b5d571c976074ee31869c96e29487098040c)._

--- a/artifacts/feat-3411/code-review.r1.md
+++ b/artifacts/feat-3411/code-review.r1.md
@@ -1,0 +1,8 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs` (stale-warning tests) — `_mockStateRepository.UpsertAsync` is not explicitly set up; relies on Moq default `Task.CompletedTask`. Works correctly; would be clearer with explicit setup if MockBehavior.Strict is ever adopted.
+- `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs` (`Handle_RecordsImportServiceError`) — `BankStatementData { ItemCount = 2 }` was a confusing red herring since `ItemCount` is not passed to `ImportStatementAsync`. Fixed to `ItemCount = 1` for consistency with other tests.

--- a/artifacts/feat-3411/design.r1.md
+++ b/artifacts/feat-3411/design.r1.md
@@ -1,0 +1,83 @@
+# Design: Bank ImportBankStatementHandler coverage gaps
+
+## Test file
+`backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs`
+
+All four new tests are added to the existing `ImportBankStatementHandlerTests` class.
+
+## Test designs
+
+### Test 1: Handle_LogsStaleWarning_WhenWatermarkIsStale
+```
+Arrange:
+  - existingState.RecordSuccess(DateTime.UtcNow.AddDays(-10), ...)
+  - _mockStateRepository returns existingState
+  - _mockBankClient.GetStatementsAsync returns []
+  - Default _handler (StaleWarningDays = 3)
+
+Act: await _handler.Handle(request, CancellationToken.None)
+
+Assert:
+  - _mockLogger.Verify(Log(LogLevel.Warning, ...), Times.Once)
+```
+
+### Test 2: Handle_DoesNotLogWarning_WhenWatermarkIsFresh
+```
+Arrange:
+  - existingState.RecordSuccess(DateTime.UtcNow.AddDays(-1), ...)
+  - _mockStateRepository returns existingState
+  - _mockBankClient.GetStatementsAsync returns []
+
+Act: await _handler.Handle(request, CancellationToken.None)
+
+Assert:
+  - _mockLogger.Verify(Log(LogLevel.Warning, ...), Times.Never)
+```
+
+### Test 3: Handle_FallsBackToInsert_WhenRetryStatementNotFoundInDb
+```
+Arrange:
+  - GetStatementsAsync returns [{ StatementId = "RETRY" }]
+  - GetExistingResultsByTransferIdsAsync returns { "RETRY" -> ProcessingError }
+  - GetStatementAsync("RETRY") returns { Data = "abo", ItemCount = 1 }
+  - ImportStatementAsync(1, "abo") returns Result.Success(true)
+  - GetByTransferIdAsync("RETRY") returns null  <-- key: null despite isRetry=true
+  - AddAsync returns the created entity
+  - Mapper maps to DTO
+
+Act: await _handler.Handle(request, CancellationToken.None)
+
+Assert:
+  - AddAsync called once
+  - UpdateAsync never called
+  - response.SuccessCount == 1
+```
+
+### Test 4: Handle_RecordsImportServiceError_WhenImportServiceReturnsFailed
+```
+Arrange:
+  - GetStatementsAsync returns [{ StatementId = "ERR" }]
+  - GetExistingResultsByTransferIdsAsync returns {}
+  - GetStatementAsync("ERR") returns { Data = "abo", ItemCount = 2 }
+  - ImportStatementAsync(1, "abo") returns Result<bool>.Failure("import-error")
+  - AddAsync captures the BankStatementImport and returns it
+  - Mapper maps to DTO with ImportResult = "import-error"
+
+Act: await _handler.Handle(request, CancellationToken.None)
+
+Assert:
+  - AddAsync called with entity where ImportResult == "import-error"
+  - response.ErrorCount == 1, SuccessCount == 0
+```
+
+## Logger assertion pattern
+```csharp
+_mockLogger.Verify(
+    x => x.Log(
+        LogLevel.Warning,
+        It.IsAny<EventId>(),
+        It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("stale")),
+        It.IsAny<Exception?>(),
+        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+    Times.Once);
+```

--- a/artifacts/feat-3411/impl/add-missing-tests.r1.md
+++ b/artifacts/feat-3411/impl/add-missing-tests.r1.md
@@ -1,0 +1,18 @@
+# Implementation: add-missing-tests r1
+
+## Changes made
+
+**File**: `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs`
+
+Added `using Microsoft.Extensions.Logging;` import and four new tests:
+
+1. **Handle_LogsStaleWarning_WhenWatermarkIsStale** — Seeds state with `LastValidImportDate = DateTime.UtcNow.AddDays(-10)` (10 days ago). Default `StaleWarningDays = 3`. Asserts `_mockLogger.Log(LogLevel.Warning, ...)` is called once with message containing "stale". Covers lines 74-78 of handler (inner-if true branch).
+
+2. **Handle_DoesNotLogWarning_WhenWatermarkIsFresh** — Seeds state with `LastValidImportDate = DateTime.UtcNow.AddDays(-1)` (1 day ago). Default `StaleWarningDays = 3`. Asserts no `LogLevel.Warning` is logged. Covers the inner-if false branch of lines 75-78.
+
+3. **Handle_FallsBackToInsert_WhenRetryStatementNotFoundInDb** — Sets `isRetry = true` via `existingTransfers["RETRY"] = ProcessingError` but makes `GetByTransferIdAsync` return null. Asserts `AddAsync` called once, `UpdateAsync` never called. Covers lines 217-218 of `UpsertExistingAsync`.
+
+4. **Handle_RecordsImportServiceError_WhenImportServiceReturnsFailed** — Makes `ImportStatementAsync` return `Result<bool>.Failure("import-error")`. Asserts `AddAsync` is called with `ImportResult = "import-error"` and response has `ErrorCount = 1`. Covers line 173 false branch of `ProcessStatementAsync`.
+
+## Test results
+`dotnet test --filter "FullyQualifiedName~ImportBankStatementHandlerTests"` → 15 passed, 0 failed

--- a/artifacts/feat-3411/review/add-missing-tests.r1.md
+++ b/artifacts/feat-3411/review/add-missing-tests.r1.md
@@ -1,0 +1,14 @@
+# Code Review: Bank ImportBankStatementHandler coverage gaps
+
+## Summary
+All four tests are correctly implemented, match the spec requirements, and follow the established Moq logger assertion pattern from `BackgroundRefreshSchedulerServiceTests`. Relative dates are used for the watermark tests. All 15 tests pass.
+
+## Review Result: PASS
+
+### task: add-missing-tests
+**Status:** PASS
+
+## Overall Notes
+The `Handle_DoesNotLogWarning_WhenWatermarkIsFresh` test asserts `Times.Never` for any `LogLevel.Warning` message containing "stale". This is correct and deterministic since the warning message in the handler always includes "stale". No documentation changes are needed — this is a test-only addition.
+
+**Status:** PASS

--- a/artifacts/feat-3411/spec.r1.md
+++ b/artifacts/feat-3411/spec.r1.md
@@ -1,0 +1,67 @@
+# Specification: Bank ImportBankStatementHandler coverage gaps
+
+## Summary
+Add unit tests to `ImportBankStatementHandlerTests` covering three branches not currently exercised: the stale-watermark warning log (both the triggered and the non-triggered branches), the `UpsertExistingAsync` null-fallback path (where the DB row is unexpectedly absent), and the import-service business-failure path (where `ImportStatementAsync` returns `IsSuccess = false`).
+
+## Background
+A weekly coverage-gap routine flagged `ImportBankStatementHandler` at 33.1% line coverage. While several tests were added in PR #3329 (retry path, exception catch), three distinct branches remain untested as of the coverage run at commit 23c3b5d.
+
+## Functional Requirements
+
+### FR-1: Stale watermark warning — triggered
+When `state.LastValidImportDate` is set and `daysBehind > StaleWarningDays`, the handler logs a Warning. A test must seed state with a date older than the threshold and assert `ILogger.Log(LogLevel.Warning, ...)` is called exactly once.
+
+**Acceptance criteria:**
+- `_mockLogger.Verify(Log(LogLevel.Warning, ...), Times.Once)` passes when `daysBehind > StaleWarningDays`.
+
+### FR-2: Stale watermark warning — not triggered
+When `state.LastValidImportDate` is set but `daysBehind <= StaleWarningDays`, no Warning is logged.
+
+**Acceptance criteria:**
+- `_mockLogger.Verify(Log(LogLevel.Warning, ...), Times.Never)` passes when `daysBehind <= StaleWarningDays`.
+
+### FR-3: UpsertExistingAsync null fallback
+When a statement is marked as a retry (`isRetry = true`) but `GetByTransferIdAsync` returns null (race / data loss), `UpsertExistingAsync` falls back to `InsertNewAsync`.
+
+**Acceptance criteria:**
+- `_mockRepository.Verify(AddAsync(...), Times.Once)` passes.
+- `_mockRepository.Verify(UpdateAsync(...), Times.Never)` passes.
+
+### FR-4: Import service business failure
+When `ImportStatementAsync` returns `Result<bool>.Failure("error-msg")` (not an exception), the handler sets `resultStatus = "error-msg"` and persists it.
+
+**Acceptance criteria:**
+- `AddAsync` is called with `ImportResult == "error-msg"`.
+- The response `ErrorCount == 1` and `SuccessCount == 0`.
+
+## Non-Functional Requirements
+
+### NFR-1: Test isolation
+Each new test must be self-contained. No shared mutable state beyond the constructor-initialized mocks.
+
+### NFR-2: Deterministic dates
+Tests that involve `daysBehind` must use relative dates (`DateTime.UtcNow.AddDays(-N)`) to remain correct regardless of when the suite runs.
+
+## Data Model
+No changes to production domain models. Tests operate on existing domain types:
+- `BankImportState` — seeded via `RecordSuccess(watermark, ...)`.
+- `BankImportWatermarkOptions` — `StaleWarningDays` controls the threshold.
+- `Result<bool>` — `Failure("msg")` constructor exercises the business-error path.
+
+## API / Interface Design
+No API changes. Unit test additions only.
+
+## Dependencies
+- Existing `Mock<ILogger<ImportBankStatementHandler>>` in test constructor.
+- Moq 4.20.72 `It.Is<It.IsAnyType>` pattern for logger verification (as used in `BackgroundRefreshSchedulerServiceTests`).
+- `Result<bool>.Failure(string)` factory method from `Domain.Shared`.
+
+## Out of Scope
+- Integration tests.
+- Changes to production handler code.
+- E2E tests.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -21,16 +21,20 @@
       "updated_at": "2026-06-29T13:26:05.723776Z"
     },
     "developing": {
+      "status": "completed",
+      "updated_at": "2026-06-29T13:28:37.136589Z"
+    },
+    "code-review": {
       "status": "in_progress",
-      "updated_at": "2026-06-29T13:26:19.882803Z"
+      "updated_at": "2026-06-29T13:28:44.082549Z"
     }
   },
   "tasks": [
     {
       "name": "add-missing-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-29T13:26:20.077685Z"
+      "updated_at": "2026-06-29T13:28:36.931813Z"
     }
   ]
 }

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-06-29T13:25:07.382800Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T13:25:07.579951Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T13:25:26.100321Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T13:25:26.309158Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-29T13:26:05.723776Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T13:26:19.882803Z"
     }
   },
   "tasks": [
     {
       "name": "add-missing-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-29T13:26:20.077685Z"
     }
   ]
 }

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-06-29T13:25:26.100321Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T13:25:26.309158Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T13:25:48.377142Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T13:25:48.580661Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T13:22:45.966880Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T13:25:07.382800Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T13:25:07.579951Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-06-29T13:25:48.377142Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T13:25:48.580661Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T13:26:05.723776Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-missing-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3411",
+  "issue_number": 3411,
+  "created_at": "2026-06-29T13:14:57.026005Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-06-29T13:22:45.966880Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3411/state.json
+++ b/artifacts/feat-3411/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-06-29T13:28:37.136589Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T13:28:44.082549Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T13:30:42.477113Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3411/task-context/add-missing-tests.md
+++ b/artifacts/feat-3411/task-context/add-missing-tests.md
@@ -1,0 +1,12 @@
+## Goal
+Add four unit tests to `ImportBankStatementHandlerTests` covering coverage gaps in `ImportBankStatementHandler`.
+
+See `artifacts/feat-3411/task-plan.r1.md` for full details.
+
+Tests to add:
+1. `Handle_LogsStaleWarning_WhenWatermarkIsStale`
+2. `Handle_DoesNotLogWarning_WhenWatermarkIsFresh`
+3. `Handle_FallsBackToInsert_WhenRetryStatementNotFoundInDb`
+4. `Handle_RecordsImportServiceError_WhenImportServiceReturnsFailed`
+
+File: `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs`

--- a/artifacts/feat-3411/task-plan.r1.md
+++ b/artifacts/feat-3411/task-plan.r1.md
@@ -1,0 +1,33 @@
+# Task Plan: Bank ImportBankStatementHandler coverage gaps
+
+### task: add-missing-tests
+
+**Goal**: Add four unit tests to `ImportBankStatementHandlerTests` covering the three coverage gaps identified in feat-3411.
+
+**File**: `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs`
+
+**Tests to add** (append after the last existing test):
+
+1. `Handle_LogsStaleWarning_WhenWatermarkIsStale`
+   - State with `LastValidImportDate = DateTime.UtcNow.AddDays(-10)` (10 days ago)
+   - Default handler: `StaleWarningDays = 3` → `10 > 3` → warning triggers
+   - Assert `_mockLogger.Log(LogLevel.Warning, ...)` called once
+
+2. `Handle_DoesNotLogWarning_WhenWatermarkIsFresh`
+   - State with `LastValidImportDate = DateTime.UtcNow.AddDays(-1)` (1 day ago)
+   - Default handler: `StaleWarningDays = 3` → `1 ≤ 3` → no warning
+   - Assert `_mockLogger.Log(LogLevel.Warning, ...)` never called
+
+3. `Handle_FallsBackToInsert_WhenRetryStatementNotFoundInDb`
+   - `existingTransfers` has `"RETRY" → ProcessingError` (so `isRetry = true`)
+   - `GetByTransferIdAsync("RETRY")` returns `null`
+   - `UpsertExistingAsync` falls back to `InsertNewAsync`
+   - Assert `AddAsync` called once, `UpdateAsync` never called
+
+4. `Handle_RecordsImportServiceError_WhenImportServiceReturnsFailed`
+   - `ImportStatementAsync` returns `Result<bool>.Failure("import-error")`
+   - Handler sets `resultStatus = "import-error"`
+   - `AddAsync` called with `ImportResult = "import-error"`
+   - Assert `response.ErrorCount == 1`, `response.SuccessCount == 0`
+
+**Validation**: Run `dotnet test --filter "FullyQualifiedName~ImportBankStatementHandlerTests"` — all tests must pass.

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
@@ -477,7 +477,7 @@ public class ImportBankStatementHandlerTests
         _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<string, string>());
         _mockBankClient.Setup(x => x.GetStatementAsync("ERR"))
-            .ReturnsAsync(new BankStatementData { Data = "abo", ItemCount = 2 });
+            .ReturnsAsync(new BankStatementData { Data = "abo", ItemCount = 1 });
         // Import service returns a business-level failure (not an exception).
         _mockImportService.Setup(x => x.ImportStatementAsync(1, "abo"))
             .ReturnsAsync(Result<bool>.Failure("import-error"));

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.Application.Features.Bank.Infrastructure.Jobs;
 using Anela.Heblo.Application.Features.Bank.UseCases.ImportBankStatement;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Shared;
+using Microsoft.Extensions.Logging;
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -363,5 +364,138 @@ public class ImportBankStatementHandlerTests
         // The failure is still recorded on the watermark state.
         _mockStateRepository.Verify(r => r.UpsertAsync(It.IsAny<BankImportState>(), It.IsAny<CancellationToken>()), Times.Once);
         captured!.LastRunStatus.Should().Be(BankImportState.StatusError);
+    }
+
+    [Fact]
+    public async Task Handle_LogsStaleWarning_WhenWatermarkIsStale()
+    {
+        var from = new DateTime(2026, 6, 10);
+        var to = new DateTime(2026, 6, 10);
+        var request = new ImportBankStatementRequest("ComgateCZK", from, to);
+        var existingState = new BankImportState("ComgateCZK");
+        // 10 days ago; default StaleWarningDays = 3, so 10 > 3 triggers the warning.
+        existingState.RecordSuccess(DateTime.UtcNow.AddDays(-10), DateTime.UtcNow, DateTime.UtcNow);
+
+        _mockStateRepository
+            .Setup(r => r.GetByAccountAsync("ComgateCZK", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingState);
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", from, to))
+            .ReturnsAsync(new List<BankStatementHeader>());
+
+        await _handler.Handle(request, CancellationToken.None);
+
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("stale")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotLogWarning_WhenWatermarkIsFresh()
+    {
+        var from = new DateTime(2026, 6, 10);
+        var to = new DateTime(2026, 6, 10);
+        var request = new ImportBankStatementRequest("ComgateCZK", from, to);
+        var existingState = new BankImportState("ComgateCZK");
+        // 1 day ago; default StaleWarningDays = 3, so 1 ≤ 3 → no warning.
+        existingState.RecordSuccess(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, DateTime.UtcNow);
+
+        _mockStateRepository
+            .Setup(r => r.GetByAccountAsync("ComgateCZK", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingState);
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", from, to))
+            .ReturnsAsync(new List<BankStatementHeader>());
+
+        await _handler.Handle(request, CancellationToken.None);
+
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("stale")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_FallsBackToInsert_WhenRetryStatementNotFoundInDb()
+    {
+        var from = new DateTime(2026, 6, 10);
+        var to = new DateTime(2026, 6, 10);
+        var request = new ImportBankStatementRequest("ComgateCZK", from, to);
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", from, to))
+            .ReturnsAsync(new List<BankStatementHeader>
+            {
+                new BankStatementHeader { StatementId = "RETRY", Date = from },
+            });
+        // existingTransfers reports the statement as a prior failure → isRetry = true.
+        _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string> { ["RETRY"] = $"{ImportStatus.ProcessingError}: old" });
+        _mockBankClient.Setup(x => x.GetStatementAsync("RETRY"))
+            .ReturnsAsync(new BankStatementData { Data = "abo", ItemCount = 1 });
+        _mockImportService.Setup(x => x.ImportStatementAsync(1, "abo"))
+            .ReturnsAsync(Result<bool>.Success(true));
+        // DB row is absent despite isRetry — UpsertExistingAsync falls back to InsertNewAsync.
+        _mockRepository.Setup(r => r.GetByTransferIdAsync("RETRY", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BankStatementImport?)null);
+        _mockRepository.Setup(r => r.AddAsync(It.IsAny<BankStatementImport>()))
+            .ReturnsAsync((BankStatementImport b) => b);
+        _mockMapper.Setup(m => m.Map<Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto>(
+                It.IsAny<BankStatementImport>()))
+            .Returns(new Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto
+            {
+                TransferId = "RETRY",
+                ImportResult = ImportStatus.Success,
+            });
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.SuccessCount.Should().Be(1);
+        _mockRepository.Verify(r => r.AddAsync(It.IsAny<BankStatementImport>()), Times.Once);
+        _mockRepository.Verify(r => r.UpdateAsync(It.IsAny<BankStatementImport>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RecordsImportServiceError_WhenImportServiceReturnsFailed()
+    {
+        var from = new DateTime(2026, 6, 10);
+        var to = new DateTime(2026, 6, 10);
+        var request = new ImportBankStatementRequest("ComgateCZK", from, to);
+        BankStatementImport? captured = null;
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", from, to))
+            .ReturnsAsync(new List<BankStatementHeader>
+            {
+                new BankStatementHeader { StatementId = "ERR", Date = from },
+            });
+        _mockRepository.Setup(r => r.GetExistingResultsByTransferIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        _mockBankClient.Setup(x => x.GetStatementAsync("ERR"))
+            .ReturnsAsync(new BankStatementData { Data = "abo", ItemCount = 2 });
+        // Import service returns a business-level failure (not an exception).
+        _mockImportService.Setup(x => x.ImportStatementAsync(1, "abo"))
+            .ReturnsAsync(Result<bool>.Failure("import-error"));
+        _mockRepository.Setup(r => r.AddAsync(It.IsAny<BankStatementImport>()))
+            .Callback<BankStatementImport>(b => captured = b)
+            .ReturnsAsync((BankStatementImport b) => b);
+        _mockMapper.Setup(m => m.Map<Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto>(
+                It.IsAny<BankStatementImport>()))
+            .Returns(new Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto
+            {
+                TransferId = "ERR",
+                ImportResult = "import-error",
+            });
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.ErrorCount.Should().Be(1);
+        response.SuccessCount.Should().Be(0);
+        captured!.ImportResult.Should().Be("import-error");
     }
 }


### PR DESCRIPTION
Closes #3411

## What the issue was
`ImportBankStatementHandler` had three untested branches flagged by the weekly coverage-gap routine: the stale-watermark `LogWarning` call (both the triggered and the non-triggered branch), the `UpsertExistingAsync` null-fallback path (where the DB row is absent despite `isRetry = true`), and the import-service business-failure path (where `ImportStatementAsync` returns `IsSuccess = false` rather than throwing).

## How it was fixed / handled
Added four unit tests to `ImportBankStatementHandlerTests`:

1. **`Handle_LogsStaleWarning_WhenWatermarkIsStale`** — seeds state with `LastValidImportDate = DateTime.UtcNow.AddDays(-10)` (10 days > default `StaleWarningDays = 3`) and asserts `ILogger.Log(LogLevel.Warning, ...)` is called exactly once with a message containing "stale". Uses relative dates to remain correct regardless of when the suite runs.

2. **`Handle_DoesNotLogWarning_WhenWatermarkIsFresh`** — seeds state with `LastValidImportDate = DateTime.UtcNow.AddDays(-1)` (1 day ≤ 3) and asserts no `LogLevel.Warning` is logged. Covers the inner-if false branch.

3. **`Handle_FallsBackToInsert_WhenRetryStatementNotFoundInDb`** — makes `existingTransfers` report a statement as a retry failure (`isRetry = true`) but makes `GetByTransferIdAsync` return `null`, exercising the `UpsertExistingAsync → InsertNewAsync` fallback. Asserts `AddAsync` called once, `UpdateAsync` never.

4. **`Handle_RecordsImportServiceError_WhenImportServiceReturnsFailed`** — makes `ImportStatementAsync` return `Result<bool>.Failure("import-error")`, exercises the `IsSuccess = false` ternary branch. Asserts `AddAsync` called with `ImportResult = "import-error"` and `response.ErrorCount = 1`.

All 15 tests pass (11 existing + 4 new).

## Artifacts
- Brief, spec, arch-review, design, task-plan, impl, review, and code-review markdown are committed in this branch under `artifacts/feat-3411/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- Stale-warning tests rely on Moq's default `Task.CompletedTask` for `UpsertAsync` (works correctly).
- `ItemCount = 2` in test 4 was a red herring (not passed to `ImportStatementAsync`); fixed to `1` for consistency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS698eBPX6z4ZU4hw5V2rQ)_