### PR TITLE
#3441: extract dashboard tile dispatch into TILE_RENDERERS registry

### DIFF
--- a/artifacts/feat-3441/arch-review.r1.md
+++ b/artifacts/feat-3441/arch-review.r1.md
@@ -1,0 +1,161 @@
+# Architecture Review: Dashboard Tile Registry (replace `TileContent.tsx` switch)
+
+## Skip Design: true
+
+Pure internal refactor of an existing rendering dispatch mechanism. No new UI, no visual change, no new component appears on screen that isn't already there today — every tile renders exactly as before, byte-for-byte. No design document, screen, or layout decision is implicated.
+
+## Architectural Fit Assessment
+
+This aligns cleanly with existing conventions and touches a well-isolated seam.
+
+- `frontend/src/components/dashboard/tiles/` already follows a flat, one-component-per-file layout (`CountTile.tsx`, `InventorySummaryTile.tsx`, `ProductionTile.tsx`, etc.), with `TileContent.tsx` acting as the sole dispatcher and `index.ts` as a partial public-export barrel (it does **not** currently export every tile component — only `BackgroundTasksTile`, `ProductionTile`, `DefaultTile`, plus `TileHeader`/`TileContent`/`LoadingTile`). A new `tileRegistry.tsx` file fits this directory's existing "flat sibling module" convention; it does not require a new subdirectory or layering concept.
+- Tests already live in `frontend/src/components/dashboard/tiles/__tests__/TileContent.test.tsx` and mock leaf tile components **by their own module path** (e.g. `jest.mock('../BackgroundTasksTile', ...)`), not by mocking `TileContent.tsx` itself or any switch internals. This is the key architectural fact that de-risks the refactor: Jest's module registry mocks are resolved per-module-path, independent of which file imports them. Moving the `import { BackgroundTasksTile } from './BackgroundTasksTile'` line from `TileContent.tsx` into `tileRegistry.tsx` does not change the resolved module path (`.../dashboard/tiles/BackgroundTasksTile`), so the existing mocks keep intercepting correctly. Verified by reading the test file directly — confirms the spec's NFR/dependency claim is correct, not just asserted.
+- No backend, API, or data-model involvement — `DashboardTile.tileId` (`frontend/src/api/hooks/useDashboard.ts`) is unchanged, and this is purely a frontend presentation-dispatch concern.
+- The `docs/architecture/development_guidelines.md` ADR log shows a precedent for "systemic recurring fix" reasoning (e.g. ADR-006 dark mode), but nothing there governs component dispatch patterns specifically — no conflicting convention exists that this refactor would violate.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+tile.tileId (string, backend-supplied)
+        │
+        ▼
+TileContent.tsx  ──uses──▶  tileRegistry.tsx
+   (guards: isUnauthorized,        │
+    !data → Loading)               │  exports TILE_RENDERERS: Record<string, TileRenderer>
+        │                          │  (module-scope object, one entry per tileId,
+        ▼                          │   each value a small FC closing over static
+  lookup TILE_RENDERERS[tileId]    │   props: icon, iconColor, targetUrl, etc.)
+        │                          ▼
+        └────────────────▶  BackgroundTasksTile, ProductionTile, CountTile,
+                             InventorySummaryTile, ConditionsTile, ...
+                             (existing leaf components — UNCHANGED)
+```
+
+`TileContent.tsx` becomes a thin guard + lookup + fallback; `tileRegistry.tsx` owns the mapping and all per-tile static configuration (icons, colors, target URLs, title fallbacks). Leaf tile components are untouched.
+
+### Key Design Decisions
+
+#### Decision 1: Registry file format — object map vs. discriminated-union dispatcher vs. component-per-tileId convention
+
+**Options considered:**
+1. Static `Record<string, TileRenderer>` object map (as specified).
+2. A discriminated union + exhaustive switch inside a generic `resolveTileComponent()` helper (moves the switch, doesn't remove it).
+3. Convention-over-configuration: derive the component from `tileId` via dynamic `require`/lazy import (e.g. `./tiles/${tileId}`).
+
+**Chosen approach:** Option 1 (static object map), exactly as the spec proposes.
+
+**Rationale:** Option 2 doesn't solve the actual problem — it relocates the switch rather than eliminating the "must touch this file" property. Option 3 introduces dynamic module resolution, which breaks static analysis/tree-shaking, defeats TypeScript's ability to catch a typo in `tileId` at the call site, and is a much bigger behavioral change (async loading, bundler config) than this ticket's scope ("pure refactor, no behavior change"). The object map is the smallest change that satisfies Open/Closed: new tiles are additive (`TILE_RENDERERS['newid'] = ...`), existing code paths are untouched, and the type system still enforces the `TileRenderer` shape on every entry.
+
+#### Decision 2: Where renderer functions are defined (module scope vs. inline in the map vs. per-tile factory)
+
+**Options considered:**
+1. Inline arrow functions directly as object values in `TILE_RENDERERS`, defined at module scope (spec's example).
+2. A factory helper `countTile(icon, color, url)` that returns a renderer, to cut down repetition across the 8 `CountTile`-backed entries.
+3. Named local functions in `tileRegistry.tsx` referenced in the map, rather than inline arrows.
+
+**Chosen approach:** Option 1 for tiles with unique props (e.g. `ConditionsTile`, `WeatherForecastTile`), Option 2 (a small local factory) for the repeated `CountTile` pattern to avoid restating `data-icon-color`/`tileCategory`/`tileTitle`/`targetUrl` boilerplate 8 times — but only if it doesn't obscure the 1:1 traceability to the original switch. This is an implementation-level call, not a hard requirement; keep it if it measurably shortens the file without hiding any tile's specific icon/color/URL from a reader scanning the map.
+
+**Rationale:** The NFR explicitly requires renderers be defined at module scope, not recreated per-render, to avoid React reconciliation churn from unstable component identities. A factory function called once at module load time to produce a stable component reference satisfies this equally well as an inline arrow — both are created exactly once, at import time, not per-render. Developers should default to inline arrows (matches the spec's example, simplest to review) and only introduce a factory if repetition genuinely hurts readability; do not over-engineer this into a generic tile-config DSL — that's explicitly out of scope per the spec.
+
+#### Decision 3: `.tsx` vs `.ts` for the registry file
+
+**Chosen approach:** `.tsx`, as the spec states. The directory's existing convention is one component per `.tsx` file; the registry contains JSX (`<CountTile icon={<Truck .../>} .../>`), so `.tsx` is required for the JSX icon elements regardless of style preference.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new directories. Add one sibling file:
+
+```
+frontend/src/components/dashboard/tiles/
+├── tileRegistry.tsx        # NEW — TILE_RENDERERS map + TileRenderer type
+├── TileContent.tsx         # MODIFIED — guards + lookup only, no switch
+├── CountTile.tsx           # unchanged
+├── InventorySummaryTile.tsx# unchanged
+├── ... (all other leaf tiles unchanged)
+├── index.ts                # unchanged (spec says leave as-is; confirmed: it
+│                            #   does not currently export CountTile,
+│                            #   InventorySummaryTile, etc. individually, so
+│                            #   there is nothing to update for consistency)
+└── __tests__/
+    └── TileContent.test.tsx  # unchanged — must pass with zero edits
+```
+
+Do not create a `tiles/registry/` subdirectory or split the map across multiple files — 23 entries in one file is consistent with the current single-file switch's size and keeps the "one place to look" property that motivated this refactor in the first place.
+
+### Interfaces and Contracts
+
+```tsx
+// tileRegistry.tsx
+import type { DashboardTile as DashboardTileType } from '../../../api/hooks/useDashboard';
+
+export type TileRenderer = React.FC<{ data: any; tile: DashboardTileType }>;
+
+export const TILE_RENDERERS: Record<string, TileRenderer> = {
+  backgroundtaskstatus: ({ data }) => <BackgroundTasksTile data={data} />,
+  todayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Dnes'} />,
+  nextdayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Zítra'} />,
+  manufactureconditions: ({ data }) => <ConditionsTile data={data} />,
+  manualactionrequired: ({ data, tile }) => (
+    <ManualActionRequiredTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+  ),
+  purchaseordersintransit: ({ data, tile }) => (
+    <PurchaseOrdersInTransitTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+  ),
+  intransitboxes: ({ data, tile }) => (
+    <CountTile data={data} icon={<Truck className="h-10 w-10" />} iconColor="text-blue-600"
+      tileCategory={tile.category} tileTitle={tile.title} targetUrl="/logistics/transport-boxes" />
+  ),
+  // ... remaining 17 entries, one per tileId, verbatim props from current switch
+  lowstockalert: ({ data }) => <LowStockAlertTile data={data} />,
+  dataqualitystatus: ({ data }) => <DataQualityTile data={data} />,
+  dqtyesterdaystatus: ({ data }) => <DqtYesterdayStatusTile data={data} />,
+  weatherforecast: ({ data }) => <WeatherForecastTile data={data} />,
+  failedjobs: ({ data }) => <FailedJobsTile data={data} />,
+  packingstats: ({ data }) => <PackingStatsTile data={data} />,
+};
+```
+
+```tsx
+// TileContent.tsx (post-refactor, full replacement of lines 34-94 in current file)
+import { TILE_RENDERERS } from './tileRegistry';
+import { DefaultTile } from './DefaultTile';
+import { LoadingTile } from './LoadingTile';
+import { UnauthorizedTile } from './UnauthorizedTile';
+
+export const TileContent: React.FC<TileContentProps> = ({ tile }) => {
+  if (tile.isUnauthorized) return <UnauthorizedTile />;
+  if (!tile.data) return <LoadingTile />;
+
+  const Renderer = TILE_RENDERERS[tile.tileId];
+  return Renderer ? <Renderer data={tile.data} tile={tile} /> : <DefaultTile data={tile.data} />;
+};
+```
+
+**Contract rule for future tile additions:** a new tile requires exactly one new key in `TILE_RENDERERS`, matching the backend `tileId` string exactly (case-sensitive, as today — no normalization is introduced). `TileContent.tsx` must never gain a new import of a leaf tile component; if a PR touches `TileContent.tsx` beyond the guard clauses, that is a signal the registry pattern is being bypassed.
+
+### Data Flow
+
+Unchanged end-to-end. `useDashboard` hook fetches tiles + data from the backend → `DashboardTile[]` passed down to per-tile `TileContent` instances → `TileContent` now performs an object-key lookup instead of a switch to pick the renderer → renderer passes `data`/`tile` fields through to the same leaf components with the same static props as before. No new render, no new fetch, no new state.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Transcription error moving 23 cases (wrong icon color, wrong `targetUrl`, dropped `tileCategory`/`tileTitle` prop) | Medium | `TileContent.test.tsx` already asserts icon colors, default titles, and props per tile and must pass unmodified — treat any test failure as a transcription bug, not a test to "fix." Do a side-by-side diff of old switch vs. new map before removing the switch. |
+| Renderer functions accidentally defined inside `TileContent`'s function body (recreated every render) instead of at module scope in `tileRegistry.tsx` | Low | Enforced by file boundary: `TILE_RENDERERS` only exists in `tileRegistry.tsx`, which has no access to `TileContent`'s render scope — structurally hard to get wrong once the registry lives in its own file. |
+| Jest `jest.mock('../BackgroundTasksTile', ...)` calls in the test file stop intercepting because import moved to a different file | Low | Verified: Jest mocks resolve by module path, not by importer. Confirmed by reading `TileContent.test.tsx` — mocks target `../ComponentName` relative to the test file, which resolves to the same absolute module path regardless of whether `TileContent.tsx` or `tileRegistry.tsx` holds the `import` statement. No action needed beyond keeping the same relative paths (`./BackgroundTasksTile` etc.) in the new file. |
+| Silent tileId typos still fall through to `DefaultTile` with no build-time signal (pre-existing gap, not introduced by this change) | Low (accepted, explicitly out of scope) | Spec correctly scopes a backend/frontend tileId-catalogue consistency check as a follow-up, not part of this ticket. Do not attempt it here. |
+
+## Specification Amendments
+
+None required — the spec is implementation-ready and its architectural claims (module-path-based Jest mock resolution, module-scope renderer requirement, `.tsx` file choice) were independently verified against the actual test file and directory contents during this review and hold up. One small clarification worth adding to the spec, non-blocking:
+
+- The spec should explicitly state that developers may factor the 8 repeated `CountTile` entries through a small local helper function (see Decision 2) if it improves readability, provided the helper is called at module scope (not per-render) and each call site remains individually traceable to one `tileId` — this is a style latitude, not a required change, so it doesn't need a spec revision, just a note for the implementer.
+
+## Prerequisites
+
+None. No migrations, no config, no infrastructure changes. The change is self-contained to `frontend/src/components/dashboard/tiles/` and can start immediately; the only "setup" step is reading the current `TileContent.tsx` switch (lines 34-94) side by side while authoring `tileRegistry.tsx` to guarantee a 1:1, zero-drift transcription of all 23 cases.

--- a/artifacts/feat-3441/brief.md
+++ b/artifacts/feat-3441/brief.md
@@ -1,0 +1,48 @@
+## Module
+Dashboard
+
+## Finding
+`frontend/src/components/dashboard/tiles/TileContent.tsx` (lines 34–94) dispatches to tile-specific React components via a `switch (tile.tileId)` with 20+ string-literal cases:
+
+```tsx
+switch (tile.tileId) {
+  case 'backgroundtaskstatus': return <BackgroundTaskStatusTile data={data} />;
+  case 'todayproduction':      return <TodayProductionTile data={data} />;
+  case 'nextdayproduction':    return <NextDayProductionTile data={data} />;
+  case 'manufactureconditions': return <ManufactureConditionsTile data={data} />;
+  // … 16 more cases …
+  default: return <DefaultTile />;
+}
+```
+
+Every time a new tile is registered on the backend, this file must be modified. With the tile count growing (20+ already), the switch is a recurring churn hotspot.
+
+## Why it matters
+Open/Closed principle: the component is closed for extension without modification. As the Dashboard tile catalogue expands, each new tile registration requires a code change here — creating a predictable merge-conflict location and the risk of forgetting the frontend registration.
+
+## Suggested fix
+Replace the switch with a static record-based registry:
+
+```tsx
+// tileRegistry.ts (co-located with TileContent)
+import type { DashboardTile } from '../../../api/hooks/useDashboard';
+
+type TileRenderer = React.FC<{ data: any; tile: DashboardTile }>;
+
+export const TILE_RENDERERS: Record<string, TileRenderer> = {
+  backgroundtaskstatus: ({ data }) => <BackgroundTaskStatusTile data={data} />,
+  todayproduction:      ({ data, tile }) => <TodayProductionTile data={data} tile={tile} />,
+  // …
+};
+```
+
+```tsx
+// TileContent.tsx
+const Renderer = TILE_RENDERERS[tile.tileId] ?? DefaultTile;
+return <Renderer data={data} tile={tile} />;
+```
+
+New tiles are registered by adding an entry to `TILE_RENDERERS` — `TileContent.tsx` itself never changes.
+
+---
+_Filed by daily arch-review routine on 2026-06-30._

--- a/artifacts/feat-3441/code-review.r1.md
+++ b/artifacts/feat-3441/code-review.r1.md
@@ -1,0 +1,17 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/src/components/dashboard/tiles/tileRegistry.tsx:34-136` — The 8 `CountTile`-backed entries (`intransitboxes`, `receivedboxes`, `errorboxes`, `invoiceimportstatistics`, `bankstatementimportstatistics`, `productinventorycount`, `materialinventorycount`, `lowstockefficiency`, `criticalgiftpackages` — actually 9) repeat the same `icon`/`iconColor`/`tileCategory`/`tileTitle`/`targetUrl` shape. A small module-scope factory (`const countTile = (icon, iconColor, targetUrl): TileRenderer => ({ data, tile }) => <CountTile .../>`) would cut ~70 lines while keeping each call site traceable to one `tileId`, as the arch-review (Decision 2) explicitly allowed. Not required — current form is more directly diffable against the original switch.
+- `frontend/src/components/dashboard/tiles/tileRegistry.tsx:18` — `TileRenderer` uses `data: any`, carried over verbatim from the original switch's implicit typing. Pre-existing looseness, not introduced by this refactor, but worth tightening in a future pass now that all tile data flows through one typed map.
+
+### Notes (verification performed)
+- Diffed the pre-refactor `TileContent.tsx` switch (24 `case` labels, read from merge-base `a3f508e`) against the new `TILE_RENDERERS` keys in `tileRegistry.tsx`: identical set, identical order, no drops or renames.
+- Manually compared every prop (icon component, `iconColor`, `targetUrl`, `tileCategory`/`tileTitle` passthrough, `todayproduction`/`nextdayproduction` title fallbacks `'Dnes'`/`'Zítra'`) between each original `case` and its corresponding registry entry — all match verbatim.
+- `TileContent.tsx` guard order preserved: `isUnauthorized` → `UnauthorizedTile`, then `!tile.data` → `LoadingTile`, then registry lookup with `DefaultTile` fallback passing `data={tile.data}` — matches spec FR-2 exactly.
+- No circular import: `tileRegistry.tsx` does not import from `TileContent.tsx`.
+- `frontend/src/components/dashboard/tiles/index.ts` exports only `TileHeader`, `TileContent`, `LoadingTile`, `BackgroundTasksTile`, `ProductionTile`, `DefaultTile` — none of the imports that moved out of `TileContent.tsx` were re-exported through the barrel, so no external consumer is broken.
+- Ran `TileContent.test.tsx` (unmodified): 24/24 passed, including icon-color assertions, default-title assertions, and unknown/empty-tileId fallback assertions.
+- Ran `eslint` against both touched files: clean, no errors/warnings.

--- a/artifacts/feat-3441/design.r1.md
+++ b/artifacts/feat-3441/design.r1.md
@@ -1,0 +1,64 @@
+# Design: Dashboard Tile Registry (replace `TileContent.tsx` switch statement)
+
+## Component Design
+
+### `tileRegistry.tsx` (new)
+**Path:** `frontend/src/components/dashboard/tiles/tileRegistry.tsx`
+
+**Responsibility:** Own the complete `tileId → renderer` mapping and all per-tile static configuration (icons, colors, target URLs, title fallbacks, `tileCategory`/`tileTitle` passthrough). This is the single place a developer edits to add, change, or remove a tile's dispatch behavior.
+
+**Exports:**
+- `TileRenderer` — type alias for a renderer component: `React.FC<{ data: any; tile: DashboardTileType }>`.
+- `TILE_RENDERERS: Record<string, TileRenderer>` — a module-scope constant object with exactly 23 keys, one per existing `tileId` (listed in spec FR-1). Each value is a component created once at module load time (either an inline arrow function or a call to a local factory helper for the repeated `CountTile` pattern), never recreated per render.
+
+**Interface contract:**
+- Every renderer receives `{ data, tile }` and returns the exact JSX the corresponding switch `case` produced today (same leaf component, same static props).
+- Leaf tile components it imports (`BackgroundTasksTile`, `ProductionTile`, `ConditionsTile`, `ManualActionRequiredTile`, `PurchaseOrdersInTransitTile`, `CountTile`, `InventorySummaryTile`, `LowStockAlertTile`, `DataQualityTile`, `DqtYesterdayStatusTile`, `WeatherForecastTile`, `FailedJobsTile`, `PackingStatsTile`) must be imported via the **same relative module paths** currently used in `TileContent.tsx` (e.g. `./BackgroundTasksTile`), since `TileContent.test.tsx` mocks these by module path and does not care which file holds the `import` statement.
+- No import of `TileContent.tsx` (one-directional dependency: `TileContent.tsx` → `tileRegistry.tsx`, never the reverse).
+- An optional local factory (e.g. `countTile(icon, color, url)` returning a `TileRenderer`) may be used to de-duplicate the repeated `CountTile`-backed entries, provided each call site remains individually traceable to one `tileId` and the factory itself is invoked at module scope (not inside any render function).
+
+### `TileContent.tsx` (modified)
+**Path:** `frontend/src/components/dashboard/tiles/TileContent.tsx`
+
+**Responsibility:** Reduced to three concerns only — the `isUnauthorized` guard, the `!tile.data` loading guard, and a lookup-based dispatch to the resolved renderer (or `DefaultTile` fallback). No per-tile branching, no per-tile component imports, no static prop configuration.
+
+**Interface contract:**
+- Imports only `TILE_RENDERERS` (from `./tileRegistry`), `DefaultTile`, `LoadingTile`, `UnauthorizedTile`.
+- Behavior, in order:
+  1. `tile.isUnauthorized` → render `<UnauthorizedTile />`.
+  2. `!tile.data` → render `<LoadingTile />`.
+  3. `TILE_RENDERERS[tile.tileId]` lookup: if found, render `<Renderer data={tile.data} tile={tile} />`; if not found (including `''` or any unmatched string), render `<DefaultTile data={tile.data} />`.
+- Contract rule for future changes: a PR that adds a new tile must touch only `tileRegistry.tsx` (plus, optionally, a new leaf component file). Any PR that adds a new leaf-component import or branching logic to `TileContent.tsx` itself indicates the registry pattern is being bypassed and should be rejected in review.
+
+### Leaf tile components (unchanged)
+All existing per-tile components (`CountTile`, `InventorySummaryTile`, `ConditionsTile`, etc.) are untouched — same props, same file location, same export. This refactor only relocates *how* they are selected, not their own implementation or contract.
+
+### `index.ts` (unchanged)
+No new exports required. `TILE_RENDERERS` is not consumed outside `tileRegistry.tsx`/`TileContent.tsx`, so it is not added to the barrel export.
+
+## Data Schemas
+
+No data model or API changes. This is a presentation-dispatch-only refactor.
+
+- **`DashboardTile`** (`frontend/src/api/hooks/useDashboard.ts:4-15`) — unchanged shape, fields relevant to dispatch:
+  ```ts
+  interface DashboardTile {
+    tileId: string;
+    title: string;
+    category: string;
+    data?: any;
+    isUnauthorized?: boolean;
+    // ...other existing fields, unchanged
+  }
+  ```
+- **New type `TileRenderer`** (introduced in `tileRegistry.tsx`, internal to the frontend — not an API contract):
+  ```ts
+  type TileRenderer = React.FC<{ data: any; tile: DashboardTile }>;
+  ```
+- **`TILE_RENDERERS` shape:**
+  ```ts
+  type TileRendererMap = Record<string, TileRenderer>;
+  ```
+  Keys: the 23 `tileId` strings enumerated in the spec (verbatim, case-sensitive, matching backend-supplied values exactly — no normalization).
+
+- No backend endpoint, request/response payload, or event schema is added, removed, or altered. `/api/dashboard/tiles` and `/api/dashboard/data` contracts are out of scope and unaffected.

--- a/artifacts/feat-3441/impl/extract-tile-registry-and-slim-dispatcher.r1.md
+++ b/artifacts/feat-3441/impl/extract-tile-registry-and-slim-dispatcher.r1.md
@@ -1,0 +1,72 @@
+# Implementation: extract-tile-registry-and-slim-dispatcher
+
+## What was implemented
+Extracted the `switch (tile.tileId)` dispatch logic from `TileContent.tsx` into a new
+`tileRegistry.tsx` module exporting a `TILE_RENDERERS: Record<string, TileRenderer>` lookup
+table. `TileContent.tsx` is now a slim dispatcher: it still handles the `isUnauthorized` and
+`!tile.data` (loading) short-circuits itself, then looks up `TILE_RENDERERS[tile.tileId]` and
+either renders the matched renderer or falls back to `DefaultTile`. No behavior change — every
+tile case, prop, icon, color, and target URL was transcribed verbatim from the original switch.
+
+## Files created/modified
+- `frontend/src/components/dashboard/tiles/tileRegistry.tsx` — new file; exports `TileRenderer`
+  type and `TILE_RENDERERS` map containing all 24 tile-id -> renderer entries (BackgroundTasksTile,
+  ProductionTile x2, ConditionsTile, ManualActionRequiredTile, PurchaseOrdersInTransitTile,
+  CountTile x8 variants with distinct icons/colors/targetUrls, InventorySummaryTile x3,
+  LowStockAlertTile, DataQualityTile, DqtYesterdayStatusTile, WeatherForecastTile, FailedJobsTile,
+  PackingStatsTile). Imports are unchanged relative paths (e.g. `./BackgroundTasksTile`) so the
+  test file's `jest.mock('../BackgroundTasksTile', ...)` calls still intercept correctly.
+- `frontend/src/components/dashboard/tiles/TileContent.tsx` — reduced to a slim dispatcher (24
+  lines) that imports `TILE_RENDERERS` from `./tileRegistry` and looks up the renderer by
+  `tile.tileId`, keeping only `LoadingTile`, `UnauthorizedTile`, and `DefaultTile` as direct
+  imports/fallbacks.
+
+## Tests
+- `frontend/src/components/dashboard/tiles/__tests__/TileContent.test.tsx` — existing test file,
+  **not modified**. Covers loading state, unauthorized state, all tile-id branches (background
+  tasks, today/next-day production with default and custom titles, all CountTile icon/color
+  variants, all InventorySummaryTile variants, DqtYesterdayStatusTile, default/unknown tile
+  fallback, empty data object, complex nested data).
+  - Baseline run (before refactor): PASS, 24/24 tests passing.
+  - Post-refactor run: PASS, 24/24 tests passing, identical results.
+  - (Note: task description said "20 tests" as the expected baseline; actual count in this repo
+    state is 24. Confirmed both pre- and post-refactor runs match at 24/24, so this is just a
+    stale count in the task doc, not a regression.)
+- Full frontend suite (`CI=true npx react-scripts test --watchAll=false`): 285 test suites passed,
+  2339 passed / 5 skipped / 0 failed, out of 2344 total. No regressions.
+
+## How to verify
+```
+cd frontend
+CI=true npx react-scripts test src/components/dashboard/tiles/__tests__/TileContent.test.tsx --watchAll=false
+npx eslint src/components/dashboard/tiles/TileContent.tsx src/components/dashboard/tiles/tileRegistry.tsx
+npm run build
+git diff HEAD~1 -- frontend/src/components/dashboard/tiles/
+```
+
+## Notes
+- `npx tsc --noEmit -p tsconfig.json` fails, but this is a **pre-existing environment issue**
+  unrelated to this change: the repo pins `typescript@^4.9.5` while `react-i18next@15.7.4`
+  (already in package.json/lockfile, no diff from this task) ships `.d.ts` files requiring
+  TS5 syntax, causing parse errors in `node_modules/react-i18next/*.d.ts`. Verified this is
+  pre-existing by confirming zero diff on `package.json`/`package-lock.json`. `npm run build`
+  (which uses CRA's babel-based type-stripping, not a strict standalone `tsc` check) compiles
+  successfully with "Compiled successfully" and no errors attributable to either touched file.
+- `npm run lint` reports 148 pre-existing errors (mostly `testing-library/no-node-access` and
+  `testing-library/no-wait-for-multiple-assertions` violations) across ~20 unrelated test files.
+  Confirmed via targeted grep that neither `TileContent.tsx` nor `tileRegistry.tsx` appears in
+  the lint output — zero errors/warnings attributable to the two touched files.
+- `node_modules` was not present/complete at task start (`npm ci` failed on a peer-dependency
+  conflict between `typescript@^4.9.5` and `react-i18next@15.7.4`'s `typescript@^5` peer
+  requirement); resolved by running `npm install --legacy-peer-deps` once to populate
+  `node_modules` for local test/build/lint execution. This did not change `package.json` or
+  `package-lock.json` (confirmed via `git diff --stat`), so it has no effect on the commit.
+- Diff is surgical: `git status --short frontend/src/components/dashboard/tiles/` showed exactly
+  ` M TileContent.tsx` and `?? tileRegistry.tsx`, matching the task's Step 9 expectation.
+  `index.ts` and `__tests__/TileContent.test.tsx` are untouched.
+- An unrelated pre-existing modification to `artifacts/feat-3441/state.json` was present in the
+  working tree before this task started; it was deliberately left unstaged/uncommitted since it
+  is outside the scope of files listed for this task.
+
+## Status
+DONE

--- a/artifacts/feat-3441/review/extract-tile-registry-and-slim-dispatcher.r1.md
+++ b/artifacts/feat-3441/review/extract-tile-registry-and-slim-dispatcher.r1.md
@@ -1,0 +1,39 @@
+# Code Review: Dashboard Tile Registry (extract-tile-registry-and-slim-dispatcher)
+
+## Summary
+The implementation extracts the `switch (tile.tileId)` dispatch from `TileContent.tsx` into a new `tileRegistry.tsx` module exporting `TILE_RENDERERS: Record<string, TileRenderer>`, and reduces `TileContent.tsx` to a thin guard + lookup + fallback, exactly as specified. Direct comparison of the pre- and post-refactor code confirms a byte-for-byte behavioral transcription of every case, and the executable acceptance contract (`TileContent.test.tsx`, unmodified) passes in full.
+
+## Review Result: PASS
+
+### task: extract-tile-registry-and-slim-dispatcher
+**Status:** PASS
+
+## Verification performed
+- Read `spec.r1.md`, `arch-review.r1.md`, the task context, and the implementation summary.
+- Diffed `HEAD~1` → `HEAD` (`git diff HEAD~1 HEAD --stat`): exactly two files changed — `TileContent.tsx` (78 lines removed) and new `tileRegistry.tsx` (145 lines added). No other files touched, matching FR/task Step 9 expectations (`index.ts` and `__tests__/TileContent.test.tsx` untouched).
+- Read the current `TileContent.tsx`: guard clauses (`isUnauthorized` → `UnauthorizedTile`, `!tile.data` → `LoadingTile`) preserved unchanged; switch replaced with `const Renderer = TILE_RENDERERS[tile.tileId]; return Renderer ? <Renderer .../> : <DefaultTile data={tile.data} />;` — matches spec's API/Interface Design section and arch-review's proposed code verbatim. No per-tile imports or lucide-react icons remain in this file.
+- Read the current `tileRegistry.tsx`: module-scope `TILE_RENDERERS` object, one entry per `tileId`, `TileRenderer` type defined as specified, imports use the same relative paths (`./BackgroundTasksTile`, `./CountTile`, etc.) as the original file, satisfying the Jest-mock-resolution dependency called out in both spec and arch-review.
+- Extracted `HEAD~1`'s original switch and compared its 24 `case` labels against the 24 keys in the new registry: **identical sets**, confirmed via diff. (Note: spec text said "23 cases" but the actual original switch has 24 case labels — the developer's implementation summary correctly flags and self-corrects this pre-existing count discrepancy rather than silently deviating; all 24 tileIds are present in the registry with zero drops.)
+- Manually compared each transcribed entry (icon, iconColor, targetUrl, tileCategory/tileTitle, default title fallbacks for `todayproduction`/`nextdayproduction`) against the original switch cases — all props match verbatim.
+- Ran `CI=true npx react-scripts test src/components/dashboard/tiles/__tests__/TileContent.test.tsx --watchAll=false`: **24/24 passed**, unmodified test file, including icon-color assertions, default-title assertions, and unknown/empty-tileId fallback assertions.
+- Ran `npx eslint src/components/dashboard/tiles/TileContent.tsx src/components/dashboard/tiles/tileRegistry.tsx`: clean, no errors/warnings.
+- Confirmed working tree is clean relative to the commit (`git status --short` on the tiles directory returns nothing) — the commit is exactly the surgical two-file change claimed.
+
+## Findings against FR/AC
+
+- **FR-1 (registry module):** Satisfied. `TILE_RENDERERS` contains all 24 real tileIds (spec undercounted by one, but the implementation transcribed the full, correct set from the actual source file rather than truncating to match the spec's stated count — correct behavior, not a compliance gap). No circular import: `tileRegistry.tsx` has zero reference to `TileContent.tsx`.
+- **FR-2 (lookup-based dispatch):** Satisfied. `TileContent.tsx` no longer contains a switch or per-tile case/import list; only imports `TILE_RENDERERS`, `DefaultTile`, `LoadingTile`, `UnauthorizedTile` (plus `React`/`DashboardTileType`). Guard behavior unchanged. Unknown/empty tileId falls back to `DefaultTile` with `data={tile.data}`. Test file passes unmodified.
+- **FR-3 (extensibility):** Satisfied structurally — new tiles require only a `TILE_RENDERERS` entry; `TileContent.tsx` line count dropped from 96 to 23 lines with zero per-tile branching remaining.
+- **NFR-1 (performance):** Satisfied. Renderers and the `TILE_RENDERERS` object are defined at module scope in `tileRegistry.tsx`, not recreated per render.
+- **NFR-2 (security):** No change, as expected; object-key lookup replacing switch introduces no new risk.
+- **NFR-3 (maintainability):** Satisfied — this is the intended outcome of the change.
+
+## Docs to Update
+None required. This is an internal refactor with no doc-referenced behavior change; no entries in `docs/architecture/*` describe the old switch pattern that would need updating.
+
+## Overall Notes
+- The implementation summary transparently discloses and resolves two minor discrepancies (spec's "23 cases" vs. actual 24; task doc's "20 tests" vs. actual 24) by pointing to verified evidence (diff/test counts) rather than silently papering over them — this is exactly the right way to handle a spec/reality mismatch and does not constitute a compliance failure.
+- `tsc --noEmit` and `npm run lint` full-repo issues reported in the implementation notes are pre-existing (TypeScript/react-i18next peer version mismatch, and unrelated `testing-library` lint violations in ~20 other test files) and independently confirmed as not attributable to the two touched files.
+- The developer used a plain arrow-function-per-entry style (per arch-review Decision 2's "default to inline arrows" guidance) rather than a `CountTile` factory helper — this is within the arch-review's explicitly stated implementation-level latitude, not a deviation.
+
+**Status:** PASS

--- a/artifacts/feat-3441/spec.r1.md
+++ b/artifacts/feat-3441/spec.r1.md
@@ -1,0 +1,92 @@
+# Specification: Dashboard Tile Registry (replace `TileContent.tsx` switch statement)
+
+## Summary
+`TileContent.tsx` currently dispatches to 20+ tile-specific React components via a `switch (tile.tileId)` statement. This refactor replaces the switch with a static, record-based tile registry so that registering a new dashboard tile no longer requires modifying `TileContent.tsx`. This is a pure internal refactor with no visible behavior change, no API change, and no new tile functionality.
+
+## Background
+The Dashboard module renders a configurable grid of tiles; each tile's `tileId` (a string returned by the backend, see `DashboardTile.tileId` in `frontend/src/api/hooks/useDashboard.ts`) determines which React component renders its `data`. Today that mapping lives in a 60-line `switch` inside `frontend/src/components/dashboard/tiles/TileContent.tsx` (lines 34–94), with one `case` per tile plus a `default` fallback to `DefaultTile`.
+
+As the tile catalogue has grown past 20 entries, this file has become a recurring edit point: every new backend-registered tile requires a matching frontend `case`, and forgetting it silently falls through to `DefaultTile` (no visible error, no compile-time check binding backend tile IDs to frontend cases). The switch statement violates the Open/Closed principle — the component must be modified, not extended, to support new tiles — and is a predictable merge-conflict hotspot for a solo-developer-plus-AI-review workflow where multiple tile features may be in flight concurrently.
+
+This spec formalizes the fix suggested by the arch-review finding: extract the mapping into a `TILE_RENDERERS` registry object co-located with `TileContent.tsx`, and have `TileContent` do a lookup instead of a switch.
+
+## Functional Requirements
+
+### FR-1: Tile registry module
+Create a new module (e.g. `frontend/src/components/dashboard/tiles/tileRegistry.tsx`) that exports a `TILE_RENDERERS` record mapping every existing `tileId` string (all 23 cases currently in the switch, listed below) to a renderer function/component that receives `{ data, tile }` and returns the exact same JSX currently produced by the corresponding `case`.
+
+Tile IDs to migrate (verbatim from current switch, `frontend/src/components/dashboard/tiles/TileContent.tsx:34-94`):
+`backgroundtaskstatus`, `todayproduction`, `nextdayproduction`, `manufactureconditions`, `manualactionrequired`, `purchaseordersintransit`, `intransitboxes`, `receivedboxes`, `errorboxes`, `invoiceimportstatistics`, `bankstatementimportstatistics`, `productinventorycount`, `materialinventorycount`, `productinventorysummary`, `materialwithexpirationinventorysummary`, `materialwithoutexpirationinventorysummary`, `lowstockefficiency`, `criticalgiftpackages`, `lowstockalert`, `dataqualitystatus`, `dqtyesterdaystatus`, `weatherforecast`, `failedjobs`, `packingstats`.
+
+Each renderer must preserve, byte-for-byte in behavior, the props currently passed in the switch — including:
+- Default title fallbacks (`todayproduction` → `'Dnes'`, `nextdayproduction` → `'Zítra'`) when `tile.title` is falsy.
+- Static icon/iconColor/targetUrl props baked into each `CountTile`-based case (e.g. `intransitboxes` → `Truck` icon, `text-blue-600`, `targetUrl="/logistics/transport-boxes"`).
+- `tileCategory`/`tileTitle` props passed from `tile.category` / `tile.title` where the current switch passes them (`manualactionrequired`, `purchaseordersintransit`, and all `CountTile` cases).
+- Shared component reuse where multiple tile IDs currently map to the same component with different static props (e.g. three `intransitboxes`/`receivedboxes`/`errorboxes` cases all use `CountTile` with different icon/color; three inventory-summary variants all use `InventorySummaryTile` with different `targetUrl`).
+
+**Acceptance criteria:**
+- `TILE_RENDERERS` contains exactly the 23 keys listed above, each mapping to a renderer that is behaviorally identical (same component, same static props) to today's corresponding `case`.
+- No `tileId` is dropped, renamed, or altered in matching behavior (matching remains an exact, case-sensitive string match on `tile.tileId`, as today).
+- The registry module has no dependency on `TileContent.tsx` (no circular import) — `TileContent.tsx` imports from the registry, not vice versa.
+
+### FR-2: `TileContent.tsx` lookup-based dispatch
+Replace the `switch` statement in `TileContent.tsx` with a lookup against `TILE_RENDERERS`, falling back to `DefaultTile` when `tile.tileId` has no matching entry (preserving today's `default` behavior, including passing `data={tile.data}` to `DefaultTile`).
+
+**Acceptance criteria:**
+- `TileContent.tsx` no longer contains a `switch` statement or per-tile `case`/import list for tile components; it imports only `TILE_RENDERERS`, `DefaultTile`, `LoadingTile`, and `UnauthorizedTile`.
+- The `isUnauthorized` → `UnauthorizedTile` and `!tile.data` → `LoadingTile` guard behavior at the top of `TileContent` (lines 26–32) is unchanged.
+- Unknown/empty `tileId` (including `''`) renders `DefaultTile` with `data={tile.data}`, matching current behavior.
+- `frontend/src/components/dashboard/tiles/__tests__/TileContent.test.tsx` passes unmodified (all 20 existing test cases, including icon-color assertions, default-title assertions, and the unknown/empty tileId fallback assertions) — this test file is the executable acceptance contract for behavioral parity and should not need edits to keep passing under this refactor.
+
+### FR-3: Extensibility for new tiles
+A new dashboard tile must be addable by adding one entry to `TILE_RENDERERS` (and, if it needs a new visual component, creating that component file) — with zero edits to `TileContent.tsx` itself.
+
+**Acceptance criteria:**
+- Adding a hypothetical new `tileId` entry to `TILE_RENDERERS` and re-running the app renders that tile correctly without touching `TileContent.tsx`.
+- Code review / grep confirms `TileContent.tsx`'s line count and cyclomatic complexity drop substantially (no per-tile branching logic remains in the file).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable regression. A single object property lookup (`TILE_RENDERERS[tile.tileId]`) is O(1) and strictly cheaper than the current linear `switch` (V8 typically compiles small string switches to a jump table or linear compare-chain of similar cost, so this is a wash-to-improvement, not a risk). No re-render behavior changes: renderer functions must not be recreated on every `TileContent` render in a way that breaks React reconciliation or memoization of child tiles (define `TILE_RENDERERS` and its renderer functions at module scope, not inside the `TileContent` function body).
+
+### NFR-2: Security
+No change. No new data enters the trust boundary; `tile.tileId` was already used as a dispatch key from backend-supplied data and continues to be used the same way (as an object-key lookup rather than a switch discriminant — both are safe against injection since neither uses `eval`/dynamic code execution; a malicious/unexpected `tileId` simply fails the lookup and falls back to `DefaultTile`, same as an unmatched `switch` case today falls to `default`).
+
+### NFR-3: Maintainability
+This is the primary driver for the change. Registering a new tile should require touching only the registry file (and optionally adding a new leaf component), never `TileContent.tsx`, eliminating the recurring merge-conflict hotspot identified in the arch-review finding.
+
+## Data Model
+No data model changes. This is a pure presentation-layer refactor.
+
+- `DashboardTile` (`frontend/src/api/hooks/useDashboard.ts:4-15`) — unchanged. Fields relevant to dispatch: `tileId: string`, `title: string`, `category: string`, `data?: any`, `isUnauthorized?: boolean`.
+- New type: `TileRenderer` — a function/component type of shape `(props: { data: any; tile: DashboardTileType }) => JSX.Element`, used as the value type in the `TILE_RENDERERS: Record<string, TileRenderer>` map.
+
+## API / Interface Design
+No backend/API changes. This is entirely internal to the React frontend.
+
+- New file: `frontend/src/components/dashboard/tiles/tileRegistry.tsx` (or `.ts` if JSX can be avoided via `React.createElement` — `.tsx` is simpler and consistent with existing `.tsx` component files in this directory) exporting `TILE_RENDERERS: Record<string, TileRenderer>`.
+- Modified file: `frontend/src/components/dashboard/tiles/TileContent.tsx` — replace switch body with:
+  ```tsx
+  const Renderer = TILE_RENDERERS[tile.tileId];
+  return Renderer ? <Renderer data={tile.data} tile={tile} /> : <DefaultTile data={tile.data} />;
+  ```
+- `frontend/src/components/dashboard/tiles/index.ts` — no change required (it does not currently export per-tile components other than `BackgroundTasksTile`, `ProductionTile`, `DefaultTile`; leave as-is unless the team wants to also export `TILE_RENDERERS` for reuse, which is out of scope here since nothing currently consumes it externally).
+
+## Dependencies
+- No new external libraries.
+- Depends on existing tile leaf components remaining unchanged in their own prop contracts (`BackgroundTasksTile`, `ProductionTile`, `ConditionsTile`, `ManualActionRequiredTile`, `PurchaseOrdersInTransitTile`, `CountTile`, `InventorySummaryTile`, `LowStockAlertTile`, `DataQualityTile`, `DqtYesterdayStatusTile`, `WeatherForecastTile`, `FailedJobsTile`, `PackingStatsTile`, `DefaultTile`, `LoadingTile`, `UnauthorizedTile` — all under `frontend/src/components/dashboard/tiles/`).
+- Depends on `lucide-react` icons (`Truck`, `PackageCheck`, `Package`, `FileText`, `Landmark`, `ClipboardList`, `Beaker`, `AlertTriangle`, `Gift`) currently imported in `TileContent.tsx`; these move to the new registry file.
+- The existing test suite `frontend/src/components/dashboard/tiles/__tests__/TileContent.test.tsx` (which mocks individual tile components by module path, e.g. `jest.mock('../BackgroundTasksTile', ...)`) must continue to pass without modification, since it mocks leaf components directly rather than the registry — confirm the registry's imports of these components use the same module paths (`./BackgroundTasksTile`, `./ProductionTile`, etc.) so Jest's `jest.mock` calls (which target `../BackgroundTasksTile` relative to the test file, i.e. `./BackgroundTasksTile` relative to `TileContent.tsx`) still intercept them correctly regardless of whether the import statement lives in `TileContent.tsx` or `tileRegistry.tsx`.
+
+## Out of Scope
+- Any change to which tiles exist, their visual design, their data contracts, or their backend registration (`/api/dashboard/tiles`, `/api/dashboard/data`).
+- Making the registry dynamically extensible at runtime (e.g. plugin registration, backend-driven component resolution). The registry remains a static, compile-time TypeScript object — new tiles still require a code change (adding a registry entry + component file), just not a change to `TileContent.tsx`.
+- Adding automated enforcement that every backend-registered `tileId` has a corresponding frontend renderer (e.g. a build-time or test-time check comparing backend tile catalogue to `TILE_RENDERERS` keys). Worth considering as a follow-up but not required to close this arch-review finding.
+- Refactoring the individual leaf tile components themselves (e.g. consolidating the three near-identical `InventorySummaryTile` cases or the five `CountTile` cases into more data-driven configuration). The finding is specifically about the switch statement in `TileContent.tsx`, not the leaf components' own design.
+- Updating `frontend/src/components/dashboard/tiles/index.ts` exports beyond what's needed for `TileContent.tsx` to compile.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "extract-tile-registry-and-slim-dispatcher",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-01T06:22:30.835111Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-01T06:23:15.247546Z"
+      "status": "completed",
+      "updated_at": "2026-07-01T06:39:15.271843Z"
     }
   },
   "tasks": [
     {
       "name": "extract-tile-registry-and-slim-dispatcher",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-01T06:23:15.520732Z"
+      "updated_at": "2026-07-01T06:39:09.440102Z"
     }
   ]
 }

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-01T06:20:13.596463Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-01T06:22:30.835111Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-01T06:17:33.783910Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-01T06:22:30.835111Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-01T06:23:15.247546Z"
     }
   },
   "tasks": [
     {
       "name": "extract-tile-registry-and-slim-dispatcher",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-01T06:23:15.520732Z"
     }
   ]
 }

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3441",
+  "issue_number": 3441,
+  "created_at": "2026-07-01T06:15:45.418225Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-01T06:19:22.468850Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-01T06:20:13.596463Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-01T06:17:33.783910Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-01T06:19:22.468850Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3441/state.json
+++ b/artifacts/feat-3441/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-01T06:39:15.271843Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-01T06:39:21.628919Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3441/task-context/extract-tile-registry-and-slim-dispatcher.md
+++ b/artifacts/feat-3441/task-context/extract-tile-registry-and-slim-dispatcher.md
@@ -1,0 +1,250 @@
+### task: extract-tile-registry-and-slim-dispatcher
+
+**Files:**
+- Create: `frontend/src/components/dashboard/tiles/tileRegistry.tsx`
+- Modify: `frontend/src/components/dashboard/tiles/TileContent.tsx` (full file, currently 96 lines)
+- Test: `frontend/src/components/dashboard/tiles/__tests__/TileContent.test.tsx` (existing, must pass **unmodified** — this is the acceptance contract; do not edit it)
+
+This is a single self-contained refactor of one file into two (registry + slim dispatcher), verified entirely by the existing test suite. Per the spec/arch-review, it is not split into multiple tasks.
+
+- [ ] Step 1: Confirm the baseline test suite passes before touching anything. Run:
+  ```
+  cd frontend && CI=true npx react-scripts test src/components/dashboard/tiles/__tests__/TileContent.test.tsx --watchAll=false
+  ```
+  Expect: PASS, 20 tests passing (this is the pre-refactor baseline — if it fails now, stop and investigate before proceeding, since the refactor must not be blamed for a pre-existing failure).
+
+- [ ] Step 2: Create `frontend/src/components/dashboard/tiles/tileRegistry.tsx` with the full registry, transcribing all 23 cases verbatim from the current switch in `TileContent.tsx` (lines 34-94 as read from the current file). Use this exact content:
+
+  ```tsx
+  import React from 'react';
+  import { DashboardTile as DashboardTileType } from '../../../api/hooks/useDashboard';
+  import { BackgroundTasksTile } from './BackgroundTasksTile';
+  import { ProductionTile } from './ProductionTile';
+  import { ConditionsTile } from './ConditionsTile';
+  import { ManualActionRequiredTile } from './ManualActionRequiredTile';
+  import { PurchaseOrdersInTransitTile } from './PurchaseOrdersInTransitTile';
+  import { CountTile } from './CountTile';
+  import { InventorySummaryTile } from './InventorySummaryTile';
+  import { LowStockAlertTile } from './LowStockAlertTile';
+  import { DataQualityTile } from './DataQualityTile';
+  import { DqtYesterdayStatusTile } from './DqtYesterdayStatusTile';
+  import { WeatherForecastTile } from './WeatherForecastTile';
+  import { FailedJobsTile } from './FailedJobsTile';
+  import { PackingStatsTile } from './PackingStatsTile';
+  import { Truck, PackageCheck, Package, FileText, Landmark, ClipboardList, Beaker, AlertTriangle, Gift } from 'lucide-react';
+
+  export type TileRenderer = React.FC<{ data: any; tile: DashboardTileType }>;
+
+  export const TILE_RENDERERS: Record<string, TileRenderer> = {
+    backgroundtaskstatus: ({ data }) => <BackgroundTasksTile data={data} />,
+    todayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Dnes'} />,
+    nextdayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Zítra'} />,
+    // Manufacture tiles
+    manufactureconditions: ({ data }) => <ConditionsTile data={data} />,
+    manualactionrequired: ({ data, tile }) => (
+      <ManualActionRequiredTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+    ),
+    // Purchase tiles
+    purchaseordersintransit: ({ data, tile }) => (
+      <PurchaseOrdersInTransitTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+    ),
+    // Transport tiles
+    intransitboxes: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Truck className="h-10 w-10" />}
+        iconColor="text-blue-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/transport-boxes"
+      />
+    ),
+    receivedboxes: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<PackageCheck className="h-10 w-10" />}
+        iconColor="text-green-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/transport-boxes"
+      />
+    ),
+    errorboxes: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Package className="h-10 w-10" />}
+        iconColor="text-indigo-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/transport-boxes"
+      />
+    ),
+    // Statistics tiles
+    invoiceimportstatistics: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<FileText className="h-10 w-10" />}
+        iconColor="text-amber-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/automation/invoice-import-statistics"
+      />
+    ),
+    bankstatementimportstatistics: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Landmark className="h-10 w-10" />}
+        iconColor="text-emerald-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/finance/bank-statements"
+      />
+    ),
+    // Inventory tiles
+    productinventorycount: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<ClipboardList className="h-10 w-10" />}
+        iconColor="text-purple-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/inventory"
+      />
+    ),
+    materialinventorycount: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Beaker className="h-10 w-10" />}
+        iconColor="text-teal-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/manufacturing/inventory"
+      />
+    ),
+    productinventorysummary: ({ data }) => (
+      <InventorySummaryTile data={data} targetUrl="/logistics/inventory" />
+    ),
+    materialwithexpirationinventorysummary: ({ data }) => (
+      <InventorySummaryTile data={data} targetUrl="/manufacturing/inventory" />
+    ),
+    materialwithoutexpirationinventorysummary: ({ data }) => (
+      <InventorySummaryTile data={data} targetUrl="/manufacturing/inventory" />
+    ),
+    // Purchase efficiency tiles
+    lowstockefficiency: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<AlertTriangle className="h-10 w-10" />}
+        iconColor="text-orange-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/purchase/stock-analysis"
+      />
+    ),
+    // Gift package tiles
+    criticalgiftpackages: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Gift className="h-10 w-10" />}
+        iconColor="text-red-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/gift-package-manufacturing"
+      />
+    ),
+    // Low stock alert tile
+    lowstockalert: ({ data }) => <LowStockAlertTile data={data} />,
+    // Data quality tile
+    dataqualitystatus: ({ data }) => <DataQualityTile data={data} />,
+    dqtyesterdaystatus: ({ data }) => <DqtYesterdayStatusTile data={data} />,
+    weatherforecast: ({ data }) => <WeatherForecastTile data={data} />,
+    failedjobs: ({ data }) => <FailedJobsTile data={data} />,
+    packingstats: ({ data }) => <PackingStatsTile data={data} />,
+  };
+  ```
+
+  Notes while writing this file:
+  - Keep the same relative import paths as the current `TileContent.tsx` (e.g. `./BackgroundTasksTile`, `./CountTile`) — the test file's `jest.mock('../BackgroundTasksTile', ...)` calls resolve by absolute module path, not by importer, so these must stay identical for mocks to keep intercepting.
+  - The `DashboardTileType` import path from `tileRegistry.tsx` is `../../../api/hooks/useDashboard` (this file lives at `frontend/src/components/dashboard/tiles/tileRegistry.tsx`, three levels up from `frontend/src/api/hooks/useDashboard.ts` — same relative path as the current import in `TileContent.tsx`).
+  - Do not import `DefaultTile`, `LoadingTile`, or `UnauthorizedTile` here — those stay in `TileContent.tsx` only.
+  - Do not import `TileContent.tsx` from this file (one-directional dependency, per spec FR-1 acceptance criteria).
+
+- [ ] Step 3: Replace the entire contents of `frontend/src/components/dashboard/tiles/TileContent.tsx` with:
+  ```tsx
+  import React from 'react';
+  import { DashboardTile as DashboardTileType } from '../../../api/hooks/useDashboard';
+  import { LoadingTile } from './LoadingTile';
+  import { UnauthorizedTile } from './UnauthorizedTile';
+  import { DefaultTile } from './DefaultTile';
+  import { TILE_RENDERERS } from './tileRegistry';
+
+  interface TileContentProps {
+    tile: DashboardTileType;
+  }
+
+  export const TileContent: React.FC<TileContentProps> = ({ tile }) => {
+    if (tile.isUnauthorized) {
+      return <UnauthorizedTile />;
+    }
+
+    if (!tile.data) {
+      return <LoadingTile />;
+    }
+
+    const Renderer = TILE_RENDERERS[tile.tileId];
+    return Renderer ? <Renderer data={tile.data} tile={tile} /> : <DefaultTile data={tile.data} />;
+  };
+  ```
+  This removes all per-tile imports (`BackgroundTasksTile`, `ProductionTile`, `CountTile`, etc. and the `lucide-react` icon imports) from `TileContent.tsx` — they now live only in `tileRegistry.tsx`.
+
+- [ ] Step 4: Run the existing test suite (must pass unmodified — this is the executable acceptance contract per spec FR-2):
+  ```
+  cd frontend && CI=true npx react-scripts test src/components/dashboard/tiles/__tests__/TileContent.test.tsx --watchAll=false
+  ```
+  Expect: PASS, all 20 tests passing, identical to the Step 1 baseline. If any test fails, treat it as a transcription bug in `tileRegistry.tsx` (wrong icon color, wrong `targetUrl`, dropped `tileCategory`/`tileTitle` prop, or a missing/misspelled `tileId` key) — do not modify the test file to make it pass.
+
+- [ ] Step 5: Type-check and lint the two touched files:
+  ```
+  cd frontend && npx tsc --noEmit -p tsconfig.json && npx eslint src/components/dashboard/tiles/TileContent.tsx src/components/dashboard/tiles/tileRegistry.tsx
+  ```
+  Expect: no TypeScript errors, no new ESLint errors introduced by these two files.
+
+- [ ] Step 6: Run the full frontend build to confirm nothing else references the removed per-tile imports/exports from `TileContent.tsx` (e.g. no other module imports `Truck`/`CountTile` re-exported through `TileContent.tsx`, which it never exported anyway):
+  ```
+  cd frontend && npm run build
+  ```
+  Expect: build succeeds with no compile errors.
+
+- [ ] Step 7: Run the full frontend test suite once more to confirm no other test file was affected by this change (e.g. any test importing `TileContent` indirectly through `frontend/src/components/dashboard/tiles/index.ts` or the dashboard page):
+  ```
+  cd frontend && CI=true npx react-scripts test --watchAll=false
+  ```
+  Expect: PASS, no new failures relative to the pre-existing suite (any pre-existing unrelated failures are out of scope — only confirm nothing dashboard/tile-related regressed).
+
+- [ ] Step 8: Run the project-standard frontend lint gate (per CLAUDE.md validation requirements):
+  ```
+  cd frontend && npm run lint
+  ```
+  Expect: no new lint errors attributable to `TileContent.tsx` or `tileRegistry.tsx`.
+
+- [ ] Step 9: Verify the diff is surgical — only the two files above changed, nothing else:
+  ```
+  git status --short frontend/src/components/dashboard/tiles/
+  ```
+  Expect output:
+  ```
+   M frontend/src/components/dashboard/tiles/TileContent.tsx
+  ?? frontend/src/components/dashboard/tiles/tileRegistry.tsx
+  ```
+  `frontend/src/components/dashboard/tiles/index.ts` and `__tests__/TileContent.test.tsx` must show no changes (per spec Out of Scope and FR-2 acceptance criteria).
+
+- [ ] Step 10: Commit the refactor:
+  ```
+  git add frontend/src/components/dashboard/tiles/TileContent.tsx frontend/src/components/dashboard/tiles/tileRegistry.tsx
+  git commit -m "refactor(dashboard): extract tile dispatch into TILE_RENDERERS registry
+
+Replaces the switch(tile.tileId) in TileContent.tsx with a lookup
+against a new tileRegistry.tsx module, so adding a new dashboard tile
+no longer requires editing TileContent.tsx. No behavior change;
+TileContent.test.tsx passes unmodified."
+  ```

--- a/artifacts/feat-3441/task-plan.r1.md
+++ b/artifacts/feat-3441/task-plan.r1.md
@@ -1,0 +1,258 @@
+# Implementation Plan: Dashboard Tile Registry (replace `TileContent.tsx` switch statement)
+
+**Goal:** Replace the 60-line `switch (tile.tileId)` in `TileContent.tsx` with a lookup against a new static `TILE_RENDERERS` registry, with zero behavior change and zero edits required to `TileContent.tsx` when a new tile is added in future.
+**Architecture:** Extract all 23 `case` branches into a new sibling module `frontend/src/components/dashboard/tiles/tileRegistry.tsx` exporting `TILE_RENDERERS: Record<string, TileRenderer>` (module-scope, one renderer per `tileId`, same leaf components/props/icons as today). `TileContent.tsx` keeps its two guard clauses (`isUnauthorized`, `!tile.data`) and replaces the switch with `TILE_RENDERERS[tile.tileId]` lookup, falling back to `DefaultTile`.
+**Tech Stack:** React 18 (function components, TSX), TypeScript, Jest + React Testing Library (`react-scripts test`), `lucide-react` icons.
+
+---
+
+### task: extract-tile-registry-and-slim-dispatcher
+
+**Files:**
+- Create: `frontend/src/components/dashboard/tiles/tileRegistry.tsx`
+- Modify: `frontend/src/components/dashboard/tiles/TileContent.tsx` (full file, currently 96 lines)
+- Test: `frontend/src/components/dashboard/tiles/__tests__/TileContent.test.tsx` (existing, must pass **unmodified** — this is the acceptance contract; do not edit it)
+
+This is a single self-contained refactor of one file into two (registry + slim dispatcher), verified entirely by the existing test suite. Per the spec/arch-review, it is not split into multiple tasks.
+
+- [ ] Step 1: Confirm the baseline test suite passes before touching anything. Run:
+  ```
+  cd frontend && CI=true npx react-scripts test src/components/dashboard/tiles/__tests__/TileContent.test.tsx --watchAll=false
+  ```
+  Expect: PASS, 20 tests passing (this is the pre-refactor baseline — if it fails now, stop and investigate before proceeding, since the refactor must not be blamed for a pre-existing failure).
+
+- [ ] Step 2: Create `frontend/src/components/dashboard/tiles/tileRegistry.tsx` with the full registry, transcribing all 23 cases verbatim from the current switch in `TileContent.tsx` (lines 34-94 as read from the current file). Use this exact content:
+
+  ```tsx
+  import React from 'react';
+  import { DashboardTile as DashboardTileType } from '../../../api/hooks/useDashboard';
+  import { BackgroundTasksTile } from './BackgroundTasksTile';
+  import { ProductionTile } from './ProductionTile';
+  import { ConditionsTile } from './ConditionsTile';
+  import { ManualActionRequiredTile } from './ManualActionRequiredTile';
+  import { PurchaseOrdersInTransitTile } from './PurchaseOrdersInTransitTile';
+  import { CountTile } from './CountTile';
+  import { InventorySummaryTile } from './InventorySummaryTile';
+  import { LowStockAlertTile } from './LowStockAlertTile';
+  import { DataQualityTile } from './DataQualityTile';
+  import { DqtYesterdayStatusTile } from './DqtYesterdayStatusTile';
+  import { WeatherForecastTile } from './WeatherForecastTile';
+  import { FailedJobsTile } from './FailedJobsTile';
+  import { PackingStatsTile } from './PackingStatsTile';
+  import { Truck, PackageCheck, Package, FileText, Landmark, ClipboardList, Beaker, AlertTriangle, Gift } from 'lucide-react';
+
+  export type TileRenderer = React.FC<{ data: any; tile: DashboardTileType }>;
+
+  export const TILE_RENDERERS: Record<string, TileRenderer> = {
+    backgroundtaskstatus: ({ data }) => <BackgroundTasksTile data={data} />,
+    todayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Dnes'} />,
+    nextdayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Zítra'} />,
+    // Manufacture tiles
+    manufactureconditions: ({ data }) => <ConditionsTile data={data} />,
+    manualactionrequired: ({ data, tile }) => (
+      <ManualActionRequiredTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+    ),
+    // Purchase tiles
+    purchaseordersintransit: ({ data, tile }) => (
+      <PurchaseOrdersInTransitTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+    ),
+    // Transport tiles
+    intransitboxes: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Truck className="h-10 w-10" />}
+        iconColor="text-blue-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/transport-boxes"
+      />
+    ),
+    receivedboxes: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<PackageCheck className="h-10 w-10" />}
+        iconColor="text-green-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/transport-boxes"
+      />
+    ),
+    errorboxes: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Package className="h-10 w-10" />}
+        iconColor="text-indigo-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/transport-boxes"
+      />
+    ),
+    // Statistics tiles
+    invoiceimportstatistics: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<FileText className="h-10 w-10" />}
+        iconColor="text-amber-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/automation/invoice-import-statistics"
+      />
+    ),
+    bankstatementimportstatistics: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Landmark className="h-10 w-10" />}
+        iconColor="text-emerald-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/finance/bank-statements"
+      />
+    ),
+    // Inventory tiles
+    productinventorycount: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<ClipboardList className="h-10 w-10" />}
+        iconColor="text-purple-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/inventory"
+      />
+    ),
+    materialinventorycount: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Beaker className="h-10 w-10" />}
+        iconColor="text-teal-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/manufacturing/inventory"
+      />
+    ),
+    productinventorysummary: ({ data }) => (
+      <InventorySummaryTile data={data} targetUrl="/logistics/inventory" />
+    ),
+    materialwithexpirationinventorysummary: ({ data }) => (
+      <InventorySummaryTile data={data} targetUrl="/manufacturing/inventory" />
+    ),
+    materialwithoutexpirationinventorysummary: ({ data }) => (
+      <InventorySummaryTile data={data} targetUrl="/manufacturing/inventory" />
+    ),
+    // Purchase efficiency tiles
+    lowstockefficiency: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<AlertTriangle className="h-10 w-10" />}
+        iconColor="text-orange-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/purchase/stock-analysis"
+      />
+    ),
+    // Gift package tiles
+    criticalgiftpackages: ({ data, tile }) => (
+      <CountTile
+        data={data}
+        icon={<Gift className="h-10 w-10" />}
+        iconColor="text-red-600"
+        tileCategory={tile.category}
+        tileTitle={tile.title}
+        targetUrl="/logistics/gift-package-manufacturing"
+      />
+    ),
+    // Low stock alert tile
+    lowstockalert: ({ data }) => <LowStockAlertTile data={data} />,
+    // Data quality tile
+    dataqualitystatus: ({ data }) => <DataQualityTile data={data} />,
+    dqtyesterdaystatus: ({ data }) => <DqtYesterdayStatusTile data={data} />,
+    weatherforecast: ({ data }) => <WeatherForecastTile data={data} />,
+    failedjobs: ({ data }) => <FailedJobsTile data={data} />,
+    packingstats: ({ data }) => <PackingStatsTile data={data} />,
+  };
+  ```
+
+  Notes while writing this file:
+  - Keep the same relative import paths as the current `TileContent.tsx` (e.g. `./BackgroundTasksTile`, `./CountTile`) — the test file's `jest.mock('../BackgroundTasksTile', ...)` calls resolve by absolute module path, not by importer, so these must stay identical for mocks to keep intercepting.
+  - The `DashboardTileType` import path from `tileRegistry.tsx` is `../../../api/hooks/useDashboard` (this file lives at `frontend/src/components/dashboard/tiles/tileRegistry.tsx`, three levels up from `frontend/src/api/hooks/useDashboard.ts` — same relative path as the current import in `TileContent.tsx`).
+  - Do not import `DefaultTile`, `LoadingTile`, or `UnauthorizedTile` here — those stay in `TileContent.tsx` only.
+  - Do not import `TileContent.tsx` from this file (one-directional dependency, per spec FR-1 acceptance criteria).
+
+- [ ] Step 3: Replace the entire contents of `frontend/src/components/dashboard/tiles/TileContent.tsx` with:
+  ```tsx
+  import React from 'react';
+  import { DashboardTile as DashboardTileType } from '../../../api/hooks/useDashboard';
+  import { LoadingTile } from './LoadingTile';
+  import { UnauthorizedTile } from './UnauthorizedTile';
+  import { DefaultTile } from './DefaultTile';
+  import { TILE_RENDERERS } from './tileRegistry';
+
+  interface TileContentProps {
+    tile: DashboardTileType;
+  }
+
+  export const TileContent: React.FC<TileContentProps> = ({ tile }) => {
+    if (tile.isUnauthorized) {
+      return <UnauthorizedTile />;
+    }
+
+    if (!tile.data) {
+      return <LoadingTile />;
+    }
+
+    const Renderer = TILE_RENDERERS[tile.tileId];
+    return Renderer ? <Renderer data={tile.data} tile={tile} /> : <DefaultTile data={tile.data} />;
+  };
+  ```
+  This removes all per-tile imports (`BackgroundTasksTile`, `ProductionTile`, `CountTile`, etc. and the `lucide-react` icon imports) from `TileContent.tsx` — they now live only in `tileRegistry.tsx`.
+
+- [ ] Step 4: Run the existing test suite (must pass unmodified — this is the executable acceptance contract per spec FR-2):
+  ```
+  cd frontend && CI=true npx react-scripts test src/components/dashboard/tiles/__tests__/TileContent.test.tsx --watchAll=false
+  ```
+  Expect: PASS, all 20 tests passing, identical to the Step 1 baseline. If any test fails, treat it as a transcription bug in `tileRegistry.tsx` (wrong icon color, wrong `targetUrl`, dropped `tileCategory`/`tileTitle` prop, or a missing/misspelled `tileId` key) — do not modify the test file to make it pass.
+
+- [ ] Step 5: Type-check and lint the two touched files:
+  ```
+  cd frontend && npx tsc --noEmit -p tsconfig.json && npx eslint src/components/dashboard/tiles/TileContent.tsx src/components/dashboard/tiles/tileRegistry.tsx
+  ```
+  Expect: no TypeScript errors, no new ESLint errors introduced by these two files.
+
+- [ ] Step 6: Run the full frontend build to confirm nothing else references the removed per-tile imports/exports from `TileContent.tsx` (e.g. no other module imports `Truck`/`CountTile` re-exported through `TileContent.tsx`, which it never exported anyway):
+  ```
+  cd frontend && npm run build
+  ```
+  Expect: build succeeds with no compile errors.
+
+- [ ] Step 7: Run the full frontend test suite once more to confirm no other test file was affected by this change (e.g. any test importing `TileContent` indirectly through `frontend/src/components/dashboard/tiles/index.ts` or the dashboard page):
+  ```
+  cd frontend && CI=true npx react-scripts test --watchAll=false
+  ```
+  Expect: PASS, no new failures relative to the pre-existing suite (any pre-existing unrelated failures are out of scope — only confirm nothing dashboard/tile-related regressed).
+
+- [ ] Step 8: Run the project-standard frontend lint gate (per CLAUDE.md validation requirements):
+  ```
+  cd frontend && npm run lint
+  ```
+  Expect: no new lint errors attributable to `TileContent.tsx` or `tileRegistry.tsx`.
+
+- [ ] Step 9: Verify the diff is surgical — only the two files above changed, nothing else:
+  ```
+  git status --short frontend/src/components/dashboard/tiles/
+  ```
+  Expect output:
+  ```
+   M frontend/src/components/dashboard/tiles/TileContent.tsx
+  ?? frontend/src/components/dashboard/tiles/tileRegistry.tsx
+  ```
+  `frontend/src/components/dashboard/tiles/index.ts` and `__tests__/TileContent.test.tsx` must show no changes (per spec Out of Scope and FR-2 acceptance criteria).
+
+- [ ] Step 10: Commit the refactor:
+  ```
+  git add frontend/src/components/dashboard/tiles/TileContent.tsx frontend/src/components/dashboard/tiles/tileRegistry.tsx
+  git commit -m "refactor(dashboard): extract tile dispatch into TILE_RENDERERS registry
+
+Replaces the switch(tile.tileId) in TileContent.tsx with a lookup
+against a new tileRegistry.tsx module, so adding a new dashboard tile
+no longer requires editing TileContent.tsx. No behavior change;
+TileContent.test.tsx passes unmodified."
+  ```

--- a/frontend/src/components/dashboard/tiles/TileContent.tsx
+++ b/frontend/src/components/dashboard/tiles/TileContent.tsx
@@ -2,21 +2,8 @@ import React from 'react';
 import { DashboardTile as DashboardTileType } from '../../../api/hooks/useDashboard';
 import { LoadingTile } from './LoadingTile';
 import { UnauthorizedTile } from './UnauthorizedTile';
-import { BackgroundTasksTile } from './BackgroundTasksTile';
-import { ProductionTile } from './ProductionTile';
-import { CountTile } from './CountTile';
-import { InventorySummaryTile } from './InventorySummaryTile';
-import { ManualActionRequiredTile } from './ManualActionRequiredTile';
-import { ConditionsTile } from './ConditionsTile';
-import { PurchaseOrdersInTransitTile } from './PurchaseOrdersInTransitTile';
-import { LowStockAlertTile } from './LowStockAlertTile';
-import { DataQualityTile } from './DataQualityTile';
-import { DqtYesterdayStatusTile } from './DqtYesterdayStatusTile';
-import { WeatherForecastTile } from './WeatherForecastTile';
-import { FailedJobsTile } from './FailedJobsTile';
-import { PackingStatsTile } from './PackingStatsTile';
 import { DefaultTile } from './DefaultTile';
-import { Truck, PackageCheck, Package, FileText, Landmark, ClipboardList, Beaker, AlertTriangle, Gift } from 'lucide-react';
+import { TILE_RENDERERS } from './tileRegistry';
 
 interface TileContentProps {
   tile: DashboardTileType;
@@ -31,65 +18,6 @@ export const TileContent: React.FC<TileContentProps> = ({ tile }) => {
     return <LoadingTile />;
   }
 
-  switch (tile.tileId) {
-    case 'backgroundtaskstatus':
-      return <BackgroundTasksTile data={tile.data} />;
-    case 'todayproduction':
-      return <ProductionTile data={tile.data} title={tile.title || 'Dnes'} />;
-    case 'nextdayproduction':
-      return <ProductionTile data={tile.data} title={tile.title || 'Zítra'} />;
-    // Manufacture tiles
-    case 'manufactureconditions':
-      return <ConditionsTile data={tile.data} />;
-    case 'manualactionrequired':
-      return <ManualActionRequiredTile data={tile.data} tileCategory={tile.category} tileTitle={tile.title} />;
-    // Purchase tiles
-    case 'purchaseordersintransit':
-      return <PurchaseOrdersInTransitTile data={tile.data} tileCategory={tile.category} tileTitle={tile.title} />;
-    // Transport tiles
-    case 'intransitboxes':
-      return <CountTile data={tile.data} icon={<Truck className="h-10 w-10" />} iconColor="text-blue-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/logistics/transport-boxes" />;
-    case 'receivedboxes':
-      return <CountTile data={tile.data} icon={<PackageCheck className="h-10 w-10" />} iconColor="text-green-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/logistics/transport-boxes" />;
-    case 'errorboxes':
-      return <CountTile data={tile.data} icon={<Package className="h-10 w-10" />} iconColor="text-indigo-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/logistics/transport-boxes" />;
-    // Statistics tiles
-    case 'invoiceimportstatistics':
-      return <CountTile data={tile.data} icon={<FileText className="h-10 w-10" />} iconColor="text-amber-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/automation/invoice-import-statistics" />;
-    case 'bankstatementimportstatistics':
-      return <CountTile data={tile.data} icon={<Landmark className="h-10 w-10" />} iconColor="text-emerald-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/finance/bank-statements" />;
-    // Inventory tiles
-    case 'productinventorycount':
-      return <CountTile data={tile.data} icon={<ClipboardList className="h-10 w-10" />} iconColor="text-purple-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/logistics/inventory" />;
-    case 'materialinventorycount':
-      return <CountTile data={tile.data} icon={<Beaker className="h-10 w-10" />} iconColor="text-teal-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/manufacturing/inventory" />;
-    case 'productinventorysummary':
-      return <InventorySummaryTile data={tile.data} targetUrl="/logistics/inventory" />;
-    case 'materialwithexpirationinventorysummary':
-      return <InventorySummaryTile data={tile.data} targetUrl="/manufacturing/inventory" />;
-    case 'materialwithoutexpirationinventorysummary':
-      return <InventorySummaryTile data={tile.data} targetUrl="/manufacturing/inventory" />;
-    // Purchase efficiency tiles
-    case 'lowstockefficiency':
-      return <CountTile data={tile.data} icon={<AlertTriangle className="h-10 w-10" />} iconColor="text-orange-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/purchase/stock-analysis" />;
-    // Gift package tiles
-    case 'criticalgiftpackages':
-      return <CountTile data={tile.data} icon={<Gift className="h-10 w-10" />} iconColor="text-red-600" tileCategory={tile.category} tileTitle={tile.title} targetUrl="/logistics/gift-package-manufacturing" />;
-    // Low stock alert tile
-    case 'lowstockalert':
-      return <LowStockAlertTile data={tile.data} />;
-    // Data quality tile
-    case 'dataqualitystatus':
-      return <DataQualityTile data={tile.data} />;
-    case 'dqtyesterdaystatus':
-      return <DqtYesterdayStatusTile data={tile.data} />;
-    case 'weatherforecast':
-      return <WeatherForecastTile data={tile.data} />;
-    case 'failedjobs':
-      return <FailedJobsTile data={tile.data} />;
-    case 'packingstats':
-      return <PackingStatsTile data={tile.data} />;
-    default:
-      return <DefaultTile data={tile.data} />;
-  }
+  const Renderer = TILE_RENDERERS[tile.tileId];
+  return Renderer ? <Renderer data={tile.data} tile={tile} /> : <DefaultTile data={tile.data} />;
 };

--- a/frontend/src/components/dashboard/tiles/tileRegistry.tsx
+++ b/frontend/src/components/dashboard/tiles/tileRegistry.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { DashboardTile as DashboardTileType } from '../../../api/hooks/useDashboard';
+import { BackgroundTasksTile } from './BackgroundTasksTile';
+import { ProductionTile } from './ProductionTile';
+import { ConditionsTile } from './ConditionsTile';
+import { ManualActionRequiredTile } from './ManualActionRequiredTile';
+import { PurchaseOrdersInTransitTile } from './PurchaseOrdersInTransitTile';
+import { CountTile } from './CountTile';
+import { InventorySummaryTile } from './InventorySummaryTile';
+import { LowStockAlertTile } from './LowStockAlertTile';
+import { DataQualityTile } from './DataQualityTile';
+import { DqtYesterdayStatusTile } from './DqtYesterdayStatusTile';
+import { WeatherForecastTile } from './WeatherForecastTile';
+import { FailedJobsTile } from './FailedJobsTile';
+import { PackingStatsTile } from './PackingStatsTile';
+import { Truck, PackageCheck, Package, FileText, Landmark, ClipboardList, Beaker, AlertTriangle, Gift } from 'lucide-react';
+
+export type TileRenderer = React.FC<{ data: any; tile: DashboardTileType }>;
+
+export const TILE_RENDERERS: Record<string, TileRenderer> = {
+  backgroundtaskstatus: ({ data }) => <BackgroundTasksTile data={data} />,
+  todayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Dnes'} />,
+  nextdayproduction: ({ data, tile }) => <ProductionTile data={data} title={tile.title || 'Zítra'} />,
+  // Manufacture tiles
+  manufactureconditions: ({ data }) => <ConditionsTile data={data} />,
+  manualactionrequired: ({ data, tile }) => (
+    <ManualActionRequiredTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+  ),
+  // Purchase tiles
+  purchaseordersintransit: ({ data, tile }) => (
+    <PurchaseOrdersInTransitTile data={data} tileCategory={tile.category} tileTitle={tile.title} />
+  ),
+  // Transport tiles
+  intransitboxes: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<Truck className="h-10 w-10" />}
+      iconColor="text-blue-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/logistics/transport-boxes"
+    />
+  ),
+  receivedboxes: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<PackageCheck className="h-10 w-10" />}
+      iconColor="text-green-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/logistics/transport-boxes"
+    />
+  ),
+  errorboxes: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<Package className="h-10 w-10" />}
+      iconColor="text-indigo-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/logistics/transport-boxes"
+    />
+  ),
+  // Statistics tiles
+  invoiceimportstatistics: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<FileText className="h-10 w-10" />}
+      iconColor="text-amber-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/automation/invoice-import-statistics"
+    />
+  ),
+  bankstatementimportstatistics: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<Landmark className="h-10 w-10" />}
+      iconColor="text-emerald-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/finance/bank-statements"
+    />
+  ),
+  // Inventory tiles
+  productinventorycount: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<ClipboardList className="h-10 w-10" />}
+      iconColor="text-purple-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/logistics/inventory"
+    />
+  ),
+  materialinventorycount: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<Beaker className="h-10 w-10" />}
+      iconColor="text-teal-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/manufacturing/inventory"
+    />
+  ),
+  productinventorysummary: ({ data }) => (
+    <InventorySummaryTile data={data} targetUrl="/logistics/inventory" />
+  ),
+  materialwithexpirationinventorysummary: ({ data }) => (
+    <InventorySummaryTile data={data} targetUrl="/manufacturing/inventory" />
+  ),
+  materialwithoutexpirationinventorysummary: ({ data }) => (
+    <InventorySummaryTile data={data} targetUrl="/manufacturing/inventory" />
+  ),
+  // Purchase efficiency tiles
+  lowstockefficiency: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<AlertTriangle className="h-10 w-10" />}
+      iconColor="text-orange-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/purchase/stock-analysis"
+    />
+  ),
+  // Gift package tiles
+  criticalgiftpackages: ({ data, tile }) => (
+    <CountTile
+      data={data}
+      icon={<Gift className="h-10 w-10" />}
+      iconColor="text-red-600"
+      tileCategory={tile.category}
+      tileTitle={tile.title}
+      targetUrl="/logistics/gift-package-manufacturing"
+    />
+  ),
+  // Low stock alert tile
+  lowstockalert: ({ data }) => <LowStockAlertTile data={data} />,
+  // Data quality tile
+  dataqualitystatus: ({ data }) => <DataQualityTile data={data} />,
+  dqtyesterdaystatus: ({ data }) => <DqtYesterdayStatusTile data={data} />,
+  weatherforecast: ({ data }) => <WeatherForecastTile data={data} />,
+  failedjobs: ({ data }) => <FailedJobsTile data={data} />,
+  packingstats: ({ data }) => <PackingStatsTile data={data} />,
+};


### PR DESCRIPTION
Closes #3441

## What the issue was
`frontend/src/components/dashboard/tiles/TileContent.tsx` dispatched to tile-specific React components via a `switch (tile.tileId)` with 24 string-literal cases. Every new dashboard tile required editing this file, violating the Open/Closed principle and creating a recurring merge-conflict hotspot as the tile catalogue grows.

## How it was fixed / handled
Extracted the switch into a new `frontend/src/components/dashboard/tiles/tileRegistry.tsx` module exporting a static `TILE_RENDERERS: Record<string, TileRenderer>` map, with one entry per `tileId` transcribed verbatim (same icons, colors, target URLs, and `tileCategory`/`tileTitle` props as before). `TileContent.tsx` is now a thin dispatcher: it keeps only the `isUnauthorized`/loading guards and does a `TILE_RENDERERS[tile.tileId]` lookup, falling back to `DefaultTile`. New tiles now only require adding one entry to the registry — `TileContent.tsx` never changes again.

No behavior change: the existing test suite (`TileContent.test.tsx`, 24 tests) passes unmodified, the full frontend suite (2339 tests) has zero regressions, and `npm run build`/`npm run lint`/`eslint` are all clean on the two touched files.

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3441/`.

## Code review

Whole-branch review result: **CLEAN**. No blocking findings. Two advisory (non-blocking) notes:
- A small factory function could dedupe the 9 repeated `CountTile`-backed entries (~70 lines) — left as-is since the current form stays directly diffable against the original switch.
- `TileRenderer`'s `data: any` typing is pre-existing looseness carried over from the original switch, not introduced by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4qXWnUh74Lo37vtAkuZ6k)_