### PR TITLE
#3415: add dual-bucket invariant and summary field tests for GetPurchaseStockAnalysisHandler

### DIFF
--- a/artifacts/feat-3415/arch-review.r1.md
+++ b/artifacts/feat-3415/arch-review.r1.md
@@ -1,0 +1,114 @@
+# Architecture Review: Test Coverage – GetPurchaseStockAnalysis Dual-Bucket Invariant and Summary Assertions
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure test addition with no production code changes. It fits cleanly into the existing test suite: `GetPurchaseStockAnalysisHandlerTests.cs` already owns xUnit + Moq + FluentAssertions, uses a shared `MakeSnapshot` factory, and isolates each test with its own mock setup. The two new tests follow exactly that pattern. No new files, no new types, no cross-module impact.
+
+The handler's dual-bucket design is explicit and stable (lines 42–72 of the handler): `allAnalysisItems` feeds `CalculateSummary`; `analysisItems` feeds paging and display. `IStockSeverityCalculator` is already mocked per-test, which is the correct approach because the calculator's real logic is not under test here — the handler's wiring of the two buckets is.
+
+## Proposed Architecture
+
+### Component Overview
+
+Two new `[Fact]` methods appended to the existing `GetPurchaseStockAnalysisHandlerTests` class. Each method:
+1. Builds a fully deterministic `List<MaterialStockSnapshot>` using the existing `MakeSnapshot` factory.
+2. Stubs `_materialCatalogMock` to return that list.
+3. Stubs `_stockSeverityCalculatorMock` with per-item `SetupSequence` so severity is predictable per snapshot call.
+4. Calls `_handler.Handle(request, CancellationToken.None)`.
+5. Asserts with FluentAssertions.
+
+No new helper classes, no new factory methods, no changes to production code.
+
+### Key Design Decisions
+
+#### Decision 1: Severity stub strategy — sequence vs. blanket
+**Options considered:**
+- Blanket `It.IsAny<>()` → `.Returns(severity)`: all items get the same severity. Used by the existing generic tests.
+- `SetupSequence`: returns different severities per successive call. Correct for multi-severity snapshots.
+- Separate `Setup` calls with specific argument matchers for `availableStock`: fragile, depends on internal calculation path.
+
+**Chosen approach:** `SetupSequence` on `DetermineStockSeverity` ordered to match the snapshot list order, since the handler calls `AnalyzeStockItem` via `snapshots.Select(...)` which preserves order.
+
+**Rationale:** Sequence-based stubbing is the only pattern that works without coupling to internal arithmetic. The `Select` over `snapshots` is deterministic and in insertion order, so the sequence fires in the same order the snapshots are declared. This is already the idiomatic Moq approach for ordered return values with an `IEnumerable.Select`.
+
+#### Decision 2: `TotalInventoryValue` formula source of truth
+**Options considered:**
+- Derive expected value at runtime inside the test using LINQ over the snapshot list.
+- Hard-code a pre-computed `decimal` literal with an inline comment showing the arithmetic.
+
+**Chosen approach:** Hard-coded literal with an inline comment (e.g. `// 10 * 5.00m + 20 * 3.00m + 0 * 0 = 110.00m`).
+
+**Rationale:** The spec requires NFR-2 (readability with explicit arithmetic). A computed expected value would make the test circular — it would never catch a sign error in `CalculateSummary` because the same formula would produce the same wrong answer. A literal forces the developer to reason about the numbers independently of the code path.
+
+#### Decision 3: `EffectiveStock` in `MakeSnapshot` — `available + ordered`
+**Chosen approach:** Keep relying on the existing `MakeSnapshot` helper which sets `EffectiveStock = available + ordered`. For FR-2, set `ordered = 0` for all items so that `EffectiveStock == available`, keeping the arithmetic trivial and the comment concise.
+
+**Rationale:** The handler uses `item.Stock.EffectiveStock` (not `Available`) in `TotalInventoryValue`. Using `ordered = 0` makes `effective = available`, eliminating a subtlety that would add noise to the comment without testing anything new.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Single file to modify:
+`backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs`
+
+Append two methods to the existing `GetPurchaseStockAnalysisHandlerTests` class. No new files.
+
+### Interfaces and Contracts
+
+All types are already in scope via the existing `using` directives at the top of the test file. No new imports needed.
+
+Key types for the two tests:
+- `StockSeverity` — enum: `Critical`, `Low`, `Optimal`, `Overstocked`, `NotConfigured`
+- `StockStatusFilter` — enum: `Critical` (for FR-1 filter request)
+- `StockAnalysisSummaryDto` — fields: `TotalProducts`, `CriticalCount`, `LowStockCount`, `OptimalCount`, `OverstockedCount`, `NotConfiguredCount`, `TotalInventoryValue` (decimal), `AnalysisPeriodStart`, `AnalysisPeriodEnd`
+- `LastPurchaseInfoDto.UnitPrice` is `decimal` — the `TotalInventoryValue` formula is `Sum((decimal)EffectiveStock * UnitPrice)` where both sides are decimal after the cast
+- `MaterialPurchaseSnapshot.UnitPrice` is `decimal`
+
+### Data Flow
+
+**FR-1 (Dual-Bucket Invariant)**
+1. Snapshot list: 2 Critical items + 2 Optimal items (total = 4).
+2. `SetupSequence` returns `Critical, Critical, Optimal, Optimal` in that order.
+3. Request: `StockStatus = StockStatusFilter.Critical`, `PageNumber = 1`, `PageSize = 10`.
+4. Handler builds `allAnalysisItems` (4 items), then `analysisItems` (2 Critical items).
+5. `Summary` is computed from `allAnalysisItems`:
+   - `TotalProducts = 4`
+   - `CriticalCount = 2`
+   - `OptimalCount = 2`
+6. Assertions:
+   - `response.Items` has count 2 and all items have `Severity == StockSeverity.Critical`
+   - `response.Summary.TotalProducts == 4`
+   - `response.Summary.OptimalCount == 2` (equality, not just > 0)
+
+**FR-2 (Summary Field Value Assertions)**
+1. Snapshot list: 1 Critical, 1 Low, 1 Optimal, 1 Overstocked, 1 NotConfigured (total = 5).
+2. `SetupSequence` returns exactly those five severities in declaration order.
+3. Each item has a controlled `available` and a `LastPurchase.UnitPrice`; `ordered = 0` so `EffectiveStock = available`.
+4. Request: no `StockStatus` filter (`StockStatusFilter.All`), explicit pinned UTC `FromDate` and `ToDate` — never `DateTime.UtcNow`.
+5. Assertions cover every `StockAnalysisSummaryDto` field with hard-coded expected values plus inline arithmetic comment.
+6. `AnalysisPeriodStart` and `AnalysisPeriodEnd` asserted equal to the pinned `fromDate`/`toDate` values.
+7. `NotConfigured` item with `lastPurchase = null` contributes `0` to `TotalInventoryValue`; document in comment.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `SetupSequence` call order differs from handler's `Select` order | Medium | Document that sequence order must match snapshot declaration order; the handler uses `snapshots.Select(...)` which preserves list insertion order. |
+| `TotalInventoryValue` cast — `EffectiveStock` is `double`, `UnitPrice` is `decimal`; C# does not allow implicit `double * decimal` | High | The handler already casts explicitly: `(decimal)i.EffectiveStock * (i.LastPurchase?.UnitPrice ?? 0)`. Use integer-friendly values to avoid floating-point noise in the hand-computed expected value. |
+| Pinned `FromDate`/`ToDate` affect `daysDiff` and `DailyConsumption` | Low | FR-2 does not assert any consumption-derived values. Severity comes from the mock. Safe to ignore. |
+| `NotConfigured` item with `lastPurchase = null` contributes `0` to `TotalInventoryValue` | Low | Document this in the inline comment for the expected value. |
+
+## Specification Amendments
+
+**Amendment 1:** FR-1 acceptance criterion says `response.Summary.OptimalCount` is "greater than zero". Strengthen to an equality assertion (`== 2`) for a stricter, self-documenting test. An equality check makes the test fail-fast when the dual-bucket invariant breaks.
+
+**Amendment 2:** The spec does not mention `AnalysisPeriodStart`/`AnalysisPeriodEnd` in FR-1. Correct — those fields are not relevant to the dual-bucket invariant and should not be asserted in FR-1.
+
+**Amendment 3:** For FR-2, always supply explicit non-null `FromDate` and `ToDate` in the request using pinned UTC `DateTime` literals, never `DateTime.UtcNow`, to keep the assertion deterministic.
+
+## Prerequisites
+
+None. All required types, infrastructure, and test utilities already exist in the codebase. The two test methods can be written and run immediately against the current production handler without any migration, configuration, or scaffolding work.

--- a/artifacts/feat-3415/brief.md
+++ b/artifacts/feat-3415/brief.md
@@ -1,0 +1,32 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseStockAnalysis/GetPurchaseStockAnalysisHandler.cs`
+
+## Coverage
+Line coverage: 30.8% (filter threshold: 60%)
+2 existing test files: `GetPurchaseStockAnalysisHandlerTests` and `GetPurchaseStockAnalysisHandlerDiacriticsTests` (covers Czech diacritic normalisation in search).
+
+## What's not tested
+
+**Invalid date range guard**:
+- When `request.FromDate > request.ToDate`, the handler returns `InvalidDateRange` with both dates in `Params`. No test covers this branch — a future refactor that accidentally inverts the check would allow impossible date windows to proceed to the catalog service.
+
+**`ShouldIncludeItem` filter predicate**:
+- All items from the snapshot are first analysed, then filtered via `ShouldIncludeItem` (request filters for severity, supplier, type, etc.) before paging. The `CalculateSummary` call, however, uses the **pre-filter** `allAnalysisItems` list — so summary totals intentionally reflect the full population, not the displayed subset. No test verifies this split-bucket design: a test with a request that filters out some items should still produce summary totals that include those items.
+
+**Export / no-pagination path**:
+- When `request.IsExport = true`, paging is skipped and all matched items are returned. No test exercises the export branch.
+
+**`CalculateSummary` content**:
+- The summary aggregates across all items regardless of the display filter. Its specific aggregation logic (counts by severity, total value, etc.) is not asserted in any test — a sign flip or off-by-one in the summary calculator would be undetectable.
+
+## Why it matters
+The dual-bucket design (filter for display, full set for summary) is a subtle intentional invariant. If it accidentally collapses to one bucket, dashboard totals would shift every time a user applies a filter — a confusing and hard-to-diagnose regression. The date guard is a cheap defensive check whose absence would surface as a 500 or a misleading empty result.
+
+## Suggested approach
+- Add a test with `FromDate = today, ToDate = yesterday` — assert `InvalidDateRange` error is returned.
+- Add a test where snapshots include items that `ShouldIncludeItem` filters out — assert the response `Items` list is smaller than the summary represents.
+- Add a test with `IsExport = true` and a large snapshot set — assert no paging is applied (all items returned).
+- Add assertions on specific `Summary` fields (e.g. count of items in each severity bucket). ~1 day effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-06-29. Based on CI run #28295125598 (23c3b5d571c976074ee31869c96e29487098040c)._

--- a/artifacts/feat-3415/code-review.r1.md
+++ b/artifacts/feat-3415/code-review.r1.md
@@ -1,0 +1,14 @@
+## Review Result: CLEAN
+
+### Blocking
+- None
+
+### Advisory
+
+- **Test 1 — missing `TotalCount` assertion.** `Handle_FilterByCriticalStatus_SummaryReflectsAllItems` asserts `Items.Count` and all three relevant `Summary` fields, but does not assert `response.TotalCount`. The handler sets `TotalCount` from the filtered list (not all items), so it should equal 2 here. Adding `response.TotalCount.Should().Be(2)` would make the paging contract explicit alongside the dual-bucket invariant and prevent a regression if that logic ever changes.
+
+- **Test 2 — `AnalysisPeriodStart`/`AnalysisPeriodEnd` not covered by test 1.** The first test omits `FromDate`/`ToDate` in the request, so the handler substitutes defaults (`UtcNow.AddYears(-1)` / `UtcNow`). This is fine because the first test's concern is the dual-bucket invariant, not the period fields. Test 2 covers them correctly with pinned UTC dates. No change needed, just noting the intentional split is sound.
+
+- **`SetupSequence` order dependency is fragile but documented.** Both tests rely on `SetupSequence` firing in snapshot-declaration order. The handler materialises `allAnalysisItems` with `.ToList()` on line 42, which guarantees order, so this is safe today. The inline comment `// Sequence must match snapshot declaration order — handler calls DetermineStockSeverity once per snapshot via Select` adequately warns future editors. No change required, but a link to the handler line (or a brief note that the `.ToList()` is what pins order) would make the comment more self-sufficient if someone ever reads the test in isolation.
+
+- **`ordered` parameter unused in new tests.** The `MakeSnapshot` helper computes `EffectiveStock = available + ordered`. Both new tests leave `ordered` at its default of `0m`, which means `EffectiveStock == available`. This is intentional (the comment says so for test 2), and the existing suite already covers `ordered > 0` in `Handle_WithOrderedStock_PopulatesEffectiveStockCorrectly`. No gap here, just confirming the choice is deliberate.

--- a/artifacts/feat-3415/design.r1.md
+++ b/artifacts/feat-3415/design.r1.md
@@ -1,0 +1,110 @@
+# Design: Test Coverage – GetPurchaseStockAnalysis Dual-Bucket Invariant and Summary Assertions
+
+## Component Design
+
+### Target: `GetPurchaseStockAnalysisHandlerTests`
+
+**File:** `backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs`
+
+Two new `[Fact]` methods are appended to the existing `GetPurchaseStockAnalysisHandlerTests` class. No new files, classes, or mocks are introduced — all infrastructure (`_materialCatalogMock`, `_stockSeverityCalculatorMock`, `_loggerMock`, `_handler`, `MakeSnapshot`) is already present.
+
+#### FR-1: `Handle_FilterByCriticalStatus_SummaryReflectsAllItems`
+
+Verifies the dual-bucket invariant: `response.Items` is filtered by severity while `response.Summary` is computed over the full unfiltered population.
+
+**Collaborators used:**
+- `_materialCatalogMock.GetStockAnalysisSnapshotsAsync` — returns 4 snapshots (2 Critical + 2 Optimal)
+- `_stockSeverityCalculatorMock.DetermineStockSeverity` via `SetupSequence` — returns Critical, Critical, Optimal, Optimal in call order
+
+**Invariant under test:** The handler calls `CalculateSummary` on `allAnalysisItems` (all 4) before applying the `StockStatus = Critical` display filter, so `Summary.TotalProducts` and `Summary.OptimalCount` must reflect the full population even though `Items` contains only 2 Critical entries.
+
+#### FR-2: `Handle_CalculateSummary_AllFieldsAreCorrect`
+
+Pins every field of `StockAnalysisSummaryDto` to exact expected values derived from a controlled 5-item snapshot.
+
+**Collaborators used:**
+- `_materialCatalogMock.GetStockAnalysisSnapshotsAsync` — returns 5 snapshots with precisely controlled `available` and `UnitPrice` values
+- `_stockSeverityCalculatorMock.DetermineStockSeverity` via `SetupSequence` — returns Critical, Low, Optimal, Overstocked, NotConfigured in call order
+
+**Constraints enforced by the arch review:**
+- All items use `ordered = 0` so `EffectiveStock = available` (avoids ambiguity in `TotalInventoryValue` formula)
+- The NotConfigured item has `lastPurchase = null` (contributes 0 to `TotalInventoryValue`)
+- `FromDate`/`ToDate` are pinned UTC literals (`new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc)`) — never `DateTime.UtcNow`
+- Expected `TotalInventoryValue` is a hard-coded decimal literal with an inline comment showing the arithmetic; it is never computed at runtime
+
+### Handler logic being exercised (read-only, no changes)
+
+`GetPurchaseStockAnalysisHandler.Handle` in
+`backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseStockAnalysis/GetPurchaseStockAnalysisHandler.cs`:
+
+- `AnalyzeStockItem` calls `_stockSeverityCalculator.DetermineStockSeverity` once per snapshot, in list order — this is what `SetupSequence` exploits
+- `CalculateSummary` operates on `allAnalysisItems` (pre-filter), computing `TotalInventoryValue` as `Sum(EffectiveStock * (LastPurchase?.UnitPrice ?? 0))`
+- Display filter (`ShouldIncludeItem`) runs after summary calculation
+
+## Data Schemas
+
+### `GetPurchaseStockAnalysisRequest` — relevant fields for both tests
+
+| Field | FR-1 value | FR-2 value |
+|---|---|---|
+| `StockStatus` | `StockStatusFilter.Critical` | `StockStatusFilter.All` |
+| `PageNumber` | `1` | `1` |
+| `PageSize` | `10` | `10` |
+| `FromDate` | _(default, not pinned)_ | `new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)` |
+| `ToDate` | _(default, not pinned)_ | `new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Utc)` |
+
+### FR-1 snapshot population (4 items)
+
+Each built via the existing `MakeSnapshot` helper with `ordered = 0`.
+
+| # | ProductCode | available | Severity (via SetupSequence) |
+|---|---|---|---|
+| 1 | `"C001"` | any | Critical |
+| 2 | `"C002"` | any | Critical |
+| 3 | `"O001"` | any | Optimal |
+| 4 | `"O002"` | any | Optimal |
+
+### FR-2 snapshot population (5 items)
+
+All items: `ordered = 0`, so `EffectiveStock = available`.
+
+| # | ProductCode | available | UnitPrice | lastPurchase | Severity |
+|---|---|---|---|---|---|
+| 1 | `"P001"` | `10m` | `5.00m` | non-null | Critical |
+| 2 | `"P002"` | `20m` | `3.00m` | non-null | Low |
+| 3 | `"P003"` | `30m` | `2.00m` | non-null | Optimal |
+| 4 | `"P004"` | `15m` | `4.00m` | non-null | Overstocked |
+| 5 | `"P005"` | `0m` | n/a | `null` | NotConfigured |
+
+`TotalInventoryValue` = (10 × 5.00) + (20 × 3.00) + (30 × 2.00) + (15 × 4.00) + 0 = **50 + 60 + 60 + 60 + 0 = 230.00m**
+
+### `StockAnalysisSummaryDto` — expected values for FR-2
+
+| Field | Expected value |
+|---|---|
+| `TotalProducts` | `5` |
+| `CriticalCount` | `1` |
+| `LowStockCount` | `1` |
+| `OptimalCount` | `1` |
+| `OverstockedCount` | `1` |
+| `NotConfiguredCount` | `1` |
+| `TotalInventoryValue` | `230.00m` |
+| `AnalysisPeriodStart` | `new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)` |
+| `AnalysisPeriodEnd` | `new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Utc)` |
+
+### FR-1 assertions
+
+| Assertion | Expected |
+|---|---|
+| `response.Items.Count` | `2` |
+| All `response.Items[*].Severity` | `StockSeverity.Critical` |
+| `response.Summary.TotalProducts` | `4` |
+| `response.Summary.OptimalCount` | `2` |
+
+### Key types (existing, unchanged)
+
+- `MaterialStockSnapshot` — source data; `LastPurchase` is `MaterialPurchaseSnapshot?`
+- `MaterialPurchaseSnapshot` — needs `UnitPrice` (decimal) and `Date` set; `Amount` and `TotalPrice` can be `0m`
+- `StockSeverity` enum — `Critical | Low | Optimal | Overstocked | NotConfigured`
+- `StockStatusFilter` enum — `All | Critical | ...`
+- `IStockSeverityCalculator.DetermineStockSeverity(double, double, double, bool, bool) : StockSeverity` — mocked via `SetupSequence`

--- a/artifacts/feat-3415/impl/add-coverage-tests.r1.md
+++ b/artifacts/feat-3415/impl/add-coverage-tests.r1.md
@@ -1,0 +1,48 @@
+# Implementation: add-coverage-tests
+
+## What was implemented
+
+Two new `[Fact]` test methods were appended to the existing `GetPurchaseStockAnalysisHandlerTests` class:
+
+1. **`Handle_FilterByCriticalStatus_SummaryReflectsAllItems`** — verifies the dual-bucket invariant: when filtering Items by `StockStatusFilter.Critical`, the Summary still reflects all 4 items (2 Critical + 2 Optimal), not just the visible filtered ones.
+
+2. **`Handle_CalculateSummary_AllFieldsAreCorrect`** — a snapshot test covering every field in `PurchaseStockAnalysisSummary`: `TotalProducts`, `CriticalCount`, `LowStockCount`, `OptimalCount`, `OverstockedCount`, `NotConfiguredCount`, `TotalInventoryValue`, `AnalysisPeriodStart`, and `AnalysisPeriodEnd`. Five items (one per severity) are set up with known unit prices; `TotalInventoryValue` is asserted to be 230.00m ((10×5.00)+(20×3.00)+(30×2.00)+(15×4.00)+(0×0)).
+
+No new files, classes, or mocks were introduced. Both tests reuse the existing `MakeSnapshot` helper and the constructor-injected `_materialCatalogMock` / `_stockSeverityCalculatorMock`.
+
+## Files created/modified
+
+- `backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs` — appended 95 lines (two `[Fact]` methods) before the final class-closing brace
+
+## Tests
+
+All tests in the `GetPurchaseStockAnalysisHandler` filter passed:
+
+```
+Passed Handle_FilterByCriticalStatus_SummaryReflectsAllItems [7 ms]
+Passed Handle_CalculateSummary_AllFieldsAreCorrect [4 ms]
+```
+
+Full test run: `Test Run Successful.` (0 failures, 0 errors)
+
+## How to verify
+
+```bash
+cd /home/user/worktrees/feature-3415-Coverage-Gap-Purchase-Getpurchasestockanalysishand
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetPurchaseStockAnalysisHandler" -v normal
+```
+
+## Notes
+
+- The `GenerateAccessMatrix` MSBuild target exits with code 134 in this worktree environment (missing `access-matrix.generated.json`). This is a pre-existing infrastructure issue unrelated to the test project; the test project compiles and runs successfully despite that warning.
+- `SetupSequence` is used for both tests to guarantee deterministic severity assignment in declaration order (the handler iterates snapshots via `Select`).
+
+## PR Summary
+
+Added two unit tests that close coverage gaps on `GetPurchaseStockAnalysisHandler`:
+- A dual-bucket invariant test confirming the Summary counts all items regardless of the Items filter.
+- A full-field snapshot test asserting every Summary property, including `TotalInventoryValue` arithmetic and date range passthrough.
+
+## Status
+DONE

--- a/artifacts/feat-3415/review/add-coverage-tests.r1.md
+++ b/artifacts/feat-3415/review/add-coverage-tests.r1.md
@@ -1,0 +1,14 @@
+# Code Review: add-coverage-tests
+
+## Summary
+
+Both test methods are present in the worktree file at lines 384 and 427 of `GetPurchaseStockAnalysisHandlerTests.cs`. All tests pass (exit code 0, 0 failures). All FR-1 and FR-2 acceptance criteria are met: dual-bucket invariant verified, all 9 `StockAnalysisSummaryDto` fields asserted, `TotalInventoryValue` arithmetic comment present, pinned UTC DateTime literals used, no production code modified.
+
+## Review Result: PASS
+
+### task: add-coverage-tests
+**Status:** PASS
+
+## Overall Notes
+
+The reviewer subagent incorrectly reported the tests as missing — it read from the main repo path (`/home/user/Anela.Heblo/...`) instead of the worktree path (`/home/user/worktrees/feature-3415-.../...`). Manual verification confirmed both methods exist in the worktree file and all 11 `GetPurchaseStockAnalysisHandler` tests pass cleanly.

--- a/artifacts/feat-3415/spec.r1.md
+++ b/artifacts/feat-3415/spec.r1.md
@@ -1,0 +1,82 @@
+# Specification: Test Coverage – GetPurchaseStockAnalysis Dual-Bucket Invariant and Summary Assertions
+
+## Summary
+
+Two untested invariants exist in `GetPurchaseStockAnalysisHandler`: (1) that the `Summary` always reflects the full item population regardless of active display filters, and (2) that specific `Summary` field values are arithmetically correct. Both gaps are high-risk because a regression would manifest as silently wrong dashboard totals rather than a crash or obvious failure.
+
+## Background
+
+`GetPurchaseStockAnalysisHandler` deliberately maintains two item buckets: `allAnalysisItems` (used for `CalculateSummary`) and `analysisItems` (filtered for display and paging). This split means a user can apply a severity or configuration filter and still see summary totals that represent the entire catalog snapshot. The existing filter tests assert only on `Items`; none verify that `Summary` is sourced from the unfiltered bucket. Separately, `CalculateSummary` aggregates six severity counts plus `TotalInventoryValue`, but no test pins any of those values — an off-by-one or sign error would be undetectable in CI.
+
+## Functional Requirements
+
+### FR-1: Dual-Bucket Invariant Test
+
+Add a test that arranges a snapshot containing items of mixed severity (at least two severity levels), applies a `StockStatus` filter that excludes one severity level, and asserts both the filtered `Items` list and the unfiltered `Summary` counts independently.
+
+**Acceptance criteria:**
+- A new test method `Handle_FilterByCriticalStatus_SummaryReflectsAllItems` exists in `GetPurchaseStockAnalysisHandlerTests.cs`.
+- The snapshot contains items of at least two distinct `StockSeverity` values (e.g. `Critical` and `Optimal`).
+- `request.StockStatus` is set to `StockStatusFilter.Critical`.
+- The assertion on `response.Items` confirms only `Critical` items are present.
+- The assertion on `response.Summary.TotalProducts` equals the total snapshot count (not the filtered count).
+- The assertion on `response.Summary.OptimalCount` is greater than zero, proving non-critical items are counted in the summary even though they are absent from `Items`.
+- The test fails if either bucket assertion is removed.
+
+### FR-2: Summary Field Value Assertions
+
+Add a test that pins every field produced by `CalculateSummary` to known, concrete values derived from a fully controlled snapshot.
+
+**Acceptance criteria:**
+- A new test method `Handle_CalculateSummary_AllFieldsAreCorrect` exists in `GetPurchaseStockAnalysisHandlerTests.cs`.
+- The snapshot is fully deterministic: exact counts per severity, known `EffectiveStock` values, and known `LastPurchase.UnitPrice` values for each item.
+- The test asserts `Summary.TotalProducts`, `Summary.CriticalCount`, `Summary.LowStockCount`, `Summary.OptimalCount`, `Summary.OverstockedCount`, `Summary.NotConfiguredCount`, and `Summary.TotalInventoryValue` each against a hand-computed expected value.
+- `Summary.AnalysisPeriodStart` and `Summary.AnalysisPeriodEnd` are asserted to equal `fromDate` and `toDate` as supplied in the request.
+- `Summary.TotalInventoryValue` is computed as `Sum(EffectiveStock * UnitPrice)` across all snapshot items (not filtered items), and the expected value in the test comment documents this formula explicitly.
+- No `StockStatus` filter is applied in this test so that `allAnalysisItems` and `analysisItems` are identical; the purpose is purely to validate aggregation arithmetic, not the dual-bucket split (FR-1 covers that).
+
+## Non-Functional Requirements
+
+### NFR-1: Test Isolation
+
+Each new test must set up its own mock data via the existing mock/stub pattern already used in `GetPurchaseStockAnalysisHandlerTests.cs`. No shared mutable state between tests.
+
+### NFR-2: Readability
+
+Expected values in FR-2 must be accompanied by an inline comment showing the arithmetic (e.g. `// 2 items × 10.0 stock × 5.00 price = 100.00`). This makes future maintenance tractable without re-deriving the formula.
+
+### NFR-3: No Production Code Changes
+
+These tests must pass against the existing handler implementation without modifying any production source file.
+
+## Data Model
+
+No new entities. Tests operate on the types already present:
+
+- `GetPurchaseStockAnalysisRequest` — `StockStatus`, `PageNumber`, `PageSize`, `IsExport`, `FromDate`, `ToDate`, `OnlyConfigured`, `SearchTerm`
+- `StockAnalysisItemDto` — `Severity`, `EffectiveStock`, `LastPurchase.UnitPrice`, `IsConfigured`
+- `StockAnalysisSummaryDto` — `TotalProducts`, `CriticalCount`, `LowStockCount`, `OptimalCount`, `OverstockedCount`, `NotConfiguredCount`, `TotalInventoryValue`, `AnalysisPeriodStart`, `AnalysisPeriodEnd`
+- `StockSeverity` enum — `Critical`, `Low`, `Optimal`, `Overstocked`, `NotConfigured`
+- `StockStatusFilter` enum — mirrors `StockSeverity` plus an `All` / default case
+
+## API / Interface Design
+
+Not applicable — this spec covers test additions only, with no change to the handler's public interface or HTTP surface.
+
+## Dependencies
+
+- Existing test infrastructure in `GetPurchaseStockAnalysisHandlerTests.cs` (xUnit, NSubstitute or Moq — whichever is already in use).
+- `IMaterialCatalog.GetStockAnalysisSnapshotsAsync` mock — already stubbed in existing tests; the new tests extend the same pattern with richer fixture data.
+
+## Out of Scope
+
+- The `Handle_InvalidDateRange_ReturnsError` branch — already covered.
+- The `Handle_ExportTrue_BypassesPaginationAndReturnsAllFilteredItems` branch — already covered.
+- The `GetPurchaseStockAnalysisHandlerDiacriticsTests` file — diacritic normalisation is already tested; no additions needed there.
+- Czech diacritic search interaction with summary — not a known risk, excluded from this work.
+- Refactoring `CalculateSummary` into a separate class or adding unit tests directly on it — not required; handler-level tests are sufficient and consistent with the existing test style.
+- Performance or load testing of the handler.
+
+## Open Questions
+
+None.

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-06-29T17:24:20.038906Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T17:24:33.781999Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T17:27:01.465027Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-coverage-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3415",
+  "issue_number": 3415,
+  "created_at": "2026-06-29T17:15:13.607894Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-29T17:18:01.449016Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -21,16 +21,20 @@
       "updated_at": "2026-06-29T17:27:01.465027Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-29T17:28:08.542798Z"
+      "status": "completed",
+      "updated_at": "2026-06-29T18:05:46.260509Z"
+    },
+    "code-review": {
+      "status": "completed",
+      "updated_at": "2026-06-29T18:08:05.027317Z"
     }
   },
   "tasks": [
     {
       "name": "add-coverage-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-29T17:28:08.803499Z"
+      "updated_at": "2026-06-29T18:05:46.057480Z"
     }
   ]
 }

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-06-29T17:27:01.465027Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T17:28:08.542798Z"
     }
   },
   "tasks": [
     {
       "name": "add-coverage-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-06-29T17:28:08.803499Z"
     }
   ]
 }

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-06-29T17:22:01.217716Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T17:24:20.038906Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-06-29T17:18:01.449016Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-29T17:22:01.217716Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3415/state.json
+++ b/artifacts/feat-3415/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-06-29T17:24:20.038906Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-29T17:24:33.781999Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3415/task-context/add-coverage-tests.md
+++ b/artifacts/feat-3415/task-context/add-coverage-tests.md
@@ -1,0 +1,176 @@
+### task: add-coverage-tests
+
+**What this task does:** Appends two new `[Fact]` test methods to the existing `GetPurchaseStockAnalysisHandlerTests` class. No new files, classes, or mocks are introduced. All infrastructure (`_materialCatalogMock`, `_stockSeverityCalculatorMock`, `_loggerMock`, `_handler`, `MakeSnapshot`) already exists in the class.
+
+**File to modify:**
+`backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs`
+
+**Insertion point:** Append both methods immediately before the final `}` that closes the class body — after the `CreateManyTestSnapshots` method (currently ending at line 381).
+
+#### Step 1 — Read the file to locate the exact insertion point
+
+Open `backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs` and confirm the last two lines are:
+
+```
+    }  // closes CreateManyTestSnapshots
+}      // closes GetPurchaseStockAnalysisHandlerTests
+```
+
+The two new methods go between these two closing braces.
+
+#### Step 2 — Insert the FR-1 test: dual-bucket invariant
+
+Using an exact-string edit tool, replace the closing brace of `CreateManyTestSnapshots` followed by the class-closing brace with those same braces plus the new FR-1 method inserted between them. The new method to insert is:
+
+```csharp
+    [Fact]
+    public async Task Handle_FilterByCriticalStatus_SummaryReflectsAllItems()
+    {
+        // 2 Critical + 2 Optimal = 4 total
+        var snapshots = new List<MaterialStockSnapshot>
+        {
+            MakeSnapshot("C001", "Critical 1", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("C002", "Critical 2", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("O001", "Optimal 1", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("O002", "Optimal 2", MaterialProductType.Material, available: 10m),
+        };
+
+        _materialCatalogMock
+            .Setup(x => x.GetStockAnalysisSnapshotsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshots);
+
+        // Sequence must match snapshot declaration order — handler calls DetermineStockSeverity once per snapshot via Select
+        _stockSeverityCalculatorMock
+            .SetupSequence(x => x.DetermineStockSeverity(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Optimal)
+            .Returns(StockSeverity.Optimal);
+
+        var request = new GetPurchaseStockAnalysisRequest
+        {
+            StockStatus = StockStatusFilter.Critical,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Items are filtered — only Critical items visible
+        response.Items.Should().HaveCount(2);
+        response.Items.Should().OnlyContain(i => i.Severity == StockSeverity.Critical);
+
+        // Summary reflects ALL 4 items (dual-bucket invariant)
+        response.Summary.TotalProducts.Should().Be(4);
+        response.Summary.OptimalCount.Should().Be(2, "non-critical items must appear in summary even when filtered from Items");
+        response.Summary.CriticalCount.Should().Be(2);
+    }
+```
+
+#### Step 3 — Insert the FR-2 test: all summary fields pinned
+
+Immediately after the FR-1 method (still before the class-closing `}`), insert:
+
+```csharp
+    [Fact]
+    public async Task Handle_CalculateSummary_AllFieldsAreCorrect()
+    {
+        var fromDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var toDate = new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        // 5 items: one per severity. ordered=0 so EffectiveStock=available.
+        // NotConfigured item has no lastPurchase (contributes 0 to TotalInventoryValue).
+        var snapshots = new List<MaterialStockSnapshot>
+        {
+            MakeSnapshot("P001", "Critical Item",     MaterialProductType.Material, available: 10m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S1", Amount = 0m, UnitPrice = 5.00m, TotalPrice = 0m }),
+            MakeSnapshot("P002", "Low Item",          MaterialProductType.Material, available: 20m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S2", Amount = 0m, UnitPrice = 3.00m, TotalPrice = 0m }),
+            MakeSnapshot("P003", "Optimal Item",      MaterialProductType.Material, available: 30m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S3", Amount = 0m, UnitPrice = 2.00m, TotalPrice = 0m }),
+            MakeSnapshot("P004", "Overstocked Item",  MaterialProductType.Material, available: 15m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S4", Amount = 0m, UnitPrice = 4.00m, TotalPrice = 0m }),
+            MakeSnapshot("P005", "NotConfigured Item",MaterialProductType.Material, available:  0m), // no lastPurchase → 0 contribution
+        };
+
+        _materialCatalogMock
+            .Setup(x => x.GetStockAnalysisSnapshotsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshots);
+
+        // Sequence matches snapshot declaration order
+        _stockSeverityCalculatorMock
+            .SetupSequence(x => x.DetermineStockSeverity(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Low)
+            .Returns(StockSeverity.Optimal)
+            .Returns(StockSeverity.Overstocked)
+            .Returns(StockSeverity.NotConfigured);
+
+        var request = new GetPurchaseStockAnalysisRequest
+        {
+            FromDate = fromDate,
+            ToDate = toDate,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.Summary.TotalProducts.Should().Be(5);
+        response.Summary.CriticalCount.Should().Be(1);
+        response.Summary.LowStockCount.Should().Be(1);
+        response.Summary.OptimalCount.Should().Be(1);
+        response.Summary.OverstockedCount.Should().Be(1);
+        response.Summary.NotConfiguredCount.Should().Be(1);
+        // (10 × 5.00) + (20 × 3.00) + (30 × 2.00) + (15 × 4.00) + (0 × 0) = 50 + 60 + 60 + 60 + 0 = 230.00
+        response.Summary.TotalInventoryValue.Should().Be(230.00m);
+        response.Summary.AnalysisPeriodStart.Should().Be(fromDate);
+        response.Summary.AnalysisPeriodEnd.Should().Be(toDate);
+    }
+```
+
+#### Step 4 — Verify the edit produces a valid file structure
+
+After both edits, the tail of the file must read (schematically):
+
+```
+    private List<MaterialStockSnapshot> CreateManyTestSnapshots(int count)
+    {
+        ...
+    }
+
+    [Fact]
+    public async Task Handle_FilterByCriticalStatus_SummaryReflectsAllItems()
+    {
+        ...
+    }
+
+    [Fact]
+    public async Task Handle_CalculateSummary_AllFieldsAreCorrect()
+    {
+        ...
+    }
+}   // ← single closing brace for the class
+```
+
+There must be exactly one closing `}` after `Handle_CalculateSummary_AllFieldsAreCorrect`. Do not add a namespace closing brace — the file uses file-scoped namespaces (`namespace Anela.Heblo.Tests.Features.Purchase;`).
+
+#### Step 5 — Run the tests
+
+```bash
+cd /home/user/worktrees/feature-3415-Coverage-Gap-Purchase-Getpurchasestockanalysishand
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetPurchaseStockAnalysisHandler" -v normal
+```
+
+Expected outcome: all tests in `GetPurchaseStockAnalysisHandlerTests` pass, including the two new ones:
+- `Handle_FilterByCriticalStatus_SummaryReflectsAllItems`
+- `Handle_CalculateSummary_AllFieldsAreCorrect`
+
+If a test fails with a `MockException` stating "Sequence contains no more elements", the `SetupSequence` call count does not match the number of snapshots.
+
+If `TotalInventoryValue` is wrong, verify that `EffectiveStock` is being used in the handler formula (not `Available`). With `ordered = 0`, `EffectiveStock = available`, so the result must still be `230.00m`.
+
+#### Step 6 — Commit
+
+Stage only the test file, then commit:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs
+git commit -m "test(purchase): add dual-bucket invariant and summary field snapshot tests for GetPurchaseStockAnalysisHandler"
+```

--- a/artifacts/feat-3415/task-plan.r1.md
+++ b/artifacts/feat-3415/task-plan.r1.md
@@ -1,0 +1,188 @@
+# GetPurchaseStockAnalysis Coverage Tests Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the steps below.
+
+**Goal:** Add two unit tests to `GetPurchaseStockAnalysisHandlerTests.cs` that verify the dual-bucket invariant (Summary reflects all items regardless of display filter) and pin all StockAnalysisSummaryDto field values.
+
+**Architecture:** Pure test addition — no production code changes. Two new `[Fact]` methods appended to the existing test class. Uses `SetupSequence` on the severity calculator mock to return per-item severities in snapshot order.
+
+**Tech Stack:** C# / xUnit / Moq / FluentAssertions / .NET 8
+
+---
+
+### task: add-coverage-tests
+
+**What this task does:** Appends two new `[Fact]` test methods to the existing `GetPurchaseStockAnalysisHandlerTests` class. No new files, classes, or mocks are introduced. All infrastructure (`_materialCatalogMock`, `_stockSeverityCalculatorMock`, `_loggerMock`, `_handler`, `MakeSnapshot`) already exists in the class.
+
+**File to modify:**
+`backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs`
+
+**Insertion point:** Append both methods immediately before the final `}` that closes the class body — after the `CreateManyTestSnapshots` method (currently ending at line 381).
+
+#### Step 1 — Read the file to locate the exact insertion point
+
+Open `backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs` and confirm the last two lines are:
+
+```
+    }  // closes CreateManyTestSnapshots
+}      // closes GetPurchaseStockAnalysisHandlerTests
+```
+
+The two new methods go between these two closing braces.
+
+#### Step 2 — Insert the FR-1 test: dual-bucket invariant
+
+Using an exact-string edit tool, replace the closing brace of `CreateManyTestSnapshots` followed by the class-closing brace with those same braces plus the new FR-1 method inserted between them. The new method to insert is:
+
+```csharp
+    [Fact]
+    public async Task Handle_FilterByCriticalStatus_SummaryReflectsAllItems()
+    {
+        // 2 Critical + 2 Optimal = 4 total
+        var snapshots = new List<MaterialStockSnapshot>
+        {
+            MakeSnapshot("C001", "Critical 1", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("C002", "Critical 2", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("O001", "Optimal 1", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("O002", "Optimal 2", MaterialProductType.Material, available: 10m),
+        };
+
+        _materialCatalogMock
+            .Setup(x => x.GetStockAnalysisSnapshotsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshots);
+
+        // Sequence must match snapshot declaration order — handler calls DetermineStockSeverity once per snapshot via Select
+        _stockSeverityCalculatorMock
+            .SetupSequence(x => x.DetermineStockSeverity(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Optimal)
+            .Returns(StockSeverity.Optimal);
+
+        var request = new GetPurchaseStockAnalysisRequest
+        {
+            StockStatus = StockStatusFilter.Critical,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Items are filtered — only Critical items visible
+        response.Items.Should().HaveCount(2);
+        response.Items.Should().OnlyContain(i => i.Severity == StockSeverity.Critical);
+
+        // Summary reflects ALL 4 items (dual-bucket invariant)
+        response.Summary.TotalProducts.Should().Be(4);
+        response.Summary.OptimalCount.Should().Be(2, "non-critical items must appear in summary even when filtered from Items");
+        response.Summary.CriticalCount.Should().Be(2);
+    }
+```
+
+#### Step 3 — Insert the FR-2 test: all summary fields pinned
+
+Immediately after the FR-1 method (still before the class-closing `}`), insert:
+
+```csharp
+    [Fact]
+    public async Task Handle_CalculateSummary_AllFieldsAreCorrect()
+    {
+        var fromDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var toDate = new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        // 5 items: one per severity. ordered=0 so EffectiveStock=available.
+        // NotConfigured item has no lastPurchase (contributes 0 to TotalInventoryValue).
+        var snapshots = new List<MaterialStockSnapshot>
+        {
+            MakeSnapshot("P001", "Critical Item",     MaterialProductType.Material, available: 10m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S1", Amount = 0m, UnitPrice = 5.00m, TotalPrice = 0m }),
+            MakeSnapshot("P002", "Low Item",          MaterialProductType.Material, available: 20m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S2", Amount = 0m, UnitPrice = 3.00m, TotalPrice = 0m }),
+            MakeSnapshot("P003", "Optimal Item",      MaterialProductType.Material, available: 30m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S3", Amount = 0m, UnitPrice = 2.00m, TotalPrice = 0m }),
+            MakeSnapshot("P004", "Overstocked Item",  MaterialProductType.Material, available: 15m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S4", Amount = 0m, UnitPrice = 4.00m, TotalPrice = 0m }),
+            MakeSnapshot("P005", "NotConfigured Item",MaterialProductType.Material, available:  0m), // no lastPurchase → 0 contribution
+        };
+
+        _materialCatalogMock
+            .Setup(x => x.GetStockAnalysisSnapshotsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshots);
+
+        // Sequence matches snapshot declaration order
+        _stockSeverityCalculatorMock
+            .SetupSequence(x => x.DetermineStockSeverity(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Low)
+            .Returns(StockSeverity.Optimal)
+            .Returns(StockSeverity.Overstocked)
+            .Returns(StockSeverity.NotConfigured);
+
+        var request = new GetPurchaseStockAnalysisRequest
+        {
+            FromDate = fromDate,
+            ToDate = toDate,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.Summary.TotalProducts.Should().Be(5);
+        response.Summary.CriticalCount.Should().Be(1);
+        response.Summary.LowStockCount.Should().Be(1);
+        response.Summary.OptimalCount.Should().Be(1);
+        response.Summary.OverstockedCount.Should().Be(1);
+        response.Summary.NotConfiguredCount.Should().Be(1);
+        // (10 × 5.00) + (20 × 3.00) + (30 × 2.00) + (15 × 4.00) + (0 × 0) = 50 + 60 + 60 + 60 + 0 = 230.00
+        response.Summary.TotalInventoryValue.Should().Be(230.00m);
+        response.Summary.AnalysisPeriodStart.Should().Be(fromDate);
+        response.Summary.AnalysisPeriodEnd.Should().Be(toDate);
+    }
+```
+
+#### Step 4 — Verify the edit produces a valid file structure
+
+After both edits, the tail of the file must read (schematically):
+
+```
+    private List<MaterialStockSnapshot> CreateManyTestSnapshots(int count)
+    {
+        ...
+    }
+
+    [Fact]
+    public async Task Handle_FilterByCriticalStatus_SummaryReflectsAllItems()
+    {
+        ...
+    }
+
+    [Fact]
+    public async Task Handle_CalculateSummary_AllFieldsAreCorrect()
+    {
+        ...
+    }
+}   // ← single closing brace for the class
+```
+
+There must be exactly one closing `}` after `Handle_CalculateSummary_AllFieldsAreCorrect`. Do not add a namespace closing brace — the file uses file-scoped namespaces (`namespace Anela.Heblo.Tests.Features.Purchase;`).
+
+#### Step 5 — Run the tests
+
+```bash
+cd /home/user/worktrees/feature-3415-Coverage-Gap-Purchase-Getpurchasestockanalysishand
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetPurchaseStockAnalysisHandler" -v normal
+```
+
+Expected outcome: all tests in `GetPurchaseStockAnalysisHandlerTests` pass, including the two new ones:
+- `Handle_FilterByCriticalStatus_SummaryReflectsAllItems`
+- `Handle_CalculateSummary_AllFieldsAreCorrect`
+
+If a test fails with a `MockException` stating "Sequence contains no more elements", the `SetupSequence` call count does not match the number of snapshots — re-check that the snapshot list length matches the number of `.Returns(...)` calls chained in the sequence.
+
+If `TotalInventoryValue` is wrong, verify that `EffectiveStock` is being used in the handler formula (not `Available`). With `ordered = 0`, `EffectiveStock = available`, so the result must still be `230.00m`.
+
+#### Step 6 — Commit
+
+Stage only the test file, then commit:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs
+git commit -m "test(purchase): add dual-bucket invariant and summary field snapshot tests for GetPurchaseStockAnalysisHandler"
+```

--- a/backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Purchase/GetPurchaseStockAnalysisHandlerTests.cs
@@ -379,4 +379,99 @@ public class GetPurchaseStockAnalysisHandlerTests
 
         return items;
     }
+
+    [Fact]
+    public async Task Handle_FilterByCriticalStatus_SummaryReflectsAllItems()
+    {
+        // 2 Critical + 2 Optimal = 4 total
+        var snapshots = new List<MaterialStockSnapshot>
+        {
+            MakeSnapshot("C001", "Critical 1", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("C002", "Critical 2", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("O001", "Optimal 1", MaterialProductType.Material, available: 10m),
+            MakeSnapshot("O002", "Optimal 2", MaterialProductType.Material, available: 10m),
+        };
+
+        _materialCatalogMock
+            .Setup(x => x.GetStockAnalysisSnapshotsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshots);
+
+        // Sequence must match snapshot declaration order — handler calls DetermineStockSeverity once per snapshot via Select
+        _stockSeverityCalculatorMock
+            .SetupSequence(x => x.DetermineStockSeverity(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Optimal)
+            .Returns(StockSeverity.Optimal);
+
+        var request = new GetPurchaseStockAnalysisRequest
+        {
+            StockStatus = StockStatusFilter.Critical,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Items are filtered — only Critical items visible
+        response.Items.Should().HaveCount(2);
+        response.Items.Should().OnlyContain(i => i.Severity == StockSeverity.Critical);
+
+        // Summary reflects ALL 4 items (dual-bucket invariant)
+        response.Summary.TotalProducts.Should().Be(4);
+        response.Summary.OptimalCount.Should().Be(2, "non-critical items must appear in summary even when filtered from Items");
+        response.Summary.CriticalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_CalculateSummary_AllFieldsAreCorrect()
+    {
+        var fromDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var toDate = new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        // 5 items: one per severity. ordered=0 so EffectiveStock=available.
+        // NotConfigured item has no lastPurchase (contributes 0 to TotalInventoryValue).
+        var snapshots = new List<MaterialStockSnapshot>
+        {
+            MakeSnapshot("P001", "Critical Item",     MaterialProductType.Material, available: 10m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S1", Amount = 0m, UnitPrice = 5.00m, TotalPrice = 0m }),
+            MakeSnapshot("P002", "Low Item",          MaterialProductType.Material, available: 20m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S2", Amount = 0m, UnitPrice = 3.00m, TotalPrice = 0m }),
+            MakeSnapshot("P003", "Optimal Item",      MaterialProductType.Material, available: 30m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S3", Amount = 0m, UnitPrice = 2.00m, TotalPrice = 0m }),
+            MakeSnapshot("P004", "Overstocked Item",  MaterialProductType.Material, available: 15m, lastPurchase: new MaterialPurchaseSnapshot { Date = fromDate, SupplierName = "S4", Amount = 0m, UnitPrice = 4.00m, TotalPrice = 0m }),
+            MakeSnapshot("P005", "NotConfigured Item",MaterialProductType.Material, available:  0m), // no lastPurchase → 0 contribution
+        };
+
+        _materialCatalogMock
+            .Setup(x => x.GetStockAnalysisSnapshotsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshots);
+
+        // Sequence matches snapshot declaration order
+        _stockSeverityCalculatorMock
+            .SetupSequence(x => x.DetermineStockSeverity(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(StockSeverity.Critical)
+            .Returns(StockSeverity.Low)
+            .Returns(StockSeverity.Optimal)
+            .Returns(StockSeverity.Overstocked)
+            .Returns(StockSeverity.NotConfigured);
+
+        var request = new GetPurchaseStockAnalysisRequest
+        {
+            FromDate = fromDate,
+            ToDate = toDate,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.Summary.TotalProducts.Should().Be(5);
+        response.Summary.CriticalCount.Should().Be(1);
+        response.Summary.LowStockCount.Should().Be(1);
+        response.Summary.OptimalCount.Should().Be(1);
+        response.Summary.OverstockedCount.Should().Be(1);
+        response.Summary.NotConfiguredCount.Should().Be(1);
+        // (10 × 5.00) + (20 × 3.00) + (30 × 2.00) + (15 × 4.00) + (0 × 0) = 50 + 60 + 60 + 60 + 0 = 230.00
+        response.Summary.TotalInventoryValue.Should().Be(230.00m);
+        response.Summary.AnalysisPeriodStart.Should().Be(fromDate);
+        response.Summary.AnalysisPeriodEnd.Should().Be(toDate);
+    }
 }


### PR DESCRIPTION
Closes #3415

## What the issue was

`GetPurchaseStockAnalysisHandler` had two untested paths:

1. **Dual-bucket invariant** — the handler builds `allAnalysisItems` (all snapshots) for the Summary and a filtered `analysisItems` for the Items page. There was no test confirming the Summary still reflects every item when a `StockStatusFilter` hides some from the Items list.

2. **Summary field completeness** — none of the existing tests pinned all nine fields of `StockAnalysisSummaryDto` in a single assertion pass (`TotalProducts`, `CriticalCount`, `LowStockCount`, `OptimalCount`, `OverstockedCount`, `NotConfiguredCount`, `TotalInventoryValue`, `AnalysisPeriodStart`, `AnalysisPeriodEnd`).

## How it was fixed / handled

Two new `[Fact]` tests were appended to `GetPurchaseStockAnalysisHandlerTests`:

- **`Handle_FilterByCriticalStatus_SummaryReflectsAllItems`** — 4 snapshots (2 Critical + 2 Optimal), `StockStatusFilter.Critical` active. Asserts `Items.Count == 2` (filtered) and `Summary.TotalProducts == 4 / OptimalCount == 2 / CriticalCount == 2` (unfiltered). Exercises the dual-bucket invariant directly.

- **`Handle_CalculateSummary_AllFieldsAreCorrect`** — 5 snapshots, one per severity, with known unit prices. Asserts all 9 Summary fields. `TotalInventoryValue` is asserted at `230.00m` with an arithmetic comment: `(10×5.00)+(20×3.00)+(30×2.00)+(15×4.00)+(0×0) = 230`. Uses `SetupSequence` to assign severities in snapshot-declaration order.

No production code was changed. All 11 `GetPurchaseStockAnalysisHandler` tests pass.

## Artifacts

Brief, spec, arch-review, design, task-plan, impl, and review markdown are committed in `artifacts/feat-3415/` on this branch. Code review result: **CLEAN** (no blocking findings).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVDPSWT69e2gZwQwzaCtbD)_