### PR TITLE
#3440: fix DashboardSettings dark-mode gaps (skeleton + new-tile ring)

### DIFF
--- a/artifacts/feat-3440/brief.md
+++ b/artifacts/feat-3440/brief.md
@@ -1,0 +1,23 @@
+## Module
+Dashboard
+
+## Finding
+`frontend/src/components/dashboard/DashboardSettings.tsx` has two dark-mode gaps:
+
+**1. Loading skeleton elements (lines 59-68)** use bare `bg-gray-200` with no `dark:` variant.
+In Graphite dark mode these render as near-white blocks on a dark surface — broken contrast.
+
+**2. "New tile" ring (line 141)** uses `ring-blue-200` with no `dark:` variant.
+`ring-blue-200` is barely visible on dark backgrounds.
+
+## Why it matters
+ADR-006 requires every component that renders color to be correct in both light and dark mode.
+These gaps produce broken contrast in the Graphite theme.
+
+## Suggested fix
+Apply design-system token mappings per `docs/design/dark-mode-conversion-guide.md`:
+- `bg-gray-200` → add `dark:bg-graphite-hover`
+- `ring-blue-200` → add `dark:ring-graphite-accent` (matches existing "new/active" ring convention used elsewhere, e.g. TransportBoxList.tsx)
+
+---
+_Filed by daily arch-review routine on 2026-06-30. Issue #3440._

--- a/artifacts/feat-3440/code-review.r1.md
+++ b/artifacts/feat-3440/code-review.r1.md
@@ -1,0 +1,13 @@
+## Review Result: CLEAN
+
+### Verification performed
+- (a) `graphite-hover` (#2E323A) and `graphite-accent` (#38BDF8) tokens confirmed present in `frontend/tailwind.config.js`.
+- (b) `bg-gray-200` -> `dark:bg-graphite-hover` matches `docs/design/dark-mode-conversion-guide.md` mapping table exactly. `ring-blue-200` -> `dark:ring-graphite-accent` is not in the literal mapping table but matches the established "active/new" ring precedent in `TransportBoxList.tsx` (lines 416, 560).
+- (c) No other `bg-gray-200` / `ring-blue-200` instances remain unconverted in this file.
+- (d) All edits are strictly additive; no light-mode classes were removed, reordered, or altered; no logic/structure changes.
+
+### Blocking
+- None
+
+### Advisory
+- None

--- a/frontend/src/components/dashboard/DashboardSettings.tsx
+++ b/frontend/src/components/dashboard/DashboardSettings.tsx
@@ -57,10 +57,10 @@ const DashboardSettings: React.FC<DashboardSettingsProps> = ({ onClose }) => {
     return (
       <div className="p-6">
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-gray-200 rounded w-1/3"></div>
+          <div className="h-6 bg-gray-200 dark:bg-graphite-hover rounded w-1/3"></div>
           <div className="space-y-3">
             {[1, 2, 3].map(i => (
-              <div key={i} className="h-16 bg-gray-200 rounded"></div>
+              <div key={i} className="h-16 bg-gray-200 dark:bg-graphite-hover rounded"></div>
             ))}
           </div>
         </div>
@@ -138,7 +138,7 @@ const DashboardSettings: React.FC<DashboardSettingsProps> = ({ onClose }) => {
                 className={`
                   p-4 rounded-lg border transition-all
                   ${isEnabled ? 'border-green-200 dark:border-emerald-400/30 bg-green-50 dark:bg-emerald-400/15' : 'border-gray-200 dark:border-graphite-border bg-white dark:bg-graphite-surface'}
-                  ${isNew ? 'ring-2 ring-blue-200' : ''}
+                  ${isNew ? 'ring-2 ring-blue-200 dark:ring-graphite-accent' : ''}
                 `}
               >
                 <div className="flex items-center justify-between">


### PR DESCRIPTION
Closes #3440

## What the issue was
`frontend/src/components/dashboard/DashboardSettings.tsx` had two dark-mode gaps flagged by the daily arch-review routine per ADR-006 (every color-rendering component must be correct in both light and dark mode):

1. The loading-skeleton bars used bare `bg-gray-200` with no `dark:` variant — rendering as near-white blocks on a dark surface in the Graphite theme.
2. The "new tile" highlight ring used `ring-blue-200` with no `dark:` variant — barely visible on dark backgrounds.

## How it was fixed
Applied the token mappings from `docs/design/dark-mode-conversion-guide.md`, purely additive (no light-mode classes touched, no logic/structure changes):

- `bg-gray-200` → `bg-gray-200 dark:bg-graphite-hover` (matches the guide's mapping table exactly; same pattern already used in `GenericFeedbackStatsBar.tsx`'s skeleton).
- `ring-blue-200` → `ring-blue-200 dark:ring-graphite-accent` (not in the guide's literal ring table, but matches the established "active/new" ring convention used elsewhere, e.g. `TransportBoxList.tsx`).

Verified both `graphite-hover` and `graphite-accent` tokens exist in `frontend/tailwind.config.js`, ran the existing `DashboardSettings` test suite (3/3 passing), and lint on the changed file is clean.

## Artifacts
Brief and code-review markdown are committed under `artifacts/feat-3440/`.

## Code review

CLEAN — no blocking or advisory findings. Verified token spelling, guide-conformance, no missed instances in the file, and no light-mode regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSAK1rHLLaZEkeJwgYg5CA)_