### PR TITLE
#3457: OrgChart connector colour reacts to ThemeContext dark mode

### DIFF
--- a/frontend/src/pages/OrgChartPage.tsx
+++ b/frontend/src/pages/OrgChartPage.tsx
@@ -10,6 +10,7 @@ import {
   Position,
   OrganizationData,
 } from './orgChartUtils';
+import { useTheme } from '../contexts/ThemeContext';
 
 interface PositionRect {
   id: string;
@@ -21,6 +22,8 @@ interface PositionRect {
 
 const OrgChartPage: React.FC = () => {
   useScreenView('Admin', 'OrgChart');
+
+  const { theme } = useTheme();
 
   // Fetch organization data from backend
   const { data: orgChartResponse, isLoading, error: queryError } = useOrgChart();
@@ -188,7 +191,7 @@ const OrgChartPage: React.FC = () => {
     const filteredPositionIds = new Set(filteredPositions.map((p) => p.id));
 
     // Connector lines must stay visible in dark mode; the light slate stroke would vanish
-    const isDarkMode = document.documentElement.classList.contains('dark');
+    const isDarkMode = theme === 'dark';
     const connectorStroke = isDarkMode ? '#3C424B' : '#94a3b8';
 
     filteredPositions.forEach((position) => {

--- a/memory/gotchas/gh-cli-unavailable-in-cloud-sessions.md
+++ b/memory/gotchas/gh-cli-unavailable-in-cloud-sessions.md
@@ -1,0 +1,27 @@
+# `gh` CLI unavailable in some cloud/remote sessions
+
+Some remote execution sessions (e.g. scheduled routines triggered via Claude
+Code on the web) do not have a working `gh` CLI, even though CLAUDE.md says
+"GitHub access via `gh` CLI only". Symptoms seen 2026-07-02:
+
+- `gh auth status` reports the `GH_TOKEN` is invalid.
+- Any `gh` subcommand that uses GitHub's GraphQL API (issue search with
+  `--search`, `gh issue view`, etc.) fails with
+  `HTTP 403: GraphQL proxying is not enabled.`
+
+These sessions instead expose the GitHub MCP server tools
+(`mcp__github__*`) and explicitly instruct using those for all GitHub
+interactions. When `gh` fails this way, don't retry — switch to the MCP
+tools directly (`list_issues`, `issue_write` for label edits — labels must
+be passed as the full desired set since `issue_write` isn't additive,
+`create_pull_request`, `pull_request_read`). PRs share the issue label
+endpoint, so `issue_write` with the PR number also works to label a PR.
+
+Also: these sessions frequently pin a single designated branch
+(`Develop on branch <name>`, `NEVER push to a different branch without
+explicit permission`) that overrides the `oneshot`/`chopchop` skills'
+default `feature/{issue}-{slug}` branch-per-issue convention. When that
+happens, skip creating a new worktree/branch and commit directly to the
+designated branch instead — the skills' branch naming is a default, not a
+hard requirement, and the environment's explicit branch pin takes
+precedence.


### PR DESCRIPTION
Closes #3457

## What the issue was
`OrgChartPage.tsx` read the current dark-mode state inside `renderConnections()` by querying the DOM directly (`document.documentElement.classList.contains('dark')`) instead of going through `ThemeContext`, the project's canonical dark-mode source of truth (ADR-006). Because this read wasn't reactive, toggling dark/light mode while viewing the org chart left the SVG connector stroke colours stale until some unrelated re-render occurred.

## How it was fixed
Replaced the raw DOM read with the reactive `useTheme()` hook from `frontend/src/contexts/ThemeContext.tsx`:
- Imported `useTheme` and called it at the top of `OrgChartPage`.
- Derived `isDarkMode` from `theme === 'dark'` inside `renderConnections()` instead of reading `document.documentElement.classList`.

Now a theme toggle triggers a re-render via React state and the connector line colours update immediately.

Verified with `npx tsc --noEmit`, `npx eslint`, and `npm run build` (all pass).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrP4dJWgSQETuii4MtXn4u)_