### PR TITLE
#3454: implementation

### DIFF
--- a/artifacts/feat-3454/arch-review.r1.md
+++ b/artifacts/feat-3454/arch-review.r1.md
@@ -1,0 +1,163 @@
+# Architecture Review: Remove DataQuality → Catalog Application-layer boundary violation in ProductPairingDqtComparer
+
+## Skip Design: true
+
+Pure backend dependency-direction refactor: new interface, one adapter class, one DI registration line, one constructor type swap, test-double type swap. No controller, MediatR contract, HTTP surface, or UI is touched.
+
+## Architectural Fit Assessment
+
+This fits the codebase's established cross-module decoupling pattern precisely, and it fits it in the most literal way possible: **the exact same module pair (DataQuality ↔ Catalog) already has two working instances of this pattern**, committed and tested:
+
+- `Anela.Heblo.Application.Features.DataQuality.Contracts.IStockOperationQuery` → `Anela.Heblo.Application.Features.Catalog.Infrastructure.DataQualityStockOperationQueryAdapter`
+- `Anela.Heblo.Application.Features.DataQuality.Contracts.IStockTakingQuery` → `Anela.Heblo.Application.Features.Catalog.Infrastructure.DataQualityStockTakingQueryAdapter`
+
+Both are `internal sealed` adapters in `Catalog/Infrastructure/`, both registered in `CatalogModule.AddCatalogModule()` at lines 61–62 with the comment `// DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.`, both have adapter-level tests under `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/`. `docs/architecture/development_guidelines.md` codifies this as the canonical pattern (the `ILeafletKnowledgeSource` write-up: consumer defines the contract, provider implements an adapter, provider registers the DI binding). The proposed `IDqtResilienceService` / `DataQualityResilienceAdapter` pair is a structural clone of these two adapters. There is no interpretation risk here — this is "do it a third time, the same way."
+
+One important fact the spec did not surface: **this exact violation is already tracked by an automated, enforced architecture test.** See Decision 3 below — this changes what "done" means for this fix.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+DataQuality module (consumer)                    Catalog module (provider)
+──────────────────────────────                   ──────────────────────────
+ProductPairingDqtComparer                          CatalogModule.AddCatalogModule()
+  ├─ IEshopStockClient        (unchanged,             registers:
+  │   Domain.Catalog.Stock,                           IDqtResilienceService →
+  │   out of scope)                                     DataQualityResilienceAdapter
+  ├─ IErpStockClient          (unchanged,
+  │   Domain.Catalog.Stock,                          DataQualityResilienceAdapter
+  │   out of scope)                                    (Catalog.Infrastructure, internal sealed)
+  └─ IDqtResilienceService  ──────depends on──────►      └─ ICatalogResilienceService (injected)
+      (DataQuality.Contracts,                               └─ CatalogResilienceService (Singleton,
+       NEW)                                                      Polly pipeline, unchanged)
+```
+
+Call-time flow is unchanged: `ProductPairingDqtComparer.CompareAsync` calls `_resilienceService.ExecuteWithResilienceAsync(...)`, now typed as `IDqtResilienceService`; DI resolves it to `DataQualityResilienceAdapter`, which forwards 1:1 to the existing `ICatalogResilienceService` singleton and its Polly pipeline (3 retries, 50%/3-min-throughput circuit breaker, 30s break, 30s timeout — all untouched in `CatalogResilienceService.cs`).
+
+### Key Design Decisions
+
+#### Decision 1: Option A (consumer-owned contract + provider adapter) over Option B (push resilience into shared clients)
+
+**Options considered:** Brief proposed both. Spec chose A with reasoning I independently verified against the actual adapter code.
+
+**Chosen approach:** Option A.
+
+**Rationale (verified, not just asserted):**
+- `IEshopStockClient` is implemented by `ShoptetStockClient` (`backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Stock/ShoptetStockClient.cs`) and `IErpStockClient` by `FlexiStockClient` (`backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Stock/FlexiStockClient.cs`). I grepped both files for `Resilience`/`Polly`/`CircuitBreaker` — zero matches. Neither adapter currently has any retry/circuit-breaker wrapping.
+- Both clients are consumed directly by multiple modules beyond DataQuality: Catalog itself (`CatalogDataRefreshService`, `EshopStockDomainService`) and FinancialOverview (`StockValueService`, confirmed via its `using Anela.Heblo.Domain.Features.Catalog.Stock;`). Option B would silently impose Catalog's resilience policy (tuned for Catalog's interactive cache-refresh workload) onto every one of these consumers — a materially larger, unrequested behavior change that violates the project's "surgical changes" rule.
+- Option A is a structural no-op relative to two adapters already in production in this exact module pair (see Architectural Fit above), so it is lower-risk and faster to review than introducing new behavior into shared adapters.
+
+I concur with the spec's choice. Do not revisit this decision during implementation.
+
+#### Decision 2: Registration lifetime — Scoped adapter over a Singleton `CatalogResilienceService`
+
+**Options considered:** Match `IDqtResilienceService` lifetime to the underlying `Singleton` `ICatalogResilienceService`, or `Scoped` to match sibling adapters.
+
+**Chosen approach:** `Scoped`, per spec FR-3.
+
+**Rationale:** Verified `CatalogModule.cs` line 92 registers `ICatalogResilienceService` as `Singleton`, while lines 61–62 register the two DataQuality-facing adapters as `Scoped`. The adapter itself is stateless (pure delegation), so a `Scoped` wrapper around a `Singleton` dependency is safe — ASP.NET Core allows a scoped service to depend on a singleton (the reverse would be the captive-dependency hazard, not this direction). Matching sibling adapter lifetime keeps `CatalogModule.cs` predictable for future readers.
+
+#### Decision 3: The architecture-boundary check already exists — the spec's NFR-3/Open-Questions section is wrong and must be corrected
+
+**Options considered:** N/A — this is a factual correction, not a design choice.
+
+**Finding:** The spec states (NFR-3): *"This is a review-time check, not an automated build-time one (no architecture-test tooling for this is confirmed present in the repo as part of this change; see Open Questions)"* and lists **Open Questions: None**. This is incorrect. `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` is a reflection-based test suite that enforces exactly this rule for many module pairs, including a rule named **`"DataQuality -> Catalog"`** (line 546 of that file), driven by a `DataQualityCatalogAllowlist` set. That allowlist currently contains this exact entry:
+
+```csharp
+// ProductPairingDqtComparer reads eshop/erp catalog clients to compare product pairing,
+// wrapped in ICatalogResilienceService for transient-fault protection.
+"Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService",
+```
+
+alongside four other (deliberately out-of-scope, per the spec) entries for `IEshopStockClient`, `IErpStockClient`, `ErpStock`, `ProductType`, `EshopStock`. The allowlist comment block even states the intended long-term fix: *"Track follow-up: introduce DataQuality-owned IProductPairingQuery contract and Catalog-side adapter that surfaces eshop/erp product snapshots without leaking Catalog types."* — i.e., this spec is a partial, deliberately-scoped-down execution of an already-anticipated cleanup, not a novel idea.
+
+**Consequence for implementation:** After FR-1–FR-4 land, the `ICatalogResilienceService` allowlist line becomes a stale/dead entry — the test will keep passing either way (an unused allowlist entry doesn't fail anything), but every other allowlist block in this file carries the explicit convention *"Entries should be removed as the underlying violations are fixed."* Leaving it in place would (a) contradict that convention, (b) misdescribe `ProductPairingDqtComparer`'s actual dependencies to the next reader, and (c) is a one-line diff that costs nothing. This is not optional cleanup — it's completing the fix by the codebase's own stated rule for this file. See Specification Amendments.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new directories. Matches the existing pattern exactly:
+
+```
+backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/
+  └── IDqtResilienceService.cs                      # NEW — consumer-owned contract
+
+backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/
+  ├── DataQualityStockOperationQueryAdapter.cs        # existing precedent (read-only)
+  ├── DataQualityStockTakingQueryAdapter.cs           # existing precedent (read-only)
+  └── DataQualityResilienceAdapter.cs                 # NEW — provider adapter
+
+backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs  # +1 registration line
+backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs  # type swap only
+
+backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs           # mock type swap
+backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs                             # remove 1 allowlist line (see amendment)
+```
+
+### Interfaces and Contracts
+
+Exactly as spec FR-1/FR-2/FR-4 define them — verified the shape matches `ICatalogResilienceService.ExecuteWithResilienceAsync<T>` byte-for-byte, so `ProductPairingDqtComparer`'s call sites require zero body changes:
+
+```csharp
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public interface IDqtResilienceService
+{
+    Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class DataQualityResilienceAdapter : IDqtResilienceService
+{
+    private readonly ICatalogResilienceService _resilienceService;
+    public DataQualityResilienceAdapter(ICatalogResilienceService resilienceService) => _resilienceService = resilienceService;
+    public Task<T> ExecuteWithResilienceAsync<T>(Func<CancellationToken, Task<T>> operation, string operationName, CancellationToken cancellationToken = default) =>
+        _resilienceService.ExecuteWithResilienceAsync(operation, operationName, cancellationToken);
+}
+```
+
+Registration in `CatalogModule.AddCatalogModule()`, grouped with the other two DataQuality-facing adapters (lines 60–62) for discoverability, same comment style:
+
+```csharp
+// DataQuality owns the resilience contract; Catalog (this module) provides the adapter implementation.
+services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
+```
+
+### Data Flow
+
+No change to runtime data flow or shape. `ProductPairingDqtComparer.CompareAsync` still calls `ExecuteWithResilienceAsync` twice (eshop list, ERP list); only the static type of `_resilienceService` and the DI resolution path change. `operationName` strings (`"ProductPairingDqtComparer.EshopList"`, `"ProductPairingDqtComparer.ErpList"`) are passed through unchanged end-to-end, preserving Polly's operation-key-based logging/circuit-breaker correlation.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Stale `ModuleBoundariesTests.cs` allowlist entry left in place, contradicting the file's own "remove entries when fixed" convention and misdescribing the comparer's real dependencies | Low (won't break the build, but is dead/misleading documentation) | Remove the `ICatalogResilienceService` line from `DataQualityCatalogAllowlist` as part of this change (see amendment below); keep the other 4 entries (`IEshopStockClient`/`IErpStockClient`/`ErpStock`/`ProductType`/`EshopStock`) since they remain genuinely out of scope |
+| `DataQualityResilienceAdapter` accidentally registered with a lifetime that creates a captive-dependency warning | Low | Use `Scoped` (matches sibling adapters); a `Scoped` service depending on a `Singleton` is safe in the depended-on direction — verified `ICatalogResilienceService` is `Singleton` at `CatalogModule.cs:92` |
+| Future contributor assumes `DataQualityResilienceAdapter` gives DataQuality its own tunable pipeline and starts changing its internals | Low | Adapter is `internal sealed` one-line delegation with no logic of its own — matches the two existing sibling adapters; any real tuning work is explicitly out of scope per spec |
+| Broader `IEshopStockClient`/`IErpStockClient` Domain-layer coupling (5 remaining allowlist entries) is left unresolved, and a future arch-review may re-flag it as if this fix ignored it | Low | Already tracked by the pre-existing allowlist comment in `ModuleBoundariesTests.cs` ("introduce DataQuality-owned IProductPairingQuery contract..."); no action needed now, just don't let this fix's PR description claim the boundary is "fully" clean |
+
+## Specification Amendments
+
+1. **Correct NFR-3 / Open Questions.** The spec's claim that no automated architecture-boundary test exists is false. `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` already enforces a `"DataQuality -> Catalog"` rule via reflection (`Consumer_types_should_not_reference_provider_owned_namespaces`), gated by an allowlist (`DataQualityCatalogAllowlist`). Update NFR-3 to reference this test by name instead of denying its existence.
+
+2. **Add FR-5b: Update the architecture test allowlist.** In `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`, remove this line from `DataQualityCatalogAllowlist` (around line 157):
+   ```csharp
+   "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService",
+   ```
+   Leave the other four entries in that set untouched (`IEshopStockClient`, `IErpStockClient`, `ErpStock`, `ProductType`, `EshopStock` — all confirmed out of scope). Also trim the block comment above the set (lines 145–148) so it no longer implies `ICatalogResilienceService` is still a live violation — e.g. drop the "wrapped in ICatalogResilienceService for transient-fault protection" clause from the `EshopStock`/`ErpStock` entries' explanatory comment (lines 151–152), since that no longer describes the remaining entries accurately.
+   **Acceptance criterion to add:** `dotnet test --filter "FullyQualifiedName~ModuleBoundariesTests"` passes, and the allowlist no longer contains any entry referencing `Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService`.
+
+3. No change to the spec's chosen approach (Option A), file layout, or interface shape — all verified correct against the codebase.
+
+## Prerequisites
+
+None. No migrations, no config, no infrastructure changes. Both `CatalogModule.AddCatalogModule()` and `DataQualityModule.AddDataQualityModule()` are already registered together in `Anela.Heblo.Application/ApplicationModule.cs` (lines 83 and 113) at every current hosting entry point — verified by grep, no `Program.cs` change needed.

--- a/artifacts/feat-3454/brief.md
+++ b/artifacts/feat-3454/brief.md
@@ -1,0 +1,44 @@
+## Module
+DataQuality
+
+## Finding
+`ProductPairingDqtComparer` (`backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs`, lines 1 and 13/19–21) directly imports and injects `ICatalogResilienceService` from the **Catalog** module's Application layer:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure; // line 1
+
+private readonly ICatalogResilienceService _resilienceService; // line 13
+
+public ProductPairingDqtComparer(
+    IEshopStockClient eshopStockClient,
+    IErpStockClient erpStockClient,
+    ICatalogResilienceService resilienceService, // line 21
+    ILogger logger)
+```
+
+`ICatalogResilienceService` is defined in `Anela.Heblo.Application.Features.Catalog.Infrastructure.CatalogResilienceService` — it is a Catalog-module-internal Application-layer service with a Polly circuit-breaker pipeline tuned for Catalog's external HTTP calls. DataQuality's Application layer is directly coupling to Catalog's Application-layer internals.
+
+This is the same boundary violation pattern as #3433 (`FinancialOverview: StockValueService directly imports Catalog-owned ERP interfaces`) — the Catalog module is the repeated source of the leak.
+
+## Why it matters
+Per `development_guidelines.md`:
+> **Direct access to another module's entities** — Violates boundaries, tight coupling
+
+And the cross-module adapter rule:
+> **Consumer (A) defines the contract.** Module A declares an interface in its own `Contracts/` folder.
+
+A DataQuality comparer should not import infrastructure internals from Catalog. If Catalog's resilience policy changes (timeout, retry count, circuit-breaker threshold), DataQuality's behavior changes without any change to DataQuality code — invisible coupling. It also prevents DataQuality from configuring resilience appropriate to its own workload.
+
+## Suggested fix
+Two options, both consistent with the documented pattern:
+
+**Option A — DataQuality owns a resilience contract:**
+Define `IDqtResilienceService` in `DataQuality/Contracts/` (mirroring `ICatalogResilienceService`'s interface shape), move the implementation to Catalog's infrastructure as `CatalogDqtResilienceAdapter`, and register in `CatalogModule.cs`. DataQuality then depends only on its own contract.
+
+**Option B — Push resilience into the adapter:**
+Move the `_resilienceService.ExecuteWithResilienceAsync(...)` calls from `ProductPairingDqtComparer` into the Catalog-side adapters that implement `IEshopStockClient` and `IErpStockClient`. DataQuality calls the interface; the adapter handles resilience internally. `ProductPairingDqtComparer` drops the `ICatalogResilienceService` dependency entirely.
+
+Option B is simpler and removes the dependency completely.
+
+---
+_Filed by daily arch-review routine on 2026-07-01._

--- a/artifacts/feat-3454/code-review.r1.md
+++ b/artifacts/feat-3454/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3454/design.r1.md
+++ b/artifacts/feat-3454/design.r1.md
@@ -1,0 +1,102 @@
+# Design: Remove DataQuality → Catalog Application-layer boundary violation in ProductPairingDqtComparer
+
+## Component Design
+
+This is a pure dependency-direction refactor (Option A: consumer-owned contract + provider-owned adapter), structurally identical to the two existing precedents in this module pair (`IStockOperationQuery`/`DataQualityStockOperationQueryAdapter` and `IStockTakingQuery`/`DataQualityStockTakingQueryAdapter`). No new runtime behavior is introduced anywhere in this design — every component below is either a pass-through interface, a one-line delegating adapter, or a type substitution at an existing call site.
+
+```
+DataQuality module (consumer)                    Catalog module (provider)
+──────────────────────────────                   ──────────────────────────
+ProductPairingDqtComparer                          CatalogModule.AddCatalogModule()
+  ├─ IEshopStockClient        (unchanged,             registers:
+  │   Domain.Catalog.Stock,                           IDqtResilienceService →
+  │   out of scope)                                     DataQualityResilienceAdapter (Scoped)
+  ├─ IErpStockClient          (unchanged,
+  │   Domain.Catalog.Stock,                          DataQualityResilienceAdapter
+  │   out of scope)                                    (Catalog.Infrastructure, internal sealed)
+  └─ IDqtResilienceService  ──────depends on──────►      └─ ICatalogResilienceService (injected)
+      (DataQuality.Contracts,                               └─ CatalogResilienceService (Singleton,
+       NEW)                                                      Polly pipeline, unchanged)
+```
+
+### `IDqtResilienceService` (new, DataQuality-owned)
+- **Location:** `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs`
+- **Namespace:** `Anela.Heblo.Application.Features.DataQuality.Contracts`
+- **Responsibility:** Defines the resilience-execution contract that `ProductPairingDqtComparer` depends on, owned by the consumer module (DataQuality) per the project's cross-module boundary rule. Shape is byte-for-byte identical to `ICatalogResilienceService.ExecuteWithResilienceAsync<T>`, so no call-site logic changes are required.
+- **Visibility:** `public` (consumed across module boundary by Catalog's adapter implementation).
+
+### `DataQualityResilienceAdapter` (new, Catalog-owned)
+- **Location:** `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs`
+- **Namespace:** `Anela.Heblo.Application.Features.Catalog.Infrastructure`
+- **Responsibility:** Implements `IDqtResilienceService` by delegating 1:1 to the existing `ICatalogResilienceService` singleton (`CatalogResilienceService`). Introduces zero new logic — pure pass-through of `operation`, `operationName`, and `cancellationToken`, and the return value.
+- **Visibility:** `internal sealed`, matching the two sibling adapters (`DataQualityStockOperationQueryAdapter`, `DataQualityStockTakingQueryAdapter`) in the same folder.
+- **Dependency:** Constructor-injects `ICatalogResilienceService`.
+
+### `ProductPairingDqtComparer` (modified, DataQuality-owned)
+- **Location:** `backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs`
+- **Change:** Constructor parameter/field type changes from `ICatalogResilienceService` to `IDqtResilienceService`; `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` is removed and replaced with `using Anela.Heblo.Application.Features.DataQuality.Contracts;`. `IEshopStockClient`/`IErpStockClient` dependencies (Domain-layer, out of scope) are unchanged. `CompareAsync` method body, mismatch-detection logic, and exception propagation are unchanged.
+
+### DI Registration (Catalog-owned, `CatalogModule.cs`)
+- Registered in `CatalogModule.AddCatalogModule()`, grouped with the existing `IStockOperationQuery`/`IStockTakingQuery` DataQuality-facing adapter registrations, with an explanatory comment matching the existing style.
+- **Lifetime:** `Scoped`, matching sibling adapters — even though the underlying `ICatalogResilienceService` is `Singleton`. A scoped adapter depending on a singleton is safe (not a captive-dependency hazard); the adapter itself is stateless.
+- `DataQualityModule.cs` is not modified — registration ownership stays with the provider (Catalog), per the documented "provider registers" rule.
+
+### Test updates
+- `ProductPairingDqtComparerTests.cs`: mock type swap from `Mock<ICatalogResilienceService>` to `Mock<IDqtResilienceService>`; all 5 existing test assertions unchanged.
+- `ModuleBoundariesTests.cs`: remove the now-stale `ProductPairingDqtComparer -> ICatalogResilienceService` entry from `DataQualityCatalogAllowlist` (the architecture test enforcing the `"DataQuality -> Catalog"` boundary rule already exists in this file and will otherwise carry a dead allowlist entry that misdescribes the comparer's post-fix dependencies). The four remaining out-of-scope entries (`IEshopStockClient`, `IErpStockClient`, `ErpStock`, `ProductType`, `EshopStock`) are left untouched.
+- Optional: adapter-level unit test for `DataQualityResilienceAdapter` verifying pure pass-through delegation (operation, operationName, cancellationToken, and return value all forwarded unchanged).
+
+## Data Schemas
+
+No data model, persistence, HTTP, or MediatR contract changes. This refactor is confined to the Application layer's internal DI graph and namespace boundaries.
+
+**New contract:**
+```csharp
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public interface IDqtResilienceService
+{
+    Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**New adapter:**
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class DataQualityResilienceAdapter : IDqtResilienceService
+{
+    private readonly ICatalogResilienceService _resilienceService;
+
+    public DataQualityResilienceAdapter(ICatalogResilienceService resilienceService)
+    {
+        _resilienceService = resilienceService;
+    }
+
+    public Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default) =>
+        _resilienceService.ExecuteWithResilienceAsync(operation, operationName, cancellationToken);
+}
+```
+
+**DI registration** (in `CatalogModule.AddCatalogModule()`):
+```csharp
+// DataQuality owns the resilience contract; Catalog (this module) provides the adapter implementation.
+services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
+```
+
+**Modified consumer constructor:**
+```csharp
+ProductPairingDqtComparer(
+    IEshopStockClient eshopStockClient,
+    IErpStockClient erpStockClient,
+    IDqtResilienceService resilienceService,   // was: ICatalogResilienceService
+    ILogger<ProductPairingDqtComparer> logger)
+```
+
+`operationName` string values (`"ProductPairingDqtComparer.EshopList"`, `"ProductPairingDqtComparer.ErpList"`) pass through unchanged end-to-end, preserving Polly operation-key-based logging/circuit-breaker correlation. Retry count (3), circuit-breaker thresholds (50% failure ratio, min throughput 3, 1-minute sampling, 30s break), and 30s timeout in `CatalogResilienceService` are untouched.

--- a/artifacts/feat-3454/impl/create-dqt-resilience-contract-and-adapter.r1.md
+++ b/artifacts/feat-3454/impl/create-dqt-resilience-contract-and-adapter.r1.md
@@ -1,0 +1,38 @@
+# Implementation: create-dqt-resilience-contract-and-adapter
+
+## What was implemented
+Created the new DataQuality-owned `IDqtResilienceService` contract (identical method shape to `ICatalogResilienceService`), a Catalog-owned `DataQualityResilienceAdapter` that delegates 1:1 to the existing `ICatalogResilienceService` singleton, registered the adapter in `CatalogModule.AddCatalogModule()` as `Scoped`, and added a delegation unit test for the adapter mirroring the two existing sibling adapter tests in the same test folder.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs` — new DataQuality-owned contract with `ExecuteWithResilienceAsync<T>`
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs` — new internal sealed adapter implementing `IDqtResilienceService` by delegating to `ICatalogResilienceService`
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — added `services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();` alongside the existing `IStockOperationQuery`/`IStockTakingQuery` adapter registrations
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs` — new test file with 2 tests
+
+## Tests
+- `DataQualityResilienceAdapterTests.ExecuteWithResilienceAsync_DelegatesToUnderlyingService_WithSameArgumentsAndReturnValue` — verifies the adapter forwards operation, operationName, and cancellation token unchanged and returns the underlying result
+- `DataQualityResilienceAdapterTests.ExecuteWithResilienceAsync_PropagatesException_WhenUnderlyingServiceThrows` — verifies exceptions from the underlying service propagate unchanged
+
+Both tests pass: `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~DataQualityResilienceAdapterTests"` → 2/2 passed.
+
+## How to verify
+```bash
+dotnet build Anela.Heblo.sln
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~DataQualityResilienceAdapterTests"
+```
+Build succeeds (0 errors); both adapter tests pass. `ProductPairingDqtComparer` still uses `ICatalogResilienceService` at this point (unchanged) — that switch is task 2.
+
+## Notes
+No deviations from the task context. `CatalogModule.cs` already had the `using Anela.Heblo.Application.Features.DataQuality.Contracts;` directive from the sibling adapters, so no new `using` was needed, as anticipated in the task context.
+
+## PR Summary
+Added a `IDqtResilienceService` contract owned by the DataQuality module and a `DataQualityResilienceAdapter` owned by the Catalog module that delegates to the existing `ICatalogResilienceService` singleton, registered in Catalog's DI module. This is the first step of removing `ProductPairingDqtComparer`'s direct dependency on Catalog's Application-layer resilience service — the comparer itself is switched over in a follow-up task.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs` — new contract
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs` — new adapter
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — DI registration
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs` — new tests
+
+## Status
+DONE

--- a/artifacts/feat-3454/impl/switch-product-pairing-comparer-to-dqt-resilience-contract.r1.md
+++ b/artifacts/feat-3454/impl/switch-product-pairing-comparer-to-dqt-resilience-contract.r1.md
@@ -1,0 +1,30 @@
+# Implementation: switch-product-pairing-comparer-to-dqt-resilience-contract
+
+## What was implemented
+Switched `ProductPairingDqtComparer`'s constructor dependency from the Catalog-owned `ICatalogResilienceService` to the new DataQuality-owned `IDqtResilienceService`, and updated the existing unit test's mock type to match. This is a pure type substitution — no method body or test assertion changes, since `IDqtResilienceService.ExecuteWithResilienceAsync<T>` has an identical signature to `ICatalogResilienceService.ExecuteWithResilienceAsync<T>`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs` — replaced the `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` import with `using Anela.Heblo.Application.Features.DataQuality.Contracts;`, and changed the `_resilienceService` field type and constructor parameter type from `ICatalogResilienceService` to `IDqtResilienceService`. `CompareAsync` and `IsSellable` were left unchanged.
+- `backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs` — replaced the same `using` directive and changed `_resilienceMock` from `Mock<ICatalogResilienceService>` to `Mock<IDqtResilienceService>`. Constructor call in `CreateSut()`, all 5 test methods, and all assertions were left unchanged.
+
+## Tests
+- `backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs` — covers: `CompareAsync_ReturnsEmpty_WhenAllProductsPaired`, `CompareAsync_ReturnsMissingInErp_WhenShoptetProductNotInErp`, `CompareAsync_ReturnsMissingInErpAndPairCodeUnresolved_WhenPairCodeNotInErp`, `CompareAsync_ReturnsMissingInShoptet_OnlyForSellableErpProducts`, `CompareAsync_WrapsBothListCalls_WithResilience`. All 5 passed after the change.
+
+## How to verify
+1. `cd /home/user/worktrees/feature-3454-Arch-Review-Dataquality-Productpairingdqtcomparer`
+2. `dotnet build Anela.Heblo.sln` — builds with 0 errors (253 pre-existing nullable-reference warnings unrelated to this change; no warning about an unused Catalog.Infrastructure using in either modified file).
+3. `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~ProductPairingDqtComparerTests" --no-build` — result: Passed! Failed: 0, Passed: 5, Skipped: 0, Total: 5.
+4. `grep -rn "using Anela.Heblo.Application.Features.Catalog" backend/src/Anela.Heblo.Application/Features/DataQuality/Services/` — returns no matches, confirming the DataQuality Services folder no longer references the Catalog Application-layer namespace.
+
+## Notes
+No deviations from the task spec. All 8 steps executed exactly as specified. `IEshopStockClient`/`IErpStockClient` remain Domain-layer types and are unaffected by this change, consistent with the spec's boundary claim.
+
+## PR Summary
+This change completes the migration of `ProductPairingDqtComparer` off the Catalog-owned `ICatalogResilienceService` onto the new DataQuality-owned `IDqtResilienceService` contract (introduced in a prior task in this series). Since the two interfaces share an identical `ExecuteWithResilienceAsync<T>` signature, this is a mechanical type substitution: the `using` directive for `Anela.Heblo.Application.Features.Catalog.Infrastructure` was replaced with one for `Anela.Heblo.Application.Features.DataQuality.Contracts` in both the comparer and its test, the field/constructor parameter/mock type were retyped to `IDqtResilienceService`, and no other logic changed. The build is clean (0 errors) and all 5 existing unit tests pass unmodified. A grep confirms the DataQuality `Services/` folder no longer imports the Catalog Application-layer namespace, reinforcing the module boundary this refactor establishes.
+
+### Changes
+- `ProductPairingDqtComparer.cs`: swapped resilience service dependency type.
+- `ProductPairingDqtComparerTests.cs`: swapped mock type to match.
+
+## Status
+DONE

--- a/artifacts/feat-3454/impl/update-architecture-boundary-allowlist.r1.md
+++ b/artifacts/feat-3454/impl/update-architecture-boundary-allowlist.r1.md
@@ -1,0 +1,29 @@
+# Implementation: update-architecture-boundary-allowlist
+
+## What was implemented
+Removed the now-stale `ProductPairingDqtComparer -> ICatalogResilienceService` entry from the `DataQualityCatalogAllowlist` in the reflection-based architecture-boundary test, and trimmed the explanatory comment above the first four remaining entries so it no longer references the resilience wrapping that was removed in the prior task (switch-product-pairing-comparer-to-dqt-resilience-contract). The four genuinely out-of-scope entries (`IEshopStockClient`, `IErpStockClient`, `ErpStock`, `ProductType`) and the `EshopStock` compiler-generated-state-machine entry were left untouched, as was the block comment documenting the `IProductPairingQuery` follow-up.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — removed the `ICatalogResilienceService` line from `DataQualityCatalogAllowlist` (was lines 151-157, now lines 149-160) and shortened the comment above the first entry from "reads eshop/erp catalog clients to compare product pairing, wrapped in ICatalogResilienceService for transient-fault protection." to "reads eshop/erp catalog clients to compare product pairing."
+
+## Tests
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — the reflection-based `"DataQuality -> Catalog"` rule (and 26 other architecture rules in the same file) verified: 27/27 passed, confirming `ProductPairingDqtComparer` no longer references `ICatalogResilienceService` or any other non-allowlisted Catalog Application-layer type.
+
+## How to verify
+1. `cd backend` (or repo root) and run `dotnet build Anela.Heblo.sln` — build succeeds, 0 errors.
+2. `dotnet test Anela.Heblo.sln --no-build --filter "FullyQualifiedName~ModuleBoundariesTests"` — 27 passed, 0 failed.
+3. `grep -n "ICatalogResilienceService" backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — returns no matches.
+4. `dotnet format Anela.Heblo.sln --verify-no-changes` — exits 0, no formatting issues.
+
+## Notes
+Ran the full solution test suite (`dotnet test Anela.Heblo.sln --no-build`) as instructed. It reported failures in `Anela.Heblo.Tests`, `Anela.Heblo.Adapters.Flexi.Tests`, and `Anela.Heblo.Adapters.Shoptet.Tests`, but every failure is a pre-existing sandbox/environment limitation unrelated to this change:
+- Tests using Testcontainers (Postgres) fail with "Docker is either not running or misconfigured" — no Docker daemon available in this sandbox.
+- Flexi/Shoptet integration tests fail because they require a live connection to external Flexi/Shoptet APIs, which aren't reachable from this sandbox.
+Grepped the failure list for `ProductPairing|ModuleBoundaries|DataQuality` — zero matches, confirming none of the failures relate to this change or the architecture-boundary rules. The scoped `ModuleBoundariesTests` filter run (step 3) passed cleanly with 27/27, which is the authoritative verification for this task.
+An unrelated pre-existing modification to `artifacts/feat-3454/state.json` was present in the worktree before this task started; it was left unstaged/uncommitted per the "surgical changes" rule, since the task only specifies committing `ModuleBoundariesTests.cs`.
+
+## PR Summary
+This change is a small cleanup that removes a stale allowlist entry from the `ModuleBoundariesTests` architecture-boundary suite. The `DataQuality -> Catalog` allowlist previously permitted `ProductPairingDqtComparer` to reference `Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService`, a dependency introduced when the comparer used a resilience wrapper around catalog clients. A prior task in this same feature branch replaced that Catalog-owned resilience contract with a DataQuality-owned equivalent, so `ProductPairingDqtComparer` no longer touches `ICatalogResilienceService` at all — leaving the allowlist entry in place would have been misleading and contrary to the file's convention of removing entries once the underlying violation is fixed. The explanatory comment above the entry was also trimmed to drop the now-inaccurate reference to resilience wrapping. Verified via the full `ModuleBoundariesTests` suite (27/27 passing), a grep confirming zero remaining references to `ICatalogResilienceService` in the file, a clean `dotnet format --verify-no-changes`, and a full-solution test run (failures observed there are pre-existing sandbox limitations — no Docker daemon and no live Flexi/Shoptet API access — unrelated to this change).
+
+## Status
+DONE

--- a/artifacts/feat-3454/review/create-dqt-resilience-contract-and-adapter.r1.md
+++ b/artifacts/feat-3454/review/create-dqt-resilience-contract-and-adapter.r1.md
@@ -1,0 +1,22 @@
+# Code Review: create-dqt-resilience-contract-and-adapter
+
+## Summary
+The implementation creates the `IDqtResilienceService` contract in `DataQuality.Contracts`, a `DataQualityResilienceAdapter` in `Catalog.Infrastructure` that delegates to the existing `ICatalogResilienceService`, registers the adapter in `CatalogModule`, and adds two delegation tests. All four files match the exact content specified in the task spec verbatim. Build and the new tests were independently verified to pass.
+
+## Review Result: PASS
+
+### task: create-dqt-resilience-contract-and-adapter
+**Status:** PASS
+
+## Verification performed
+- Read all four files directly (not just the implementation summary) and diffed them against the exact code blocks in the task spec — byte-for-byte match for `IDqtResilienceService.cs`, `DataQualityResilienceAdapter.cs`, `DataQualityResilienceAdapterTests.cs`, and the `CatalogModule.cs` edit (new `services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();` line with matching comment style, placed immediately after the existing `IStockOperationQuery`/`IStockTakingQuery` registrations as instructed).
+- Confirmed `CatalogModule.cs` already had the `using Anela.Heblo.Application.Features.DataQuality.Contracts;` directive (line 21), so no new using was needed, as the task predicted.
+- Ran `dotnet build Anela.Heblo.sln` from the worktree root: succeeded, 0 errors (253 pre-existing nullable warnings unrelated to this change).
+- Ran `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~DataQualityResilienceAdapterTests" --no-build`: `Passed! - Failed: 0, Passed: 2, Skipped: 0, Total: 2` in `Anela.Heblo.Tests.dll`. (An earlier, non-`--no-build` invocation of the same command hung for ~9 minutes with near-zero CPU usage in this sandboxed environment — killed and re-run with `--no-build`, which completed in 18ms. This looks like an environment/VSTest-discovery quirk unrelated to the code under review, not a defect.)
+- Confirmed via `git show HEAD --stat` that the commit contains exactly the four expected files with additive-only diffs (2 lines added to `CatalogModule.cs`, no deletions), consistent with the "surgical change" expectation.
+
+## Docs to Update
+None — this is an internal contract/adapter addition with no user-facing or architectural-doc impact beyond what the task itself covers (a later task in this feature updates the architecture boundary allowlist).
+
+## Overall Notes
+Straightforward, spec-compliant, additive change. The adapter is a pure 1:1 delegation with no added behavior, correctly scoped as `internal sealed`, and the DI registration follows the established sibling-adapter pattern in the same module. No functional risk observed. `ProductPairingDqtComparer` is confirmed untouched, matching the task's stated scope (switch-over is a separate follow-up task).

--- a/artifacts/feat-3454/review/switch-product-pairing-comparer-to-dqt-resilience-contract.r1.md
+++ b/artifacts/feat-3454/review/switch-product-pairing-comparer-to-dqt-resilience-contract.r1.md
@@ -1,0 +1,25 @@
+# Code Review: switch-product-pairing-comparer-to-dqt-resilience-contract
+
+## Summary
+The implementation is a pure type substitution exactly as specified: `ProductPairingDqtComparer` and its unit test now depend on the DataQuality-owned `IDqtResilienceService` instead of the Catalog-owned `ICatalogResilienceService`. The diff matches the task spec line-for-line, the build is clean, all 5 targeted unit tests pass, and the module-boundary grep returns no matches.
+
+## Review Result: PASS
+
+### task: switch-product-pairing-comparer-to-dqt-resilience-contract
+**Status:** PASS
+
+## Verification performed
+- Read task spec and implementation summary.
+- Read `ProductPairingDqtComparer.cs` and `ProductPairingDqtComparerTests.cs` in full — confirmed only the `using` directive, field type, constructor parameter type, and mock type changed; `CompareAsync`, `IsSellable`, `CreateSut()`, all 5 test methods, and all assertions are byte-for-byte unchanged.
+- `git show HEAD` (commit `a5ed537`) confirms the diff is exactly the two hunks specified in steps 1–4 of the task, nothing more.
+- Confirmed `IDqtResilienceService` (`backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs`) exposes `Task<T> ExecuteWithResilienceAsync<T>(Func<CancellationToken, Task<T>> operation, string operationName, CancellationToken cancellationToken = default)` — identical signature to `ICatalogResilienceService`, validating the "pure type substitution" claim and explaining why no test-body changes were needed.
+- Confirmed DI registration exists (`CatalogModule.cs:64`: `services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>()`), so the new constructor dependency resolves at runtime.
+- `dotnet build Anela.Heblo.sln` — 0 errors, 253 warnings (all pre-existing nullable-reference warnings in unrelated files; no unused-`using` warning in either modified file).
+- `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~ProductPairingDqtComparerTests" --no-build` — Passed: 5, Failed: 0, Skipped: 0.
+- `grep -rn "using Anela.Heblo.Application.Features.Catalog" backend/src/Anela.Heblo.Application/Features/DataQuality/Services/` — no matches (exit code 1 / empty output), confirming the module-boundary claim.
+
+## Docs to Update
+None.
+
+## Overall Notes
+No deviations from spec. No architecture violations. Implementation summary is accurate and matches the verified code/build/test evidence.

--- a/artifacts/feat-3454/review/update-architecture-boundary-allowlist.r1.md
+++ b/artifacts/feat-3454/review/update-architecture-boundary-allowlist.r1.md
@@ -1,0 +1,38 @@
+# Code Review: update-architecture-boundary-allowlist
+
+## Summary
+The implementation exactly matches the task spec: the stale `ProductPairingDqtComparer -> ICatalogResilienceService` allowlist entry was removed from `DataQualityCatalogAllowlist` in `ModuleBoundariesTests.cs`, and the explanatory comment above the first four entries was trimmed to drop the now-inaccurate reference to resilience wrapping. The four genuinely out-of-scope entries and the block comment documenting the `IProductPairingQuery` follow-up were left untouched, as instructed. All verification steps were independently re-run and confirmed.
+
+## Review Result: PASS
+
+### task: update-architecture-boundary-allowlist
+**Status:** PASS
+
+Verification performed independently:
+- `git show HEAD` (commit `968f7e1`): diff is exactly the spec's prescribed change — one line removed (`ICatalogResilienceService` entry) and the preceding comment trimmed. No unrelated changes.
+- `dotnet build Anela.Heblo.sln`: succeeded, 0 errors (253 pre-existing warnings, unrelated to this change).
+- `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~ModuleBoundariesTests" --no-build`: 27/27 passed, 0 failed.
+- `grep -n "ICatalogResilienceService" backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`: no matches (confirmed).
+- `dotnet format Anela.Heblo.sln --verify-no-changes`: clean, no output (no formatting issues).
+- Ran the full solution test suite (`dotnet test Anela.Heblo.sln --no-build`) directly rather than only trusting the developer's report. Results: `Anela.Heblo.Tests.dll` 64 failed/5391 passed, `Anela.Heblo.Adapters.Flexi.Tests.dll` 72 failed/247 passed, `Anela.Heblo.Adapters.Shoptet.Tests.dll` 13 failed/113 passed; all other projects (HomeAssistant, Plaud, OpenMeteo) passed cleanly. Inspected the failures directly:
+  - `Anela.Heblo.Tests` failures are all `System.ArgumentException: Docker is either not running or misconfigured` from `Testcontainers.PostgreSql` (e.g. `KnowledgeBaseRepositoryIntegrationTests`) — no Docker daemon in this sandbox, pre-existing/unrelated.
+  - `Anela.Heblo.Adapters.Flexi.Tests` failures are in `Anela.Heblo.Adapters.Flexi.Tests.Integration.FlexiCatalogSalesClientIntegrationTests`, also failing with the same Testcontainers/Docker error.
+  - `Anela.Heblo.Adapters.Shoptet.Tests` failures are in the `Integration` namespace (e.g. `PickingListIntegrationTests`), which require a live Shoptet connection unavailable in this sandbox.
+  - Grepped the full test-run log for `ProductPairing|ModuleBoundaries|DataQuality` — zero matches among any `[FAIL]` lines. None of the 149 failures relate to this change or any of the 3 tasks in this feature.
+- This confirms the developer's r1 report's claim about pre-existing/environment-only failures is accurate, not an unverified assumption.
+
+## End-to-end feature verification (all 3 tasks)
+Confirmed the original issue — `ProductPairingDqtComparer` (DataQuality Application layer) importing Catalog's Application-layer `ICatalogResilienceService` — is now fully resolved:
+- `a922cce` — Added DataQuality-owned `IDqtResilienceService` contract plus a Catalog-side adapter (`DataQualityResilienceAdapter`) implementing it, keeping the Catalog dependency direction correct (Catalog implements DataQuality's contract, not the reverse).
+- `a5ed537` — Switched `ProductPairingDqtComparer` to consume `IDqtResilienceService` instead of `ICatalogResilienceService`.
+- `968f7e1` (this task) — Removed the now-stale allowlist entry that had permitted the old dependency.
+- `grep -rn "ICatalogResilienceService" backend/src/Anela.Heblo.Application/Features/DataQuality/` returns no matches — confirms zero remaining references to the Catalog-owned resilience service anywhere in the DataQuality Application layer.
+- `grep -n "IDqtResilienceService\|ICatalogResilienceService" backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs` shows the comparer now depends only on `IDqtResilienceService`.
+
+The feature is complete and internally consistent across all three commits.
+
+## Docs to Update
+None.
+
+## Overall Notes
+No issues found. The change is minimal, surgical, and precisely matches the task spec's prescribed diff. The developer's claim about pre-existing sandbox-only test failures (no Docker daemon, no live Flexi/Shoptet API access) was independently verified by inspecting failure stack traces and namespaces, not just taken on faith — confirmed accurate.

--- a/artifacts/feat-3454/spec.r1.md
+++ b/artifacts/feat-3454/spec.r1.md
@@ -1,0 +1,186 @@
+# Specification: Remove DataQuality → Catalog Application-layer boundary violation in ProductPairingDqtComparer
+
+## Summary
+`ProductPairingDqtComparer` (DataQuality module) directly depends on `ICatalogResilienceService`, an Application-layer internal service owned by the Catalog module. This violates the project's documented module-boundary rule that cross-module reads must go through a consumer-owned contract. This spec defines a DataQuality-owned resilience contract (`IDqtResilienceService`), implemented by a Catalog-side adapter, following the exact pattern already established in this codebase for `IStockOperationQuery`/`IStockTakingQuery`. No behavioral change to retry/circuit-breaker/timeout semantics is intended — this is a pure dependency-direction fix.
+
+## Background
+`docs/architecture/development_guidelines.md` establishes the cross-module communication rule: when module A needs read/behavioral access to something owned by module B, **A defines the contract in its own `Contracts/` folder**, and **B implements an adapter that delegates to its internal service**, registered by B in its own `{Module}.cs`. This pattern is already implemented twice in this exact module pair:
+
+- `Anela.Heblo.Application.Features.DataQuality.Contracts.IStockOperationQuery` → implemented by `Anela.Heblo.Application.Features.Catalog.Infrastructure.DataQualityStockOperationQueryAdapter`, registered in `CatalogModule.cs`.
+- `Anela.Heblo.Application.Features.DataQuality.Contracts.IStockTakingQuery` → implemented by `Anela.Heblo.Application.Features.Catalog.Infrastructure.DataQualityStockTakingQueryAdapter`, registered in `CatalogModule.cs`.
+
+`ProductPairingDqtComparer` (`backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs`) does not follow this pattern for its resilience needs: it imports `Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService` directly and injects the Catalog-owned singleton `CatalogResilienceService` to wrap its two calls to `IEshopStockClient.ListAsync` and `IErpStockClient.ListAsync`. This means:
+
+- DataQuality's resilience behavior (retry count, backoff, circuit-breaker thresholds, timeout) silently changes whenever Catalog tunes its own pipeline for Catalog's workload — with no corresponding DataQuality code change or review trigger.
+- DataQuality cannot tune resilience appropriate to its own (batch, non-interactive, tolerant-of-latency) comparison workload independently of Catalog's (interactive, cache-refresh) workload.
+- This is the same violation pattern previously filed as #3433 (`FinancialOverview.StockValueService` importing Catalog-owned ERP interfaces directly), flagged by the same daily arch-review routine, confirming Catalog is a repeat source of leaked Application-layer internals.
+
+This is a finding from the daily architecture-review routine (filed 2026-07-01), not a functional bug report — there is no reported production incident. The fix is scoped narrowly to `ProductPairingDqtComparer`'s dependency on `ICatalogResilienceService`; it does not address `ProductPairingDqtComparer`'s existing (unflagged) direct dependency on the Catalog-owned Domain interfaces `IEshopStockClient`/`IErpStockClient`, which live in `Anela.Heblo.Domain.Features.Catalog.Stock` and are already consumed directly by other modules (e.g. `FinancialOverview.StockValueService`) — that is a separate, out-of-scope architectural question.
+
+### Why Option A (contract + adapter) over Option B (push resilience into the shared client adapters)
+The brief proposes two options. Investigation of the actual code rules out Option B as the correct choice for this fix:
+
+- `IEshopStockClient` is implemented by `ShoptetStockClient` and `IErpStockClient` by `FlexiStockClient`, both in the **Adapters** layer (`Anela.Heblo.Adapters.ShoptetApi`, `Anela.Heblo.Adapters.Flexi`), not in Catalog's Application layer. They are shared infrastructure consumed by multiple modules — Catalog itself (`CatalogDataRefreshService`, `EshopStockDomainService`), FinancialOverview (`StockValueService`), and DataQuality (`ProductPairingDqtComparer`).
+- Neither adapter currently wraps its calls with `ICatalogResilienceService` or any retry/circuit-breaker logic; each has its own bespoke try/catch/log-and-rethrow. Moving `ExecuteWithResilienceAsync` calls into these adapters would apply Catalog's resilience policy to **every** consumer of these shared clients (including ones that today have no resilience wrapping at all, like `StockValueService` and `CatalogDataRefreshService`'s direct calls), which is a materially larger behavioral change than this finding calls for and conflicts with the "surgical changes" project rule.
+- Option A exactly mirrors the two adapters already in place for this same module pair (`DataQualityStockOperationQueryAdapter`, `DataQualityStockTakingQueryAdapter`), so it is the lowest-risk, most consistent fix and requires no code changes outside DataQuality's contract + Catalog's adapter registration.
+
+This spec therefore specifies **Option A**.
+
+## Functional Requirements
+
+### FR-1: DataQuality-owned resilience contract
+Define a new interface `IDqtResilienceService` in `Anela.Heblo.Application.Features.DataQuality.Contracts` (file: `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs`), mirroring the shape of `ICatalogResilienceService`:
+
+```csharp
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public interface IDqtResilienceService
+{
+    Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**Acceptance criteria:**
+- Interface lives under `DataQuality/Contracts/`, namespace `Anela.Heblo.Application.Features.DataQuality.Contracts`.
+- Method signature is identical in shape to `ICatalogResilienceService.ExecuteWithResilienceAsync<T>` (same generic execution wrapper pattern), so the call sites in `ProductPairingDqtComparer` require no logic changes beyond the injected type and `using` statement.
+- No DataQuality code references `Anela.Heblo.Application.Features.Catalog.*` anywhere after this change (verified by `grep -rn "Features.Catalog" backend/src/Anela.Heblo.Application/Features/DataQuality` returning no `using` of Catalog Application-layer namespaces from Application-layer DataQuality files under `Services/`, excluding the pre-existing, out-of-scope `IEshopStockClient`/`IErpStockClient` Domain-layer references).
+
+### FR-2: Catalog-side adapter implementing the contract
+Add an adapter class in Catalog's Infrastructure folder that implements `IDqtResilienceService` by delegating to the existing `CatalogResilienceService`/`ICatalogResilienceService` singleton, following the naming convention of the existing `DataQualityStockOperationQueryAdapter` / `DataQualityStockTakingQueryAdapter`.
+
+File: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs`
+
+```csharp
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class DataQualityResilienceAdapter : IDqtResilienceService
+{
+    private readonly ICatalogResilienceService _resilienceService;
+
+    public DataQualityResilienceAdapter(ICatalogResilienceService resilienceService)
+    {
+        _resilienceService = resilienceService;
+    }
+
+    public Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default) =>
+        _resilienceService.ExecuteWithResilienceAsync(operation, operationName, cancellationToken);
+}
+```
+
+**Acceptance criteria:**
+- Class is `internal sealed`, matching the visibility of the existing two adapters in the same folder.
+- Class lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure` (provider-owned), not in DataQuality.
+- Adapter delegates 1:1 to `ICatalogResilienceService` — no new resilience logic, no behavior change to retry count, backoff, circuit-breaker thresholds, or timeout for calls that currently go through this path.
+- `operationName` values passed through unchanged (`"ProductPairingDqtComparer.EshopList"`, `"ProductPairingDqtComparer.ErpList"`) so existing log correlation / circuit-breaker operation-key semantics are preserved.
+
+### FR-3: DI registration owned by the provider
+Register the adapter in `CatalogModule.cs` (provider-owned registration, per the documented rule that "the consumer module never touches this registration"), immediately adjacent to the existing `IStockOperationQuery`/`IStockTakingQuery` DataQuality-adapter registrations for discoverability, with a comment matching the existing style:
+
+```csharp
+// DataQuality owns the resilience contract; Catalog (this module) provides the adapter implementation.
+services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
+```
+
+Location: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`, near lines 60–62 (the existing `IStockOperationQuery`/`IStockTakingQuery` registrations) or near line 92 (`ICatalogResilienceService` registration) — implementer's choice, but must be grouped with one of these two existing blocks and carry an explanatory comment.
+
+**Acceptance criteria:**
+- Registration lifetime is `Scoped`, matching the other two DataQuality-facing adapters in `CatalogModule.cs` (not `Singleton`, even though the underlying `ICatalogResilienceService` is registered as `Singleton` — the adapter itself has no state, so lifetime mismatch is not a functional concern, but `Scoped` keeps it consistent with sibling adapters).
+- `DataQualityModule.cs` is **not** modified to register `IDqtResilienceService` — registration must live in `CatalogModule.cs` per the "provider registers" rule.
+- Application still resolves `IDqtResilienceService` successfully at startup (no DI resolution failure) whenever both `CatalogModule.AddCatalogModule()` and `DataQualityModule.AddDataQualityModule()` are registered together, which is the case in `Program.cs` for all current hosting entry points.
+
+### FR-4: Update `ProductPairingDqtComparer` to depend on the new contract
+Modify `backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs`:
+- Remove `using Anela.Heblo.Application.Features.Catalog.Infrastructure;`.
+- Add `using Anela.Heblo.Application.Features.DataQuality.Contracts;`.
+- Change the constructor parameter and backing field type from `ICatalogResilienceService` to `IDqtResilienceService` (field name `_resilienceService` may stay unchanged; only the type changes).
+- No change to `CompareAsync` method body — both `_resilienceService.ExecuteWithResilienceAsync(...)` call sites are unchanged since the interface shape is identical.
+
+**Acceptance criteria:**
+- `ProductPairingDqtComparer` no longer references any type from `Anela.Heblo.Application.Features.Catalog.*`.
+- `ProductPairingDqtComparer`'s public behavior (mismatch detection logic, `DriftComparisonResult` output, exception propagation on resilience exhaustion) is unchanged — this is a pure type-substitution refactor.
+
+### FR-5: Update existing unit tests
+Modify `backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs`:
+- Replace `Mock<ICatalogResilienceService> _resilienceMock` with `Mock<IDqtResilienceService> _resilienceMock`.
+- Replace the `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` with `using Anela.Heblo.Application.Features.DataQuality.Contracts;`.
+- All 5 existing test cases (`CompareAsync_ReturnsEmpty_WhenAllProductsPaired`, `CompareAsync_ReturnsMissingInErp_WhenShoptetProductNotInErp`, `CompareAsync_ReturnsMissingInErpAndPairCodeUnresolved_WhenPairCodeNotInErp`, `CompareAsync_ReturnsMissingInShoptet_OnlyForSellableErpProducts`, `CompareAsync_WrapsBothListCalls_WithResilience`) must continue to pass unmodified in their assertions — only the mocked type changes.
+
+**Acceptance criteria:**
+- All 5 existing tests pass after the type substitution with no assertion changes.
+- No test references `ICatalogResilienceService` anywhere in the DataQuality test namespace after this change.
+
+### FR-6 (recommended, optional): Adapter-level unit test
+Add a small test for `DataQualityResilienceAdapter` verifying it delegates to the injected `ICatalogResilienceService` unchanged (operation, operationName, cancellationToken all passed through, return value passed through). This is optional given the adapter is a one-line delegation, but is consistent with test coverage on the two sibling adapters if such tests exist.
+
+**Acceptance criteria:**
+- If added, test lives under `backend/test/Anela.Heblo.Tests/Features/Catalog/` (or wherever sibling adapter tests, if any, are located) and verifies pass-through delegation only — no new resilience behavior to test.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavioral equivalence
+This change must produce byte-for-byte identical runtime behavior for `ProductPairingDqtComparer`: same retry count (3), same exponential backoff with jitter, same circuit-breaker thresholds (50% failure ratio, min throughput 3, 1-minute sampling, 30s break duration), same 30s timeout, same log messages emitted by `CatalogResilienceService`, same `InvalidOperationException` wrapping on `BrokenCircuitException`. The adapter introduces zero new logic — it is a pure pass-through. (A future, separate change may choose to give DataQuality its own tuned resilience pipeline; that is explicitly out of scope here — see Out of Scope.)
+
+### NFR-2: Security
+No change. No new external dependencies, no new secrets, no change to authentication/authorization. Internal DI wiring change only.
+
+### NFR-3: Compile-time boundary enforcement
+After this change, no source file under `Anela.Heblo.Application/Features/DataQuality/` may contain a `using Anela.Heblo.Application.Features.Catalog.*;` directive that references Catalog's `Infrastructure`, `Services`, `Cache`, `CostProviders`, `Validators`, `UseCases`, or `DashboardTiles` namespaces (i.e. anything other than Catalog's own `Contracts/` folder, which does not apply here since DataQuality is the consumer, not Catalog). This is a review-time check, not an automated build-time one (no architecture-test tooling for this is confirmed present in the repo as part of this change; see Open Questions).
+
+## Data Model
+No data model changes. No new entities, no persistence changes, no DTOs. This is a pure DI/interface-boundary refactor within the Application layer.
+
+## API / Interface Design
+
+**New contract** (DataQuality-owned):
+```
+Anela.Heblo.Application.Features.DataQuality.Contracts.IDqtResilienceService
+    Task<T> ExecuteWithResilienceAsync<T>(Func<CancellationToken, Task<T>> operation, string operationName, CancellationToken cancellationToken = default)
+```
+
+**New adapter** (Catalog-owned, internal):
+```
+Anela.Heblo.Application.Features.Catalog.Infrastructure.DataQualityResilienceAdapter : IDqtResilienceService
+    (delegates to ICatalogResilienceService)
+```
+
+**DI registration** (in `CatalogModule.AddCatalogModule`):
+```
+services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
+```
+
+**Modified consumer**:
+```
+ProductPairingDqtComparer(
+    IEshopStockClient eshopStockClient,
+    IErpStockClient erpStockClient,
+    IDqtResilienceService resilienceService,   // was: ICatalogResilienceService
+    ILogger<ProductPairingDqtComparer> logger)
+```
+
+No HTTP endpoints, no MediatR requests/responses, and no UI are affected by this change.
+
+## Dependencies
+- Depends on the existing `ICatalogResilienceService`/`CatalogResilienceService` implementation in `Anela.Heblo.Application.Features.Catalog.Infrastructure` remaining functionally unchanged and registered as `Singleton` in `CatalogModule.cs` (line 92, unchanged by this spec).
+- Depends on both `CatalogModule.AddCatalogModule()` and `DataQualityModule.AddDataQualityModule()` being registered together at startup (already the case; verify in `Program.cs`, not expected to require changes).
+- No new NuGet packages, no new external services.
+
+## Out of Scope
+- Giving DataQuality its own independently-tuned resilience pipeline (different retry/circuit-breaker/timeout parameters). This change only relocates the dependency direction; it does not change policy values. A future change could give `DataQualityResilienceAdapter` (or a DataQuality-owned `DqtResilienceService` implementation) its own Polly pipeline if DataQuality's workload characteristics warrant it — that is a product/architecture decision outside this fix.
+- `ProductPairingDqtComparer`'s direct dependency on `IEshopStockClient`/`IErpStockClient` (Catalog-owned Domain-layer interfaces in `Anela.Heblo.Domain.Features.Catalog.Stock`). The brief and this finding scope the violation specifically to the Application-layer `ICatalogResilienceService`; the Domain-layer stock-client interfaces are consumed directly by multiple modules today (including `FinancialOverview.StockValueService`) and are not flagged here. Whether Domain-layer interfaces under a module's namespace should also be wrapped in consumer-owned contracts is a broader architectural question for a separate review item.
+- Fixing the previously-filed, structurally-similar #3433 (`FinancialOverview.StockValueService` importing Catalog-owned ERP interfaces). Referenced only as precedent; not remediated by this change.
+- Any change to `ShoptetStockClient` or `FlexiStockClient` (the Adapters-layer implementations of `IEshopStockClient`/`IErpStockClient`). Option B from the brief (pushing resilience into these adapters) is explicitly rejected for this fix — see Background section for reasoning.
+- Automated architecture-boundary enforcement (e.g. an ArchUnit-style test that fails the build if DataQuality references Catalog's Application-layer namespaces). Not currently present in the repo as far as this investigation found; introducing one is a separate, larger initiative.
+- Any change to `StockWriteBackDqtComparer`, `InvoiceDqtComparer`, or other `DataQuality/Services/*` classes, even if they have similar or different cross-module dependencies — this spec is scoped to `ProductPairingDqtComparer` only, per the brief.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "create-dqt-resilience-contract-and-adapter",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-02T05:27:28.252774Z"
+      "updated_at": "2026-07-02T06:07:03.648695Z"
     },
     {
       "name": "switch-product-pairing-comparer-to-dqt-resilience-contract",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-02T06:07:07.280513Z"
     },
     {
       "name": "update-architecture-boundary-allowlist",

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-02T05:15:44.822574Z"
+      "status": "completed",
+      "updated_at": "2026-07-02T05:18:24.124243Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-02T05:18:24.448151Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "switch-product-pairing-comparer-to-dqt-resilience-contract",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-02T06:07:07.280513Z"
+      "updated_at": "2026-07-02T06:12:38.000258Z"
     },
     {
       "name": "update-architecture-boundary-allowlist",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-02T06:12:42.103832Z"
     }
   ]
 }

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3454",
+  "issue_number": 3454,
+  "created_at": "2026-07-02T05:15:02.811283Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-07-02T05:15:30.904934Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-02T05:26:50.323071Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-02T05:27:28.035864Z"
+      "status": "completed",
+      "updated_at": "2026-07-02T06:26:12.992919Z"
     }
   },
   "tasks": [
@@ -40,9 +40,9 @@
     },
     {
       "name": "update-architecture-boundary-allowlist",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-02T06:12:42.103832Z"
+      "updated_at": "2026-07-02T06:26:12.604696Z"
     }
   ]
 }

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-02T05:18:24.124243Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-02T05:18:24.448151Z"
+      "status": "completed",
+      "updated_at": "2026-07-02T05:22:10.763913Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-02T05:22:26.561476Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-02T05:22:10.763913Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-02T05:22:26.561476Z"
+      "status": "completed",
+      "updated_at": "2026-07-02T05:23:14.247294Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-02T05:23:14.575161Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-02T06:26:12.992919Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-02T06:26:26.449067Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-02T05:26:50.323071Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-02T05:27:28.035864Z"
     }
   },
   "tasks": [
     {
       "name": "create-dqt-resilience-contract-and-adapter",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-02T05:27:28.252774Z"
     },
     {
       "name": "switch-product-pairing-comparer-to-dqt-resilience-contract",

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -6,7 +6,7 @@
   "phases": {
     "analyzing": {
       "status": "in_progress",
-      "updated_at": "2026-07-02T05:15:30.904934Z"
+      "updated_at": "2026-07-02T05:15:44.822574Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3454/state.json
+++ b/artifacts/feat-3454/state.json
@@ -17,13 +17,32 @@
       "updated_at": "2026-07-02T05:23:14.247294Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-02T05:23:14.575161Z"
+      "status": "completed",
+      "updated_at": "2026-07-02T05:26:50.323071Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "create-dqt-resilience-contract-and-adapter",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "switch-product-pairing-comparer-to-dqt-resilience-contract",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "update-architecture-boundary-allowlist",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3454/task-context/create-dqt-resilience-contract-and-adapter.md
+++ b/artifacts/feat-3454/task-context/create-dqt-resilience-contract-and-adapter.md
@@ -1,0 +1,151 @@
+### task: create-dqt-resilience-contract-and-adapter
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:60-62`
+
+This task creates the new DataQuality-owned contract, the Catalog-owned adapter that implements it, registers the adapter in Catalog's DI module, and adds a small delegation test for the adapter (mirroring the existing sibling adapter tests in the same test folder).
+
+- [ ] Step 1: Create the new contract file `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public interface IDqtResilienceService
+{
+    Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] Step 2: Create the new adapter file `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class DataQualityResilienceAdapter : IDqtResilienceService
+{
+    private readonly ICatalogResilienceService _resilienceService;
+
+    public DataQualityResilienceAdapter(ICatalogResilienceService resilienceService)
+    {
+        _resilienceService = resilienceService;
+    }
+
+    public Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default) =>
+        _resilienceService.ExecuteWithResilienceAsync(operation, operationName, cancellationToken);
+}
+```
+
+- [ ] Step 3: Open `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`. Find these two existing lines (currently at lines 60-62):
+
+```csharp
+        // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
+        services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
+        services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+```
+
+Replace them with (adding the new registration immediately after, with its own explanatory comment matching the existing style):
+
+```csharp
+        // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
+        services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
+        services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+        // DataQuality owns the resilience contract; Catalog (this module) provides the adapter implementation.
+        services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
+```
+
+Note: `CatalogModule.cs` already has `using Anela.Heblo.Application.Features.DataQuality.Contracts;` at line 21 (used by `IStockOperationQuery`/`IStockTakingQuery`), so no new `using` directive is needed — `IDqtResilienceService` resolves from the same namespace.
+
+- [ ] Step 4: Create the adapter test file `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class DataQualityResilienceAdapterTests
+{
+    private readonly Mock<ICatalogResilienceService> _resilienceService = new();
+
+    private DataQualityResilienceAdapter CreateAdapter() => new(_resilienceService.Object);
+
+    [Fact]
+    public async Task ExecuteWithResilienceAsync_DelegatesToUnderlyingService_WithSameArgumentsAndReturnValue()
+    {
+        // Arrange
+        Func<CancellationToken, Task<int>> operation = _ => Task.FromResult(42);
+        const string operationName = "TestOperation";
+        using var cts = new CancellationTokenSource();
+
+        _resilienceService
+            .Setup(r => r.ExecuteWithResilienceAsync(operation, operationName, cts.Token))
+            .ReturnsAsync(42);
+
+        // Act
+        var result = await CreateAdapter().ExecuteWithResilienceAsync(operation, operationName, cts.Token);
+
+        // Assert
+        result.Should().Be(42);
+        _resilienceService.Verify(
+            r => r.ExecuteWithResilienceAsync(operation, operationName, cts.Token),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteWithResilienceAsync_PropagatesException_WhenUnderlyingServiceThrows()
+    {
+        // Arrange
+        Func<CancellationToken, Task<int>> operation = _ => Task.FromResult(0);
+        const string operationName = "FailingOperation";
+
+        _resilienceService
+            .Setup(r => r.ExecuteWithResilienceAsync(operation, operationName, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        // Act
+        var act = () => CreateAdapter().ExecuteWithResilienceAsync(operation, operationName, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+}
+```
+
+- [ ] Step 5: From the repository root (`/home/user/worktrees/feature-3454-Arch-Review-Dataquality-Productpairingdqtcomparer`), build the solution to verify the new contract, adapter, and DI registration compile:
+
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Confirm the build succeeds with no errors. `ProductPairingDqtComparer` still uses `ICatalogResilienceService` at this point (unchanged), so this step only proves the new types and DI wiring compile alongside the existing code.
+
+- [ ] Step 6: Run the new adapter test to confirm it passes:
+
+```bash
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~DataQualityResilienceAdapterTests"
+```
+
+Confirm both tests pass (2 total).
+
+- [ ] Step 7: Commit:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+git commit -m "Add IDqtResilienceService contract and Catalog-side adapter"
+```
+
+---

--- a/artifacts/feat-3454/task-context/switch-product-pairing-comparer-to-dqt-resilience-contract.md
+++ b/artifacts/feat-3454/task-context/switch-product-pairing-comparer-to-dqt-resilience-contract.md
@@ -1,0 +1,150 @@
+### task: switch-product-pairing-comparer-to-dqt-resilience-contract
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs:1-28`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs:1-15`
+
+This task switches `ProductPairingDqtComparer`'s constructor dependency from the Catalog-owned `ICatalogResilienceService` to the new DataQuality-owned `IDqtResilienceService`, and updates the existing unit test's mock type to match. No method body or test assertion changes — this is a pure type substitution enabled by the identical interface shape.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs`. Replace the `using` block at the top of the file (lines 1-5):
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.Extensions.Logging;
+```
+
+with:
+
+```csharp
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.Extensions.Logging;
+```
+
+- [ ] Step 2: In the same file, replace the field declaration and constructor (lines 9-28):
+
+```csharp
+public class ProductPairingDqtComparer : IDriftDqtComparer
+{
+    private readonly IEshopStockClient _eshopStockClient;
+    private readonly IErpStockClient _erpStockClient;
+    private readonly ICatalogResilienceService _resilienceService;
+    private readonly ILogger<ProductPairingDqtComparer> _logger;
+
+    public DqtTestType TestType => DqtTestType.ProductPairing;
+
+    public ProductPairingDqtComparer(
+        IEshopStockClient eshopStockClient,
+        IErpStockClient erpStockClient,
+        ICatalogResilienceService resilienceService,
+        ILogger<ProductPairingDqtComparer> logger)
+    {
+        _eshopStockClient = eshopStockClient;
+        _erpStockClient = erpStockClient;
+        _resilienceService = resilienceService;
+        _logger = logger;
+    }
+```
+
+with:
+
+```csharp
+public class ProductPairingDqtComparer : IDriftDqtComparer
+{
+    private readonly IEshopStockClient _eshopStockClient;
+    private readonly IErpStockClient _erpStockClient;
+    private readonly IDqtResilienceService _resilienceService;
+    private readonly ILogger<ProductPairingDqtComparer> _logger;
+
+    public DqtTestType TestType => DqtTestType.ProductPairing;
+
+    public ProductPairingDqtComparer(
+        IEshopStockClient eshopStockClient,
+        IErpStockClient erpStockClient,
+        IDqtResilienceService resilienceService,
+        ILogger<ProductPairingDqtComparer> logger)
+    {
+        _eshopStockClient = eshopStockClient;
+        _erpStockClient = erpStockClient;
+        _resilienceService = resilienceService;
+        _logger = logger;
+    }
+```
+
+Do not change anything else in this file — `CompareAsync` and `IsSellable` are unchanged.
+
+- [ ] Step 3: Open `backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs`. Replace the `using` block at the top of the file (lines 1-7):
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+```
+
+with:
+
+```csharp
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+```
+
+- [ ] Step 4: In the same file, replace this line (line 15):
+
+```csharp
+    private readonly Mock<ICatalogResilienceService> _resilienceMock = new();
+```
+
+with:
+
+```csharp
+    private readonly Mock<IDqtResilienceService> _resilienceMock = new();
+```
+
+Do not change anything else in this file — the constructor call in `CreateSut()`, all 5 test methods, and all assertions are unchanged since `IDqtResilienceService.ExecuteWithResilienceAsync<T>` has the identical signature to `ICatalogResilienceService.ExecuteWithResilienceAsync<T>`.
+
+- [ ] Step 5: From the repository root, build the solution:
+
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Confirm the build succeeds with no errors and no warnings about unused `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` in either modified file (both files' Catalog-Infrastructure `using` directives were removed in steps 1 and 3).
+
+- [ ] Step 6: Run the comparer's unit tests:
+
+```bash
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~ProductPairingDqtComparerTests"
+```
+
+Confirm all 5 existing tests pass: `CompareAsync_ReturnsEmpty_WhenAllProductsPaired`, `CompareAsync_ReturnsMissingInErp_WhenShoptetProductNotInErp`, `CompareAsync_ReturnsMissingInErpAndPairCodeUnresolved_WhenPairCodeNotInErp`, `CompareAsync_ReturnsMissingInShoptet_OnlyForSellableErpProducts`, `CompareAsync_WrapsBothListCalls_WithResilience`.
+
+- [ ] Step 7: Verify no file under DataQuality's `Services/` folder references the Catalog Application-layer namespace anymore (this scans the whole folder, not just the file changed in this task, to confirm the module-wide boundary claim from the spec — `IEshopStockClient`/`IErpStockClient` are Domain-layer, not Application-layer, so they are correctly excluded by this pattern):
+
+```bash
+grep -rn "using Anela.Heblo.Application.Features.Catalog" backend/src/Anela.Heblo.Application/Features/DataQuality/Services/
+```
+
+Confirm this returns no matches (empty output).
+
+- [ ] Step 8: Commit:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs
+git commit -m "Switch ProductPairingDqtComparer to DataQuality-owned IDqtResilienceService"
+```
+
+---

--- a/artifacts/feat-3454/task-context/update-architecture-boundary-allowlist.md
+++ b/artifacts/feat-3454/task-context/update-architecture-boundary-allowlist.md
@@ -1,0 +1,93 @@
+### task: update-architecture-boundary-allowlist
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs:151-157`
+
+This task removes the now-stale `ProductPairingDqtComparer -> ICatalogResilienceService` entry from the `DataQuality -> Catalog` architecture-boundary allowlist, since that dependency no longer exists after the previous task. The four remaining, genuinely out-of-scope entries (`IEshopStockClient`, `IErpStockClient`, `ErpStock`, `ProductType`, `EshopStock`) stay untouched. This file enforces module-boundary rules via a reflection-based xUnit test (`backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`) with a `"DataQuality -> Catalog"` rule driven by the `DataQualityCatalogAllowlist` set — leaving a stale entry would contradict that file's own documented convention that entries are removed once the underlying violation is fixed.
+
+- [ ] Step 1: Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Find this block (currently at lines 149-163):
+
+```csharp
+    private static readonly HashSet<string> DataQualityCatalogAllowlist = new(StringComparer.Ordinal)
+    {
+        // ProductPairingDqtComparer reads eshop/erp catalog clients to compare product pairing,
+        // wrapped in ICatalogResilienceService for transient-fault protection.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IEshopStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IErpStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStock",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.ProductType",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService",
+
+        // Compiler-generated async state machines and lambdas for CompareAsync capture EshopStock.
+        // The declaring-type check covers nested types (<CompareAsync>d__6, <<CompareAsync>b__6_1>d)
+        // via this single parent entry.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.EshopStock",
+    };
+```
+
+Replace it with (the `ICatalogResilienceService` line removed, and the explanatory comment above the first four entries trimmed so it no longer references resilience wrapping that no longer applies):
+
+```csharp
+    private static readonly HashSet<string> DataQualityCatalogAllowlist = new(StringComparer.Ordinal)
+    {
+        // ProductPairingDqtComparer reads eshop/erp catalog clients to compare product pairing.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IEshopStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IErpStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStock",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.ProductType",
+
+        // Compiler-generated async state machines and lambdas for CompareAsync capture EshopStock.
+        // The declaring-type check covers nested types (<CompareAsync>d__6, <<CompareAsync>b__6_1>d)
+        // via this single parent entry.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.EshopStock",
+    };
+```
+
+Do not change the block comment above this set (currently at lines 145-148, describing the `DataQualityCatalogAllowlist` follow-up tracking) — it still accurately describes the four remaining out-of-scope entries and the tracked `IProductPairingQuery` follow-up.
+
+- [ ] Step 2: From the repository root, build the solution:
+
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Confirm the build succeeds with no errors.
+
+- [ ] Step 3: Run the architecture boundary tests:
+
+```bash
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Confirm all tests in this file pass, including the `"DataQuality -> Catalog"` rule — this proves `ProductPairingDqtComparer` no longer references `Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService` (or any other non-allowlisted Catalog Application-layer type) via reflection, independent of the earlier manual `grep` check.
+
+- [ ] Step 4: Confirm no remaining reference to `ICatalogResilienceService` exists anywhere in the allowlist file:
+
+```bash
+grep -n "ICatalogResilienceService" backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+```
+
+Confirm this returns no matches (empty output).
+
+- [ ] Step 5: Run the full test suite one final time to confirm nothing else regressed from the full set of changes across all three tasks:
+
+```bash
+dotnet test Anela.Heblo.sln
+```
+
+Confirm the run completes with 0 failures.
+
+- [ ] Step 6: Run `dotnet format` to confirm formatting is clean across all changed files:
+
+```bash
+dotnet format Anela.Heblo.sln --verify-no-changes
+```
+
+If this reports formatting issues, run `dotnet format Anela.Heblo.sln` (without `--verify-no-changes`) to auto-fix, then re-stage the affected files before committing.
+
+- [ ] Step 7: Commit:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "Remove stale ICatalogResilienceService entry from DataQuality->Catalog allowlist"
+```

--- a/artifacts/feat-3454/task-plan.r1.md
+++ b/artifacts/feat-3454/task-plan.r1.md
@@ -1,0 +1,406 @@
+# Implementation Plan: Remove DataQuality → Catalog Application-layer boundary violation in ProductPairingDqtComparer
+
+**Goal:** Replace `ProductPairingDqtComparer`'s direct dependency on Catalog's Application-layer `ICatalogResilienceService` with a DataQuality-owned contract (`IDqtResilienceService`), implemented by a Catalog-side adapter, so DataQuality no longer imports Catalog Application-layer internals.
+
+**Architecture:** Pure dependency-direction refactor, structurally identical to the existing `IStockOperationQuery`/`DataQualityStockOperationQueryAdapter` and `IStockTakingQuery`/`DataQualityStockTakingQueryAdapter` pattern in this same module pair. DataQuality defines `IDqtResilienceService` in its own `Contracts/` folder; Catalog implements `DataQualityResilienceAdapter` in its `Infrastructure/` folder that delegates 1:1 to the existing `ICatalogResilienceService` singleton; Catalog registers the adapter in its own `CatalogModule.cs` (provider registers, per the documented rule). No retry/circuit-breaker/timeout behavior changes — this is a type-substitution refactor only.
+
+**Tech Stack:** .NET 8, xUnit, Moq, FluentAssertions
+
+---
+
+### task: create-dqt-resilience-contract-and-adapter
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs:60-62`
+
+This task creates the new DataQuality-owned contract, the Catalog-owned adapter that implements it, registers the adapter in Catalog's DI module, and adds a small delegation test for the adapter (mirroring the existing sibling adapter tests in the same test folder).
+
+- [ ] Step 1: Create the new contract file `backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public interface IDqtResilienceService
+{
+    Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] Step 2: Create the new adapter file `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class DataQualityResilienceAdapter : IDqtResilienceService
+{
+    private readonly ICatalogResilienceService _resilienceService;
+
+    public DataQualityResilienceAdapter(ICatalogResilienceService resilienceService)
+    {
+        _resilienceService = resilienceService;
+    }
+
+    public Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default) =>
+        _resilienceService.ExecuteWithResilienceAsync(operation, operationName, cancellationToken);
+}
+```
+
+- [ ] Step 3: Open `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`. Find these two existing lines (currently at lines 60-62):
+
+```csharp
+        // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
+        services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
+        services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+```
+
+Replace them with (adding the new registration immediately after, with its own explanatory comment matching the existing style):
+
+```csharp
+        // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
+        services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
+        services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+        // DataQuality owns the resilience contract; Catalog (this module) provides the adapter implementation.
+        services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
+```
+
+Note: `CatalogModule.cs` already has `using Anela.Heblo.Application.Features.DataQuality.Contracts;` at line 21 (used by `IStockOperationQuery`/`IStockTakingQuery`), so no new `using` directive is needed — `IDqtResilienceService` resolves from the same namespace.
+
+- [ ] Step 4: Create the adapter test file `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class DataQualityResilienceAdapterTests
+{
+    private readonly Mock<ICatalogResilienceService> _resilienceService = new();
+
+    private DataQualityResilienceAdapter CreateAdapter() => new(_resilienceService.Object);
+
+    [Fact]
+    public async Task ExecuteWithResilienceAsync_DelegatesToUnderlyingService_WithSameArgumentsAndReturnValue()
+    {
+        // Arrange
+        Func<CancellationToken, Task<int>> operation = _ => Task.FromResult(42);
+        const string operationName = "TestOperation";
+        using var cts = new CancellationTokenSource();
+
+        _resilienceService
+            .Setup(r => r.ExecuteWithResilienceAsync(operation, operationName, cts.Token))
+            .ReturnsAsync(42);
+
+        // Act
+        var result = await CreateAdapter().ExecuteWithResilienceAsync(operation, operationName, cts.Token);
+
+        // Assert
+        result.Should().Be(42);
+        _resilienceService.Verify(
+            r => r.ExecuteWithResilienceAsync(operation, operationName, cts.Token),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteWithResilienceAsync_PropagatesException_WhenUnderlyingServiceThrows()
+    {
+        // Arrange
+        Func<CancellationToken, Task<int>> operation = _ => Task.FromResult(0);
+        const string operationName = "FailingOperation";
+
+        _resilienceService
+            .Setup(r => r.ExecuteWithResilienceAsync(operation, operationName, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        // Act
+        var act = () => CreateAdapter().ExecuteWithResilienceAsync(operation, operationName, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+}
+```
+
+- [ ] Step 5: From the repository root (`/home/user/worktrees/feature-3454-Arch-Review-Dataquality-Productpairingdqtcomparer`), build the solution to verify the new contract, adapter, and DI registration compile:
+
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Confirm the build succeeds with no errors. `ProductPairingDqtComparer` still uses `ICatalogResilienceService` at this point (unchanged), so this step only proves the new types and DI wiring compile alongside the existing code.
+
+- [ ] Step 6: Run the new adapter test to confirm it passes:
+
+```bash
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~DataQualityResilienceAdapterTests"
+```
+
+Confirm both tests pass (2 total).
+
+- [ ] Step 7: Commit:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+git commit -m "Add IDqtResilienceService contract and Catalog-side adapter"
+```
+
+---
+
+### task: switch-product-pairing-comparer-to-dqt-resilience-contract
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs:1-28`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs:1-15`
+
+This task switches `ProductPairingDqtComparer`'s constructor dependency from the Catalog-owned `ICatalogResilienceService` to the new DataQuality-owned `IDqtResilienceService`, and updates the existing unit test's mock type to match. No method body or test assertion changes — this is a pure type substitution enabled by the identical interface shape.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs`. Replace the `using` block at the top of the file (lines 1-5):
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.Extensions.Logging;
+```
+
+with:
+
+```csharp
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.Extensions.Logging;
+```
+
+- [ ] Step 2: In the same file, replace the field declaration and constructor (lines 9-28):
+
+```csharp
+public class ProductPairingDqtComparer : IDriftDqtComparer
+{
+    private readonly IEshopStockClient _eshopStockClient;
+    private readonly IErpStockClient _erpStockClient;
+    private readonly ICatalogResilienceService _resilienceService;
+    private readonly ILogger<ProductPairingDqtComparer> _logger;
+
+    public DqtTestType TestType => DqtTestType.ProductPairing;
+
+    public ProductPairingDqtComparer(
+        IEshopStockClient eshopStockClient,
+        IErpStockClient erpStockClient,
+        ICatalogResilienceService resilienceService,
+        ILogger<ProductPairingDqtComparer> logger)
+    {
+        _eshopStockClient = eshopStockClient;
+        _erpStockClient = erpStockClient;
+        _resilienceService = resilienceService;
+        _logger = logger;
+    }
+```
+
+with:
+
+```csharp
+public class ProductPairingDqtComparer : IDriftDqtComparer
+{
+    private readonly IEshopStockClient _eshopStockClient;
+    private readonly IErpStockClient _erpStockClient;
+    private readonly IDqtResilienceService _resilienceService;
+    private readonly ILogger<ProductPairingDqtComparer> _logger;
+
+    public DqtTestType TestType => DqtTestType.ProductPairing;
+
+    public ProductPairingDqtComparer(
+        IEshopStockClient eshopStockClient,
+        IErpStockClient erpStockClient,
+        IDqtResilienceService resilienceService,
+        ILogger<ProductPairingDqtComparer> logger)
+    {
+        _eshopStockClient = eshopStockClient;
+        _erpStockClient = erpStockClient;
+        _resilienceService = resilienceService;
+        _logger = logger;
+    }
+```
+
+Do not change anything else in this file — `CompareAsync` and `IsSellable` are unchanged.
+
+- [ ] Step 3: Open `backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs`. Replace the `using` block at the top of the file (lines 1-7):
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+```
+
+with:
+
+```csharp
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+```
+
+- [ ] Step 4: In the same file, replace this line (line 15):
+
+```csharp
+    private readonly Mock<ICatalogResilienceService> _resilienceMock = new();
+```
+
+with:
+
+```csharp
+    private readonly Mock<IDqtResilienceService> _resilienceMock = new();
+```
+
+Do not change anything else in this file — the constructor call in `CreateSut()`, all 5 test methods, and all assertions are unchanged since `IDqtResilienceService.ExecuteWithResilienceAsync<T>` has the identical signature to `ICatalogResilienceService.ExecuteWithResilienceAsync<T>`.
+
+- [ ] Step 5: From the repository root, build the solution:
+
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Confirm the build succeeds with no errors and no warnings about unused `using Anela.Heblo.Application.Features.Catalog.Infrastructure;` in either modified file (both files' Catalog-Infrastructure `using` directives were removed in steps 1 and 3).
+
+- [ ] Step 6: Run the comparer's unit tests:
+
+```bash
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~ProductPairingDqtComparerTests"
+```
+
+Confirm all 5 existing tests pass: `CompareAsync_ReturnsEmpty_WhenAllProductsPaired`, `CompareAsync_ReturnsMissingInErp_WhenShoptetProductNotInErp`, `CompareAsync_ReturnsMissingInErpAndPairCodeUnresolved_WhenPairCodeNotInErp`, `CompareAsync_ReturnsMissingInShoptet_OnlyForSellableErpProducts`, `CompareAsync_WrapsBothListCalls_WithResilience`.
+
+- [ ] Step 7: Verify no file under DataQuality's `Services/` folder references the Catalog Application-layer namespace anymore (this scans the whole folder, not just the file changed in this task, to confirm the module-wide boundary claim from the spec — `IEshopStockClient`/`IErpStockClient` are Domain-layer, not Application-layer, so they are correctly excluded by this pattern):
+
+```bash
+grep -rn "using Anela.Heblo.Application.Features.Catalog" backend/src/Anela.Heblo.Application/Features/DataQuality/Services/
+```
+
+Confirm this returns no matches (empty output).
+
+- [ ] Step 8: Commit:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs
+git commit -m "Switch ProductPairingDqtComparer to DataQuality-owned IDqtResilienceService"
+```
+
+---
+
+### task: update-architecture-boundary-allowlist
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs:151-157`
+
+This task removes the now-stale `ProductPairingDqtComparer -> ICatalogResilienceService` entry from the `DataQuality -> Catalog` architecture-boundary allowlist, since that dependency no longer exists after the previous task. The four remaining, genuinely out-of-scope entries (`IEshopStockClient`, `IErpStockClient`, `ErpStock`, `ProductType`, `EshopStock`) stay untouched. This file enforces module-boundary rules via a reflection-based xUnit test (`backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`) with a `"DataQuality -> Catalog"` rule driven by the `DataQualityCatalogAllowlist` set — leaving a stale entry would contradict that file's own documented convention that entries are removed once the underlying violation is fixed.
+
+- [ ] Step 1: Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Find this block (currently at lines 149-163):
+
+```csharp
+    private static readonly HashSet<string> DataQualityCatalogAllowlist = new(StringComparer.Ordinal)
+    {
+        // ProductPairingDqtComparer reads eshop/erp catalog clients to compare product pairing,
+        // wrapped in ICatalogResilienceService for transient-fault protection.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IEshopStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IErpStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStock",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.ProductType",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService",
+
+        // Compiler-generated async state machines and lambdas for CompareAsync capture EshopStock.
+        // The declaring-type check covers nested types (<CompareAsync>d__6, <<CompareAsync>b__6_1>d)
+        // via this single parent entry.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.EshopStock",
+    };
+```
+
+Replace it with (the `ICatalogResilienceService` line removed, and the explanatory comment above the first four entries trimmed so it no longer references resilience wrapping that no longer applies):
+
+```csharp
+    private static readonly HashSet<string> DataQualityCatalogAllowlist = new(StringComparer.Ordinal)
+    {
+        // ProductPairingDqtComparer reads eshop/erp catalog clients to compare product pairing.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IEshopStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IErpStockClient",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStock",
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.ProductType",
+
+        // Compiler-generated async state machines and lambdas for CompareAsync capture EshopStock.
+        // The declaring-type check covers nested types (<CompareAsync>d__6, <<CompareAsync>b__6_1>d)
+        // via this single parent entry.
+        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.EshopStock",
+    };
+```
+
+Do not change the block comment above this set (currently at lines 145-148, describing the `DataQualityCatalogAllowlist` follow-up tracking) — it still accurately describes the four remaining out-of-scope entries and the tracked `IProductPairingQuery` follow-up.
+
+- [ ] Step 2: From the repository root, build the solution:
+
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Confirm the build succeeds with no errors.
+
+- [ ] Step 3: Run the architecture boundary tests:
+
+```bash
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Confirm all tests in this file pass, including the `"DataQuality -> Catalog"` rule — this proves `ProductPairingDqtComparer` no longer references `Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService` (or any other non-allowlisted Catalog Application-layer type) via reflection, independent of the earlier manual `grep` check.
+
+- [ ] Step 4: Confirm no remaining reference to `ICatalogResilienceService` exists anywhere in the allowlist file:
+
+```bash
+grep -n "ICatalogResilienceService" backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+```
+
+Confirm this returns no matches (empty output).
+
+- [ ] Step 5: Run the full test suite one final time to confirm nothing else regressed from the full set of changes across all three tasks:
+
+```bash
+dotnet test Anela.Heblo.sln
+```
+
+Confirm the run completes with 0 failures.
+
+- [ ] Step 6: Run `dotnet format` to confirm formatting is clean across all changed files:
+
+```bash
+dotnet format Anela.Heblo.sln --verify-no-changes
+```
+
+If this reports formatting issues, run `dotnet format Anela.Heblo.sln` (without `--verify-no-changes`) to auto-fix, then re-stage the affected files before committing.
+
+- [ ] Step 7: Commit:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "Remove stale ICatalogResilienceService entry from DataQuality->Catalog allowlist"
+```

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -60,6 +60,8 @@ public static class CatalogModule
         // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
         services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
         services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+        // DataQuality owns the resilience contract; Catalog (this module) provides the adapter implementation.
+        services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
 
         // Cross-module contract: Catalog implements Manufacture's IManufactureCatalogSource via adapter.
         // DI registration is owned by the provider (Catalog), not the consumer (Manufacture).

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityResilienceAdapter.cs
@@ -1,0 +1,19 @@
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class DataQualityResilienceAdapter : IDqtResilienceService
+{
+    private readonly ICatalogResilienceService _resilienceService;
+
+    public DataQualityResilienceAdapter(ICatalogResilienceService resilienceService)
+    {
+        _resilienceService = resilienceService;
+    }
+
+    public Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default) =>
+        _resilienceService.ExecuteWithResilienceAsync(operation, operationName, cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IDqtResilienceService.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public interface IDqtResilienceService
+{
+    Task<T> ExecuteWithResilienceAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        string operationName,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/ProductPairingDqtComparer.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.DataQuality;
@@ -10,7 +10,7 @@ public class ProductPairingDqtComparer : IDriftDqtComparer
 {
     private readonly IEshopStockClient _eshopStockClient;
     private readonly IErpStockClient _erpStockClient;
-    private readonly ICatalogResilienceService _resilienceService;
+    private readonly IDqtResilienceService _resilienceService;
     private readonly ILogger<ProductPairingDqtComparer> _logger;
 
     public DqtTestType TestType => DqtTestType.ProductPairing;
@@ -18,7 +18,7 @@ public class ProductPairingDqtComparer : IDriftDqtComparer
     public ProductPairingDqtComparer(
         IEshopStockClient eshopStockClient,
         IErpStockClient erpStockClient,
-        ICatalogResilienceService resilienceService,
+        IDqtResilienceService resilienceService,
         ILogger<ProductPairingDqtComparer> logger)
     {
         _eshopStockClient = eshopStockClient;

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -148,13 +148,11 @@ public class ModuleBoundariesTests
     // adapter that surfaces eshop/erp product snapshots without leaking Catalog types.
     private static readonly HashSet<string> DataQualityCatalogAllowlist = new(StringComparer.Ordinal)
     {
-        // ProductPairingDqtComparer reads eshop/erp catalog clients to compare product pairing,
-        // wrapped in ICatalogResilienceService for transient-fault protection.
+        // ProductPairingDqtComparer reads eshop/erp catalog clients to compare product pairing.
         "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IEshopStockClient",
         "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.IErpStockClient",
         "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStock",
         "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Domain.Features.Catalog.ProductType",
-        "Anela.Heblo.Application.Features.DataQuality.Services.ProductPairingDqtComparer -> Anela.Heblo.Application.Features.Catalog.Infrastructure.ICatalogResilienceService",
 
         // Compiler-generated async state machines and lambdas for CompareAsync capture EshopStock.
         // The declaring-type check covers nested types (<CompareAsync>d__6, <<CompareAsync>b__6_1>d)

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityResilienceAdapterTests.cs
@@ -1,0 +1,54 @@
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class DataQualityResilienceAdapterTests
+{
+    private readonly Mock<ICatalogResilienceService> _resilienceService = new();
+
+    private DataQualityResilienceAdapter CreateAdapter() => new(_resilienceService.Object);
+
+    [Fact]
+    public async Task ExecuteWithResilienceAsync_DelegatesToUnderlyingService_WithSameArgumentsAndReturnValue()
+    {
+        // Arrange
+        Func<CancellationToken, Task<int>> operation = _ => Task.FromResult(42);
+        const string operationName = "TestOperation";
+        using var cts = new CancellationTokenSource();
+
+        _resilienceService
+            .Setup(r => r.ExecuteWithResilienceAsync(operation, operationName, cts.Token))
+            .ReturnsAsync(42);
+
+        // Act
+        var result = await CreateAdapter().ExecuteWithResilienceAsync(operation, operationName, cts.Token);
+
+        // Assert
+        result.Should().Be(42);
+        _resilienceService.Verify(
+            r => r.ExecuteWithResilienceAsync(operation, operationName, cts.Token),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteWithResilienceAsync_PropagatesException_WhenUnderlyingServiceThrows()
+    {
+        // Arrange
+        Func<CancellationToken, Task<int>> operation = _ => Task.FromResult(0);
+        const string operationName = "FailingOperation";
+
+        _resilienceService
+            .Setup(r => r.ExecuteWithResilienceAsync(operation, operationName, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        // Act
+        var act = () => CreateAdapter().ExecuteWithResilienceAsync(operation, operationName, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/ProductPairingDqtComparerTests.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
 using Anela.Heblo.Application.Features.DataQuality.Services;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.DataQuality;
@@ -12,7 +12,7 @@ public class ProductPairingDqtComparerTests
 {
     private readonly Mock<IEshopStockClient> _eshopMock = new();
     private readonly Mock<IErpStockClient> _erpMock = new();
-    private readonly Mock<ICatalogResilienceService> _resilienceMock = new();
+    private readonly Mock<IDqtResilienceService> _resilienceMock = new();
     private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.Today);
 
     public ProductPairingDqtComparerTests()


### PR DESCRIPTION
Closes #3454

## What the issue was
`ProductPairingDqtComparer` (DataQuality module, Application layer) directly imported and injected `ICatalogResilienceService` from the Catalog module's Application layer — a cross-module boundary violation. DataQuality's Application layer was coupling to Catalog's Application-layer internals (a Polly circuit-breaker service tuned for Catalog's own workload), so changes to Catalog's resilience policy would silently change DataQuality's behavior with no corresponding DataQuality code change. This was the same pattern already flagged and fixed once before in issue #3433.

## How it was fixed / handled
Followed the project's documented cross-module adapter rule ("consumer defines the contract, provider implements an adapter") — the same pattern already used twice in this exact module pair (`IStockOperationQuery`/`IStockTakingQuery`):

1. **Added `IDqtResilienceService`** — a new DataQuality-owned contract in `DataQuality/Contracts/`, with a method shape identical to `ICatalogResilienceService.ExecuteWithResilienceAsync<T>`.
2. **Added `DataQualityResilienceAdapter`** — a Catalog-owned, `internal sealed` adapter in `Catalog/Infrastructure/` that implements `IDqtResilienceService` by delegating 1:1 to the existing `ICatalogResilienceService` singleton. Registered as `Scoped` in `CatalogModule.AddCatalogModule()`, alongside the two existing sibling adapters.
3. **Switched `ProductPairingDqtComparer`** to depend on `IDqtResilienceService` instead of `ICatalogResilienceService` — a pure type substitution since the interface shapes are identical; no method body changes.
4. **Removed the now-stale allowlist entry** for `ProductPairingDqtComparer -> ICatalogResilienceService` from the reflection-based `ModuleBoundariesTests.cs` (`DataQualityCatalogAllowlist`), since the dependency it permitted no longer exists.

No runtime behavior changes: retry count, circuit-breaker thresholds, and timeout in the underlying `CatalogResilienceService` are untouched; `operationName` values pass through unchanged, preserving Polly's operation-key correlation.

## Artifacts
Brief, spec, architecture review, design, task plan, per-task impl/review, and the final whole-branch code review are committed under `artifacts/feat-3454/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01TmGiAuHMwbZ6uH8V4UQRdL)_