### PR TITLE
#3476: relocate RunExpeditionListPrintFixResult to its actual usage site

### DIFF
--- a/artifacts/feat-3476/arch-review.r1.md
+++ b/artifacts/feat-3476/arch-review.r1.md
@@ -1,0 +1,85 @@
+# Architecture Review: Remove dead `RunExpeditionListPrintFixResult` type and enforce return-type contract on `useRunExpeditionListPrintFix`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a type-only cleanup confined to the frontend API-hooks layer (`frontend/src/api/hooks/`). It touches no runtime behavior, no HTTP contract, no UI, and no backend code. Verified directly:
+
+- `useExpeditionListArchive.ts:32-34` declares `export interface RunExpeditionListPrintFixResult { totalCount: number }` and nothing in that file references it — it's orphaned.
+- The actual mutation it was presumably meant to describe, `useRunExpeditionListPrintFix`, lives in the unrelated `useExpeditionList.ts` (line 5) and currently has an untyped `mutationFn` (`useMutation({...})` with no generics), so `useMutation`'s `TData` resolves to `any`.
+- The sole consumer, `ExpeditionListArchivePage.tsx:61,130-131`, calls `runFixMutation.mutateAsync()` and reads `result.totalCount` — today with zero compiler enforcement since the type is `any`.
+- Project-wide grep confirms `RunExpeditionListPrintFixResult` has no importers outside its declaring file, matching the spec's claim.
+
+This fits the codebase's existing convention in the same file: `usePrintExpeditionOrder` (lines 29-59 of `useExpeditionList.ts`) already uses the `useMutation<TData, TError, TVariables>` pattern with an exported response interface (`BaseResponse` from `../../types/errors`) directly informing the mutation's generics. The proposed change simply brings `useRunExpeditionListPrintFix` in line with its sibling in the same file, using a locally-defined interface instead of a shared one (appropriate since `RunExpeditionListPrintFixResult`'s shape is specific to this one endpoint).
+
+No architectural boundary is crossed: both files remain in `frontend/src/api/hooks/`, both are consumed only by page-level components, and the module each type lives in already matches the module owning the hook that returns it. There is no case for introducing a shared types file, a barrel export, or any structural change beyond what the spec describes.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. Existing structure:
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` — archive/reprint feature hooks (`useExpeditionDates`, `useExpeditionListsByDate`, `useReprintExpeditionList`). Loses its dead, misplaced interface.
+- `frontend/src/api/hooks/useExpeditionList.ts` — print-fix and print-order mutations (`useRunExpeditionListPrintFix`, `usePrintExpeditionOrder`). Gains the interface it should have owned from the start, applied to its own mutation's generics.
+- `frontend/src/pages/ExpeditionListArchivePage.tsx` — sole consumer; unaffected in behavior, but `result.totalCount` (line 131) becomes type-checked instead of `any`-typed.
+
+### Key Design Decisions
+1. **Colocate the type with the hook that produces it, not with the module that happens to share naming similarity.** `RunExpeditionListPrintFixResult` belongs next to `useRunExpeditionListPrintFix`, consistent with every other response interface in both files (`GetExpeditionDatesResponse` next to `useExpeditionDates`, `ReprintExpeditionListResponse` next to `useReprintExpeditionList`, etc.).
+2. **Reuse the existing generic-parameter pattern (`useMutation<TData, TError, TVariables>`) already established by `usePrintExpeditionOrder`** rather than inventing a new typing convention. `TVariables = void` since the hook takes no arguments — this is a standard, idiomatic choice already implied by the spec.
+3. **No runtime validation is introduced.** `response.json()` remains an unchecked type assertion at the JS/TS boundary; this change only enforces the type at the point where the caller (`ExpeditionListArchivePage.tsx`) reads `.totalCount`. This is consistent with how every other hook in this file already behaves (e.g., `usePrintExpeditionOrder`, `useExpeditionDates`) — none of them do runtime schema validation of API responses. Introducing one here would be scope creep relative to the rest of the module.
+4. **Do not touch the `apiClient as any` casts.** These exist identically in `usePrintExpeditionOrder` in the same file; fixing them is an unrelated, broader pattern change explicitly out of scope per the spec.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files or directories. Both files stay exactly where they are:
+```
+frontend/src/api/hooks/
+  useExpeditionListArchive.ts   (interface removed)
+  useExpeditionList.ts          (interface added, mutation typed)
+```
+
+### Interfaces and Contracts
+- Remove from `useExpeditionListArchive.ts` (lines 32-34):
+  ```typescript
+  export interface RunExpeditionListPrintFixResult {
+    totalCount: number;
+  }
+  ```
+  along with the blank line it leaves behind, to avoid a stray double-blank-line diff artifact between `ReprintExpeditionListResponse` and the `// --- Query Keys ---` section comment.
+
+- Add to `useExpeditionList.ts`, directly above `useRunExpeditionListPrintFix`:
+  ```typescript
+  export interface RunExpeditionListPrintFixResult {
+    totalCount: number;
+  }
+  ```
+  This is a plain TypeScript interface for a frontend API-response shape, not a C# DTO — CLAUDE.md's "DTOs are classes, never records" rule governs backend/OpenAPI-generated contract types and does not apply here; `interface` is the file's existing convention for these shapes (every other response type in both files is an `interface`, not a `class` or `type` alias), so no deviation is warranted.
+
+- Type the mutation itself:
+  ```typescript
+  export const useRunExpeditionListPrintFix = () => {
+    return useMutation<RunExpeditionListPrintFixResult, Error, void>({
+      mutationFn: async (): Promise<RunExpeditionListPrintFixResult> => {
+        ...
+        return await response.json();
+      },
+    });
+  };
+  ```
+  This mirrors `usePrintExpeditionOrder`'s `useMutation<BaseResponse, Error, { orderCode: string }>` shape one-for-one, substituting `void` for the variables generic since this mutation takes no input.
+
+### Data Flow
+Unchanged. `ExpeditionListArchivePage.tsx` → `useRunExpeditionListPrintFix().mutateAsync()` → `POST /api/expedition-list/run-fix` → JSON body `{ totalCount: number }` → displayed in a success toast (line 131). The only difference is that `result` in `mutateAsync()`'s resolved value is now statically known to be `RunExpeditionListPrintFixResult` instead of `any`, so `.totalCount` is checked against a `number` field instead of being an unchecked property access.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A currently-hidden importer of `RunExpeditionListPrintFixResult` from `useExpeditionListArchive.ts` exists that grep missed (e.g. via a barrel/re-export file) | Low | `npm run build` will fail loudly with a missing-export error if so; the spec's acceptance criteria already requires a clean build as the verification gate. Grep across `frontend/src` in this review found only the two hook files and no re-export barrels for this module. |
+| Adding an explicit `RunExpeditionListPrintFixResult` type surfaces a latent type mismatch if the backend's actual JSON shape has drifted from `{ totalCount: number }` (e.g. field renamed) | Low | This is precisely the intended benefit of the change (per spec Background) — if `npm run build`/`lint` surface a new error at `ExpeditionListArchivePage.tsx:131`, that is a legitimate, valuable finding, not a defect in this change. Out of scope to fix if it surfaces (per spec's "Out of Scope"); should be flagged separately if it happens. |
+| Blank-line/formatting churn in `useExpeditionListArchive.ts` beyond the minimal deletion, tripping a stricter lint/format rule | Low | FR-1's acceptance criteria explicitly calls for removing only the dead block and its trailing blank line, "consistent with surrounding style" — a single, minimal diff hunk. `npm run lint`/`dotnet format`-equivalent (ESLint/Prettier for FE) will catch any stray formatting issues. |
+
+## Specification Amendments
+None. The spec is precise, self-contained, and already identifies the correct acceptance criteria (build/lint clean, no other importers, behavior-neutral). No gaps found during exploration — the referenced line numbers (32-34 in the archive file, `usePrintExpeditionOrder`'s generic pattern) match the actual source exactly.
+
+## Prerequisites
+None. This change has no dependency on other in-flight work, no backend coordination, and no ordering constraints — it can be implemented and merged independently.

--- a/artifacts/feat-3476/brief.md
+++ b/artifacts/feat-3476/brief.md
@@ -1,0 +1,47 @@
+# [arch-review] ExpeditionListArchive: RunExpeditionListPrintFixResult interface is dead code in useExpeditionListArchive.ts
+
+## Module
+ExpeditionListArchive
+
+## Finding
+`useExpeditionListArchive.ts` (lines 32–34) exports an interface that is never imported anywhere:
+
+```typescript
+// frontend/src/api/hooks/useExpeditionListArchive.ts  lines 32-34
+export interface RunExpeditionListPrintFixResult {
+  totalCount: number;
+}
+```
+
+The hook that actually performs the print-fix operation — `useRunExpeditionListPrintFix` — lives in a different file (`frontend/src/api/hooks/useExpeditionList.ts`) and has no explicit return-type annotation. `ExpeditionListArchivePage.tsx` imports the hook from that file and accesses `result.totalCount` against the untyped `response.json()` result.
+
+A project-wide grep confirms `RunExpeditionListPrintFixResult` has zero importers.
+
+## Why it matters
+- The orphaned type implies the archive hooks module is responsible for the print-fix feature, when it is not. Future developers may try to re-use or extend it, expecting it to be wired up.
+- The actual `useRunExpeditionListPrintFix` return value is untyped (`any`), so the intended contract (`{ totalCount: number }`) is silently unenforced. A backend rename goes undetected by TypeScript.
+
+## Suggested fix
+Two small changes:
+
+1. **Delete** `RunExpeditionListPrintFixResult` from `useExpeditionListArchive.ts`.
+2. **Add** an explicit return-type annotation in `useExpeditionList.ts` so the contract is enforced where the hook actually lives:
+
+```typescript
+// frontend/src/api/hooks/useExpeditionList.ts
+interface RunFixResult {
+  totalCount: number;
+}
+
+export const useRunExpeditionListPrintFix = () => {
+  return useMutation({
+    mutationFn: async (): Promise => {
+      // ...
+      return await response.json() as RunFixResult;
+    },
+  });
+};
+```
+
+---
+_Filed by daily arch-review routine on 2026-07-03._

--- a/artifacts/feat-3476/code-review.r1.md
+++ b/artifacts/feat-3476/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3476/impl/relocate-print-fix-result-type-and-type-mutation.r1.md
+++ b/artifacts/feat-3476/impl/relocate-print-fix-result-type-and-type-mutation.r1.md
@@ -1,0 +1,32 @@
+# Implementation: relocate-print-fix-result-type-and-type-mutation
+
+## What was implemented
+Moved the `RunExpeditionListPrintFixResult` interface out of `useExpeditionListArchive.ts` (where it was dead/orphaned) into `useExpeditionList.ts`, directly above `useRunExpeditionListPrintFix`, which is the hook that actually produces/consumes it. Added explicit generics `<RunExpeditionListPrintFixResult, Error, void>` to the `useMutation` call and an explicit `Promise<RunExpeditionListPrintFixResult>` return type on `mutationFn`, matching the existing `usePrintExpeditionOrder` pattern in the same file. No runtime/behavioral changes: HTTP method, headers, endpoint path, and error handling are unchanged.
+
+## Files created/modified
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` — deleted the orphaned `RunExpeditionListPrintFixResult` interface (and the blank line it left behind between `ReprintExpeditionListResponse` and the `// --- Query Keys ---` comment). No other changes.
+- `frontend/src/api/hooks/useExpeditionList.ts` — added the `RunExpeditionListPrintFixResult` interface directly above `useRunExpeditionListPrintFix`; gave `useMutation` explicit generics `<RunExpeditionListPrintFixResult, Error, void>` and gave `mutationFn` an explicit `Promise<RunExpeditionListPrintFixResult>` return type. Body of the mutation (URL construction, `apiClient as any` casts, fetch call, error handling) is untouched.
+
+## Tests
+N/A — type-only change verified by build/lint. `ExpeditionListArchivePage.tsx` already imports `useRunExpeditionListPrintFix` from `useExpeditionList` (not from the archive hooks file), so no consumer changes were needed; it type-checks cleanly against the new explicit `totalCount: number` return type with no `any` involved.
+
+## How to verify
+1. `grep -rn "RunExpeditionListPrintFixResult" frontend/src` — only `frontend/src/api/hooks/useExpeditionList.ts` matches (3 lines: interface declaration, `useMutation` generic, `mutationFn` return type).
+2. `cd frontend && npm run build` — compiles successfully, no new type errors (had to `npm ci --legacy-peer-deps` first since `node_modules` was absent in this worktree and `react-i18next` has a `typescript@^5` peer conflict with the pinned `typescript@4.9.5` — pre-existing, unrelated to this change).
+3. `cd frontend && npm run lint` — 148 pre-existing errors / 14 pre-existing warnings, all in unrelated test files (testing-library rules, unused imports, import ordering). Neither `useExpeditionList.ts`, `useExpeditionListArchive.ts`, nor `ExpeditionListArchivePage.tsx` appear anywhere in the lint output — confirmed via grep against the full lint log — so this change introduces zero new lint issues.
+4. `git diff` on both files shows only the minimal, spec-matching edits (no reordering, no unrelated formatting churn).
+
+## Notes
+- `node_modules` did not exist in this worktree; `npm ci` failed with an ERESOLVE conflict (`react-i18next@15.7.4` wants `typescript@^5`, project pins `typescript@4.9.5`). Used `npm ci --legacy-peer-deps` to install, which is an environment-setup workaround only — no `package.json`/`package-lock.json` changes were made. This conflict is pre-existing and out of scope for this task; noting it here for visibility.
+- Per the task's explicit out-of-scope list, `ExpeditionListArchivePage.tsx` was not touched — it already imports from the correct module and required no changes.
+- `artifacts/` directory was left untouched per instructions (not staged/committed), except that `artifacts/feat-3476/state.json` showed as pre-existing modified in git status before this task began; it was not staged in this task's commit.
+
+## PR Summary
+Relocates the `RunExpeditionListPrintFixResult` type from `useExpeditionListArchive.ts` (where it was unused/orphaned) to `useExpeditionList.ts`, right next to the `useRunExpeditionListPrintFix` hook that actually returns it. The hook's `useMutation` call now has explicit generics and an explicit `mutationFn` return type instead of relying on implicit `any`, matching the sibling `usePrintExpeditionOrder` hook's pattern. Purely a type-level refactor — no HTTP behavior, error handling, or endpoint changed.
+
+### Changes
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` — removed the dead `RunExpeditionListPrintFixResult` interface.
+- `frontend/src/api/hooks/useExpeditionList.ts` — added `RunExpeditionListPrintFixResult`, added explicit `useMutation<RunExpeditionListPrintFixResult, Error, void>` generics and `mutationFn` return type.
+
+## Status
+DONE

--- a/artifacts/feat-3476/review/relocate-print-fix-result-type-and-type-mutation.r1.md
+++ b/artifacts/feat-3476/review/relocate-print-fix-result-type-and-type-mutation.r1.md
@@ -1,0 +1,27 @@
+# Code Review: relocate-print-fix-result-type-and-type-mutation
+
+## Summary
+This is a clean, minimal, type-only refactor exactly matching the spec: the orphaned `RunExpeditionListPrintFixResult` interface was removed from `useExpeditionListArchive.ts` and relocated directly above `useRunExpeditionListPrintFix` in `useExpeditionList.ts`, with explicit `useMutation<TData, TError, TVariables>` generics and a typed `mutationFn` return matching the sibling `usePrintExpeditionOrder` pattern. Independent verification (diff inspection, full-file reads, grep, `tsc --noEmit`, `npm run build`, `npm run lint`, and the relevant Jest suites) confirms no behavioral change and no regressions.
+
+## Review Result: PASS
+
+### task: relocate-print-fix-result-type-and-type-mutation
+**Status:** PASS
+
+**Verification performed:**
+- `git show f72e97b` confirms the diff is exactly the two described hunks — no unrelated changes.
+- Full contents of `useExpeditionList.ts` and `useExpeditionListArchive.ts` read: the interface is now declared directly above `useRunExpeditionListPrintFix` (lines 5-7), `useMutation<RunExpeditionListPrintFixResult, Error, void>` and `mutationFn: async (): Promise<RunExpeditionListPrintFixResult>` are in place, and the HTTP call/error-handling body is byte-for-byte unchanged. In the archive file, the dead interface and its blank line are gone, leaving a single blank line between `ReprintExpeditionListResponse` and `// --- Query Keys ---` (no double-blank-line artifact).
+- `grep -rn "RunExpeditionListPrintFixResult" frontend/src` returns only 3 matches, all in `useExpeditionList.ts` (interface + generic + return type) — zero remaining references in the archive file or elsewhere.
+- `ExpeditionListArchivePage.tsx` imports `useRunExpeditionListPrintFix` from `../api/hooks/useExpeditionList` (unchanged) and reads `result.totalCount` at the `handleRunFix` call site — this now type-checks against the concrete interface instead of `any`. The file was not touched, as required.
+- `npx tsc --noEmit -p .` produces no errors attributable to either changed file or the consuming page (all errors present are pre-existing `react-i18next`/TypeScript version-mismatch noise in `node_modules`, unrelated to this change).
+- `npm run build` completes with "Compiled successfully."
+- `npm run lint` produces no output referencing either changed file or the consuming page.
+- Ran the two directly relevant Jest suites (`useExpeditionList.test.ts`, `ExpeditionListArchivePage.test.tsx`): 2 suites / 16 tests, all passing (one pre-existing, unrelated `act()` warning from `ToastProvider` in an unrelated code path).
+
+No functional requirement, architecture guidance item, or acceptance criterion from spec.r1.md / arch-review.r1.md is violated. No new tests were required (type-only change) and none were added, consistent with the spec.
+
+## Docs to Update
+None. This is an internal, non-behavioral TypeScript type refactor with no new public behavior, concepts, or operational changes.
+
+## Overall Notes
+Implementation is faithful to both the spec and the arch review, with no scope creep (the pre-existing `apiClient as any` casts and the `npm ci` peer-dependency conflict noted in the impl summary were correctly left untouched/unfixed, as instructed). Nothing further needed.

--- a/artifacts/feat-3476/spec.r1.md
+++ b/artifacts/feat-3476/spec.r1.md
@@ -1,0 +1,117 @@
+# Specification: Remove dead `RunExpeditionListPrintFixResult` type and enforce return-type contract on `useRunExpeditionListPrintFix`
+
+## Summary
+`useExpeditionListArchive.ts` exports an interface, `RunExpeditionListPrintFixResult`, that has zero importers anywhere in the codebase and describes a hook (`useRunExpeditionListPrintFix`) that actually lives in a different file, `useExpeditionList.ts`. This spec covers deleting the orphaned type and adding an explicit, enforced return-type annotation to the real hook so a future backend contract change (e.g. renaming `totalCount`) is caught by TypeScript instead of silently passing through as `any`.
+
+## Background
+`ExpeditionListArchivePage.tsx` calls `useRunExpeditionListPrintFix()` (defined in `frontend/src/api/hooks/useExpeditionList.ts`) and reads `result.totalCount` off the mutation result. That hook's `mutationFn` returns `await response.json()` with no type annotation, so `useMutation`'s generic resolves to `any` — the `.totalCount` access is completely unchecked by the compiler.
+
+Meanwhile, `useExpeditionListArchive.ts` — a different, unrelated hooks module for the archive/reprint feature — separately declares an interface named `RunExpeditionListPrintFixResult` that models the exact same `{ totalCount: number }` shape, but it is never imported or referenced by `useRunExpeditionListPrintFix` or anything else (confirmed via project-wide grep). This is dead code that misleadingly implies the archive module owns the print-fix feature, and it does nothing to enforce the actual contract at its real call site.
+
+This is a small, mechanical cleanup with no behavioral or API changes: move the type definition to where it's actually used, and wire it into the mutation's generic type parameters.
+
+## Functional Requirements
+
+### FR-1: Delete the orphaned `RunExpeditionListPrintFixResult` interface from `useExpeditionListArchive.ts`
+Remove lines 32–34 of `frontend/src/api/hooks/useExpeditionListArchive.ts`:
+
+```typescript
+export interface RunExpeditionListPrintFixResult {
+  totalCount: number;
+}
+```
+
+No other code in `useExpeditionListArchive.ts` references this interface, so no other changes are needed in that file.
+
+**Acceptance criteria:**
+- `RunExpeditionListPrintFixResult` no longer appears anywhere in `useExpeditionListArchive.ts`.
+- A project-wide search (e.g. `grep -r "RunExpeditionListPrintFixResult" frontend/src`) after the change returns matches only in the new location defined by FR-2 (i.e., zero remaining references tied to the archive file).
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` otherwise remains unchanged (no reordering, no formatting churn beyond removing the dead block and the blank line it leaves behind, consistent with surrounding style).
+
+### FR-2: Define and apply an explicit return-type contract for `useRunExpeditionListPrintFix`
+In `frontend/src/api/hooks/useExpeditionList.ts`:
+
+1. Add an exported interface (reusing the deleted name so any future search for it resolves at its true home) directly above `useRunExpeditionListPrintFix`:
+   ```typescript
+   export interface RunExpeditionListPrintFixResult {
+     totalCount: number;
+   }
+   ```
+2. Annotate the `useMutation` call with this type as its result generic, and annotate `mutationFn`'s return type:
+   ```typescript
+   export const useRunExpeditionListPrintFix = () => {
+     return useMutation<RunExpeditionListPrintFixResult, Error, void>({
+       mutationFn: async (): Promise<RunExpeditionListPrintFixResult> => {
+         const apiClient = getAuthenticatedApiClient();
+         const relativeUrl = `/api/expedition-list/run-fix`;
+         const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+
+         const response = await (apiClient as any).http.fetch(fullUrl, {
+           method: "POST",
+           headers: { "Content-Type": "application/json" },
+         });
+
+         if (!response.ok) {
+           const errorData = await response.json().catch(() => null);
+           throw new Error(
+             errorData?.errorMessage ?? `HTTP error! status: ${response.status}`
+           );
+         }
+
+         return await response.json();
+       },
+     });
+   };
+   ```
+   The exact shape of the `useMutation` generic parameters (`TData, TError, TVariables`) must match the existing pattern used elsewhere in the same file (see `usePrintExpeditionOrder`, which uses `useMutation<BaseResponse, Error, { orderCode: string }>`) — `useRunExpeditionListPrintFix` takes no variables, so `TVariables` is `void`.
+3. Do not change the runtime behavior, the HTTP call, error handling, or the endpoint path — this is a type-only change.
+
+**Acceptance criteria:**
+- `useRunExpeditionListPrintFix`'s `useMutation` call has an explicit `RunExpeditionListPrintFixResult` (or equivalent) type parameter — no more implicit `any` return.
+- `result.totalCount` in `ExpeditionListArchivePage.tsx` (wherever it consumes this hook's mutation result) type-checks against `totalCount: number` with no `any` involved.
+- If the backend response shape ever omits or renames `totalCount`, this is a type-only assertion at the JS/TS boundary (since `response.json()` is inherently untyped at runtime) — TypeScript enforcement is at the call-site usage of the typed result, not at deserialization. Note this limitation explicitly in code only if a comment already exists nearby; otherwise no new comment is required.
+- `npm run build` and `npm run lint` in `frontend/` succeed with no new errors or warnings introduced by this change.
+- No other file that imports from `useExpeditionList.ts` or `useExpeditionListArchive.ts` breaks as a result of this change (verified by build).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — this is a compile-time-only type change with zero runtime behavior difference. No performance impact.
+
+### NFR-2: Security
+Not applicable — no change to authentication, authorization, data handling, or the API surface. The HTTP call, headers, and endpoint remain identical.
+
+## Data Model
+No backend or persisted data model changes. The only "data model" affected is the TypeScript-side shape of the print-fix mutation result:
+
+```typescript
+interface RunExpeditionListPrintFixResult {
+  totalCount: number;
+}
+```
+
+This mirrors the existing (already correct) runtime shape returned by `POST /api/expedition-list/run-fix` — no backend changes are required or implied.
+
+## API / Interface Design
+No HTTP API changes. This spec only touches TypeScript module boundaries:
+- **Removed export:** `RunExpeditionListPrintFixResult` from `frontend/src/api/hooks/useExpeditionListArchive.ts`.
+- **Added export:** `RunExpeditionListPrintFixResult` from `frontend/src/api/hooks/useExpeditionList.ts`.
+- **Changed signature:** `useRunExpeditionListPrintFix()`'s returned `UseMutationResult` now has `TData = RunExpeditionListPrintFixResult` instead of the previously implicit `any`.
+
+Any file currently importing `RunExpeditionListPrintFixResult` from `useExpeditionListArchive.ts` would need updating — but per the brief and a confirmed project-wide grep, no such importer exists today, so this is a non-breaking move in practice.
+
+## Dependencies
+- `@tanstack/react-query` (`useMutation` generics) — already a dependency, no version change.
+- No new libraries, no backend/API changes, no other feature dependencies.
+
+## Out of Scope
+- Any change to the actual HTTP call, error handling, or endpoint (`/api/expedition-list/run-fix`) in `useRunExpeditionListPrintFix`.
+- Fixing the pre-existing pattern of casting `apiClient` to `any` to access `.baseUrl` and `.http.fetch` (used identically in `usePrintExpeditionOrder` in the same file) — this is a separate, broader pattern not called out in the brief.
+- Runtime validation/parsing of the JSON response (e.g. via a schema validator) to guard against a backend contract change at runtime — the brief's concern is strictly about compile-time type enforcement.
+- Any change to `ExpeditionListArchivePage.tsx` itself, since the type change is expected to be a drop-in compatible narrowing of what was previously `any`.
+- Renaming or restructuring `useExpeditionListArchive.ts` or `useExpeditionList.ts` beyond the specific additions/deletions described above.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-04T05:19:09.985855Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-04T05:19:21.827042Z"
+      "status": "completed",
+      "updated_at": "2026-07-04T05:29:24.323896Z"
     }
   },
   "tasks": [
     {
       "name": "relocate-print-fix-result-type-and-type-mutation",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T05:19:22.066336Z"
+      "updated_at": "2026-07-04T05:29:23.901664Z"
     }
   ]
 }

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-04T05:19:09.985855Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-04T05:19:21.827042Z"
     }
   },
   "tasks": [
     {
       "name": "relocate-print-fix-result-type-and-type-mutation",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T05:19:22.066336Z"
     }
   ]
 }

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-04T05:18:17.242824Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T05:18:26.299269Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T05:19:09.985855Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "relocate-print-fix-result-type-and-type-mutation",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-04T05:29:24.323896Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-04T05:29:28.915830Z"
+      "status": "completed",
+      "updated_at": "2026-07-04T05:31:24.594763Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-04T05:29:24.323896Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-04T05:29:28.915830Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-04T05:16:51.835376Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T05:18:17.242824Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T05:16:51.835376Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3476/state.json
+++ b/artifacts/feat-3476/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3476",
+  "issue_number": 3476,
+  "created_at": "2026-07-04T05:15:18.939609Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3476/task-context/relocate-print-fix-result-type-and-type-mutation.md
+++ b/artifacts/feat-3476/task-context/relocate-print-fix-result-type-and-type-mutation.md
@@ -1,0 +1,64 @@
+### task: relocate-print-fix-result-type-and-type-mutation
+Perform a type-only, mechanical refactor across two files in `frontend/src/api/hooks/`. No runtime/behavioral changes, no backend changes, no UI changes.
+
+**1. `frontend/src/api/hooks/useExpeditionListArchive.ts`**
+- Delete the orphaned interface (lines ~32-34):
+  ```typescript
+  export interface RunExpeditionListPrintFixResult {
+    totalCount: number;
+  }
+  ```
+- Also remove the blank line it leaves behind so there isn't a stray double-blank-line between `ReprintExpeditionListResponse` and the `// --- Query Keys ---` section comment. No other changes to this file — no reordering, no unrelated formatting.
+
+**2. `frontend/src/api/hooks/useExpeditionList.ts`**
+- Add this interface directly above `useRunExpeditionListPrintFix`:
+  ```typescript
+  export interface RunExpeditionListPrintFixResult {
+    totalCount: number;
+  }
+  ```
+- Update the `useRunExpeditionListPrintFix` hook to add explicit generics to `useMutation` and an explicit return type on `mutationFn`, matching the existing `usePrintExpeditionOrder` pattern (`useMutation<TData, TError, TVariables>`) in the same file:
+  ```typescript
+  export const useRunExpeditionListPrintFix = () => {
+    return useMutation<RunExpeditionListPrintFixResult, Error, void>({
+      mutationFn: async (): Promise<RunExpeditionListPrintFixResult> => {
+        const apiClient = getAuthenticatedApiClient();
+        const relativeUrl = `/api/expedition-list/run-fix`;
+        const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+
+        const response = await (apiClient as any).http.fetch(fullUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => null);
+          throw new Error(
+            errorData?.errorMessage ?? `HTTP error! status: ${response.status}`
+          );
+        }
+
+        return await response.json();
+      },
+    });
+  };
+  ```
+- Do not touch the `apiClient as any` casts, the HTTP call, error handling, or the endpoint path — this is purely adding type annotations. `TVariables` is `void` since the hook takes no arguments.
+
+**Explicitly out of scope (do not touch):**
+- `ExpeditionListArchivePage.tsx` — should remain a drop-in-compatible consumer; no edits expected there. If `npm run build` surfaces a new type error at its `result.totalCount` usage (~line 131), that indicates a genuine pre-existing backend/frontend contract drift — do not silently "fix" it by loosening types; report it rather than papering over it, per the arch review's noted risk.
+- The `apiClient as any` cast pattern (unrelated, pre-existing, used identically elsewhere in the file).
+- Any runtime validation of the JSON response.
+
+**Acceptance criteria (from spec):**
+- `RunExpeditionListPrintFixResult` no longer appears anywhere in `useExpeditionListArchive.ts`.
+- `RunExpeditionListPrintFixResult` is now exported from `useExpeditionList.ts`, directly above `useRunExpeditionListPrintFix`.
+- `useRunExpeditionListPrintFix`'s `useMutation` call has explicit generics `<RunExpeditionListPrintFixResult, Error, void>` — no more implicit `any` return.
+- `result.totalCount` in `ExpeditionListArchivePage.tsx` type-checks against `totalCount: number` with no `any` involved.
+- No behavioral change: HTTP method, headers, endpoint path, and error handling are byte-for-byte identical to before.
+
+**Verification steps:**
+1. `grep -r "RunExpeditionListPrintFixResult" frontend/src` — confirm the only match is in `useExpeditionList.ts` (zero remaining references in `useExpeditionListArchive.ts`).
+2. `cd frontend && npm run build` — must succeed with no new errors introduced by this change (including in `ExpeditionListArchivePage.tsx`).
+3. `cd frontend && npm run lint` — must succeed with no new warnings/errors, and no stray blank-line/formatting diff artifacts in `useExpeditionListArchive.ts`.
+4. Manually diff both changed files to confirm the edits are minimal and match exactly what's described above (no unrelated reordering or formatting churn).

--- a/artifacts/feat-3476/task-plan.r1.md
+++ b/artifacts/feat-3476/task-plan.r1.md
@@ -1,0 +1,66 @@
+# Task Plan: Remove dead `RunExpeditionListPrintFixResult` type and enforce return-type contract on `useRunExpeditionListPrintFix`
+
+### task: relocate-print-fix-result-type-and-type-mutation
+Perform a type-only, mechanical refactor across two files in `frontend/src/api/hooks/`. No runtime/behavioral changes, no backend changes, no UI changes.
+
+**1. `frontend/src/api/hooks/useExpeditionListArchive.ts`**
+- Delete the orphaned interface (lines ~32-34):
+  ```typescript
+  export interface RunExpeditionListPrintFixResult {
+    totalCount: number;
+  }
+  ```
+- Also remove the blank line it leaves behind so there isn't a stray double-blank-line between `ReprintExpeditionListResponse` and the `// --- Query Keys ---` section comment. No other changes to this file — no reordering, no unrelated formatting.
+
+**2. `frontend/src/api/hooks/useExpeditionList.ts`**
+- Add this interface directly above `useRunExpeditionListPrintFix`:
+  ```typescript
+  export interface RunExpeditionListPrintFixResult {
+    totalCount: number;
+  }
+  ```
+- Update the `useRunExpeditionListPrintFix` hook to add explicit generics to `useMutation` and an explicit return type on `mutationFn`, matching the existing `usePrintExpeditionOrder` pattern (`useMutation<TData, TError, TVariables>`) in the same file:
+  ```typescript
+  export const useRunExpeditionListPrintFix = () => {
+    return useMutation<RunExpeditionListPrintFixResult, Error, void>({
+      mutationFn: async (): Promise<RunExpeditionListPrintFixResult> => {
+        const apiClient = getAuthenticatedApiClient();
+        const relativeUrl = `/api/expedition-list/run-fix`;
+        const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+
+        const response = await (apiClient as any).http.fetch(fullUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => null);
+          throw new Error(
+            errorData?.errorMessage ?? `HTTP error! status: ${response.status}`
+          );
+        }
+
+        return await response.json();
+      },
+    });
+  };
+  ```
+- Do not touch the `apiClient as any` casts, the HTTP call, error handling, or the endpoint path — this is purely adding type annotations. `TVariables` is `void` since the hook takes no arguments.
+
+**Explicitly out of scope (do not touch):**
+- `ExpeditionListArchivePage.tsx` — should remain a drop-in-compatible consumer; no edits expected there. If `npm run build` surfaces a new type error at its `result.totalCount` usage (~line 131), that indicates a genuine pre-existing backend/frontend contract drift — do not silently "fix" it by loosening types; report it rather than papering over it, per the arch review's noted risk.
+- The `apiClient as any` cast pattern (unrelated, pre-existing, used identically elsewhere in the file).
+- Any runtime validation of the JSON response.
+
+**Acceptance criteria (from spec):**
+- `RunExpeditionListPrintFixResult` no longer appears anywhere in `useExpeditionListArchive.ts`.
+- `RunExpeditionListPrintFixResult` is now exported from `useExpeditionList.ts`, directly above `useRunExpeditionListPrintFix`.
+- `useRunExpeditionListPrintFix`'s `useMutation` call has explicit generics `<RunExpeditionListPrintFixResult, Error, void>` — no more implicit `any` return.
+- `result.totalCount` in `ExpeditionListArchivePage.tsx` type-checks against `totalCount: number` with no `any` involved.
+- No behavioral change: HTTP method, headers, endpoint path, and error handling are byte-for-byte identical to before.
+
+**Verification steps:**
+1. `grep -r "RunExpeditionListPrintFixResult" frontend/src` — confirm the only match is in `useExpeditionList.ts` (zero remaining references in `useExpeditionListArchive.ts`).
+2. `cd frontend && npm run build` — must succeed with no new errors introduced by this change (including in `ExpeditionListArchivePage.tsx`).
+3. `cd frontend && npm run lint` — must succeed with no new warnings/errors, and no stray blank-line/formatting diff artifacts in `useExpeditionListArchive.ts`.
+4. Manually diff both changed files to confirm the edits are minimal and match exactly what's described above (no unrelated reordering or formatting churn).

--- a/frontend/src/api/hooks/useExpeditionList.ts
+++ b/frontend/src/api/hooks/useExpeditionList.ts
@@ -2,9 +2,13 @@ import { useMutation } from "@tanstack/react-query";
 import { getAuthenticatedApiClient } from "../client";
 import { BaseResponse } from "../../types/errors";
 
+export interface RunExpeditionListPrintFixResult {
+  totalCount: number;
+}
+
 export const useRunExpeditionListPrintFix = () => {
-  return useMutation({
-    mutationFn: async () => {
+  return useMutation<RunExpeditionListPrintFixResult, Error, void>({
+    mutationFn: async (): Promise<RunExpeditionListPrintFixResult> => {
       const apiClient = getAuthenticatedApiClient();
       const relativeUrl = `/api/expedition-list/run-fix`;
       const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;

--- a/frontend/src/api/hooks/useExpeditionListArchive.ts
+++ b/frontend/src/api/hooks/useExpeditionListArchive.ts
@@ -29,10 +29,6 @@ export interface ReprintExpeditionListResponse {
   params: Record<string, string> | null;
 }
 
-export interface RunExpeditionListPrintFixResult {
-  totalCount: number;
-}
-
 // --- Query Keys ---
 
 const expeditionArchiveKeys = {


### PR DESCRIPTION
Closes #3476

## What the issue was
`useExpeditionListArchive.ts` exported a `RunExpeditionListPrintFixResult` interface that had zero importers anywhere in the codebase — it described the return shape of `useRunExpeditionListPrintFix`, but that hook actually lives in a different file, `useExpeditionList.ts`, and had no return-type annotation at all (its `useMutation` resolved to implicit `any`). The orphaned type misleadingly implied the archive module owned the print-fix feature, and the real hook's contract (`{ totalCount: number }`) was silently unenforced by TypeScript.

## How it was fixed / handled
Purely a type-only refactor, no behavioral change:
- Deleted the dead `RunExpeditionListPrintFixResult` interface from `frontend/src/api/hooks/useExpeditionListArchive.ts`.
- Added the interface to `frontend/src/api/hooks/useExpeditionList.ts`, directly above `useRunExpeditionListPrintFix`, and gave the `useMutation` call explicit generics `<RunExpeditionListPrintFixResult, Error, void>` plus an explicit `Promise<RunExpeditionListPrintFixResult>` return type on `mutationFn` — matching the existing `usePrintExpeditionOrder` pattern in the same file.
- No changes to the HTTP call, headers, endpoint path, or error handling. `ExpeditionListArchivePage.tsx`'s existing `result.totalCount` read now type-checks against a real `totalCount: number` instead of `any`.

Verified via `npm run build` and `npm run lint` (no new errors/warnings on the touched files), plus a full autonomous pipeline run (spec → architecture review → task plan → implementation → task review → whole-branch code review, all committed under `artifacts/feat-3476/`).

## Artifacts
- Brief, spec, architecture review, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3476/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

The diff is a small, purely mechanical type-only move: the dead `RunExpeditionListPrintFixResult` interface was deleted from `useExpeditionListArchive.ts` and re-added directly above `useRunExpeditionListPrintFix` in `useExpeditionList.ts`, with `useMutation<RunExpeditionListPrintFixResult, Error, void>` and an explicit `mutationFn` return-type annotation added. Verified: no remaining references to the type in the old file, no other importers broken (`ExpeditionListArchivePage.tsx`'s `result.totalCount` usage now type-checks against the moved interface), HTTP call/error-handling logic byte-identical to before, and eslint passes clean on all three touched/consumer files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MSEw52tovBPDXjyLjS7VsC)_