### PR TITLE
#3479: dark mode variants for Leaflet generator feature

### DIFF
--- a/artifacts/feat-3479/arch-review.r1.md
+++ b/artifacts/feat-3479/arch-review.r1.md
@@ -1,0 +1,89 @@
+# Architecture Review: Leaflet Generator — Graphite Dark Mode Compliance (ADR-006)
+
+## Skip Design: true
+
+This is a class-level dark-mode styling fix applied to three existing components. No new UI components, screens, layouts, interaction patterns, or visual design decisions are introduced — the token map and conventions already exist and are already in production use elsewhere in the codebase (`frontend/src/features/articles/*`). There is nothing here for a designer to review; the only design authority is `docs/design/dark-mode-conversion-guide.md`, which is already accepted (ADR-006).
+
+## Architectural Fit Assessment
+
+This spec is architecturally sound and low-risk. I verified all three claims that matter for approving it as-is:
+
+1. **The spec's line numbers and class strings are accurate.** I read all three source files (`LeafletGeneratorPage.tsx` 57 lines, `LeafletDocumentsTab.tsx` 515 lines, `LeafletGenerateTab.tsx` 102 lines) and every cited line/class in FR-1 through FR-3 matches the current file content exactly (e.g. line 14 `indexed: 'bg-green-100 text-green-800'`, line 33 `bg-white rounded-lg shadow-xl`, line 470-474 page-number ternary, line 88-90 skeleton bars). No drift between spec and code.
+
+2. **The token map is the one already in force.** `docs/design/dark-mode-conversion-guide.md` and ADR-006 (`docs/architecture/development_guidelines.md` lines 294-298) define exactly the mapping the spec applies. `frontend/tailwind.config.js` (lines 48-62) already defines the full `graphite.*` scale and `boxShadow.soft-dark`; nothing needs to be added there.
+
+3. **The convention is already load-bearing elsewhere**, not invented for this feature. `frontend/src/features/articles/` (`ArticleList.tsx`, `ArticleDebugPanel.tsx`, `articleStatusConfig.ts`, `ArticleGenerationForm.tsx`, `ArticleSourceList.tsx`, `ArticleDetail.tsx`) already ships this exact pattern set:
+   - Status color maps: `'bg-green-100 text-green-700 dark:bg-emerald-900/30 dark:text-emerald-300'` (articleStatusConfig.ts:15) — identical shape to the spec's `StatusBadge` fix.
+   - Fallback/neutral pill: `'bg-gray-100 text-gray-700 dark:bg-graphite-surface-2 dark:text-graphite-muted'` (ArticleDebugPanel.tsx:32) — identical to the spec's FR-2a fallback treatment.
+   - Raw input bundle: `dark:border-graphite-border dark:bg-graphite-surface-2 dark:text-graphite-text dark:placeholder-graphite-faint` (ArticleGenerationForm.tsx:91, 81, 176, 183) — identical to the spec's FR-2d input/select treatment.
+   - Hover backgrounds: `hover:bg-gray-50 dark:hover:bg-white/5` (ArticleList.tsx:47) — identical to the spec's row/button hover treatment.
+   - `divide-gray-100 dark:divide-graphite-border`, `border-t dark:border-graphite-border`, `bg-blue-50 dark:bg-graphite-accent/10` — all present verbatim in shipped code.
+
+   Conclusion: there is no new abstraction to design. The correct architectural posture is to confirm the mechanical mapping and get out of the way.
+
+I have one substantive disagreement with the spec (Decision 2 below) and one scope note (Decision 3), both minor; neither changes the overall shape of the work.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. Three existing presentational components in `frontend/src/features/leaflet-generator/` get additive `className` edits only:
+
+- `LeafletGeneratorPage.tsx` — tab shell (header, tab nav)
+- `LeafletDocumentsTab.tsx` — filter bar, table, `StatusBadge`, `ConfirmDeleteDialog`, `SortableHeader`, pagination footer (all defined in this one file)
+- `LeafletGenerateTab.tsx` — error banners, loading skeleton
+
+`LeafletUploadTab.tsx`, `LeafletForm.tsx`, `LeafletResult.tsx`, `LeafletChunkDetailModal.tsx` remain untouched (correctly out of scope per the brief — flag as follow-up work, not silently expand this spec).
+
+### Key Design Decisions
+
+#### Decision 1: Confirm — mechanical token mapping, no abstraction
+**Options considered:** (a) apply `dark:` utility classes directly per the guide's table, matching the `articles` feature precedent; (b) extract a shared `StatusBadge`/`colorMap` component or hook shared across features to avoid repeating the color-map pattern.
+**Chosen approach:** (a). Apply `dark:` classes directly, file by file, exactly as the spec enumerates.
+**Rationale:** ADR-006's decision text explicitly frames this as additive utility-class work, not a components refactor. `articles` already has its own local `StatusBadge`-equivalent colorMap (`articleStatusConfig.ts`) that is not shared with `leaflet-generator`'s local `StatusBadge`, and the two status vocabularies (`indexed/processing/failed` vs `Queued/Researching/Writing/Generated/Failed`) don't overlap cleanly. Introducing a shared badge abstraction now would be an uninvited refactor outside this fix's blast radius — exactly what the brief and CLAUDE.md's "surgical changes" rule warn against. Leave the two colorMaps as parallel, independently-themed literals.
+
+#### Decision 2: Amend — solid action buttons should NOT be blanket-exempted
+**Options considered:** (a) accept the spec's Open Question A3 as-is — leave all `bg-{indigo,red,gray}-600 ... text-white` buttons unchanged since "solid saturated buttons with white text retain WCAG-sufficient contrast against both light and Graphite backgrounds"; (b) require a per-button check against the guide before exempting.
+**Chosen approach:** (b), with a narrow correction to FR-2b/FR-2d/FR-3's scope, not the whole exemption.
+**Rationale:** The technical claim in A3 (solid `-600`/`-700` background + white text has sufficient contrast on any surface) is true and is a reasonable general rule — the guide itself doesn't map solid buttons, and I found no counter-example in the `articles` feature where a solid action button was given a `dark:` variant. So the exemption is correctly grounded. However, the guide's silence should not be read as "any button using text-white is exempt" — it should be read as "solid saturated background + white text is exempt because contrast is invariant." The distinction matters for a reviewer skimming this list later: keep A3 confined to buttons that are *both* solid-saturated (`bg-*-600`+) *and* white text, not "buttons that render text-white for any reason." All buttons the spec cites (Filtrovat = indigo-600, Vymazat = gray-500/600, Smazat = red-600) satisfy this narrower rule, so **no code changes result from this decision** — it's a documentation tightening, not a functional change. Record it so a future arch-review pass doesn't need to re-litigate A3 for a different, less-saturated button.
+
+#### Decision 3: Reject scope creep — do not "fix" `bg-gray-500` on the Vymazat button
+The spec correctly leaves `bg-gray-500 hover:bg-gray-600 text-white` (Vymazat button, line 341) unchanged. Flagging explicitly: `bg-gray-500` is a mid-tone that is *not* white-on-white-adjacent, so at a glance it looks more like a candidate for the neutral-surface mapping than the accent-button mapping. It is not — it is a solid button with white text, same as the indigo Filtrovat button next to it, and A3's contrast argument applies identically. No action; call-out is to prevent an implementer "fixing" this during PR review under a mistaken read of the guide.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No structural changes. All edits stay within the existing three files in `frontend/src/features/leaflet-generator/`. No new files, no new directories, no new shared modules.
+
+### Interfaces and Contracts
+None affected. No props, no component signatures, no exported types change. `Props` (`canDelete: boolean`), `SortableHeaderProps`, `ConfirmDeleteDialog`'s inline prop type, and `ErrorBanner`/`ApiError` in `LeafletGenerateTab.tsx` are all untouched — verified by reading the full files; the spec's claim that no interfaces change is correct.
+
+### Data Flow
+Unaffected — this is presentation-only. `useLeafletDocumentsQuery`, `useLeafletContentTypesQuery`, `useDeleteLeafletDocumentMutation` (`frontend/src/api/hooks/useLeaflet.ts`), URL-param sync (`useSearchParams`), and `usePermissionsContext`/`hasPermission('marketing.leaflet.write')` gating are all read-only dependencies of this change and must not be touched, consistent with NFR-2.
+
+### Execution order (for the implementer)
+Follow the spec's own ordering — `LeafletDocumentsTab.tsx` first (highest surface area: FR-2a through FR-2h), then `LeafletGeneratorPage.tsx` (FR-1), then `LeafletGenerateTab.tsx` (FR-3). Within `LeafletDocumentsTab.tsx`, do the `StatusBadge` color map and `ConfirmDeleteDialog` first (self-contained, low line-count), then the filter bar, then the table body, then pagination — each is independently verifiable by toggling dark mode and eyeballing that region before moving to the next.
+
+### Verification approach
+No new automated visual regression infrastructure is needed for a change this size (per Out of Scope), but each FR's acceptance criteria are individually checkable by hand:
+- Toggle dark mode (Graphite) via `ThemeContext`, confirm each region matches the token map.
+- Toggle back to light mode, confirm pixel-identical rendering to pre-change (per FR-2's acceptance criteria) — since every change is a pure `dark:`-prefixed addition, light-mode DOM output is unaffected by construction; this is a low-risk claim to verify by diffing `className` strings rather than requiring a screenshot tool.
+- `npm run build` and `npm run lint` per CLAUDE.md's standard validation gate — no new lint categories are introduced by this change (no new custom classes, no arbitrary-value Tailwind syntax beyond what's already in the token map, e.g. `graphite-accent/10` and `white/5` which are standard Tailwind opacity-modifier syntax already used elsewhere in `articles`).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Implementer treats A3 (solid buttons) as "any white-text element is exempt" and skips a button that actually needs a dark variant | Low | Decision 2 above narrows the exemption explicitly to solid `-600`+ saturated backgrounds + white text; PR reviewer should spot-check any new/changed button against this narrower rule, not the spec's broader phrasing |
+| Ternary/template-literal edits (tab active state, sort chevrons, pagination active page) introduce a syntax error in the class string interpolation | Low | These are mechanical string edits inside existing template literals with well-defined branch boundaries (spec cites exact original strings); a `tsc`/`npm run build` pass will catch any malformed JSX/template literal immediately |
+| Reviewer or implementer "improves" adjacent code while in the file (e.g., the `(response as any).id` cast noted in Out of Scope, or unrelated lint warnings) | Low | Explicitly called out as Out of Scope in the spec and reinforced by CLAUDE.md's "surgical changes" rule — no action needed beyond flagging it in code review if it happens |
+| `LeafletUploadTab.tsx` / `LeafletForm.tsx` / `LeafletResult.tsx` / `LeafletChunkDetailModal.tsx` remain dark-mode-broken after this fix, and a user navigating between tabs sees inconsistent theming (documents/generate tabs themed, upload tab not) | Medium (UX, not correctness) | Already flagged in the spec's Out of Scope with a note to file a follow-up arch-review item; recommend filing that follow-up issue immediately after this PR merges so the tab-level inconsistency window is short |
+
+## Specification Amendments
+
+1. **Narrow Open Question A3's stated rationale** (see Decision 2): the exemption for solid action buttons applies specifically to *solid, saturated (`-600`/`-700`+) background + white text* combinations, not to "any button using `text-white`." No code changes result — this is a one-sentence clarification for the PR description / commit message so a future reviewer doesn't misapply the exemption to a lighter-background button elsewhere in the app.
+2. No other amendments. The FR-1/FR-2/FR-3 line-by-line mapping was independently verified against the current source files and against the accepted guide/ADR and is approved as written.
+
+## Prerequisites
+
+None. `frontend/tailwind.config.js` already defines the full `graphite.*` token scale and `boxShadow.soft-dark` (confirmed at lines 48-62 and 67); `docs/design/dark-mode-conversion-guide.md` and ADR-006 are already accepted; the `articles` feature already demonstrates every mapping this spec needs in shipped code. Implementation can start immediately with no setup work.

--- a/artifacts/feat-3479/brief.md
+++ b/artifacts/feat-3479/brief.md
@@ -1,0 +1,42 @@
+## Module
+Leaflet
+
+## Finding
+Every component in the `frontend/src/features/leaflet-generator/` feature directory uses light-only Tailwind classes with no `dark:` counterparts. ADR-006 (accepted 2026-06-25) requires every component that renders color to work correctly in both the light and Graphite dark themes.
+
+Affected files and example violations:
+
+**`LeafletGeneratorPage.tsx`** (lines 26–55)
+- Tab nav: `border-gray-200`, `text-gray-500`, `hover:text-gray-700`, `text-gray-900`
+- Active tab indicator: `border-blue-600 text-blue-600` — no `dark:` variant
+
+**`LeafletDocumentsTab.tsx`** (entire component, 515 lines)
+- Filter bar card: `bg-white shadow` — renders as white on dark background
+- Table: `divide-gray-200`, `bg-gray-50` (header), `divide-gray-100` (rows), `hover:bg-gray-50`
+- Sortable header: `text-gray-500`, `hover:bg-gray-100`, `text-gray-300`, `text-indigo-600`
+- Status badges: `bg-green-100 text-green-800`, `bg-yellow-100 text-yellow-800`, `bg-red-100 text-red-800` — raw Tailwind hues with no dark variant
+- Cell text: `text-gray-900`, `text-gray-500`
+- Delete confirmation dialog: `bg-white rounded-lg`, `text-gray-600`
+- Pagination: `bg-white`, `border-gray-300`, `text-gray-700`, `hover:bg-gray-50`
+
+**`LeafletGenerateTab.tsx`** (lines 63–70, 87–90)
+- Error banners: `bg-amber-100 text-amber-900`, `bg-red-100 text-red-900` — no dark counterparts
+- Loading skeleton: `bg-gray-200` — visible as bright stripe on dark background
+
+## Why it matters
+ADR-006 states: "Every frontend component that renders color **must render correctly in both light and dark mode**. Applies to all routes, modals, drawers, tab panels, tables, forms, badges, and shared components." The Leaflet feature is one of the most visually complex screens (table, filter bar, modal, tab panel) and will render with broken contrast in Graphite dark mode.
+
+## Suggested fix
+For each component, add `dark:` variants following the `docs/design/dark-mode-conversion-guide.md` token map:
+- `bg-white` → `dark:bg-graphite-surface`
+- `text-gray-900` → `dark:text-graphite-text`
+- `text-gray-500` / `text-gray-600` → `dark:text-graphite-muted`
+- `border-gray-200` / `border-gray-300` → `dark:border-graphite-border`
+- `bg-gray-50` / `hover:bg-gray-50` / `hover:bg-gray-100` → `dark:bg-graphite-surface-2` / `dark:hover:bg-graphite-surface-2`
+- `divide-gray-200` / `divide-gray-100` → `dark:divide-graphite-border`
+- Status badges: use `~900/30` bg + `~300` text pattern in dark (e.g., `dark:bg-green-900/30 dark:text-green-300`)
+
+Start with `LeafletDocumentsTab.tsx` (most impact) and proceed through the other components.
+
+---
+_Filed by daily arch-review routine on 2026-07-04._

--- a/artifacts/feat-3479/code-review.r1.md
+++ b/artifacts/feat-3479/code-review.r1.md
@@ -1,0 +1,8 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx:18` — The fallback badge pairs `dark:bg-graphite-surface-2` with `dark:bg-graphite-surface-2` used elsewhere for the `<thead>` background (line 357); on rows adjacent to the header this fallback pill may blend into the header row visually. Not a bug (matches spec A5/FR-2a exactly), just worth a visual sanity check since it's the only badge variant using a neutral surface token instead of a semantic `~900/30` pill.
+- `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx:390` — Per spec A4, `hover:text-red-600` intentionally has no `dark:` hover variant; consider revisiting in a follow-up if the icon-only delete button reads as low-contrast against `dark:text-graphite-faint` at rest in Graphite mode (cosmetic, out of scope for this fix).

--- a/artifacts/feat-3479/impl/dark-mode-leaflet-documents-tab.r1.md
+++ b/artifacts/feat-3479/impl/dark-mode-leaflet-documents-tab.r1.md
@@ -1,0 +1,77 @@
+# Implementation: dark-mode-leaflet-documents-tab
+
+## What was implemented
+Added Tailwind `dark:` class variants to every raw-color utility in
+`LeafletDocumentsTab.tsx` per the task-context spec: the `StatusBadge` color
+map (indexed/processing/failed/fallback), the `ConfirmDeleteDialog` panel,
+body/warning text, and cancel button, the `SortableHeader` header cell and
+chevron-active/inactive ternaries, the filter bar (container, icons, labels,
+filename input, both `<select>` filters), the empty-state message, the
+loading skeleton and error text, the results table (divide colors, thead,
+tbody, row hover, cell text colors, delete icon button), and the pagination
+footer (container, mobile prev/next buttons, result-count/label text,
+page-size select, nav shadow, prev/page-number/next nav buttons, including
+the active/inactive page-number ternary). The three solid action buttons
+(delete-confirm "Smazat", "Filtrovat", "Vymazat") were left unchanged per
+the spec's explicit exemption. No markup, props, state, sorting/pagination/
+filtering logic, URL-param sync, permission checks, or API calls were
+touched.
+
+## Files created/modified
+- `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx` — added
+  `dark:` Tailwind variants to all raw-color utility classes as enumerated in
+  the task context file (status badges, delete dialog, sortable header,
+  filter bar, table, pagination footer). Purely additive class-string
+  changes.
+
+## Tests
+No new tests required — this is a styling-only change with no
+markup/logic changes. Verified via:
+- `npm run build` (from `frontend/`) — compiled successfully, no
+  TypeScript/JSX errors.
+- `npm run lint` (from `frontend/`) — 162 pre-existing problems (148
+  errors, 14 warnings) across unrelated test files, confirmed identical
+  before and after this change (verified via `git stash`/`git stash pop`
+  comparison). Linting the changed file directly
+  (`npx eslint src/features/leaflet-generator/LeafletDocumentsTab.tsx`)
+  produced zero errors/warnings.
+
+## How to verify
+1. `cd frontend && npm install` (or reuse existing `node_modules`).
+2. `npm run build` — should compile with no errors.
+3. `npx eslint src/features/leaflet-generator/LeafletDocumentsTab.tsx` —
+   should report no problems.
+4. Run the app, open the Leaflet Documents tab, toggle to dark theme, and
+   visually confirm: status badges render with distinct muted colors,
+   the delete-confirmation dialog uses dark surface/border/text tokens,
+   the filter bar/table/pagination footer all use graphite dark tokens
+   instead of raw white/gray backgrounds, and the three solid action
+   buttons (Smazat/Filtrovat/Vymazat) are unchanged (still solid
+   indigo/red/gray with white text) in both themes.
+
+## Notes
+No deviations from the task spec. Class changes were applied by exact
+string match as instructed; all line numbers in the spec were
+approximate but every target string was unique and located successfully.
+The `node_modules` directory for the worktree's `frontend/` was missing;
+`npm install` failed due to a pre-existing peer-dependency conflict
+(`react-i18next` requires `typescript@^5`, but the project pins
+`typescript@^4.9.5`) unrelated to this change, so a symlink to the main
+checkout's `frontend/node_modules` was used locally to run `build`/`lint`
+and then removed before committing — it is not part of the commit.
+
+## PR Summary
+This change adds dark-mode Tailwind class variants throughout
+`LeafletDocumentsTab.tsx` (status badges, delete-confirmation dialog,
+sortable table header, filter bar, results table, and pagination footer)
+so the Leaflet Documents tab renders correctly under the Graphite dark
+theme, following the conventions in `docs/design/dark-mode-conversion-guide.md`
+and ADR-006. The change is purely additive to `className` strings — no
+markup, component logic, state, sorting/pagination/filtering behavior, or
+API calls were altered. Three solid action buttons (delete-confirm,
+Filtrovat, Vymazat) were intentionally left without `dark:` variants since
+their saturated backgrounds with white text already have sufficient
+contrast in both themes.
+
+## Status
+DONE

--- a/artifacts/feat-3479/impl/dark-mode-leaflet-generate-tab.r1.md
+++ b/artifacts/feat-3479/impl/dark-mode-leaflet-generate-tab.r1.md
@@ -1,0 +1,51 @@
+# Implementation: dark-mode-leaflet-generate-tab
+
+## What was implemented
+Added Tailwind `dark:` class variants to `LeafletGenerateTab.tsx` so the error banners and the
+inline loading-skeleton bars render correctly under the Graphite dark theme, per
+`docs/design/dark-mode-conversion-guide.md`.
+
+- Error banner (`insufficient` variant): `bg-amber-100 text-amber-900` →
+  `bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300`.
+- Error banner (`transient`/other variant): `bg-red-100 text-red-900` →
+  `bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300`.
+- Three loading-skeleton bars: each `bg-gray-200` base now also has `dark:bg-graphite-hover`.
+
+No other markup, logic, or the `LeafletForm`/`LeafletResult` components were touched. The
+pre-existing `(response as any).id` cast was left untouched per scope instructions.
+
+## Files created/modified
+- `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx` — added `dark:` Tailwind
+  variants to the error-banner ternary and the three skeleton-bar `className`s.
+
+## Tests
+No new tests required for this styling-only change. Ran `npm run build` (compiled successfully,
+no new warnings) and `npm run lint` (0 issues in this file; the 148 pre-existing lint errors in
+the repo are all in unrelated test files, confirmed unaffected by this change).
+
+## How to verify
+1. `cd frontend && npm run build` — should compile successfully.
+2. `npm run lint` — should show no errors/warnings for `LeafletGenerateTab.tsx`.
+3. Run the app, switch to Graphite dark theme, open the Leaflet Generator "Generate" tab:
+   - Trigger a 422 (insufficient KB) response → banner should show `amber-900/30` background with
+     `amber-300` text.
+   - Trigger any other error → banner should show `red-900/30` background with `red-300` text.
+   - While a generation request is in flight, the three skeleton bars should render with
+     `graphite-hover` background, visually distinct from the page background.
+
+## Notes
+No deviations from the task spec. Class changes match the concrete list exactly, including using
+`dark:bg-graphite-hover` (not `dark:bg-graphite-surface-2`, which is the token used by the
+unrelated `LeafletDocumentsTab.tsx` skeleton) as specified.
+
+## PR Summary
+This change adds dark-mode Tailwind variants to `LeafletGenerateTab.tsx`'s error banners and
+loading-skeleton bars so they render legibly under the Graphite dark theme, following the
+project's dark-mode conversion guide. The error banners now use a `~900/30` background with
+`~300` text color for both the "insufficient knowledge base" and generic/transient error states,
+and the three skeleton placeholder bars now include a `dark:bg-graphite-hover` background. The
+change is purely additive/CSS-only — no logic changes, and `LeafletForm`/`LeafletResult` were not
+touched.
+
+## Status
+DONE

--- a/artifacts/feat-3479/impl/dark-mode-leaflet-generator-page.r1.md
+++ b/artifacts/feat-3479/impl/dark-mode-leaflet-generator-page.r1.md
@@ -1,0 +1,56 @@
+# Implementation: dark-mode-leaflet-generator-page
+
+## What was implemented
+Added Tailwind `dark:` class variants to the page header and tab-bar navigation in
+`LeafletGeneratorPage.tsx` so the tab shell renders correctly under the Graphite dark theme
+(ADR-006), per `docs/design/dark-mode-conversion-guide.md`. The change is purely additive to
+`className` strings — no markup structure, props, the `tabs` array, conditional tab-rendering
+logic, or the `hasPermission('marketing.leaflet.write')` gating were touched.
+
+## Files created/modified
+- `frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx` —
+  - Header icon: `text-blue-600` → added `dark:text-graphite-accent`.
+  - Heading: `text-gray-900` → added `dark:text-graphite-text`.
+  - Tab bar container: `border-gray-200` → added `dark:border-graphite-border`.
+  - Active tab branch: `border-blue-600 text-blue-600` → added
+    `dark:border-graphite-accent dark:text-graphite-accent`.
+  - Inactive tab branch: `border-transparent text-gray-500 hover:text-gray-700` → added
+    `dark:text-graphite-muted dark:hover:text-graphite-text`.
+
+## Tests
+No new tests required for this styling-only change (purely additive Tailwind `dark:` classes,
+no logic changes). `npm run build` and `npm run lint` were run from `frontend/` to confirm the
+change compiles and lints cleanly.
+
+## How to verify
+1. `cd frontend && npm install --legacy-peer-deps` (if `node_modules` is not already present).
+2. `CI=true npm run build` — compiles successfully with no new errors.
+3. `npm run lint` — no lint errors reported for `LeafletGeneratorPage.tsx` (pre-existing,
+   unrelated lint errors exist elsewhere in the test suite, e.g. `testing-library/no-node-access`
+   violations in various `__tests__` files — these are baseline issues, not introduced by this
+   change).
+4. Manually: toggle the app to Graphite dark theme and open the Leaflet Generator page
+   (`/marketing/leaflet-generator` or equivalent route) to visually confirm the header icon,
+   heading, tab bar bottom border, and active/inactive tab colors render using the Graphite
+   dark tokens.
+
+## Notes
+- `node_modules` was not present in the worktree; installed with `npm install --legacy-peer-deps`
+  to match the flag used in the repo's CI workflows (`ci-feature-branch.yml`,
+  `ci-main-branch.yml`) due to a pre-existing `react-i18next`/`typescript` peer-dependency
+  conflict unrelated to this change.
+- `artifacts/feat-3479/state.json` had an unstaged modification (task status tracking, presumably
+  updated by the orchestrator) at the time of this task; it was intentionally left out of this
+  commit since it's not part of the requested source change.
+- No deviations from the task spec; all four required class-level changes were applied exactly
+  as specified.
+
+## PR Summary
+This change adds Tailwind `dark:` class variants to the header and tab-bar navigation of the
+Leaflet Generator page so it renders correctly under the Graphite dark theme, following
+ADR-006 and the project's dark-mode conversion guide. It is a surgical, additive-only CSS class
+change — no markup, props, or logic were altered. Verified with a clean `npm run build` and
+`npm run lint` (no new lint errors introduced).
+
+## Status
+DONE

--- a/artifacts/feat-3479/review/dark-mode-leaflet-documents-tab.r1.md
+++ b/artifacts/feat-3479/review/dark-mode-leaflet-documents-tab.r1.md
@@ -1,0 +1,15 @@
+# Code Review: dark-mode-leaflet-documents-tab
+
+## Summary
+The diff was checked line-by-line against every enumerated class change in the task context, and every single one matches exactly (both `dark:` classes added and target color values). The three solid action buttons (delete-confirm, Filtrovat, Vymazat) were correctly left untouched, and no unrelated markup, props, state, or logic was altered.
+
+## Review Result: PASS
+
+### task: dark-mode-leaflet-documents-tab
+**Status:** PASS
+
+## Overall Notes
+- `StatusBadge` color map, `ConfirmDeleteDialog`, `SortableHeader` (including both chevron ternaries), filter bar (container, icons, labels, filename input, both selects), empty state, loading skeleton, error text, table (divide colors, thead, tbody, row hover, cell text, delete icon button), and pagination footer (container, mobile buttons, result text, page-size select, nav shadow, prev/page-number/next buttons including the active/inactive ternary) all have the exact `dark:` classes specified in the task context, appended without disturbing existing light-mode classes.
+- Verified via `grep` that the three solid action buttons (`bg-red-600 text-white hover:bg-red-700` delete-confirm, `bg-indigo-600 hover:bg-indigo-700` Filtrovat, `bg-gray-500 hover:bg-gray-600` Vymazat) remain byte-for-byte unchanged, as required.
+- No JSX structure, props, handlers, or unrelated files were touched — the diff is confined to `className` string edits in `LeafletDocumentsTab.tsx`.
+- No malformed className strings or syntax issues found in the diff.

--- a/artifacts/feat-3479/review/dark-mode-leaflet-generate-tab.r1.md
+++ b/artifacts/feat-3479/review/dark-mode-leaflet-generate-tab.r1.md
@@ -1,0 +1,17 @@
+# Code Review: dark-mode-leaflet-generate-tab
+
+## Summary
+The implementation makes exactly the class-level changes specified in the task context: both error-banner ternary branches gained the `~900/30` background / `~300` text dark variants, and all three skeleton bars gained `dark:bg-graphite-hover`. The diff is minimal (1 file, 5 insertions/5 deletions), confined to the specified lines, with no changes to `LeafletForm`, `LeafletResult`, or the pre-existing `(response as any).id` cast.
+
+## Review Result: PASS
+
+### task: dark-mode-leaflet-generate-tab
+**Status:** PASS
+
+## Overall Notes
+- Verified via `git show 5909799` that the diff touches only the error-banner ternary and the three skeleton `className`s — nothing else in the file changed.
+- Class values match the task spec verbatim: `bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300`, `bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300`, and `bg-gray-200 dark:bg-graphite-hover` on all three skeleton divs.
+- Correctly used `dark:bg-graphite-hover` (not `dark:bg-graphite-surface-2`) per the spec's explicit instruction not to harmonize with `LeafletDocumentsTab.tsx`'s different skeleton token.
+- `LeafletForm`/`LeafletResult` imports and usage are untouched; the `(response as any).id` cast is untouched, as required.
+- Change is purely additive to existing class strings — no reordering, no structural/logic changes.
+- Did not independently re-run `npm run build`/`npm run lint` or visually verify rendering (browser-dependent); the developer's summary reports both passing, which is consistent with the class-only nature of the diff.

--- a/artifacts/feat-3479/review/dark-mode-leaflet-generator-page.r1.md
+++ b/artifacts/feat-3479/review/dark-mode-leaflet-generator-page.r1.md
@@ -1,0 +1,32 @@
+# Code Review: dark-mode-leaflet-generator-page
+
+## Summary
+The implementation applies exactly the four required `dark:` class additions to
+`LeafletGeneratorPage.tsx` — header icon, heading, tab-bar container border, and both branches of the
+tab button template literal — with wording that matches the spec verbatim. `git show --stat` confirms
+the commit touches only this one file with 5 insertions/5 deletions, and the diff shows no structural,
+prop, or logic changes.
+
+## Review Result: PASS
+
+### task: dark-mode-leaflet-generator-page
+**Status:** PASS
+
+## Docs to Update
+(None)
+
+## Overall Notes
+- All four acceptance-criteria class changes verified directly against the diff:
+  - `text-blue-600` → `+ dark:text-graphite-accent` on the `FileText` icon.
+  - `text-gray-900` → `+ dark:text-graphite-text` on the `<h1>`.
+  - `border-gray-200` → `+ dark:border-graphite-border` on the tab-bar container.
+  - Active tab branch gains `dark:border-graphite-accent dark:text-graphite-accent`; inactive branch
+    gains `dark:text-graphite-muted dark:hover:text-graphite-text` — matching the spec exactly.
+- Light-mode classes are left unchanged in every case (purely additive).
+- The `tabs` array, conditional rendering, and the `hasPermission('marketing.leaflet.write')` gating
+  are untouched per `git show`.
+- The `graphite-*` token names used here are consistent with existing usage across ~130 other files in
+  the codebase (e.g. `Sidebar.tsx`, `TopBar.tsx`, `ThemeToggle.tsx`), so this is not introducing a new
+  or one-off naming convention.
+- Build/lint verification was not independently re-run in this review (per task instructions, not
+  required for a styling-only diff review); the implementation summary reports both passed cleanly.

--- a/artifacts/feat-3479/spec.r1.md
+++ b/artifacts/feat-3479/spec.r1.md
@@ -1,0 +1,187 @@
+# Specification: Leaflet Generator — Graphite Dark Mode Compliance (ADR-006)
+
+## Summary
+Add Tailwind `dark:` class variants to the three Leaflet Generator feature components (`LeafletGeneratorPage.tsx`, `LeafletDocumentsTab.tsx`, `LeafletGenerateTab.tsx`) so they render with correct contrast and surface colors under the "Graphite" dark theme, per ADR-006 and the token mapping in `docs/design/dark-mode-conversion-guide.md`. This is a purely additive, surgical CSS-class change — no markup structure, props, logic, or light-mode appearance may change.
+
+## Background
+ADR-006 (accepted 2026-06-25) requires every frontend component that renders color to work correctly in both light and Graphite dark mode, across routes, modals, tab panels, tables, and badges. The Leaflet Generator feature (`frontend/src/features/leaflet-generator/`) was built with light-only Tailwind utility classes (`bg-white`, `text-gray-*`, `border-gray-*`, raw `bg-{color}-100`/`text-{color}-800` badges, etc.) and has no `dark:` variants anywhere. A daily automated arch-review routine flagged this on 2026-07-04. The feature includes a tab shell, a data table with filters/sorting/pagination, a delete-confirmation modal, and a generation form with loading skeletons and error banners — the same set of pattern types ADR-006 explicitly calls out (tables, modals, tab panels, badges).
+
+The project's global dark-mode conversion guide (`docs/design/dark-mode-conversion-guide.md`) defines the canonical raw-Tailwind-class → `dark:` mapping and the custom Graphite color tokens available in `frontend/tailwind.config.js` (`graphite.bg`, `.surface`, `.surface-2`, `.hover`, `.chrome`, `.border`, `.border-strong`, `.text`, `.muted`, `.faint`, `.accent`, `.accent-strong`, `.accent-ink`), plus `boxShadow.soft-dark`. This spec applies that mapping mechanically to the three affected files, enumerating every raw color utility class found in each and its required `dark:` addition.
+
+Out of the three files listed in the brief, `LeafletUploadTab.tsx` and `LeafletForm.tsx`/`LeafletResult.tsx`/`LeafletChunkDetailModal.tsx` are siblings in the same directory but are **not** in scope for this change (see Out of Scope) — only the three files named in the brief are covered.
+
+## Functional Requirements
+
+### FR-1: `LeafletGeneratorPage.tsx` — page header and tab navigation dark-mode support
+Add `dark:` variants to the page header text/icon and the tab-bar underline/text colors so the tab shell renders correctly on the Graphite background.
+
+Concrete changes (current line numbers in the file as read; may shift slightly but content is unique and locatable by string match):
+
+- Line 27 — icon: `<FileText className="w-6 h-6 text-blue-600" />`
+  - `text-blue-600` is a non-accent-context icon color paired with a heading; treat consistent with the tab active-accent usage below → add `dark:text-graphite-accent`.
+- Line 28 — heading: `className="text-2xl font-semibold text-gray-900"`
+  - `text-gray-900` → add `dark:text-graphite-text`.
+- Line 31 — tab bar container: `className="border-b border-gray-200"`
+  - `border-gray-200` → add `dark:border-graphite-border`.
+- Lines 37–41 — tab button template literal:
+  ```
+  className={`py-2 text-sm font-medium border-b-2 transition-colors ${
+    activeTab === tab.id
+      ? 'border-blue-600 text-blue-600'
+      : 'border-transparent text-gray-500 hover:text-gray-700'
+  }`}
+  ```
+  - Active branch `'border-blue-600 text-blue-600'` → `'border-blue-600 text-blue-600 dark:border-graphite-accent dark:text-graphite-accent'`.
+  - Inactive branch `'border-transparent text-gray-500 hover:text-gray-700'` → `'border-transparent text-gray-500 hover:text-gray-700 dark:text-graphite-muted dark:hover:text-graphite-text'` (guide has no explicit `hover:text-gray-700` rule; `hover:text-gray-700` is a "move toward primary text on hover" affordance, so its dark equivalent is `dark:hover:text-graphite-text`, consistent with the muted→text hover pattern used for the primary heading color — see Open Questions/assumption A1).
+
+**Acceptance criteria:**
+- All four raw-color classes identified above have a corresponding `dark:` class appended in the same `className` string/branch, with light classes unchanged.
+- The active tab indicator (bottom border + label) uses `dark:border-graphite-accent dark:text-graphite-accent` in Graphite mode.
+- The inactive tab label is `dark:text-graphite-muted` at rest and `dark:hover:text-graphite-text` on hover.
+- No structural, prop, or logic changes; `tabs` array and conditional rendering (lines 18–22, 50–52) are untouched.
+
+### FR-2: `LeafletDocumentsTab.tsx` — filter bar, table, badges, dialog, pagination
+This is the highest-impact file (515 lines, full table/filter/modal/pagination UI). Add `dark:` variants to every raw-color utility across five sub-regions: the `StatusBadge` color map, the `ConfirmDeleteDialog`, the `SortableHeader`, the filter bar, and the table + pagination footer.
+
+**FR-2a: `StatusBadge` color map (lines 12–24)**
+The `colorMap` object maps status → Tailwind classes. Per guide rule 5 ("For color maps... add dark variants to each value string") and the status/semantic mapping table:
+
+- `indexed: 'bg-green-100 text-green-800'` → `'bg-green-100 text-green-800 dark:bg-emerald-900/30 dark:text-emerald-300'`
+- `processing: 'bg-yellow-100 text-yellow-800'` → `'bg-yellow-100 text-yellow-800 dark:bg-amber-900/30 dark:text-amber-300'`
+- `failed: 'bg-red-100 text-red-800'` → `'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'`
+- fallback `?? 'bg-gray-100 text-gray-800'` → `'bg-gray-100 text-gray-800 dark:bg-graphite-surface-2 dark:text-graphite-muted'` (guide's `bg-gray-100` → `dark:bg-graphite-surface-2` background rule; `text-gray-800` → `dark:text-graphite-muted` text rule; this is the "unknown status" fallback pill, not a semantic color, so it follows the neutral surface/text mapping rather than the status-pill `~900/30`/`~300` pattern).
+
+**FR-2b: `ConfirmDeleteDialog` (lines 26–57)**
+- Line 33 — `className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full"`
+  - `bg-white` → add `dark:bg-graphite-surface`; `shadow-xl` is not in the guide's shadow list (only `shadow`/`shadow-sm`/`shadow-md`) — leave `shadow-xl` unchanged per guide rule 1 (don't invent mappings beyond the table); see Open Questions A2 for the explicit assumption.
+  - Heading `text-lg font-semibold` (line 34) has no color utility — no change needed.
+- Line 35 — `className="text-sm text-gray-600 mb-4"` → `text-gray-600` → add `dark:text-graphite-muted`.
+- Line 39 — `className="text-sm text-red-600 mb-3"` → `text-red-600` → add `dark:text-red-400` (guide: `text-red-600`/`text-red-500` → `dark:text-red-400`).
+- Line 44 — Cancel button `className="px-4 py-2 text-sm rounded border border-gray-300 hover:bg-gray-50"` → `border-gray-300` → add `dark:border-graphite-border`; `hover:bg-gray-50` → add `dark:hover:bg-white/5`.
+- Line 50 — Confirm/delete button `className="px-4 py-2 text-sm rounded bg-red-600 text-white hover:bg-red-700"` — this is a solid destructive-action button (bg-red-600 + text-white), not a status pill or neutral surface; the guide does not map solid semantic action buttons. Leave unchanged (see Open Questions A3): solid `bg-red-600`/`hover:bg-red-700`/`text-white` combinations already have sufficient contrast against both light and dark backgrounds and are not covered by any guide rule, so no `dark:` classes are added here (same treatment applies to `bg-indigo-600 hover:bg-indigo-700 text-white` and `bg-gray-500 hover:bg-gray-600 text-white` buttons in FR-2d below).
+
+**FR-2c: `SortableHeader` (lines 59–87)**
+- Line 71 — `className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none"`
+  - `text-gray-500` → add `dark:text-graphite-muted`.
+  - `hover:bg-gray-100` → add `dark:hover:bg-white/5`.
+- Lines 77–79 and 80–82 — chevron icon classNames (ternary, ChevronUp/ChevronDown):
+  ```
+  `h-3 w-3 ${isActive && !sortDescending ? 'text-indigo-600' : 'text-gray-300'}`
+  `h-3 w-3 -mt-1 ${isActive && sortDescending ? 'text-indigo-600' : 'text-gray-300'}`
+  ```
+  - Per guide rule 4 (add the dark variant inside each ternary branch): `'text-indigo-600'` → `'text-indigo-600 dark:text-graphite-accent'`; `'text-gray-300'` → `'text-gray-300 dark:text-graphite-faint'`.
+
+**FR-2d: Filter bar (lines 272–347)**
+- Line 273 — `className="bg-white shadow rounded-lg p-4 mb-4"` → `bg-white` → add `dark:bg-graphite-surface`; `shadow` → add `dark:shadow-soft-dark`.
+- Line 277 — `<Filter className="h-4 w-4 text-gray-400 mr-2" />` → `text-gray-400` → add `dark:text-graphite-faint`.
+- Line 278 — `<span className="text-sm font-medium text-gray-900">` → `text-gray-900` → add `dark:text-graphite-text`.
+- Line 284 — `<Search className="h-4 w-4 text-gray-400" />` → `text-gray-400` → add `dark:text-graphite-faint`.
+- Line 292 — filename input: `className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 sm:text-sm border-gray-300 rounded-md"`
+  - This is a raw input (not using `.input` design-system class). Per guide's "Inputs / selects / textareas (raw)" rule, append the full input dark bundle: `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text dark:placeholder-graphite-faint`. `focus:ring-indigo-500`/`focus:border-indigo-500` are left as-is per guide rule ("focus rings OK as-is").
+- Line 304 — status `<select>`: `className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"` → same raw-input treatment: append `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text`. (No placeholder on a `<select>`, so `dark:placeholder-graphite-faint` is omitted.)
+- Line 320 — content-type `<select>`: identical classes to line 304 → same treatment: append `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text`.
+- Line 335 — "Filtrovat" button: `className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-md transition-colors duration-200 text-sm"` — solid primary action button; no guide mapping for solid indigo buttons. Leave unchanged (consistent with FR-2b's A3 assumption).
+- Line 341 — "Vymazat" button: `className="bg-gray-500 hover:bg-gray-600 text-white font-medium py-2 px-3 rounded-md transition-colors duration-200 text-sm"` — solid secondary action button with `text-white`; sufficient contrast on any background. Leave unchanged (same A3 assumption).
+
+**FR-2e: Empty state (line 350)**
+- `className="text-gray-500 text-sm text-center py-8"` → `text-gray-500` → add `dark:text-graphite-muted`.
+
+**FR-2f: Table (lines 355–400)**
+- Line 356 — `className="min-w-full divide-y divide-gray-200 text-sm"` → `divide-gray-200` → add `dark:divide-graphite-border`.
+- Line 357 — `<thead className="bg-gray-50">` → `bg-gray-50` → add `dark:bg-graphite-surface-2`.
+- Line 363 — `<th className="px-6 py-3" />` — no color utility, no change.
+- Line 366 — `<tbody className="divide-y divide-gray-100">` → `divide-gray-100` → add `dark:divide-graphite-border`.
+- Line 370 — row template literal: `` `hover:bg-gray-50 ${doc.firstChunkId ? 'cursor-pointer' : ''}` `` → `hover:bg-gray-50` → add `dark:hover:bg-white/5` (the ternary branch itself, `cursor-pointer`/`''`, has no color and needs no change).
+- Line 373 — `className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"` → `text-gray-900` → add `dark:text-graphite-text`.
+- Lines 377 and 380 — both `className="px-6 py-4 whitespace-nowrap text-sm text-gray-500"` → `text-gray-500` → add `dark:text-graphite-muted` (both occurrences).
+- Line 390 — delete icon button: `className="text-gray-400 hover:text-red-600 transition-colors"` → `text-gray-400` → add `dark:text-graphite-faint`; `hover:text-red-600` is a semantic danger hover with no guide mapping — leave unchanged (danger-red hover retains sufficient contrast in dark mode; see Open Questions A4).
+
+**FR-2g: Pagination footer (lines 403–491)**
+- Line 403 — `className="bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs"` → `bg-white` → add `dark:bg-graphite-surface`; `border-gray-200` → add `dark:border-graphite-border`.
+- Lines 408 and 415 (mobile Předchozí/Další buttons) — `className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"` (both identical) → `border-gray-300` → add `dark:border-graphite-border`; `text-gray-700` → add `dark:text-graphite-muted`; `bg-white` → add `dark:bg-graphite-surface`; `hover:bg-gray-50` → add `dark:hover:bg-white/5`.
+- Line 422 — `className="text-xs text-gray-600"` (result count) → `text-gray-600` → add `dark:text-graphite-muted`.
+- Line 427 — `className="text-xs text-gray-600"` ("Zobrazit:" label) → `text-gray-600` → add `dark:text-graphite-muted`.
+- Line 434 — page-size `<select>`: `className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"` → raw select, append `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text` (focus ring untouched).
+- Line 444 — `className="relative z-0 inline-flex rounded shadow-sm -space-x-px"` → `shadow-sm` → add `dark:shadow-soft-dark`.
+- Line 450 — prev-page nav button: `className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"` → `border-gray-300` → `dark:border-graphite-border`; `bg-white` → `dark:bg-graphite-surface`; `text-gray-500` → `dark:text-graphite-muted`; `hover:bg-gray-50` → `dark:hover:bg-white/5`.
+- Lines 470–474 — numbered page-button ternary:
+  ```
+  pageNum === pageNumber
+    ? 'z-10 bg-indigo-50 border-indigo-500 text-indigo-600'
+    : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+  ```
+  - Active branch → `'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-graphite-accent/10 dark:border-graphite-accent dark:text-graphite-accent'` (guide's accent bg/border/text active mapping).
+  - Inactive branch → `'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-graphite-surface dark:border-graphite-border dark:text-graphite-muted dark:hover:bg-white/5'`.
+- Line 484 — next-page nav button, same classes as line 450 → same treatment: `border-gray-300` → `dark:border-graphite-border`; `bg-white` → `dark:bg-graphite-surface`; `text-gray-500` → `dark:text-graphite-muted`; `hover:bg-gray-50` → `dark:hover:bg-white/5`.
+
+**FR-2h: Loading skeleton (lines 256–263) and error text (line 267)**
+- Line 260 — `className="h-10 bg-gray-100 rounded"` → `bg-gray-100` → add `dark:bg-graphite-surface-2` (per guide: `bg-gray-100` → `dark:bg-graphite-surface-2`, panels/badges/inputs category, applies equally to skeleton blocks — see Open Questions A5 for why this is not mapped to `bg-graphite-hover` despite visually being a "loading stripe").
+- Line 267 — `className="text-red-600 text-sm"` → `text-red-600` → add `dark:text-red-400`.
+
+**Acceptance criteria (FR-2, all sub-parts):**
+- Every raw Tailwind color utility enumerated above has the specified `dark:` class appended in place, in the same string/branch, without altering any light-mode class, JSX structure, prop, or handler.
+- The `StatusBadge` component renders all three named statuses (`indexed`, `processing`, `failed`) plus the unknown-status fallback with visibly distinct, sufficiently-contrasted pill colors in Graphite mode.
+- The delete-confirmation modal's backdrop, panel, body text, and error text are legible on the Graphite background; the two action buttons are unchanged (already high-contrast).
+- The table header, row dividers, hover state, cell text, and pagination controls all use Graphite surface/border/text tokens instead of `white`/`gray-*` in dark mode.
+- The active vs. inactive sort-chevron and active vs. inactive page-number states remain visually distinguishable in dark mode via `dark:text-graphite-accent` / `dark:bg-graphite-accent/10` etc.
+- Visual/manual check (or Playwright screenshot diff if available) confirms no light-mode regression: toggling the theme back to light must render pixel-identical to the current (pre-change) light mode.
+
+### FR-3: `LeafletGenerateTab.tsx` — error banners and loading skeleton
+- Lines 63–67 — error banner ternary:
+  ```
+  errorBanner.kind === 'insufficient'
+    ? 'bg-amber-100 text-amber-900'
+    : 'bg-red-100 text-red-900'
+  ```
+  - `'bg-amber-100 text-amber-900'` → `'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300'` (guide's yellow/amber status mapping applied to the amber warning banner).
+  - `'bg-red-100 text-red-900'` → `'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300'` (guide's red status mapping).
+- Lines 88–90 — loading skeleton bars: `className="h-4 bg-gray-200 rounded w-3/4"`, `className="h-4 bg-gray-200 rounded"`, `className="h-4 bg-gray-200 rounded w-5/6"` (three sibling divs, identical `bg-gray-200` base) → each `bg-gray-200` → add `dark:bg-graphite-hover` (guide: `bg-gray-200` → `dark:bg-graphite-hover`).
+
+**Acceptance criteria:**
+- Both error-banner variants (`insufficient` / `transient`) render with the `~900/30` background + `~300` text pattern in Graphite mode, matching the badge/status convention used elsewhere in the app.
+- All three loading-skeleton bars use `dark:bg-graphite-hover` and are visually distinguishable from the Graphite page background (no "bright stripe" regression called out in the original finding).
+- `LeafletForm` and `LeafletResult` (rendered as children on lines 74 and 93) are out of scope and untouched — this file's changes are limited to the banner and inline skeleton markup owned directly by `LeafletGenerateTab`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance impact is expected or in scope: this change only adds static Tailwind utility classes (compiled at build time), with zero new JS logic, state, re-renders, or bundle-size-relevant dependencies. `npm run build` output size may grow negligibly (a handful of already-whitelisted utility classes/token colors defined in `tailwind.config.js`); no budget or benchmark is required.
+
+### NFR-2: Security
+Not applicable. No auth, data-handling, API surface, or permission logic is touched. `hasPermission('marketing.leaflet.write')` gating (`LeafletGeneratorPage.tsx` line 13) and all `canUpload`/`canDelete` prop plumbing must remain byte-for-byte unchanged.
+
+## Data Model
+Not applicable — this is a presentation-layer styling change. No entities, DTOs, or API contracts are modified. (For reference, `LeafletDocumentSummary` and the `useLeaflet` query/mutation hooks in `frontend/src/api/hooks/useLeaflet.ts` are consumed as-is and must not be touched.)
+
+## API / Interface Design
+Not applicable — no backend endpoints, MediatR handlers, or generated API client changes. This spec only touches JSX `className` attributes in three existing React components:
+- `frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx`
+- `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx`
+- `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`
+
+No new components, hooks, routes, or props are introduced. The dark theme itself is activated globally via Tailwind's `darkMode: 'class'` strategy (already configured in `frontend/tailwind.config.js`); this change only supplies the missing `dark:` variants so these three files respond correctly when the `dark` class is present on a root ancestor.
+
+## Dependencies
+- `frontend/tailwind.config.js` — must already define the `graphite` color scale (`bg`, `surface`, `surface-2`, `hover`, `chrome`, `border`, `border-strong`, `text`, `muted`, `faint`, `accent`, `accent-strong`, `accent-ink`) and `boxShadow.soft-dark`. Confirmed present at lines 48–62 and 67 of the current config — no config changes are needed for this spec.
+- `docs/design/dark-mode-conversion-guide.md` — authoritative mapping table and rules; this spec's every FR item traces to a rule in that guide (or an explicit assumption noted below where the guide is silent).
+- ADR-006 (referenced in the brief; not read directly, but its requirement — "every component that renders color must render correctly in both light and dark mode" — is treated as the compliance bar).
+- No new npm packages, no backend changes, no OpenAPI/client regeneration required.
+
+## Out of Scope
+- `LeafletUploadTab.tsx`, `LeafletForm.tsx`, `LeafletResult.tsx`, `LeafletChunkDetailModal.tsx`, and any other sibling file under `frontend/src/features/leaflet-generator/` not named in the brief — these may have the same violations but are not covered by this fix; a follow-up arch-review item should be filed if needed.
+- Solid-color primary/secondary/danger action buttons using `bg-{color}-600 ... text-white` (e.g., "Filtrovat", "Vymazat", "Smazat", delete-confirm) — left unchanged per Open Questions assumption A3, since the guide does not define a mapping for solid action buttons and their contrast is already theme-independent.
+- Any change to component structure, state management, URL-param sync logic, sorting/pagination/filtering behavior, permission checks, or API calls.
+- Any new automated dark-mode visual regression test infrastructure (Playwright screenshot baselines) — manual verification is assumed sufficient for this scoped fix; the testing-strategy doc does not currently mandate visual regression coverage for this feature.
+- Global Tailwind config changes — the Graphite token set is assumed complete and correct as-is (confirmed present).
+- Fixing any of the three files' *other* pre-existing lint/type/accessibility issues not related to dark-mode contrast (e.g., the `(response as any).id` cast in `LeafletGenerateTab.tsx` line 38) — untouched, out of scope.
+
+## Open Questions
+All ambiguities below were resolved with an explicit, documented assumption so the pipeline can proceed without a human decision; flagged here for the architect/reviewer to double-check during PR review.
+
+- **A1** (`LeafletGeneratorPage.tsx` inactive tab hover): the guide has no explicit rule for `hover:text-gray-700`. Assumption: since `text-gray-700` maps to `dark:text-graphite-muted` per the text table and the hover is a "move toward heading emphasis" affordance, `dark:hover:text-graphite-text` was chosen (mirrors the muted→text relationship used for headings elsewhere). If the architect prefers a lighter hover (e.g., staying muted-adjacent), this is a one-line tweak.
+- **A2** (`ConfirmDeleteDialog` panel shadow): `shadow-xl` is not in the guide's shadow table (only `shadow`/`shadow-sm`/`shadow-md` are mapped). Assumption: leave `shadow-xl` as-is, unmapped, rather than guessing at a `dark:shadow-soft-dark` substitution not sanctioned by the guide.
+- **A3** (solid action buttons): `bg-{indigo,red,gray}-600/700 text-white` buttons are not covered by any guide rule. Assumption: no `dark:` variant needed — solid saturated buttons with white text retain WCAG-sufficient contrast against both light and Graphite backgrounds, so they're treated as already dark-mode-safe. This affects the "Filtrovat", "Vymazat" buttons in `LeafletDocumentsTab.tsx` and the "Smazat"/"Zrušit"-adjacent confirm button in `ConfirmDeleteDialog`.
+- **A4** (delete-icon hover, `hover:text-red-600` on line 390 of `LeafletDocumentsTab.tsx`): no guide rule for hover-only semantic-danger text. Assumption: leave unmapped for the same reason as A3 (saturated red-600 remains legible on a dark surface).
+- **A5** (loading skeleton `bg-gray-100` in `LeafletDocumentsTab.tsx` line 260 vs. `bg-gray-200` in `LeafletGenerateTab.tsx` lines 88–90): the guide maps these to different tokens (`dark:bg-graphite-surface-2` vs. `dark:bg-graphite-hover` respectively) even though both are "loading skeleton" bars. Assumption: followed the guide literally by source Tailwind class rather than by visual role, since the guide's rule 5 is keyed on the raw class, not semantic intent — this preserves the brief's exact suggested mapping for `bg-gray-200` → `dark:bg-graphite-hover` (brief line 24) while applying the general `bg-gray-100` rule to the other file's skeleton.
+
+## Status: COMPLETE

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-04T08:41:42.432360Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-04T08:41:47.715796Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-04T08:20:30.505541Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T08:20:40.993172Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T08:22:30.482703Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -25,5 +25,24 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "dark-mode-leaflet-documents-tab",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "dark-mode-leaflet-generator-page",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "dark-mode-leaflet-generate-tab",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T08:18:24.759236Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-04T08:18:24.759236Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T08:20:30.505541Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "dark-mode-leaflet-documents-tab",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:23:12.818727Z"
+      "updated_at": "2026-07-04T08:31:17.482886Z"
     },
     {
       "name": "dark-mode-leaflet-generator-page",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:31:22.516447Z"
     },
     {
       "name": "dark-mode-leaflet-generate-tab",

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-04T08:41:42.432360Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-04T08:41:47.715796Z"
+      "status": "completed",
+      "updated_at": "2026-07-04T08:42:43.055487Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-04T08:22:30.482703Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-04T08:23:12.559127Z"
+      "status": "completed",
+      "updated_at": "2026-07-04T08:41:42.432360Z"
     }
   },
   "tasks": [
@@ -40,9 +40,9 @@
     },
     {
       "name": "dark-mode-leaflet-generate-tab",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:37:28.878206Z"
+      "updated_at": "2026-07-04T08:41:36.469914Z"
     }
   ]
 }

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "dark-mode-leaflet-generator-page",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:31:22.516447Z"
+      "updated_at": "2026-07-04T08:37:24.512124Z"
     },
     {
       "name": "dark-mode-leaflet-generate-tab",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:37:28.878206Z"
     }
   ]
 }

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-04T08:22:30.482703Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-04T08:23:12.559127Z"
     }
   },
   "tasks": [
     {
       "name": "dark-mode-leaflet-documents-tab",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:23:12.818727Z"
     },
     {
       "name": "dark-mode-leaflet-generator-page",

--- a/artifacts/feat-3479/state.json
+++ b/artifacts/feat-3479/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3479",
+  "issue_number": 3479,
+  "created_at": "2026-07-04T08:15:16.621942Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3479/task-context/dark-mode-leaflet-documents-tab.md
+++ b/artifacts/feat-3479/task-context/dark-mode-leaflet-documents-tab.md
@@ -1,0 +1,166 @@
+### task: dark-mode-leaflet-documents-tab
+
+**Goal:** Add Tailwind `dark:` class variants to every raw-color utility in
+`LeafletDocumentsTab.tsx` (status badges, delete-confirmation dialog, sortable table header, filter
+bar, table body, and pagination footer) so the component renders correctly under the Graphite dark
+theme, per ADR-006 and `docs/design/dark-mode-conversion-guide.md`. This is the highest-impact file
+in this fix (515 lines) — do it first.
+
+**File to change:** `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx`
+
+**Scope discipline:** This is a purely additive, surgical CSS-class change. Do not alter markup
+structure, props, state, sorting/pagination/filtering logic, URL-param sync, permission checks
+(`canDelete`), or API calls. Do not touch any other file. Do not "fix" the pre-existing
+`(response as any).id`-style issues or any other unrelated lint/type/accessibility problem you may
+notice — flag it in a comment if you want, but do not change it.
+
+**Concrete class-level changes required** (line numbers are approximate/as-of-spec; locate by exact
+string match, content is unique):
+
+**1. `StatusBadge` color map (around lines 12–24).** The `colorMap` object maps status → Tailwind
+classes. Add a `dark:` variant to each value string:
+- `indexed: 'bg-green-100 text-green-800'` → `'bg-green-100 text-green-800 dark:bg-emerald-900/30 dark:text-emerald-300'`
+- `processing: 'bg-yellow-100 text-yellow-800'` → `'bg-yellow-100 text-yellow-800 dark:bg-amber-900/30 dark:text-amber-300'`
+- `failed: 'bg-red-100 text-red-800'` → `'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'`
+- fallback `?? 'bg-gray-100 text-gray-800'` → `'bg-gray-100 text-gray-800 dark:bg-graphite-surface-2 dark:text-graphite-muted'`
+
+**2. `ConfirmDeleteDialog` (around lines 26–57):**
+- Dialog panel `className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full"` → add
+  `dark:bg-graphite-surface` for `bg-white`. Leave `shadow-xl` unchanged (not in the guide's shadow
+  table — do not invent a mapping for it).
+- Heading `text-lg font-semibold` — no color utility present, no change.
+- Body text `className="text-sm text-gray-600 mb-4"` → add `dark:text-graphite-muted` for
+  `text-gray-600`.
+- Warning/error text `className="text-sm text-red-600 mb-3"` → add `dark:text-red-400` for
+  `text-red-600`.
+- Cancel button `className="px-4 py-2 text-sm rounded border border-gray-300 hover:bg-gray-50"` →
+  add `dark:border-graphite-border` for `border-gray-300` and `dark:hover:bg-white/5` for
+  `hover:bg-gray-50`.
+- Confirm/delete button `className="px-4 py-2 text-sm rounded bg-red-600 text-white hover:bg-red-700"`
+  → **leave unchanged**. This is a solid destructive-action button (saturated `bg-red-600` +
+  `text-white`); the guide does not map solid action buttons, and solid `-600`/`-700` backgrounds
+  with white text retain sufficient contrast in both light and dark mode by construction. Do not
+  add a `dark:` variant here.
+
+**3. `SortableHeader` (around lines 59–87):**
+- `className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none"`
+  → add `dark:text-graphite-muted` for `text-gray-500` and `dark:hover:bg-white/5` for
+  `hover:bg-gray-100`.
+- Chevron icon ternaries (ChevronUp and ChevronDown, two near-identical template literals):
+  ```
+  `h-3 w-3 ${isActive && !sortDescending ? 'text-indigo-600' : 'text-gray-300'}`
+  `h-3 w-3 -mt-1 ${isActive && sortDescending ? 'text-indigo-600' : 'text-gray-300'}`
+  ```
+  In BOTH ternaries: `'text-indigo-600'` → `'text-indigo-600 dark:text-graphite-accent'`;
+  `'text-gray-300'` → `'text-gray-300 dark:text-graphite-faint'`.
+
+**4. Filter bar (around lines 272–347):**
+- Container `className="bg-white shadow rounded-lg p-4 mb-4"` → add `dark:bg-graphite-surface` for
+  `bg-white` and `dark:shadow-soft-dark` for `shadow`.
+- `<Filter className="h-4 w-4 text-gray-400 mr-2" />` → add `dark:text-graphite-faint` for
+  `text-gray-400`.
+- `<span className="text-sm font-medium text-gray-900">` → add `dark:text-graphite-text` for
+  `text-gray-900`.
+- `<Search className="h-4 w-4 text-gray-400" />` → add `dark:text-graphite-faint` for
+  `text-gray-400`.
+- Filename input `className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 sm:text-sm border-gray-300 rounded-md"`
+  → append the full raw-input dark bundle: `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text dark:placeholder-graphite-faint`.
+  Leave `focus:ring-indigo-500`/`focus:border-indigo-500` unchanged (focus rings are fine as-is).
+- Status `<select>` `className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"`
+  → append `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text` (no
+  placeholder dark class — it's a `<select>`, not a text input).
+- Content-type `<select>` — identical classes to the status select above → same treatment: append
+  `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text`.
+- "Filtrovat" button `className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-md transition-colors duration-200 text-sm"`
+  → **leave unchanged** (solid saturated primary button, same rationale as the delete-confirm
+  button above — no guide mapping, contrast already sufficient).
+- "Vymazat" button `className="bg-gray-500 hover:bg-gray-600 text-white font-medium py-2 px-3 rounded-md transition-colors duration-200 text-sm"`
+  → **leave unchanged**. Note: despite `bg-gray-500` looking like a "neutral surface" candidate at
+  a glance, it is a solid button with white text, not a surface — do not map it to
+  `dark:bg-graphite-surface-2` or similar. Same rationale as the other solid-button exemptions.
+
+**5. Empty state:**
+- `className="text-gray-500 text-sm text-center py-8"` → add `dark:text-graphite-muted` for
+  `text-gray-500`.
+
+**6. Table (around lines 355–400):**
+- `className="min-w-full divide-y divide-gray-200 text-sm"` → add `dark:divide-graphite-border`
+  for `divide-gray-200`.
+- `<thead className="bg-gray-50">` → add `dark:bg-graphite-surface-2` for `bg-gray-50`.
+- `<th className="px-6 py-3" />` — no color utility, no change.
+- `<tbody className="divide-y divide-gray-100">` → add `dark:divide-graphite-border` for
+  `divide-gray-100`.
+- Row template literal `` `hover:bg-gray-50 ${doc.firstChunkId ? 'cursor-pointer' : ''}` `` → add
+  `dark:hover:bg-white/5` for `hover:bg-gray-50` (the `cursor-pointer`/`''` ternary branch itself
+  needs no change).
+- `className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"` → add
+  `dark:text-graphite-text` for `text-gray-900`.
+- Both occurrences of `className="px-6 py-4 whitespace-nowrap text-sm text-gray-500"` → add
+  `dark:text-graphite-muted` for `text-gray-500` (apply to both).
+- Delete icon button `className="text-gray-400 hover:text-red-600 transition-colors"` → add
+  `dark:text-graphite-faint` for `text-gray-400`. Leave `hover:text-red-600` unchanged (no guide
+  mapping for danger-hover text; saturated red-600 stays legible on dark surfaces).
+
+**7. Loading skeleton and error text (around lines 256–267):**
+- `className="h-10 bg-gray-100 rounded"` (skeleton block) → add `dark:bg-graphite-surface-2` for
+  `bg-gray-100`.
+- `className="text-red-600 text-sm"` (error text) → add `dark:text-red-400` for `text-red-600`.
+
+**8. Pagination footer (around lines 403–491):**
+- `className="bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs"`
+  → add `dark:bg-graphite-surface` for `bg-white` and `dark:border-graphite-border` for
+  `border-gray-200`.
+- Mobile "Předchozí" and "Další" buttons (both share the identical class string)
+  `className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"`
+  → in BOTH buttons: add `dark:border-graphite-border` for `border-gray-300`,
+  `dark:text-graphite-muted` for `text-gray-700`, `dark:bg-graphite-surface` for `bg-white`,
+  `dark:hover:bg-white/5` for `hover:bg-gray-50`.
+- Result-count text `className="text-xs text-gray-600"` → add `dark:text-graphite-muted` for
+  `text-gray-600`.
+- "Zobrazit:" label `className="text-xs text-gray-600"` → add `dark:text-graphite-muted` for
+  `text-gray-600`.
+- Page-size `<select>` `className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"`
+  → append `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text` (leave
+  focus-ring classes unchanged).
+- `className="relative z-0 inline-flex rounded shadow-sm -space-x-px"` → add
+  `dark:shadow-soft-dark` for `shadow-sm`.
+- Prev-page nav button `className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"`
+  → add `dark:border-graphite-border` for `border-gray-300`, `dark:bg-graphite-surface` for
+  `bg-white`, `dark:text-graphite-muted` for `text-gray-500`, `dark:hover:bg-white/5` for
+  `hover:bg-gray-50`.
+- Numbered page-button ternary:
+  ```
+  pageNum === pageNumber
+    ? 'z-10 bg-indigo-50 border-indigo-500 text-indigo-600'
+    : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+  ```
+  - Active branch → `'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-graphite-accent/10 dark:border-graphite-accent dark:text-graphite-accent'`.
+  - Inactive branch → `'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-graphite-surface dark:border-graphite-border dark:text-graphite-muted dark:hover:bg-white/5'`.
+- Next-page nav button — identical classes to the prev-page nav button above → same treatment:
+  add `dark:border-graphite-border`, `dark:bg-graphite-surface`, `dark:text-graphite-muted`,
+  `dark:hover:bg-white/5`.
+
+**Important note on "solid action buttons" (do not deviate):** the delete-confirm button, the
+"Filtrovat" button, and the "Vymazat" button all use a solid saturated background (`-500`/`-600`+)
+with `text-white`. None of them get a `dark:` variant. This is deliberate — the design guide has no
+mapping for solid action buttons because their contrast is already sufficient on any background —
+not an oversight. Do not add `dark:` classes to these three buttons even if they look inconsistent
+with everything else in the file getting a dark variant.
+
+**Acceptance criteria:**
+- Every raw Tailwind color utility enumerated above has the specified `dark:` class appended in
+  place, in the same string/branch, without altering any light-mode class, JSX structure, prop, or
+  handler.
+- The three solid action buttons (delete-confirm, Filtrovat, Vymazat) remain unchanged — no `dark:`
+  classes added to them.
+- No light-only `bg-white`/`bg-gray-*`/`text-gray-*`/`border-gray-*`/`divide-gray-*` class remains
+  without a corresponding `dark:` counterpart anywhere in this file, except the three solid action
+  buttons noted above.
+- `StatusBadge` renders all three named statuses (`indexed`, `processing`, `failed`) plus the
+  unknown-status fallback with visibly distinct pill colors when the `dark` class is applied to a
+  root ancestor.
+- Component compiles with no TypeScript/JSX errors.
+- `npm run build` and `npm run lint` (from `frontend/`) pass with no new errors or warnings.
+
+---
+

--- a/artifacts/feat-3479/task-context/dark-mode-leaflet-generate-tab.md
+++ b/artifacts/feat-3479/task-context/dark-mode-leaflet-generate-tab.md
@@ -1,0 +1,43 @@
+### task: dark-mode-leaflet-generate-tab
+
+**Goal:** Add Tailwind `dark:` class variants to the error banners and loading-skeleton bars in
+`LeafletGenerateTab.tsx` so they render correctly under the Graphite dark theme, per ADR-006 and
+`docs/design/dark-mode-conversion-guide.md`.
+
+**File to change:** `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`
+
+**Scope discipline:** This is a purely additive, surgical CSS-class change, limited strictly to the
+banner and inline skeleton markup owned directly by `LeafletGenerateTab`. `LeafletForm` and
+`LeafletResult` (rendered as children elsewhere in this file) are out of scope — do not touch them
+or their source files. Do not fix the pre-existing `(response as any).id` cast or any other
+unrelated issue in this file — leave it untouched.
+
+**Concrete class-level changes required** (line numbers are approximate/as-of-spec; locate by exact
+string match, content is unique):
+
+- Error banner ternary:
+  ```
+  errorBanner.kind === 'insufficient'
+    ? 'bg-amber-100 text-amber-900'
+    : 'bg-red-100 text-red-900'
+  ```
+  - `'bg-amber-100 text-amber-900'` → `'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300'`.
+  - `'bg-red-100 text-red-900'` → `'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300'`.
+- Loading skeleton bars — three sibling divs, each with a `bg-gray-200` base:
+  `className="h-4 bg-gray-200 rounded w-3/4"`, `className="h-4 bg-gray-200 rounded"`,
+  `className="h-4 bg-gray-200 rounded w-5/6"` → in EACH of the three, add `dark:bg-graphite-hover`
+  for `bg-gray-200` (note: this is a different target token than the `bg-gray-100` skeleton in
+  `LeafletDocumentsTab.tsx`, which maps to `dark:bg-graphite-surface-2` — that is correct and
+  intentional; the two files' skeletons use different source classes and therefore different
+  target tokens per the guide's literal class-based mapping. Do not "harmonize" them to the same
+  token.)
+
+**Acceptance criteria:**
+- Both error-banner variants (`insufficient` / other/transient) render with the `~900/30`
+  background + `~300` text pattern in Graphite mode.
+- All three loading-skeleton bars use `dark:bg-graphite-hover` and are visually distinguishable
+  from the Graphite page background.
+- `LeafletForm` and `LeafletResult` remain untouched — no changes outside this file's own banner
+  and skeleton markup.
+- Component compiles with no TypeScript/JSX errors.
+- `npm run build` and `npm run lint` (from `frontend/`) pass with no new errors or warnings.

--- a/artifacts/feat-3479/task-context/dark-mode-leaflet-generator-page.md
+++ b/artifacts/feat-3479/task-context/dark-mode-leaflet-generator-page.md
@@ -1,0 +1,48 @@
+### task: dark-mode-leaflet-generator-page
+
+**Goal:** Add Tailwind `dark:` class variants to the page header and tab-bar navigation in
+`LeafletGeneratorPage.tsx` so the tab shell renders correctly under the Graphite dark theme, per
+ADR-006 and `docs/design/dark-mode-conversion-guide.md`.
+
+**File to change:** `frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx`
+
+**Scope discipline:** This is a purely additive, surgical CSS-class change. Do not alter markup
+structure, props, the `tabs` array, conditional tab-rendering logic, or the
+`hasPermission('marketing.leaflet.write')` gating — all must remain byte-for-byte unchanged except
+for the specific `className` edits below.
+
+**Concrete class-level changes required** (line numbers are approximate/as-of-spec; locate by exact
+string match, content is unique):
+
+- Header icon `<FileText className="w-6 h-6 text-blue-600" />` → add `dark:text-graphite-accent`
+  for `text-blue-600`.
+- Heading `className="text-2xl font-semibold text-gray-900"` → add `dark:text-graphite-text` for
+  `text-gray-900`.
+- Tab bar container `className="border-b border-gray-200"` → add `dark:border-graphite-border` for
+  `border-gray-200`.
+- Tab button template literal:
+  ```
+  className={`py-2 text-sm font-medium border-b-2 transition-colors ${
+    activeTab === tab.id
+      ? 'border-blue-600 text-blue-600'
+      : 'border-transparent text-gray-500 hover:text-gray-700'
+  }`}
+  ```
+  - Active branch `'border-blue-600 text-blue-600'` →
+    `'border-blue-600 text-blue-600 dark:border-graphite-accent dark:text-graphite-accent'`.
+  - Inactive branch `'border-transparent text-gray-500 hover:text-gray-700'` →
+    `'border-transparent text-gray-500 hover:text-gray-700 dark:text-graphite-muted dark:hover:text-graphite-text'`.
+
+**Acceptance criteria:**
+- All four raw-color classes identified above have a corresponding `dark:` class appended in the
+  same `className` string/branch, with light classes unchanged.
+- The active tab indicator (bottom border + label) uses `dark:border-graphite-accent
+  dark:text-graphite-accent` in Graphite mode.
+- The inactive tab label is `dark:text-graphite-muted` at rest and `dark:hover:text-graphite-text`
+  on hover.
+- No structural, prop, or logic changes; the `tabs` array and conditional rendering are untouched.
+- Component compiles with no TypeScript/JSX errors.
+- `npm run build` and `npm run lint` (from `frontend/`) pass with no new errors or warnings.
+
+---
+

--- a/artifacts/feat-3479/task-plan.r1.md
+++ b/artifacts/feat-3479/task-plan.r1.md
@@ -1,0 +1,292 @@
+# Task Plan: Leaflet Generator — Graphite Dark Mode Compliance (ADR-006)
+
+## Overview
+
+This is a small, mechanical, purely-additive Tailwind `dark:` class fix across three existing
+React components in `frontend/src/features/leaflet-generator/`. No markup structure, props, logic,
+component interfaces, or light-mode appearance may change — every edit is an addition of `dark:`
+utility classes to existing `className` strings/branches, per the token map in
+`docs/design/dark-mode-conversion-guide.md` (ADR-006). No design work is needed (Skip Design: true)
+and no backend/API/data-model changes are involved.
+
+The change is split into three tasks, one per file, matching the arch-review's specified execution
+order (highest surface area first):
+
+1. `dark-mode-leaflet-documents-tab` — `LeafletDocumentsTab.tsx` (highest impact: filter bar, table,
+   `StatusBadge`, `ConfirmDeleteDialog`, `SortableHeader`, pagination footer).
+2. `dark-mode-leaflet-generator-page` — `LeafletGeneratorPage.tsx` (page header + tab navigation).
+3. `dark-mode-leaflet-generate-tab` — `LeafletGenerateTab.tsx` (error banners + loading skeleton).
+
+Each task is independently implementable and reviewable; do them in the order above but each
+section below is fully self-contained.
+
+Common ground rules for ALL three tasks (repeated in each task section so each is self-contained):
+- Only add `dark:`-prefixed Tailwind classes to existing `className` strings/template
+  literals/ternary branches. Never remove, reorder, or alter an existing light-mode class.
+- Do not touch JSX structure, component props, exported types, event handlers, hooks, or any
+  non-styling logic.
+- Do not "fix" or refactor anything not explicitly listed below, even if it looks related (e.g.
+  solid-color action buttons using `bg-{color}-600/700 ... text-white` are intentionally left
+  unchanged — see the per-file notes).
+- Validation gate for all three tasks: `npm run build` and `npm run lint` (run from `frontend/`)
+  must pass with no new errors/warnings.
+
+---
+
+### task: dark-mode-leaflet-documents-tab
+
+**Goal:** Add Tailwind `dark:` class variants to every raw-color utility in
+`LeafletDocumentsTab.tsx` (status badges, delete-confirmation dialog, sortable table header, filter
+bar, table body, and pagination footer) so the component renders correctly under the Graphite dark
+theme, per ADR-006 and `docs/design/dark-mode-conversion-guide.md`. This is the highest-impact file
+in this fix (515 lines) — do it first.
+
+**File to change:** `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx`
+
+**Scope discipline:** This is a purely additive, surgical CSS-class change. Do not alter markup
+structure, props, state, sorting/pagination/filtering logic, URL-param sync, permission checks
+(`canDelete`), or API calls. Do not touch any other file. Do not "fix" the pre-existing
+`(response as any).id`-style issues or any other unrelated lint/type/accessibility problem you may
+notice — flag it in a comment if you want, but do not change it.
+
+**Concrete class-level changes required** (line numbers are approximate/as-of-spec; locate by exact
+string match, content is unique):
+
+**1. `StatusBadge` color map (around lines 12–24).** The `colorMap` object maps status → Tailwind
+classes. Add a `dark:` variant to each value string:
+- `indexed: 'bg-green-100 text-green-800'` → `'bg-green-100 text-green-800 dark:bg-emerald-900/30 dark:text-emerald-300'`
+- `processing: 'bg-yellow-100 text-yellow-800'` → `'bg-yellow-100 text-yellow-800 dark:bg-amber-900/30 dark:text-amber-300'`
+- `failed: 'bg-red-100 text-red-800'` → `'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'`
+- fallback `?? 'bg-gray-100 text-gray-800'` → `'bg-gray-100 text-gray-800 dark:bg-graphite-surface-2 dark:text-graphite-muted'`
+
+**2. `ConfirmDeleteDialog` (around lines 26–57):**
+- Dialog panel `className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full"` → add
+  `dark:bg-graphite-surface` for `bg-white`. Leave `shadow-xl` unchanged (not in the guide's shadow
+  table — do not invent a mapping for it).
+- Heading `text-lg font-semibold` — no color utility present, no change.
+- Body text `className="text-sm text-gray-600 mb-4"` → add `dark:text-graphite-muted` for
+  `text-gray-600`.
+- Warning/error text `className="text-sm text-red-600 mb-3"` → add `dark:text-red-400` for
+  `text-red-600`.
+- Cancel button `className="px-4 py-2 text-sm rounded border border-gray-300 hover:bg-gray-50"` →
+  add `dark:border-graphite-border` for `border-gray-300` and `dark:hover:bg-white/5` for
+  `hover:bg-gray-50`.
+- Confirm/delete button `className="px-4 py-2 text-sm rounded bg-red-600 text-white hover:bg-red-700"`
+  → **leave unchanged**. This is a solid destructive-action button (saturated `bg-red-600` +
+  `text-white`); the guide does not map solid action buttons, and solid `-600`/`-700` backgrounds
+  with white text retain sufficient contrast in both light and dark mode by construction. Do not
+  add a `dark:` variant here.
+
+**3. `SortableHeader` (around lines 59–87):**
+- `className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none"`
+  → add `dark:text-graphite-muted` for `text-gray-500` and `dark:hover:bg-white/5` for
+  `hover:bg-gray-100`.
+- Chevron icon ternaries (ChevronUp and ChevronDown, two near-identical template literals):
+  ```
+  `h-3 w-3 ${isActive && !sortDescending ? 'text-indigo-600' : 'text-gray-300'}`
+  `h-3 w-3 -mt-1 ${isActive && sortDescending ? 'text-indigo-600' : 'text-gray-300'}`
+  ```
+  In BOTH ternaries: `'text-indigo-600'` → `'text-indigo-600 dark:text-graphite-accent'`;
+  `'text-gray-300'` → `'text-gray-300 dark:text-graphite-faint'`.
+
+**4. Filter bar (around lines 272–347):**
+- Container `className="bg-white shadow rounded-lg p-4 mb-4"` → add `dark:bg-graphite-surface` for
+  `bg-white` and `dark:shadow-soft-dark` for `shadow`.
+- `<Filter className="h-4 w-4 text-gray-400 mr-2" />` → add `dark:text-graphite-faint` for
+  `text-gray-400`.
+- `<span className="text-sm font-medium text-gray-900">` → add `dark:text-graphite-text` for
+  `text-gray-900`.
+- `<Search className="h-4 w-4 text-gray-400" />` → add `dark:text-graphite-faint` for
+  `text-gray-400`.
+- Filename input `className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 sm:text-sm border-gray-300 rounded-md"`
+  → append the full raw-input dark bundle: `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text dark:placeholder-graphite-faint`.
+  Leave `focus:ring-indigo-500`/`focus:border-indigo-500` unchanged (focus rings are fine as-is).
+- Status `<select>` `className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"`
+  → append `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text` (no
+  placeholder dark class — it's a `<select>`, not a text input).
+- Content-type `<select>` — identical classes to the status select above → same treatment: append
+  `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text`.
+- "Filtrovat" button `className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-md transition-colors duration-200 text-sm"`
+  → **leave unchanged** (solid saturated primary button, same rationale as the delete-confirm
+  button above — no guide mapping, contrast already sufficient).
+- "Vymazat" button `className="bg-gray-500 hover:bg-gray-600 text-white font-medium py-2 px-3 rounded-md transition-colors duration-200 text-sm"`
+  → **leave unchanged**. Note: despite `bg-gray-500` looking like a "neutral surface" candidate at
+  a glance, it is a solid button with white text, not a surface — do not map it to
+  `dark:bg-graphite-surface-2` or similar. Same rationale as the other solid-button exemptions.
+
+**5. Empty state:**
+- `className="text-gray-500 text-sm text-center py-8"` → add `dark:text-graphite-muted` for
+  `text-gray-500`.
+
+**6. Table (around lines 355–400):**
+- `className="min-w-full divide-y divide-gray-200 text-sm"` → add `dark:divide-graphite-border`
+  for `divide-gray-200`.
+- `<thead className="bg-gray-50">` → add `dark:bg-graphite-surface-2` for `bg-gray-50`.
+- `<th className="px-6 py-3" />` — no color utility, no change.
+- `<tbody className="divide-y divide-gray-100">` → add `dark:divide-graphite-border` for
+  `divide-gray-100`.
+- Row template literal `` `hover:bg-gray-50 ${doc.firstChunkId ? 'cursor-pointer' : ''}` `` → add
+  `dark:hover:bg-white/5` for `hover:bg-gray-50` (the `cursor-pointer`/`''` ternary branch itself
+  needs no change).
+- `className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"` → add
+  `dark:text-graphite-text` for `text-gray-900`.
+- Both occurrences of `className="px-6 py-4 whitespace-nowrap text-sm text-gray-500"` → add
+  `dark:text-graphite-muted` for `text-gray-500` (apply to both).
+- Delete icon button `className="text-gray-400 hover:text-red-600 transition-colors"` → add
+  `dark:text-graphite-faint` for `text-gray-400`. Leave `hover:text-red-600` unchanged (no guide
+  mapping for danger-hover text; saturated red-600 stays legible on dark surfaces).
+
+**7. Loading skeleton and error text (around lines 256–267):**
+- `className="h-10 bg-gray-100 rounded"` (skeleton block) → add `dark:bg-graphite-surface-2` for
+  `bg-gray-100`.
+- `className="text-red-600 text-sm"` (error text) → add `dark:text-red-400` for `text-red-600`.
+
+**8. Pagination footer (around lines 403–491):**
+- `className="bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs"`
+  → add `dark:bg-graphite-surface` for `bg-white` and `dark:border-graphite-border` for
+  `border-gray-200`.
+- Mobile "Předchozí" and "Další" buttons (both share the identical class string)
+  `className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"`
+  → in BOTH buttons: add `dark:border-graphite-border` for `border-gray-300`,
+  `dark:text-graphite-muted` for `text-gray-700`, `dark:bg-graphite-surface` for `bg-white`,
+  `dark:hover:bg-white/5` for `hover:bg-gray-50`.
+- Result-count text `className="text-xs text-gray-600"` → add `dark:text-graphite-muted` for
+  `text-gray-600`.
+- "Zobrazit:" label `className="text-xs text-gray-600"` → add `dark:text-graphite-muted` for
+  `text-gray-600`.
+- Page-size `<select>` `className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"`
+  → append `dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text` (leave
+  focus-ring classes unchanged).
+- `className="relative z-0 inline-flex rounded shadow-sm -space-x-px"` → add
+  `dark:shadow-soft-dark` for `shadow-sm`.
+- Prev-page nav button `className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"`
+  → add `dark:border-graphite-border` for `border-gray-300`, `dark:bg-graphite-surface` for
+  `bg-white`, `dark:text-graphite-muted` for `text-gray-500`, `dark:hover:bg-white/5` for
+  `hover:bg-gray-50`.
+- Numbered page-button ternary:
+  ```
+  pageNum === pageNumber
+    ? 'z-10 bg-indigo-50 border-indigo-500 text-indigo-600'
+    : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+  ```
+  - Active branch → `'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-graphite-accent/10 dark:border-graphite-accent dark:text-graphite-accent'`.
+  - Inactive branch → `'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-graphite-surface dark:border-graphite-border dark:text-graphite-muted dark:hover:bg-white/5'`.
+- Next-page nav button — identical classes to the prev-page nav button above → same treatment:
+  add `dark:border-graphite-border`, `dark:bg-graphite-surface`, `dark:text-graphite-muted`,
+  `dark:hover:bg-white/5`.
+
+**Important note on "solid action buttons" (do not deviate):** the delete-confirm button, the
+"Filtrovat" button, and the "Vymazat" button all use a solid saturated background (`-500`/`-600`+)
+with `text-white`. None of them get a `dark:` variant. This is deliberate — the design guide has no
+mapping for solid action buttons because their contrast is already sufficient on any background —
+not an oversight. Do not add `dark:` classes to these three buttons even if they look inconsistent
+with everything else in the file getting a dark variant.
+
+**Acceptance criteria:**
+- Every raw Tailwind color utility enumerated above has the specified `dark:` class appended in
+  place, in the same string/branch, without altering any light-mode class, JSX structure, prop, or
+  handler.
+- The three solid action buttons (delete-confirm, Filtrovat, Vymazat) remain unchanged — no `dark:`
+  classes added to them.
+- No light-only `bg-white`/`bg-gray-*`/`text-gray-*`/`border-gray-*`/`divide-gray-*` class remains
+  without a corresponding `dark:` counterpart anywhere in this file, except the three solid action
+  buttons noted above.
+- `StatusBadge` renders all three named statuses (`indexed`, `processing`, `failed`) plus the
+  unknown-status fallback with visibly distinct pill colors when the `dark` class is applied to a
+  root ancestor.
+- Component compiles with no TypeScript/JSX errors.
+- `npm run build` and `npm run lint` (from `frontend/`) pass with no new errors or warnings.
+
+---
+
+### task: dark-mode-leaflet-generator-page
+
+**Goal:** Add Tailwind `dark:` class variants to the page header and tab-bar navigation in
+`LeafletGeneratorPage.tsx` so the tab shell renders correctly under the Graphite dark theme, per
+ADR-006 and `docs/design/dark-mode-conversion-guide.md`.
+
+**File to change:** `frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx`
+
+**Scope discipline:** This is a purely additive, surgical CSS-class change. Do not alter markup
+structure, props, the `tabs` array, conditional tab-rendering logic, or the
+`hasPermission('marketing.leaflet.write')` gating — all must remain byte-for-byte unchanged except
+for the specific `className` edits below.
+
+**Concrete class-level changes required** (line numbers are approximate/as-of-spec; locate by exact
+string match, content is unique):
+
+- Header icon `<FileText className="w-6 h-6 text-blue-600" />` → add `dark:text-graphite-accent`
+  for `text-blue-600`.
+- Heading `className="text-2xl font-semibold text-gray-900"` → add `dark:text-graphite-text` for
+  `text-gray-900`.
+- Tab bar container `className="border-b border-gray-200"` → add `dark:border-graphite-border` for
+  `border-gray-200`.
+- Tab button template literal:
+  ```
+  className={`py-2 text-sm font-medium border-b-2 transition-colors ${
+    activeTab === tab.id
+      ? 'border-blue-600 text-blue-600'
+      : 'border-transparent text-gray-500 hover:text-gray-700'
+  }`}
+  ```
+  - Active branch `'border-blue-600 text-blue-600'` →
+    `'border-blue-600 text-blue-600 dark:border-graphite-accent dark:text-graphite-accent'`.
+  - Inactive branch `'border-transparent text-gray-500 hover:text-gray-700'` →
+    `'border-transparent text-gray-500 hover:text-gray-700 dark:text-graphite-muted dark:hover:text-graphite-text'`.
+
+**Acceptance criteria:**
+- All four raw-color classes identified above have a corresponding `dark:` class appended in the
+  same `className` string/branch, with light classes unchanged.
+- The active tab indicator (bottom border + label) uses `dark:border-graphite-accent
+  dark:text-graphite-accent` in Graphite mode.
+- The inactive tab label is `dark:text-graphite-muted` at rest and `dark:hover:text-graphite-text`
+  on hover.
+- No structural, prop, or logic changes; the `tabs` array and conditional rendering are untouched.
+- Component compiles with no TypeScript/JSX errors.
+- `npm run build` and `npm run lint` (from `frontend/`) pass with no new errors or warnings.
+
+---
+
+### task: dark-mode-leaflet-generate-tab
+
+**Goal:** Add Tailwind `dark:` class variants to the error banners and loading-skeleton bars in
+`LeafletGenerateTab.tsx` so they render correctly under the Graphite dark theme, per ADR-006 and
+`docs/design/dark-mode-conversion-guide.md`.
+
+**File to change:** `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`
+
+**Scope discipline:** This is a purely additive, surgical CSS-class change, limited strictly to the
+banner and inline skeleton markup owned directly by `LeafletGenerateTab`. `LeafletForm` and
+`LeafletResult` (rendered as children elsewhere in this file) are out of scope — do not touch them
+or their source files. Do not fix the pre-existing `(response as any).id` cast or any other
+unrelated issue in this file — leave it untouched.
+
+**Concrete class-level changes required** (line numbers are approximate/as-of-spec; locate by exact
+string match, content is unique):
+
+- Error banner ternary:
+  ```
+  errorBanner.kind === 'insufficient'
+    ? 'bg-amber-100 text-amber-900'
+    : 'bg-red-100 text-red-900'
+  ```
+  - `'bg-amber-100 text-amber-900'` → `'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300'`.
+  - `'bg-red-100 text-red-900'` → `'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300'`.
+- Loading skeleton bars — three sibling divs, each with a `bg-gray-200` base:
+  `className="h-4 bg-gray-200 rounded w-3/4"`, `className="h-4 bg-gray-200 rounded"`,
+  `className="h-4 bg-gray-200 rounded w-5/6"` → in EACH of the three, add `dark:bg-graphite-hover`
+  for `bg-gray-200` (note: this is a different target token than the `bg-gray-100` skeleton in
+  `LeafletDocumentsTab.tsx`, which maps to `dark:bg-graphite-surface-2` — that is correct and
+  intentional; the two files' skeletons use different source classes and therefore different
+  target tokens per the guide's literal class-based mapping. Do not "harmonize" them to the same
+  token.)
+
+**Acceptance criteria:**
+- Both error-banner variants (`insufficient` / other/transient) render with the `~900/30`
+  background + `~300` text pattern in Graphite mode.
+- All three loading-skeleton bars use `dark:bg-graphite-hover` and are visually distinguishable
+  from the Graphite page background.
+- `LeafletForm` and `LeafletResult` remain untouched — no changes outside this file's own banner
+  and skeleton markup.
+- Component compiles with no TypeScript/JSX errors.
+- `npm run build` and `npm run lint` (from `frontend/`) pass with no new errors or warnings.

--- a/frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx
@@ -11,11 +11,11 @@ import LeafletChunkDetailModal from './LeafletChunkDetailModal';
 
 const StatusBadge: React.FC<{ status: string }> = ({ status }) => {
   const colorMap: Record<string, string> = {
-    indexed: 'bg-green-100 text-green-800',
-    processing: 'bg-yellow-100 text-yellow-800',
-    failed: 'bg-red-100 text-red-800',
+    indexed: 'bg-green-100 text-green-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+    processing: 'bg-yellow-100 text-yellow-800 dark:bg-amber-900/30 dark:text-amber-300',
+    failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
   };
-  const classes = colorMap[status.toLowerCase()] ?? 'bg-gray-100 text-gray-800';
+  const classes = colorMap[status.toLowerCase()] ?? 'bg-gray-100 text-gray-800 dark:bg-graphite-surface-2 dark:text-graphite-muted';
   return (
     <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${classes}`}>
       {status}
@@ -30,18 +30,18 @@ const ConfirmDeleteDialog: React.FC<{
   onCancel: () => void;
 }> = ({ document, error, onConfirm, onCancel }) => (
   <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-    <div className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full">
+    <div className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full dark:bg-graphite-surface">
       <h2 className="text-lg font-semibold mb-2">Smazat dokument?</h2>
-      <p className="text-sm text-gray-600 mb-4">
+      <p className="text-sm text-gray-600 mb-4 dark:text-graphite-muted">
         Opravdu chcete smazat <strong>{document.filename}</strong>? Tato akce je nevratná.
       </p>
       {error && (
-        <p className="text-sm text-red-600 mb-3">{error}</p>
+        <p className="text-sm text-red-600 mb-3 dark:text-red-400">{error}</p>
       )}
       <div className="flex justify-end gap-2">
         <button
           onClick={onCancel}
-          className="px-4 py-2 text-sm rounded border border-gray-300 hover:bg-gray-50"
+          className="px-4 py-2 text-sm rounded border border-gray-300 hover:bg-gray-50 dark:border-graphite-border dark:hover:bg-white/5"
         >
           Zrušit
         </button>
@@ -68,17 +68,17 @@ const SortableHeader: React.FC<SortableHeaderProps> = ({ column, sortBy, sortDes
   const isActive = sortBy === column;
   return (
     <th
-      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none"
+      className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 select-none dark:text-graphite-muted dark:hover:bg-white/5"
       onClick={() => onSort(column)}
     >
       <div className="flex items-center space-x-1">
         <span>{children}</span>
         <div className="flex flex-col">
           <ChevronUp
-            className={`h-3 w-3 ${isActive && !sortDescending ? 'text-indigo-600' : 'text-gray-300'}`}
+            className={`h-3 w-3 ${isActive && !sortDescending ? 'text-indigo-600 dark:text-graphite-accent' : 'text-gray-300 dark:text-graphite-faint'}`}
           />
           <ChevronDown
-            className={`h-3 w-3 -mt-1 ${isActive && sortDescending ? 'text-indigo-600' : 'text-gray-300'}`}
+            className={`h-3 w-3 -mt-1 ${isActive && sortDescending ? 'text-indigo-600 dark:text-graphite-accent' : 'text-gray-300 dark:text-graphite-faint'}`}
           />
         </div>
       </div>
@@ -257,31 +257,31 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
     return (
       <div className="space-y-2 animate-pulse">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="h-10 bg-gray-100 rounded" />
+          <div key={i} className="h-10 bg-gray-100 rounded dark:bg-graphite-surface-2" />
         ))}
       </div>
     );
   }
 
   if (error) {
-    return <div className="text-red-600 text-sm">Nepodařilo se načíst dokumenty.</div>;
+    return <div className="text-red-600 text-sm dark:text-red-400">Nepodařilo se načíst dokumenty.</div>;
   }
 
   return (
     <>
       {/* Filter bar */}
-      <div className="bg-white shadow rounded-lg p-4 mb-4">
+      <div className="bg-white shadow rounded-lg p-4 mb-4 dark:bg-graphite-surface dark:shadow-soft-dark">
         <div className="flex items-center justify-between flex-wrap gap-3">
           <div className="flex items-center gap-3 flex-1 min-w-0">
             <div className="flex items-center">
-              <Filter className="h-4 w-4 text-gray-400 mr-2" />
-              <span className="text-sm font-medium text-gray-900">Filtry:</span>
+              <Filter className="h-4 w-4 text-gray-400 mr-2 dark:text-graphite-faint" />
+              <span className="text-sm font-medium text-gray-900 dark:text-graphite-text">Filtry:</span>
             </div>
 
             <div className="flex-1 max-w-xs">
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Search className="h-4 w-4 text-gray-400" />
+                  <Search className="h-4 w-4 text-gray-400 dark:text-graphite-faint" />
                 </div>
                 <input
                   type="text"
@@ -289,7 +289,7 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
                   onChange={(e) => setFilenameInput(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleApplyFilters()}
                   placeholder="Název souboru..."
-                  className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 sm:text-sm border-gray-300 rounded-md"
+                  className="focus:ring-indigo-500 focus:border-indigo-500 block w-full pl-10 pr-3 py-2 sm:text-sm border-gray-300 rounded-md dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text dark:placeholder-graphite-faint"
                 />
               </div>
             </div>
@@ -301,7 +301,7 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
                   setStatusFilter(e.target.value);
                   setPageNumber(1);
                 }}
-                className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+                className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text"
               >
                 <option value="">Vše (stav)</option>
                 <option value="indexed">Indexováno</option>
@@ -317,7 +317,7 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
                   setContentTypeFilter(e.target.value);
                   setPageNumber(1);
                 }}
-                className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+                className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text"
               >
                 <option value="">Vše (typ)</option>
                 {(contentTypesData?.contentTypes ?? []).map((ct) => (
@@ -347,14 +347,14 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
       </div>
 
       {documents.length === 0 ? (
-        <div className="text-gray-500 text-sm text-center py-8">
+        <div className="text-gray-500 text-sm text-center py-8 dark:text-graphite-muted">
           Žádné dokumenty neodpovídají zadaným filtrům.
         </div>
       ) : (
         <>
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-sm">
-              <thead className="bg-gray-50">
+            <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-graphite-border">
+              <thead className="bg-gray-50 dark:bg-graphite-surface-2">
                 <tr>
                   <SortableHeader column="Filename" sortBy={sortBy} sortDescending={sortDescending} onSort={handleSort}>Soubor</SortableHeader>
                   <SortableHeader column="Status" sortBy={sortBy} sortDescending={sortDescending} onSort={handleSort}>Stav</SortableHeader>
@@ -363,21 +363,21 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
                   {canDelete && <th className="px-6 py-3" />}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-100">
+              <tbody className="divide-y divide-gray-100 dark:divide-graphite-border">
                 {documents.map((doc) => (
                   <tr
                     key={doc.id}
-                    className={`hover:bg-gray-50 ${doc.firstChunkId ? 'cursor-pointer' : ''}`}
+                    className={`hover:bg-gray-50 dark:hover:bg-white/5 ${doc.firstChunkId ? 'cursor-pointer' : ''}`}
                     onClick={() => doc.firstChunkId && setSelectedChunkId(doc.firstChunkId)}
                   >
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{doc.filename}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-graphite-text">{doc.filename}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
                       <StatusBadge status={doc.status} />
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-graphite-muted">
                       {new Date(doc.ingestedAt).toLocaleDateString('cs-CZ')}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-graphite-muted">
                       {doc.indexedAt
                         ? new Date(doc.indexedAt).toLocaleDateString('cs-CZ')
                         : '–'}
@@ -387,7 +387,7 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
                         <button
                           onClick={(e) => { e.stopPropagation(); setPendingDelete(doc); }}
                           title="Smazat dokument"
-                          className="text-gray-400 hover:text-red-600 transition-colors"
+                          className="text-gray-400 hover:text-red-600 transition-colors dark:text-graphite-faint"
                         >
                           <Trash2 className="w-4 h-4" />
                         </button>
@@ -400,38 +400,38 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
           </div>
 
           {/* Pagination footer */}
-          <div className="bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs">
+          <div className="bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs dark:bg-graphite-surface dark:border-graphite-border">
             <div className="flex-1 flex justify-between sm:hidden">
               <button
                 onClick={() => setPageNumber((p) => Math.max(1, p - 1))}
                 disabled={pageNumber <= 1}
-                className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-graphite-border dark:text-graphite-muted dark:bg-graphite-surface dark:hover:bg-white/5"
               >
                 Předchozí
               </button>
               <button
                 onClick={() => setPageNumber((p) => Math.min(totalPages, p + 1))}
                 disabled={pageNumber >= totalPages}
-                className="ml-2 relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="ml-2 relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-graphite-border dark:text-graphite-muted dark:bg-graphite-surface dark:hover:bg-white/5"
               >
                 Další
               </button>
             </div>
             <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
               <div className="flex items-center space-x-3">
-                <p className="text-xs text-gray-600">
+                <p className="text-xs text-gray-600 dark:text-graphite-muted">
                   {Math.min((pageNumber - 1) * pageSize + 1, data?.totalCount ?? 0)}–
                   {Math.min(pageNumber * pageSize, data?.totalCount ?? 0)} z {data?.totalCount ?? 0}
                 </p>
                 <div className="flex items-center space-x-1">
-                  <span className="text-xs text-gray-600">Zobrazit:</span>
+                  <span className="text-xs text-gray-600 dark:text-graphite-muted">Zobrazit:</span>
                   <select
                     value={pageSize}
                     onChange={(e) => {
                       setPageSize(parseInt(e.target.value, 10));
                       setPageNumber(1);
                     }}
-                    className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
+                    className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text"
                   >
                     <option value={10}>10</option>
                     <option value={20}>20</option>
@@ -441,13 +441,13 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
               </div>
               <div>
                 <nav
-                  className="relative z-0 inline-flex rounded shadow-sm -space-x-px"
+                  className="relative z-0 inline-flex rounded shadow-sm -space-x-px dark:shadow-soft-dark"
                   aria-label="Pagination"
                 >
                   <button
                     onClick={() => setPageNumber((p) => Math.max(1, p - 1))}
                     disabled={pageNumber <= 1}
-                    className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-graphite-border dark:bg-graphite-surface dark:text-graphite-muted dark:hover:bg-white/5"
                   >
                     <ChevronLeft className="h-3 w-3" />
                   </button>
@@ -469,8 +469,8 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
                         onClick={() => setPageNumber(pageNum)}
                         className={`relative inline-flex items-center px-2 py-1 border text-xs font-medium ${
                           pageNum === pageNumber
-                            ? 'z-10 bg-indigo-50 border-indigo-500 text-indigo-600'
-                            : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+                            ? 'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-graphite-accent/10 dark:border-graphite-accent dark:text-graphite-accent'
+                            : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-graphite-surface dark:border-graphite-border dark:text-graphite-muted dark:hover:bg-white/5'
                         }`}
                       >
                         {pageNum}
@@ -481,7 +481,7 @@ const LeafletDocumentsTab: React.FC<Props> = ({ canDelete }) => {
                   <button
                     onClick={() => setPageNumber((p) => Math.min(totalPages, p + 1))}
                     disabled={pageNumber >= totalPages}
-                    className="relative inline-flex items-center px-1 py-1 rounded-r border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="relative inline-flex items-center px-1 py-1 rounded-r border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:border-graphite-border dark:bg-graphite-surface dark:text-graphite-muted dark:hover:bg-white/5"
                   >
                     <ChevronRight className="h-3 w-3" />
                   </button>

--- a/frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
@@ -62,8 +62,8 @@ const LeafletGenerateTab: React.FC = () => {
           role="alert"
           className={`mb-4 rounded p-3 text-sm ${
             errorBanner.kind === 'insufficient'
-              ? 'bg-amber-100 text-amber-900'
-              : 'bg-red-100 text-red-900'
+              ? 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300'
+              : 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300'
           }`}
         >
           {errorBanner.message}
@@ -85,9 +85,9 @@ const LeafletGenerateTab: React.FC = () => {
         <div>
           {isLoading ? (
             <div className="animate-pulse space-y-2">
-              <div className="h-4 bg-gray-200 rounded w-3/4" />
-              <div className="h-4 bg-gray-200 rounded" />
-              <div className="h-4 bg-gray-200 rounded w-5/6" />
+              <div className="h-4 bg-gray-200 dark:bg-graphite-hover rounded w-3/4" />
+              <div className="h-4 bg-gray-200 dark:bg-graphite-hover rounded" />
+              <div className="h-4 bg-gray-200 dark:bg-graphite-hover rounded w-5/6" />
             </div>
           ) : (
             <LeafletResult content={result} generationId={generationId} onRegenerate={generate} />

--- a/frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx
@@ -24,11 +24,11 @@ export default function LeafletGeneratorPage() {
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-center gap-3">
-        <FileText className="w-6 h-6 text-blue-600" />
-        <h1 className="text-2xl font-semibold text-gray-900">Generátor letáků</h1>
+        <FileText className="w-6 h-6 text-blue-600 dark:text-graphite-accent" />
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-graphite-text">Generátor letáků</h1>
       </div>
 
-      <div className="border-b border-gray-200">
+      <div className="border-b border-gray-200 dark:border-graphite-border">
         <nav className="flex gap-6" aria-label="Tabs">
           {tabs.map((tab) => (
             <button
@@ -36,8 +36,8 @@ export default function LeafletGeneratorPage() {
               onClick={() => setActiveTab(tab.id)}
               className={`py-2 text-sm font-medium border-b-2 transition-colors ${
                 activeTab === tab.id
-                  ? 'border-blue-600 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700'
+                  ? 'border-blue-600 text-blue-600 dark:border-graphite-accent dark:text-graphite-accent'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-graphite-muted dark:hover:text-graphite-text'
               }`}
             >
               {tab.label}


### PR DESCRIPTION
Closes #3479

## What the issue was
Every component in `frontend/src/features/leaflet-generator/` used light-only Tailwind classes with no `dark:` counterparts, violating ADR-006 (every component that renders color must render correctly in both light and Graphite dark themes). The Leaflet feature (table, filter bar, modal, tab panel) would render with broken contrast in dark mode.

## How it was fixed / handled
Added `dark:` Tailwind variants across the three affected components, following the token map in `docs/design/dark-mode-conversion-guide.md`:

- **`LeafletDocumentsTab.tsx`** (highest impact) — status badges, delete-confirmation dialog, sortable table header, filter bar, table body, and pagination footer now carry Graphite-appropriate dark variants (e.g. `~900/30` bg + `~300` text pattern for status badges, `dark:bg-graphite-surface` for cards/dialogs, `dark:text-graphite-text`/`dark:text-graphite-muted` for text).
- **`LeafletGeneratorPage.tsx`** — header icon/heading, tab-bar container, and active/inactive tab states now have dark variants.
- **`LeafletGenerateTab.tsx`** — error banners (amber/red) and loading skeleton bars now have dark variants.

Solid-color action buttons were intentionally left unchanged since they're already contrast-safe in both themes.

The change was driven through the full AgentHarness pipeline (analyst → architect → planner → developer/reviewer per file → whole-branch code review), with design skipped since this is a pure styling fix with no new UI components. All artifacts are committed under `artifacts/feat-3479/`.

## Artifacts
- Brief, spec, arch-review, task plan, per-task impl/review, and final code-review markdown are committed in this branch under `artifacts/feat-3479/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx:18` — The fallback badge pairs `dark:bg-graphite-surface-2` with the same token used for the `<thead>` background (line 357); on rows adjacent to the header this fallback pill may blend into the header row visually. Not a bug (matches spec exactly), just worth a visual sanity check since it's the only badge variant using a neutral surface token instead of a semantic `~900/30` pill.
- `frontend/src/features/leaflet-generator/LeafletDocumentsTab.tsx:390` — `hover:text-red-600` intentionally has no `dark:` hover variant per spec; consider revisiting in a follow-up if the icon-only delete button reads as low-contrast against `dark:text-graphite-faint` at rest in Graphite mode (cosmetic, out of scope for this fix).


---
_Generated by [Claude Code](https://claude.ai/code/session_01B35hZq3qELz8YvmUr7jVcM)_