### PR TITLE
fix: send shipment package dimensions to Shoptet in centimetres

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Shipments/ShoptetShipmentClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Shipments/ShoptetShipmentClient.cs
@@ -144,9 +144,9 @@ public class ShoptetShipmentClient : IShipmentClient
         var packages = Enumerable.Range(0, packageCount)
             .Select(_ => new ShoptetCreatePackageDto
             {
-                Width = command.Package.WidthMm,
-                Height = command.Package.HeightMm,
-                Depth = command.Package.DepthMm,
+                Width = command.Package.WidthCm,
+                Height = command.Package.HeightCm,
+                Depth = command.Package.DepthCm,
                 Weight = weightKg,
             })
             .ToList();

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ResetOrderShipment/ResetOrderShipmentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ResetOrderShipment/ResetOrderShipmentHandler.cs
@@ -83,9 +83,9 @@ public class ResetOrderShipmentHandler : IRequestHandler<ResetOrderShipmentReque
             PackageCount = n,
             Package = new ShipmentPackage
             {
-                WidthMm = _shipmentSettings.DefaultPackageWidthMm,
-                HeightMm = _shipmentSettings.DefaultPackageHeightMm,
-                DepthMm = _shipmentSettings.DefaultPackageDepthMm,
+                WidthCm = _shipmentSettings.DefaultPackageWidthCm,
+                HeightCm = _shipmentSettings.DefaultPackageHeightCm,
+                DepthCm = _shipmentSettings.DefaultPackageDepthCm,
                 WeightGrams = perPackageWeightGrams,
             },
         };

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs
@@ -136,9 +136,9 @@ public class ScanPackingOrderHandler : IRequestHandler<ScanPackingOrderRequest, 
             PackageCount = n,
             Package = new ShipmentPackage
             {
-                WidthMm = _shipmentSettings.DefaultPackageWidthMm,
-                HeightMm = _shipmentSettings.DefaultPackageHeightMm,
-                DepthMm = _shipmentSettings.DefaultPackageDepthMm,
+                WidthCm = _shipmentSettings.DefaultPackageWidthCm,
+                HeightCm = _shipmentSettings.DefaultPackageHeightCm,
+                DepthCm = _shipmentSettings.DefaultPackageDepthCm,
                 WeightGrams = perPackageWeightGrams,
             },
         };

--- a/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/ShipmentCreation.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/ShipmentCreation.cs
@@ -16,9 +16,9 @@ public class CreateShipmentCommand
 
 public class ShipmentPackage
 {
-    public int WidthMm { get; set; }
-    public int HeightMm { get; set; }
-    public int DepthMm { get; set; }
+    public int WidthCm { get; set; }
+    public int HeightCm { get; set; }
+    public int DepthCm { get; set; }
     public int WeightGrams { get; set; }
 }
 

--- a/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/ShipmentLabelsSettings.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/ShipmentLabelsSettings.cs
@@ -4,11 +4,11 @@ public class ShipmentLabelsSettings
 {
     public const string ConfigurationKey = "ShipmentLabels";
 
-    public int DefaultPackageWidthMm { get; set; } = 300;
+    public int DefaultPackageWidthCm { get; set; } = 30;
 
-    public int DefaultPackageHeightMm { get; set; } = 200;
+    public int DefaultPackageHeightCm { get; set; } = 20;
 
-    public int DefaultPackageDepthMm { get; set; } = 150;
+    public int DefaultPackageDepthCm { get; set; } = 15;
 
     public int MinPackageWeightGrams { get; set; } = 100;
 

--- a/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/UseCases/CreateOrderShipment/CreateOrderShipmentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShipmentLabels/UseCases/CreateOrderShipment/CreateOrderShipmentHandler.cs
@@ -80,9 +80,9 @@ public class CreateOrderShipmentHandler
                 CarrierCode = shippingOptions[0].CarrierCode,
                 Package = new ShipmentPackage
                 {
-                    WidthMm = _settings.DefaultPackageWidthMm,
-                    HeightMm = _settings.DefaultPackageHeightMm,
-                    DepthMm = _settings.DefaultPackageDepthMm,
+                    WidthCm = _settings.DefaultPackageWidthCm,
+                    HeightCm = _settings.DefaultPackageHeightCm,
+                    DepthCm = _settings.DefaultPackageDepthCm,
                     WeightGrams = packageWeightGrams,
                 },
             };

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetShipmentClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetShipmentClientTests.cs
@@ -542,9 +542,9 @@ public class ShoptetShipmentClientTests
             CarrierCode = "123",
             Package = new ShipmentPackage
             {
-                WidthMm = 300,
-                HeightMm = 200,
-                DepthMm = 150,
+                WidthCm = 30,
+                HeightCm = 20,
+                DepthCm = 15,
                 WeightGrams = 500,
             }
         };
@@ -563,6 +563,9 @@ public class ShoptetShipmentClientTests
         data.GetProperty("orderCode").GetString().Should().Be("0001234");
         data.GetProperty("shippingId").GetInt32().Should().Be(123);
         data.GetProperty("packages")[0].GetProperty("weight").GetString().Should().Be("0.500");
+        data.GetProperty("packages")[0].GetProperty("width").GetInt32().Should().Be(30);
+        data.GetProperty("packages")[0].GetProperty("height").GetInt32().Should().Be(20);
+        data.GetProperty("packages")[0].GetProperty("depth").GetInt32().Should().Be(15);
     }
 
     [Fact]
@@ -578,7 +581,7 @@ public class ShoptetShipmentClientTests
         {
             OrderCode = "0001234",
             CarrierCode = "123",
-            Package = new ShipmentPackage { WidthMm = 300, HeightMm = 200, DepthMm = 150, WeightGrams = 500 }
+            Package = new ShipmentPackage { WidthCm = 30, HeightCm = 20, DepthCm = 15, WeightGrams = 500 }
         };
 
         // Act

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ResetOrderShipmentHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ResetOrderShipmentHandlerTests.cs
@@ -16,9 +16,9 @@ public class ResetOrderShipmentHandlerTests
 
     private static readonly ShipmentLabelsSettings DefaultLabelSettings = new()
     {
-        DefaultPackageWidthMm = 300,
-        DefaultPackageHeightMm = 200,
-        DefaultPackageDepthMm = 150,
+        DefaultPackageWidthCm = 30,
+        DefaultPackageHeightCm = 20,
+        DefaultPackageDepthCm = 15,
         MinPackageWeightGrams = 100,
     };
 

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs
@@ -23,9 +23,9 @@ public class ScanPackingOrderHandlerTests
 
     private static readonly ShipmentLabelsSettings DefaultLabelSettings = new()
     {
-        DefaultPackageWidthMm = 300,
-        DefaultPackageHeightMm = 200,
-        DefaultPackageDepthMm = 150,
+        DefaultPackageWidthCm = 30,
+        DefaultPackageHeightCm = 20,
+        DefaultPackageDepthCm = 15,
         MinPackageWeightGrams = 100,
     };
 

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderPackerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderPackerTests.cs
@@ -25,9 +25,9 @@ public class ScanPackingOrderPackerTests
 
     private static readonly ShipmentLabelsSettings DefaultLabelSettings = new()
     {
-        DefaultPackageWidthMm = 300,
-        DefaultPackageHeightMm = 200,
-        DefaultPackageDepthMm = 150,
+        DefaultPackageWidthCm = 30,
+        DefaultPackageHeightCm = 20,
+        DefaultPackageDepthCm = 15,
         MinPackageWeightGrams = 100,
     };
 

--- a/backend/test/Anela.Heblo.Tests/Application/ShipmentLabels/CreateOrderShipmentHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/ShipmentLabels/CreateOrderShipmentHandlerTests.cs
@@ -16,9 +16,9 @@ public class CreateOrderShipmentHandlerTests
 
     private static readonly ShipmentLabelsSettings DefaultSettings = new()
     {
-        DefaultPackageWidthMm = 300,
-        DefaultPackageHeightMm = 200,
-        DefaultPackageDepthMm = 150,
+        DefaultPackageWidthCm = 30,
+        DefaultPackageHeightCm = 20,
+        DefaultPackageDepthCm = 15,
         MinPackageWeightGrams = 100,
     };
 

--- a/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
@@ -92,7 +92,7 @@ public class GetConfigurationHandlerTests
         // Arrange
         var handler = CreateHandler(new Dictionary<string, string?>
         {
-            [ConfigurationConstants.APP_VERSION] = "1.0.0"
+            [InfrastructureConfigurationKeys.APP_VERSION] = "1.0.0"
         });
         var before = DateTime.UtcNow;
 

--- a/backend/test/Anela.Heblo.Tests/Features/Packaging/ScanPackingOrderHandlerPackagePersistenceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Packaging/ScanPackingOrderHandlerPackagePersistenceTests.cs
@@ -48,9 +48,9 @@ public class ScanPackingOrderHandlerPackagePersistenceTests
         var shipmentSettings = Options.Create(new ShipmentLabelsSettings
         {
             MinPackageWeightGrams = 100,
-            DefaultPackageWidthMm = 300,
-            DefaultPackageHeightMm = 200,
-            DefaultPackageDepthMm = 150,
+            DefaultPackageWidthCm = 30,
+            DefaultPackageHeightCm = 20,
+            DefaultPackageDepthCm = 15,
         });
         var authRepo = new Mock<IAuthorizationRepository>();
         return new ScanPackingOrderHandler(

--- a/docs/features/packaging.md
+++ b/docs/features/packaging.md
@@ -141,7 +141,7 @@ See `docs/integrations/shoptet-api.md` §11 for shipment endpoints. Constraints:
 |---|---|---|---|
 | `ShoptetOrdersSettings:PackingStateId` | `appsettings.json` | 26 | Shoptet status ID for "Balí se" |
 | `ShipmentLabels:MinPackageWeightGrams` | `appsettings.json` | 100 | Floor for package weight sent to carrier |
-| `ShipmentLabels:DefaultPackage*Mm` | `appsettings.json` | 300×200×150 | Default package dimensions |
+| `ShipmentLabels:DefaultPackage*Cm` | `appsettings.json` | 30×20×15 | Default package dimensions (cm — Shoptet reads these as centimetres) |
 | Kiosk mode (print auto-confirm) | Browser/OS setting | — | Set at device level; not app-configurable |
 
 ## 10. Future Improvements (out of scope here)

--- a/docs/integrations/shoptet-api.md
+++ b/docs/integrations/shoptet-api.md
@@ -1128,9 +1128,9 @@ Creates a shipment for an order. Triggers Balikobot carrier API call synchronous
     "bankAccountId": null,
     "packages": [
       {
-        "width": 300,
-        "height": 200,
-        "depth": 150,
+        "width": 30,
+        "height": 20,
+        "depth": 15,
         "weight": "0.500"
       }
     ]
@@ -1160,7 +1160,7 @@ Creates a shipment for an order. Triggers Balikobot carrier API call synchronous
 
 *Variant A: by dimensions*
 ```json
-{ "width": 300, "height": 200, "depth": 150, "weight": "0.500" }
+{ "width": 30, "height": 20, "depth": 15, "weight": "0.500" }
 ```
 
 *Variant B: by packaging type + weight*
@@ -1175,7 +1175,7 @@ Creates a shipment for an order. Triggers Balikobot carrier API call synchronous
 
 **Weight unit: kilograms (kg).** The `weight` field accepts `string | null | integer`. String format is decimal kg (e.g. `"0.500"`, `"1.00"`). The `typeWeight` schema in the OpenAPI spec confirms: *"weight in kg, unpacked. 3 decimal places."* The GET response `shipmentPackage.weight` examples show `1` (numeric, kg).
 
-**Dimensions** (`width`, `height`, `depth`) are integers in **millimetres** — the OpenAPI spec examples show `10`, `20`, `30`.
+**Dimensions** (`width`, `height`, `depth`) are integers in **centimetres**. The OpenAPI spec examples (`10`, `20`, `30`) originally led us to assume millimetres, but a live order confirmed centimetres: sending `300/200/150` made Shoptet display a `3 m × 2 m × 1.5 m` package (i.e. it read the values as cm). We now send `30/20/15` for the default `0.3 × 0.2 × 0.15 m` box. _(Finding confirmed 2026-07-03.)_
 
 #### Response shape (201 Created)
 


### PR DESCRIPTION
Shoptet's `/api/shipments` `width`/`height`/`depth` fields are **centimetres**, not millimetres as our field names and docs assumed, so our `300/200/150` defaults were showing up as an absurd `3 × 2 × 1.5 m` package (and being sent to the carrier). This converts the defaults to `30/20/15`, renames `...Mm` → `...Cm` across `ShipmentLabelsSettings`, `ShipmentPackage`, the three shipment handlers, the Shoptet client and all tests, and corrects `docs/integrations/shoptet-api.md` and `docs/features/packaging.md`. A new serialization assertion in `ShoptetShipmentClientTests` locks the cm values on the wire. Also fixes an unrelated pre-existing compile break in `GetConfigurationHandlerTests` (`ConfigurationConstants.APP_VERSION` → `InfrastructureConfigurationKeys.APP_VERSION`, a leftover from an earlier refactor) so the test project builds. The centimetre interpretation still needs live confirmation against a real Shoptet order (no sandbox exists), after which the doc finding is confirmed.