### PR TITLE
#3447: implementation

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/Bank/BankAccountSettings.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Bank/BankAccountSettings.cs
@@ -2,7 +2,7 @@ namespace Anela.Heblo.Domain.Features.Bank;
 
 public class BankAccountSettings
 {
-    public static string ConfigurationKey { get; set; } = "BankAccounts";
+    public const string ConfigurationKey = "BankAccounts";
 
     public List<BankAccountConfiguration> Accounts { get; set; }
 }


### PR DESCRIPTION
Closes #3447

## What the issue was
`BankAccountSettings.ConfigurationKey` (`backend/src/Anela.Heblo.Domain/Features/Bank/BankAccountSettings.cs`) was declared as a mutable static property with a public setter. Any code — including a test — could overwrite it at runtime, and since `BankModule.AddBankModule` reads it via `configuration.GetSection(BankAccountSettings.ConfigurationKey)`, a mutation before that call would silently rebind bank account configuration to the wrong section key, leaving all accounts empty with no compile-time or runtime guard against it.

## How it was fixed / handled
Changed `ConfigurationKey` from `public static string ConfigurationKey { get; set; } = "BankAccounts";` to `public const string ConfigurationKey = "BankAccounts";`, matching the existing `BankImportWatermarkOptions.SectionName` convention used elsewhere in the same module. Verified no code (production or test) ever calls the setter, so this is a behavior-preserving, compile-time-safe change.

Verified: `dotnet build` (0 errors) and `dotnet format --verify-no-changes` pass; ran the Bank test suite (290 passed — the 12 failures are pre-existing Testcontainers/Docker-daemon-unavailable failures in this sandbox, unrelated to this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_0137V1QDQSF2hiUAuD457Ymw)_