### PR TITLE
#3461: Remove direct filesystem I/O from ExpeditionListService

### DIFF
--- a/artifacts/feat-3461/arch-review.r1.md
+++ b/artifacts/feat-3461/arch-review.r1.md
@@ -1,0 +1,182 @@
+# Architecture Review: Remove direct filesystem I/O from ExpeditionListService
+
+## Skip Design: true
+
+This is a pure backend refactor (interface extraction + DI rewiring) with zero UI surface. `IExpeditionListService`'s public contract, the generated PDFs, email content, and print-queue behavior are all explicitly required to stay unchanged (spec NFR-4, "Out of Scope"). No new or changed screens, components, or visual decisions are involved. Confirmed by reading the spec end-to-end — nothing in FR-1 through FR-6 touches `frontend/`.
+
+## Architectural Fit Assessment
+
+This fits the codebase's established Clean Architecture layering exactly, and the spec correctly identifies the precedent to mirror: `IPrintQueueSink`.
+
+Verified in the actual code:
+- `Anela.Heblo.Application.Shared.Printing.IPrintQueueSink` (`backend/src/Anela.Heblo.Application/Shared/Printing/IPrintQueueSink.cs`) is a one-method Application-owned contract taking only primitives (`IEnumerable<string>`, no `System.IO` types in the signature).
+- `FileSystemPrintQueueSink` (`backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemPrintQueueSink.cs`) implements it with raw `File.Copy`/`Directory.CreateDirectory` calls, living under `Adapters/`, not `Application/Features/*/Services/`.
+- `FileSystemAdapterServiceCollectionExtensions.AddFileSystemPrintQueueSink()` registers it as `AddScoped<IPrintQueueSink, FileSystemPrintQueueSink>()`.
+- The composition root, `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (`AddPrintQueueSink`, ~line 404), switches on `ExpeditionList:PrintSink` config and calls `AddFileSystemPrintQueueSink()` in the default branch (line 436).
+- `docs/architecture/filesystem.md` codifies this explicitly under "Application Layer" component placement rules: *"I/O placement rule: Concrete `IPrintQueueSink` implementations and any I/O-bound service live in adapter projects under `backend/src/Adapters/`, not in `Features/{Feature}/Services/`."*
+
+`ExpeditionListService.cs` (`backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs`, lines 70-109) violates exactly this rule via inline `File.Exists`/`File.Delete`/`File.ReadAllBytesAsync`. The fix — a new `ITemporaryFileAccessor` contract implemented by a sibling class next to `FileSystemPrintQueueSink` — is not a new pattern; it is the same pattern applied a second time in the same feature, in the same adapter project. This is low architectural risk and high consistency payoff.
+
+One correction to the spec's framing: the "consumer owns the contract" pattern documented in `docs/architecture/development_guidelines.md` ("Cross-Module Communication Example: ILeafletKnowledgeSource") is designed for **cross-module** dependency inversion (module A depends on module B's data without touching B's internals). `ITemporaryFileAccessor` is not cross-module — both the contract and its only consumer live inside `Features/ExpeditionList`. The correct precedent is the **intra-module Application/Adapter split** already used for `IPrintQueueSink`, not the cross-module contract-ownership pattern. The spec already says this in a parenthetical ("applied here intra-module for I/O rather than cross-module data access") — this review makes it the primary framing, since citing the cross-module pattern as the main precedent could mislead an implementer into over-engineering (e.g., adding an allowlist entry in `ModuleBoundariesTests.cs`, which is unnecessary here — see Specification Amendments).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Application (Application layer)
+  Features/ExpeditionList/
+    Contracts/
+      ITemporaryFileAccessor.cs          <- NEW: consumer-facing I/O contract
+    Services/
+      ExpeditionListService.cs           <- MODIFIED: injects ITemporaryFileAccessor,
+                                             no more File.* calls
+                    |
+                    | depends on (interface only)
+                    v
+Anela.Heblo.Adapters.FileSystem (Adapter layer)
+    Features/ExpeditionList/
+      FileSystemPrintQueueSink.cs         (existing, unchanged)
+      FileSystemTemporaryFileAccessor.cs  <- NEW: System.IO-backed implementation
+    FileSystemAdapterServiceCollectionExtensions.cs  <- MODIFIED: new registration method
+                    ^
+                    | composed by
+                    |
+Anela.Heblo.API (Composition root)
+    Extensions/ServiceCollectionExtensions.cs  <- MODIFIED: calls new registration
+                                                   unconditionally (not behind the
+                                                   PrintSink switch)
+```
+
+Dependency direction is unchanged from today: `Application` defines the interface, `Adapters.FileSystem` implements it, `API` wires the binding. `Application` never references `Adapters.FileSystem` directly — this already holds for `IPrintQueueSink` and the spec's "Dependencies" section correctly restates it.
+
+### Key Design Decisions
+
+#### Decision 1: New standalone contract vs. folding into an existing one
+
+**Options considered:**
+- (a) New `ITemporaryFileAccessor` interface, as the spec proposes.
+- (b) Extend `IPrintQueueSink` with read/delete methods.
+- (c) Change `IExpeditionPickingSource`/`ExpeditionPickingResult` to return bytes/streams instead of paths, eliminating the need for any file-path abstraction (the brief's "even cleaner" alternative).
+
+**Chosen approach:** (a), matching the spec.
+
+**Rationale:** `IPrintQueueSink` models "hand a batch of files to a print destination" — a fundamentally different responsibility from "read/delete a temp file I already own." Conflating them (option b) would force every `IPrintQueueSink` implementation (`AzureBlobPrintQueueSink`, `CupsPrintQueueSink`, `CombinedPrintQueueSink`) to also implement file-read/delete semantics they don't need, since those are keyed/swapped independently via the `ExpeditionList:PrintSink` config switch — verified in `ServiceCollectionExtensions.AddPrintQueueSink`. Option (c) is architecturally cleaner long-term (it was called out as such in the original brief) but is a materially larger change: it touches `IExpeditionPickingSource`, `LogisticsExpeditionPickingAdapter`, `IPickingListSource`, `ShoptetApiExpeditionListSource`, and `IPrintQueueSink.SendAsync` (which also takes file paths, per `IPrintQueueSink.cs`) — a cross-cutting redesign of the whole picking/printing pipeline, not a scoped fix for one Application-layer boundary violation. Correctly deferred; do not bundle it into this change.
+
+#### Decision 2: Method shape — `DeleteIfExists` vs. separate `Exists`/`Delete`
+
+**Options considered:**
+- (a) Single `DeleteIfExists(string path)` method (spec's choice).
+- (b) Mirror `File.Exists`/`File.Delete` as two interface members, letting the caller compose them (as the original brief's `Delete` name implied, though the brief also showed a single `Delete`).
+
+**Chosen approach:** (a).
+
+**Rationale:** Exposing `Exists` as a standalone member invites a check-then-act race and needlessly widens the interface surface for a caller (`ExpeditionListService.Cleanup`) that only ever wants "make sure this is gone." A single idempotent `DeleteIfExists` is the minimal contract the consumer needs and is trivially mockable (`Verify(x => x.DeleteIfExists(path), Times.Once)`), which is the whole point of this refactor (NFR-3). This is a case where deviating slightly from the brief's literal proposal is correct — noted as a spec amendment below since it's already what the spec chose.
+
+#### Decision 3: DI registration — unconditional vs. inside the `PrintSink` switch
+
+**Options considered:**
+- (a) Register `ITemporaryFileAccessor` unconditionally in `AddPrintQueueSink` (or a sibling method called from the same place), regardless of which `PrintSink` value is configured.
+- (b) Register it only in the `default` branch alongside `AddFileSystemPrintQueueSink()`, mirroring where the spec's example diff is anchored (line ~436).
+
+**Chosen approach:** (a) — register unconditionally, not gated by the `PrintSink` switch.
+
+**Rationale:** `ExpeditionListService.Cleanup`/`SendEmailCopy` operate on temp files regardless of which print sink is active — even when `PrintSink=AzureBlob` or `Cups`, the exported PDFs still land on local disk first (per `IExpeditionPickingSource.CreatePickingListAsync`'s `ExportedFiles`) and still need local read/delete. If registration is only added to the `default` case, resolving `IExpeditionListService` under `PrintSink=AzureBlob` or `Cups` throws a DI resolution error — a regression the spec's own FR-3 acceptance criteria explicitly rules out ("resolves with no DI errors in all existing environments"). The spec's prose gets this right ("unconditionally... since... temporary-file read/delete is not swapped per environment today") but its FR-3 code anchor ("alongside... at line ~436") sits inside the `default:` case of the switch — that's the wrong anchor point. See Specification Amendments.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New files (paths verified against actual project structure):
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs` — new interface, alongside existing `IExpeditionPickingSource.cs` in the same folder.
+- `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs` — new class, alongside existing `FileSystemPrintQueueSink.cs`.
+
+Modified files:
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` — constructor + `Cleanup`/`SendEmailCopy` bodies.
+- `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs` — add `AddFileSystemTemporaryFileAccessor()`.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — call the new registration method **outside/before** the `switch (printSink)` block in `AddPrintQueueSink`, so it runs for every branch. Do not place it inside the `default:` case.
+
+Test files (verified locations):
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs` and `ExpeditionListServiceOrderStateTests.cs` — both already construct `ExpeditionListService` via a private `CreateService()` helper with `Mock<T>` fields; add a `Mock<ITemporaryFileAccessor>` field there and pass `.Object` into the constructor call.
+- No dedicated `Anela.Heblo.Adapters.FileSystem.Tests` project exists — `FileSystemPrintQueueSinkTests.cs` (the direct precedent for testing this adapter) already lives in `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/`. Put the new `FileSystemTemporaryFileAccessorTests.cs` in that same folder, not in a new adapter-specific test project (spec FR-5's "adapter's own test project, if one exists" — it does not; use the existing convention).
+
+### Interfaces and Contracts
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface ITemporaryFileAccessor
+{
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
+    void DeleteIfExists(string path);
+}
+```
+
+```csharp
+// backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs
+namespace Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessor : ITemporaryFileAccessor
+{
+    public Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
+        => File.ReadAllBytesAsync(path, cancellationToken);
+
+    public void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}
+```
+
+```csharp
+// backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs
+public static IServiceCollection AddFileSystemTemporaryFileAccessor(this IServiceCollection services)
+{
+    services.AddScoped<ITemporaryFileAccessor, FileSystemTemporaryFileAccessor>();
+    return services;
+}
+```
+
+Lifetime: `Scoped`, matching `IPrintQueueSink`'s existing registration — consistency over the (valid but marginal) observation that the type is stateless and could be `Singleton`. Don't introduce a lifetime inconsistency between two adapters in the same feature for no functional benefit.
+
+`ExpeditionListService` constructor gains one parameter; append it after `IPrintQueueSink printQueueSink` and before `ILogger` to keep the logger last, consistent with the current parameter ordering convention (options/dependencies first, logger last):
+
+```csharp
+public ExpeditionListService(
+    IExpeditionPickingSource pickingSource,
+    IEmailSender emailSender,
+    TimeProvider clock,
+    IOptions<PrintPickingListOptions> options,
+    IPrintQueueSink printQueueSink,
+    ITemporaryFileAccessor temporaryFileAccessor,
+    ILogger<ExpeditionListService> logger)
+```
+
+### Data Flow
+
+Unchanged at the level that matters (external behavior): `PrintPickingListAsync` still calls `_pickingSource.CreatePickingListAsync`, gets back `ExpeditionPickingResult.ExportedFiles` (still `IList<string>` — paths, not bytes, per the "Out of Scope" decision to defer Decision 1's option (c)), then `Cleanup` and `SendEmailCopy` still operate on those paths. The only change is that `Cleanup`/`SendEmailCopy` now go through `_temporaryFileAccessor` instead of calling `System.IO.File` inline — an indirection with no new round-trips, no new I/O, no behavior change (per spec NFR-1).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| New registration placed inside the `default:` branch of `AddPrintQueueSink`'s switch (as the spec's FR-3 line-number anchor suggests) breaks `IExpeditionListService` resolution when `PrintSink=AzureBlob`/`Cups`/`Combined` | High | Register `ITemporaryFileAccessor` unconditionally, before/outside the `switch` statement in `AddPrintQueueSink` — not conditionally on the `PrintSink` value. Covered by spec FR-3's acceptance criterion "no DI errors in all existing environments," which implementers must actually exercise for non-default `PrintSink` values, not just the default. |
+| `CancellationToken` now flows into `ReadAllBytesAsync` inside `SendEmailCopy`, which previously ignored it — a real (if minor) behavior change during a "pure refactor" | Low | Accept it; it only causes earlier/more-precise cancellation on an already-cancelled token, which is strictly more correct. Call it out explicitly in the PR description per NFR-4's "pure refactor" framing so it isn't mistaken for scope creep. |
+| Someone treats this as precedent for the cross-module "consumer owns the contract" pattern and adds an unneeded `ModuleBoundariesTests.cs` allowlist/rule entry for `ExpeditionList` | Low | This review's framing (Architectural Fit Assessment) should be read by whoever implements FR-6's investigation step — no new module-boundary rule is needed since both sides of `ITemporaryFileAccessor` live in the same `Features/ExpeditionList` namespace tree. |
+| Test rewrite (FR-5) misses a real-filesystem dependency because `ExpeditionListServiceOrderStateTests.PrintPickingListAsync_CleanupRunsAfterSuccess` (line 119-139) currently uses `Path.GetTempFileName()` + `Assert.False(File.Exists(tmpFile))`, coupling the assertion to the real filesystem | Low | Verified this test exists and is exactly the one FR-5 must rewrite: replace with `_temporaryFileAccessor.Setup(...)`/`Verify(x => x.DeleteIfExists(path), Times.Once)`, dropping `Path.GetTempFileName()` and the `File.Exists` assertion entirely. |
+
+## Specification Amendments
+
+1. **FR-3 anchor point is wrong.** The spec says to call the new registration "alongside... `services.AddFileSystemPrintQueueSink();` call at line ~436" — but line 436 is inside the `default:` case of the `switch (printSink)` block in `AddPrintQueueSink` (`ServiceCollectionExtensions.cs`). Registering there only wires `ITemporaryFileAccessor` when `PrintSink` is unset/`"FileSystem"`, breaking DI for `AzureBlob`/`Cups`/`Combined`. Amend FR-3 to say: call `services.AddFileSystemTemporaryFileAccessor()` **once, unconditionally, before the `switch` statement** inside `AddPrintQueueSink` (or immediately after `services.AddCupsPrinting(configuration)` at the top of that method) — not inside any branch.
+
+2. **FR-6's premise should be corrected, not just "investigated."** This review already did the investigation FR-6 asks for: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` exists, but it is a **namespace-reference boundary checker** (asserts module A's types don't reference module B's forbidden namespaces), not an I/O-call detector. There is no existing reflection-based check for `File.*`/`System.IO` usage inside `Features/*/Services/` anywhere in the test suite. FR-6's acceptance criterion ("investigation is done and documented in the PR description") is satisfied by citing this review; implementers do not need to re-derive it. Adding an automated I/O-call guard remains optional/out-of-scope, as the spec already states.
+
+3. **Test project location for FR-5's new adapter test.** FR-5 hedges between "the adapter's own test project, if one exists, or a new lightweight test." Confirmed: no adapter-specific test project exists for `Anela.Heblo.Adapters.FileSystem` — its existing test (`FileSystemPrintQueueSinkTests.cs`) lives in `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/`. Amend FR-5 to specify that path directly for `FileSystemTemporaryFileAccessorTests.cs`, removing the ambiguity.
+
+4. **Constructor parameter placement.** FR-4 says "existing parameters and their order are otherwise preserved as closely as practical." This review specifies the exact position: after `printQueueSink`, before `logger` (see Implementation Guidance) — matching the codebase convention of logger-last observed in this same constructor today.
+
+## Prerequisites
+
+None beyond what already exists in the repository. No new project references are needed (`Anela.Heblo.API` already references `Anela.Heblo.Adapters.FileSystem` for `AddFileSystemPrintQueueSink`), no migrations, no config changes, no infrastructure provisioning. This can start immediately.

--- a/artifacts/feat-3461/brief.md
+++ b/artifacts/feat-3461/brief.md
@@ -1,0 +1,39 @@
+## Module
+ExpeditionList
+
+## Finding
+`ExpeditionListService` (Application layer) directly calls filesystem APIs in two private methods:
+
+- **`Cleanup()`** (`Services/ExpeditionListService.cs` lines 70–78): calls `File.Exists(f)` and `File.Delete(f)` to remove temporary PDF files after dispatch.
+- **`SendEmailCopy()`** (`Services/ExpeditionListService.cs` lines 95–104): calls `File.ReadAllBytesAsync(a)` to read each exported PDF before attaching it to the outgoing email.
+
+The file paths come from `ExpeditionPickingResult.ExportedFiles`, which is populated by the `IExpeditionPickingSource` adapter. The Application layer thus knows about and manipulates filesystem paths, which is an infrastructure concern.
+
+`docs/architecture/filesystem.md` states:
+> **I/O placement rule**: Concrete `IPrintQueueSink` implementations and any I/O-bound service live in adapter projects under `backend/src/Adapters/`, not in `Features/{Feature}/Services/`.
+
+All other I/O-bound services in the printing pipeline (`AzureBlobPrintQueueSink`, `CupsPrintQueueSink`, `FileSystemPrintQueueSink`) correctly live under `backend/src/Adapters/`. `ExpeditionListService` breaks this pattern.
+
+## Why it matters
+- The Application layer is supposed to be infrastructure-agnostic. Direct `File.*` calls make the service untestable without a real filesystem and couple it to the host OS's file system.
+- `ExpeditionListServicePrintSinkTests` and `ExpeditionListServiceOrderStateTests` (in `backend/test/`) have to work around this — any test that exercises `PrintPickingListAsync` with email or cleanup paths needs real temp files rather than mocks.
+- Any future migration to a non-filesystem picking source (e.g. in-memory byte streams) requires changing both the picking source adapter AND the Application-layer service.
+
+## Suggested fix
+Abstract temporary-file lifecycle behind a thin interface, e.g.:
+
+```csharp
+// In Application/Shared/Printing/ or Application/Features/ExpeditionList/Contracts/
+public interface ITemporaryFileAccessor
+{
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken ct = default);
+    void Delete(string path);
+}
+```
+
+Register a `System.IO`-backed implementation in `Adapters/` (or in the `FileSystem` adapter). Inject it into `ExpeditionListService` instead of calling `File.*` directly. The `Cleanup` and `SendEmailCopy` methods then delegate to this abstraction and become unit-testable with a mock.
+
+If the picking source can be changed to return `byte[]`/`Stream` instead of file paths, that is an even cleaner solution — it removes the need for the accessor entirely and stops filesystem paths from leaking into `ExpeditionPickingResult.ExportedFiles`.
+
+---
+_Filed by daily arch-review routine on 2026-07-02._

--- a/artifacts/feat-3461/code-review.r1.md
+++ b/artifacts/feat-3461/code-review.r1.md
@@ -1,0 +1,17 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs:109` — `_emailSender.SendEmailAsync(message)` still doesn't pass the `cancellationToken` that's now threaded through `SendEmailCopy`. Pre-existing gap (unchanged by this diff, `IEmailSender.SendEmailAsync` already accepts an optional token), but now that the token is available in scope it would be a trivial, free improvement to wire it through — out of scope for this surgical refactor, just flagging for a follow-up.
+
+### Verification performed beyond reading the diff
+- Confirmed `IExpeditionListService` is untouched — only the concrete `ExpeditionListService` constructor changed; all three callers (`PrintExpeditionOrderHandler`, `RunExpeditionListPrintFixHandler`, `PrintPickingListJob`) go through the interface and are unaffected.
+- Confirmed `Cleanup`/`SendEmailCopy` are private with no other callers.
+- Confirmed `ITemporaryFileAccessor` is registered exactly once (`AddFileSystemTemporaryFileAccessor()`), unconditionally, before the `PrintSink` switch — matching the spec's "works regardless of configured PrintSink" requirement, mirroring `IPrintQueueSink`'s adapter split, with no duplicate/conflicting registrations in any switch branch.
+- Confirmed the `ConfigurationConstants.APP_VERSION` → `InfrastructureConfigurationKeys.APP_VERSION` change in `GetConfigurationHandlerTests.cs` is not a stray/unrelated edit: `ConfigurationConstants` no longer has an `APP_VERSION` member (moved to `InfrastructureConfigurationKeys` in already-merged main commit `bbedc9f`), so this is a required fix to keep the branch compiling, not a bug.
+- Confirmed `EmailAttachment`/`EmailMessage` field usage in the new `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes` test matches the actual model shapes.
+- Full solution build (`dotnet build` on `Anela.Heblo.API.csproj`, which pulls in Application/Domain/Adapters): 0 errors.
+- Targeted test run (`--filter "FullyQualifiedName~ExpeditionList|FullyQualifiedName~GetConfigurationHandlerTests"`): 170/170 passed, including the new `FileSystemTemporaryFileAccessorTests` and the updated `ExpeditionListServiceOrderStateTests`/`ExpeditionListServicePrintSinkTests`.
+- Implementation matches spec `spec.r1.md` FR-1 through FR-5 exactly (interface shape, adapter placement, DI registration, service refactor, and test coverage requirements all satisfied).

--- a/artifacts/feat-3461/design.r1.md
+++ b/artifacts/feat-3461/design.r1.md
@@ -1,0 +1,74 @@
+# Design: Remove direct filesystem I/O from ExpeditionListService
+
+## Component Design
+
+### `ITemporaryFileAccessor` (new, Application layer)
+- **Location:** `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs`
+- **Responsibility:** Consumer-owned abstraction over temp-file read/delete operations needed by `ExpeditionListService`. Mirrors the existing intra-module split already used for `IPrintQueueSink` (Application defines the contract, `Adapters.FileSystem` implements it) — not the cross-module "consumer owns the contract" pattern, since both sides live inside `Features/ExpeditionList`.
+- **Contract:**
+  ```csharp
+  namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+  public interface ITemporaryFileAccessor
+  {
+      Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
+      void DeleteIfExists(string path);
+  }
+  ```
+- **Design notes:**
+  - No `System.IO` types (`File`, `Path`, `Directory`, `Stream`) appear in the signature — only `string`/`byte[]`/`CancellationToken`.
+  - `DeleteIfExists` is a single idempotent method rather than separate `Exists`/`Delete` members, avoiding a check-then-act race and keeping the surface minimal for mocking (`Verify(x => x.DeleteIfExists(path), Times.Once)`).
+  - `Path.GetFileName(a)` in `SendEmailCopy` remains inline in `ExpeditionListService` — it's a pure string operation, not filesystem I/O, and stays out of the abstraction.
+
+### `FileSystemTemporaryFileAccessor` (new, Adapter layer)
+- **Location:** `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs`
+- **Responsibility:** `System.IO.File`-backed implementation of `ITemporaryFileAccessor`. Sits alongside the existing `FileSystemPrintQueueSink` in the same feature folder.
+- **Behavior:**
+  - `ReadAllBytesAsync` passes through to `File.ReadAllBytesAsync(path, cancellationToken)` — same exceptions propagate on failure (`FileNotFoundException`, `IOException`) as today; no new error handling added.
+  - `DeleteIfExists` guards with `File.Exists` before calling `File.Delete`, preserving current no-op-if-absent semantics.
+  - Stateless; no constructor dependencies.
+
+### `ExpeditionListService` (modified, Application layer)
+- **Location:** `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs`
+- **Change:** Gains a new required constructor dependency, `ITemporaryFileAccessor temporaryFileAccessor`, inserted after `IPrintQueueSink printQueueSink` and before `ILogger` (preserving the existing dependencies-first/logger-last convention):
+  ```csharp
+  public ExpeditionListService(
+      IExpeditionPickingSource pickingSource,
+      IEmailSender emailSender,
+      TimeProvider clock,
+      IOptions<PrintPickingListOptions> options,
+      IPrintQueueSink printQueueSink,
+      ITemporaryFileAccessor temporaryFileAccessor,
+      ILogger<ExpeditionListService> logger)
+  ```
+- `Cleanup(ExpeditionPickingResult result)` and `SendEmailCopy(IList<string> files, IEnumerable<string> emailRecipients)` delegate to `_temporaryFileAccessor.DeleteIfExists(...)` / `_temporaryFileAccessor.ReadAllBytesAsync(...)` instead of calling `System.IO.File` directly. No other logic in either method changes.
+- Public contract `IExpeditionListService.PrintPickingListAsync` is unaffected — this is purely an internal implementation detail.
+- Minor accepted behavior change: `SendEmailCopy` now forwards `CancellationToken` into `ReadAllBytesAsync` (current code does not pass a token to `File.ReadAllBytesAsync`). This only makes cancellation take effect earlier/more precisely and is not a functional regression.
+
+### `FileSystemAdapterServiceCollectionExtensions` (modified, Adapter layer)
+- **Location:** `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs`
+- **Change:** New method `AddFileSystemTemporaryFileAccessor(this IServiceCollection services)` registering `services.AddScoped<ITemporaryFileAccessor, FileSystemTemporaryFileAccessor>();` — `Scoped` lifetime to match `IPrintQueueSink`'s existing registration, for consistency (the type is stateless, but no functional benefit to diverging).
+
+### Composition root wiring (modified)
+- **Location:** `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`, inside `AddPrintQueueSink`.
+- **Change:** Call `services.AddFileSystemTemporaryFileAccessor();` **once, unconditionally, before** the `switch (printSink)` block — not inside the `default:` case. Temp-file read/delete is required regardless of which `PrintSink` (`FileSystem` / `AzureBlob` / `Cups` / `Combined`) is active, since exported PDFs always land on local disk first via `IExpeditionPickingSource.CreatePickingListAsync`. Placing the call inside `default:` would leave `IExpeditionListService` unresolvable under non-default `PrintSink` configs — this is the corrected anchor point per the architecture review.
+
+### Test updates
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs` and `ExpeditionListServiceOrderStateTests.cs`: add a `Mock<ITemporaryFileAccessor>` field to each `CreateService()` helper, pass `.Object` into the constructor. Replace any real-filesystem setup (e.g. `Path.GetTempFileName()` + `Assert.False(File.Exists(tmpFile))` in the cleanup test) with mock setup/verification (`DeleteIfExists` invoked once per `ExportedFiles` entry; `ReadAllBytesAsync` stubbed to return known bytes for attachment assertions).
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs` (new): exercises the real filesystem in isolation — `DeleteIfExists` on a non-existent path is a no-op; `ReadAllBytesAsync` returns actual file bytes. This is the one place real I/O in tests is appropriate, since it is now confined to the adapter.
+
+## Data Schemas
+
+No persistent data model, database schema, or HTTP/REST/MediatR contract changes. This is an internal DI/interface refactor. Summary of type-level changes:
+
+| Type | Layer | Change |
+|---|---|---|
+| `ITemporaryFileAccessor` | `Anela.Heblo.Application` (`Features/ExpeditionList/Contracts/`) | New interface: `Task<byte[]> ReadAllBytesAsync(string path, CancellationToken)`, `void DeleteIfExists(string path)` |
+| `FileSystemTemporaryFileAccessor` | `Anela.Heblo.Adapters.FileSystem` (`Features/ExpeditionList/`) | New class implementing the above via `System.IO.File` |
+| `ExpeditionListService` | `Anela.Heblo.Application` (`Features/ExpeditionList/Services/`) | Modified: new constructor parameter `ITemporaryFileAccessor temporaryFileAccessor`; `Cleanup`/`SendEmailCopy` bodies delegate to it instead of `File.*` |
+| `FileSystemAdapterServiceCollectionExtensions` | `Anela.Heblo.Adapters.FileSystem` | New method `AddFileSystemTemporaryFileAccessor()` registering `ITemporaryFileAccessor` as `Scoped` |
+| `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` | `Anela.Heblo.API` | Modified: `AddPrintQueueSink` calls `AddFileSystemTemporaryFileAccessor()` unconditionally, before the `PrintSink` switch |
+
+`ExpeditionPickingResult.ExportedFiles` (`IList<string>`) is unchanged — file paths remain the transport between `IExpeditionPickingSource` and `ExpeditionListService`; no move to `byte[]`/`Stream` in this change (deferred, see spec Out of Scope).
+
+No HTTP endpoints, MediatR request/response DTOs, or event payloads are introduced or modified.

--- a/artifacts/feat-3461/impl/add-temporary-file-accessor-contract-and-adapter.r1.md
+++ b/artifacts/feat-3461/impl/add-temporary-file-accessor-contract-and-adapter.r1.md
@@ -1,0 +1,39 @@
+# Implementation: add-temporary-file-accessor-contract-and-adapter
+
+## What was implemented
+Added the `ITemporaryFileAccessor` contract to the Application layer and its `FileSystemTemporaryFileAccessor` implementation to the FileSystem adapter project, registered unconditionally in the composition root (before the `PrintSink` switch). `ExpeditionListService` itself is untouched in this task, per plan.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs` — new interface: `Task<byte[]> ReadAllBytesAsync(string, CancellationToken)`, `void DeleteIfExists(string)`.
+- `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs` — new `System.IO.File`-backed implementation.
+- `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs` — added `AddFileSystemTemporaryFileAccessor()` extension method.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — calls `AddFileSystemTemporaryFileAccessor()` unconditionally inside `AddPrintQueueSink`, before the `PrintSink` switch.
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs` — new test file, 4 tests covering read/delete happy and missing-file paths.
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — unrelated one-line fix (see Notes).
+
+## Tests
+- `FileSystemTemporaryFileAccessorTests` (4 new tests): read existing file, read missing file throws `FileNotFoundException`, delete existing file, delete non-existent file is a no-op. All pass.
+- Full `ExpeditionList` test slice (`dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList`): 164 passed, 0 failed.
+
+## How to verify
+```
+cd backend && dotnet build ../Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList
+```
+
+## Notes
+`GetConfigurationHandlerTests.cs` line 92 had a pre-existing, unrelated compile error on the branch base (`ConfigurationConstants.APP_VERSION`, but `APP_VERSION` had already moved to `InfrastructureConfigurationKeys` in a prior merged PR — every other reference in the same file already used the new symbol; this one site was missed). This blocked `dotnet build` for the whole solution, so it was fixed as a one-line symbol-name correction to unblock this task's build. No behavior change; not otherwise in scope for this feature.
+
+## PR Summary
+Introduces `ITemporaryFileAccessor` (Application layer) and `FileSystemTemporaryFileAccessor` (FileSystem adapter), mirroring the existing `IPrintQueueSink`/`FileSystemPrintQueueSink` split, and wires it into DI unconditionally so it's available regardless of the configured `PrintSink`. `ExpeditionListService` does not yet use the new type — that's the next task.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs` — new
+- `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs` — new
+- `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs` — new registration method
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — wired the new registration
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs` — new
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — unrelated pre-existing build-break fix
+
+## Status
+DONE

--- a/artifacts/feat-3461/impl/refactor-expeditionlistservice-to-use-temporary-file-accessor.r1.md
+++ b/artifacts/feat-3461/impl/refactor-expeditionlistservice-to-use-temporary-file-accessor.r1.md
@@ -1,0 +1,36 @@
+# Implementation: refactor-expeditionlistservice-to-use-temporary-file-accessor
+
+## What was implemented
+Injected `ITemporaryFileAccessor` into `ExpeditionListService` and replaced the bodies of `Cleanup` and `SendEmailCopy` to delegate to it instead of calling `System.IO.File` directly. `SendEmailCopy` now accepts and forwards a `CancellationToken` into `ReadAllBytesAsync`. Updated both existing test files to mock `ITemporaryFileAccessor`, rewrote `PrintPickingListAsync_CleanupRunsAfterSuccess` to assert against the mock instead of the real filesystem, and added a new test asserting email attachments are built from the accessor's returned bytes.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` — new `ITemporaryFileAccessor` constructor dependency; `Cleanup`/`SendEmailCopy` delegate to it instead of `File.*`; `SendEmailCopy` gained a `CancellationToken` parameter forwarded from `PrintPickingListAsync`'s batch callback.
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs` — added `Mock<ITemporaryFileAccessor>` field, threaded into `CreateService()`.
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs` — added `Mock<ITemporaryFileAccessor>` field; rewrote `PrintPickingListAsync_CleanupRunsAfterSuccess` to use a fake path + `Verify(DeleteIfExists(...), Times.Once)` instead of `Path.GetTempFileName()`/`File.Exists`; added new test `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes`.
+
+## Tests
+- `ExpeditionListServicePrintSinkTests` (2 tests, assertions unchanged): pass.
+- `ExpeditionListServiceOrderStateTests` (6 tests: original 5 + new `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes`): pass.
+- Full `ExpeditionList` test slice (`dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList`): 165 passed, 0 failed (up from 164 in the previous task — one net new test).
+- `grep -n "File\." backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` returns zero matches for `File.Exists`/`File.Delete`/`File.ReadAllBytesAsync` (`Path.GetFileName` remains, correctly — it's not I/O).
+
+## How to verify
+```
+dotnet build Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList
+git diff --stat  # only the 5 files across both tasks are touched (plus the unrelated pre-existing fix in task 1)
+```
+
+## Notes
+No deviations from the task-context plan. `IExpeditionListService.cs` (public interface) was not modified, as required.
+
+## PR Summary
+Completes the ExpeditionList I/O-placement fix: `ExpeditionListService` no longer calls `System.IO.File` directly, delegating all temp-file read/delete to the `ITemporaryFileAccessor` abstraction added in the prior task. Existing print-sink and order-state test suites are updated to mock the new dependency, and a new test pins that email attachments are built from the bytes the accessor returns.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` — refactored to use `ITemporaryFileAccessor`
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs` — mock wiring
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs` — mock wiring, rewritten cleanup test, new attachment test
+
+## Status
+DONE

--- a/artifacts/feat-3461/review/add-temporary-file-accessor-contract-and-adapter.r1.md
+++ b/artifacts/feat-3461/review/add-temporary-file-accessor-contract-and-adapter.r1.md
@@ -1,0 +1,20 @@
+# Code Review: add-temporary-file-accessor-contract-and-adapter
+
+## Summary
+The implementation successfully introduces the `ITemporaryFileAccessor` contract to the Application layer with a `System.IO`-backed adapter in the FileSystem project, registers it unconditionally in DI before the `PrintSink` switch, and includes 4 comprehensive unit tests. All acceptance criteria are met: build succeeds, formatting is clean, 164 existing tests pass alongside 4 new tests, and the contract contains no `System.IO` types in its signatures.
+
+## Review Result: PASS
+
+### task: add-temporary-file-accessor-contract-and-adapter
+**Status:** PASS
+
+## Docs to Update
+No documentation updates required. The implementation is scoped to internal contracts and adapters with no public API changes or architecture shifts.
+
+## Overall Notes
+- The one-line correction in `GetConfigurationHandlerTests.cs` (`ConfigurationConstants.APP_VERSION` → `InfrastructureConfigurationKeys.APP_VERSION`) is a pre-existing stale reference unrelated to this task but necessary to unblock the build. Acceptable as a side-fix during implementation.
+- Interface design is clean: `ReadAllBytesAsync` and `DeleteIfExists` use only `string` and `Task<byte[]>` in signatures, keeping `System.IO` abstracted behind the adapter layer.
+- DI registration pattern follows project conventions: unconditional `AddFileSystemTemporaryFileAccessor()` call placed before the `switch (printSink)` block, ensuring no resolution errors regardless of PrintSink configuration.
+- Scoped lifetime for the adapter is appropriate for file I/O operations.
+
+**Status:** PASS

--- a/artifacts/feat-3461/review/refactor-expeditionlistservice-to-use-temporary-file-accessor.r1.md
+++ b/artifacts/feat-3461/review/refactor-expeditionlistservice-to-use-temporary-file-accessor.r1.md
@@ -1,0 +1,28 @@
+# Code Review: refactor-expeditionlistservice-to-use-temporary-file-accessor
+
+## Summary
+Implementation correctly injects `ITemporaryFileAccessor` into `ExpeditionListService`, replaces all direct `File.*` I/O calls in `Cleanup` and `SendEmailCopy` with delegation to the accessor, and properly updates both test files with mocked dependencies. Refactored test correctly moves from real filesystem to mocked verification; new test comprehensively validates email attachment bytes flow through the accessor.
+
+## Review Result: PASS
+
+### task: refactor-expeditionlistservice-to-use-temporary-file-accessor
+**Status:** PASS
+
+## Overall Notes
+
+**Dependency injection:** Clean constructor injection; all three constructor parameters assigned correctly.
+
+**I/O removal:**
+- `Cleanup()`: `File.Exists()` + `File.Delete()` → `_temporaryFileAccessor.DeleteIfExists()`
+- `SendEmailCopy()`: `File.ReadAllBytesAsync()` → `_temporaryFileAccessor.ReadAllBytesAsync()`
+- `Path.GetFileName()` correctly retained (not I/O, required for attachment metadata)
+
+**CancellationToken handling:** Properly threaded from caller through `SendEmailCopy` to `ReadAllBytesAsync` call.
+
+**Test refactoring sound:**
+- `PrintPickingListAsync_CleanupRunsAfterSuccess` moves from real `Path.GetTempFileName()` to fake path + mock verification via `Verify(DeleteIfExists(...), Times.Once)` — eliminates filesystem coupling without losing coverage intent.
+- New test `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes` comprehensively validates the flow: mocks accessor bytes → captures email message → verifies Base64 content, filename, and MIME type match.
+
+**Test infrastructure:** Both test files correctly instantiate `Mock<ITemporaryFileAccessor>` and pass to `CreateService()`; mocks are properly wired in constructor call.
+
+**Acceptance criteria met:** All acceptance criteria addressed (no file I/O direct calls, both test suites pass, zero grep matches for `File.Exists`/`File.Delete`/`File.ReadAllBytesAsync`, no interface changes).

--- a/artifacts/feat-3461/spec.r1.md
+++ b/artifacts/feat-3461/spec.r1.md
@@ -1,0 +1,200 @@
+# Specification: Remove direct filesystem I/O from ExpeditionListService (Application layer)
+
+## Summary
+`ExpeditionListService` in `Anela.Heblo.Application.Features.ExpeditionList.Services` currently calls `File.Exists`, `File.Delete`, and `File.ReadAllBytesAsync` directly, violating the repo's documented I/O placement rule that concrete I/O-bound work must live in `backend/src/Adapters/`. This spec defines a new `ITemporaryFileAccessor` abstraction — owned by the ExpeditionList module's contracts and implemented by the existing FileSystem adapter project — so the Application-layer service becomes filesystem-agnostic and fully unit-testable with mocks, matching the pattern already used for `IPrintQueueSink`.
+
+## Background
+`docs/architecture/filesystem.md` states the I/O placement rule explicitly:
+> Concrete `IPrintQueueSink` implementations and any I/O-bound service live in adapter projects under `backend/src/Adapters/`, not in `Features/{Feature}/Services/`.
+
+The printing pipeline already follows this correctly: `FileSystemPrintQueueSink`, `AzureBlobPrintQueueSink`, and `CupsPrintQueueSink` all live under `backend/src/Adapters/*` and implement the Application-owned `IPrintQueueSink` contract (`Anela.Heblo.Application.Shared.Printing.IPrintQueueSink`). `ExpeditionListService`, however, bypasses this pattern in two private methods:
+
+- `Cleanup(ExpeditionPickingResult result)` (lines 70–79): iterates `result.ExportedFiles` and calls `File.Exists(f)` / `File.Delete(f)` directly to remove temporary PDFs after a batch is dispatched.
+- `SendEmailCopy(IList<string> files, IEnumerable<string> emailRecipients)` (lines 81–109): calls `File.ReadAllBytesAsync(a)` directly to read each exported PDF before base64-encoding it into an `EmailAttachment`.
+
+Both file lists originate as `IList<string>` paths supplied by `IExpeditionPickingSource.CreatePickingListAsync` (via `ExpeditionPickingResult.ExportedFiles` and the `onBatchFilesReady` callback), which today is implemented by `LogisticsExpeditionPickingAdapter` delegating to `IPickingListSource` (bound to `ShoptetApiExpeditionListSource`). The Application layer therefore both receives filesystem paths from an adapter *and* performs raw filesystem I/O on them itself — the second half of that is the violation this spec fixes.
+
+Consequences of the current state, per the architecture-review finding:
+- The service cannot be unit tested without a real filesystem for any path that exercises email or cleanup behavior; `ExpeditionListServicePrintSinkTests` and `ExpeditionListServiceOrderStateTests` must currently work around this using real temp files rather than pure mocks.
+- The service is coupled to the host OS's filesystem semantics, which blocks any future migration of the picking source to return in-memory byte streams instead of file paths without also touching the Application-layer service.
+
+This is a **pure refactor**: no user-facing behavior, business logic, or output should change. `PrintPickingListAsync`'s external contract (`IExpeditionListService`), the generated PDFs, the email content, and print-queue behavior must all remain identical.
+
+## Functional Requirements
+
+### FR-1: Introduce `ITemporaryFileAccessor` contract in the Application layer
+Define a new interface that captures exactly the temporary-file operations `ExpeditionListService` needs — read bytes, and delete-if-exists — with no leakage of `System.IO` types beyond primitive `string`/`byte[]`.
+
+```csharp
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface ITemporaryFileAccessor
+{
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
+    void DeleteIfExists(string path);
+}
+```
+
+Placement: `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs`, following the existing consumer-owns-the-contract pattern used for `IExpeditionPickingSource` (see `docs/architecture/development_guidelines.md`, "Cross-Module Communication" pattern, applied here intra-module for I/O rather than cross-module data access).
+
+**Acceptance criteria:**
+- Interface has exactly two members: an async byte-read and a delete-if-exists operation (naming may be adjusted during implementation review, but the shape — no `File.Exists` exposed separately, no `Stream` leakage — must match).
+- Interface lives under `Application/Features/ExpeditionList/Contracts/`, not `Services/`.
+- No `System.IO` (`File`, `Path`, `Directory`) types appear in the interface signature.
+
+### FR-2: Implement `ITemporaryFileAccessor` in the FileSystem adapter project
+Add a concrete implementation backed by `System.IO.File` in `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/`, alongside the existing `FileSystemPrintQueueSink` for the same feature.
+
+```csharp
+namespace Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessor : ITemporaryFileAccessor
+{
+    public Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
+        => File.ReadAllBytesAsync(path, cancellationToken);
+
+    public void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}
+```
+
+**Acceptance criteria:**
+- Class lives in `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs`.
+- Behavior is byte-identical to the current inline code: `ReadAllBytesAsync` passes through `CancellationToken`; `DeleteIfExists` is a no-op when the file is already absent (matches current `File.Exists` guard, avoiding a `FileNotFoundException` from a bare `File.Delete`).
+- No behavior change: same exceptions propagate on read failure (e.g., `FileNotFoundException`, `IOException`) as today, since callers currently do not catch around `File.ReadAllBytesAsync`.
+
+### FR-3: Register the new implementation in DI
+Extend `FileSystemAdapterServiceCollectionExtensions` (or add a sibling extension method) so the composition root (`Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`) can register `ITemporaryFileAccessor` the same way it registers `IPrintQueueSink` today via `AddFileSystemPrintQueueSink()`.
+
+**Acceptance criteria:**
+- A new method (e.g. `AddFileSystemTemporaryFileAccessor()`) or an addition to the existing registration method registers `services.AddScoped<ITemporaryFileAccessor, FileSystemTemporaryFileAccessor>();` (lifetime should match `IPrintQueueSink`'s existing `Scoped` registration for consistency, unless implementation review determines `Singleton` is safe/preferable — the type is stateless).
+- `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` calls this registration unconditionally alongside (or as part of) the existing `services.AddFileSystemPrintQueueSink();` call at line ~436, since — unlike the print sink, which has environment-specific alternatives (Azure Blob, CUPS) — temporary-file read/delete is not swapped per environment today.
+- Application starts successfully and `IExpeditionListService` resolves with no DI errors in all existing environments (local, staging).
+
+### FR-4: Refactor `ExpeditionListService` to use `ITemporaryFileAccessor` instead of direct `File.*` calls
+Inject `ITemporaryFileAccessor` into `ExpeditionListService`'s constructor. Replace the bodies of `Cleanup` and `SendEmailCopy` to delegate to the injected accessor instead of calling `System.IO.File` directly. Remove the now-unused `File.Exists`/`File.Delete`/`File.ReadAllBytesAsync` calls entirely from this file.
+
+`Cleanup` becomes:
+```csharp
+private Task Cleanup(ExpeditionPickingResult result)
+{
+    foreach (var f in result.ExportedFiles)
+    {
+        _temporaryFileAccessor.DeleteIfExists(f);
+    }
+
+    return Task.CompletedTask;
+}
+```
+
+`SendEmailCopy`'s attachment loop becomes:
+```csharp
+foreach (var a in files)
+{
+    var bytes = await _temporaryFileAccessor.ReadAllBytesAsync(a, cancellationToken);
+    message.Attachments.Add(new EmailAttachment
+    {
+        FileName = Path.GetFileName(a),
+        Content = Convert.ToBase64String(bytes),
+        ContentType = "application/pdf"
+    });
+}
+```
+
+**Acceptance criteria:**
+- `ExpeditionListService.cs` no longer contains any `File.*` calls (verified by absence of `using System.IO;`-only members like `File.Exists`, `File.Delete`, `File.ReadAllBytesAsync` in the file, and by a grep for `System.IO.File` returning nothing in this file).
+- `Path.GetFileName(a)` (a pure string operation, not I/O) may remain inline — it is not filesystem access and is out of scope for the abstraction (confirm during implementation; if reviewers prefer full purity, this can also move behind the accessor, see Open Questions).
+- `SendEmailCopy` passes `CancellationToken` through to `ReadAllBytesAsync` (note: current code does **not** pass the token to `File.ReadAllBytesAsync` — this is a minor behavior addition; confirm acceptable, see Open Questions).
+- Constructor signature adds `ITemporaryFileAccessor temporaryFileAccessor` as a new required parameter; existing parameters and their order are otherwise preserved as closely as practical (exact position is an implementation detail, not user-visible).
+- `IExpeditionListService` public interface is unchanged — this is an internal implementation detail of `ExpeditionListService`.
+
+### FR-5: Update or add unit tests to use a mocked `ITemporaryFileAccessor`
+Update `ExpeditionListServicePrintSinkTests` and `ExpeditionListServiceOrderStateTests` (both in `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/`) to construct `ExpeditionListService` with a `Mock<ITemporaryFileAccessor>` instead of relying on real temporary files on disk for any test path that exercises `Cleanup` or `SendEmailCopy`.
+
+**Acceptance criteria:**
+- Every existing test in both files continues to pass after the refactor, with the same assertions.
+- Any test that previously created real temp files specifically to satisfy `File.Exists`/`File.ReadAllBytesAsync` inside `ExpeditionListService` is rewritten to instead set up `Mock<ITemporaryFileAccessor>` return values (e.g., `_temporaryFileAccessor.Setup(x => x.ReadAllBytesAsync(path, It.IsAny<CancellationToken>())).ReturnsAsync(someBytes)`), and no longer touches the real filesystem for that purpose.
+- At least one test asserts `DeleteIfExists` is invoked once per file in `ExpeditionPickingResult.ExportedFiles` after `PrintPickingListAsync` completes (covering `Cleanup`).
+- At least one test asserts email attachments are built from bytes returned by the mocked `ReadAllBytesAsync`, without depending on real file content (covering `SendEmailCopy`).
+- A new unit test exists for `FileSystemTemporaryFileAccessor` itself (in the adapter's own test project, if one exists, or a new lightweight test) verifying `DeleteIfExists` on a non-existent path is a no-op and `ReadAllBytesAsync` returns the file's actual bytes — this is the one place real filesystem interaction is appropriate, since it is now isolated to the adapter.
+
+### FR-6: Preserve architectural boundary going forward
+No new test is strictly required beyond FR-5, but implementers should check whether `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` (or a sibling architecture test) already has a reflection-based check for I/O calls in `Features/*/Services/`. If such a check does not exist, adding one is **optional** for this change (see Out of Scope) but recommended as a follow-up to prevent regression.
+
+**Acceptance criteria:**
+- Investigation is done and documented in the PR description (found existing check / no check exists), even if a new automated guard is not added in this change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance regression versus current behavior. File read/delete operations are the same OS-level calls, just routed through one extra interface indirection (negligible overhead, sub-microsecond per call). No additional I/O round-trips are introduced. `AddScoped` DI resolution cost is negligible relative to the PDF generation and printing work already being done in this code path.
+
+### NFR-2: Security
+No change to the security posture. The accessor operates only on paths already produced internally by `IExpeditionPickingSource` (not user-supplied input), so no new path-traversal or injection surface is introduced. No new secrets, credentials, or external endpoints are involved.
+
+### NFR-3: Testability
+This is the primary driver of the change. After this refactor, `ExpeditionListService` unit tests must be constructible entirely with mocks (`Mock<IExpeditionPickingSource>`, `Mock<IEmailSender>`, `Mock<IPrintQueueSink>`, `Mock<ITemporaryFileAccessor>`) with zero dependency on the real filesystem, temp directories, or `File.*` static calls in test setup/teardown.
+
+### NFR-4: Backward compatibility
+`IExpeditionListService.PrintPickingListAsync` signature and behavior are unchanged from the caller's perspective (`PrintExpeditionOrderHandler`, `PrintPickingListJob`, `RunExpeditionListPrintFixHandler` if applicable). No API contract, request/response DTO, or MediatR handler changes are required.
+
+## Data Model
+No persistent data model changes. This is a pure DI/interface refactor affecting only the following types:
+
+| Type | Layer | Change |
+|---|---|---|
+| `ITemporaryFileAccessor` | `Anela.Heblo.Application` (`Features/ExpeditionList/Contracts/`) | New interface |
+| `FileSystemTemporaryFileAccessor` | `Anela.Heblo.Adapters.FileSystem` (`Features/ExpeditionList/`) | New class |
+| `ExpeditionListService` | `Anela.Heblo.Application` (`Features/ExpeditionList/Services/`) | Modified: new constructor dependency, `Cleanup`/`SendEmailCopy` bodies delegate to accessor instead of `File.*` |
+| `FileSystemAdapterServiceCollectionExtensions` | `Anela.Heblo.Adapters.FileSystem` | Modified/extended: new DI registration method |
+| `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` | `Anela.Heblo.API` | Modified: calls new registration method |
+
+`ExpeditionPickingResult.ExportedFiles` (`IList<string>`) is unchanged — this spec does not attempt the "even cleaner" alternative of eliminating file paths from the contract entirely (see Out of Scope).
+
+## API / Interface Design
+
+```csharp
+// Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs
+public interface ITemporaryFileAccessor
+{
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
+    void DeleteIfExists(string path);
+}
+```
+
+```csharp
+// Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs
+public class FileSystemTemporaryFileAccessor : ITemporaryFileAccessor { /* System.IO-backed */ }
+```
+
+```csharp
+// Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs
+public static IServiceCollection AddFileSystemTemporaryFileAccessor(this IServiceCollection services);
+// or fold into the existing AddFileSystemPrintQueueSink(), renamed/expanded if scope allows
+```
+
+No HTTP/REST endpoints, MediatR requests, or frontend surfaces are affected by this change — it is entirely internal to the backend Application/Adapter layers.
+
+## Dependencies
+- Existing `Anela.Heblo.Adapters.FileSystem` project (already referenced by `Anela.Heblo.API` for `AddFileSystemPrintQueueSink()`; no new project reference needed).
+- Existing `Anela.Heblo.Application` → `Anela.Heblo.Adapters.FileSystem` DI wiring pattern (composition happens in `Anela.Heblo.API`, consistent with Clean Architecture — Application never references Adapters directly).
+- No third-party library additions.
+- No changes to `IExpeditionPickingSource`, `LogisticsExpeditionPickingAdapter`, or the Shoptet/Logistics picking pipeline are required for this change.
+
+## Out of Scope
+- Changing `IExpeditionPickingSource`/`ExpeditionPickingResult` to return `byte[]`/`Stream` instead of file paths (the brief's "even cleaner" alternative). This is a larger, cross-cutting change affecting the picking source adapter chain (`LogisticsExpeditionPickingAdapter`, `IPickingListSource`, `ShoptetApiExpeditionListSource`) and print-queue sinks (`IPrintQueueSink.SendAsync` also takes file paths). Worth a separate architecture discussion, not bundled into this fix.
+- Adding a new automated architecture test (reflection-based boundary check) to prevent future regressions of this kind — investigation is required (FR-6) but adding the guard itself is optional for this change.
+- Any change to `IPrintQueueSink` or its existing implementations (`FileSystemPrintQueueSink`, `AzureBlobPrintQueueSink`, `CupsPrintQueueSink`, `CombinedPrintQueueSink`) — these already comply with the I/O placement rule and are untouched.
+- Any change to email content, PDF generation, print-queue behavior, or the `PrintExpeditionOrderHandler`/`PrintPickingListJob`/`RunExpeditionListPrintFixHandler` call sites.
+- Retry/resilience behavior for file read or delete failures — current behavior (exceptions propagate uncaught) is preserved as-is.
+
+## Open Questions
+- FR-4 proposes passing `CancellationToken` through to `ReadAllBytesAsync` in `SendEmailCopy`, which the current code does not do (`File.ReadAllBytesAsync(a)` with no token). This is a minor behavior change (cancellation now takes effect during attachment reads, not just before). Confirm this is acceptable, or should the accessor's `ReadAllBytesAsync` be called without forwarding the token to preserve exact current behavior?
+- Should `DeleteIfExists` naming/shape match exactly what the brief proposed (`Delete(string path)` with an internal `Exists` check hidden, vs. separate `Exists`/`Delete` members as two calls)? This spec assumes a single `DeleteIfExists` method to keep the interface minimal and avoid exposing a race-prone `Exists`-then-`Delete` pattern to callers — confirm this is preferred over a literal `File.Exists`/`File.Delete` mirror.
+- Should the DI registration for `ITemporaryFileAccessor` be folded into the existing `AddFileSystemPrintQueueSink()` method (renaming it to something like `AddFileSystemAdapter()`), or added as a clearly separate `AddFileSystemTemporaryFileAccessor()` call? Both achieve the same runtime result; this is a naming/organization preference for the implementer to confirm, given `AddFileSystemPrintQueueSink` is currently named specifically for the sink.
+- Should `Path.GetFileName(a)` in `SendEmailCopy` (a pure string operation, no filesystem access) also move behind the accessor for full purity, or is it acceptable to leave inline since it does not touch the filesystem? This spec assumes it stays inline (it is not I/O).
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -17,13 +17,26 @@
       "updated_at": "2026-07-03T05:21:08.512984Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-03T05:24:35.653652Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-temporary-file-accessor-contract-and-adapter",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "refactor-expeditionlistservice-to-use-temporary-file-accessor",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-03T05:17:20.308031Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-03T05:20:08.576756Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-03T05:20:19.818592Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3461",
+  "issue_number": 3461,
+  "created_at": "2026-07-03T05:14:57.808655Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-03T05:17:20.308031Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "add-temporary-file-accessor-contract-and-adapter",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-03T05:24:54.654606Z"
+      "updated_at": "2026-07-03T05:55:32.781035Z"
     },
     {
       "name": "refactor-expeditionlistservice-to-use-temporary-file-accessor",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-03T05:55:36.172325Z"
     }
   ]
 }

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-03T06:24:20.103073Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-03T06:24:20.451339Z"
+      "status": "completed",
+      "updated_at": "2026-07-03T06:37:19.430329Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-03T06:24:20.103073Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-03T06:24:20.451339Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-03T05:20:08.576756Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-03T05:20:19.818592Z"
+      "status": "completed",
+      "updated_at": "2026-07-03T05:21:08.512984Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-03T05:24:35.653652Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-03T05:24:54.455463Z"
+      "status": "completed",
+      "updated_at": "2026-07-03T06:24:20.103073Z"
     }
   },
   "tasks": [
@@ -34,9 +34,9 @@
     },
     {
       "name": "refactor-expeditionlistservice-to-use-temporary-file-accessor",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-03T05:55:36.172325Z"
+      "updated_at": "2026-07-03T06:24:14.017971Z"
     }
   ]
 }

--- a/artifacts/feat-3461/state.json
+++ b/artifacts/feat-3461/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-03T05:24:35.653652Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-03T05:24:54.455463Z"
     }
   },
   "tasks": [
     {
       "name": "add-temporary-file-accessor-contract-and-adapter",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-03T05:24:54.654606Z"
     },
     {
       "name": "refactor-expeditionlistservice-to-use-temporary-file-accessor",

--- a/artifacts/feat-3461/task-context/add-temporary-file-accessor-contract-and-adapter.md
+++ b/artifacts/feat-3461/task-context/add-temporary-file-accessor-contract-and-adapter.md
@@ -1,0 +1,235 @@
+### task: add-temporary-file-accessor-contract-and-adapter
+
+
+**What this task does:** Introduces the new `ITemporaryFileAccessor` contract in the Application layer, its `System.IO`-backed implementation in the FileSystem adapter project, registers it in DI (unconditionally, not gated by the `PrintSink` switch), and adds a new unit test for the adapter implementation. `ExpeditionListService` is **not** modified in this task — it keeps using `File.*` directly for now. This task must leave the build green and all existing tests passing, with the new type present but unused by production code except via DI registration.
+
+**File(s) to create/modify:**
+- Create: `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs`
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs`
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs`
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs`
+
+#### Step 1 — Create the `ITemporaryFileAccessor` contract
+
+Create `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs` with exactly this content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface ITemporaryFileAccessor
+{
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
+    void DeleteIfExists(string path);
+}
+```
+
+This mirrors the existing `IExpeditionPickingSource.cs` in the same folder (see that file for style precedent — plain interface, no XML doc header, file-scoped namespace). No `System.IO` types appear in the signature, per spec FR-1.
+
+#### Step 2 — Create the `FileSystemTemporaryFileAccessor` adapter implementation
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs` with exactly this content:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+namespace Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessor : ITemporaryFileAccessor
+{
+    public Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
+        => File.ReadAllBytesAsync(path, cancellationToken);
+
+    public void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}
+```
+
+This sits alongside the existing `FileSystemPrintQueueSink.cs` in the same folder and preserves identical semantics to the code currently inline in `ExpeditionListService` (same guard-then-delete pattern, same pass-through read with cancellation token).
+
+#### Step 3 — Register the new implementation in `FileSystemAdapterServiceCollectionExtensions`
+
+Modify `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs`. Current file:
+
+```csharp
+using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Anela.Heblo.Application.Shared.Printing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.FileSystem;
+
+public static class FileSystemAdapterServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the filesystem-based <see cref="IPrintQueueSink"/> implementation.
+    /// PrintPickingListOptions is bound by ExpeditionListModule in the Application layer,
+    /// so this extension takes no IConfiguration parameter.
+    /// </summary>
+    public static IServiceCollection AddFileSystemPrintQueueSink(this IServiceCollection services)
+    {
+        services.AddScoped<IPrintQueueSink, FileSystemPrintQueueSink>();
+        return services;
+    }
+}
+```
+
+Replace its contents with:
+
+```csharp
+using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Shared.Printing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.FileSystem;
+
+public static class FileSystemAdapterServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the filesystem-based <see cref="IPrintQueueSink"/> implementation.
+    /// PrintPickingListOptions is bound by ExpeditionListModule in the Application layer,
+    /// so this extension takes no IConfiguration parameter.
+    /// </summary>
+    public static IServiceCollection AddFileSystemPrintQueueSink(this IServiceCollection services)
+    {
+        services.AddScoped<IPrintQueueSink, FileSystemPrintQueueSink>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the filesystem-based <see cref="ITemporaryFileAccessor"/> implementation.
+    /// Used by ExpeditionListService to read/delete exported PDFs regardless of which
+    /// print sink (ExpeditionList:PrintSink) is configured, since exported files always
+    /// land on local disk first.
+    /// </summary>
+    public static IServiceCollection AddFileSystemTemporaryFileAccessor(this IServiceCollection services)
+    {
+        services.AddScoped<ITemporaryFileAccessor, FileSystemTemporaryFileAccessor>();
+        return services;
+    }
+}
+```
+
+#### Step 4 — Wire the registration into the composition root, outside the `PrintSink` switch
+
+Modify `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Find the `AddPrintQueueSink` method (around line 406):
+
+```csharp
+    public static IServiceCollection AddPrintQueueSink(this IServiceCollection services, IConfiguration configuration)
+    {
+        // The CUPS label-printing infrastructure (ILabelPrintingService) is always available —
+        // it is used by MaterialContainer label printing regardless of the expedition print sink.
+        services.AddCupsPrinting(configuration);
+
+        var printSink = configuration["ExpeditionList:PrintSink"];
+        switch (printSink)
+        {
+```
+
+Change it to add the new unconditional registration right after `AddCupsPrinting`, **before** the `switch`:
+
+```csharp
+    public static IServiceCollection AddPrintQueueSink(this IServiceCollection services, IConfiguration configuration)
+    {
+        // The CUPS label-printing infrastructure (ILabelPrintingService) is always available —
+        // it is used by MaterialContainer label printing regardless of the expedition print sink.
+        services.AddCupsPrinting(configuration);
+
+        // Temp-file read/delete is needed regardless of which PrintSink is configured — exported
+        // PDFs always land on local disk first (see IExpeditionPickingSource.CreatePickingListAsync),
+        // so this is registered unconditionally rather than inside the switch below.
+        services.AddFileSystemTemporaryFileAccessor();
+
+        var printSink = configuration["ExpeditionList:PrintSink"];
+        switch (printSink)
+        {
+```
+
+Leave the rest of the method (the `switch` block and its four cases, lines ~413–438) completely unchanged — do **not** add `AddFileSystemTemporaryFileAccessor()` inside the `default:` case; it must only appear once, before the switch. `Anela.Heblo.API` already references `Anela.Heblo.Adapters.FileSystem` (used for `AddFileSystemPrintQueueSink` in the same file), so no new project reference or `using` is needed for the new call itself — `FileSystemAdapterServiceCollectionExtensions` is a `public static class` in a namespace already in scope where `AddFileSystemPrintQueueSink()` is called.
+
+#### Step 5 — Add a unit test for `FileSystemTemporaryFileAccessor`
+
+Create `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs`:
+
+```csharp
+using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessorTests : IDisposable
+{
+    private readonly string _testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    public FileSystemTemporaryFileAccessorTests()
+    {
+        Directory.CreateDirectory(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir)) Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_ExistingFile_ReturnsFileContent()
+    {
+        var path = Path.Combine(_testDir, "file.pdf");
+        var expectedBytes = new byte[] { 1, 2, 3, 4, 5 };
+        await File.WriteAllBytesAsync(path, expectedBytes);
+
+        var accessor = new FileSystemTemporaryFileAccessor();
+        var bytes = await accessor.ReadAllBytesAsync(path);
+
+        Assert.Equal(expectedBytes, bytes);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_MissingFile_ThrowsFileNotFoundException()
+    {
+        var path = Path.Combine(_testDir, "does-not-exist.pdf");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() => accessor.ReadAllBytesAsync(path));
+    }
+
+    [Fact]
+    public void DeleteIfExists_ExistingFile_DeletesIt()
+    {
+        var path = Path.Combine(_testDir, "file.pdf");
+        File.WriteAllText(path, "content");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        accessor.DeleteIfExists(path);
+
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void DeleteIfExists_NonExistentFile_DoesNotThrow()
+    {
+        var path = Path.Combine(_testDir, "never-existed.pdf");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        var exception = Record.Exception(() => accessor.DeleteIfExists(path));
+
+        Assert.Null(exception);
+    }
+}
+```
+
+This follows the same `IDisposable` + `Path.GetTempPath()`/`Guid.NewGuid()` temp-directory pattern already used in `FileSystemPrintQueueSinkTests.cs` in the same folder.
+
+#### Acceptance criteria
+
+- `dotnet build` succeeds for the whole solution (run from `backend/`: `dotnet build`).
+- `dotnet format` produces no diff (or is applied) for all files touched in this task.
+- New tests in `FileSystemTemporaryFileAccessorTests.cs` (4 tests) pass: run `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~FileSystemTemporaryFileAccessorTests`.
+- All pre-existing tests still pass (this task does not touch `ExpeditionListService.cs` or its tests): run `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList`.
+- Starting the API locally (or via the existing test harness) with no `ExpeditionList:PrintSink` config set, and separately with `ExpeditionList:PrintSink=AzureBlob`/`Cups`/`Combined`, must not throw a DI resolution error — verify by inspecting that `AddFileSystemTemporaryFileAccessor()` is called unconditionally (i.e., visually confirm in the diff that the call sits before the `switch (printSink)` line, not inside any `case`). If an integration/smoke test already exercises `AddPrintQueueSink` for multiple `PrintSink` values, it must still pass; if none exists, this is verified by code inspection only (no new test is required for this — out of scope per spec FR-3's acceptance criteria, which is satisfied by correct placement).
+- `ITemporaryFileAccessor.cs` contains no `System.IO` types in its member signatures (visually confirm: only `string`, `byte[]`, `Task`, `CancellationToken`).
+
+---

--- a/artifacts/feat-3461/task-context/refactor-expeditionlistservice-to-use-temporary-file-accessor.md
+++ b/artifacts/feat-3461/task-context/refactor-expeditionlistservice-to-use-temporary-file-accessor.md
@@ -1,0 +1,421 @@
+### task: refactor-expeditionlistservice-to-use-temporary-file-accessor
+
+
+**What this task does:** Injects `ITemporaryFileAccessor` into `ExpeditionListService`, replaces the bodies of `Cleanup` and `SendEmailCopy` to delegate to it instead of calling `System.IO.File` directly, and removes all direct `File.*` usage from the file. Updates the two existing test files (`ExpeditionListServicePrintSinkTests.cs`, `ExpeditionListServiceOrderStateTests.cs`) to construct `ExpeditionListService` with a `Mock<ITemporaryFileAccessor>`, including rewriting the one test that currently depends on the real filesystem (`PrintPickingListAsync_CleanupRunsAfterSuccess`). Depends on `add-temporary-file-accessor-contract-and-adapter` being complete (needs `ITemporaryFileAccessor` and `FileSystemTemporaryFileAccessor` to exist).
+
+**File(s) to create/modify:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs`
+
+#### Step 1 — Refactor `ExpeditionListService.cs`
+
+Replace the full contents of `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Xcc.Services.Email;
+using Anela.Heblo.Application.Shared.Printing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.ExpeditionList.Services;
+
+public class ExpeditionListService : IExpeditionListService
+{
+    private readonly IExpeditionPickingSource _pickingSource;
+    private readonly IEmailSender _emailSender;
+    private readonly TimeProvider _clock;
+    private readonly IOptions<PrintPickingListOptions> _options;
+    private readonly IPrintQueueSink _printQueueSink;
+    private readonly ITemporaryFileAccessor _temporaryFileAccessor;
+    private readonly ILogger<ExpeditionListService> _logger;
+
+    public ExpeditionListService(
+        IExpeditionPickingSource pickingSource,
+        IEmailSender emailSender,
+        TimeProvider clock,
+        IOptions<PrintPickingListOptions> options,
+        IPrintQueueSink printQueueSink,
+        ITemporaryFileAccessor temporaryFileAccessor,
+        ILogger<ExpeditionListService> logger)
+    {
+        _pickingSource = pickingSource;
+        _emailSender = emailSender;
+        _clock = clock;
+        _options = options;
+        _printQueueSink = printQueueSink;
+        _temporaryFileAccessor = temporaryFileAccessor;
+        _logger = logger;
+    }
+
+    public async Task<ExpeditionPickingResult> PrintPickingListAsync(
+        ExpeditionPickingRequest request,
+        IList<string>? emailList = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Generating new expedition list");
+
+        Func<IList<string>, Task>? batchCallback = null;
+
+        if (request.SendToPrinter || (emailList != null && emailList.Any()))
+        {
+            batchCallback = async files =>
+            {
+                if (request.SendToPrinter)
+                {
+                    await _printQueueSink.SendAsync(files, cancellationToken);
+                    _logger.LogDebug("Batch sent to print queue");
+                }
+
+                if (emailList != null && emailList.Any())
+                {
+                    await SendEmailCopy(files, emailList, cancellationToken);
+                    _logger.LogDebug("Batch email copy sent");
+                }
+            };
+        }
+
+        var result = await _pickingSource.CreatePickingListAsync(request, batchCallback, cancellationToken);
+
+        _logger.LogDebug("Expedition list complete — {Total} orders processed", result.TotalCount);
+
+        await Cleanup(result);
+
+        return result;
+    }
+
+    private Task Cleanup(ExpeditionPickingResult result)
+    {
+        foreach (var f in result.ExportedFiles)
+        {
+            _temporaryFileAccessor.DeleteIfExists(f);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task SendEmailCopy(IList<string> files, IEnumerable<string> emailRecipients, CancellationToken cancellationToken)
+    {
+        var now = _clock.GetLocalNow();
+        var message = new EmailMessage
+        {
+            From = _options.Value.EmailSender,
+            Subject = $"Expedice {now:yyyy-MM-dd}",
+            HtmlContent = $@"
+<strong>Expedice vygenerovana {now:yyyy-MM-dd HH:mm:ss}</strong></br>
+</br>
+</br>
+",
+            To = emailRecipients.ToList()
+        };
+
+        foreach (var a in files)
+        {
+            var bytes = await _temporaryFileAccessor.ReadAllBytesAsync(a, cancellationToken);
+            message.Attachments.Add(new EmailAttachment
+            {
+                FileName = Path.GetFileName(a),
+                Content = Convert.ToBase64String(bytes),
+                ContentType = "application/pdf"
+            });
+        }
+
+        await _emailSender.SendEmailAsync(message);
+        _logger.LogDebug("Sent email copy");
+    }
+}
+```
+
+Notes on this change versus the original file:
+- New constructor parameter `ITemporaryFileAccessor temporaryFileAccessor`, positioned after `printQueueSink` and before `logger` (matches the design doc's specified ordering: dependencies first, logger last).
+- `Cleanup` now calls `_temporaryFileAccessor.DeleteIfExists(f)` instead of the inline `File.Exists`/`File.Delete` guard.
+- `SendEmailCopy` gained a `CancellationToken cancellationToken` parameter (it previously took none) so it can forward the token into `_temporaryFileAccessor.ReadAllBytesAsync(a, cancellationToken)`. Its single call site inside `PrintPickingListAsync`'s `batchCallback` is updated to pass `cancellationToken` through. This is the one accepted minor behavior change called out in spec FR-4/Open Questions and the arch-review's risk table: cancellation now takes effect during attachment reads, not just before — not a functional regression.
+- `Path.GetFileName(a)` remains inline (pure string operation, not I/O — confirmed out of scope for the accessor by both the spec and design doc).
+- `using System.IO;` is not present and must not be added — confirm the file has zero remaining `File.*`/`System.IO.File` references (there is no explicit `using System.IO;` in the original file already, since `File`/`Path` were resolved via implicit global usings or the SDK's implicit usings; do not add one).
+- `IExpeditionListService` (the public interface) is untouched — do not modify `IExpeditionListService.cs`.
+
+#### Step 2 — Update `ExpeditionListServicePrintSinkTests.cs`
+
+Modify `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs`. Add a `Mock<ITemporaryFileAccessor>` field and pass it into the constructor call in `CreateService()`:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Application.Shared.Printing;
+using Anela.Heblo.Xcc.Services.Email;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class ExpeditionListServicePrintSinkTests
+{
+    private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
+    private readonly Mock<IEmailSender> _emailSender = new();
+    private readonly Mock<IPrintQueueSink> _printQueueSink = new();
+    private readonly Mock<ITemporaryFileAccessor> _temporaryFileAccessor = new();
+
+    private ExpeditionListService CreateService() => new ExpeditionListService(
+        _pickingSource.Object,
+        _emailSender.Object,
+        TimeProvider.System,
+        Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
+        _printQueueSink.Object,
+        _temporaryFileAccessor.Object,
+        NullLogger<ExpeditionListService>.Instance);
+
+    private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)
+    {
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(
+                async (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                {
+                    if (cb != null)
+                        await cb(filesToPassToCallback);
+                    return new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 };
+                });
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_SendToPrinterTrue_CallsSink()
+    {
+        var batchFiles = new List<string>();
+        SetupSourceInvokingCallback(batchFiles);
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = true };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request);
+
+        _printQueueSink.Verify(
+            x => x.SendAsync(batchFiles, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_SendToPrinterFalse_DoesNotCallSink()
+    {
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 });
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request);
+
+        _printQueueSink.Verify(
+            x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}
+```
+
+Only the `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` addition, the new `_temporaryFileAccessor` field, and the extra `.Object` argument in `CreateService()` are new — the two `[Fact]` test bodies are unchanged (they don't touch cleanup/email behavior).
+
+#### Step 3 — Update `ExpeditionListServiceOrderStateTests.cs`
+
+Modify `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs`. Same field + constructor change as Step 2, **plus** rewrite `PrintPickingListAsync_CleanupRunsAfterSuccess` to use the mock instead of `Path.GetTempFileName()`/`File.Exists`:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Application.Shared.Printing;
+using Anela.Heblo.Xcc.Services.Email;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class ExpeditionListServiceOrderStateTests
+{
+    private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
+    private readonly Mock<IEmailSender> _emailSender = new();
+    private readonly Mock<IPrintQueueSink> _printQueueSink = new();
+    private readonly Mock<ITemporaryFileAccessor> _temporaryFileAccessor = new();
+
+    private ExpeditionListService CreateService() => new ExpeditionListService(
+        _pickingSource.Object,
+        _emailSender.Object,
+        TimeProvider.System,
+        Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
+        _printQueueSink.Object,
+        _temporaryFileAccessor.Object,
+        NullLogger<ExpeditionListService>.Instance);
+
+    private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)
+    {
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(
+                async (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                {
+                    if (cb != null)
+                        await cb(filesToPassToCallback);
+                    return new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 };
+                });
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenEmailThrows_ExceptionPropagates()
+    {
+        SetupSourceInvokingCallback(new List<string>());
+        _emailSender
+            .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("SMTP failure"));
+
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = false };
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<Exception>(() =>
+            svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" }));
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenPrinterThrows_ExceptionPropagates()
+    {
+        SetupSourceInvokingCallback(new List<string>());
+        _printQueueSink
+            .Setup(x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Print queue failure"));
+
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = true };
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<Exception>(() => svc.PrintPickingListAsync(request));
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenAllSucceed_PrinterCalledBeforeEmail()
+    {
+        var callOrder = new List<string>();
+        SetupSourceInvokingCallback(new List<string>());
+
+        _printQueueSink
+            .Setup(x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("printer"))
+            .Returns(Task.CompletedTask);
+
+        _emailSender
+            .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("email"))
+            .Returns(Task.CompletedTask);
+
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = true };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" });
+
+        Assert.Equal(new[] { "printer", "email" }, callOrder);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenNeitherPrinterNorEmail_NullCallbackPassedToSource()
+    {
+        Func<IList<string>, Task>? capturedCallback = null;
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(
+                (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                    capturedCallback = cb)
+            .ReturnsAsync(new ExpeditionPickingResult { ExportedFiles = new List<string>() });
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request, emailList: null);
+
+        Assert.Null(capturedCallback);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_CleanupRunsAfterSuccess()
+    {
+        var exportedFile = "/tmp/expedition-export-fake.pdf";
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExpeditionPickingResult
+            {
+                ExportedFiles = new[] { exportedFile },
+                TotalCount = 1,
+            });
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request);
+
+        _temporaryFileAccessor.Verify(x => x.DeleteIfExists(exportedFile), Times.Once);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes()
+    {
+        var exportedFile = "/tmp/expedition-export-fake.pdf";
+        var expectedBytes = new byte[] { 10, 20, 30 };
+        SetupSourceInvokingCallback(new List<string> { exportedFile });
+        _temporaryFileAccessor
+            .Setup(x => x.ReadAllBytesAsync(exportedFile, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedBytes);
+
+        EmailMessage? capturedMessage = null;
+        _emailSender
+            .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((msg, _) => capturedMessage = msg)
+            .Returns(Task.CompletedTask);
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" });
+
+        Assert.NotNull(capturedMessage);
+        var attachment = Assert.Single(capturedMessage!.Attachments);
+        Assert.Equal(Convert.ToBase64String(expectedBytes), attachment.Content);
+        Assert.Equal("expedition-export-fake.pdf", attachment.FileName);
+        Assert.Equal("application/pdf", attachment.ContentType);
+    }
+}
+```
+
+Changes versus the original file:
+- Added `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` and the `_temporaryFileAccessor` field, threaded into `CreateService()`.
+- `PrintPickingListAsync_CleanupRunsAfterSuccess` no longer calls `Path.GetTempFileName()` or asserts `File.Exists`; it uses a fake path string and asserts `_temporaryFileAccessor.Verify(x => x.DeleteIfExists(exportedFile), Times.Once)` — satisfying spec FR-5's "at least one test asserts `DeleteIfExists` is invoked once per file in `ExportedFiles`" and the arch-review's risk-table item calling this test out by name.
+- Added new test `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes`, satisfying spec FR-5's "at least one test asserts email attachments are built from bytes returned by the mocked `ReadAllBytesAsync`". It stubs `ReadAllBytesAsync` to return known bytes, captures the outgoing `EmailMessage` via `_emailSender`'s callback, and asserts the attachment's `Content` is the base64 of those exact bytes, with `FileName` derived correctly via `Path.GetFileName` and `ContentType` set to `"application/pdf"`. This requires `EmailMessage`/`EmailAttachment` to have `Attachments` (`IList<EmailAttachment>`), `Content`, `FileName`, `ContentType` properties matching what `ExpeditionListService.SendEmailCopy` already populates (see the current file, lines 96-105) — no changes needed to `EmailMessage`/`EmailAttachment` themselves, only reuse of existing shapes.
+- All four pre-existing tests other than `PrintPickingListAsync_CleanupRunsAfterSuccess` are otherwise textually unchanged.
+
+#### Acceptance criteria
+
+- `dotnet build` succeeds for the whole solution.
+- `dotnet format` produces no diff (or is applied) for all files touched.
+- `grep -n "File\." backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` (or equivalent search) returns **zero** matches for `File.Exists`, `File.Delete`, or `File.ReadAllBytesAsync` — confirming FR-4's "no `File.*` calls" acceptance criterion. (`Path.GetFileName` is expected to remain and is not an I/O call.)
+- All tests in `ExpeditionListServicePrintSinkTests.cs` pass (2 tests, unchanged assertions): `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionListServicePrintSinkTests`.
+- All tests in `ExpeditionListServiceOrderStateTests.cs` pass (6 tests: the original 5 plus the new `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes`): `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionListServiceOrderStateTests`.
+- `PrintPickingListAsync_CleanupRunsAfterSuccess` no longer references `Path.GetTempFileName()` or `File.Exists` — confirm by inspection of the diff.
+- Full `ExpeditionList` test slice still green: `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList` (includes `FileSystemTemporaryFileAccessorTests`, `FileSystemPrintQueueSinkTests`, `PrintExpeditionOrderHandlerTests`, etc. from the prior task and pre-existing suite — none of these should be affected by this task's changes, but must still pass).
+- No changes made to `IExpeditionListService.cs`, `PrintExpeditionOrderHandler.cs`, `PrintPickingListJob.cs`, or `RunExpeditionListPrintFixHandler.cs` — confirm via `git diff --stat` that only the five files listed under "File(s) to create/modify" across both tasks are touched.
+
+---

--- a/artifacts/feat-3461/task-plan.r1.md
+++ b/artifacts/feat-3461/task-plan.r1.md
@@ -1,0 +1,669 @@
+# Remove direct filesystem I/O from ExpeditionListService — Implementation Plan
+
+**Goal:** Eliminate the direct `File.Exists`/`File.Delete`/`File.ReadAllBytesAsync` calls in `ExpeditionListService` (Application layer) by introducing an `ITemporaryFileAccessor` abstraction, implemented by a new `FileSystemTemporaryFileAccessor` in the `Anela.Heblo.Adapters.FileSystem` project, mirroring the existing `IPrintQueueSink` / `FileSystemPrintQueueSink` split. This is a pure refactor — no change to `IExpeditionListService`'s public contract, generated PDFs, email content, or print-queue behavior.
+
+**Architecture:** `Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs` defines a two-member, `System.IO`-free contract (`ReadAllBytesAsync`, `DeleteIfExists`). `Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs` implements it with the exact same `System.IO.File` calls the service currently makes inline. `Anela.Heblo.API`'s composition root registers the implementation **unconditionally** (not inside the `PrintSink` config switch), since temp-file cleanup/read is needed regardless of which print sink is active. `ExpeditionListService` is refactored to depend on the interface instead of `System.IO.File` directly. Existing unit tests are updated to mock `ITemporaryFileAccessor` instead of touching the real filesystem.
+
+**Tech Stack:** C# / .NET 8, xUnit, Moq, `Microsoft.Extensions.DependencyInjection`. Backend only — no frontend changes.
+
+---
+
+### task: add-temporary-file-accessor-contract-and-adapter
+
+**What this task does:** Introduces the new `ITemporaryFileAccessor` contract in the Application layer, its `System.IO`-backed implementation in the FileSystem adapter project, registers it in DI (unconditionally, not gated by the `PrintSink` switch), and adds a new unit test for the adapter implementation. `ExpeditionListService` is **not** modified in this task — it keeps using `File.*` directly for now. This task must leave the build green and all existing tests passing, with the new type present but unused by production code except via DI registration.
+
+**File(s) to create/modify:**
+- Create: `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs`
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs`
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs`
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs`
+
+#### Step 1 — Create the `ITemporaryFileAccessor` contract
+
+Create `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs` with exactly this content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface ITemporaryFileAccessor
+{
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
+    void DeleteIfExists(string path);
+}
+```
+
+This mirrors the existing `IExpeditionPickingSource.cs` in the same folder (see that file for style precedent — plain interface, no XML doc header, file-scoped namespace). No `System.IO` types appear in the signature, per spec FR-1.
+
+#### Step 2 — Create the `FileSystemTemporaryFileAccessor` adapter implementation
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs` with exactly this content:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+namespace Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessor : ITemporaryFileAccessor
+{
+    public Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
+        => File.ReadAllBytesAsync(path, cancellationToken);
+
+    public void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}
+```
+
+This sits alongside the existing `FileSystemPrintQueueSink.cs` in the same folder and preserves identical semantics to the code currently inline in `ExpeditionListService` (same guard-then-delete pattern, same pass-through read with cancellation token).
+
+#### Step 3 — Register the new implementation in `FileSystemAdapterServiceCollectionExtensions`
+
+Modify `backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs`. Current file:
+
+```csharp
+using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Anela.Heblo.Application.Shared.Printing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.FileSystem;
+
+public static class FileSystemAdapterServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the filesystem-based <see cref="IPrintQueueSink"/> implementation.
+    /// PrintPickingListOptions is bound by ExpeditionListModule in the Application layer,
+    /// so this extension takes no IConfiguration parameter.
+    /// </summary>
+    public static IServiceCollection AddFileSystemPrintQueueSink(this IServiceCollection services)
+    {
+        services.AddScoped<IPrintQueueSink, FileSystemPrintQueueSink>();
+        return services;
+    }
+}
+```
+
+Replace its contents with:
+
+```csharp
+using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Shared.Printing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.FileSystem;
+
+public static class FileSystemAdapterServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the filesystem-based <see cref="IPrintQueueSink"/> implementation.
+    /// PrintPickingListOptions is bound by ExpeditionListModule in the Application layer,
+    /// so this extension takes no IConfiguration parameter.
+    /// </summary>
+    public static IServiceCollection AddFileSystemPrintQueueSink(this IServiceCollection services)
+    {
+        services.AddScoped<IPrintQueueSink, FileSystemPrintQueueSink>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the filesystem-based <see cref="ITemporaryFileAccessor"/> implementation.
+    /// Used by ExpeditionListService to read/delete exported PDFs regardless of which
+    /// print sink (ExpeditionList:PrintSink) is configured, since exported files always
+    /// land on local disk first.
+    /// </summary>
+    public static IServiceCollection AddFileSystemTemporaryFileAccessor(this IServiceCollection services)
+    {
+        services.AddScoped<ITemporaryFileAccessor, FileSystemTemporaryFileAccessor>();
+        return services;
+    }
+}
+```
+
+#### Step 4 — Wire the registration into the composition root, outside the `PrintSink` switch
+
+Modify `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Find the `AddPrintQueueSink` method (around line 406):
+
+```csharp
+    public static IServiceCollection AddPrintQueueSink(this IServiceCollection services, IConfiguration configuration)
+    {
+        // The CUPS label-printing infrastructure (ILabelPrintingService) is always available —
+        // it is used by MaterialContainer label printing regardless of the expedition print sink.
+        services.AddCupsPrinting(configuration);
+
+        var printSink = configuration["ExpeditionList:PrintSink"];
+        switch (printSink)
+        {
+```
+
+Change it to add the new unconditional registration right after `AddCupsPrinting`, **before** the `switch`:
+
+```csharp
+    public static IServiceCollection AddPrintQueueSink(this IServiceCollection services, IConfiguration configuration)
+    {
+        // The CUPS label-printing infrastructure (ILabelPrintingService) is always available —
+        // it is used by MaterialContainer label printing regardless of the expedition print sink.
+        services.AddCupsPrinting(configuration);
+
+        // Temp-file read/delete is needed regardless of which PrintSink is configured — exported
+        // PDFs always land on local disk first (see IExpeditionPickingSource.CreatePickingListAsync),
+        // so this is registered unconditionally rather than inside the switch below.
+        services.AddFileSystemTemporaryFileAccessor();
+
+        var printSink = configuration["ExpeditionList:PrintSink"];
+        switch (printSink)
+        {
+```
+
+Leave the rest of the method (the `switch` block and its four cases, lines ~413–438) completely unchanged — do **not** add `AddFileSystemTemporaryFileAccessor()` inside the `default:` case; it must only appear once, before the switch. `Anela.Heblo.API` already references `Anela.Heblo.Adapters.FileSystem` (used for `AddFileSystemPrintQueueSink` in the same file), so no new project reference or `using` is needed for the new call itself — `FileSystemAdapterServiceCollectionExtensions` is a `public static class` in a namespace already in scope where `AddFileSystemPrintQueueSink()` is called.
+
+#### Step 5 — Add a unit test for `FileSystemTemporaryFileAccessor`
+
+Create `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs`:
+
+```csharp
+using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessorTests : IDisposable
+{
+    private readonly string _testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    public FileSystemTemporaryFileAccessorTests()
+    {
+        Directory.CreateDirectory(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir)) Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_ExistingFile_ReturnsFileContent()
+    {
+        var path = Path.Combine(_testDir, "file.pdf");
+        var expectedBytes = new byte[] { 1, 2, 3, 4, 5 };
+        await File.WriteAllBytesAsync(path, expectedBytes);
+
+        var accessor = new FileSystemTemporaryFileAccessor();
+        var bytes = await accessor.ReadAllBytesAsync(path);
+
+        Assert.Equal(expectedBytes, bytes);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_MissingFile_ThrowsFileNotFoundException()
+    {
+        var path = Path.Combine(_testDir, "does-not-exist.pdf");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() => accessor.ReadAllBytesAsync(path));
+    }
+
+    [Fact]
+    public void DeleteIfExists_ExistingFile_DeletesIt()
+    {
+        var path = Path.Combine(_testDir, "file.pdf");
+        File.WriteAllText(path, "content");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        accessor.DeleteIfExists(path);
+
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void DeleteIfExists_NonExistentFile_DoesNotThrow()
+    {
+        var path = Path.Combine(_testDir, "never-existed.pdf");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        var exception = Record.Exception(() => accessor.DeleteIfExists(path));
+
+        Assert.Null(exception);
+    }
+}
+```
+
+This follows the same `IDisposable` + `Path.GetTempPath()`/`Guid.NewGuid()` temp-directory pattern already used in `FileSystemPrintQueueSinkTests.cs` in the same folder.
+
+#### Acceptance criteria
+
+- `dotnet build` succeeds for the whole solution (run from `backend/`: `dotnet build`).
+- `dotnet format` produces no diff (or is applied) for all files touched in this task.
+- New tests in `FileSystemTemporaryFileAccessorTests.cs` (4 tests) pass: run `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~FileSystemTemporaryFileAccessorTests`.
+- All pre-existing tests still pass (this task does not touch `ExpeditionListService.cs` or its tests): run `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList`.
+- Starting the API locally (or via the existing test harness) with no `ExpeditionList:PrintSink` config set, and separately with `ExpeditionList:PrintSink=AzureBlob`/`Cups`/`Combined`, must not throw a DI resolution error — verify by inspecting that `AddFileSystemTemporaryFileAccessor()` is called unconditionally (i.e., visually confirm in the diff that the call sits before the `switch (printSink)` line, not inside any `case`). If an integration/smoke test already exercises `AddPrintQueueSink` for multiple `PrintSink` values, it must still pass; if none exists, this is verified by code inspection only (no new test is required for this — out of scope per spec FR-3's acceptance criteria, which is satisfied by correct placement).
+- `ITemporaryFileAccessor.cs` contains no `System.IO` types in its member signatures (visually confirm: only `string`, `byte[]`, `Task`, `CancellationToken`).
+
+---
+
+### task: refactor-expeditionlistservice-to-use-temporary-file-accessor
+
+**What this task does:** Injects `ITemporaryFileAccessor` into `ExpeditionListService`, replaces the bodies of `Cleanup` and `SendEmailCopy` to delegate to it instead of calling `System.IO.File` directly, and removes all direct `File.*` usage from the file. Updates the two existing test files (`ExpeditionListServicePrintSinkTests.cs`, `ExpeditionListServiceOrderStateTests.cs`) to construct `ExpeditionListService` with a `Mock<ITemporaryFileAccessor>`, including rewriting the one test that currently depends on the real filesystem (`PrintPickingListAsync_CleanupRunsAfterSuccess`). Depends on `add-temporary-file-accessor-contract-and-adapter` being complete (needs `ITemporaryFileAccessor` and `FileSystemTemporaryFileAccessor` to exist).
+
+**File(s) to create/modify:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs`
+
+#### Step 1 — Refactor `ExpeditionListService.cs`
+
+Replace the full contents of `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Xcc.Services.Email;
+using Anela.Heblo.Application.Shared.Printing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.ExpeditionList.Services;
+
+public class ExpeditionListService : IExpeditionListService
+{
+    private readonly IExpeditionPickingSource _pickingSource;
+    private readonly IEmailSender _emailSender;
+    private readonly TimeProvider _clock;
+    private readonly IOptions<PrintPickingListOptions> _options;
+    private readonly IPrintQueueSink _printQueueSink;
+    private readonly ITemporaryFileAccessor _temporaryFileAccessor;
+    private readonly ILogger<ExpeditionListService> _logger;
+
+    public ExpeditionListService(
+        IExpeditionPickingSource pickingSource,
+        IEmailSender emailSender,
+        TimeProvider clock,
+        IOptions<PrintPickingListOptions> options,
+        IPrintQueueSink printQueueSink,
+        ITemporaryFileAccessor temporaryFileAccessor,
+        ILogger<ExpeditionListService> logger)
+    {
+        _pickingSource = pickingSource;
+        _emailSender = emailSender;
+        _clock = clock;
+        _options = options;
+        _printQueueSink = printQueueSink;
+        _temporaryFileAccessor = temporaryFileAccessor;
+        _logger = logger;
+    }
+
+    public async Task<ExpeditionPickingResult> PrintPickingListAsync(
+        ExpeditionPickingRequest request,
+        IList<string>? emailList = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Generating new expedition list");
+
+        Func<IList<string>, Task>? batchCallback = null;
+
+        if (request.SendToPrinter || (emailList != null && emailList.Any()))
+        {
+            batchCallback = async files =>
+            {
+                if (request.SendToPrinter)
+                {
+                    await _printQueueSink.SendAsync(files, cancellationToken);
+                    _logger.LogDebug("Batch sent to print queue");
+                }
+
+                if (emailList != null && emailList.Any())
+                {
+                    await SendEmailCopy(files, emailList, cancellationToken);
+                    _logger.LogDebug("Batch email copy sent");
+                }
+            };
+        }
+
+        var result = await _pickingSource.CreatePickingListAsync(request, batchCallback, cancellationToken);
+
+        _logger.LogDebug("Expedition list complete — {Total} orders processed", result.TotalCount);
+
+        await Cleanup(result);
+
+        return result;
+    }
+
+    private Task Cleanup(ExpeditionPickingResult result)
+    {
+        foreach (var f in result.ExportedFiles)
+        {
+            _temporaryFileAccessor.DeleteIfExists(f);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task SendEmailCopy(IList<string> files, IEnumerable<string> emailRecipients, CancellationToken cancellationToken)
+    {
+        var now = _clock.GetLocalNow();
+        var message = new EmailMessage
+        {
+            From = _options.Value.EmailSender,
+            Subject = $"Expedice {now:yyyy-MM-dd}",
+            HtmlContent = $@"
+<strong>Expedice vygenerovana {now:yyyy-MM-dd HH:mm:ss}</strong></br>
+</br>
+</br>
+",
+            To = emailRecipients.ToList()
+        };
+
+        foreach (var a in files)
+        {
+            var bytes = await _temporaryFileAccessor.ReadAllBytesAsync(a, cancellationToken);
+            message.Attachments.Add(new EmailAttachment
+            {
+                FileName = Path.GetFileName(a),
+                Content = Convert.ToBase64String(bytes),
+                ContentType = "application/pdf"
+            });
+        }
+
+        await _emailSender.SendEmailAsync(message);
+        _logger.LogDebug("Sent email copy");
+    }
+}
+```
+
+Notes on this change versus the original file:
+- New constructor parameter `ITemporaryFileAccessor temporaryFileAccessor`, positioned after `printQueueSink` and before `logger` (matches the design doc's specified ordering: dependencies first, logger last).
+- `Cleanup` now calls `_temporaryFileAccessor.DeleteIfExists(f)` instead of the inline `File.Exists`/`File.Delete` guard.
+- `SendEmailCopy` gained a `CancellationToken cancellationToken` parameter (it previously took none) so it can forward the token into `_temporaryFileAccessor.ReadAllBytesAsync(a, cancellationToken)`. Its single call site inside `PrintPickingListAsync`'s `batchCallback` is updated to pass `cancellationToken` through. This is the one accepted minor behavior change called out in spec FR-4/Open Questions and the arch-review's risk table: cancellation now takes effect during attachment reads, not just before — not a functional regression.
+- `Path.GetFileName(a)` remains inline (pure string operation, not I/O — confirmed out of scope for the accessor by both the spec and design doc).
+- `using System.IO;` is not present and must not be added — confirm the file has zero remaining `File.*`/`System.IO.File` references (there is no explicit `using System.IO;` in the original file already, since `File`/`Path` were resolved via implicit global usings or the SDK's implicit usings; do not add one).
+- `IExpeditionListService` (the public interface) is untouched — do not modify `IExpeditionListService.cs`.
+
+#### Step 2 — Update `ExpeditionListServicePrintSinkTests.cs`
+
+Modify `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs`. Add a `Mock<ITemporaryFileAccessor>` field and pass it into the constructor call in `CreateService()`:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Application.Shared.Printing;
+using Anela.Heblo.Xcc.Services.Email;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class ExpeditionListServicePrintSinkTests
+{
+    private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
+    private readonly Mock<IEmailSender> _emailSender = new();
+    private readonly Mock<IPrintQueueSink> _printQueueSink = new();
+    private readonly Mock<ITemporaryFileAccessor> _temporaryFileAccessor = new();
+
+    private ExpeditionListService CreateService() => new ExpeditionListService(
+        _pickingSource.Object,
+        _emailSender.Object,
+        TimeProvider.System,
+        Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
+        _printQueueSink.Object,
+        _temporaryFileAccessor.Object,
+        NullLogger<ExpeditionListService>.Instance);
+
+    private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)
+    {
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(
+                async (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                {
+                    if (cb != null)
+                        await cb(filesToPassToCallback);
+                    return new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 };
+                });
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_SendToPrinterTrue_CallsSink()
+    {
+        var batchFiles = new List<string>();
+        SetupSourceInvokingCallback(batchFiles);
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = true };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request);
+
+        _printQueueSink.Verify(
+            x => x.SendAsync(batchFiles, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_SendToPrinterFalse_DoesNotCallSink()
+    {
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 });
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request);
+
+        _printQueueSink.Verify(
+            x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}
+```
+
+Only the `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` addition, the new `_temporaryFileAccessor` field, and the extra `.Object` argument in `CreateService()` are new — the two `[Fact]` test bodies are unchanged (they don't touch cleanup/email behavior).
+
+#### Step 3 — Update `ExpeditionListServiceOrderStateTests.cs`
+
+Modify `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs`. Same field + constructor change as Step 2, **plus** rewrite `PrintPickingListAsync_CleanupRunsAfterSuccess` to use the mock instead of `Path.GetTempFileName()`/`File.Exists`:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Application.Shared.Printing;
+using Anela.Heblo.Xcc.Services.Email;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class ExpeditionListServiceOrderStateTests
+{
+    private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
+    private readonly Mock<IEmailSender> _emailSender = new();
+    private readonly Mock<IPrintQueueSink> _printQueueSink = new();
+    private readonly Mock<ITemporaryFileAccessor> _temporaryFileAccessor = new();
+
+    private ExpeditionListService CreateService() => new ExpeditionListService(
+        _pickingSource.Object,
+        _emailSender.Object,
+        TimeProvider.System,
+        Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
+        _printQueueSink.Object,
+        _temporaryFileAccessor.Object,
+        NullLogger<ExpeditionListService>.Instance);
+
+    private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)
+    {
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(
+                async (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                {
+                    if (cb != null)
+                        await cb(filesToPassToCallback);
+                    return new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 };
+                });
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenEmailThrows_ExceptionPropagates()
+    {
+        SetupSourceInvokingCallback(new List<string>());
+        _emailSender
+            .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("SMTP failure"));
+
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = false };
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<Exception>(() =>
+            svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" }));
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenPrinterThrows_ExceptionPropagates()
+    {
+        SetupSourceInvokingCallback(new List<string>());
+        _printQueueSink
+            .Setup(x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Print queue failure"));
+
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = true };
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<Exception>(() => svc.PrintPickingListAsync(request));
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenAllSucceed_PrinterCalledBeforeEmail()
+    {
+        var callOrder = new List<string>();
+        SetupSourceInvokingCallback(new List<string>());
+
+        _printQueueSink
+            .Setup(x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("printer"))
+            .Returns(Task.CompletedTask);
+
+        _emailSender
+            .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("email"))
+            .Returns(Task.CompletedTask);
+
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = true };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" });
+
+        Assert.Equal(new[] { "printer", "email" }, callOrder);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_WhenNeitherPrinterNorEmail_NullCallbackPassedToSource()
+    {
+        Func<IList<string>, Task>? capturedCallback = null;
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(
+                (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                    capturedCallback = cb)
+            .ReturnsAsync(new ExpeditionPickingResult { ExportedFiles = new List<string>() });
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request, emailList: null);
+
+        Assert.Null(capturedCallback);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_CleanupRunsAfterSuccess()
+    {
+        var exportedFile = "/tmp/expedition-export-fake.pdf";
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
+                It.IsAny<Func<IList<string>, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ExpeditionPickingResult
+            {
+                ExportedFiles = new[] { exportedFile },
+                TotalCount = 1,
+            });
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request);
+
+        _temporaryFileAccessor.Verify(x => x.DeleteIfExists(exportedFile), Times.Once);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes()
+    {
+        var exportedFile = "/tmp/expedition-export-fake.pdf";
+        var expectedBytes = new byte[] { 10, 20, 30 };
+        SetupSourceInvokingCallback(new List<string> { exportedFile });
+        _temporaryFileAccessor
+            .Setup(x => x.ReadAllBytesAsync(exportedFile, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedBytes);
+
+        EmailMessage? capturedMessage = null;
+        _emailSender
+            .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((msg, _) => capturedMessage = msg)
+            .Returns(Task.CompletedTask);
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" });
+
+        Assert.NotNull(capturedMessage);
+        var attachment = Assert.Single(capturedMessage!.Attachments);
+        Assert.Equal(Convert.ToBase64String(expectedBytes), attachment.Content);
+        Assert.Equal("expedition-export-fake.pdf", attachment.FileName);
+        Assert.Equal("application/pdf", attachment.ContentType);
+    }
+}
+```
+
+Changes versus the original file:
+- Added `using Anela.Heblo.Application.Features.ExpeditionList.Contracts;` and the `_temporaryFileAccessor` field, threaded into `CreateService()`.
+- `PrintPickingListAsync_CleanupRunsAfterSuccess` no longer calls `Path.GetTempFileName()` or asserts `File.Exists`; it uses a fake path string and asserts `_temporaryFileAccessor.Verify(x => x.DeleteIfExists(exportedFile), Times.Once)` — satisfying spec FR-5's "at least one test asserts `DeleteIfExists` is invoked once per file in `ExportedFiles`" and the arch-review's risk-table item calling this test out by name.
+- Added new test `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes`, satisfying spec FR-5's "at least one test asserts email attachments are built from bytes returned by the mocked `ReadAllBytesAsync`". It stubs `ReadAllBytesAsync` to return known bytes, captures the outgoing `EmailMessage` via `_emailSender`'s callback, and asserts the attachment's `Content` is the base64 of those exact bytes, with `FileName` derived correctly via `Path.GetFileName` and `ContentType` set to `"application/pdf"`. This requires `EmailMessage`/`EmailAttachment` to have `Attachments` (`IList<EmailAttachment>`), `Content`, `FileName`, `ContentType` properties matching what `ExpeditionListService.SendEmailCopy` already populates (see the current file, lines 96-105) — no changes needed to `EmailMessage`/`EmailAttachment` themselves, only reuse of existing shapes.
+- All four pre-existing tests other than `PrintPickingListAsync_CleanupRunsAfterSuccess` are otherwise textually unchanged.
+
+#### Acceptance criteria
+
+- `dotnet build` succeeds for the whole solution.
+- `dotnet format` produces no diff (or is applied) for all files touched.
+- `grep -n "File\." backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` (or equivalent search) returns **zero** matches for `File.Exists`, `File.Delete`, or `File.ReadAllBytesAsync` — confirming FR-4's "no `File.*` calls" acceptance criterion. (`Path.GetFileName` is expected to remain and is not an I/O call.)
+- All tests in `ExpeditionListServicePrintSinkTests.cs` pass (2 tests, unchanged assertions): `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionListServicePrintSinkTests`.
+- All tests in `ExpeditionListServiceOrderStateTests.cs` pass (6 tests: the original 5 plus the new `PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes`): `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionListServiceOrderStateTests`.
+- `PrintPickingListAsync_CleanupRunsAfterSuccess` no longer references `Path.GetTempFileName()` or `File.Exists` — confirm by inspection of the diff.
+- Full `ExpeditionList` test slice still green: `dotnet test backend/test/Anela.Heblo.Tests --filter FullyQualifiedName~ExpeditionList` (includes `FileSystemTemporaryFileAccessorTests`, `FileSystemPrintQueueSinkTests`, `PrintExpeditionOrderHandlerTests`, etc. from the prior task and pre-existing suite — none of these should be affected by this task's changes, but must still pass).
+- No changes made to `IExpeditionListService.cs`, `PrintExpeditionOrderHandler.cs`, `PrintPickingListJob.cs`, or `RunExpeditionListPrintFixHandler.cs` — confirm via `git diff --stat` that only the five files listed under "File(s) to create/modify" across both tasks are touched.
+
+---
+
+## Post-implementation note (FR-6, informational — no task required)
+
+Per the architecture review's investigation (already completed, no further action needed): `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` exists but is a **namespace-reference boundary checker** (asserts module A's types don't reference module B's forbidden namespaces) — it is not a reflection-based `File.*`/`System.IO` call detector, and no such detector exists elsewhere in the test suite. Adding one is optional and explicitly out of scope for this change (spec FR-6, "Out of Scope"). When writing the PR description, state this finding ("investigated: no existing I/O-call guard exists; `ModuleBoundariesTests.cs` checks namespace references only, not applicable here; not adding a new guard, per spec Out of Scope") to satisfy FR-6's acceptance criterion — this does not require a code task.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/Features/ExpeditionList/FileSystemTemporaryFileAccessor.cs
@@ -1,0 +1,15 @@
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+namespace Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessor : ITemporaryFileAccessor
+{
+    public Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
+        => File.ReadAllBytesAsync(path, cancellationToken);
+
+    public void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.FileSystem/FileSystemAdapterServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 using Anela.Heblo.Application.Shared.Printing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +15,18 @@ public static class FileSystemAdapterServiceCollectionExtensions
     public static IServiceCollection AddFileSystemPrintQueueSink(this IServiceCollection services)
     {
         services.AddScoped<IPrintQueueSink, FileSystemPrintQueueSink>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the filesystem-based <see cref="ITemporaryFileAccessor"/> implementation.
+    /// Used by ExpeditionListService to read/delete exported PDFs regardless of which
+    /// print sink (ExpeditionList:PrintSink) is configured, since exported files always
+    /// land on local disk first.
+    /// </summary>
+    public static IServiceCollection AddFileSystemTemporaryFileAccessor(this IServiceCollection services)
+    {
+        services.AddScoped<ITemporaryFileAccessor, FileSystemTemporaryFileAccessor>();
         return services;
     }
 }

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -409,6 +409,11 @@ public static class ServiceCollectionExtensions
         // it is used by MaterialContainer label printing regardless of the expedition print sink.
         services.AddCupsPrinting(configuration);
 
+        // Temp-file read/delete is needed regardless of which PrintSink is configured — exported
+        // PDFs always land on local disk first (see IExpeditionPickingSource.CreatePickingListAsync),
+        // so this is registered unconditionally rather than inside the switch below.
+        services.AddFileSystemTemporaryFileAccessor();
+
         var printSink = configuration["ExpeditionList:PrintSink"];
         switch (printSink)
         {

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ITemporaryFileAccessor.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface ITemporaryFileAccessor
+{
+    Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
+    void DeleteIfExists(string path);
+}

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs
@@ -13,6 +13,7 @@ public class ExpeditionListService : IExpeditionListService
     private readonly TimeProvider _clock;
     private readonly IOptions<PrintPickingListOptions> _options;
     private readonly IPrintQueueSink _printQueueSink;
+    private readonly ITemporaryFileAccessor _temporaryFileAccessor;
     private readonly ILogger<ExpeditionListService> _logger;
 
     public ExpeditionListService(
@@ -21,6 +22,7 @@ public class ExpeditionListService : IExpeditionListService
         TimeProvider clock,
         IOptions<PrintPickingListOptions> options,
         IPrintQueueSink printQueueSink,
+        ITemporaryFileAccessor temporaryFileAccessor,
         ILogger<ExpeditionListService> logger)
     {
         _pickingSource = pickingSource;
@@ -28,6 +30,7 @@ public class ExpeditionListService : IExpeditionListService
         _clock = clock;
         _options = options;
         _printQueueSink = printQueueSink;
+        _temporaryFileAccessor = temporaryFileAccessor;
         _logger = logger;
     }
 
@@ -52,7 +55,7 @@ public class ExpeditionListService : IExpeditionListService
 
                 if (emailList != null && emailList.Any())
                 {
-                    await SendEmailCopy(files, emailList);
+                    await SendEmailCopy(files, emailList, cancellationToken);
                     _logger.LogDebug("Batch email copy sent");
                 }
             };
@@ -71,14 +74,13 @@ public class ExpeditionListService : IExpeditionListService
     {
         foreach (var f in result.ExportedFiles)
         {
-            if (File.Exists(f))
-                File.Delete(f);
+            _temporaryFileAccessor.DeleteIfExists(f);
         }
 
         return Task.CompletedTask;
     }
 
-    private async Task SendEmailCopy(IList<string> files, IEnumerable<string> emailRecipients)
+    private async Task SendEmailCopy(IList<string> files, IEnumerable<string> emailRecipients, CancellationToken cancellationToken)
     {
         var now = _clock.GetLocalNow();
         var message = new EmailMessage
@@ -95,7 +97,7 @@ public class ExpeditionListService : IExpeditionListService
 
         foreach (var a in files)
         {
-            var bytes = await File.ReadAllBytesAsync(a);
+            var bytes = await _temporaryFileAccessor.ReadAllBytesAsync(a, cancellationToken);
             message.Attachments.Add(new EmailAttachment
             {
                 FileName = Path.GetFileName(a),

--- a/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
@@ -92,7 +92,7 @@ public class GetConfigurationHandlerTests
         // Arrange
         var handler = CreateHandler(new Dictionary<string, string?>
         {
-            [ConfigurationConstants.APP_VERSION] = "1.0.0"
+            [InfrastructureConfigurationKeys.APP_VERSION] = "1.0.0"
         });
         var before = DateTime.UtcNow;
 

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs
@@ -15,6 +15,7 @@ public class ExpeditionListServiceOrderStateTests
     private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
     private readonly Mock<IEmailSender> _emailSender = new();
     private readonly Mock<IPrintQueueSink> _printQueueSink = new();
+    private readonly Mock<ITemporaryFileAccessor> _temporaryFileAccessor = new();
 
     private ExpeditionListService CreateService() => new ExpeditionListService(
         _pickingSource.Object,
@@ -22,6 +23,7 @@ public class ExpeditionListServiceOrderStateTests
         TimeProvider.System,
         Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
         _printQueueSink.Object,
+        _temporaryFileAccessor.Object,
         NullLogger<ExpeditionListService>.Instance);
 
     private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)
@@ -118,7 +120,7 @@ public class ExpeditionListServiceOrderStateTests
     [Fact]
     public async Task PrintPickingListAsync_CleanupRunsAfterSuccess()
     {
-        var tmpFile = Path.GetTempFileName();
+        var exportedFile = "/tmp/expedition-export-fake.pdf";
         _pickingSource
             .Setup(x => x.CreatePickingListAsync(
                 It.IsAny<ExpeditionPickingRequest>(),
@@ -126,7 +128,7 @@ public class ExpeditionListServiceOrderStateTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ExpeditionPickingResult
             {
-                ExportedFiles = new[] { tmpFile },
+                ExportedFiles = new[] { exportedFile },
                 TotalCount = 1,
             });
 
@@ -135,6 +137,34 @@ public class ExpeditionListServiceOrderStateTests
 
         await svc.PrintPickingListAsync(request);
 
-        Assert.False(File.Exists(tmpFile));
+        _temporaryFileAccessor.Verify(x => x.DeleteIfExists(exportedFile), Times.Once);
+    }
+
+    [Fact]
+    public async Task PrintPickingListAsync_EmailAttachments_BuiltFromAccessorBytes()
+    {
+        var exportedFile = "/tmp/expedition-export-fake.pdf";
+        var expectedBytes = new byte[] { 10, 20, 30 };
+        SetupSourceInvokingCallback(new List<string> { exportedFile });
+        _temporaryFileAccessor
+            .Setup(x => x.ReadAllBytesAsync(exportedFile, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedBytes);
+
+        EmailMessage? capturedMessage = null;
+        _emailSender
+            .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((msg, _) => capturedMessage = msg)
+            .Returns(Task.CompletedTask);
+
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
+        var svc = CreateService();
+
+        await svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" });
+
+        Assert.NotNull(capturedMessage);
+        var attachment = Assert.Single(capturedMessage!.Attachments);
+        Assert.Equal(Convert.ToBase64String(expectedBytes), attachment.Content);
+        Assert.Equal("expedition-export-fake.pdf", attachment.FileName);
+        Assert.Equal("application/pdf", attachment.ContentType);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs
@@ -15,6 +15,7 @@ public class ExpeditionListServicePrintSinkTests
     private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
     private readonly Mock<IEmailSender> _emailSender = new();
     private readonly Mock<IPrintQueueSink> _printQueueSink = new();
+    private readonly Mock<ITemporaryFileAccessor> _temporaryFileAccessor = new();
 
     private ExpeditionListService CreateService() => new ExpeditionListService(
         _pickingSource.Object,
@@ -22,6 +23,7 @@ public class ExpeditionListServicePrintSinkTests
         TimeProvider.System,
         Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
         _printQueueSink.Object,
+        _temporaryFileAccessor.Object,
         NullLogger<ExpeditionListService>.Instance);
 
     private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemTemporaryFileAccessorTests.cs
@@ -1,0 +1,64 @@
+using Anela.Heblo.Adapters.FileSystem.Features.ExpeditionList;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.ExpeditionList;
+
+public class FileSystemTemporaryFileAccessorTests : IDisposable
+{
+    private readonly string _testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    public FileSystemTemporaryFileAccessorTests()
+    {
+        Directory.CreateDirectory(_testDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDir)) Directory.Delete(_testDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_ExistingFile_ReturnsFileContent()
+    {
+        var path = Path.Combine(_testDir, "file.pdf");
+        var expectedBytes = new byte[] { 1, 2, 3, 4, 5 };
+        await File.WriteAllBytesAsync(path, expectedBytes);
+
+        var accessor = new FileSystemTemporaryFileAccessor();
+        var bytes = await accessor.ReadAllBytesAsync(path);
+
+        Assert.Equal(expectedBytes, bytes);
+    }
+
+    [Fact]
+    public async Task ReadAllBytesAsync_MissingFile_ThrowsFileNotFoundException()
+    {
+        var path = Path.Combine(_testDir, "does-not-exist.pdf");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() => accessor.ReadAllBytesAsync(path));
+    }
+
+    [Fact]
+    public void DeleteIfExists_ExistingFile_DeletesIt()
+    {
+        var path = Path.Combine(_testDir, "file.pdf");
+        File.WriteAllText(path, "content");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        accessor.DeleteIfExists(path);
+
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void DeleteIfExists_NonExistentFile_DoesNotThrow()
+    {
+        var path = Path.Combine(_testDir, "never-existed.pdf");
+        var accessor = new FileSystemTemporaryFileAccessor();
+
+        var exception = Record.Exception(() => accessor.DeleteIfExists(path));
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
Closes #3461

## What the issue was
`ExpeditionListService` (Application layer) called `System.IO.File.Exists`/`File.Delete`/`File.ReadAllBytesAsync` directly in its private `Cleanup` and `SendEmailCopy` methods, violating this repo's I/O placement rule (`docs/architecture/filesystem.md`): concrete I/O-bound work must live in adapter projects under `backend/src/Adapters/`, not in `Features/{Feature}/Services/`. Every other I/O-bound service in the printing pipeline (`FileSystemPrintQueueSink`, `AzureBlobPrintQueueSink`, `CupsPrintQueueSink`) already followed this pattern — `ExpeditionListService` was the one exception, which made it untestable without a real filesystem for any path touching cleanup or email.

## How it was fixed
Introduced `ITemporaryFileAccessor` (Application layer, `Features/ExpeditionList/Contracts/`) — a two-member, `System.IO`-free contract (`ReadAllBytesAsync`, `DeleteIfExists`) — and its `FileSystemTemporaryFileAccessor` implementation in the `Anela.Heblo.Adapters.FileSystem` project, mirroring the existing `IPrintQueueSink`/`FileSystemPrintQueueSink` split. It's registered unconditionally in DI (before the `PrintSink` config switch), since exported PDFs always land on local disk first regardless of which print sink is active.

`ExpeditionListService` now depends on `ITemporaryFileAccessor` instead of calling `File.*` directly; `Cleanup` and `SendEmailCopy` delegate to it. `SendEmailCopy` also now forwards its `CancellationToken` into `ReadAllBytesAsync` (previously unused there) — a minor, non-breaking improvement.

Existing tests (`ExpeditionListServicePrintSinkTests`, `ExpeditionListServiceOrderStateTests`) were updated to mock `ITemporaryFileAccessor` instead of touching the real filesystem, including rewriting `PrintPickingListAsync_CleanupRunsAfterSuccess` and adding a new test asserting email attachments are built from the accessor's returned bytes. A new `FileSystemTemporaryFileAccessorTests` covers the adapter itself against a real temp directory.

Along the way, a pre-existing unrelated compile break was fixed: `GetConfigurationHandlerTests.cs` still referenced `ConfigurationConstants.APP_VERSION`, but that constant had already moved to `InfrastructureConfigurationKeys` in a prior merged PR — this one test site was missed and blocked the build.

Investigated per the original finding's FR-6: no reflection-based `File.*`/`System.IO`-call guard exists elsewhere in the test suite (`ModuleBoundariesTests.cs` only checks namespace references, not I/O calls) — adding one is out of scope for this change per the spec.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3461/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs:109` — `_emailSender.SendEmailAsync(message)` still doesn't pass the `cancellationToken` that's now threaded through `SendEmailCopy`. Pre-existing gap (unchanged by this diff), but now that the token is in scope it would be a trivial follow-up to wire it through.

## Testing
- `dotnet build` — 0 errors.
- Full `ExpeditionList` test slice: 165/165 passed.
- Full backend test suite: 5419 passed, 64 failed (all pre-existing Testcontainers/Docker-dependent integration tests failing due to no Docker daemon in this sandbox — unrelated to this change; none touch `ExpeditionList` or `Configuration`), 4 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZsDdQQFhFoPQaLNmmM7zY)_