### PR TITLE
#3430: Move cross-cutting config keys to Domain/Shared

### DIFF
--- a/artifacts/feat-3430/arch-review.r1.md
+++ b/artifacts/feat-3430/arch-review.r1.md
@@ -1,0 +1,131 @@
+# Architecture Review: Move Cross-Cutting Configuration Keys to Domain/Shared
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The spec is correct and the refactor is necessary. `ConfigurationConstants.BYPASS_JWT_VALIDATION`, `USE_MOCK_AUTH`, and `APP_VERSION` are consumed by 10 files across 4 projects (`Application`, `API`, `Adapters.Microsoft365`, and the test project) — none of which are the Configuration feature module. Sourcing these constants from `Anela.Heblo.Domain.Features.Configuration` imposes a hard compile-time dependency on the Configuration feature module from unrelated modules, which directly violates the project's "no direct references between feature modules" rule (`development_guidelines.md`, Required Practices).
+
+`Domain/Shared/` is already the established home for exactly this kind of cross-module domain primitive: `Result`, `CurrencyCode`, and `Cooling` all live there and share the same `Anela.Heblo.Domain.Shared` namespace. Moving the three infrastructure config keys there is the correct classification: they are deployment-mode signals consumed by bootstrapping code across the entire solution, not Configuration-feature domain concepts.
+
+The two remaining constants (`DEFAULT_VERSION`, `DEFAULT_ENVIRONMENT`) are internal to the Configuration feature and are used only in `GetConfigurationHandler` and its tests as fallback values and test assertions. They stay put.
+
+One real-world nuance the spec captures but does not fully resolve: `ServiceCollectionExtensions.cs` and `E2ETestAuthenticationMiddleware.cs` both carry `using Anela.Heblo.Domain.Features.Configuration;` but do not reference `ConfigurationConstants` by name anywhere in their bodies. The `using` directive in both files is therefore already a dead import (the compiler would surface this as a warning under `dotnet format`). After this refactor those imports disappear entirely without requiring any constant-reference substitution; the implementer just removes the `using`.
+
+The spec's consumer table lists `E2ETestAuthenticationMiddleware.cs` with "(uses namespace, verify which constants)" — the answer, confirmed by inspection: it uses only the literal string `"UseMockAuth"` directly (line 132), never `ConfigurationConstants`. The import is stale. Same finding for `ServiceCollectionExtensions.cs`: uses `"UseMockAuth"` as a raw string literal (line 191), `ConfigurationConstants` is never referenced. Both files need only import removal, not constant substitution.
+
+`MarketingModule.cs` was listed in the brief but is NOT in the spec's file table. Inspection confirms it never uses `ConfigurationConstants` — it registers `NoOpOutlookCalendarSync` unconditionally and does not read auth configuration at all. It does not import `Anela.Heblo.Domain.Features.Configuration`. No change needed.
+
+`GetConfigurationHandlerTests.cs` uses `ConfigurationConstants.APP_VERSION`, `ConfigurationConstants.USE_MOCK_AUTH`, and `ConfigurationConstants.DEFAULT_VERSION`. After the move, the test must switch its `using` to `Anela.Heblo.Domain.Shared` for `APP_VERSION` and `USE_MOCK_AUTH`, while keeping `Anela.Heblo.Domain.Features.Configuration` for `DEFAULT_VERSION` (which remains in `ConfigurationConstants`). This file is absent from the spec's FR-3 file table — it is a gap that must be addressed.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Domain/Shared/                                  ← already exists
+  InfrastructureConfigurationKeys.cs            ← NEW FILE (FR-1)
+  Result.cs
+  CurrencyCode.cs
+  Cooling.cs
+
+Domain/Features/Configuration/
+  ConfigurationConstants.cs                     ← MODIFIED: remove 3 constants, keep 2 (FR-2)
+  ApplicationConfiguration.cs                   ← unchanged
+
+Application/Features/Configuration/
+  GetConfigurationHandler.cs                    ← switch 2 constant refs to Domain.Shared (FR-3)
+
+test/Anela.Heblo.Tests/Features/Configuration/
+  GetConfigurationHandlerTests.cs               ← switch 2 constant refs to Domain.Shared (gap, see below)
+```
+
+All Application feature modules (`CatalogDocumentsModule`, `KnowledgeBaseModule`, `PhotobankModule`, `MeetingTasksModule`) and all API infrastructure files (`AuthenticationExtensions`, `HangfireAuthenticationMiddleware`, `HangfireDashboardTokenAuthorizationFilter`) switch from `ConfigurationConstants.BYPASS_JWT_VALIDATION` / `USE_MOCK_AUTH` to `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION` / `USE_MOCK_AUTH`. `ServiceCollectionExtensions.cs` and `E2ETestAuthenticationMiddleware.cs` drop their stale `using Anela.Heblo.Domain.Features.Configuration;` lines without any constant substitution. `Microsoft365AdapterServiceCollectionExtensions.cs` replaces both constant references.
+
+No `.csproj` changes are needed: all consumers already reference `Anela.Heblo.Domain`, which is where the new file lands.
+
+### Key Design Decisions
+
+#### Decision 1: Class name — InfrastructureConfigurationKeys vs. alternatives
+**Options considered:**
+- `InfrastructureConfigurationKeys` (spec proposal)
+- `AppConfigurationKeys`
+- `EnvironmentConfigurationKeys`
+- `SharedConfigurationKeys`
+
+**Chosen approach:** `InfrastructureConfigurationKeys` as proposed by the spec.
+
+**Rationale:** The three constants are read by infrastructure bootstrapping code (authentication setup, DI wiring, adapter selection) — not by business logic or domain entities. The name accurately captures their role: they are configuration keys that control infrastructure-mode switches (`BypassJwtValidation`, `UseMockAuth`) and a deployment metadata value (`APP_VERSION`). `AppConfigurationKeys` would collide conceptually with the existing Configuration feature's purpose. `InfrastructureConfigurationKeys` is unambiguous and consistent with the project's naming style (`InfrastructureConstants` already exists in the API layer for HTTP/CORS constants).
+
+#### Decision 2: Keep ConfigurationConstants or delete it
+**Options considered:**
+- Delete `ConfigurationConstants` entirely after removing the three cross-cutting constants
+- Keep it with the two remaining constants (`DEFAULT_VERSION`, `DEFAULT_ENVIRONMENT`)
+
+**Chosen approach:** Keep `ConfigurationConstants` with `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`.
+
+**Rationale:** Both remaining constants are used by `GetConfigurationHandler` and its tests. They represent fallback values for Configuration-feature-owned response fields, not infrastructure mode switches. They belong to the Configuration feature domain and should stay there.
+
+#### Decision 3: Scope of the test file update
+**Options considered:**
+- Leave `GetConfigurationHandlerTests.cs` untouched (tests use the config key strings as dictionary keys, which still work)
+- Update `GetConfigurationHandlerTests.cs` to match the moved constants
+
+**Chosen approach:** Update `GetConfigurationHandlerTests.cs`.
+
+**Rationale:** The test uses `ConfigurationConstants.APP_VERSION` and `ConfigurationConstants.USE_MOCK_AUTH` as dictionary keys in `IConfiguration` setup and as assertions. After the move those constants no longer live in `ConfigurationConstants`, so the file will produce a compilation error unless updated. This is not optional. The spec lists FR-4 ("full solution compiles") as a hard acceptance criterion; this update is a prerequisite. The spec's file table omits this file — the implementer must include it.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+1. Create `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs` with namespace `Anela.Heblo.Domain.Shared`, class `public static InfrastructureConfigurationKeys`, three `public const string` members with identical string values to today's `ConfigurationConstants`.
+
+2. Edit `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs`: remove the three constant declarations. File retains `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`.
+
+3. For each consumer file in the table below, perform the mechanical substitution and `using` update:
+
+| File | Action |
+|------|--------|
+| `Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` | Replace `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`; swap `using` |
+| `Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` | Replace `ConfigurationConstants.BYPASS_JWT_VALIDATION`; swap `using` |
+| `Application/Features/Photobank/PhotobankModule.cs` | Replace `ConfigurationConstants.BYPASS_JWT_VALIDATION`; swap `using` |
+| `Application/Features/MeetingTasks/MeetingTasksModule.cs` | Replace `ConfigurationConstants.BYPASS_JWT_VALIDATION`; swap `using` |
+| `Application/Features/Configuration/GetConfigurationHandler.cs` | Replace `ConfigurationConstants.USE_MOCK_AUTH` and `ConfigurationConstants.APP_VERSION`; add `using Anela.Heblo.Domain.Shared;`, retain `using Anela.Heblo.Domain.Features.Configuration;` (for `DEFAULT_VERSION` / `DEFAULT_ENVIRONMENT` via `ApplicationConfiguration.CreateWithDefaults`) |
+| `API/Extensions/AuthenticationExtensions.cs` | Replace `ConfigurationConstants.USE_MOCK_AUTH` and `ConfigurationConstants.BYPASS_JWT_VALIDATION`; swap `using` for the Configuration import (retain the Authorization import) |
+| `API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs` | Replace `ConfigurationConstants.USE_MOCK_AUTH` and `ConfigurationConstants.BYPASS_JWT_VALIDATION`; swap `using` |
+| `API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs` | Remove stale `using Anela.Heblo.Domain.Features.Configuration;` (no constant references present) |
+| `API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs` | Replace `ConfigurationConstants.USE_MOCK_AUTH` and `ConfigurationConstants.BYPASS_JWT_VALIDATION`; swap `using` (retain `using Anela.Heblo.Domain.Features.Authorization;`) |
+| `API/Extensions/ServiceCollectionExtensions.cs` | Remove stale `using Anela.Heblo.Domain.Features.Configuration;` (no constant references present) |
+| `Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs` | Replace `ConfigurationConstants.USE_MOCK_AUTH` and `ConfigurationConstants.BYPASS_JWT_VALIDATION`; swap `using` |
+| `test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` | Replace `ConfigurationConstants.APP_VERSION` and `ConfigurationConstants.USE_MOCK_AUTH` with `InfrastructureConfigurationKeys` equivalents; add `using Anela.Heblo.Domain.Shared;`, retain `using Anela.Heblo.Domain.Features.Configuration;` for `ConfigurationConstants.DEFAULT_VERSION` |
+
+### Interfaces and Contracts
+
+No new interfaces or contracts are introduced. `InfrastructureConfigurationKeys` is a `public static` class with `public const string` members — the same pattern as the existing `ConfigurationConstants` and `InfrastructureConstants` classes in the codebase. No abstraction layer is needed for string constants.
+
+### Data Flow
+
+N/A — pure structural refactor. The string values are unchanged; runtime behavior is identical before and after.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Test file (`GetConfigurationHandlerTests.cs`) omitted from the spec's file table, causing a compilation error if not updated | High | Implementer must include this file in the change set; it is enumerated explicitly above |
+| `ServiceCollectionExtensions.cs` and `E2ETestAuthenticationMiddleware.cs` carry stale `using` imports that are not tracked as constant-reference updates in the spec — risk of leaving dead imports in place | Low | Both files are in the table above with explicit "remove stale using" instructions; `dotnet format` will surface any remaining dead imports |
+| `GetConfigurationHandler.cs` uses both moved constants (`APP_VERSION`, `USE_MOCK_AUTH`) and an unmoved one (`DEFAULT_VERSION` is used implicitly via `ApplicationConfiguration.CreateWithDefaults` which has `"1.0.0"` hardcoded — no constant reference) — risk of accidentally removing the Configuration feature `using` entirely | Low | The handler only needs `using Anela.Heblo.Domain.Features.Configuration;` for `ConfigurationConstants.DEFAULT_VERSION` check — confirm there is no direct reference; if absent, the Configuration `using` can be removed from the handler too |
+| `ModuleBoundariesTests.cs` does not currently check the Configuration → other-feature boundary; after the move, no new architecture test is needed (the violation is eliminated, not moved) | Low | No test change required; `dotnet build` success is the verification criterion |
+| Constant name collision if a future developer adds an `InfrastructureConfigurationKeys` type elsewhere | Very Low | The `Anela.Heblo.Domain.Shared` namespace is unique and not re-declared in other assemblies |
+
+## Specification Amendments
+
+**FA-1 (Gap — required fix):** Add `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` to the FR-3 file table. The file uses `ConfigurationConstants.APP_VERSION` (lines 31, 47, 78) and `ConfigurationConstants.USE_MOCK_AUTH` (line 79) as dictionary keys in in-memory `IConfiguration` setup. After `APP_VERSION` and `USE_MOCK_AUTH` are removed from `ConfigurationConstants`, this file will not compile. The fix is: add `using Anela.Heblo.Domain.Shared;` and replace the two constant references with `InfrastructureConfigurationKeys.APP_VERSION` and `InfrastructureConfigurationKeys.USE_MOCK_AUTH`. The `ConfigurationConstants.DEFAULT_VERSION` references on lines 55 and 69 stay as-is — `DEFAULT_VERSION` remains in `ConfigurationConstants`.
+
+**FA-2 (Clarification — no code change):** The spec lists `API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs` and `API/Extensions/ServiceCollectionExtensions.cs` as using "namespace, verify which constants." Confirmed: neither file references `ConfigurationConstants` by name. Both files' `using Anela.Heblo.Domain.Features.Configuration;` directives are stale dead imports. The correct action for both is import removal only, with no constant substitution.
+
+**FA-3 (Scope confirmation):** `MarketingModule.cs` was mentioned in the brief but correctly excluded from the spec. Confirmed: it does not import `Anela.Heblo.Domain.Features.Configuration` and uses no constants from that namespace. No change required.
+
+## Prerequisites
+
+None. All referenced projects already reference `Anela.Heblo.Domain` via their `.csproj` files. No new project references, NuGet packages, or migration steps are needed before implementation begins.

--- a/artifacts/feat-3430/brief.md
+++ b/artifacts/feat-3430/brief.md
@@ -1,0 +1,26 @@
+## Module
+Configuration
+
+## Finding
+`ConfigurationConstants.BYPASS_JWT_VALIDATION` is defined in `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs:13` but is imported and used directly by at least 8 modules and infrastructure files outside the Configuration module:
+
+- `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs`
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/Services/NoOpOutlookCalendarSync.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs`
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs`
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs`
+- `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs`
+
+Each consumer reads `IConfiguration` directly using this constant key string, but to access the string they import `Anela.Heblo.Domain.Features.Configuration`, creating a direct dependency from many feature modules into the Configuration module's domain layer.
+
+## Why it matters
+The development guidelines require that "no direct references between feature modules" exist and that "communication [happens] only through contracts/interfaces." Importing a string constant from another module's domain namespace is a form of direct coupling: if the constant name, value, or namespace changes, all nine consumers break. It also makes `ConfigurationConstants` a de-facto shared global that belongs to no single module.
+
+## Suggested fix
+Move `BYPASS_JWT_VALIDATION` (and `APP_VERSION`, `USE_MOCK_AUTH` if they follow the same pattern) to `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs` (or similar cross-cutting shared location under `Domain/Shared/`). This decouples the constant from the Configuration feature module while keeping it in a clearly-owned, single location. Each consumer then imports from `Domain.Shared`, which is already the accepted home for cross-module domain utilities, rather than from another feature's namespace.
+
+---
+_Filed by daily arch-review routine on 2026-06-29._

--- a/artifacts/feat-3430/code-review.r1.md
+++ b/artifacts/feat-3430/code-review.r1.md
@@ -1,0 +1,33 @@
+# Code Review: feat-3430
+
+## Summary
+
+The refactoring correctly creates `InfrastructureConfigurationKeys` in `Domain/Shared`, removes the three constants from `ConfigurationConstants`, and updates all callers. All string values are identical to the originals, `dotnet build` is clean, `dotnet format --verify-no-changes` exits 0, and all 52 Configuration tests pass.
+
+Note: F-1 below was initially flagged as blocking but is a false positive — `using Anela.Heblo.Domain.Features.Configuration` in `GetConfigurationHandler.cs` is legitimately required for `ApplicationConfiguration` (defined in that namespace, used on lines 54 and 69). `dotnet format --verify-no-changes` confirms no unused import warning.
+
+## Result: CLEAN
+
+## Findings
+
+No blocking issues found.
+
+## Advisory (non-blocking)
+
+**A-1: `USE_MOCK_AUTH` constant is not fully adopted by consumer files touched in this diff**
+
+Several files updated in this diff to use `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION` still read `UseMockAuth` via a raw string literal on the very next or nearby line:
+
+- `CatalogDocumentsModule.cs` line 27
+- `KnowledgeBaseModule.cs` line 61
+- `MeetingTasksModule.cs` line 23
+- `PhotobankModule.cs` line 42
+- `E2ETestAuthenticationMiddleware.cs` line 130
+- `ServiceCollectionExtensions.cs` line 190
+- `ApplicationBuilderExtensions.cs` line 27
+
+These were pre-existing literals, not introduced by this diff, so they are out of scope for FR-3. However, the new constant exists precisely to eliminate these raw strings. A follow-up task to swap all remaining `"UseMockAuth"` literals to `InfrastructureConfigurationKeys.USE_MOCK_AUTH` would complete the intent of the refactoring.
+
+**A-2: `GetConfigurationHandlerTests.cs` retains `using Anela.Heblo.Domain.Features.Configuration`**
+
+This import is legitimately needed — `ConfigurationConstants.DEFAULT_VERSION` is referenced on lines 56 and 70. No change required.

--- a/artifacts/feat-3430/impl/move-constant.r1.md
+++ b/artifacts/feat-3430/impl/move-constant.r1.md
@@ -1,0 +1,45 @@
+# Implementation: move-constant
+
+## What was implemented
+
+Moved three configuration key constants (`APP_VERSION`, `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION`) from `Anela.Heblo.Domain.Features.Configuration.ConfigurationConstants` to the new `Anela.Heblo.Domain.Shared.InfrastructureConfigurationKeys` class. Updated all consumers across infrastructure, API, adapter, application, and test layers. Removed stale using directives from two files that no longer reference the domain configuration namespace. String values are unchanged.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs` — created with `APP_VERSION`, `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION`
+- `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs` — removed three constants; only `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT` remain
+- `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` — switched using + constant reference
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` — switched using + constant reference
+- `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` — switched using + constant reference
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs` — switched using + constant reference
+- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs` — kept existing using, added `Anela.Heblo.Domain.Shared`, updated USE_MOCK_AUTH and APP_VERSION references
+- `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs` — switched using + both constant references
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs` — switched using + both constant references
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs` — removed stale `using Anela.Heblo.Domain.Features.Configuration;` only
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs` — switched using + both constant references
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — removed stale `using Anela.Heblo.Domain.Features.Configuration;` only
+- `backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs` — switched using + both constant references
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — added `using Anela.Heblo.Domain.Shared;`, updated APP_VERSION and USE_MOCK_AUTH references; kept DEFAULT_VERSION on ConfigurationConstants
+
+## Tests
+
+`dotnet build Anela.Heblo.sln`: 0 errors, 253 warnings (pre-existing).
+`dotnet test Anela.Heblo.Tests.csproj --no-build`: Passed 5389, Failed 64 (all failures are Docker/Testcontainers not available in this environment — pre-existing, unrelated to this change), Skipped 4.
+Configuration-specific tests: 52 passed, 0 failed.
+
+## How to verify
+
+1. `dotnet build Anela.Heblo.sln` — should produce 0 errors
+2. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Configuration"` — 52 tests pass
+3. Confirm `InfrastructureConfigurationKeys` is in `Anela.Heblo.Domain.Shared` namespace
+4. Confirm `ConfigurationConstants` only has `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`
+5. Confirm no remaining references to `ConfigurationConstants.APP_VERSION`, `ConfigurationConstants.USE_MOCK_AUTH`, or `ConfigurationConstants.BYPASS_JWT_VALIDATION` in the codebase
+
+## Notes
+
+- Raw string literals `"UseMockAuth"` in module files (not constant references) were left unchanged as specified
+- `GetConfigurationHandler` retains both `Anela.Heblo.Domain.Features.Configuration` (for `DEFAULT_VERSION` used indirectly via `ApplicationConfiguration.CreateWithDefaults`) and `Anela.Heblo.Domain.Shared`
+- Docker-dependent tests fail in this environment due to no Docker daemon — pre-existing condition, not introduced by this change
+
+## Status
+DONE

--- a/artifacts/feat-3430/review/move-constant.r1.md
+++ b/artifacts/feat-3430/review/move-constant.r1.md
@@ -1,0 +1,17 @@
+# Code Review: Move Cross-Cutting Configuration Keys to Domain/Shared
+
+## Summary
+The implementation correctly moves `APP_VERSION`, `USE_MOCK_AUTH`, and `BYPASS_JWT_VALIDATION` from `ConfigurationConstants` into the new `InfrastructureConfigurationKeys` class in `Domain/Shared`. All files in scope per the task specification have been updated. The three moved constants no longer exist on `ConfigurationConstants`, and `ConfigurationConstants` retains only `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`. No file outside `Domain/Features/Configuration/` imports `Anela.Heblo.Domain.Features.Configuration` for the moved constants. All acceptance criteria are satisfied.
+
+## Review Result: PASS
+
+### task: move-constant
+**Status:** PASS
+
+## Overall Notes
+The implementation is surgically correct within its stated scope. A few observations that are out of scope for this task but worth noting for future cleanup:
+
+- Several files (`CatalogDocumentsModule`, `KnowledgeBaseModule`, `PhotobankModule`, `MeetingTasksModule`, `E2ETestAuthenticationMiddleware`, `ServiceCollectionExtensions.AddSwaggerServices`, `ApplicationBuilderExtensions`) still read `"UseMockAuth"` via a raw string literal rather than `InfrastructureConfigurationKeys.USE_MOCK_AUTH`. The task spec explicitly limited Application module files to only switching the `BYPASS_JWT_VALIDATION` reference and listed `E2ETestAuthenticationMiddleware` and `ServiceCollectionExtensions` as "remove stale using only" changes, so these raw strings are pre-existing and were correctly left untouched. They represent an incremental cleanup opportunity once this change is merged.
+- `GetConfigurationHandlerTests.cs` correctly retains `using Anela.Heblo.Domain.Features.Configuration` for the `ConfigurationConstants.DEFAULT_VERSION` reference and the new `using Anela.Heblo.Domain.Shared` for the moved constants — both usings are live.
+- `GetConfigurationHandler.cs` correctly retains `using Anela.Heblo.Domain.Features.Configuration` because `ApplicationConfiguration` lives in that namespace.
+- No stray raw `"BypassJwtValidation"` strings were found outside the new constant definition itself.

--- a/artifacts/feat-3430/spec.r1.md
+++ b/artifacts/feat-3430/spec.r1.md
@@ -1,0 +1,120 @@
+# Specification: Move Cross-Cutting Configuration Keys to Domain/Shared
+
+## Summary
+
+`ConfigurationConstants` in `Domain/Features/Configuration/` currently acts as a de-facto shared global imported by 10 files across 4 projects (Application feature modules, API infrastructure, and the Microsoft365 adapter), violating the module-boundary rule that forbids direct references between feature modules. This refactor extracts the infrastructure configuration key constants (`BYPASS_JWT_VALIDATION`, `USE_MOCK_AUTH`, `APP_VERSION`) into a new cross-cutting file under `Domain/Shared/`, eliminating the illegal coupling with a mechanical rename and namespace swap.
+
+## Background
+
+The development guidelines state: "No direct references between feature modules — communication only through contracts/interfaces." `ConfigurationConstants` lives in `Anela.Heblo.Domain.Features.Configuration`, a feature module namespace. Ten consumers across CatalogDocuments, KnowledgeBase, Photobank, MeetingTasks, Marketing (via NoOpOutlookCalendarSync registration), the API infrastructure layer, and the Microsoft365 adapter all import `Anela.Heblo.Domain.Features.Configuration` solely to access these string keys. This creates a hard compile-time dependency from unrelated modules into the Configuration feature's domain layer. Any rename or namespace reorganisation in the Configuration module would break all ten consumers silently at compile time.
+
+The fix is purely structural: move the three cross-cutting constants to `Domain/Shared/`, which is already the accepted home for cross-module domain utilities (`Result`, `CurrencyCode`, `Cooling`, etc.). `GetConfigurationHandler`, which legitimately owns the Configuration feature, will keep using the same constants — they just come from a neutral namespace.
+
+## Functional Requirements
+
+### FR-1: Create InfrastructureConfigurationKeys in Domain/Shared
+
+Create a new static class `InfrastructureConfigurationKeys` at `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs` in namespace `Anela.Heblo.Domain.Shared`. It must contain the following constants with identical string values to those currently in `ConfigurationConstants`:
+
+```csharp
+public const string APP_VERSION = "APP_VERSION";
+public const string USE_MOCK_AUTH = "UseMockAuth";
+public const string BYPASS_JWT_VALIDATION = "BypassJwtValidation";
+```
+
+**Acceptance criteria:**
+- File exists at the specified path.
+- Namespace is `Anela.Heblo.Domain.Shared`.
+- All three constants are present with exactly the same string values as they have today in `ConfigurationConstants`.
+- Class is `public static`.
+
+### FR-2: Remove the three constants from ConfigurationConstants
+
+Remove `APP_VERSION`, `USE_MOCK_AUTH`, and `BYPASS_JWT_VALIDATION` from `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs`. The remaining constants (`DEFAULT_VERSION`, `DEFAULT_ENVIRONMENT`) stay in place — they are owned by the Configuration feature and are not cross-cutting.
+
+**Acceptance criteria:**
+- `ConfigurationConstants` no longer declares `APP_VERSION`, `USE_MOCK_AUTH`, or `BYPASS_JWT_VALIDATION`.
+- `ConfigurationConstants` still declares `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`.
+- The file compiles cleanly.
+
+### FR-3: Update all consumers to reference InfrastructureConfigurationKeys
+
+Replace every occurrence of `ConfigurationConstants.BYPASS_JWT_VALIDATION`, `ConfigurationConstants.USE_MOCK_AUTH`, and `ConfigurationConstants.APP_VERSION` in the following files with `InfrastructureConfigurationKeys.<CONSTANT_NAME>`. Add `using Anela.Heblo.Domain.Shared;` where not already present. Remove `using Anela.Heblo.Domain.Features.Configuration;` from each file where it is no longer needed.
+
+Files to update (all confirmed to import `Anela.Heblo.Domain.Features.Configuration` and use the constants being moved):
+
+| File | Constants used |
+|------|---------------|
+| `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` | `BYPASS_JWT_VALIDATION` |
+| `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` | `BYPASS_JWT_VALIDATION` |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` | `BYPASS_JWT_VALIDATION` |
+| `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs` | `BYPASS_JWT_VALIDATION` |
+| `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs` | `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION` |
+| `backend/src/Anela.Heblo.API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs` | `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION` |
+| `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs` | (uses namespace, verify which constants) |
+| `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs` | `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION` |
+| `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` | (uses namespace, verify which constants) |
+| `backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs` | `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION` |
+
+The `GetConfigurationHandler` (`backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs`) also uses these constants. It must be updated in the same pass: switch its `using` to `Anela.Heblo.Domain.Shared` for the moved constants while retaining the `using Anela.Heblo.Domain.Features.Configuration;` import for `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT` if it uses those.
+
+**Acceptance criteria:**
+- No file outside `Domain/Features/Configuration/` imports `Anela.Heblo.Domain.Features.Configuration` for the sole purpose of using the three moved constants.
+- `using Anela.Heblo.Domain.Features.Configuration;` is removed from any file where it was only present to reference the moved constants.
+- All listed files compile cleanly.
+
+### FR-4: Full solution compiles and tests pass
+
+After the above changes, the entire backend solution must build without errors or warnings introduced by this change.
+
+**Acceptance criteria:**
+- `dotnet build` exits 0 with no new errors or warnings.
+- `dotnet format --verify-no-changes` exits 0 (or formatting is applied if the project uses auto-format).
+- All existing unit and integration tests pass.
+
+## Non-Functional Requirements
+
+### NFR-1: No behavioral change
+
+This is a pure structural refactor. The string values of all constants are identical before and after. No runtime behavior changes — environment variable names, `appsettings.json` keys, and application logic are unaffected.
+
+**Acceptance criteria:**
+- The constant values `"APP_VERSION"`, `"UseMockAuth"`, and `"BypassJwtValidation"` are unchanged.
+- No logic is altered in any consumer file beyond changing the class name and namespace import.
+
+### NFR-2: No new inter-module dependencies introduced
+
+After the change, `Domain/Shared` is the only shared import consumers need. No consumer should gain a new dependency on any feature module's namespace as a side-effect.
+
+### NFR-3: Surgical scope
+
+Only the files listed in FR-3 (plus the new file from FR-1 and `ConfigurationConstants.cs` from FR-2) are modified. No reformatting, comment edits, or unrelated cleanup.
+
+## Data Model
+
+N/A — this is a pure code structural refactor with no database or entity changes.
+
+## API / Interface Design
+
+N/A — no API surface, DTOs, or contracts are modified. The key strings are identical, so no configuration file or environment variable changes are needed.
+
+## Dependencies
+
+- `Anela.Heblo.Domain` project — new file is added here; no new project references are introduced.
+- All consumer projects (`Application`, `API`, `Adapters.Microsoft365`) already reference `Anela.Heblo.Domain`, so no `.csproj` changes are required.
+
+## Out of Scope
+
+- Moving `DEFAULT_VERSION` or `DEFAULT_ENVIRONMENT` — these are used only within the Configuration feature and should remain in `ConfigurationConstants`.
+- Introducing a typed options class or `IOptions<T>` binding to replace the raw `IConfiguration.GetValue<bool>` calls — that is a separate architectural improvement.
+- Changing the string values of any constant.
+- Modifying any frontend code or API contracts.
+- Updating the `Configuration` module's query handler logic beyond the namespace import change.
+- Deleting `ConfigurationConstants` entirely — it retains two constants that legitimately belong to the Configuration feature.
+- Any E2E or integration test changes — runtime behavior is identical.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3430/state.json
+++ b/artifacts/feat-3430/state.json
@@ -21,16 +21,20 @@
       "updated_at": "2026-06-30T05:24:23.361091Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-06-30T05:24:37.255261Z"
+      "status": "completed",
+      "updated_at": "2026-06-30T05:32:51.879599Z"
+    },
+    "code-review": {
+      "status": "completed",
+      "updated_at": "2026-06-30T05:38:09.721119Z"
     }
   },
   "tasks": [
     {
       "name": "move-constant",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-06-30T05:24:37.474798Z"
+      "updated_at": "2026-06-30T05:32:51.678719Z"
     }
   ]
 }

--- a/artifacts/feat-3430/state.json
+++ b/artifacts/feat-3430/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3430",
+  "issue_number": 3430,
+  "created_at": "2026-06-30T05:15:10.720695Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-06-30T05:18:21.422699Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3430/state.json
+++ b/artifacts/feat-3430/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-06-30T05:22:07.251735Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-06-30T05:22:07.446960Z"
+      "status": "completed",
+      "updated_at": "2026-06-30T05:24:23.361091Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3430/state.json
+++ b/artifacts/feat-3430/state.json
@@ -21,9 +21,16 @@
       "updated_at": "2026-06-30T05:24:23.361091Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-30T05:24:37.255261Z"
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "move-constant",
+      "status": "in_progress",
+      "revision": 1,
+      "updated_at": "2026-06-30T05:24:37.474798Z"
+    }
+  ]
 }

--- a/artifacts/feat-3430/state.json
+++ b/artifacts/feat-3430/state.json
@@ -6,19 +6,19 @@
   "phases": {
     "analyzing": {
       "status": "completed",
-      "updated_at": "2026-06-30T05:18:21.422699Z"
+      "updated_at": "2026-06-30T05:18:31.509488Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-30T05:22:06.992360Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-06-30T05:22:07.251735Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-06-30T05:22:07.446960Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3430/task-context/move-constant.md
+++ b/artifacts/feat-3430/task-context/move-constant.md
@@ -1,0 +1,154 @@
+# Task Plan: feat-3430
+
+### task: move-constant
+
+**Goal:** Create InfrastructureConfigurationKeys, remove constants from ConfigurationConstants, update all consumers, verify build.
+
+**Context:**
+Three configuration key constants (`BYPASS_JWT_VALIDATION`, `USE_MOCK_AUTH`, `APP_VERSION`) are defined in `Anela.Heblo.Domain.Features.Configuration.ConfigurationConstants` but are used across infrastructure, API, and adapter layers — far outside the Configuration feature boundary. The refactor moves them to `Anela.Heblo.Domain.Shared.InfrastructureConfigurationKeys` so their namespace reflects their cross-cutting nature. The remaining constants in `ConfigurationConstants` (`DEFAULT_VERSION`, `DEFAULT_ENVIRONMENT`) are domain/Configuration-specific and stay put.
+
+Key constraints:
+- String values of all three constants must remain unchanged: `"APP_VERSION"`, `"UseMockAuth"`, `"BypassJwtValidation"`.
+- `GetConfigurationHandler` and its test both need `Anela.Heblo.Domain.Features.Configuration` retained (for `DEFAULT_VERSION`/`DEFAULT_ENVIRONMENT`) but must also add `Anela.Heblo.Domain.Shared` for the moved constants.
+- Several module files (`CatalogDocumentsModule`, `KnowledgeBaseModule`, `PhotobankModule`, `MeetingTasksModule`) already use raw string `"UseMockAuth"` (not the constant) for `useMockAuth` — the spec asks only that their `BYPASS_JWT_VALIDATION` reference is switched; the raw string `"UseMockAuth"` lines are left as-is since they do not reference the constant.
+- `E2ETestAuthenticationMiddleware` and `ServiceCollectionExtensions` import `Anela.Heblo.Domain.Features.Configuration` but do not reference any of the three moved constants. Their stale using directives should be removed.
+
+**Files to create/modify:**
+
+- `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs` (create)
+- `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs` (modify)
+- `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs` (modify)
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs` (modify)
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs` (modify — remove stale using only)
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs` (modify)
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (modify — remove stale using only)
+- `backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs` (modify)
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` (modify)
+
+**Implementation steps:**
+
+1. **Create `InfrastructureConfigurationKeys.cs`**
+
+   Create `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs`:
+   ```csharp
+   namespace Anela.Heblo.Domain.Shared;
+
+   public static class InfrastructureConfigurationKeys
+   {
+       public const string APP_VERSION = "APP_VERSION";
+       public const string USE_MOCK_AUTH = "UseMockAuth";
+       public const string BYPASS_JWT_VALIDATION = "BypassJwtValidation";
+   }
+   ```
+
+2. **Remove three constants from `ConfigurationConstants.cs`**
+
+   Remove the `APP_VERSION`, `USE_MOCK_AUTH`, and `BYPASS_JWT_VALIDATION` lines. The resulting file keeps only:
+   ```csharp
+   namespace Anela.Heblo.Domain.Features.Configuration;
+
+   /// <summary>
+   /// Configuration constants and keys
+   /// </summary>
+   public static class ConfigurationConstants
+   {
+       // Default values
+       public const string DEFAULT_VERSION = "1.0.0";
+       public const string DEFAULT_ENVIRONMENT = "Production";
+   }
+   ```
+
+3. **Update `CatalogDocumentsModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal on line 27 is left unchanged (it does not use the constant).
+
+4. **Update `KnowledgeBaseModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal is left unchanged.
+
+5. **Update `PhotobankModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal is left unchanged.
+
+6. **Update `MeetingTasksModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal is left unchanged.
+
+7. **Update `GetConfigurationHandler.cs`**
+
+   - Keep `using Anela.Heblo.Domain.Features.Configuration;` (needed for `DEFAULT_VERSION`/`DEFAULT_ENVIRONMENT` via `ApplicationConfiguration.CreateWithDefaults`).
+   - Add `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+   - Change `ConfigurationConstants.APP_VERSION` → `InfrastructureConfigurationKeys.APP_VERSION`
+
+8. **Update `AuthenticationExtensions.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+9. **Update `HangfireAuthenticationMiddleware.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+10. **Update `E2ETestAuthenticationMiddleware.cs`**
+
+    - Remove the stale `using Anela.Heblo.Domain.Features.Configuration;` line. The file uses only a raw string `"UseMockAuth"` on line 131 inside `ShouldBeRegistered`, which is not a constant reference and does not need changing.
+
+11. **Update `HangfireDashboardTokenAuthorizationFilter.cs`**
+
+    - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+    - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+    - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+12. **Update `ServiceCollectionExtensions.cs`**
+
+    - Remove the stale `using Anela.Heblo.Domain.Features.Configuration;` line. No constant from that namespace is actually referenced in the file body (the `"UseMockAuth"` on line 191 inside `AddSwaggerServices` is a raw string literal).
+
+13. **Update `Microsoft365AdapterServiceCollectionExtensions.cs`**
+
+    - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+    - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+    - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+14. **Update `GetConfigurationHandlerTests.cs`**
+
+    - Keep `using Anela.Heblo.Domain.Features.Configuration;` (still needed for `ConfigurationConstants.DEFAULT_VERSION` used in two test assertions).
+    - Add `using Anela.Heblo.Domain.Shared;`
+    - Change `ConfigurationConstants.APP_VERSION` → `InfrastructureConfigurationKeys.APP_VERSION` (appears in two test cases as dictionary key).
+    - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH` (appears in one test case as dictionary key).
+    - Leave `ConfigurationConstants.DEFAULT_VERSION` references unchanged.
+
+15. **Run `dotnet build`**
+
+    ```
+    dotnet build backend/Anela.Heblo.sln
+    ```
+    Fix any remaining `CS0117` (missing member) or `CS8019` (unused using) errors before declaring done.
+
+**Tests to write/update:**
+
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — update existing tests as described in step 14. No new tests are required; behaviour is unchanged.
+
+**Acceptance criteria:**
+
+- `dotnet build` exits 0 with no errors or warnings introduced by this change.
+- No file outside `Domain/Features/Configuration/` imports `Anela.Heblo.Domain.Features.Configuration` for the three moved constants (`APP_VERSION`, `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION`).
+- `ConfigurationConstants` retains only `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`.
+- `InfrastructureConfigurationKeys` contains exactly `APP_VERSION = "APP_VERSION"`, `USE_MOCK_AUTH = "UseMockAuth"`, `BYPASS_JWT_VALIDATION = "BypassJwtValidation"` — string values identical to the originals.
+- All existing tests pass (`dotnet test`).

--- a/artifacts/feat-3430/task-plan.r1.md
+++ b/artifacts/feat-3430/task-plan.r1.md
@@ -1,0 +1,154 @@
+# Task Plan: feat-3430
+
+### task: move-constant
+
+**Goal:** Create InfrastructureConfigurationKeys, remove constants from ConfigurationConstants, update all consumers, verify build.
+
+**Context:**
+Three configuration key constants (`BYPASS_JWT_VALIDATION`, `USE_MOCK_AUTH`, `APP_VERSION`) are defined in `Anela.Heblo.Domain.Features.Configuration.ConfigurationConstants` but are used across infrastructure, API, and adapter layers — far outside the Configuration feature boundary. The refactor moves them to `Anela.Heblo.Domain.Shared.InfrastructureConfigurationKeys` so their namespace reflects their cross-cutting nature. The remaining constants in `ConfigurationConstants` (`DEFAULT_VERSION`, `DEFAULT_ENVIRONMENT`) are domain/Configuration-specific and stay put.
+
+Key constraints:
+- String values of all three constants must remain unchanged: `"APP_VERSION"`, `"UseMockAuth"`, `"BypassJwtValidation"`.
+- `GetConfigurationHandler` and its test both need `Anela.Heblo.Domain.Features.Configuration` retained (for `DEFAULT_VERSION`/`DEFAULT_ENVIRONMENT`) but must also add `Anela.Heblo.Domain.Shared` for the moved constants.
+- Several module files (`CatalogDocumentsModule`, `KnowledgeBaseModule`, `PhotobankModule`, `MeetingTasksModule`) already use raw string `"UseMockAuth"` (not the constant) for `useMockAuth` — the spec asks only that their `BYPASS_JWT_VALIDATION` reference is switched; the raw string `"UseMockAuth"` lines are left as-is since they do not reference the constant.
+- `E2ETestAuthenticationMiddleware` and `ServiceCollectionExtensions` import `Anela.Heblo.Domain.Features.Configuration` but do not reference any of the three moved constants. Their stale using directives should be removed.
+
+**Files to create/modify:**
+
+- `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs` (create)
+- `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs` (modify)
+- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs` (modify)
+- `backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs` (modify)
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs` (modify)
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs` (modify — remove stale using only)
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs` (modify)
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (modify — remove stale using only)
+- `backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs` (modify)
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` (modify)
+
+**Implementation steps:**
+
+1. **Create `InfrastructureConfigurationKeys.cs`**
+
+   Create `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs`:
+   ```csharp
+   namespace Anela.Heblo.Domain.Shared;
+
+   public static class InfrastructureConfigurationKeys
+   {
+       public const string APP_VERSION = "APP_VERSION";
+       public const string USE_MOCK_AUTH = "UseMockAuth";
+       public const string BYPASS_JWT_VALIDATION = "BypassJwtValidation";
+   }
+   ```
+
+2. **Remove three constants from `ConfigurationConstants.cs`**
+
+   Remove the `APP_VERSION`, `USE_MOCK_AUTH`, and `BYPASS_JWT_VALIDATION` lines. The resulting file keeps only:
+   ```csharp
+   namespace Anela.Heblo.Domain.Features.Configuration;
+
+   /// <summary>
+   /// Configuration constants and keys
+   /// </summary>
+   public static class ConfigurationConstants
+   {
+       // Default values
+       public const string DEFAULT_VERSION = "1.0.0";
+       public const string DEFAULT_ENVIRONMENT = "Production";
+   }
+   ```
+
+3. **Update `CatalogDocumentsModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal on line 27 is left unchanged (it does not use the constant).
+
+4. **Update `KnowledgeBaseModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal is left unchanged.
+
+5. **Update `PhotobankModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal is left unchanged.
+
+6. **Update `MeetingTasksModule.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+   - The `"UseMockAuth"` raw string literal is left unchanged.
+
+7. **Update `GetConfigurationHandler.cs`**
+
+   - Keep `using Anela.Heblo.Domain.Features.Configuration;` (needed for `DEFAULT_VERSION`/`DEFAULT_ENVIRONMENT` via `ApplicationConfiguration.CreateWithDefaults`).
+   - Add `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+   - Change `ConfigurationConstants.APP_VERSION` → `InfrastructureConfigurationKeys.APP_VERSION`
+
+8. **Update `AuthenticationExtensions.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+9. **Update `HangfireAuthenticationMiddleware.cs`**
+
+   - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+   - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+   - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+10. **Update `E2ETestAuthenticationMiddleware.cs`**
+
+    - Remove the stale `using Anela.Heblo.Domain.Features.Configuration;` line. The file uses only a raw string `"UseMockAuth"` on line 131 inside `ShouldBeRegistered`, which is not a constant reference and does not need changing.
+
+11. **Update `HangfireDashboardTokenAuthorizationFilter.cs`**
+
+    - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+    - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+    - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+12. **Update `ServiceCollectionExtensions.cs`**
+
+    - Remove the stale `using Anela.Heblo.Domain.Features.Configuration;` line. No constant from that namespace is actually referenced in the file body (the `"UseMockAuth"` on line 191 inside `AddSwaggerServices` is a raw string literal).
+
+13. **Update `Microsoft365AdapterServiceCollectionExtensions.cs`**
+
+    - Replace `using Anela.Heblo.Domain.Features.Configuration;` with `using Anela.Heblo.Domain.Shared;`
+    - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH`
+    - Change `ConfigurationConstants.BYPASS_JWT_VALIDATION` → `InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION`
+
+14. **Update `GetConfigurationHandlerTests.cs`**
+
+    - Keep `using Anela.Heblo.Domain.Features.Configuration;` (still needed for `ConfigurationConstants.DEFAULT_VERSION` used in two test assertions).
+    - Add `using Anela.Heblo.Domain.Shared;`
+    - Change `ConfigurationConstants.APP_VERSION` → `InfrastructureConfigurationKeys.APP_VERSION` (appears in two test cases as dictionary key).
+    - Change `ConfigurationConstants.USE_MOCK_AUTH` → `InfrastructureConfigurationKeys.USE_MOCK_AUTH` (appears in one test case as dictionary key).
+    - Leave `ConfigurationConstants.DEFAULT_VERSION` references unchanged.
+
+15. **Run `dotnet build`**
+
+    ```
+    dotnet build backend/Anela.Heblo.sln
+    ```
+    Fix any remaining `CS0117` (missing member) or `CS8019` (unused using) errors before declaring done.
+
+**Tests to write/update:**
+
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — update existing tests as described in step 14. No new tests are required; behaviour is unchanged.
+
+**Acceptance criteria:**
+
+- `dotnet build` exits 0 with no errors or warnings introduced by this change.
+- No file outside `Domain/Features/Configuration/` imports `Anela.Heblo.Domain.Features.Configuration` for the three moved constants (`APP_VERSION`, `USE_MOCK_AUTH`, `BYPASS_JWT_VALIDATION`).
+- `ConfigurationConstants` retains only `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`.
+- `InfrastructureConfigurationKeys` contains exactly `APP_VERSION = "APP_VERSION"`, `USE_MOCK_AUTH = "UseMockAuth"`, `BYPASS_JWT_VALIDATION = "BypassJwtValidation"` — string values identical to the originals.
+- All existing tests pass (`dotnet test`).

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Microsoft365/Microsoft365AdapterServiceCollectionExtensions.cs
@@ -3,7 +3,7 @@ using Anela.Heblo.Adapters.Microsoft365.UserManagement;
 using Anela.Heblo.Application.Features.Marketing.Services;
 using Anela.Heblo.Application.Features.Photobank.Services;
 using Anela.Heblo.Application.Features.UserManagement.Services;
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,8 +15,8 @@ public static class Microsoft365AdapterServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var useMockAuth = configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, false);
-        var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
+        var useMockAuth = configuration.GetValue<bool>(InfrastructureConfigurationKeys.USE_MOCK_AUTH, false);
+        var bypassJwt = configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, false);
 
         if (useMockAuth || bypassJwt)
         {

--- a/backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Policy;
 using Anela.Heblo.API.Infrastructure.Authentication;
 using Anela.Heblo.API.Infrastructure;
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Anela.Heblo.Domain.Features.Authorization;
 
 namespace Anela.Heblo.API.Extensions;
@@ -16,8 +16,8 @@ public static class AuthenticationExtensions
     {
         // Mock authentication is ONLY controlled by UseMockAuth configuration variable
         // Environment name does NOT influence authentication mode (per updated specification)
-        var useMockAuth = builder.Configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, defaultValue: false);
-        var bypassJwtValidation = builder.Configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, defaultValue: false);
+        var useMockAuth = builder.Configuration.GetValue<bool>(InfrastructureConfigurationKeys.USE_MOCK_AUTH, defaultValue: false);
+        var bypassJwtValidation = builder.Configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, defaultValue: false);
 
         // Log authentication mode for debugging
         logger.LogInformation("Authentication Configuration - Environment: {Environment}, UseMockAuth: {UseMockAuth}, BypassJwtValidation: {BypassJwtValidation}",

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -9,7 +9,6 @@ using Anela.Heblo.API.Infrastructure.ExceptionHandling;
 using Anela.Heblo.API.Infrastructure.Telemetry;
 using Anela.Heblo.API.Infrastructure;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Anela.Heblo.Domain.Features.Configuration;
 using Microsoft.OpenApi.Models;
 using Hangfire;
 using Hangfire.MemoryStorage;

--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ETestAuthenticationMiddleware.cs
@@ -2,7 +2,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
-using Anela.Heblo.Domain.Features.Configuration;
 
 namespace Anela.Heblo.API.Infrastructure.Authentication;
 

--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/HangfireAuthenticationMiddleware.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http.Extensions;
 
@@ -36,8 +36,8 @@ public class HangfireAuthenticationMiddleware
             return;
         }
 
-        var useMockAuth = _configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, defaultValue: false);
-        var bypassJwtValidation = _configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, defaultValue: false);
+        var useMockAuth = _configuration.GetValue<bool>(InfrastructureConfigurationKeys.USE_MOCK_AUTH, defaultValue: false);
+        var bypassJwtValidation = _configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, defaultValue: false);
 
         // Check if we should use mock authentication
         if (useMockAuth || bypassJwtValidation)

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireDashboardTokenAuthorizationFilter.cs
@@ -1,7 +1,7 @@
 using Hangfire.Dashboard;
 using System.Security.Claims;
 using Anela.Heblo.API.Infrastructure;
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Anela.Heblo.Domain.Features.Authorization;
 
 namespace Anela.Heblo.API.Infrastructure.Hangfire;
@@ -24,8 +24,8 @@ public class HangfireDashboardTokenAuthorizationFilter : IDashboardAuthorization
     public bool Authorize(DashboardContext context)
     {
         var httpContext = context.GetHttpContext();
-        var useMockAuth = _configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, defaultValue: false);
-        var bypassJwtValidation = _configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, defaultValue: false);
+        var useMockAuth = _configuration.GetValue<bool>(InfrastructureConfigurationKeys.USE_MOCK_AUTH, defaultValue: false);
+        var bypassJwtValidation = _configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, defaultValue: false);
 
         // Check if we should use mock authentication
         if (useMockAuth || bypassJwtValidation)

--- a/backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs
@@ -1,6 +1,6 @@
 using Anela.Heblo.Application.Features.CatalogDocuments.Infrastructure;
 using Anela.Heblo.Application.Features.CatalogDocuments.Services;
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,7 +25,7 @@ public static class CatalogDocumentsModule
             && !options.PIF.DriveId.Contains("secrets.json");
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
+        var bypassJwt = configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, false);
 
         if (drivesConfigured && !useMockAuth && !bypassJwt)
         {

--- a/backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
 using System.Reflection;
 using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using MediatR;
 
 namespace Anela.Heblo.Application.Features.Configuration;
@@ -63,7 +64,7 @@ public class GetConfigurationHandler : IRequestHandler<GetConfigurationRequest, 
         var environment = _environment.EnvironmentName;
 
         // Get mock auth setting
-        var useMockAuth = _configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, false);
+        var useMockAuth = _configuration.GetValue<bool>(InfrastructureConfigurationKeys.USE_MOCK_AUTH, false);
 
         var config = ApplicationConfiguration.CreateWithDefaults(version, environment, useMockAuth);
 
@@ -73,7 +74,7 @@ public class GetConfigurationHandler : IRequestHandler<GetConfigurationRequest, 
     private string? GetVersionFromSources()
     {
         // 1. Try environment variable first (CI/CD pipeline)
-        var version = _configuration[ConfigurationConstants.APP_VERSION];
+        var version = _configuration[InfrastructureConfigurationKeys.APP_VERSION];
         if (!string.IsNullOrEmpty(version))
         {
             _logger.LogDebug("Version resolved from configuration: {Version}", version);

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
@@ -6,7 +6,7 @@ using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
 using Microsoft.Identity.Web;
 using Anela.Heblo.Application.Features.KnowledgeBase.Services.DocumentExtractors;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.AskQuestion;
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Persistence.KnowledgeBase;
 using MediatR;
@@ -59,7 +59,7 @@ public static class KnowledgeBaseModule
         configuration.GetSection("KnowledgeBase").Bind(kbOptions);
         var sharePointConfigured = kbOptions.OneDriveFolderMappings.Any(m => !string.IsNullOrWhiteSpace(m.DriveId));
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwtValidation = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
+        var bypassJwtValidation = configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, false);
 
         if (sharePointConfigured && !useMockAuth && !bypassJwtValidation)
         {

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs
@@ -1,5 +1,5 @@
 using Anela.Heblo.Application.Features.MeetingTasks.Services;
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Anela.Heblo.Domain.Features.MeetingTasks;
 using Anela.Heblo.Persistence.MeetingTasks;
 using Microsoft.Extensions.AI;
@@ -21,7 +21,7 @@ public static class MeetingTasksModule
             .ValidateOnStart();
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
+        var bypassJwt = configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, false);
 
         if (!useMockAuth && !bypassJwt)
         {

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -16,7 +16,7 @@ using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
 using Anela.Heblo.Application.Features.Photobank.Validators;
-using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using Anela.Heblo.Domain.Features.Photobank;
 using Anela.Heblo.Persistence.Photobank;
 using FluentValidation;
@@ -40,7 +40,7 @@ public static class PhotobankModule
         services.AddScoped<IPhotobankTagsCache, PhotobankTagsCache>();
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwtValidation = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
+        var bypassJwtValidation = configuration.GetValue<bool>(InfrastructureConfigurationKeys.BYPASS_JWT_VALIDATION, false);
 
         if (useMockAuth || bypassJwtValidation)
         {

--- a/backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs
@@ -5,13 +5,6 @@ namespace Anela.Heblo.Domain.Features.Configuration;
 /// </summary>
 public static class ConfigurationConstants
 {
-    // Environment variable keys
-    public const string APP_VERSION = "APP_VERSION";
-
-    // Configuration keys
-    public const string USE_MOCK_AUTH = "UseMockAuth";
-    public const string BYPASS_JWT_VALIDATION = "BypassJwtValidation";
-
     // Default values
     public const string DEFAULT_VERSION = "1.0.0";
     public const string DEFAULT_ENVIRONMENT = "Production";

--- a/backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs
+++ b/backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Domain.Shared;
+
+public static class InfrastructureConfigurationKeys
+{
+    public const string APP_VERSION = "APP_VERSION";
+    public const string USE_MOCK_AUTH = "UseMockAuth";
+    public const string BYPASS_JWT_VALIDATION = "BypassJwtValidation";
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.Configuration;
 using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Shared;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -28,7 +29,7 @@ public class GetConfigurationHandlerTests
         // Arrange
         var handler = CreateHandler(new Dictionary<string, string?>
         {
-            [ConfigurationConstants.APP_VERSION] = "2.5.1-ci.42"
+            [InfrastructureConfigurationKeys.APP_VERSION] = "2.5.1-ci.42"
         });
 
         // Act
@@ -44,7 +45,7 @@ public class GetConfigurationHandlerTests
         // Arrange
         var handler = CreateHandler(new Dictionary<string, string?>
         {
-            [ConfigurationConstants.APP_VERSION] = ""
+            [InfrastructureConfigurationKeys.APP_VERSION] = ""
         });
 
         // Act
@@ -75,8 +76,8 @@ public class GetConfigurationHandlerTests
         // Arrange — regression guard: surgical change must not break UseMockAuth wiring
         var handler = CreateHandler(new Dictionary<string, string?>
         {
-            [ConfigurationConstants.APP_VERSION] = "1.2.3",
-            [ConfigurationConstants.USE_MOCK_AUTH] = "true"
+            [InfrastructureConfigurationKeys.APP_VERSION] = "1.2.3",
+            [InfrastructureConfigurationKeys.USE_MOCK_AUTH] = "true"
         });
 
         // Act


### PR DESCRIPTION
Closes #3430

## What the issue was

`ConfigurationConstants.BYPASS_JWT_VALIDATION`, `USE_MOCK_AUTH`, and `APP_VERSION` were defined in `Anela.Heblo.Domain.Features.Configuration` but consumed by 12 files across 4 projects (Application feature modules, API infrastructure, Microsoft365 adapter, and tests). This created a direct compile-time dependency from unrelated modules into the Configuration feature's domain layer, violating the "no direct references between feature modules" rule in the development guidelines.

## How it was fixed

Created `backend/src/Anela.Heblo.Domain/Shared/InfrastructureConfigurationKeys.cs` with the three constants at identical string values, and removed them from `ConfigurationConstants` (which retains `DEFAULT_VERSION` and `DEFAULT_ENVIRONMENT`). Updated all 12 consumers to import `Anela.Heblo.Domain.Shared` instead of `Anela.Heblo.Domain.Features.Configuration`. Two files (`E2ETestAuthenticationMiddleware.cs`, `ServiceCollectionExtensions.cs`) had only stale using directives — those were removed without any constant substitution.

No `.csproj` changes needed — all consumers already reference `Anela.Heblo.Domain`. String values are unchanged; this is a pure structural refactor with no behavioral impact.

## Artifacts
- Brief, spec, arch-review, task plan, impl, review, and code-review markdown are committed in this branch under `artifacts/feat-3430/`.

## Code review

Result: **CLEAN** — `dotnet build` 0 errors, `dotnet format --verify-no-changes` exits 0, 52 Configuration tests pass.

Advisory (non-blocking, pre-existing): several Application module files still read `UseMockAuth` via raw string literal rather than `InfrastructureConfigurationKeys.USE_MOCK_AUTH`. These were out of scope for this PR but are a natural follow-up cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Gxwu3nm5VdUV2WGkBLN18)_