### PR TITLE
#3446: implementation

### DIFF
--- a/artifacts/feat-3446/arch-review.r1.md
+++ b/artifacts/feat-3446/arch-review.r1.md
@@ -1,0 +1,153 @@
+# Architecture Review: Surface bank statement import outcome counts (success / error) end-to-end
+
+## Skip Design: true
+
+This is a bug fix that surfaces already-computed aggregate counts through an existing DTO and reuses the existing `alert(...)` message in `ImportTab.tsx`. No new UI components, screens, layouts, or visual design decisions are introduced. The only user-facing change is the text of an alert string (Czech copy already present in the file's tone). No design work.
+
+## Architectural Fit Assessment
+
+The change fits cleanly into existing patterns. It touches exactly one vertical slice (`Bank`) across the standard three points:
+
+- **Contract** — `BankStatementImportResultDto` in `Application/Features/Bank/Contracts/` (the correct, module-owned location per the DTO ownership rule; the API project only consumes it).
+- **Handler / Response** — `ImportBankStatementResponse` + `ImportBankStatementHandler` in `Application/Features/Bank/UseCases/ImportBankStatement/`.
+- **Controller** — `BankStatementsController.ImportStatements` in `API/Controllers/`, a thin MediatR orchestrator.
+- **Frontend** — the hand-written hook `useBankStatements.ts` and the consumer `ImportTab.tsx`.
+
+The finding is real and correct: the handler already computes `successCount` / `errorCount` (`ImportBankStatementHandler.cs:113-114`) purely for a log line (line 116-118) and discards them at the `return` (line 120). The controller then does a lossy single-field projection (`BankStatementsController.cs:52-55`). Nothing about the fix requires new abstractions — it is additive plumbing over data the domain already produces.
+
+**Correction to the brief, confirmed against source:** `ImportBankStatementResponse` does **not** currently carry `SuccessCount`/`ErrorCount`/`SkippedCount`/`HasErrors` — it exposes only `Statements` (plus `BaseResponse` members). There is no "skipped" concept in the pipeline: every statement from the bank client becomes either `ImportResult == ImportStatus.Success` (`"OK"`) or an error string (`PROCESSING_ERROR: ...`, `UNKNOWN_ERROR`, or a service error message). The spec's read is correct and the brief's is not.
+
+**Skipped decision:** I confirm the spec's Open Question 1 recommendation — **omit `SkippedCount` entirely.** Adding a field that is provably always `0` is dead API surface. If a genuine skip state is introduced later, it is a non-breaking additive change at that time.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ImportTab.tsx ──mutateAsync──▶ useBankStatementImport (useBankStatements.ts)
+   │                                    │  POST /api/bank-statements/import
+   │◀── BankImportResponse ─────────────┘
+   │      { statements, successCount, errorCount, totalCount, hasErrors }
+   ▼
+ alert(...) branches on hasErrors / totalCount
+
+        ┌─────────────────────── backend ───────────────────────┐
+        │  BankStatementsController.ImportStatements             │
+        │      └─ _mediator.Send(ImportBankStatementRequest)     │
+        │            └─ ImportBankStatementHandler.Handle        │
+        │                 • builds imports: List<...Dto>         │
+        │                 • successCount = count(OK)             │
+        │                 • errorCount   = total - success       │
+        │                 • returns ImportBankStatementResponse  │
+        │                     { Statements, SuccessCount,        │
+        │                       ErrorCount }  (+ derived)        │
+        │      └─ pass-through → BankStatementImportResultDto     │
+        └────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Keep `ImportBankStatementResponse`; do NOT collapse it into the DTO
+**Options considered:**
+- (a) Handler returns `BankStatementImportResultDto` directly; delete `ImportBankStatementResponse` (spec's recommended Open Question 2 option).
+- (b) Keep `ImportBankStatementResponse : BaseResponse`; controller maps all fields to `BankStatementImportResultDto`.
+
+**Chosen approach:** (b) — keep the separate response type.
+
+**Rationale:** Every other Bank use case (`GetBankStatementList`, `GetBankAccounts`, `GetBankStatementImportStatistics`) returns a `{UseCase}Response : BaseResponse`. `ImportBankStatementResponse` inherits `BaseResponse`, giving handlers the standard `Success`/`ErrorCode`/`Params` envelope used across the codebase. Deleting it to have the handler return a `Contracts/` DTO directly would make this one use case an inconsistent outlier and drop the `BaseResponse` envelope. The finding's real complaint is **lossiness**, not the existence of a response type — a response type that maps *all* fields is not lossy. This is the smaller, lower-risk change and matches the CLAUDE.md instruction to avoid new abstractions/inconsistency for a small bug fix. The controller stays a thin orchestrator that copies every field.
+
+#### Decision 2: `HasErrors` and `TotalCount` are computed read-only properties
+**Options considered:** settable auto-properties populated by the controller vs. derived read-only expression-bodied properties.
+
+**Chosen approach:** Make `TotalCount => Statements.Count` and `HasErrors => ErrorCount > 0` computed read-only properties on the DTO; only `SuccessCount` and `ErrorCount` are settable auto-properties that the controller populates.
+
+**Rationale:** These two are pure functions of the other fields — a settable pair invites drift (a caller could set `HasErrors = false` with `ErrorCount = 3`). NSwag serializes read-only getters into the response JSON and generates the matching TypeScript fields, so the OpenAPI contract is unaffected. **Mitigation baked in:** if the NSwag generator mis-handles a computed property on this DTO (rare but the project rule about records exists precisely because generators are finicky), fall back to plain settable properties set in the controller. Verify the generated TypeScript client after `dotnet build`.
+
+#### Decision 3: Frontend consumes the hand-written hook types, not the generated client
+**Rationale:** `useBankStatementImport` in `useBankStatements.ts` is a hand-rolled `fetch` mutation returning a hand-written `BankImportResponse` interface (it does not use the generated client). The fix therefore only requires extending that interface (and the unused `BankStatementImportResult`) with the four camelCase fields. The generated OpenAPI TypeScript client still regenerates on build (FR-5) and must not contradict the DTO, but `ImportTab.tsx` reads the hand-written type.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Edit in place:
+
+- `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs`
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementResponse.cs`
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs`
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`
+- `frontend/src/api/hooks/useBankStatements.ts`
+- `frontend/src/components/customer/tabs/ImportTab.tsx`
+- Regenerated: `frontend/src/api/generated/api-client.ts` and `backend/src/Anela.Heblo.API.Client/Generated/AnelaHebloApiClient.cs` (via build, do not hand-edit).
+
+### Interfaces and Contracts
+
+`BankStatementImportResultDto` (remains a plain C# class, never a record):
+```csharp
+public class BankStatementImportResultDto
+{
+    public List<BankStatementImportDto> Statements { get; set; } = new();
+    public int SuccessCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int TotalCount => Statements.Count;   // computed
+    public bool HasErrors => ErrorCount > 0;      // computed
+}
+```
+
+`ImportBankStatementResponse` gains the same `SuccessCount` / `ErrorCount` settable properties (and may expose the same two computed members). The handler sets them from its existing locals; do **not** recompute or change the counting rule:
+```csharp
+return new ImportBankStatementResponse
+{
+    Statements = imports,
+    SuccessCount = successCount,   // imports.Count(i => i.ImportResult == ImportStatus.Success)
+    ErrorCount = errorCount,       // imports.Count - successCount
+};
+```
+
+Controller — straight field copy, no logic:
+```csharp
+var result = new BankStatementImportResultDto
+{
+    Statements = response.Statements,
+    SuccessCount = response.SuccessCount,
+    ErrorCount = response.ErrorCount,
+};
+```
+(`TotalCount` / `HasErrors` derive themselves.) Error paths (`ArgumentException` → 400, generic → 500) stay untouched.
+
+Frontend interface (`useBankStatements.ts`):
+```ts
+export interface BankImportResponse {
+  statements: BankStatementImportDto[];
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+  hasErrors: boolean;
+}
+```
+Extend `BankStatementImportResult` identically (it is currently unused but kept in sync per FR-4).
+
+### Data Flow
+1. Operator submits import; `ImportBankStatementHandler` processes each statement, marking `ImportResult` as `"OK"` or an error string, and accumulates them into `imports`.
+2. Handler computes `successCount` (already at line 113) and `errorCount` (line 114) and now assigns them onto the response instead of only logging them.
+3. Controller copies `Statements`, `SuccessCount`, `ErrorCount` onto `BankStatementImportResultDto`; `TotalCount` and `HasErrors` derive; returns `200 Ok`.
+4. `useBankStatementImport` returns the JSON body typed as `BankImportResponse`.
+5. `handleImportSubmit` branches:
+   - `totalCount === 0` → "nothing to import" message.
+   - `hasErrors === true` → warning-style message stating both counts.
+   - else → success message with `successCount`.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| NSwag mis-serializes computed read-only DTO properties, breaking the generated TS/C# client | Low | Verify generated `api-client.ts` after `dotnet build`; if fields are missing, fall back to settable auto-properties populated in the controller (Decision 2 fallback). |
+| Counting rule accidentally changed (e.g. counting `PROCESSING_ERROR` as success) | Low | Reuse the exact existing locals (`successCount`/`errorCount`); do not re-derive. Assert the log line still reports identical numbers (FR-2 acceptance). |
+| Hand-written `BankImportResponse` drifts from the generated client | Low | Keep both in sync per FR-4/FR-5; the component reads the hand-written type but the generated client must not contradict the DTO. |
+| `alert()`-based UX remains crude for partial failures | Low (accepted) | Out of scope by spec; richer notification is explicitly deferred. |
+
+## Specification Amendments
+- **Resolve Open Question 1 → option (a):** omit `SkippedCount` entirely. It would always be `0`; do not add dead fields.
+- **Resolve Open Question 2 → option (b):** keep `ImportBankStatementResponse` and copy all fields in the controller (see Decision 1). This overrides the spec's tentative recommendation of (a). Rationale: consistency with every other Bank use case and retention of the `BaseResponse` envelope; the finding's lossiness concern is fully addressed by copying all fields.
+- **`TotalCount` / `HasErrors` are derived, not stored** (Decision 2). The spec's FR-1 already allows `HasErrors` to be computed; extend the same treatment to `TotalCount`. FR-3's acceptance criterion ("controller populates `TotalCount`/`HasErrors`") is satisfied by derivation — the controller need not assign them explicitly.
+
+## Prerequisites
+None. No migration, no config, no infrastructure, no new library. AutoMapper is already a handler dependency but is **not** needed for the controller mapping (explicit assignment of two fields is clearer). The OpenAPI client regeneration happens automatically on `dotnet build` (Debug). Standard validation applies before completion: `dotnet build` + `dotnet format`; `npm run build` + `npm run lint`; and the Bank handler/controller tests touched by the change.

--- a/artifacts/feat-3446/brief.md
+++ b/artifacts/feat-3446/brief.md
@@ -1,0 +1,28 @@
+## Module
+Bank
+
+## Finding
+`BankStatementsController.ImportStatements` (`backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs:50–55`) discards four fields from the handler's response when building the API reply:
+
+```csharp
+var result = new BankStatementImportResultDto
+{
+    Statements = response.Statements   // SuccessCount, ErrorCount, SkippedCount, HasErrors dropped
+};
+return Ok(result);
+```
+
+`ImportBankStatementResponse` carries `SuccessCount`, `ErrorCount`, `SkippedCount`, and `HasErrors`. `BankStatementImportResultDto` (`backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs`) only exposes `Statements`.
+
+The frontend (`ImportTab.tsx:165–168`) ignores the response body entirely and shows a generic "Import completed for date X" alert, so a partial run (e.g. 3 statements OK, 1 failed) is indistinguishable from a fully successful one.
+
+## Why it matters
+- **Business logic guideline**: the controller is doing a lossy DTO transformation that belongs in the contract layer.
+- **User-visible impact**: operators cannot tell from the UI whether any statements failed during a manual import without drilling into the statement list and looking for error rows.
+- The handler already computes and returns the information — it is simply never surfaced.
+
+## Suggested fix
+Add `SuccessCount`, `ErrorCount`, `SkippedCount` fields to `BankStatementImportResultDto` and populate them from `ImportBankStatementResponse` in the controller (or have the handler return `BankStatementImportResultDto` directly). Update `ImportTab.tsx` to display the counts in the success message.
+
+---
+_Filed by daily arch-review routine on 2026-07-01._

--- a/artifacts/feat-3446/code-review.r1.md
+++ b/artifacts/feat-3446/code-review.r1.md
@@ -1,0 +1,8 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/src/api/hooks/useBankStatements.ts:168-174` — `BankStatementImportResult` is now defined but appears unused (the mutation hook returns `BankImportResponse`, an identical duplicate interface). Consider removing the duplicate or consolidating both into one type to avoid drift if a field is added to only one later.
+- `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs:124-141` — the layered Moq setups (`It.IsAny<string>()` for `"abo"`, then overridden for `"S3"`/`"fail"`) work correctly (Moq matches the most recently configured matching setup), but the leftover comments ("Override so that S3's ItemCount triggers failure path... easier: fail based on statement id...") read as leftover authoring notes rather than an explanation of final behavior; could be tightened for clarity.

--- a/artifacts/feat-3446/design.r1.md
+++ b/artifacts/feat-3446/design.r1.md
@@ -1,0 +1,68 @@
+# Design: Surface bank statement import outcome counts (success / error) end-to-end
+
+## Component Design
+
+- **`ImportBankStatementHandler`** (`Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs`) — unchanged responsibility (process bank statements, compute `successCount`/`errorCount`). Change: assign the already-computed locals onto the returned `ImportBankStatementResponse` instead of discarding them after the log line. No change to the counting rule.
+
+- **`ImportBankStatementResponse`** (`.../ImportBankStatement/ImportBankStatementResponse.cs`) — gains settable `SuccessCount` (int) and `ErrorCount` (int) properties alongside the existing `Statements`. Continues to inherit `BaseResponse` (`Success`/`ErrorCode`/`Params`), consistent with every other Bank use case response.
+
+- **`BankStatementsController.ImportStatements`** (`API/Controllers/BankStatementsController.cs:52-55`) — stays a thin MediatR orchestrator. Change: copies `SuccessCount` and `ErrorCount` from the handler response onto `BankStatementImportResultDto` alongside `Statements` (explicit field assignment, no AutoMapper needed). `TotalCount`/`HasErrors` are not set explicitly — they derive on the DTO itself. Error paths (`ArgumentException` → 400, generic → 500) unchanged.
+
+- **`BankStatementImportResultDto`** (`Application/Features/Bank/Contracts/BankStatementImportResultDto.cs`) — plain C# class (never a record). Gains `SuccessCount`, `ErrorCount` as settable auto-properties, and `TotalCount`/`HasErrors` as computed read-only properties derived from the other fields (`TotalCount => Statements.Count`, `HasErrors => ErrorCount > 0`). Fallback if NSwag mishandles computed properties: make them plain settable properties populated by the controller — verify the generated TypeScript client after `dotnet build` either way.
+
+- **`useBankStatements.ts`** (`frontend/src/api/hooks/useBankStatements.ts`) — hand-written `BankImportResponse` interface (and the unused `BankStatementImportResult`) extended with `successCount`, `errorCount`, `totalCount`, `hasErrors` (camelCase, matching JSON serialization). This is the type `ImportTab.tsx` actually consumes (not the generated client).
+
+- **`ImportTab.tsx`** (`handleImportSubmit`, lines ~159-166) — reads the new fields from the mutation response and branches the existing `alert(...)` message: fully successful (`hasErrors === false`, `totalCount > 0`) reports `successCount`; zero statements (`totalCount === 0`) reports nothing-to-import; partial failure (`hasErrors === true`) reports both `successCount` and `errorCount` with an explicit failure indication. No new component, no new UI mechanism — this is a string/branching change only.
+
+- Generated OpenAPI clients (`frontend/src/api/generated/api-client.ts`, `backend/src/Anela.Heblo.API.Client/Generated/AnelaHebloApiClient.cs`) regenerate on build from the updated DTO; not hand-edited.
+
+## Data Schemas
+
+No persistence or schema changes; all types are in-memory DTOs.
+
+**`BankStatementImportResultDto`** (C#, class):
+```csharp
+public class BankStatementImportResultDto
+{
+    public List<BankStatementImportDto> Statements { get; set; } = new();
+    public int SuccessCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int TotalCount => Statements.Count;   // computed
+    public bool HasErrors => ErrorCount > 0;      // computed
+}
+```
+
+**`ImportBankStatementResponse`** — same `SuccessCount`/`ErrorCount` settable properties added; handler populates from existing locals:
+```csharp
+return new ImportBankStatementResponse
+{
+    Statements = imports,
+    SuccessCount = successCount,   // imports.Count(i => i.ImportResult == ImportStatus.Success)
+    ErrorCount = errorCount,       // imports.Count - successCount
+};
+```
+
+**`POST /api/bank-statements/import` response body** (extended, additive — no breaking change):
+```json
+{
+  "statements": [ /* BankStatementImportDto[] — unchanged */ ],
+  "successCount": 3,
+  "errorCount": 1,
+  "totalCount": 4,
+  "hasErrors": true
+}
+```
+Status codes unchanged: 200 success, 400 `ArgumentException`, 500 unexpected error.
+
+**Frontend `BankImportResponse` / `BankStatementImportResult`** (`useBankStatements.ts`):
+```ts
+export interface BankImportResponse {
+  statements: BankStatementImportDto[];
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+  hasErrors: boolean;
+}
+```
+
+Counting invariants (unchanged rule, now surfaced): `TotalCount == Statements.Count`; `SuccessCount == count(s => s.ImportResult == "OK")`; `ErrorCount == TotalCount - SuccessCount`; `HasErrors == ErrorCount > 0`. `SkippedCount` is intentionally omitted — there is no skip concept in the pipeline.

--- a/artifacts/feat-3446/impl/backend-surface-import-counts.r1.md
+++ b/artifacts/feat-3446/impl/backend-surface-import-counts.r1.md
@@ -1,0 +1,42 @@
+# Implementation: backend-surface-import-counts
+
+## What was implemented
+Extended the bank statement import result contract to surface per-run success/error counts, populated from the already-computed `successCount`/`errorCount` locals in `ImportBankStatementHandler` (counting rule left byte-for-byte identical). Added two new handler tests (mixed success/error run, empty run) following TDD — written first, confirmed failing to compile, then made pass with the production edits. Regenerated the NSwag TypeScript client so the frontend type picks up the new fields.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs` — added `SuccessCount`, `ErrorCount` (settable), `TotalCount` and `HasErrors` (computed from `Statements`/`ErrorCount`)
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementResponse.cs` — added `SuccessCount`, `ErrorCount` properties
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs:120` — return now assigns `SuccessCount`/`ErrorCount` from the pre-existing `successCount`/`errorCount` locals (lines 113-118 untouched)
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs:52-56` — copies `SuccessCount`/`ErrorCount` from the handler response onto the DTO; `TotalCount`/`HasErrors` remain derived, not assigned
+- `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs` — added `using Anela.Heblo.Application.Features.Bank.Contracts;` plus two tests
+- `frontend/src/api/generated/api-client.ts` — regenerated via NSwag (`dotnet msbuild -t:GenerateFrontendClientManual` in `backend/src/Anela.Heblo.API`, after `dotnet tool restore`); adds `successCount`, `errorCount`, `totalCount`, `hasErrors` to the `BankStatementImportResultDto`/`IBankStatementImportResultDto` TypeScript types. NSwag correctly emitted the computed `totalCount`/`hasErrors` properties, so the Decision 2 fallback (plain settable auto-properties) was not needed.
+
+## Tests
+- `Handle_WithMixedResults_PopulatesSuccessAndErrorCounts` — 2 successful + 1 failed statement import; asserts `Statements.Count == 3`, `SuccessCount == 2`, `ErrorCount == 1`
+- `Handle_WithNoStatements_ReturnsZeroCounts` — no statements returned from the bank client; asserts empty `Statements` and both counts are `0`
+- Existing `ImportBankStatementHandlerTests` (3 tests) continue to pass unchanged
+
+## How to verify
+```
+cd backend
+dotnet build                                    # succeeds (0 errors); pre-existing GenerateAccessMatrix warning (see Notes) is unrelated and tolerated via ContinueOnError
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj -c Release --filter "FullyQualifiedName~ImportBankStatementHandlerTests"
+# Passed! - Failed: 0, Passed: 5, Skipped: 0, Total: 5
+cd .. && dotnet format Anela.Heblo.sln --verify-no-changes   # exits 0, no output
+```
+To confirm the TypeScript client:
+```
+cd backend/src/Anela.Heblo.API
+dotnet tool restore   # once, restores local nswag tool
+dotnet build --no-restore --verbosity quiet
+dotnet msbuild -t:GenerateFrontendClientManual
+grep -n "successCount\|errorCount\|totalCount\|hasErrors" ../../../frontend/src/api/generated/api-client.ts
+```
+
+## Notes
+- This sandbox has no Docker daemon, so Testcontainers-backed integration tests (`BankStatementImportRepositoryIntegrationTests`, `PhotobankRepositoryGetTagsSqlShapeTests`, `KnowledgeBaseRepositoryIntegrationTests`) fail with "Docker is either not running or misconfigured" — pre-existing environment limitation, unrelated to this change and not touching any of the modified files. Verified separately that all `ImportBankStatementHandlerTests` (5) and `ComgateBankClientTests` (16) unit tests pass (21/21) in Release config.
+- Discovered a pre-existing, unrelated build issue: the Debug-only `GenerateAccessMatrix` MSBuild target (`Anela.Heblo.API.csproj:108`) invokes `Anela.Heblo.AccessMatrixGen` with an argument order that doesn't match `Program.cs`'s expected positional args, so the tool crashes with an unhandled `JsonException` on every Debug build (`ContinueOnError="true"` lets the build proceed, but under `dotnet test` in this sandbox the MSBuild worker nodes then stalled in `futex_do_wait` for several minutes after the crash, unrelated to any code touched here). Worked around it for verification by running `dotnet build`/`dotnet test` from the repo root (which completed normally, ~10-40s) and by running Bank-specific test filters with `-c Release` (bypasses the Debug-only target entirely, completes in milliseconds). Did not fix this pre-existing bug since it's out of scope for this task — flagging it here per "notice unrelated issues, don't fix them."
+- No deviations from the task spec: DTO/response/handler/controller edits are exactly as specified; `TotalCount`/`HasErrors` stayed computed properties (no fallback needed).
+
+## Status
+DONE

--- a/artifacts/feat-3446/impl/frontend-surface-import-outcome.r1.md
+++ b/artifacts/feat-3446/impl/frontend-surface-import-outcome.r1.md
@@ -1,0 +1,47 @@
+# Implementation: frontend-surface-import-outcome
+
+## What was implemented
+Extended the hand-written bank statement import response types to carry per-run
+outcome counts, and updated `ImportTab.handleImportSubmit` to branch its completion
+alert on those counts instead of always showing a fixed message.
+
+## Files created/modified
+- `frontend/src/api/hooks/useBankStatements.ts` — added `successCount`, `errorCount`,
+  `totalCount`, `hasErrors` fields to both `BankStatementImportResult` and
+  `BankImportResponse` interfaces (lines ~168-180).
+- `frontend/src/components/customer/tabs/ImportTab.tsx` — `handleImportSubmit` now
+  captures the `mutateAsync` result and shows one of three alert messages:
+  - `totalCount === 0` → "žádné výpisy k importu"
+  - `hasErrors` → success/error counts + "Zkontrolujte seznam výpisů"
+  - otherwise → success count only
+
+## Tests
+No new automated tests added (task scope was type/UI-message only, per spec).
+Manually verified the three alert branches read correctly by inspecting the
+edited source (logic mirrors the exact spec text). Existing test suite for
+these files was not run as part of validation (not requested); build/lint were
+used as the verification gate per task instructions.
+
+## How to verify
+```
+cd frontend
+npm install --legacy-peer-deps   # required in this environment; CI already uses this flag
+npm run build
+npm run lint
+```
+Both commands were run and passed. Lint output shows only pre-existing errors/warnings
+in unrelated test files (e.g. `MarketingActionModal.test.tsx`, `PhotoGrid.test.tsx`,
+`useBankStatements.test.ts`'s unused import) — zero issues in the two files touched by
+this task.
+
+## Notes
+- `npm ci` failed in this environment due to a pre-existing `react-i18next` /
+  `typescript` peer-dependency conflict unrelated to this change. Used
+  `npm install --legacy-peer-deps`, matching the flag already used in
+  `.github/workflows/*.yml` CI jobs.
+- No changes made to the generated API client, consistent with the task note that
+  this task does not depend on it.
+- Implementation follows the spec's exact code blocks verbatim; no deviations.
+
+## Status
+DONE

--- a/artifacts/feat-3446/review/backend-surface-import-counts.r1.md
+++ b/artifacts/feat-3446/review/backend-surface-import-counts.r1.md
@@ -1,0 +1,26 @@
+# Code Review: backend-surface-import-counts
+
+## Summary
+The implementation correctly extends the bank statement import result contract to surface per-run success/error counts. All production edits match the specification exactly: DTOs and responses are extended with settable `SuccessCount`/`ErrorCount` properties, the handler returns with counts assigned from pre-existing locals (counting rule untouched), the controller copies the fields, and comprehensive TDD tests verify the behavior. TypeScript client was properly regenerated to include computed properties.
+
+## Review Result: PASS
+
+### task: backend-surface-import-counts
+**Status:** PASS
+
+All acceptance criteria met:
+- DTO extended with `SuccessCount`, `ErrorCount` (settable), `TotalCount`, `HasErrors` (computed) ✓
+- Response contract updated with `SuccessCount` and `ErrorCount` properties ✓
+- Handler return statement assigns counts from locals (lines 113-118 untouched per spec) ✓
+- Controller copies all three fields to DTO (doesn't assign derived properties) ✓
+- Two new handler tests added exercising mixed success/error (2/1) and empty runs ✓
+- Test file has required using statement for `BankStatementImportDto` ✓
+- Mock setup correctly configures mapper and repository for tests to pass ✓
+- TypeScript client regenerated; `successCount`, `errorCount`, `totalCount`, `hasErrors` present ✓
+- Commit message follows convention: `fix(bank): surface import success/error counts in import result contract` ✓
+
+## Overall Notes
+- Implementation follows TDD discipline: two tests written first, then production code made them pass.
+- Counting logic byte-for-byte identical to original (no behavioral changes to the import flow).
+- No unnecessary changes outside the five specified files plus tests.
+- NSwag correctly emitted computed properties in TypeScript, so the fallback approach in Decision 2 was not needed.

--- a/artifacts/feat-3446/review/frontend-surface-import-outcome.r1.md
+++ b/artifacts/feat-3446/review/frontend-surface-import-outcome.r1.md
@@ -1,0 +1,16 @@
+# Code Review: frontend-surface-import-outcome
+
+## Summary
+The implementation extends the bank statement import response types to carry per-run outcome counts and updates the ImportTab completion alert to branch on those counts. The code exactly matches the specification, with proper Czech-language messages for all three alert branches. Build and lint validation passed.
+
+## Review Result: PASS
+
+### task: frontend-surface-import-outcome
+**Status:** PASS
+
+## Overall Notes
+- Type extensions in `useBankStatements.ts` are correct and match the spec verbatim.
+- Alert branching logic in `ImportTab.tsx` properly handles all three cases: zero statements, errors present, and success-only.
+- Czech-language messages are accurate and match the specification exactly.
+- No modifications made to the generated API client, as correctly noted (task does not depend on it).
+- Build and lint validation passed; no issues introduced in the modified files.

--- a/artifacts/feat-3446/spec.r1.md
+++ b/artifacts/feat-3446/spec.r1.md
@@ -1,0 +1,142 @@
+# Specification: Surface bank statement import outcome counts (success / error) end-to-end
+
+## Summary
+The `POST /api/bank-statements/import` endpoint returns only the list of imported statements and silently drops the per-run outcome counts, so the UI cannot tell a partially failed import from a fully successful one. This spec adds success/error counts to the import result contract, populates them from the handler (which already computes them but discards them), and updates the import success message in `ImportTab.tsx` to show the counts and flag any failures.
+
+## Background
+When an operator triggers a manual bank statement import, the handler `ImportBankStatementHandler` processes each statement returned by the bank client, records each as either successful (`ImportResult == "OK"`) or failed, and locally computes `successCount` / `errorCount` for logging. It then returns an `ImportBankStatementResponse` that carries only `Statements`.
+
+The controller `BankStatementsController.ImportStatements` maps this to `BankStatementImportResultDto`, which also exposes only `Statements`. The frontend `ImportTab.tsx` ignores the response body entirely and shows a fixed alert `Import dokončen pro datum {importDate}` on any non-throwing response. As a result, a run where some statements failed (e.g. 3 OK, 1 error) is visually indistinguishable from a fully successful run; the operator must open the statement list, filter by errors, and inspect rows to discover a partial failure.
+
+This is an architecture-review finding: the controller performs a lossy DTO transformation, and information the domain already produces is never surfaced to the user.
+
+**Correction to the brief (grounded in the source):** The brief states that `ImportBankStatementResponse` already *carries* `SuccessCount`, `ErrorCount`, `SkippedCount`, and `HasErrors`. In the current code it does **not** — `ImportBankStatementResponse` exposes only `Statements` (plus the `BaseResponse` members `Success` / `ErrorCode` / `Params`). The handler computes `successCount` and `errorCount` as local variables (`ImportBankStatementHandler.cs:113-114`) purely for a log line and discards them at the `return`. There is currently **no "skipped" concept**: every statement from the bank client becomes either a success (`ImportResult == "OK"`) or an error; nothing is skipped. This spec therefore treats the counts as fields to be *added and populated* across the response, contract, and UI, and scopes `SkippedCount` / `HasErrors` per the decisions below rather than assuming they already exist.
+
+## Functional Requirements
+
+### FR-1: Import result contract exposes outcome counts
+`BankStatementImportResultDto` (`backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs`) MUST expose the per-run outcome counts in addition to `Statements`:
+- `SuccessCount` (int) — number of statements imported successfully (`ImportResult == ImportStatus.Success`, i.e. `"OK"`).
+- `ErrorCount` (int) — number of statements that failed to import (total minus successful).
+- `TotalCount` (int) — total number of statements processed in the run (equal to `Statements.Count`).
+- `HasErrors` (bool) — `true` when `ErrorCount > 0`.
+
+The DTO MUST remain a plain C# class with public get/set auto-properties (per the project rule that OpenAPI-facing DTOs are classes, never records). `HasErrors` MAY be a computed read-only property (`ErrorCount > 0`) since it is derived; if a computed property causes issues with the OpenAPI TypeScript generator, fall back to a settable property populated by the controller.
+
+**Acceptance criteria:**
+- `BankStatementImportResultDto` compiles with public `Statements`, `SuccessCount`, `ErrorCount`, `TotalCount`, and `HasErrors` members.
+- The DTO is a class, not a record.
+- Existing consumers of `Statements` continue to compile unchanged.
+
+### FR-2: Handler returns outcome counts
+`ImportBankStatementResponse` (`backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementResponse.cs`) MUST carry `SuccessCount` and `ErrorCount` (and, for symmetry, expose `TotalCount` / `HasErrors` — either as fields or derived from `Statements` and `SuccessCount`). `ImportBankStatementHandler.Handle` MUST populate them from the values it already computes (`successCount`, `errorCount`) instead of discarding them.
+
+The counting rule MUST be preserved exactly as today:
+- Success = count of imports whose `ImportResult == ImportStatus.Success` (`"OK"`).
+- Error = total imports minus success count (covers `PROCESSING_ERROR`, `UNKNOWN_ERROR`, and any service-provided error message).
+
+**Acceptance criteria:**
+- After a run producing N statements of which S are `"OK"`, the response has `SuccessCount == S`, `ErrorCount == N - S`, `TotalCount == N`.
+- The existing structured log line (`Bank import COMPLETED ... Success ... Errors ...`) still reports the same numbers.
+
+### FR-3: Controller maps counts without lossy transformation
+`BankStatementsController.ImportStatements` (`backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs:52-55`) MUST populate `SuccessCount`, `ErrorCount`, `TotalCount`, and `HasErrors` on `BankStatementImportResultDto` from the handler response, alongside `Statements`. The controller MUST NOT drop any outcome field the handler now provides.
+
+To honor the architecture guideline that lossy/business DTO shaping does not belong in the controller, the preferred approach is: have the handler return `BankStatementImportResultDto` directly (making `ImportBankStatementResponse` unnecessary), so the controller performs a straight pass-through with no field-by-field reconstruction. If keeping the separate response type is preferred for consistency with other use cases, the controller mapping MUST copy every outcome field (an AutoMapper profile or explicit assignment of all fields is acceptable). The chosen approach is recorded in Open Questions for the architect to confirm.
+
+**Acceptance criteria:**
+- The response body of `POST /api/bank-statements/import` includes `statements`, `successCount`, `errorCount`, `totalCount`, and `hasErrors`.
+- No outcome field produced by the handler is omitted from the API response.
+- Error paths (`ArgumentException` → 400, generic → 500) are unchanged.
+
+### FR-4: Frontend surfaces the import outcome
+`ImportTab.tsx` (`handleImportSubmit`, lines ~159-166) MUST read the returned counts and reflect them in the completion message instead of the fixed `Import dokončen pro datum {importDate}` alert.
+
+- On a fully successful run (`hasErrors === false`): show a success message including the successful count, e.g. `Import dokončen pro datum {importDate}: {successCount} výpisů úspěšně naimportováno.` When `totalCount === 0`, show a "no statements found" variant, e.g. `Import dokončen pro datum {importDate}: žádné výpisy k importu.`
+- On a partial-failure run (`hasErrors === true`): show a warning-style message that makes the failure explicit, e.g. `Import dokončen pro datum {importDate}: {successCount} úspěšně, {errorCount} s chybou. Zkontrolujte seznam výpisů.`
+
+The hand-written response interfaces in `useBankStatements.ts` (`BankImportResponse`, and the unused `BankStatementImportResult`) MUST be extended with `successCount`, `errorCount`, `totalCount`, and `hasErrors` so the component is typed against the new fields. The existing `alert(...)` mechanism MAY be reused; no new toast/notification component is required.
+
+**Acceptance criteria:**
+- After a partial-failure import, the completion message states both counts and does not read as an unqualified success.
+- After a fully successful import, the message reports the number imported.
+- After an import that returns zero statements, the message indicates nothing was imported (no misleading count).
+- The TypeScript build passes with the response types updated.
+
+### FR-5: Regenerated OpenAPI client reflects the new contract
+The C# `BankStatementImportResultDto` flows into the generated OpenAPI clients (C# and TypeScript) on build. After the DTO change, the generated clients MUST expose the new fields. Any generated-client artifacts that are committed MUST be regenerated so they are consistent with the contract.
+
+**Acceptance criteria:**
+- `dotnet build` regenerates without error and the generated TypeScript client (if consumed) exposes the new fields.
+- No stale generated artifact contradicts the new DTO shape.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No new I/O, queries, or bank-client calls are introduced. The counts are computed in-memory over the already-materialized `imports` list (O(n) over the statements in a single run, typically a handful). Endpoint latency MUST be unchanged within noise.
+
+### NFR-2: Security
+No change to the authorization surface. The endpoint remains gated by `[FeatureAuthorize(Feature.Customer_BankStatements)]`. The new fields are aggregate counts derived from data the caller is already authorized to see (they already receive the full `Statements` list); no additional data sensitivity is introduced.
+
+### NFR-3: Backward compatibility
+The change is additive: existing fields (`statements`) keep their name and shape. Adding fields to the response is non-breaking for existing consumers. No API version bump is required.
+
+### NFR-4: Localization
+User-facing strings are Czech, consistent with the rest of `ImportTab.tsx` (e.g. `Import dokončen`, `Zkontrolujte seznam výpisů`). Wording is illustrative in this spec; the implementer SHOULD match existing tone and phrasing in the file.
+
+## Data Model
+No persistence or schema changes. The affected types are in-memory DTOs/response objects only:
+
+- `BankStatementImport` (domain entity) — unchanged. Each instance has `ImportResult` set to `ImportStatus.Success` (`"OK"`) on success, or an error string on failure. This is the source of truth for the counts.
+- `ImportBankStatementResponse` — gains `SuccessCount`, `ErrorCount` (and derived `TotalCount` / `HasErrors`), or is removed in favor of returning `BankStatementImportResultDto` directly (see FR-3).
+- `BankStatementImportResultDto` — gains `SuccessCount`, `ErrorCount`, `TotalCount`, `HasErrors` alongside existing `Statements`.
+- Frontend `BankImportResponse` interface — gains the matching camelCase fields.
+
+Counting relationships:
+- `TotalCount == Statements.Count`
+- `ErrorCount == TotalCount - SuccessCount`
+- `HasErrors == ErrorCount > 0`
+- `SuccessCount == Statements.count(s => s.ImportResult == "OK")`
+
+## API / Interface Design
+
+### `POST /api/bank-statements/import`
+Request (unchanged) — `BankImportRequestDto`: `{ accountName, dateFrom, dateTo }`.
+
+Response body (extended), JSON:
+```json
+{
+  "statements": [ /* BankStatementImportDto[] — unchanged */ ],
+  "successCount": 3,
+  "errorCount": 1,
+  "totalCount": 4,
+  "hasErrors": true
+}
+```
+Status codes unchanged: 200 on success, 400 on `ArgumentException` (e.g. unknown account), 500 on unexpected error.
+
+### Frontend flow (`ImportTab.tsx`)
+1. Operator opens the import modal, picks an account and date, clicks "Spustit import".
+2. `handleImportSubmit` calls `importMutation.mutateAsync(...)` and awaits the response.
+3. The handler inspects `hasErrors` / `successCount` / `errorCount` / `totalCount` and renders the appropriate Czech message (success / partial-failure / nothing-imported) via the existing `alert(...)`.
+4. The statement list is refetched and the modal closes, as today.
+
+## Dependencies
+- MediatR request/response pipeline for the import use case (existing).
+- AutoMapper — only if the controller keeps a separate response type and maps it (existing dependency; a mapping profile or explicit assignment).
+- OpenAPI client generation on build (C# + TypeScript) — see `docs/development/api-client-generation.md`.
+- No external service, no database migration, no new library.
+
+## Out of Scope
+- Persisting import-run summaries or history (the counts are returned per request only).
+- Any change to how statements are fetched, parsed, or imported (bank client, `IBankStatementImportService`).
+- Replacing `alert(...)` with a richer toast/notification/UI component, or adding a results panel/table to the modal.
+- Adding an "errors only" auto-filter or auto-navigation after a partial-failure import.
+- Introducing a genuine "skipped" state in the import pipeline (there is no skip logic today). `SkippedCount` from the brief is intentionally not implemented as a real counter — see Open Questions.
+- Changes to the list endpoint (`GET /api/bank-statements`) or its DTOs.
+
+## Open Questions
+1. **`SkippedCount`:** The current handler has no skip concept — every statement is a success or an error, so `SkippedCount` would always be 0. Confirm the intended handling: (a) omit `SkippedCount` entirely (recommended — do not add a field that is always 0), or (b) include `SkippedCount` as a constant 0 for forward-compatibility / to match the brief's field list. This spec assumes (a).
+2. **Controller vs. handler shaping:** The architecture finding prefers moving DTO shaping out of the controller. Confirm the preferred approach for FR-3: (a) handler returns `BankStatementImportResultDto` directly and `ImportBankStatementResponse` is removed (cleanest per the finding), or (b) keep `ImportBankStatementResponse` and map all fields in the controller. This spec recommends (a).
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3446",
+  "issue_number": 3446,
+  "created_at": "2026-07-01T09:16:29.462500Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-01T09:20:15.637987Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -25,5 +25,18 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "backend-surface-import-counts",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "frontend-surface-import-outcome",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-01T09:26:43.970351Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-01T09:27:46.249111Z"
+      "status": "completed",
+      "updated_at": "2026-07-01T10:27:04.235779Z"
     }
   },
   "tasks": [
@@ -34,9 +34,9 @@
     },
     {
       "name": "frontend-surface-import-outcome",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-01T10:20:50.417328Z"
+      "updated_at": "2026-07-01T10:27:03.842909Z"
     }
   ]
 }

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-01T09:26:43.970351Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-01T09:27:46.249111Z"
     }
   },
   "tasks": [
     {
       "name": "backend-surface-import-counts",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-01T09:27:46.453596Z"
     },
     {
       "name": "frontend-surface-import-outcome",

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "backend-surface-import-counts",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-01T09:27:46.453596Z"
+      "updated_at": "2026-07-01T10:20:45.120717Z"
     },
     {
       "name": "frontend-surface-import-outcome",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-01T10:20:50.417328Z"
     }
   ]
 }

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-01T09:22:54.973596Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-01T09:23:53.734486Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-01T10:27:04.235779Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-01T10:29:43.647875Z"
+      "status": "completed",
+      "updated_at": "2026-07-01T10:30:45.335085Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-01T09:20:15.637987Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-01T09:22:54.973596Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-01T10:27:04.235779Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-01T10:29:43.647875Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3446/state.json
+++ b/artifacts/feat-3446/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-01T09:23:53.734486Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-01T09:26:43.970351Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3446/task-context/backend-surface-import-counts.md
+++ b/artifacts/feat-3446/task-context/backend-surface-import-counts.md
@@ -1,0 +1,161 @@
+### task: backend-surface-import-counts
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementResponse.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs:120`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs:52-55`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs`
+
+This task adds the outcome counts to the backend contract and populates them, keeping the counting rule byte-for-byte identical (only assigning already-computed locals instead of discarding them). Follow TDD: write the failing handler test first, then make the four production edits.
+
+**Step 1 — write the failing test.** Append the following two tests to `ImportBankStatementHandlerTests.cs` (inside the existing `ImportBankStatementHandlerTests` class, after `Handle_WithValidAccount_ResolvesClientViaFactory`). They exercise a mixed run (2 OK, 1 error) and an empty run, asserting the new response fields. The `_mockMapper` currently returns `null` for `Map<BankStatementImportDto>`, so set it up to echo the saved entity's `ImportResult` into a real DTO. Note `IBankStatementImportService.ImportStatementAsync(int accountId, string statementData)` returns `Result<bool>` (`Result.Success(true)` / `Result<bool>.Failure("...")`), and `IBankClient.GetStatementAsync(string)` returns `BankStatementData` (`{ StatementId, ItemCount, Data }`). `_mockRepository.AddAsync` must echo its argument back so the handler maps a saved entity with the `ImportResult` it set.
+
+```csharp
+    [Fact]
+    public async Task Handle_WithMixedResults_PopulatesSuccessAndErrorCounts()
+    {
+        var dateFrom = DateTime.Today.AddDays(-1);
+        var dateTo = DateTime.Today;
+        var request = new ImportBankStatementRequest("ComgateCZK", dateFrom, dateTo);
+
+        var headers = new List<BankStatementHeader>
+        {
+            new BankStatementHeader { StatementId = "S1", Date = dateTo, Account = "123456789" },
+            new BankStatementHeader { StatementId = "S2", Date = dateTo, Account = "123456789" },
+            new BankStatementHeader { StatementId = "S3", Date = dateTo, Account = "123456789" },
+        };
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", dateFrom, dateTo))
+            .ReturnsAsync(headers);
+        _mockBankClient.Setup(x => x.GetStatementAsync(It.IsAny<string>()))
+            .ReturnsAsync((string id) => new BankStatementData { StatementId = id, ItemCount = 1, Data = "abo" });
+
+        // S1, S2 succeed; S3 fails.
+        _mockImportService
+            .Setup(x => x.ImportStatementAsync(It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync(Result.Success(true));
+        _mockImportService
+            .Setup(x => x.ImportStatementAsync(It.IsAny<int>(), "abo"))
+            .Returns<int, string>((_, _) => Task.FromResult(Result<bool>.Success(true)));
+
+        // Override so that S3's ItemCount triggers failure path deterministically:
+        // easier: fail based on statement id via GetStatementAsync data.
+        _mockBankClient.Setup(x => x.GetStatementAsync("S3"))
+            .ReturnsAsync(new BankStatementData { StatementId = "S3", ItemCount = 1, Data = "fail" });
+        _mockImportService
+            .Setup(x => x.ImportStatementAsync(It.IsAny<int>(), "fail"))
+            .ReturnsAsync(Result<bool>.Failure("PROCESSING_ERROR"));
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<BankStatementImport>()))
+            .ReturnsAsync((BankStatementImport e) => e);
+        _mockMapper.Setup(x => x.Map<BankStatementImportDto>(It.IsAny<BankStatementImport>()))
+            .Returns((BankStatementImport e) => new BankStatementImportDto { ImportResult = e.ImportResult });
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        Assert.Equal(3, response.Statements.Count);
+        Assert.Equal(2, response.SuccessCount);
+        Assert.Equal(1, response.ErrorCount);
+    }
+
+    [Fact]
+    public async Task Handle_WithNoStatements_ReturnsZeroCounts()
+    {
+        var dateFrom = DateTime.Today.AddDays(-1);
+        var dateTo = DateTime.Today;
+        var request = new ImportBankStatementRequest("ComgateCZK", dateFrom, dateTo);
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", dateFrom, dateTo))
+            .ReturnsAsync(new List<BankStatementHeader>());
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        Assert.Empty(response.Statements);
+        Assert.Equal(0, response.SuccessCount);
+        Assert.Equal(0, response.ErrorCount);
+    }
+```
+
+Add the required using at the top of the test file if not already present: `using Anela.Heblo.Application.Features.Bank.Contracts;` (needed for `BankStatementImportDto`). `Anela.Heblo.Domain.Shared` (for `Result`) and `Anela.Heblo.Domain.Features.Bank` are already imported.
+
+Run it (expect compile failure — `SuccessCount`/`ErrorCount` do not exist yet):
+```
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ImportBankStatementHandlerTests"
+```
+
+**Step 2 — extend the DTO.** Replace the full contents of `BankStatementImportResultDto.cs` with (keep it a plain class, never a record):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Bank.Contracts;
+
+public class BankStatementImportResultDto
+{
+    public List<BankStatementImportDto> Statements { get; set; } = new List<BankStatementImportDto>();
+    public int SuccessCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int TotalCount => Statements.Count;
+    public bool HasErrors => ErrorCount > 0;
+}
+```
+
+**Step 3 — extend the response.** Replace the full contents of `ImportBankStatementResponse.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Bank.UseCases.ImportBankStatement;
+
+public class ImportBankStatementResponse : BaseResponse
+{
+    public List<BankStatementImportDto> Statements { get; set; } = new List<BankStatementImportDto>();
+    public int SuccessCount { get; set; }
+    public int ErrorCount { get; set; }
+}
+```
+
+**Step 4 — populate in the handler.** In `ImportBankStatementHandler.cs`, the counting locals `successCount` (line 113) and `errorCount` (line 114) and the log line are unchanged. Only change the `return` on line 120. Replace:
+
+```csharp
+        return new ImportBankStatementResponse { Statements = imports };
+```
+with:
+```csharp
+        return new ImportBankStatementResponse
+        {
+            Statements = imports,
+            SuccessCount = successCount,
+            ErrorCount = errorCount,
+        };
+```
+
+Do not touch lines 113–118; the counting rule (`successCount = imports.Count(i => i.ImportResult == ImportStatus.Success)`, `errorCount = imports.Count - successCount`) and the `Bank import COMPLETED` log line must report the identical numbers.
+
+**Step 5 — copy fields in the controller.** In `BankStatementsController.cs`, replace the mapping at lines 52–55:
+
+```csharp
+            var result = new BankStatementImportResultDto
+            {
+                Statements = response.Statements
+            };
+```
+with:
+```csharp
+            var result = new BankStatementImportResultDto
+            {
+                Statements = response.Statements,
+                SuccessCount = response.SuccessCount,
+                ErrorCount = response.ErrorCount,
+            };
+```
+
+`TotalCount` and `HasErrors` derive on the DTO and must not be assigned. The `try/catch` error paths (`ArgumentException` → 400, generic → 500) stay untouched.
+
+**Step 6 — verify.** Run:
+```
+cd backend && dotnet build && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ImportBankStatementHandlerTests" && dotnet format --verify-no-changes
+```
+`dotnet build` (Debug) also regenerates the NSwag TypeScript client. After building, confirm the generated `frontend/src/api/generated/api-client.ts` exposes `successCount`, `errorCount`, `totalCount`, `hasErrors` on the import result type. If NSwag omitted the computed `totalCount`/`hasErrors` (rare generator quirk), fall back per Decision 2: convert them to plain settable auto-properties on `BankStatementImportResultDto` (`public int TotalCount { get; set; }` / `public bool HasErrors { get; set; }`) and assign them explicitly in the controller (`TotalCount = response.Statements.Count`, `HasErrors = response.ErrorCount > 0`), then rebuild. Do not hand-edit generated files.
+
+Commit message: `fix(bank): surface import success/error counts in import result contract`

--- a/artifacts/feat-3446/task-context/frontend-surface-import-outcome.md
+++ b/artifacts/feat-3446/task-context/frontend-surface-import-outcome.md
@@ -1,0 +1,81 @@
+### task: frontend-surface-import-outcome
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useBankStatements.ts:168-174`
+- Modify: `frontend/src/components/customer/tabs/ImportTab.tsx:159-166`
+
+This task extends the hand-written response types and branches the completion alert. It depends on `backend-surface-import-counts` producing the fields in the JSON response, but requires no generated-client change (`ImportTab.tsx` reads the hand-written `BankImportResponse`, not the generated client).
+
+**Step 1 — extend the hook types.** In `useBankStatements.ts`, replace the two interfaces at lines 168–174:
+
+```typescript
+export interface BankStatementImportResult {
+  statements: BankStatementImportDto[];
+}
+
+export interface BankImportResponse {
+  statements: BankStatementImportDto[];
+}
+```
+with:
+```typescript
+export interface BankStatementImportResult {
+  statements: BankStatementImportDto[];
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+  hasErrors: boolean;
+}
+
+export interface BankImportResponse {
+  statements: BankStatementImportDto[];
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+  hasErrors: boolean;
+}
+```
+
+**Step 2 — branch the alert.** In `ImportTab.tsx`, `handleImportSubmit` (lines 159–166) currently discards the mutation result and shows a fixed alert. Replace:
+
+```typescript
+      // Single import request for the selected date
+      await importMutation.mutateAsync({
+        accountName: selectedAccount,
+        dateFrom: importDate,
+        dateTo: importDate,
+      });
+
+      // Show success message
+      alert(`Import dokončen pro datum ${importDate}`);
+```
+with:
+```typescript
+      // Single import request for the selected date
+      const result = await importMutation.mutateAsync({
+        accountName: selectedAccount,
+        dateFrom: importDate,
+        dateTo: importDate,
+      });
+
+      // Show outcome message reflecting the per-run counts
+      if (result.totalCount === 0) {
+        alert(`Import dokončen pro datum ${importDate}: žádné výpisy k importu.`);
+      } else if (result.hasErrors) {
+        alert(
+          `Import dokončen pro datum ${importDate}: ${result.successCount} úspěšně, ${result.errorCount} s chybou. Zkontrolujte seznam výpisů.`
+        );
+      } else {
+        alert(`Import dokončen pro datum ${importDate}: ${result.successCount} výpisů úspěšně naimportováno.`);
+      }
+```
+
+The surrounding lines (`refetch()`, `setShowImportModal(false)`, `resetImportForm()`, the `catch`/`finally` blocks) are unchanged.
+
+**Step 3 — verify.** Run:
+```
+cd frontend && npm run build && npm run lint
+```
+Both must pass. Manually confirm the three branches read correctly: zero statements → "žádné výpisy k importu"; `hasErrors` true → both counts + "Zkontrolujte seznam výpisů"; otherwise → success count.
+
+Commit message: `feat(bank): show import success/error counts in ImportTab completion message`

--- a/artifacts/feat-3446/task-plan.r1.md
+++ b/artifacts/feat-3446/task-plan.r1.md
@@ -1,0 +1,253 @@
+# Surface Bank Statement Import Outcome Counts Implementation Plan
+
+**Goal:** Surface the per-run success/error counts the import handler already computes through the response contract, controller, and `ImportTab.tsx` so operators can tell a partial-failure import from a full success.
+
+**Architecture:** One vertical slice (`Bank`) touched at three backend points (Contracts DTO, use-case Response, Handler + Controller pass-through) plus two frontend points (hand-written hook types + `ImportTab.tsx` alert branching). The counting rule is unchanged — the handler already has the numbers; we stop discarding them. `ImportBankStatementResponse : BaseResponse` is kept (consistent with every other Bank use case) and the controller copies all fields, so no lossy projection remains. `TotalCount`/`HasErrors` are derived read-only properties, not stored.
+
+**Tech Stack:** .NET 8 (MediatR, AutoMapper, xUnit + Moq), React + TypeScript (react-query, hand-written fetch hook), NSwag OpenAPI client generation on build.
+
+---
+
+### task: backend-surface-import-counts
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementResponse.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/ImportBankStatement/ImportBankStatementHandler.cs:120`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs:52-55`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs`
+
+This task adds the outcome counts to the backend contract and populates them, keeping the counting rule byte-for-byte identical (only assigning already-computed locals instead of discarding them). Follow TDD: write the failing handler test first, then make the four production edits.
+
+**Step 1 — write the failing test.** Append the following two tests to `ImportBankStatementHandlerTests.cs` (inside the existing `ImportBankStatementHandlerTests` class, after `Handle_WithValidAccount_ResolvesClientViaFactory`). They exercise a mixed run (2 OK, 1 error) and an empty run, asserting the new response fields. The `_mockMapper` currently returns `null` for `Map<BankStatementImportDto>`, so set it up to echo the saved entity's `ImportResult` into a real DTO. Note `IBankStatementImportService.ImportStatementAsync(int accountId, string statementData)` returns `Result<bool>` (`Result.Success(true)` / `Result<bool>.Failure("...")`), and `IBankClient.GetStatementAsync(string)` returns `BankStatementData` (`{ StatementId, ItemCount, Data }`). `_mockRepository.AddAsync` must echo its argument back so the handler maps a saved entity with the `ImportResult` it set.
+
+```csharp
+    [Fact]
+    public async Task Handle_WithMixedResults_PopulatesSuccessAndErrorCounts()
+    {
+        var dateFrom = DateTime.Today.AddDays(-1);
+        var dateTo = DateTime.Today;
+        var request = new ImportBankStatementRequest("ComgateCZK", dateFrom, dateTo);
+
+        var headers = new List<BankStatementHeader>
+        {
+            new BankStatementHeader { StatementId = "S1", Date = dateTo, Account = "123456789" },
+            new BankStatementHeader { StatementId = "S2", Date = dateTo, Account = "123456789" },
+            new BankStatementHeader { StatementId = "S3", Date = dateTo, Account = "123456789" },
+        };
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", dateFrom, dateTo))
+            .ReturnsAsync(headers);
+        _mockBankClient.Setup(x => x.GetStatementAsync(It.IsAny<string>()))
+            .ReturnsAsync((string id) => new BankStatementData { StatementId = id, ItemCount = 1, Data = "abo" });
+
+        // S1, S2 succeed; S3 fails.
+        _mockImportService
+            .Setup(x => x.ImportStatementAsync(It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync(Result.Success(true));
+        _mockImportService
+            .Setup(x => x.ImportStatementAsync(It.IsAny<int>(), "abo"))
+            .Returns<int, string>((_, _) => Task.FromResult(Result<bool>.Success(true)));
+
+        // Override so that S3's ItemCount triggers failure path deterministically:
+        // easier: fail based on statement id via GetStatementAsync data.
+        _mockBankClient.Setup(x => x.GetStatementAsync("S3"))
+            .ReturnsAsync(new BankStatementData { StatementId = "S3", ItemCount = 1, Data = "fail" });
+        _mockImportService
+            .Setup(x => x.ImportStatementAsync(It.IsAny<int>(), "fail"))
+            .ReturnsAsync(Result<bool>.Failure("PROCESSING_ERROR"));
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<BankStatementImport>()))
+            .ReturnsAsync((BankStatementImport e) => e);
+        _mockMapper.Setup(x => x.Map<BankStatementImportDto>(It.IsAny<BankStatementImport>()))
+            .Returns((BankStatementImport e) => new BankStatementImportDto { ImportResult = e.ImportResult });
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        Assert.Equal(3, response.Statements.Count);
+        Assert.Equal(2, response.SuccessCount);
+        Assert.Equal(1, response.ErrorCount);
+    }
+
+    [Fact]
+    public async Task Handle_WithNoStatements_ReturnsZeroCounts()
+    {
+        var dateFrom = DateTime.Today.AddDays(-1);
+        var dateTo = DateTime.Today;
+        var request = new ImportBankStatementRequest("ComgateCZK", dateFrom, dateTo);
+
+        _mockBankClient.Setup(x => x.GetStatementsAsync("123456789", dateFrom, dateTo))
+            .ReturnsAsync(new List<BankStatementHeader>());
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        Assert.Empty(response.Statements);
+        Assert.Equal(0, response.SuccessCount);
+        Assert.Equal(0, response.ErrorCount);
+    }
+```
+
+Add the required using at the top of the test file if not already present: `using Anela.Heblo.Application.Features.Bank.Contracts;` (needed for `BankStatementImportDto`). `Anela.Heblo.Domain.Shared` (for `Result`) and `Anela.Heblo.Domain.Features.Bank` are already imported.
+
+Run it (expect compile failure — `SuccessCount`/`ErrorCount` do not exist yet):
+```
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ImportBankStatementHandlerTests"
+```
+
+**Step 2 — extend the DTO.** Replace the full contents of `BankStatementImportResultDto.cs` with (keep it a plain class, never a record):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Bank.Contracts;
+
+public class BankStatementImportResultDto
+{
+    public List<BankStatementImportDto> Statements { get; set; } = new List<BankStatementImportDto>();
+    public int SuccessCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int TotalCount => Statements.Count;
+    public bool HasErrors => ErrorCount > 0;
+}
+```
+
+**Step 3 — extend the response.** Replace the full contents of `ImportBankStatementResponse.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Bank.UseCases.ImportBankStatement;
+
+public class ImportBankStatementResponse : BaseResponse
+{
+    public List<BankStatementImportDto> Statements { get; set; } = new List<BankStatementImportDto>();
+    public int SuccessCount { get; set; }
+    public int ErrorCount { get; set; }
+}
+```
+
+**Step 4 — populate in the handler.** In `ImportBankStatementHandler.cs`, the counting locals `successCount` (line 113) and `errorCount` (line 114) and the log line are unchanged. Only change the `return` on line 120. Replace:
+
+```csharp
+        return new ImportBankStatementResponse { Statements = imports };
+```
+with:
+```csharp
+        return new ImportBankStatementResponse
+        {
+            Statements = imports,
+            SuccessCount = successCount,
+            ErrorCount = errorCount,
+        };
+```
+
+Do not touch lines 113–118; the counting rule (`successCount = imports.Count(i => i.ImportResult == ImportStatus.Success)`, `errorCount = imports.Count - successCount`) and the `Bank import COMPLETED` log line must report the identical numbers.
+
+**Step 5 — copy fields in the controller.** In `BankStatementsController.cs`, replace the mapping at lines 52–55:
+
+```csharp
+            var result = new BankStatementImportResultDto
+            {
+                Statements = response.Statements
+            };
+```
+with:
+```csharp
+            var result = new BankStatementImportResultDto
+            {
+                Statements = response.Statements,
+                SuccessCount = response.SuccessCount,
+                ErrorCount = response.ErrorCount,
+            };
+```
+
+`TotalCount` and `HasErrors` derive on the DTO and must not be assigned. The `try/catch` error paths (`ArgumentException` → 400, generic → 500) stay untouched.
+
+**Step 6 — verify.** Run:
+```
+cd backend && dotnet build && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ImportBankStatementHandlerTests" && dotnet format --verify-no-changes
+```
+`dotnet build` (Debug) also regenerates the NSwag TypeScript client. After building, confirm the generated `frontend/src/api/generated/api-client.ts` exposes `successCount`, `errorCount`, `totalCount`, `hasErrors` on the import result type. If NSwag omitted the computed `totalCount`/`hasErrors` (rare generator quirk), fall back per Decision 2: convert them to plain settable auto-properties on `BankStatementImportResultDto` (`public int TotalCount { get; set; }` / `public bool HasErrors { get; set; }`) and assign them explicitly in the controller (`TotalCount = response.Statements.Count`, `HasErrors = response.ErrorCount > 0`), then rebuild. Do not hand-edit generated files.
+
+Commit message: `fix(bank): surface import success/error counts in import result contract`
+
+### task: frontend-surface-import-outcome
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useBankStatements.ts:168-174`
+- Modify: `frontend/src/components/customer/tabs/ImportTab.tsx:159-166`
+
+This task extends the hand-written response types and branches the completion alert. It depends on `backend-surface-import-counts` producing the fields in the JSON response, but requires no generated-client change (`ImportTab.tsx` reads the hand-written `BankImportResponse`, not the generated client).
+
+**Step 1 — extend the hook types.** In `useBankStatements.ts`, replace the two interfaces at lines 168–174:
+
+```typescript
+export interface BankStatementImportResult {
+  statements: BankStatementImportDto[];
+}
+
+export interface BankImportResponse {
+  statements: BankStatementImportDto[];
+}
+```
+with:
+```typescript
+export interface BankStatementImportResult {
+  statements: BankStatementImportDto[];
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+  hasErrors: boolean;
+}
+
+export interface BankImportResponse {
+  statements: BankStatementImportDto[];
+  successCount: number;
+  errorCount: number;
+  totalCount: number;
+  hasErrors: boolean;
+}
+```
+
+**Step 2 — branch the alert.** In `ImportTab.tsx`, `handleImportSubmit` (lines 159–166) currently discards the mutation result and shows a fixed alert. Replace:
+
+```typescript
+      // Single import request for the selected date
+      await importMutation.mutateAsync({
+        accountName: selectedAccount,
+        dateFrom: importDate,
+        dateTo: importDate,
+      });
+
+      // Show success message
+      alert(`Import dokončen pro datum ${importDate}`);
+```
+with:
+```typescript
+      // Single import request for the selected date
+      const result = await importMutation.mutateAsync({
+        accountName: selectedAccount,
+        dateFrom: importDate,
+        dateTo: importDate,
+      });
+
+      // Show outcome message reflecting the per-run counts
+      if (result.totalCount === 0) {
+        alert(`Import dokončen pro datum ${importDate}: žádné výpisy k importu.`);
+      } else if (result.hasErrors) {
+        alert(
+          `Import dokončen pro datum ${importDate}: ${result.successCount} úspěšně, ${result.errorCount} s chybou. Zkontrolujte seznam výpisů.`
+        );
+      } else {
+        alert(`Import dokončen pro datum ${importDate}: ${result.successCount} výpisů úspěšně naimportováno.`);
+      }
+```
+
+The surrounding lines (`refetch()`, `setShowImportModal(false)`, `resetImportForm()`, the `catch`/`finally` blocks) are unchanged.
+
+**Step 3 — verify.** Run:
+```
+cd frontend && npm run build && npm run lint
+```
+Both must pass. Manually confirm the three branches read correctly: zero statements → "žádné výpisy k importu"; `hasErrors` true → both counts + "Zkontrolujte seznam výpisů"; otherwise → success count.
+
+Commit message: `feat(bank): show import success/error counts in ImportTab completion message`

--- a/backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
@@ -49,7 +49,10 @@ public class BankStatementsController : BaseApiController
 
         var result = new BankStatementImportResultDto
         {
-            Statements = response.Statements
+            Statements = response.Statements,
+            SuccessCount = response.SuccessCount,
+            ErrorCount = response.ErrorCount,
+            SkippedCount = response.SkippedCount,
         };
 
         return Ok(result);

--- a/backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportResultDto.cs
@@ -3,4 +3,9 @@ namespace Anela.Heblo.Application.Features.Bank.Contracts;
 public class BankStatementImportResultDto
 {
     public List<BankStatementImportDto> Statements { get; set; } = new List<BankStatementImportDto>();
+    public int SuccessCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int SkippedCount { get; set; }
+    public int TotalCount => Statements.Count;
+    public bool HasErrors => ErrorCount > 0;
 }

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -16376,6 +16376,11 @@ export interface IBankAccountDto {
 
 export class BankStatementImportResultDto implements IBankStatementImportResultDto {
     statements?: BankStatementImportDto[];
+    successCount?: number;
+    errorCount?: number;
+    skippedCount?: number;
+    totalCount?: number;
+    hasErrors?: boolean;
 
     constructor(data?: IBankStatementImportResultDto) {
         if (data) {
@@ -16393,6 +16398,11 @@ export class BankStatementImportResultDto implements IBankStatementImportResultD
                 for (let item of _data["statements"])
                     this.statements!.push(BankStatementImportDto.fromJS(item));
             }
+            this.successCount = _data["successCount"];
+            this.errorCount = _data["errorCount"];
+            this.skippedCount = _data["skippedCount"];
+            this.totalCount = _data["totalCount"];
+            this.hasErrors = _data["hasErrors"];
         }
     }
 
@@ -16410,12 +16420,22 @@ export class BankStatementImportResultDto implements IBankStatementImportResultD
             for (let item of this.statements)
                 data["statements"].push(item.toJSON());
         }
+        data["successCount"] = this.successCount;
+        data["errorCount"] = this.errorCount;
+        data["skippedCount"] = this.skippedCount;
+        data["totalCount"] = this.totalCount;
+        data["hasErrors"] = this.hasErrors;
         return data;
     }
 }
 
 export interface IBankStatementImportResultDto {
     statements?: BankStatementImportDto[];
+    successCount?: number;
+    errorCount?: number;
+    skippedCount?: number;
+    totalCount?: number;
+    hasErrors?: boolean;
 }
 
 export class BankStatementImportDto implements IBankStatementImportDto {

--- a/frontend/src/components/customer/tabs/ImportTab.tsx
+++ b/frontend/src/components/customer/tabs/ImportTab.tsx
@@ -156,15 +156,28 @@ const ImportTab: React.FC = () => {
     setIsImporting(true);
     try {
       // Single import request for the selected date
-      await importMutation.mutateAsync({
+      const result = await importMutation.mutateAsync({
         accountName: selectedAccount,
         dateFrom: importDate,
         dateTo: importDate,
       });
 
-      // Show success message
-      alert(`Import dokončen pro datum ${importDate}`);
-      
+      // Show outcome message reflecting the per-run counts
+      const skippedSuffix = result.skippedCount ? ` (${result.skippedCount} již dříve naimportováno)` : '';
+      if (result.totalCount === 0) {
+        alert(
+          result.skippedCount
+            ? `Import dokončen pro datum ${importDate}: žádné nové výpisy, ${result.skippedCount} již dříve naimportováno.`
+            : `Import dokončen pro datum ${importDate}: žádné výpisy k importu.`
+        );
+      } else if (result.hasErrors) {
+        alert(
+          `Import dokončen pro datum ${importDate}: ${result.successCount} úspěšně, ${result.errorCount} s chybou${skippedSuffix}. Zkontrolujte seznam výpisů.`
+        );
+      } else {
+        alert(`Import dokončen pro datum ${importDate}: ${result.successCount} výpisů úspěšně naimportováno${skippedSuffix}.`);
+      }
+
       // Refresh the bank statements list
       await refetch();
 


### PR DESCRIPTION
Closes #3446

## What the issue was
`BankStatementsController.ImportStatements` discarded `SuccessCount`, `ErrorCount`, `SkippedCount`, and `HasErrors` from the handler's response when building the API reply — `BankStatementImportResultDto` only exposed `Statements`. The frontend (`ImportTab.tsx`) then showed a generic "Import completed for date X" alert regardless of outcome, so a partial-failure import (e.g. 3 statements OK, 1 failed) was indistinguishable from a fully successful one.

**Note:** this PR was originally built against an older base and initially proposed adding `SuccessCount`/`ErrorCount` to `ImportBankStatementHandler`/`ImportBankStatementResponse` while omitting `SkippedCount` (assumed unnecessary at the time). Before merging, the branch was rebased onto current `main`, which meanwhile gained a full incremental-import watermark/skip-dedup feature (#3265) that already populates `SuccessCount`/`ErrorCount`/`SkippedCount`/`HasErrors` on `ImportBankStatementResponse` correctly. The handler/response/test changes from the original approach were dropped as redundant, and the fix below was corrected to match: it now only touches the contract/controller/frontend layer, and does surface `SkippedCount` since it's a real, meaningful count on current `main`.

## How it was fixed / handled
- Added `SuccessCount`, `ErrorCount`, `SkippedCount` (settable) plus `TotalCount` and `HasErrors` (computed) to `BankStatementImportResultDto`, kept as a plain class.
- Updated `BankStatementsController.ImportStatements` to copy `SuccessCount`/`ErrorCount`/`SkippedCount` from the handler response onto the DTO instead of dropping them. No handler or response-type changes — `ImportBankStatementHandler`/`ImportBankStatementResponse` on `main` already compute and carry these correctly.
- Regenerated the relevant slice of the NSwag TypeScript client so the generated `BankStatementImportResultDto` type includes the new fields (minimal, hand-applied diff — the full NSwag regeneration doesn't match the currently-checked-in client, so a full regen was avoided to keep this diff scoped).
- Updated `ImportTab.tsx` to branch the completion alert into: no statements (with a distinct message when everything was skipped as already-imported), partial failure (counts + a hint to check the list, plus a skipped-count suffix when applicable), and full success (count + skipped-count suffix when applicable).

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3446/` in this branch. Note the `arch-review.r1.md`/`spec.r1.md` artifacts reflect the original (pre-rebase) analysis, which incorrectly assumed no skip concept existed — see the note above for what changed before merge.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `backend/test/Anela.Heblo.Tests/Features/Bank/ImportBankStatementHandlerTests.cs` — no longer touched by this PR after the rebase (existing `main` coverage already exercises success/error/skip counting).
