### PR TITLE
#3478: GenerateLeafletHandler error-signaling consistency fix

### DIFF
--- a/artifacts/feat-3478/arch-review.r1.md
+++ b/artifacts/feat-3478/arch-review.r1.md
@@ -1,0 +1,166 @@
+# Architecture Review: `GenerateLeafletHandler` error-signaling consistency fix
+
+## Skip Design: true
+
+This is a pure backend/contract consistency fix confined to the Leaflet module (Application + API layers), one MCP tool, and one existing frontend component's error-branching logic. No new screens, layouts, or visual components are introduced — the only frontend change (FR-7) swaps which condition drives an *already-existing* amber/red banner. No design review is needed.
+
+## Architectural Fit Assessment
+
+The spec's proposal is a straight application of a pattern that is already the dominant idiom in this codebase, not a new one being introduced. I verified directly:
+
+- `BaseResponse` (`backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs`) already supports the exact three-constructor shape the spec assumes: parameterless (success), `(ErrorCodes, Dictionary<string,string>?)` (expected business error), and `(Exception)` (unexpected error, reserved — correctly flagged by the spec's NFR-2 as *not* to be used here).
+- `BaseApiController.HandleResponse<T>` (`backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs`) already does exactly what the spec says: reflects on the `[HttpStatusCode]` attribute of the response's `ErrorCode` and dispatches to the matching `ActionResult`. Every other action in `LeafletController.cs` (`GetChunkDetail`, `SubmitFeedback`, `GetGeneration`, `GetDocuments`, `UploadDocument`, `DeleteDocument`, `GetFeedbackList`) already calls `return HandleResponse(result);` with zero try/catch. `Generate` is the sole outlier.
+- `ErrorCodes.cs` already has a `// Leaflet module errors (25XX)` block ending at `LeafletFeedbackAlreadySubmitted = 2503`, and already has precedent for `[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]` on other "not enough data" conditions in other modules (`ArticleNotGenerated = 2406`, `ManufacturedInventoryInsufficientStock = 1216`, `TransportBoxStateChangeError = 1402`). Adding `LeafletEmptyRetrieval = 2504` with the same attribute is squarely in-pattern, not a new convention.
+- `SubmitLeafletFeedbackResponse` (`backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackRequest.cs`) is the two-constructor template the spec asks `GenerateLeafletResponse` to copy — confirmed identical in shape to what FR-2 proposes.
+- The global exception pipeline exists and is real, not hypothetical: `ServiceCollectionExtensions.AddCrossCuttingServices` (`backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`) registers `UnauthorizedAccessExceptionHandler`, `ValidationExceptionHandler`, `ArgumentExceptionHandler` (all in `backend/src/Anela.Heblo.API/Infrastructure/ExceptionHandling/`) plus `AddProblemDetails()`. None of these three handlers match a generic embedding/chat-client failure, so an unexpected exception from `GenerateLeafletHandler` genuinely will fall through to ASP.NET's default `ProblemDetails` 500 response once the controller's catch-all is removed. This is the correct, already-existing "sink" — no new infrastructure is needed to answer the spec's now-settled Open Question.
+- I confirmed the frontend regression the spec identifies in FR-7 is real, not speculative, by reading the generated client's `throwException` (`frontend/src/api/generated/api-client.ts:41260`): `if (result !== null && result !== undefined) throw result;` — it throws the parsed body object directly. `GenerateLeafletResponse.fromJS(...)` (line 24070) produces a real class instance, so `err instanceof GenerateLeafletResponse` in the spec's proposed fix works as written. Today's `processLeaflet_Generate` parses the 422 branch as `ProblemDetails.fromJS(...)`; after regeneration it will parse as `GenerateLeafletResponse.fromJS(...)`, which has no `status` field — confirming `isApiError`'s current duck-typing check would silently break.
+
+**Conclusion: the spec is architecturally sound and requires no material redesign.** My job here is to pin down the few implementation-order and safety details the spec leaves implicit, and to formally close the one item it left open.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────┐        ┌──────────────────────────────┐
+│ LeafletGenerateTab.tsx  │        │  api-client.ts (generated)    │
+│  - reads err.errorCode  │◄───────┤  processLeaflet_Generate:      │
+│    instead of err.status│        │   200 -> GenerateLeafletResponse│
+└─────────────────────────┘        │   422 -> throw GenerateLeafletResponse (was ProblemDetails)
+              ▲                    │   400 -> throw ProblemDetails (unchanged, model validation)
+              │ HTTP 422/200       │   (502 branch removed; unmapped -> generic throwException)
+              │                    └──────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────┐
+│ LeafletController.Generate  (no try/catch — matches every other  │
+│  action in this controller)                                      │
+│   var result = await _mediator.Send(request, ct);                │
+│   return HandleResponse(result);   // BaseApiController           │
+└─────────────────────────────────────────────────────────────────┘
+              │ MediatR
+              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ GenerateLeafletHandler.Handle                                     │
+│   kbHits/leafletHits both empty                                  │
+│     -> return new GenerateLeafletResponse(                       │
+│           ErrorCodes.LeafletEmptyRetrieval, { detail: "..." })    │
+│   otherwise -> unchanged two-stage generation, return success DTO │
+│   unexpected exception (embedding/chat client failure)            │
+│     -> propagates unhandled -> ASP.NET AddExceptionHandler chain  │
+│        (Unauthorized/Validation/Argument handlers, none match)    │
+│     -> falls through to AddProblemDetails() default -> 500        │
+└─────────────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ LeafletTools.GenerateLeaflet (MCP)                                │
+│   var response = await _mediator.Send(...);                      │
+│   if (!response.Success) throw new McpException(...);            │
+│   catch (Exception) remains, for genuinely unexpected failures    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Where the empty-retrieval condition is signaled
+**Options considered:**
+(a) Keep throwing `EmptyRetrievalException`, move the catch to middleware/`IExceptionHandler`.
+(b) Return a `BaseResponse`-derived error DTO from the handler (the spec's choice), mapped by the existing `HandleResponse` + `[HttpStatusCode]` reflection mechanism.
+
+**Chosen approach:** (b), exactly as specified.
+
+**Rationale:** Option (a) would introduce a *second* error-signaling idiom into a codebase that has exactly one (`BaseResponse` + `HandleResponse`) everywhere else, including the other four Leaflet handlers. `EmptyRetrievalException` is not a genuinely exceptional/unexpected condition — "the KB doesn't cover this topic yet" is an anticipated business outcome of a search operation, structurally identical to `LeafletFeedbackNotFound` or `ArticleNotGenerated`, both of which are already response error codes, not exceptions. Domain exceptions should be reserved for truly unexpected failures (the embedding/chat client throwing), which is exactly what's left to fall through to the global pipeline. This keeps a single, consistent rule: **expected business outcomes are response values; only truly unexpected failures are exceptions.**
+
+#### Decision 2: Disposition of the "safety net" catch-all (the spec's now-resolved Open Question)
+**Options considered:**
+(a) Remove the controller's catch-all entirely; unexpected exceptions fall through to ASP.NET's global `ProblemDetails` pipeline, resulting in a generic 500.
+(b) Add a new `IExceptionHandler` (e.g. `ExternalServiceExceptionHandler`) alongside `UnauthorizedAccessExceptionHandler`/`ValidationExceptionHandler`/`ArgumentExceptionHandler`, mapping embedding/chat-client failures to 502 with a friendly message, preserving the current external contract for infra failures.
+
+**Chosen approach:** (a) — confirmed by the pipeline owner, matches the brief's explicit suggested fix ("remove the try/catch... rely on HandleResponse"). Treat as settled; do not re-litigate.
+
+**Rationale:** This aligns with the brief's own stated rationale ("silently catches all other exceptions as 502, which swallows potential bugs") and with the pattern already established for `UnauthorizedAccessException`/`ValidationException`/`ArgumentException` — infra-layer exception mapping lives in `Infrastructure/ExceptionHandling/*`, not in individual controllers. Scope is important: this decision applies *only* to `LeafletController.Generate`. It does not retroactively justify adding a generic external-service-failure `IExceptionHandler` as part of this fix — that remains explicitly out of scope per the spec, and should only be built later if a genuine cross-module need materializes (YAGNI — don't build the 502 middleware speculatively for one call site).
+
+#### Decision 3: Preserve HTTP 422, change body shape (accept the breaking body-shape change)
+**Options considered:**
+(a) Preserve both the status code and the exact `ProblemDetails { status, title, detail }` body shape (e.g., by having `HandleResponse` special-case this one error code to emit `ProblemDetails` instead of the DTO).
+(b) Preserve the status code (422) via `[HttpStatusCode]`, but let the body become the standard `GenerateLeafletResponse { success: false, errorCode, params }` shape, consistent with every other error in the module.
+
+**Chosen approach:** (b), as specified.
+
+**Rationale:** Option (a) would require a special case inside `HandleResponse` (used by every controller in the codebase, not just Leaflet) purely to preserve one endpoint's legacy body shape — that is exactly the kind of bespoke, non-uniform behavior this fix is meant to eliminate. There is exactly one internal consumer of the old shape (`LeafletGenerateTab.tsx`), and it is being updated in the same change (FR-7). No external/third-party consumers are known (this is an internal SPA + MCP tool, not a published public API with external versioning guarantees). Given a single known internal consumer already being fixed, breaking the body shape while holding the status code fixed is the right trade — it buys the same one-idiom consistency for the whole module.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files or directories beyond one deletion. All work is in existing files:
+
+```
+backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs                                      (add member)
+backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/
+    GenerateLeafletResponse.cs                                                                (add 2 ctors)
+    GenerateLeafletHandler.cs                                                                  (throw -> return)
+    EmptyRetrievalException.cs                                                                 (delete)
+backend/src/Anela.Heblo.API/Controllers/LeafletController.cs                                   (Generate: drop try/catch)
+backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs                                           (GenerateLeaflet: inspect response)
+frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx                                  (errorCode check, drop isApiError if unused elsewhere)
+frontend/src/api/generated/api-client.ts                                                        (auto-regenerated on build — do not hand-edit)
+```
+
+Test files to update in place (no new test files needed — this is a behavior-preserving-at-the-HTTP-status-level refactor):
+```
+backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
+backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs
+backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs
+```
+
+### Interfaces and Contracts
+
+- `ErrorCodes.LeafletEmptyRetrieval = 2504`, `[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]`, placed immediately after `LeafletFeedbackAlreadySubmitted = 2503` in the existing `// Leaflet module errors (25XX)` block — do not renumber or reorder existing members (their numeric values are the wire contract for the TS enum).
+- `GenerateLeafletResponse` gains the two-constructor shape already used by `SubmitLeafletFeedbackResponse`. No other property changes.
+- `LeafletController.Generate` signature changes from `Task<IActionResult>` to `Task<ActionResult<GenerateLeafletResponse>>` — required for `HandleResponse<T>`'s generic constraint (`where T : BaseResponse`) and consistent with every sibling action.
+- `[ProducesResponseType]` attributes on `Generate`: keep `200 -> GenerateLeafletResponse`, keep `400 -> ProblemDetails` (model validation, untouched), change `422` from `ProblemDetails` to `GenerateLeafletResponse`, remove `502` entirely (no code path produces it anymore).
+- `LeafletTools.GenerateLeaflet` keeps its outer `catch (McpException)` rethrow and generic `catch (Exception)` block (legitimate MCP boundary translation for real infra failures) but replaces the `catch (EmptyRetrievalException)` block with a post-`Send` `if (!response.Success)` check.
+
+### Data Flow
+
+**Empty-retrieval path (REST):**
+1. Client `POST /api/leaflet/generate` with a topic that has zero KB/leaflet hits.
+2. `GenerateLeafletHandler.Handle` returns early with `GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, { detail: "..." })`, `Success = false`.
+3. `LeafletController.Generate` calls `HandleResponse(result)` → reflects `[HttpStatusCode]` on `LeafletEmptyRetrieval` → `422` → `StatusCode(422, response)`.
+4. Generated TS client (`processLeaflet_Generate`) parses body as `GenerateLeafletResponse`, throws it via `throwException`.
+5. `LeafletGenerateTab.tsx` catches, checks `err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval`, shows amber banner.
+
+**Empty-retrieval path (MCP):**
+1. `LeafletTools.GenerateLeaflet` sends the same request, gets the same `Success = false` response.
+2. Inspects `response.Success`, throws `McpException` with the user-facing message — externally unchanged from today.
+
+**Unexpected failure path (e.g., embedding client throws) (REST):**
+1. Exception propagates out of `GenerateLeafletHandler.Handle`, uncaught by `LeafletController.Generate` (no try/catch left).
+2. ASP.NET's registered `IExceptionHandler`s run in order (`UnauthorizedAccessExceptionHandler`, `ValidationExceptionHandler`, `ArgumentExceptionHandler`) — none match a generic exception.
+3. Falls through to `AddProblemDetails()` default → generic `ProblemDetails` with status `500`, no Leaflet-specific message, no stack trace exposed (existing, already-correct behavior — not new to this fix).
+
+**Unexpected failure path (MCP):** unchanged — `LeafletTools`'s generic `catch (Exception)` still converts to `McpException("Leaflet generation failed. Please try again.")`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Monitoring/alerting dashboards keyed on HTTP 502 for "Leaflet generation transient failure" silently stop firing (502→500 change is real and was flagged in the spec) | Medium | Since the Open Question is now settled as full removal, explicitly check (grep) for any Azure/App Insights alert rule, dashboard, or synthetic monitor referencing `leaflet` + `502` before merging; if found, update it to watch for 500s on `POST /api/leaflet/generate` instead. This is an ops-config check, not a code change, and should not block the PR but should be a checklist item. |
+| Frontend 422 body-shape change breaks silently if `LeafletGenerateTab.tsx` (FR-7) is forgotten during implementation | High if missed | FR-7 is not optional — it must land in the **same PR** as FR-4 (controller change), not as a follow-up. Add an explicit test asserting `isApiError`-based branching is gone and `errorCode`-based branching is present (e.g., a component test mocking a thrown `GenerateLeafletResponse`). |
+| Deleting `EmptyRetrievalException.cs` before all three consumers (`GenerateLeafletHandler`, `LeafletController`, `LeafletTools`) are updated causes a compile break | Low (compiler catches it) | Order the change as: FR-1 (ErrorCodes) → FR-2 (response ctor) → FR-3 (handler) → FR-4 (controller) → FR-5 (MCP tool) → FR-6 (delete exception file) → FR-7 (frontend) → FR-8 (tests). Do FR-6 last, after `dotnet build` has zero references. |
+| `GenerateLeafletResponse`'s `Params["detail"]` string is in English while the frontend's own fallback copy is Czech; a future consumer might mistakenly display the English `Params["detail"]` to end users | Low | Not this fix's concern per FR-7 (the frontend already ignores the server string and uses its own Czech copy), but worth a one-line code comment on `Params["detail"]` in the handler noting it is for API-consumer/log diagnostics, not for direct end-user display, to prevent future misuse. |
+| `HandleResponse`'s `Forbid()` branch for `ErrorCodes.Forbidden` (used by `SubmitLeafletFeedbackHandler`) returns no body — irrelevant here since `LeafletEmptyRetrieval` maps to `UnprocessableEntity`, which falls into the `_ => StatusCode(...)` default arm and does carry the response body | None (verified, no action needed) | Already confirmed by reading `BaseApiController.HandleResponse`: `UnprocessableEntity` isn't one of the explicitly special-cased switch arms (`BadRequest`, `NotFound`, `Unauthorized`, `Forbidden`, `ServiceUnavailable`, `InternalServerError`), so it falls to `_ => StatusCode((int)statusCode, response)`, which does include the body. No gap. |
+
+## Specification Amendments
+
+The spec is implementation-ready as written. Two small clarifications to make explicit during implementation (not scope changes):
+
+1. **Open Question is closed.** Per the pipeline owner: full removal of the try/catch (spec's option (a) throughout FR-4/FR-8) is confirmed. Do not implement a scoped safety-net `IExceptionHandler` as part of this fix; that remains explicitly out of scope (as the spec's own "Out of Scope" section already states as a *possible* follow-up). `Generate_returns_502_on_unexpected_exception` in `LeafletControllerTests.cs` should be **replaced** (not deleted with no equivalent) with a test asserting the exception now propagates unhandled, mirroring the adjacent `Generate_propagates_OperationCanceledException` test, per FR-8's own guidance.
+2. **Implementation order matters for a clean compile.** The spec lists FR-1 through FR-8 in dependency order already; follow that order literally (ErrorCodes → response ctor → handler → controller → MCP tool → delete exception → frontend → tests) rather than parallelizing, since FR-3/FR-4/FR-5 all depend on FR-1/FR-2 existing, and FR-6 depends on FR-3/FR-4/FR-5 all being done first.
+
+No functional, contract, or scope changes to the spec are needed.
+
+## Prerequisites
+
+- None. No migrations, no new config, no new infrastructure. All target types (`BaseResponse`, `HandleResponse`, `ErrorCodes`, `IExceptionHandler` registrations) already exist and are exercised by other Leaflet handlers today.
+- A local `dotnet build` after the backend changes will auto-regenerate `frontend/src/api/generated/api-client.ts` per this project's existing OpenAPI-client-generation convention (`docs/development/api-client-generation.md`) — the frontend change (FR-7) must be written against the *regenerated* client's shape, not guessed at, since generated TS class field names/nullability can shift slightly. Regenerate first, then write FR-7.

--- a/artifacts/feat-3478/brief.md
+++ b/artifacts/feat-3478/brief.md
@@ -1,0 +1,53 @@
+## Module
+Leaflet
+
+## Finding
+`GenerateLeafletHandler` throws a domain exception when the knowledge base returns no results, forcing the controller to catch it and decide the HTTP status code:
+
+**Handler** (`backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs`, lines 63–67):
+```csharp
+if (kbHits.Count == 0 && leafletHits.Count == 0)
+{
+    throw new EmptyRetrievalException(
+        "Knowledge Base does not yet cover this topic; try a broader phrasing");
+}
+```
+
+**Controller** (`backend/src/Anela.Heblo.API/Controllers/LeafletController.cs`, lines 39–66):
+```csharp
+try
+{
+    var response = await _mediator.Send(request, ct);
+    return Ok(response);
+}
+catch (EmptyRetrievalException ex)
+{
+    return UnprocessableEntity(new ProblemDetails { Status = 422, ... });
+}
+catch (Exception ex)
+{
+    // maps all other exceptions to 502
+    return StatusCode(502, ...);
+}
+```
+
+Every other handler in the Leaflet module returns an error response object with an error code instead of throwing:
+- `SubmitLeafletFeedbackHandler` → `new SubmitLeafletFeedbackResponse(ErrorCodes.Forbidden, ...)`
+- `GetLeafletGenerationHandler` → `new GetLeafletGenerationResponse(ErrorCodes.LeafletFeedbackNotFound)`
+- `GetLeafletChunkDetailHandler` → `new GetLeafletChunkDetailResponse(ErrorCodes.LeafletChunkNotFound)`
+
+## Why it matters
+The forbidden practices in `docs/architecture/development_guidelines.md` explicitly state: **"Business logic in Controller class — Business logic should be in MediatR handlers."** The controller knowing that `EmptyRetrievalException` maps to HTTP 422 is a business-logic decision that belongs in the handler or in a shared exception-to-problem-details middleware. It also makes the controller import a domain exception type from the Application layer and silently catches *all other* exceptions as 502, which swallows potential bugs.
+
+The inconsistency also means two different error-signalling patterns co-exist in the same module, increasing cognitive load.
+
+## Suggested fix
+Minimal fix: replace the throw with a response error code.
+
+1. Add `ErrorCodes.EmptyRetrieval` (or reuse an existing generic code like `ErrorCodes.NoContent`).
+2. Have `GenerateLeafletHandler.Handle` return `new GenerateLeafletResponse(ErrorCodes.EmptyRetrieval) { ... }` with the user-facing detail in a response property instead of throwing.
+3. Remove the try/catch from `LeafletController.Generate` and rely on `HandleResponse` (already used by every other action in the controller) to produce the correct HTTP result.
+4. Delete `EmptyRetrievalException.cs` if it has no other consumers.
+
+---
+_Filed by daily arch-review routine on 2026-07-04._

--- a/artifacts/feat-3478/code-review.r1.md
+++ b/artifacts/feat-3478/code-review.r1.md
@@ -1,0 +1,18 @@
+# Code Review: GenerateLeafletHandler error-signaling consistency fix
+
+## Summary
+Whole-branch diff (12 files, backend handler/controller/MCP-tool/tests + frontend component/test/generated client) reviewed against `spec.r1.md`. The fix correctly replaces the thrown `EmptyRetrievalException` with a response-coded error (`ErrorCodes.LeafletEmptyRetrieval`) across all four consumers identified in the spec (handler, controller, MCP tool, frontend), deletes the now-dead exception type, and updates all affected tests. No correctness bugs found.
+
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+## Docs to Update
+None — this is an internal error-signaling consistency refactor with no change to documented setup steps, CLI commands, or project layout.
+
+## Overall Notes
+The unrelated `api-client.ts` churn (GetPackingStatisticsResponse, DqtUnsupportedTestType, etc.) is catch-up regeneration for already-merged backend changes on `origin/main` that hadn't been regenerated yet — inherent to running the generator now, not introduced by this feature. The pre-existing, unrelated backend test-project build break (`ConfigurationConstants.APP_VERSION` in `GetConfigurationHandlerTests.cs`) blocked running `dotnet test` for the backend changes in this diff; all backend test code was verified by careful manual reading instead of execution. Frontend tests were actually run and passed.

--- a/artifacts/feat-3478/impl/add-error-code.r1.md
+++ b/artifacts/feat-3478/impl/add-error-code.r1.md
@@ -1,0 +1,20 @@
+# Implementation: add-error-code
+
+## What was implemented
+Added a new `ErrorCodes` enum member, `LeafletEmptyRetrieval = 2504`, decorated with `[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]`, inserted immediately after `LeafletFeedbackAlreadySubmitted = 2503` in the Leaflet module errors (25XX) block. No existing members were renumbered or reordered.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` — added `LeafletEmptyRetrieval = 2504` (HTTP 422 UnprocessableEntity) to the Leaflet module errors (25XX) section.
+
+## Tests
+None. This is a pure enum-member addition with no branching logic to unit test in isolation; its effect will be exercised by tests added in later tasks once the handler/controller/MCP tool actually reference this error code.
+
+## How to verify
+1. Inspect `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` lines ~276-285 to confirm `LeafletEmptyRetrieval = 2504` is present with the `UnprocessableEntity` attribute, and that `LeafletChunkNotFound` (2501), `LeafletFeedbackNotFound` (2502), and `LeafletFeedbackAlreadySubmitted` (2503) remain unchanged.
+2. Build the Application project: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — builds with 0 errors (51 pre-existing warnings, unrelated to this change).
+
+## Notes
+- `dotnet build Anela.Heblo.sln` (the full solution) fails with a pre-existing, unrelated error: `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs(95,37): error CS0117: 'ConfigurationConstants' does not contain a definition for 'APP_VERSION'`. I confirmed via `git stash` that this error exists on the branch independent of this change (i.e., it reproduces with `ErrorCodes.cs` reverted to its pre-task state), so it is out of scope for this task. Verification was instead done by building the `Anela.Heblo.Application` project directly, which contains `ErrorCodes.cs` and compiles cleanly.
+
+## Status
+DONE_WITH_CONCERNS

--- a/artifacts/feat-3478/impl/controller-drops-trycatch.r1.md
+++ b/artifacts/feat-3478/impl/controller-drops-trycatch.r1.md
@@ -1,0 +1,83 @@
+# Implementation: controller-drops-trycatch
+
+## What was implemented
+`LeafletController.Generate` now matches every other action in the file: no try/catch,
+`return HandleResponse(result);`, return type `Task<ActionResult<GenerateLeafletResponse>>`.
+The action no longer catches `EmptyRetrievalException` (422), `OperationCanceledException`
+(rethrow), or generic `Exception` (502) — it delegates entirely to `BaseApiController.HandleResponse`,
+which already maps `ErrorCodes.LeafletEmptyRetrieval` to HTTP 422 via the
+`[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]` attribute on that enum value, and lets any
+unhandled exception (including `OperationCanceledException` and unexpected exceptions) propagate.
+
+The `[ProducesResponseType]` attributes were updated: the `502` attribute was removed entirely, and
+the `422` attribute's payload type changed from `ProblemDetails` to `GenerateLeafletResponse` (since
+`HandleResponse` now returns the response DTO itself on error, not a `ProblemDetails`). The `400`
+`ProblemDetails` attribute and its `using Microsoft.AspNetCore.Mvc;` were left untouched since
+`ProblemDetails` is still referenced by that attribute.
+
+`EmptyRetrievalException` is intentionally not deleted — `backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs`
+still references it (out of scope for this task). Confirmed via repo-wide grep that after this change,
+neither `LeafletController.cs` nor `LeafletControllerTests.cs` reference `EmptyRetrievalException` anymore.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs` — `Generate` action rewritten to drop
+  try/catch, delegate to `HandleResponse(result)`, return `Task<ActionResult<GenerateLeafletResponse>>`,
+  and updated `[ProducesResponseType]` attributes (removed 502, changed 422 payload type).
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs` — updated the three
+  `Generate_*` tests that exercised the old try/catch behavior:
+  - `Generate_returns_200_with_response_on_success` — assertion changed from
+    `Assert.IsType<OkObjectResult>(result)` to `Assert.IsType<OkObjectResult>(result.Result)` to match
+    the new `ActionResult<T>` return type.
+  - `Generate_returns_422_on_EmptyRetrievalException` replaced with
+    `Generate_returns_422_on_LeafletEmptyRetrieval_error`, which mocks the mediator to return a
+    `GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)` (response-based error, not an
+    exception) and asserts a 422 `ObjectResult` carrying that response DTO.
+  - `Generate_returns_502_on_unexpected_exception` replaced with `Generate_propagates_unexpected_exception`,
+    which asserts that an `InvalidOperationException` thrown by the mediator now propagates unhandled
+    out of `Generate` (mirroring the existing `Generate_propagates_OperationCanceledException` test,
+    which was left unchanged since its shape already matched the post-fix behavior).
+
+## Tests
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs` covers: 200 success,
+  422 via response-based error code, unhandled generic exception propagation, and unhandled
+  `OperationCanceledException` propagation for the `Generate` action (plus pre-existing unchanged
+  coverage for the other actions in the controller).
+
+## How to verify
+- `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj` — succeeded with 0 errors (160
+  pre-existing warnings unrelated to this change, plus one pre-existing non-fatal AccessMatrixGen
+  post-build script warning, also unrelated).
+- Manually traced `BaseApiController.HandleResponse` (`backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs`)
+  and `ErrorCodes.LeafletEmptyRetrieval` (`backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:283-284`,
+  tagged `[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]`) to confirm the 422 response-based path
+  is wired correctly end-to-end, since the test project cannot currently be compiled/run (see Notes).
+- Repo-wide grep confirmed `GenerateLeafletHandler` (`backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs:64-69`)
+  already returns the response-based `GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)`
+  on empty retrieval rather than throwing, so this controller change is consistent with the current
+  handler behavior.
+- Once the unrelated `GetConfigurationHandlerTests.cs` build break is fixed, run:
+  `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~LeafletControllerTests"`
+
+## Notes
+- KNOWN ISSUE (pre-existing, confirmed on `origin/main`, unrelated to this task): the
+  `Anela.Heblo.Tests` project fails to **build** due to a compile error in
+  `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs`
+  (`ConfigurationConstants.APP_VERSION` missing). This means the test file changes in this task could
+  not be validated with a compiler/test-runner "red/green" signal. I did not modify that unrelated
+  file. Instead, I verified correctness by: reading the full, current content of both files before
+  editing; confirming the exact shape of `GenerateLeafletResponse`'s constructor
+  (`GenerateLeafletResponse(ErrorCodes errorCode, Dictionary<string, string>? details = null)`) and
+  `ErrorCodes.LeafletEmptyRetrieval`'s HTTP-status mapping against the real source; and confirming via
+  grep that `GenerateLeafletHandler` already returns this response shape on empty retrieval (i.e. this
+  controller task is consistent with already-existing handler behavior, presumably from a prior task
+  in this same feature sequence).
+- No unused `using` directives needed removal: `EmptyRetrievalException` was never imported via its own
+  `using` in either file (it lives in the already-required
+  `Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet` namespace, needed for
+  `GenerateLeafletRequest`/`GenerateLeafletResponse`), and `ProblemDetails` (`Microsoft.AspNetCore.Mvc`)
+  is still needed for the `400` `[ProducesResponseType]` attribute.
+- `[FeatureAuthorize(Feature.Marketing_Leaflet, AccessLevel.Write)]` and `[HttpPost("generate")]` were
+  preserved exactly as they existed in the current code.
+
+## Status
+DONE

--- a/artifacts/feat-3478/impl/frontend-error-branch-fix.r1.md
+++ b/artifacts/feat-3478/impl/frontend-error-branch-fix.r1.md
@@ -1,0 +1,57 @@
+# Implementation: frontend-error-branch-fix
+
+## What was implemented
+
+Regenerated the OpenAPI TypeScript client from the updated backend (which now returns `GenerateLeafletResponse` with `errorCode: LeafletEmptyRetrieval` on HTTP 422 instead of throwing and returning `ProblemDetails`). Updated `LeafletGenerateTab.tsx`'s catch block to detect the empty-retrieval case via the typed response instance and its `errorCode` field instead of the old HTTP-status duck-typing (`ApiError`/`isApiError`). Added a new test file covering both the empty-retrieval banner and the generic-error banner paths, since no test previously existed for this component.
+
+Verified via generated code inspection that NSwag's `throwException` helper throws the parsed `result` object directly (not wrapped in an `ApiException`), so `err instanceof GenerateLeafletResponse` is the correct/only check needed — no `.response`/`.result` unwrapping required.
+
+## Files created/modified
+
+- `frontend/src/api/generated/api-client.ts` — regenerated via `dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateFrontendClientManual` (after `dotnet tool restore` to make `nswag` available). Confirms `ErrorCodes.LeafletEmptyRetrieval` now exists and the `leaflet_Generate` 422 branch parses/throws `GenerateLeafletResponse.fromJS(...)` (previously `ProblemDetails.fromJS(...)`). This regeneration also picked up unrelated churn from other in-flight backend work (a new `GetPackingStatistics`-related set of DTOs/classes) — this is normal full-spec regeneration output, not hand-edited or stripped.
+- `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx` — replaced the `ApiError`/`isApiError` HTTP-status duck-typing helper with a typed check: `err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval`. Imports `ErrorCodes` and `GenerateLeafletResponse` from `../../api/generated/api-client`. The old helper interface/function was removed since nothing else in the file used it. No other logic, JSX, or unrelated code was touched.
+- `frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx` (new) — two tests:
+  1. Mocked `client.leaflet_Generate` rejects with a `GenerateLeafletResponse` instance (`success: false`, `errorCode: ErrorCodes.LeafletEmptyRetrieval`) → asserts the `role="alert"` banner shows `'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.'` with the amber (`bg-amber-100`) class.
+  2. Mocked `client.leaflet_Generate` rejects with a generic `Error` → asserts the banner shows `'Generování selhalo. Zkuste to prosím znovu.'` with the red (`bg-red-100`) class.
+
+  Mocks `../../../api/client` (`getAuthenticatedApiClient`), and — following the existing pattern in `LeafletResult.test.tsx` — mocks `react-markdown` (ESM-only, breaks Jest's CJS transform) and `../../../api/hooks/useLeaflet` (`useSubmitLeafletFeedbackMutation`), both of which are transitively imported via `LeafletResult`, which `LeafletGenerateTab` renders.
+
+## Tests
+
+Ran: `cd frontend && npx react-scripts test src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx --watchAll=false`
+
+```
+PASS src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx
+  LeafletGenerateTab
+    ✓ shows the insufficient knowledge banner when the API rejects with LeafletEmptyRetrieval (105 ms)
+    ✓ shows the transient failure banner for a generic error (25 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       2 passed, 2 total
+```
+
+Also ran the full leaflet-generator suite to check for regressions: `cd frontend && npx react-scripts test src/features/leaflet-generator --watchAll=false`
+
+```
+Test Suites: 7 passed, 7 total
+Tests:       54 passed, 54 total
+```
+
+`LeafletGeneratorPage.test.tsx` (which mocks `LeafletGenerateTab` wholesale) is unaffected, as expected.
+
+## How to verify
+
+1. `cd frontend && npx react-scripts test src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx --watchAll=false`
+2. `cd frontend && npx react-scripts test src/features/leaflet-generator --watchAll=false`
+3. `cd frontend && npm run build` (production build)
+4. `cd frontend && npm run lint` (repo-wide; only pre-existing issues remain elsewhere — `npx eslint src/features/leaflet-generator/LeafletGenerateTab.tsx src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx` in isolation is clean)
+
+## Notes
+
+- `frontend/node_modules` was not present in the worktree; installed with `npm install --legacy-peer-deps` (matches the flag used in `.github/workflows/ci-feature-branch.yml` / `ci-main-branch.yml`, since a plain `npm ci`/`npm install` hits an ERESOLVE peer-dependency conflict between `typescript@4.9.5` and `react-i18next`'s `typescript@^5` peer — pre-existing, unrelated to this change).
+- `dotnet tool restore` was required before `dotnet msbuild -t:GenerateFrontendClientManual` would work (the `nswag` local tool wasn't restored in this worktree yet); this is a one-time environment setup step, not a code change.
+- `npm run lint` reports 148 pre-existing errors / 15 warnings across the wider frontend codebase (mostly `testing-library/no-node-access` and `no-wait-for-multiple-assertions` in unrelated test files) — none of these are in files touched by this task, and are explicitly out of scope per the task instructions.
+- The regenerated `api-client.ts` includes unrelated additions (`GetPackingStatisticsResponse` and related DTOs) from other in-flight backend work already present in this worktree's backend source. This is expected/normal full-spec regeneration output and was included as-is, per the task instructions.
+
+## Status
+DONE

--- a/artifacts/feat-3478/impl/handler-returns-response.r1.md
+++ b/artifacts/feat-3478/impl/handler-returns-response.r1.md
@@ -1,0 +1,30 @@
+# Implementation: handler-returns-response
+
+## What was implemented
+Replaced the `throw new EmptyRetrievalException(...)` in `GenerateLeafletHandler.Handle` with an early
+`return new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)` when both `kbHits` and
+`leafletHits` are empty. This uses the `GenerateLeafletResponse(ErrorCodes, Dictionary<string,string>?)`
+constructor and `ErrorCodes.LeafletEmptyRetrieval = 2504`, both already committed in prior tasks
+(`add-error-code`, `response-error-constructor`). The `EmptyRetrievalException` class itself was left
+untouched — it is still referenced by `LeafletController` and `LeafletTools`, which will be updated in
+later tasks in this pipeline.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs` — added `using Anela.Heblo.Application.Shared;`; replaced the throw on dual-empty retrieval with a `return new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } })`. No other lines changed.
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs` — added `using Anela.Heblo.Application.Shared;` (alphabetically ordered among existing usings); renamed/rewrote `Handle_dual_empty_retrieval_throws_EmptyRetrievalException` to `Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error`, asserting `response.Success == false`, `response.ErrorCode == ErrorCodes.LeafletEmptyRetrieval`, and `response.Params["detail"]` containing the expected diagnostic text, instead of asserting a thrown exception.
+
+## Tests
+- `GenerateLeafletHandlerTests.Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error` — verifies that when both KB and leaflet similarity search return zero hits, the handler returns (rather than throws) a `GenerateLeafletResponse` with `Success = false`, `ErrorCode = ErrorCodes.LeafletEmptyRetrieval`, and a `Params["detail"]` entry containing "Knowledge Base does not yet cover this topic".
+- All other existing tests in the file were read and confirmed unaffected (mock field names `_kb`/`_leaflets`, `SetupEmbeddings()`, `CreateHandler()`, and request-construction pattern all matched the sketch in the task exactly — no adaptation was needed).
+
+## How to verify
+- `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — succeeds with 0 errors (139 pre-existing warnings unrelated to this change).
+- Test file was verified by careful manual reading against the actual handler signature (`GenerateLeafletResponse(ErrorCodes, Dictionary<string,string>?)`), `BaseResponse` fields (`Success`, `ErrorCode`, `Params`), and the other passing tests' helper/mock usage in the same file — types, method signatures, and mock setups all line up.
+- Once the unrelated `Anela.Heblo.Tests` build break (`ConfigurationConstants.APP_VERSION` missing in `GetConfigurationHandlerTests.cs`) is fixed by another task, run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GenerateLeafletHandlerTests"` to confirm the whole test class (including the new/renamed test) passes.
+
+## Notes
+- **Known limitation**: `Anela.Heblo.Tests` currently fails to *build* (not just fails tests) due to a pre-existing, unrelated compile error in `GetConfigurationHandlerTests.cs` (`ConfigurationConstants.APP_VERSION` missing), confirmed present on `origin/main` before this feature branch existed. `dotnet test` could not be run as a result. Correctness of the new/renamed test was instead verified by careful reading: the mock objects (`_kb`, `_leaflets`, `_embeddings`), `SetupEmbeddings()`, `CreateHandler()`, and `GenerateLeafletRequest` construction pattern all matched exactly what other passing tests in the same file already use, and the response shape (`Success`, `ErrorCode`, `Params`) matches `BaseResponse`'s error constructor exactly.
+- Only the intended lines changed in the handler; no other behavior (word-length switch, audience label switch, cold-start logging, chat calls) was touched.
+
+## Status
+DONE_WITH_CONCERNS

--- a/artifacts/feat-3478/impl/mcp-tool-inspects-response.r1.md
+++ b/artifacts/feat-3478/impl/mcp-tool-inspects-response.r1.md
@@ -1,0 +1,33 @@
+# Implementation: mcp-tool-inspects-response
+
+## What was implemented
+`LeafletTools.GenerateLeaflet` no longer catches `EmptyRetrievalException` (that exception is never thrown by the handler anymore — the handler returns a failed `GenerateLeafletResponse` instead). The MCP tool now inspects `response.Success` after calling `_mediator.Send(...)` and throws `McpException` before serializing when the call failed, so the MCP boundary never silently returns a `success: false` JSON payload as if it were a normal result.
+
+- If `response.Success` is `false` and `response.ErrorCode == ErrorCodes.LeafletEmptyRetrieval`, the tool throws `McpException("Knowledge Base does not yet cover this topic; try a broader phrasing")`.
+- For any other failed response, it throws `McpException("Leaflet generation failed. Please try again.")`.
+- Only on `response.Success == true` does it return `JsonSerializer.Serialize(response)`.
+- The outer `catch (McpException) { throw; }` and `catch (Exception ex) { ...log...; throw new McpException("Leaflet generation failed. Please try again."); }` blocks are unchanged — they still translate genuinely unexpected exceptions (not business-logic failures) at the MCP protocol boundary.
+- Added `using Anela.Heblo.Application.Shared;` to both the implementation and test file (for `ErrorCodes`).
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs` — removed the `catch (EmptyRetrievalException ex)` block; added a `response.Success` check after `_mediator.Send(...)` that throws `McpException` with the appropriate message before returning the serialized response.
+- `backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs` — replaced `GenerateLeaflet_wraps_EmptyRetrievalException_as_McpException` (which mocked the mediator to throw `EmptyRetrievalException`) with `GenerateLeaflet_throws_McpException_on_LeafletEmptyRetrieval_response` (which mocks the mediator to return a `GenerateLeafletResponse` constructed with `ErrorCodes.LeafletEmptyRetrieval`), asserting the thrown `McpException.Message` equals the expected user-facing message.
+
+## Tests
+- `backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs`:
+  - `GenerateLeaflet_returns_serialized_response_on_success` — unchanged, still covers the happy path.
+  - `GenerateLeaflet_throws_McpException_on_invalid_audience` / `_on_invalid_length` — unchanged, cover input validation.
+  - `GenerateLeaflet_throws_McpException_on_LeafletEmptyRetrieval_response` — new/replaced test covering the `response.Success == false` + `ErrorCode == ErrorCodes.LeafletEmptyRetrieval` path now that the handler returns a failed response instead of throwing.
+  - `GenerateLeaflet_wraps_unexpected_exception_with_generic_message` — unchanged, still covers the generic `catch (Exception ex)` path and logger verification.
+
+## How to verify
+- `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj` — succeeds with 0 errors (160 pre-existing warnings unrelated to this change, plus a pre-existing non-fatal post-build AccessMatrixGen tool warning that does not affect compilation).
+- `grep -n EmptyRetrievalException backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs` — no matches (confirmed dead code fully removed).
+- Manual code read of `LeafletToolsTests.cs` confirms the new test's mock setup (`ReturnsAsync(errorResponse)` where `errorResponse = new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)`) matches `GenerateLeafletResponse`'s actual constructor signature (`GenerateLeafletResponse(ErrorCodes errorCode, Dictionary<string, string>? details = null)`) and `BaseResponse.Success` (set to `false` by that constructor), so the assertion path exercises the new `if (!response.Success)` branch correctly.
+
+## Notes
+- Per the task's known-issue callout, `Anela.Heblo.Tests` cannot currently be built/run via `dotnet test` because of a pre-existing, unrelated compile error in `GetConfigurationHandlerTests.cs` (missing `ConfigurationConstants.APP_VERSION`), confirmed present on `origin/main`. This is not addressed here. Test correctness for `LeafletToolsTests.cs` was instead verified by careful manual reading against the real `GenerateLeafletResponse`/`BaseResponse` source (confirmed `Success`/`ErrorCode` properties and the two-arg error constructor exist exactly as used).
+- No other references to `EmptyRetrievalException` remain in `LeafletTools.cs`; the `using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;` was kept since `GenerateLeafletRequest`/`GenerateLeafletResponse` still live there and are still used.
+
+## Status
+DONE

--- a/artifacts/feat-3478/impl/remove-exception-and-tests.r1.md
+++ b/artifacts/feat-3478/impl/remove-exception-and-tests.r1.md
@@ -1,0 +1,23 @@
+# Implementation: remove-exception-and-tests
+
+## What was implemented
+Deleted `EmptyRetrievalException.cs` after confirming (via repo-wide grep) it had zero remaining consumers following the previous three tasks (handler, controller, MCP tool).
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs` — deleted.
+
+## Tests
+No new tests — this is a pure deletion of dead code, already covered by the prior tasks' test updates.
+
+## How to verify
+```bash
+grep -rn "EmptyRetrievalException" backend/ --include="*.cs"   # expect no output
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj   # 0 errors
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj                   # 0 errors
+```
+
+## Notes
+`dotnet test`/full-solution build still blocked by the pre-existing, unrelated `ConfigurationConstants.APP_VERSION` compile error (confirmed on `origin/main`), unrelated to this deletion.
+
+## Status
+DONE

--- a/artifacts/feat-3478/impl/response-error-constructor.r1.md
+++ b/artifacts/feat-3478/impl/response-error-constructor.r1.md
@@ -1,0 +1,24 @@
+# Implementation: response-error-constructor
+
+## What was implemented
+Added the two-constructor shape to `GenerateLeafletResponse` (parameterless success constructor + `(ErrorCodes errorCode, Dictionary<string, string>? details = null)` error constructor calling the matching `BaseResponse` constructor), matching the pattern used by `SubmitLeafletFeedbackResponse`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs` — added the two constructors; no other changes.
+
+## Tests
+None added — this is a pure constructor addition to a DTO with no behavior of its own (verified `BaseResponse`'s matching constructor signature first). It is exercised by the handler test added in the next task (`handler-returns-response`).
+
+## How to verify
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+Build succeeds with 0 errors. The existing success-path object-initializer usage in `GenerateLeafletHandler.cs` (`new GenerateLeafletResponse { Content = ..., ... }`) still compiles unchanged since the parameterless constructor remains.
+
+Note: `dotnet test`/`dotnet build` at the solution or full-test-project level currently fail repo-wide due to a **pre-existing, unrelated** error (`ConfigurationConstants.APP_VERSION` missing in `GetConfigurationHandlerTests.cs`), confirmed present on `origin/main` before this branch existed. Verification here was scoped to the `Anela.Heblo.Application` project directly, which builds clean.
+
+## Notes
+No deviations from the task context. `BaseResponse`'s protected constructor `(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)` matches the snippet exactly.
+
+## Status
+DONE_WITH_CONCERNS

--- a/artifacts/feat-3478/review/add-error-code.r1.md
+++ b/artifacts/feat-3478/review/add-error-code.r1.md
@@ -1,0 +1,9 @@
+# Code Review: add-error-code
+
+## Summary
+Pure enum-member addition, verified against the task context and the actual diff (commit 087d3f8). Value 2504 is unique, correctly placed after LeafletFeedbackAlreadySubmitted, tagged with the correct HttpStatusCode attribute, no existing members renumbered or reordered. Build of the Application project confirms 0 errors, only pre-existing warnings.
+
+## Review Result: PASS
+
+### task: add-error-code
+**Status:** PASS

--- a/artifacts/feat-3478/review/controller-drops-trycatch.r1.md
+++ b/artifacts/feat-3478/review/controller-drops-trycatch.r1.md
@@ -1,0 +1,9 @@
+# Code Review: controller-drops-trycatch
+
+## Summary
+Verified against commit b93a44c: `LeafletController.Generate` now delegates entirely to `HandleResponse(result)`, no try/catch remains, return type is `Task<ActionResult<GenerateLeafletResponse>>`, and the `502` ProducesResponseType is removed while `422` now points at `GenerateLeafletResponse`. Confirmed `HandleResponse`'s switch statement maps `HttpStatusCode.UnprocessableEntity` to `StatusCode(422, response)` (the default arm), so the rewritten test's `Assert.IsType<ObjectResult>(result.Result); Assert.Equal(422, ...)` assertions are correct against the real implementation. The three rewritten tests (200 success, 422 error-response, propagated-exception) and the untouched OperationCanceledException test all match actual code paths. Repo-wide grep confirms no remaining `EmptyRetrievalException` reference in either file (still referenced by the out-of-scope `LeafletTools.cs`, addressed in a later task).
+
+## Review Result: PASS
+
+### task: controller-drops-trycatch
+**Status:** PASS

--- a/artifacts/feat-3478/review/frontend-error-branch-fix.r1.md
+++ b/artifacts/feat-3478/review/frontend-error-branch-fix.r1.md
@@ -1,0 +1,9 @@
+# Code Review: frontend-error-branch-fix
+
+## Summary
+Verified against commit eaf0766: `LeafletGenerateTab.tsx`'s catch block now checks `err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval`, replacing the old HTTP-status duck-typing (`isApiError`/`ApiError` removed cleanly, nothing else in the file used them). New test file has 2 passing tests (verified via actual reported test run: `Tests: 2 passed, 2 total`), and the full leaflet-generator suite regression check passed (`7 passed, 7 total / 54 passed, 54 total`). `npm run build` compiled successfully; lint on the two touched files is clean (repo-wide pre-existing lint errors are unrelated). The 454-line `api-client.ts` diff includes unrelated catch-up regeneration for an already-merged backend endpoint (`GetPackingStatisticsResponse`) that had never been regenerated on main — confirmed this is pre-existing staleness, not scope creep introduced by this task.
+
+## Review Result: PASS
+
+### task: frontend-error-branch-fix
+**Status:** PASS

--- a/artifacts/feat-3478/review/handler-returns-response.r1.md
+++ b/artifacts/feat-3478/review/handler-returns-response.r1.md
@@ -1,0 +1,9 @@
+# Code Review: handler-returns-response
+
+## Summary
+Verified against commit 45466f1: the handler no longer throws `EmptyRetrievalException`; it returns `GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)` with the detail message preserved. The rewritten test's mock fields, helpers, and request construction match the rest of the file. Only the two intended files changed, no unrelated lines touched, `EmptyRetrievalException.cs` untouched (deletion is a later task).
+
+## Review Result: PASS
+
+### task: handler-returns-response
+**Status:** PASS

--- a/artifacts/feat-3478/review/mcp-tool-inspects-response.r1.md
+++ b/artifacts/feat-3478/review/mcp-tool-inspects-response.r1.md
@@ -1,0 +1,9 @@
+# Code Review: mcp-tool-inspects-response
+
+## Summary
+Verified against commit e4cd1a1: `LeafletTools.GenerateLeaflet` now checks `response.Success` after `_mediator.Send`, throwing `McpException` with the correct message for `ErrorCodes.LeafletEmptyRetrieval` and a generic message otherwise. The dead `catch (EmptyRetrievalException)` block is removed while the `McpException` rethrow and generic `catch (Exception)` (legitimate MCP boundary translation) are preserved. Test rewritten to mock a response-based failure instead of a thrown exception, asserting the same externally-observable message. Zero remaining references to `EmptyRetrievalException` in either file.
+
+## Review Result: PASS
+
+### task: mcp-tool-inspects-response
+**Status:** PASS

--- a/artifacts/feat-3478/review/remove-exception-and-tests.r1.md
+++ b/artifacts/feat-3478/review/remove-exception-and-tests.r1.md
@@ -1,0 +1,9 @@
+# Code Review: remove-exception-and-tests
+
+## Summary
+Verified via `grep -rn "EmptyRetrievalException" backend/ --include="*.cs"` — zero matches after deletion. Both affected projects (Application, API) build clean with 0 errors.
+
+## Review Result: PASS
+
+### task: remove-exception-and-tests
+**Status:** PASS

--- a/artifacts/feat-3478/review/response-error-constructor.r1.md
+++ b/artifacts/feat-3478/review/response-error-constructor.r1.md
@@ -1,0 +1,9 @@
+# Code Review: response-error-constructor
+
+## Summary
+Verified against commit fb7fbca and `BaseResponse.cs`: the added constructor signature `(ErrorCodes errorCode, Dictionary<string, string>? details = null)` matches `BaseResponse`'s protected `(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)` constructor exactly. Parameterless constructor preserves existing success-path object-initializer usage. Application project builds clean.
+
+## Review Result: PASS
+
+### task: response-error-constructor
+**Status:** PASS

--- a/artifacts/feat-3478/spec.r1.md
+++ b/artifacts/feat-3478/spec.r1.md
@@ -1,0 +1,260 @@
+# Specification: `GenerateLeafletHandler` error-signaling consistency fix
+
+## Summary
+`GenerateLeafletHandler` (Leaflet module) currently throws a domain exception (`EmptyRetrievalException`) when the knowledge base and leaflet style corpus both return zero relevant hits, forcing `LeafletController.Generate` to catch that exception and a generic `Exception` to decide HTTP status codes — a business-logic decision that belongs in the handler, and a pattern inconsistent with every other handler in the module. This fix converts the empty-retrieval case into a normal error-code response (`ErrorCodes.LeafletEmptyRetrieval`) returned by the handler, lets the existing `HandleResponse` helper produce the HTTP result (as every sibling Leaflet action already does), removes the controller's try/catch and its dependency on an Application-layer exception type, and deletes the now-dead `EmptyRetrievalException` type and its remaining consumer-side workarounds.
+
+## Background
+An architecture-review finding (filed 2026-07-04) identified that `GenerateLeafletHandler.Handle` (`backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs`, lines 63–67) throws `EmptyRetrievalException` when `kbHits.Count == 0 && leafletHits.Count == 0`, and that `LeafletController.Generate` (`backend/src/Anela.Heblo.API/Controllers/LeafletController.cs`, lines 39–66) wraps the `_mediator.Send` call in a try/catch that maps `EmptyRetrievalException` → HTTP 422 and any other exception → HTTP 502, with a friendly message.
+
+This is inconsistent with every other handler in the same module:
+- `SubmitLeafletFeedbackHandler` returns `new SubmitLeafletFeedbackResponse(ErrorCodes.Forbidden, ...)` / `ErrorCodes.LeafletFeedbackNotFound` / `ErrorCodes.LeafletFeedbackAlreadySubmitted`.
+- `GetLeafletGenerationHandler` returns `new GetLeafletGenerationResponse(ErrorCodes.LeafletFeedbackNotFound)`.
+- `GetLeafletChunkDetailHandler` returns `new GetLeafletChunkDetailResponse(ErrorCodes.LeafletChunkNotFound)`.
+
+All three response types derive from `BaseResponse` (`backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs`), which carries `Success`, `ErrorCode` (an `ErrorCodes` enum value), and an optional `Params` dictionary. `BaseApiController.HandleResponse<T>` (`backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs`) inspects `response.Success`/`response.ErrorCode`, looks up the `[HttpStatusCode(...)]` attribute on the matching `ErrorCodes` enum member via reflection, and returns the corresponding `ActionResult`. Every other action in `LeafletController` already calls `return HandleResponse(result);` with no try/catch. `docs/architecture/development_guidelines.md` lists "Business logic in Controller class" as a forbidden practice — the controller currently owns the exception→status-code mapping for this one case, which is exactly that.
+
+Per `docs/architecture/development_guidelines.md`, this fix does not change module boundaries or persistence — it is a pure consistency/refactor fix confined to the Leaflet module (Application + API layers) plus its two callers.
+
+## Functional Requirements
+
+### FR-1: Add a dedicated `ErrorCodes` member for the empty-retrieval condition
+Add a new member to the Leaflet section (25XX range) of `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`, immediately after the existing `LeafletFeedbackAlreadySubmitted = 2503`:
+
+```csharp
+[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]
+LeafletEmptyRetrieval = 2504,
+```
+
+Tagging it `UnprocessableEntity` preserves the current external HTTP contract (422) for this specific condition — no client-visible status-code regression.
+
+**Acceptance criteria:**
+- `ErrorCodes.LeafletEmptyRetrieval = 2504` exists in the `// Leaflet module errors (25XX)` block.
+- It is decorated with `[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]`.
+- `frontend/src/api/generated/api-client.ts`'s generated `ErrorCodes` TS enum includes `LeafletEmptyRetrieval` after the next OpenAPI client regeneration (automatic on build per project conventions — no manual edit).
+
+### FR-2: Give `GenerateLeafletResponse` an error-constructing constructor
+`GenerateLeafletResponse` (`backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`) currently has only the implicit parameterless constructor. Add the same two-constructor shape used by `SubmitLeafletFeedbackResponse`:
+
+```csharp
+public GenerateLeafletResponse() { }
+
+public GenerateLeafletResponse(ErrorCodes errorCode, Dictionary<string, string>? details = null)
+    : base(errorCode, details) { }
+```
+
+**Acceptance criteria:**
+- `new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)` compiles and sets `Success = false`, `ErrorCode = ErrorCodes.LeafletEmptyRetrieval`, `Params` as passed, per `BaseResponse`'s existing constructor behavior.
+- The success-path usage (`new GenerateLeafletResponse { Content = ..., KbSourceCount = ..., LeafletSourceCount = ... }`, lines 134–139 of the handler) is unaffected — `Success` defaults to `true` via `BaseResponse`'s parameterless constructor.
+
+### FR-3: `GenerateLeafletHandler` returns an error response instead of throwing
+Replace lines 63–67 of `GenerateLeafletHandler.Handle`:
+
+```csharp
+if (kbHits.Count == 0 && leafletHits.Count == 0)
+{
+    throw new EmptyRetrievalException(
+        "Knowledge Base does not yet cover this topic; try a broader phrasing");
+}
+```
+
+with an early return:
+
+```csharp
+if (kbHits.Count == 0 && leafletHits.Count == 0)
+{
+    return new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+        new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
+}
+```
+
+The user-facing detail text is preserved verbatim in `Params["detail"]` (same key convention as the `"generationId"` param used by `SubmitLeafletFeedbackHandler`/others), rather than being lost. No other line in the handler changes — the KB/leaflet retrieval calls above this check, and the two-stage LLM generation below it, are untouched.
+
+**Acceptance criteria:**
+- When both `kbHits` and `leafletHits` are empty, `Handle` returns (does not throw) a `GenerateLeafletResponse` with `Success == false`, `ErrorCode == ErrorCodes.LeafletEmptyRetrieval`, and `Params["detail"]` containing the original message text.
+- When either collection is non-empty, behavior is unchanged (existing cold-start logging and two-stage generation still run).
+- `GenerateLeafletHandler.cs` no longer references `EmptyRetrievalException`.
+
+### FR-4: `LeafletController.Generate` delegates to `HandleResponse`
+Replace the entire method body (lines 37–67 of `LeafletController.cs`), including the try/catch for `EmptyRetrievalException`, `OperationCanceledException`, and the catch-all `Exception` → 502 mapping, with the same shape used by every other action in the file:
+
+```csharp
+[HttpPost("generate")]
+[FeatureAuthorize(Feature.Marketing_Leaflet, AccessLevel.Write)]
+[ProducesResponseType(typeof(GenerateLeafletResponse), 200)]
+[ProducesResponseType(typeof(ProblemDetails), 400)]
+[ProducesResponseType(typeof(GenerateLeafletResponse), 422)]
+public async Task<ActionResult<GenerateLeafletResponse>> Generate([FromBody] GenerateLeafletRequest request, CancellationToken ct)
+{
+    var result = await _mediator.Send(request, ct);
+    return HandleResponse(result);
+}
+```
+
+Notes on the specific attribute/signature changes:
+- Return type changes from `Task<IActionResult>` to `Task<ActionResult<GenerateLeafletResponse>>`, matching every other action in this controller (`GetChunkDetail`, `SubmitFeedback`, `GetGeneration`, etc.) and `HandleResponse<T>`'s signature.
+- The `[ProducesResponseType(typeof(ProblemDetails), 422)]` attribute is changed to `typeof(GenerateLeafletResponse)`, because `HandleResponse` now returns the actual `GenerateLeafletResponse` DTO (with `success: false`, `errorCode`, `params`) on the 422 path, not a `ProblemDetails` object. This is a **breaking change to the documented/generated 422 response shape** — see FR-6.
+- The `[ProducesResponseType(typeof(ProblemDetails), 400)]` attribute is retained: it reflects ASP.NET's automatic `[ApiController]` model-validation response (triggered by the `[Required]`/`[MinLength]`/`[MaxLength]` attributes on `GenerateLeafletRequest`), which is unrelated to this fix and unaffected by it.
+- The `[ProducesResponseType(typeof(ProblemDetails), 502)]` attribute is removed — there is no code path left in this action that produces a 502. Any genuinely unexpected exception (e.g., an embedding/chat-client failure) now propagates out of the action to ASP.NET's global exception-handling pipeline (`services.AddExceptionHandler<...>()` + `services.AddProblemDetails()` in `ServiceCollectionExtensions.AddCrossCuttingServices`), which returns a generic `ProblemDetails` response. **This changes the status code for unexpected failures from 502 to whatever the global pipeline's default is (500, since no registered `IExceptionHandler` specifically matches generic exceptions) and drops the custom "Leaflet generation failed. Please try again." message.** This is a deliberate consequence of removing the catch-all per the brief's rationale ("silently catches all other exceptions as 502, which swallows potential bugs") — see Open Questions for confirmation before implementation.
+
+**Acceptance criteria:**
+- `LeafletController.Generate` contains no try/catch block.
+- `LeafletController.cs` no longer references `EmptyRetrievalException`.
+- A mocked `IMediator.Send` returning a `GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)` causes `Generate` to return an `ObjectResult`/`UnprocessableEntityObjectResult` with `StatusCode == 422` and `Value` equal to that same `GenerateLeafletResponse` instance (via `HandleResponse`'s existing `StatusCode` switch, default arm).
+- A mocked `IMediator.Send` returning a successful `GenerateLeafletResponse` causes `Generate` to return `OkObjectResult` with that response, unchanged from today.
+- A mocked `IMediator.Send` that throws (e.g., `InvalidOperationException`) is **not** caught by `Generate` — it propagates out of the action (verified by an integration-level or middleware test, not a controller-unit-test catch expectation).
+
+### FR-5: Update the MCP tool consumer (`LeafletTools.GenerateLeaflet`)
+`backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs` (lines 52–55) also catches `EmptyRetrievalException` and rethrows it as `McpException(ex.Message)`. Once `GenerateLeafletHandler` stops throwing that exception (FR-3), this catch block becomes dead code and the MCP tool would silently return a "successful" JSON payload with `success: false` instead of surfacing an MCP-level error. Update `GenerateLeaflet` to check the response after the `_mediator.Send` call, mirroring how a non-throwing handler result should be surfaced over MCP:
+
+```csharp
+var response = await _mediator.Send(new GenerateLeafletRequest
+{
+    Topic = topic,
+    Audience = audienceEnum,
+    Length = lengthEnum
+}, ct);
+
+if (!response.Success)
+{
+    var message = response.ErrorCode == ErrorCodes.LeafletEmptyRetrieval
+        ? "Knowledge Base does not yet cover this topic; try a broader phrasing"
+        : "Leaflet generation failed. Please try again.";
+    throw new McpException(message);
+}
+
+return JsonSerializer.Serialize(response);
+```
+
+Remove the now-unreachable `catch (EmptyRetrievalException ex) { throw new McpException(ex.Message); }` block (lines 52–55). Keep the existing `catch (McpException)` rethrow and the generic `catch (Exception ex)` → `McpException("Leaflet generation failed. Please try again.")` block — those handle genuinely unexpected failures (e.g., embedding/chat client exceptions) and are a legitimate MCP-protocol boundary translation, not the "business logic in caller" problem the brief targets.
+
+**Acceptance criteria:**
+- `LeafletTools.cs` no longer references `EmptyRetrievalException`.
+- A mocked `IMediator.Send` returning `GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)` causes `GenerateLeaflet` to throw `McpException` with the empty-retrieval message (same externally-observable behavior as before, achieved via response inspection instead of exception catching).
+- A mocked `IMediator.Send` returning a successful response still returns the serialized JSON payload, unchanged.
+
+### FR-6: Delete `EmptyRetrievalException`
+After FR-4 and FR-5 land, `EmptyRetrievalException` (`backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs`) has zero remaining consumers (confirmed: only `LeafletController.cs` and `LeafletTools.cs` referenced it; both are updated by this fix). Delete the file.
+
+**Acceptance criteria:**
+- `EmptyRetrievalException.cs` is removed from the repository.
+- A repo-wide search for `EmptyRetrievalException` returns no matches outside of removed/updated test files (see FR-8).
+
+### FR-7: Frontend: fix the 422 error-shape regression in `LeafletGenerateTab.tsx`
+Changing the `[ProducesResponseType]` attribute for the 422 case (FR-4) from `ProblemDetails` to `GenerateLeafletResponse` changes what the auto-generated TypeScript client (`frontend/src/api/generated/api-client.ts`, regenerated automatically on build) parses and throws for a 422 response. Today, `processLeaflet_Generate` parses 422 bodies as `ProblemDetails` and `throwException` throws that parsed object directly, so the caught `err` has `.status` (422) and `.detail` (the message) — which is exactly what `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`'s `isApiError`/`ApiError` duck-typing (lines 7–19) checks for.
+
+After this fix, the thrown `err` on a 422 will instead be a `GenerateLeafletResponse` instance (fields: `success`, `errorCode`, `params`, `content`, `id`, `kbSourceCount`, `leafletSourceCount` — inherited from `BaseResponse`/`GenerateLeafletResponse`'s generated TS classes). It has **no `status` field**, so `isApiError(err)` will return `false` for this case, and the component's `catch` block (lines 39–52) will fall through to the generic `'transient'` red banner ("Generování selhalo...") instead of the intended `'insufficient'` amber banner — a silent UX regression if left unfixed.
+
+Update `LeafletGenerateTab.tsx` to detect this case via the response's `errorCode` field instead of HTTP status:
+
+```ts
+import { ErrorCodes, GenerateLeafletResponse } from '../../api/generated/api-client';
+// ...
+} catch (err: unknown) {
+  if (err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval) {
+    setErrorBanner({
+      kind: 'insufficient',
+      message: 'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+    });
+  } else {
+    setErrorBanner({
+      kind: 'transient',
+      message: 'Generování selhalo. Zkuste to prosím znovu.',
+    });
+  }
+}
+```
+
+The existing hardcoded Czech fallback message can be used directly (no server-supplied detail text is needed client-side any more, since the server-side `Params["detail"]` string from FR-3 is in English and was never surfaced to end users through this path anyway — the component already had its own Czech copy as the primary/fallback text).
+
+The now-unused `ApiError`/`isApiError` helper (lines 7–19) should be removed if nothing else in the file uses it; keep it only if another code path in the same file still depends on `status`-based detection.
+
+**Acceptance criteria:**
+- After regenerating the OpenAPI client, submitting a topic with zero KB/leaflet hits shows the amber "insufficient knowledge" banner (not the red "transient" banner).
+- Any other failure (network error, unexpected 500, etc.) still shows the red "transient" banner.
+- `npm run build` and `npm run lint` pass.
+
+### FR-8: Update existing tests to match the new contract
+The following existing tests assert the old throw/catch behavior and must be updated (not just left failing):
+
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs`, test `Handle_dual_empty_retrieval_throws_EmptyRetrievalException` (around line 85): change from `await act.Should().ThrowAsync<EmptyRetrievalException>();` to asserting the handler *returns* a `GenerateLeafletResponse` with `Success == false` and `ErrorCode == ErrorCodes.LeafletEmptyRetrieval`. Rename the test to reflect the new behavior (e.g. `Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error`).
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs`:
+  - `Generate_returns_422_on_EmptyRetrievalException` (lines 74–102): change the mediator mock from `.ThrowsAsync(new EmptyRetrievalException(...))` to `.ReturnsAsync(new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...))`; assert the result is a `422` `ObjectResult`/`UnprocessableEntityObjectResult` whose `Value` is the `GenerateLeafletResponse` (not `ProblemDetails`), with `ErrorCode == ErrorCodes.LeafletEmptyRetrieval`.
+  - `Generate_returns_502_on_unexpected_exception` (lines 104–133): this test's premise no longer holds (see FR-4's open question). Pending the answer, either delete it or replace it with a test confirming the exception now propagates unhandled out of `Generate` (e.g. `await Assert.ThrowsAsync<InvalidOperationException>(() => controller.Generate(request, CancellationToken.None));`), consistent with `Generate_propagates_OperationCanceledException` immediately below it.
+  - `Generate_propagates_OperationCanceledException` (lines 135–155): behavior is unchanged (still propagates); no changes required, though the test may be simplified now that there's no explicit `catch (OperationCanceledException) { throw; }` to exercise.
+- `backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs`, test `GenerateLeaflet_wraps_EmptyRetrievalException_as_McpException` (around lines 63–90): change the mediator mock from `.ThrowsAsync(new EmptyRetrievalException(...))` to `.ReturnsAsync(new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...))`; keep asserting that `GenerateLeaflet` throws `McpException` with the expected message. Rename the test accordingly.
+
+**Acceptance criteria:**
+- `dotnet build` and the full `Anela.Heblo.Tests` suite pass with no reference to `EmptyRetrievalException` remaining anywhere in the test project.
+- No test is skipped or deleted without an equivalent replacement asserting the new behavior (except the 502 test, whose disposition depends on the Open Question below).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable impact. Returning a DTO from an early `if` branch is at least as cheap as throwing and catching a `.NET` exception (exception throw/catch has non-trivial overhead versus a normal return), so this is a minor net improvement on the empty-retrieval path, not a regression. No new allocations of consequence (one small `Dictionary<string,string>`, same order of magnitude as today's `Params` usage in sibling handlers).
+
+### NFR-2: Security / information disclosure
+- The `Params["detail"]` message set in FR-3 must remain the curated, user-safe string already in use today ("Knowledge Base does not yet cover this topic; try a broader phrasing") — do **not** use `BaseResponse`'s `Exception`-based constructor (which serializes `ex.ToString()`, including stack traces, into `Params`) for this expected business condition; that constructor is reserved for genuinely unexpected failures.
+- Removing the catch-all in `LeafletController.Generate` (FR-4) must not cause internal exception details (message, stack trace) to leak to the client. This is delegated to the existing global `AddProblemDetails()` pipeline, which by default does not include exception details unless the environment is configured for it (verify `IncludeExceptionDetails` / development-only behavior is already correctly scoped — this is existing, unchanged infrastructure, not new to this fix).
+
+### NFR-3: Consistency / maintainability
+After this fix, all five Leaflet-module handlers (`GenerateLeafletHandler`, `SubmitLeafletFeedbackHandler`, `GetLeafletGenerationHandler`, `GetLeafletChunkDetailHandler`, and the others already following the pattern) use exactly one error-signaling idiom: return a `BaseResponse`-derived DTO with `ErrorCode` set, mapped to HTTP status by `HandleResponse` via `[HttpStatusCode]` attributes on `ErrorCodes`. No handler in the module throws a domain exception for an expected/anticipated business condition; no controller action in `LeafletController` contains a try/catch for business-logic error mapping.
+
+### NFR-4: Backward compatibility (HTTP contract)
+For the specific empty-retrieval case, the HTTP status code returned to REST API clients must remain `422 Unprocessable Entity` (achieved via the `[HttpStatusCode(HttpStatusCode.UnprocessableEntity)]` attribute on the new `ErrorCodes.LeafletEmptyRetrieval` member) — only the response *body shape* changes (from `ProblemDetails { status, title, detail }` to `GenerateLeafletResponse { success: false, errorCode: "LeafletEmptyRetrieval", params: { detail: "..." }, content: "", ... }`). Any consumer that only branches on HTTP status code is unaffected; any consumer that reads `.detail` from the body must be updated (this repo has exactly one such consumer — `LeafletGenerateTab.tsx`, addressed in FR-7).
+
+## Data Model
+No persistence/schema changes. The only "data model" change is the addition of one member to the in-memory `ErrorCodes` enum (`Anela.Heblo.Application.Shared.ErrorCodes.LeafletEmptyRetrieval = 2504`), which flows into the generated OpenAPI schema and TypeScript client as an additional enum value on rebuild.
+
+## API / Interface Design
+
+`POST /api/leaflet/generate`
+
+**Before (error path):**
+```
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/json
+
+{
+  "status": 422,
+  "title": "Insufficient knowledge",
+  "detail": "Knowledge Base does not yet cover this topic; try a broader phrasing"
+}
+```
+
+**After (error path) — same status code, new body shape:**
+```
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/json
+
+{
+  "success": false,
+  "errorCode": "LeafletEmptyRetrieval",
+  "params": { "detail": "Knowledge Base does not yet cover this topic; try a broader phrasing" },
+  "content": "",
+  "id": null,
+  "kbSourceCount": 0,
+  "leafletSourceCount": 0
+}
+```
+
+Success path (`200 OK`) is unchanged in shape (`GenerateLeafletResponse` with `success: true`).
+
+MCP tool `GenerateLeaflet` (exposed via `LeafletTools.cs`): externally-observable behavior unchanged — still throws `McpException` with a message when the KB has no coverage for the topic; internal mechanism changes from exception-catch to response-inspection (FR-5).
+
+## Dependencies
+None new. This fix touches only existing types/services already in the Leaflet module: `ErrorCodes`, `BaseResponse`, `BaseApiController.HandleResponse`, `GenerateLeafletHandler`, `GenerateLeafletResponse`, `LeafletController`, `LeafletTools`, and their respective test files, plus the auto-generated OpenAPI TypeScript client and the one frontend component that special-cases this error.
+
+## Out of Scope
+- Any change to the retrieval/generation logic itself (embedding search, RAG query expansion, two-stage chat generation) — only the empty-result signaling path changes.
+- A general-purpose reusable "external-service transient failure → 502" exception handler for the Leaflet module or others. If the Open Question below is answered "keep a safety net," a minimal, scoped solution (e.g., a dedicated `IExceptionHandler` or a narrower catch inside the handler itself) is a follow-up decision, not part of this fix.
+- Any change to the other four Leaflet handlers, which already follow the target pattern correctly and need no modification.
+- Changes to `ArticleGeneration` or other modules' analogous "not generated yet" error codes (e.g. `ErrorCodes.ArticleNotGenerated`), even though they follow the same pattern this fix reinforces — out of scope for this specific arch-review finding.
+
+## Open Questions
+
+1. **Should `LeafletController.Generate` retain a safety-net catch-all that maps genuinely unexpected exceptions (e.g., embedding/chat-client transient failures) to a distinct status code (today: 502 with a friendly "please try again" message), or should those now fall through entirely to the global ASP.NET exception-handling pipeline (`AddProblemDetails()`), which returns a generic `ProblemDetails` with status 500 and no leaflet-specific messaging?**
+   The brief's suggested fix ("remove the try/catch ... rely on HandleResponse") and its stated rationale ("silently catches all other exceptions as 502, which swallows potential bugs") both point toward full removal, which is what this spec assumes (FR-4, FR-8). However, this is a genuine externally-visible behavior change (502 → 500, loss of the custom message) that may affect monitoring/alerting dashboards or any external caller keyed on 502 for "AI generation transient failure" versus 500 for "server bug." Please confirm before implementation whether:
+   - (a) full removal is acceptable (this spec's assumption), or
+   - (b) a scoped safety net should be preserved — e.g., a dedicated `IExceptionHandler` registered alongside `UnauthorizedAccessExceptionHandler`/`ValidationExceptionHandler`/`ArgumentExceptionHandler` in `ServiceCollectionExtensions.AddCrossCuttingServices` that maps specific external-service exception types (e.g., failures from the embedding/chat clients) to 502, without reintroducing a per-action try/catch in the controller.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -46,15 +46,15 @@
     },
     {
       "name": "controller-drops-trycatch",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:24:23.262578Z"
+      "updated_at": "2026-07-04T08:27:55.092773Z"
     },
     {
       "name": "mcp-tool-inspects-response",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:27:59.624862Z"
     },
     {
       "name": "remove-exception-and-tests",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-04T07:36:29.092486Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-04T07:36:57.693265Z"
     }
   },
   "tasks": [
     {
       "name": "add-error-code",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T07:36:57.883465Z"
     },
     {
       "name": "response-error-constructor",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-04T08:42:24.422559Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-04T08:42:34.864145Z"
+      "status": "completed",
+      "updated_at": "2026-07-04T08:44:48.334722Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -58,15 +58,15 @@
     },
     {
       "name": "remove-exception-and-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:30:40.273020Z"
+      "updated_at": "2026-07-04T08:31:45.102183Z"
     },
     {
       "name": "frontend-error-branch-fix",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:31:49.143533Z"
     }
   ]
 }

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-04T07:21:42.732056Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-04T07:24:37.325334Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T07:27:52.853112Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T07:27:58.047117Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -17,13 +17,56 @@
       "updated_at": "2026-07-04T07:27:58.047117Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-04T07:36:29.092486Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-error-code",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "response-error-constructor",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "handler-returns-response",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "controller-drops-trycatch",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "mcp-tool-inspects-response",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "remove-exception-and-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "frontend-error-branch-fix",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3478",
+  "issue_number": 3478,
+  "created_at": "2026-07-04T07:15:32.448711Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-04T07:21:42.732056Z"
+      "status": "completed",
+      "updated_at": "2026-07-04T07:24:37.325334Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "add-error-code",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T07:36:57.883465Z"
+      "updated_at": "2026-07-04T07:42:59.541207Z"
     },
     {
       "name": "response-error-constructor",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T07:43:05.049060Z"
     },
     {
       "name": "handler-returns-response",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "response-error-constructor",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T07:43:05.049060Z"
+      "updated_at": "2026-07-04T08:21:06.272452Z"
     },
     {
       "name": "handler-returns-response",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:21:10.241947Z"
     },
     {
       "name": "controller-drops-trycatch",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -52,15 +52,15 @@
     },
     {
       "name": "mcp-tool-inspects-response",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:27:59.624862Z"
+      "updated_at": "2026-07-04T08:30:36.669569Z"
     },
     {
       "name": "remove-exception-and-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:30:40.273020Z"
     },
     {
       "name": "frontend-error-branch-fix",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -40,15 +40,15 @@
     },
     {
       "name": "handler-returns-response",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:21:10.241947Z"
+      "updated_at": "2026-07-04T08:24:18.937775Z"
     },
     {
       "name": "controller-drops-trycatch",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-04T08:24:23.262578Z"
     },
     {
       "name": "mcp-tool-inspects-response",

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-04T08:42:24.422559Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-04T08:42:34.864145Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3478/state.json
+++ b/artifacts/feat-3478/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-04T07:36:29.092486Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-04T07:36:57.693265Z"
+      "status": "completed",
+      "updated_at": "2026-07-04T08:42:24.422559Z"
     }
   },
   "tasks": [
@@ -64,9 +64,9 @@
     },
     {
       "name": "frontend-error-branch-fix",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-04T08:31:49.143533Z"
+      "updated_at": "2026-07-04T08:42:17.820743Z"
     }
   ]
 }

--- a/artifacts/feat-3478/task-context/add-error-code.md
+++ b/artifacts/feat-3478/task-context/add-error-code.md
@@ -1,0 +1,45 @@
+### task: add-error-code
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:276-283`
+
+This is a pure enum-member addition — no branching logic, so there is no meaningful unit test to write for it in isolation (its effect is exercised by the tests added in later tasks, once the handler/controller/MCP tool actually use it). Skipping a dedicated test here is deliberate, not an oversight.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`. Find the `// Leaflet module errors (25XX)` block:
+  ```csharp
+      // Leaflet module errors (25XX)
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletChunkNotFound = 2501,
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletFeedbackNotFound = 2502,
+      [HttpStatusCode(HttpStatusCode.Conflict)]
+      LeafletFeedbackAlreadySubmitted = 2503,
+
+      // Photobank errors (26XX)
+  ```
+- [ ] Step 2: Add a new member immediately after `LeafletFeedbackAlreadySubmitted = 2503,`, before the `// Photobank errors (26XX)` comment:
+  ```csharp
+      // Leaflet module errors (25XX)
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletChunkNotFound = 2501,
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletFeedbackNotFound = 2502,
+      [HttpStatusCode(HttpStatusCode.Conflict)]
+      LeafletFeedbackAlreadySubmitted = 2503,
+      [HttpStatusCode(HttpStatusCode.UnprocessableEntity)]
+      LeafletEmptyRetrieval = 2504,
+
+      // Photobank errors (26XX)
+  ```
+  Do not renumber or reorder any existing members — their numeric values are the wire contract for the generated TypeScript enum.
+- [ ] Step 3: Build the backend to confirm the enum still compiles:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+- [ ] Step 4: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+  git commit -m "#3478: add ErrorCodes.LeafletEmptyRetrieval (422) for Leaflet empty-retrieval case"
+  ```
+
+---

--- a/artifacts/feat-3478/task-context/controller-drops-trycatch.md
+++ b/artifacts/feat-3478/task-context/controller-drops-trycatch.md
@@ -1,0 +1,173 @@
+### task: controller-drops-trycatch
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs:31-67`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs:42-155`
+
+Make `LeafletController.Generate` match every other action in the file: no try/catch, `return HandleResponse(result);`, return type `Task<ActionResult<GenerateLeafletResponse>>`. `EmptyRetrievalException` is still not deleted (the MCP tool still references it until the next task), but after this task nothing in `LeafletController.cs` or `LeafletControllerTests.cs` references it any more.
+
+- [ ] Step 1 (failing tests): Open `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs`. Replace the existing `Generate_returns_200_with_response_on_success` test (lines 42-72) — the assertion must change from `Assert.IsType<OkObjectResult>(result)` to `Assert.IsType<OkObjectResult>(result.Result)` because `Generate`'s return type is about to change from `Task<IActionResult>` to `Task<ActionResult<GenerateLeafletResponse>>`:
+  ```csharp
+      [Fact]
+      public async Task Generate_returns_200_with_response_on_success()
+      {
+          // Arrange
+          var request = new GenerateLeafletRequest
+          {
+              Topic = "Vitamin C serum",
+              Audience = AudienceType.EndConsumer,
+              Length = LeafletLength.Short,
+          };
+
+          var expectedResponse = new GenerateLeafletResponse
+          {
+              Success = true,
+              Content = "Vitamin C serum is great for your skin.",
+          };
+
+          _mediatorMock
+              .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(expectedResponse);
+
+          var controller = CreateController();
+
+          // Act
+          var result = await controller.Generate(request, CancellationToken.None);
+
+          // Assert
+          var okResult = Assert.IsType<OkObjectResult>(result.Result);
+          var response = Assert.IsType<GenerateLeafletResponse>(okResult.Value);
+          Assert.Equal(expectedResponse.Content, response.Content);
+      }
+  ```
+- [ ] Step 2: Replace `Generate_returns_422_on_EmptyRetrievalException` (lines 74-102) with a test asserting the response-based 422 path:
+  ```csharp
+      [Fact]
+      public async Task Generate_returns_422_on_LeafletEmptyRetrieval_error()
+      {
+          // Arrange
+          var request = new GenerateLeafletRequest
+          {
+              Topic = "Unknown topic",
+              Audience = AudienceType.EndConsumer,
+              Length = LeafletLength.Short,
+          };
+
+          var errorResponse = new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+              new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
+
+          _mediatorMock
+              .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(errorResponse);
+
+          var controller = CreateController();
+
+          // Act
+          var result = await controller.Generate(request, CancellationToken.None);
+
+          // Assert
+          var objectResult = Assert.IsType<ObjectResult>(result.Result);
+          Assert.Equal(422, objectResult.StatusCode);
+
+          var response = Assert.IsType<GenerateLeafletResponse>(objectResult.Value);
+          Assert.False(response.Success);
+          Assert.Equal(ErrorCodes.LeafletEmptyRetrieval, response.ErrorCode);
+      }
+  ```
+- [ ] Step 3: Replace `Generate_returns_502_on_unexpected_exception` (lines 104-133) with a test asserting the exception now propagates unhandled (mirroring `Generate_propagates_OperationCanceledException` immediately below it):
+  ```csharp
+      [Fact]
+      public async Task Generate_propagates_unexpected_exception()
+      {
+          // Arrange
+          var request = new GenerateLeafletRequest
+          {
+              Topic = "Retinol cream",
+              Audience = AudienceType.EndConsumer,
+              Length = LeafletLength.Short,
+          };
+
+          _mediatorMock
+              .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
+              .ThrowsAsync(new InvalidOperationException("Internal system failure with stack trace details"));
+
+          var controller = CreateController();
+
+          // Act & Assert
+          await Assert.ThrowsAsync<InvalidOperationException>(
+              () => controller.Generate(request, CancellationToken.None));
+      }
+  ```
+- [ ] Step 4: Leave `Generate_propagates_OperationCanceledException` (lines 135-155) exactly as-is — its shape (`await Assert.ThrowsAsync<OperationCanceledException>(() => controller.Generate(...))`) already matches the post-fix behavior.
+- [ ] Step 5: Run the `LeafletControllerTests` class to confirm the three edited tests fail against the current controller (it still has the try/catch and the `Task<IActionResult>` signature, so `result.Result` won't even compile yet — that's expected, it proves the test now demands the new signature):
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+  Expect a **compile error** on `result.Result` (current `Generate` returns `Task<IActionResult>`, which has no `.Result` property) — this is the "red" state proving the test drives the next step.
+- [ ] Step 6 (implementation): Open `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs`. Replace the `Generate` method and its attributes (lines 31-67):
+  ```csharp
+      [HttpPost("generate")]
+      [FeatureAuthorize(Feature.Marketing_Leaflet, AccessLevel.Write)]
+      [ProducesResponseType(typeof(GenerateLeafletResponse), 200)]
+      [ProducesResponseType(typeof(ProblemDetails), 400)]
+      [ProducesResponseType(typeof(ProblemDetails), 422)]
+      [ProducesResponseType(typeof(ProblemDetails), 502)]
+      public async Task<IActionResult> Generate([FromBody] GenerateLeafletRequest request, CancellationToken ct)
+      {
+          try
+          {
+              var response = await _mediator.Send(request, ct);
+              return Ok(response);
+          }
+          catch (EmptyRetrievalException ex)
+          {
+              return UnprocessableEntity(new ProblemDetails
+              {
+                  Status = 422,
+                  Title = "Insufficient knowledge",
+                  Detail = ex.Message,
+              });
+          }
+          catch (OperationCanceledException)
+          {
+              throw;
+          }
+          catch (Exception ex)
+          {
+              Logger.LogError(ex, "Leaflet generation failed");
+              return StatusCode(502, new ProblemDetails
+              {
+                  Status = 502,
+                  Title = "Generation failed",
+                  Detail = "Leaflet generation failed. Please try again.",
+              });
+          }
+      }
+  ```
+  with:
+  ```csharp
+      [HttpPost("generate")]
+      [FeatureAuthorize(Feature.Marketing_Leaflet, AccessLevel.Write)]
+      [ProducesResponseType(typeof(GenerateLeafletResponse), 200)]
+      [ProducesResponseType(typeof(ProblemDetails), 400)]
+      [ProducesResponseType(typeof(GenerateLeafletResponse), 422)]
+      public async Task<ActionResult<GenerateLeafletResponse>> Generate([FromBody] GenerateLeafletRequest request, CancellationToken ct)
+      {
+          var result = await _mediator.Send(request, ct);
+          return HandleResponse(result);
+      }
+  ```
+  Note what changed: the try/catch is gone; the return type changed from `Task<IActionResult>` to `Task<ActionResult<GenerateLeafletResponse>>` (matching `HandleResponse<T>`'s generic constraint and every sibling action); the `422` attribute now points at `GenerateLeafletResponse` instead of `ProblemDetails`; the `502` attribute is removed entirely (no code path produces it any more — an unexpected exception now propagates to ASP.NET's global `AddProblemDetails()` pipeline, which is already registered in `ServiceCollectionExtensions.AddCrossCuttingServices` and needs no changes here).
+- [ ] Step 7: Build, then run the `LeafletControllerTests` class:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~LeafletControllerTests"
+  ```
+  All tests in the class should now pass, including the untouched `Generate_propagates_OperationCanceledException`.
+- [ ] Step 8: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.API/Controllers/LeafletController.cs backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs
+  git commit -m "#3478: LeafletController.Generate delegates to HandleResponse, drops try/catch"
+  ```
+
+---

--- a/artifacts/feat-3478/task-context/frontend-error-branch-fix.md
+++ b/artifacts/feat-3478/task-context/frontend-error-branch-fix.md
@@ -1,0 +1,222 @@
+### task: frontend-error-branch-fix
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`
+- Test: `frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx` (new file)
+
+Changing the `422` `[ProducesResponseType]` from `ProblemDetails` to `GenerateLeafletResponse` (previous controller task) changes what the generated TypeScript client parses and throws on a 422 response. Regenerate the client first so the exact generated shape is known, then fix the one component that special-cased the old shape, verified with a new test file (none existed for this component before).
+
+- [ ] Step 1: Regenerate the OpenAPI TypeScript client from the now-updated backend (requires the backend to build successfully, which it does after the previous tasks):
+  ```bash
+  dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateFrontendClientManual
+  ```
+- [ ] Step 2: Confirm the regenerated `frontend/src/api/generated/api-client.ts` now has `LeafletEmptyRetrieval` in the `ErrorCodes` TS enum, and that `processLeaflet_Generate`'s `422` branch now parses the body as `GenerateLeafletResponse.fromJS(...)` instead of `ProblemDetails.fromJS(...)`:
+  ```bash
+  grep -n "LeafletEmptyRetrieval" frontend/src/api/generated/api-client.ts
+  grep -n -A6 'status === 422' frontend/src/api/generated/api-client.ts | grep -A6 "processLeaflet_Generate" -m1
+  ```
+  If the `422` branch still says `ProblemDetails.fromJS`, stop — the backend attribute change (`controller-drops-trycatch` task) or the regeneration step didn't take effect; re-run step 1 after confirming `dotnet build backend/Anela.Heblo.API` succeeds.
+- [ ] Step 3 (failing test): Create `frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx`:
+  ```tsx
+  import React from 'react';
+  import { render, screen, fireEvent } from '@testing-library/react';
+  import '@testing-library/jest-dom';
+  import LeafletGenerateTab from '../LeafletGenerateTab';
+  import { getAuthenticatedApiClient } from '../../../api/client';
+  import { ErrorCodes, GenerateLeafletResponse } from '../../../api/generated/api-client';
+
+  jest.mock('../../../api/client', () => ({
+    getAuthenticatedApiClient: jest.fn(),
+  }));
+
+  const mockGetAuthenticatedApiClient = getAuthenticatedApiClient as jest.Mock;
+
+  const fillTopicAndSubmit = () => {
+    fireEvent.change(screen.getByLabelText('Téma'), { target: { value: 'Bisabolol' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Vygenerovat leták' }));
+  };
+
+  describe('LeafletGenerateTab', () => {
+    let mockGenerate: jest.Mock;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGenerate = jest.fn();
+      mockGetAuthenticatedApiClient.mockReturnValue({ leaflet_Generate: mockGenerate });
+    });
+
+    it('shows the amber insufficient-knowledge banner when the server returns LeafletEmptyRetrieval', async () => {
+      const errorResponse = new GenerateLeafletResponse();
+      errorResponse.success = false;
+      errorResponse.errorCode = ErrorCodes.LeafletEmptyRetrieval;
+      mockGenerate.mockRejectedValue(errorResponse);
+
+      render(<LeafletGenerateTab />);
+      fillTopicAndSubmit();
+
+      const banner = await screen.findByRole('alert');
+      expect(banner).toHaveTextContent(
+        'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.'
+      );
+      expect(banner.className).toContain('bg-amber-100');
+    });
+
+    it('shows the red transient banner for any other thrown error', async () => {
+      mockGenerate.mockRejectedValue(new Error('network error'));
+
+      render(<LeafletGenerateTab />);
+      fillTopicAndSubmit();
+
+      const banner = await screen.findByRole('alert');
+      expect(banner).toHaveTextContent('Generování selhalo. Zkuste to prosím znovu.');
+      expect(banner.className).toContain('bg-red-100');
+    });
+  });
+  ```
+- [ ] Step 4: Run the new test file to confirm it fails against the current component (it still checks `isApiError(err) && err.status === 422`, and the mocked rejected `GenerateLeafletResponse` instance has no `.status` field, so both tests would currently show the red "transient" banner — the first test's assertion on `bg-amber-100` will fail):
+  ```bash
+  cd frontend && npx react-scripts test src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx --watchAll=false
+  ```
+  Expect the first test (`shows the amber insufficient-knowledge banner...`) to fail.
+- [ ] Step 5 (implementation): Open `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`. Current content:
+  ```tsx
+  import React, { useState } from 'react';
+  import LeafletForm from './LeafletForm';
+  import LeafletResult from './LeafletResult';
+  import { getAuthenticatedApiClient } from '../../api/client';
+  import { AudienceType, GenerateLeafletRequest, LeafletLength } from '../../api/generated/api-client';
+
+  interface ErrorBanner {
+    kind: 'insufficient' | 'transient';
+    message: string;
+  }
+
+  interface ApiError {
+    status: number;
+    detail?: string;
+  }
+
+  function isApiError(err: unknown): err is ApiError {
+    return typeof err === 'object' && err !== null && typeof (err as Record<string, unknown>)['status'] === 'number';
+  }
+
+  const LeafletGenerateTab: React.FC = () => {
+    const [topic, setTopic] = useState('');
+    const [audience, setAudience] = useState<AudienceType>(AudienceType.EndConsumer);
+    const [length, setLength] = useState<LeafletLength>(LeafletLength.Medium);
+    const [result, setResult] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [generationId, setGenerationId] = useState<string | null>(null);
+    const [errorBanner, setErrorBanner] = useState<ErrorBanner | null>(null);
+
+    const generate = async () => {
+      setIsLoading(true);
+      setGenerationId(null);
+      setErrorBanner(null);
+      try {
+        const client = getAuthenticatedApiClient();
+        const response = await client.leaflet_Generate(new GenerateLeafletRequest({ topic, audience, length }));
+        setResult(response.content ?? '');
+        setGenerationId((response as any).id ?? null);
+      } catch (err: unknown) {
+        if (isApiError(err) && err.status === 422) {
+          setErrorBanner({
+            kind: 'insufficient',
+            message:
+              err.detail ??
+              'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+          });
+        } else {
+          setErrorBanner({
+            kind: 'transient',
+            message: 'Generování selhalo. Zkuste to prosím znovu.',
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+  ```
+  Replace it with:
+  ```tsx
+  import React, { useState } from 'react';
+  import LeafletForm from './LeafletForm';
+  import LeafletResult from './LeafletResult';
+  import { getAuthenticatedApiClient } from '../../api/client';
+  import {
+    AudienceType,
+    ErrorCodes,
+    GenerateLeafletRequest,
+    GenerateLeafletResponse,
+    LeafletLength,
+  } from '../../api/generated/api-client';
+
+  interface ErrorBanner {
+    kind: 'insufficient' | 'transient';
+    message: string;
+  }
+
+  const LeafletGenerateTab: React.FC = () => {
+    const [topic, setTopic] = useState('');
+    const [audience, setAudience] = useState<AudienceType>(AudienceType.EndConsumer);
+    const [length, setLength] = useState<LeafletLength>(LeafletLength.Medium);
+    const [result, setResult] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [generationId, setGenerationId] = useState<string | null>(null);
+    const [errorBanner, setErrorBanner] = useState<ErrorBanner | null>(null);
+
+    const generate = async () => {
+      setIsLoading(true);
+      setGenerationId(null);
+      setErrorBanner(null);
+      try {
+        const client = getAuthenticatedApiClient();
+        const response = await client.leaflet_Generate(new GenerateLeafletRequest({ topic, audience, length }));
+        setResult(response.content ?? '');
+        setGenerationId((response as any).id ?? null);
+      } catch (err: unknown) {
+        if (err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval) {
+          setErrorBanner({
+            kind: 'insufficient',
+            message: 'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+          });
+        } else {
+          setErrorBanner({
+            kind: 'transient',
+            message: 'Generování selhalo. Zkuste to prosím znovu.',
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+  ```
+  The rest of the file (the JSX in the `return (...)` block) is unchanged. The now-unused `ApiError` interface and `isApiError` function are removed — nothing else in the file used them.
+- [ ] Step 6: Run the new test file again to confirm both tests now pass:
+  ```bash
+  cd frontend && npx react-scripts test src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx --watchAll=false
+  ```
+- [ ] Step 7: Run the full frontend test suite to confirm no regression elsewhere (in particular `LeafletGeneratorPage.test.tsx`, which mocks `LeafletGenerateTab` wholesale and is unaffected):
+  ```bash
+  cd frontend && npm test -- --watchAll=false
+  ```
+- [ ] Step 8: Run the frontend build and lint (required by this repo's validation gate):
+  ```bash
+  cd frontend && npm run build && npm run lint
+  ```
+- [ ] Step 9: Commit (include the regenerated `api-client.ts`, since the frontend build depends on it being in sync with the backend contract):
+  ```bash
+  git add frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx frontend/src/api/generated/api-client.ts
+  git commit -m "#3478: LeafletGenerateTab detects LeafletEmptyRetrieval via errorCode instead of HTTP status"
+  ```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `dotnet build Anela.Heblo.sln` and `dotnet format Anela.Heblo.sln` — both clean.
+- [ ] `dotnet test Anela.Heblo.sln` — full backend suite green.
+- [ ] `cd frontend && npm run build && npm run lint` — both clean.
+- [ ] `cd frontend && npm test -- --watchAll=false` — full frontend suite green.
+- [ ] `grep -rn "EmptyRetrievalException" backend/` returns no matches anywhere in the repository.
+- [ ] Manual sanity check of the acceptance criteria in `artifacts/feat-3478/spec.r1.md`: FR-1 (enum member + TS enum), FR-2 (response ctor), FR-3 (handler returns, doesn't throw), FR-4 (controller has no try/catch, signature matches), FR-5 (MCP tool inspects `response.Success`), FR-6 (exception type deleted), FR-7 (frontend banner logic), FR-8 (all four listed test files updated, no test deleted without a replacement) are each satisfied by the task(s) above.

--- a/artifacts/feat-3478/task-context/handler-returns-response.md
+++ b/artifacts/feat-3478/task-context/handler-returns-response.md
@@ -1,0 +1,125 @@
+### task: handler-returns-response
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs:1-8,63-67`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs:1-11,84-103`
+
+Replace the `throw new EmptyRetrievalException(...)` in `GenerateLeafletHandler.Handle` with an early `return` of the new error DTO from the previous two tasks. `EmptyRetrievalException` itself is **not deleted yet** (its other consumers — `LeafletController` and `LeafletTools` — are updated in later tasks); it simply stops being referenced by the handler.
+
+- [ ] Step 1 (failing test): Open `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs`. Add the missing using directive at the top (needed for `ErrorCodes`):
+  ```csharp
+  using Anela.Heblo.Application.Features.Leaflet;
+  using Anela.Heblo.Application.Features.Leaflet.Contracts;
+  using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+  using Anela.Heblo.Application.Shared;
+  using Anela.Heblo.Application.Shared.Rag;
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using FluentAssertions;
+  using Microsoft.Extensions.AI;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Options;
+  using Moq;
+  using Xunit;
+  ```
+  (only the `using Anela.Heblo.Application.Shared;` line is new — insert it alphabetically where shown).
+- [ ] Step 2: Replace the test `Handle_dual_empty_retrieval_throws_EmptyRetrievalException` (currently at lines 84-103):
+  ```csharp
+      [Fact]
+      public async Task Handle_dual_empty_retrieval_throws_EmptyRetrievalException()
+      {
+          // Arrange
+          SetupEmbeddings();
+
+          _kb.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<KnowledgeSearchResult>());
+          _leaflets.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync([]);
+
+          var handler = CreateHandler();
+          var request = new GenerateLeafletRequest { Topic = "retinol", Audience = AudienceType.EndConsumer, Length = LeafletLength.Short };
+
+          // Act
+          var act = () => handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          await act.Should().ThrowAsync<EmptyRetrievalException>();
+      }
+  ```
+  with:
+  ```csharp
+      [Fact]
+      public async Task Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error()
+      {
+          // Arrange
+          SetupEmbeddings();
+
+          _kb.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<KnowledgeSearchResult>());
+          _leaflets.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync([]);
+
+          var handler = CreateHandler();
+          var request = new GenerateLeafletRequest { Topic = "retinol", Audience = AudienceType.EndConsumer, Length = LeafletLength.Short };
+
+          // Act
+          var response = await handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          response.Success.Should().BeFalse();
+          response.ErrorCode.Should().Be(ErrorCodes.LeafletEmptyRetrieval);
+          response.Params.Should().NotBeNull();
+          response.Params!.Should().ContainKey("detail");
+          response.Params!["detail"].Should().Contain("Knowledge Base does not yet cover this topic");
+      }
+  ```
+- [ ] Step 3: Run just this test file to confirm it fails against the current handler (still throws):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeafletHandlerTests.Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error"
+  ```
+  Expect a failure — the handler still throws `EmptyRetrievalException`, so `await handler.Handle(...)` throws instead of returning.
+- [ ] Step 4 (implementation): Open `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs`. Add the missing using directive at the top:
+  ```csharp
+  using Anela.Heblo.Application.Features.Leaflet.Contracts;
+  using Anela.Heblo.Application.Shared;
+  using Anela.Heblo.Application.Shared.Http;
+  using Anela.Heblo.Application.Shared.Rag;
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using MediatR;
+  using Microsoft.Extensions.AI;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Options;
+  ```
+  (only `using Anela.Heblo.Application.Shared;` is new).
+- [ ] Step 5: Replace lines 63-67:
+  ```csharp
+          if (kbHits.Count == 0 && leafletHits.Count == 0)
+          {
+              throw new EmptyRetrievalException(
+                  "Knowledge Base does not yet cover this topic; try a broader phrasing");
+          }
+  ```
+  with:
+  ```csharp
+          if (kbHits.Count == 0 && leafletHits.Count == 0)
+          {
+              // Params["detail"] is for API-consumer/log diagnostics only, not for direct end-user display.
+              return new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+                  new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
+          }
+  ```
+  No other line in the handler changes.
+- [ ] Step 6: Run the test again to confirm it now passes:
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeafletHandlerTests.Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error"
+  ```
+- [ ] Step 7: Run the whole `GenerateLeafletHandlerTests` class (the other tests exercise the non-empty paths and must still pass unchanged):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeafletHandlerTests"
+  ```
+- [ ] Step 8: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
+  git commit -m "#3478: GenerateLeafletHandler returns LeafletEmptyRetrieval error instead of throwing"
+  ```
+
+---

--- a/artifacts/feat-3478/task-context/mcp-tool-inspects-response.md
+++ b/artifacts/feat-3478/task-context/mcp-tool-inspects-response.md
@@ -1,0 +1,175 @@
+### task: mcp-tool-inspects-response
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs:1-61`
+- Test: `backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs:1-16,62-78`
+
+`LeafletTools.GenerateLeaflet` currently catches `EmptyRetrievalException` and rethrows it as `McpException`. Since the handler no longer throws that exception (previous task), this catch is dead code, and the tool would otherwise silently return a `success: false` JSON payload instead of surfacing an MCP-level error. Replace the catch with a post-`Send` check on `response.Success`.
+
+- [ ] Step 1 (failing test): Open `backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs`. Add the missing using directive:
+  ```csharp
+  using System.Text.Json;
+  using Anela.Heblo.API.MCP.Tools;
+  using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+  using Anela.Heblo.Application.Shared;
+  using MediatR;
+  using Microsoft.Extensions.Logging;
+  using ModelContextProtocol;
+  using Moq;
+  using Xunit;
+  ```
+  (only `using Anela.Heblo.Application.Shared;` is new).
+- [ ] Step 2: Replace `GenerateLeaflet_wraps_EmptyRetrievalException_as_McpException` (lines 62-78):
+  ```csharp
+      [Fact]
+      public async Task GenerateLeaflet_wraps_EmptyRetrievalException_as_McpException()
+      {
+          // Arrange
+          const string emptyRetrievalMessage = "No relevant documents were found for the given topic.";
+
+          _mediator
+              .Setup(m => m.Send(It.IsAny<GenerateLeafletRequest>(), It.IsAny<CancellationToken>()))
+              .ThrowsAsync(new EmptyRetrievalException(emptyRetrievalMessage));
+
+          // Act
+          var exception = await Assert.ThrowsAsync<McpException>(() =>
+              CreateTools().GenerateLeaflet("Some topic", "B2B", "Medium"));
+
+          // Assert
+          Assert.Equal(emptyRetrievalMessage, exception.Message);
+      }
+  ```
+  with:
+  ```csharp
+      [Fact]
+      public async Task GenerateLeaflet_throws_McpException_on_LeafletEmptyRetrieval_response()
+      {
+          // Arrange
+          var errorResponse = new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+              new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
+
+          _mediator
+              .Setup(m => m.Send(It.IsAny<GenerateLeafletRequest>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(errorResponse);
+
+          // Act
+          var exception = await Assert.ThrowsAsync<McpException>(() =>
+              CreateTools().GenerateLeaflet("Some topic", "B2B", "Medium"));
+
+          // Assert
+          Assert.Equal("Knowledge Base does not yet cover this topic; try a broader phrasing", exception.Message);
+      }
+  ```
+- [ ] Step 3: Run this test to confirm it fails against the current tool (it currently checks a thrown `EmptyRetrievalException`, so a returned `GenerateLeafletResponse` with `Success == false` falls through to `return JsonSerializer.Serialize(response);` instead of throwing):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeaflet_throws_McpException_on_LeafletEmptyRetrieval_response"
+  ```
+  Expect failure (no `McpException` is thrown).
+- [ ] Step 4 (implementation): Open `backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs`. Add the missing using directive:
+  ```csharp
+  using System.ComponentModel;
+  using System.Text.Json;
+  using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+  using Anela.Heblo.Application.Shared;
+  using MediatR;
+  using Microsoft.Extensions.Logging;
+  using ModelContextProtocol;
+  using ModelContextProtocol.Server;
+  ```
+  (only `using Anela.Heblo.Application.Shared;` is new).
+- [ ] Step 5: Replace the body of `GenerateLeaflet` (lines 25-61):
+  ```csharp
+      public async Task<string> GenerateLeaflet(
+          [Description("Leaflet topic (1-200 characters), e.g. 'Bisabolol pro citlivou pleť'")] string topic,
+          [Description("Audience: 'EndConsumer' or 'B2B'")] string audience,
+          [Description("Length: 'Short', 'Medium', or 'Long'")] string length,
+          CancellationToken ct = default)
+      {
+          try
+          {
+              if (!Enum.TryParse<AudienceType>(audience, ignoreCase: true, out var audienceEnum))
+                  throw new McpException($"Invalid audience '{audience}'");
+
+              if (!Enum.TryParse<LeafletLength>(length, ignoreCase: true, out var lengthEnum))
+                  throw new McpException($"Invalid length '{length}'");
+
+              var response = await _mediator.Send(new GenerateLeafletRequest
+              {
+                  Topic = topic,
+                  Audience = audienceEnum,
+                  Length = lengthEnum
+              }, ct);
+
+              return JsonSerializer.Serialize(response);
+          }
+          catch (McpException)
+          {
+              throw;
+          }
+          catch (EmptyRetrievalException ex)
+          {
+              throw new McpException(ex.Message);
+          }
+          catch (Exception ex)
+          {
+              _logger.LogError(ex, "MCP GenerateLeaflet failed");
+              throw new McpException("Leaflet generation failed. Please try again.");
+          }
+      }
+  ```
+  with:
+  ```csharp
+      public async Task<string> GenerateLeaflet(
+          [Description("Leaflet topic (1-200 characters), e.g. 'Bisabolol pro citlivou pleť'")] string topic,
+          [Description("Audience: 'EndConsumer' or 'B2B'")] string audience,
+          [Description("Length: 'Short', 'Medium', or 'Long'")] string length,
+          CancellationToken ct = default)
+      {
+          try
+          {
+              if (!Enum.TryParse<AudienceType>(audience, ignoreCase: true, out var audienceEnum))
+                  throw new McpException($"Invalid audience '{audience}'");
+
+              if (!Enum.TryParse<LeafletLength>(length, ignoreCase: true, out var lengthEnum))
+                  throw new McpException($"Invalid length '{length}'");
+
+              var response = await _mediator.Send(new GenerateLeafletRequest
+              {
+                  Topic = topic,
+                  Audience = audienceEnum,
+                  Length = lengthEnum
+              }, ct);
+
+              if (!response.Success)
+              {
+                  var message = response.ErrorCode == ErrorCodes.LeafletEmptyRetrieval
+                      ? "Knowledge Base does not yet cover this topic; try a broader phrasing"
+                      : "Leaflet generation failed. Please try again.";
+                  throw new McpException(message);
+              }
+
+              return JsonSerializer.Serialize(response);
+          }
+          catch (McpException)
+          {
+              throw;
+          }
+          catch (Exception ex)
+          {
+              _logger.LogError(ex, "MCP GenerateLeaflet failed");
+              throw new McpException("Leaflet generation failed. Please try again.");
+          }
+      }
+  ```
+  The outer `catch (McpException)` rethrow and the generic `catch (Exception)` block are kept — they handle genuinely unexpected failures (e.g. embedding/chat client exceptions), a legitimate MCP-protocol boundary translation, not the "business logic in caller" problem this fix targets.
+- [ ] Step 6: Run the full `LeafletToolsTests` class (the success test and the two invalid-enum tests, plus the unrelated `GenerateLeaflet_wraps_unexpected_exception_with_generic_message` test, must all still pass unchanged):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~LeafletToolsTests"
+  ```
+- [ ] Step 7: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs
+  git commit -m "#3478: LeafletTools.GenerateLeaflet inspects response.Success instead of catching EmptyRetrievalException"
+  ```
+
+---

--- a/artifacts/feat-3478/task-context/remove-exception-and-tests.md
+++ b/artifacts/feat-3478/task-context/remove-exception-and-tests.md
@@ -1,0 +1,35 @@
+### task: remove-exception-and-tests
+
+**Files:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs`
+
+After the three previous tasks, `EmptyRetrievalException` has zero remaining consumers in source or test code. Confirm that, then delete it.
+
+- [ ] Step 1: Search the whole repository for any remaining reference:
+  ```bash
+  grep -rn "EmptyRetrievalException" backend/ --include="*.cs"
+  ```
+  Expect exactly one match: the type's own definition in `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs`. If any other match appears, stop and fix it before continuing (it means an earlier task's edit was incomplete).
+- [ ] Step 2: Delete the file:
+  ```bash
+  git rm backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs
+  ```
+- [ ] Step 3: Build the backend to confirm nothing else referenced it:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+- [ ] Step 4: Run the full backend test suite:
+  ```bash
+  dotnet test Anela.Heblo.sln
+  ```
+- [ ] Step 5: Re-run the grep to confirm zero remaining references anywhere in the repo (source and tests):
+  ```bash
+  grep -rn "EmptyRetrievalException" backend/ --include="*.cs"
+  ```
+  Expect no output.
+- [ ] Step 6: Commit.
+  ```bash
+  git commit -m "#3478: delete dead EmptyRetrievalException type"
+  ```
+
+---

--- a/artifacts/feat-3478/task-context/response-error-constructor.md
+++ b/artifacts/feat-3478/task-context/response-error-constructor.md
@@ -1,0 +1,71 @@
+### task: response-error-constructor
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`
+
+Give `GenerateLeafletResponse` the same two-constructor shape `SubmitLeafletFeedbackResponse` already has, so the handler can construct an error response in the next task. Adding constructors to a DTO with no behavior of its own isn't independently unit-testable in a meaningful way (there is no logic branch to assert on beyond "the base class sets these properties," which is already covered by existing `BaseResponse` behavior) — this task is verified by the handler test in the next task, which is the first real caller of the new constructor.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`. Current content:
+  ```csharp
+  using System.Text.Json.Serialization;
+  using Anela.Heblo.Application.Shared;
+
+  namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+
+  public class GenerateLeafletResponse : BaseResponse
+  {
+      [JsonPropertyName("content")]
+      public string Content { get; set; } = string.Empty;
+
+      [JsonPropertyName("id")]
+      public Guid? Id { get; set; }
+
+      [JsonPropertyName("kbSourceCount")]
+      public int KbSourceCount { get; set; }
+
+      [JsonPropertyName("leafletSourceCount")]
+      public int LeafletSourceCount { get; set; }
+  }
+  ```
+- [ ] Step 2: Add the two constructors (mirroring `SubmitLeafletFeedbackResponse` in `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackRequest.cs:23-26`):
+  ```csharp
+  using System.Text.Json.Serialization;
+  using Anela.Heblo.Application.Shared;
+
+  namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+
+  public class GenerateLeafletResponse : BaseResponse
+  {
+      public GenerateLeafletResponse() { }
+
+      public GenerateLeafletResponse(ErrorCodes errorCode, Dictionary<string, string>? details = null)
+          : base(errorCode, details) { }
+
+      [JsonPropertyName("content")]
+      public string Content { get; set; } = string.Empty;
+
+      [JsonPropertyName("id")]
+      public Guid? Id { get; set; }
+
+      [JsonPropertyName("kbSourceCount")]
+      public int KbSourceCount { get; set; }
+
+      [JsonPropertyName("leafletSourceCount")]
+      public int LeafletSourceCount { get; set; }
+  }
+  ```
+- [ ] Step 3: Build the backend — confirm the existing success-path usage (`new GenerateLeafletResponse { Content = ..., KbSourceCount = ..., LeafletSourceCount = ... }` in `GenerateLeafletHandler.cs:134-139`) still compiles unchanged:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+- [ ] Step 4: Run the full backend test suite to confirm nothing broke:
+  ```bash
+  dotnet test Anela.Heblo.sln
+  ```
+- [ ] Step 5: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
+  git commit -m "#3478: add error-constructing constructor to GenerateLeafletResponse"
+  ```
+
+---

--- a/artifacts/feat-3478/task-plan.r1.md
+++ b/artifacts/feat-3478/task-plan.r1.md
@@ -1,0 +1,862 @@
+# Implementation Plan: `GenerateLeafletHandler` error-signaling consistency fix
+
+**Goal:** Stop `GenerateLeafletHandler` from throwing `EmptyRetrievalException` for the expected "no KB/leaflet hits" business outcome. Make it return a normal `GenerateLeafletResponse` with `ErrorCode = ErrorCodes.LeafletEmptyRetrieval` instead, let `LeafletController.Generate` delegate to the existing `HandleResponse` helper (dropping its try/catch), update the one MCP tool consumer and the one frontend consumer that special-cased the old exception/`ProblemDetails` shape, and delete the now-dead `EmptyRetrievalException` type. The external HTTP contract keeps `422 Unprocessable Entity` for this case; only the response *body* shape changes.
+
+**Architecture:** Clean Architecture / Vertical Slice monorepo (.NET 8 + React). MediatR request/handler per use case; every handler returns a `BaseResponse`-derived DTO (`Success`, `ErrorCode`, `Params`); `BaseApiController.HandleResponse<T>` reflects on the `[HttpStatusCode]` attribute of the response's `ErrorCode` to pick the HTTP status. This fix makes `GenerateLeafletHandler`/`LeafletController.Generate` conform to that single existing idiom (already used by every other Leaflet handler/action) instead of using a bespoke throw/catch path.
+
+**Tech Stack:** C# / .NET 8 (MediatR, ASP.NET Core, xUnit, Moq, FluentAssertions), TypeScript / React (Jest, React Testing Library, NSwag-generated OpenAPI client).
+
+---
+
+### task: add-error-code
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:276-283`
+
+This is a pure enum-member addition — no branching logic, so there is no meaningful unit test to write for it in isolation (its effect is exercised by the tests added in later tasks, once the handler/controller/MCP tool actually use it). Skipping a dedicated test here is deliberate, not an oversight.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`. Find the `// Leaflet module errors (25XX)` block:
+  ```csharp
+      // Leaflet module errors (25XX)
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletChunkNotFound = 2501,
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletFeedbackNotFound = 2502,
+      [HttpStatusCode(HttpStatusCode.Conflict)]
+      LeafletFeedbackAlreadySubmitted = 2503,
+
+      // Photobank errors (26XX)
+  ```
+- [ ] Step 2: Add a new member immediately after `LeafletFeedbackAlreadySubmitted = 2503,`, before the `// Photobank errors (26XX)` comment:
+  ```csharp
+      // Leaflet module errors (25XX)
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletChunkNotFound = 2501,
+      [HttpStatusCode(HttpStatusCode.NotFound)]
+      LeafletFeedbackNotFound = 2502,
+      [HttpStatusCode(HttpStatusCode.Conflict)]
+      LeafletFeedbackAlreadySubmitted = 2503,
+      [HttpStatusCode(HttpStatusCode.UnprocessableEntity)]
+      LeafletEmptyRetrieval = 2504,
+
+      // Photobank errors (26XX)
+  ```
+  Do not renumber or reorder any existing members — their numeric values are the wire contract for the generated TypeScript enum.
+- [ ] Step 3: Build the backend to confirm the enum still compiles:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+- [ ] Step 4: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+  git commit -m "#3478: add ErrorCodes.LeafletEmptyRetrieval (422) for Leaflet empty-retrieval case"
+  ```
+
+---
+
+### task: response-error-constructor
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`
+
+Give `GenerateLeafletResponse` the same two-constructor shape `SubmitLeafletFeedbackResponse` already has, so the handler can construct an error response in the next task. Adding constructors to a DTO with no behavior of its own isn't independently unit-testable in a meaningful way (there is no logic branch to assert on beyond "the base class sets these properties," which is already covered by existing `BaseResponse` behavior) — this task is verified by the handler test in the next task, which is the first real caller of the new constructor.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`. Current content:
+  ```csharp
+  using System.Text.Json.Serialization;
+  using Anela.Heblo.Application.Shared;
+
+  namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+
+  public class GenerateLeafletResponse : BaseResponse
+  {
+      [JsonPropertyName("content")]
+      public string Content { get; set; } = string.Empty;
+
+      [JsonPropertyName("id")]
+      public Guid? Id { get; set; }
+
+      [JsonPropertyName("kbSourceCount")]
+      public int KbSourceCount { get; set; }
+
+      [JsonPropertyName("leafletSourceCount")]
+      public int LeafletSourceCount { get; set; }
+  }
+  ```
+- [ ] Step 2: Add the two constructors (mirroring `SubmitLeafletFeedbackResponse` in `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackRequest.cs:23-26`):
+  ```csharp
+  using System.Text.Json.Serialization;
+  using Anela.Heblo.Application.Shared;
+
+  namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+
+  public class GenerateLeafletResponse : BaseResponse
+  {
+      public GenerateLeafletResponse() { }
+
+      public GenerateLeafletResponse(ErrorCodes errorCode, Dictionary<string, string>? details = null)
+          : base(errorCode, details) { }
+
+      [JsonPropertyName("content")]
+      public string Content { get; set; } = string.Empty;
+
+      [JsonPropertyName("id")]
+      public Guid? Id { get; set; }
+
+      [JsonPropertyName("kbSourceCount")]
+      public int KbSourceCount { get; set; }
+
+      [JsonPropertyName("leafletSourceCount")]
+      public int LeafletSourceCount { get; set; }
+  }
+  ```
+- [ ] Step 3: Build the backend — confirm the existing success-path usage (`new GenerateLeafletResponse { Content = ..., KbSourceCount = ..., LeafletSourceCount = ... }` in `GenerateLeafletHandler.cs:134-139`) still compiles unchanged:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+- [ ] Step 4: Run the full backend test suite to confirm nothing broke:
+  ```bash
+  dotnet test Anela.Heblo.sln
+  ```
+- [ ] Step 5: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
+  git commit -m "#3478: add error-constructing constructor to GenerateLeafletResponse"
+  ```
+
+---
+
+### task: handler-returns-response
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs:1-8,63-67`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs:1-11,84-103`
+
+Replace the `throw new EmptyRetrievalException(...)` in `GenerateLeafletHandler.Handle` with an early `return` of the new error DTO from the previous two tasks. `EmptyRetrievalException` itself is **not deleted yet** (its other consumers — `LeafletController` and `LeafletTools` — are updated in later tasks); it simply stops being referenced by the handler.
+
+- [ ] Step 1 (failing test): Open `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs`. Add the missing using directive at the top (needed for `ErrorCodes`):
+  ```csharp
+  using Anela.Heblo.Application.Features.Leaflet;
+  using Anela.Heblo.Application.Features.Leaflet.Contracts;
+  using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+  using Anela.Heblo.Application.Shared;
+  using Anela.Heblo.Application.Shared.Rag;
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using FluentAssertions;
+  using Microsoft.Extensions.AI;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Options;
+  using Moq;
+  using Xunit;
+  ```
+  (only the `using Anela.Heblo.Application.Shared;` line is new — insert it alphabetically where shown).
+- [ ] Step 2: Replace the test `Handle_dual_empty_retrieval_throws_EmptyRetrievalException` (currently at lines 84-103):
+  ```csharp
+      [Fact]
+      public async Task Handle_dual_empty_retrieval_throws_EmptyRetrievalException()
+      {
+          // Arrange
+          SetupEmbeddings();
+
+          _kb.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<KnowledgeSearchResult>());
+          _leaflets.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync([]);
+
+          var handler = CreateHandler();
+          var request = new GenerateLeafletRequest { Topic = "retinol", Audience = AudienceType.EndConsumer, Length = LeafletLength.Short };
+
+          // Act
+          var act = () => handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          await act.Should().ThrowAsync<EmptyRetrievalException>();
+      }
+  ```
+  with:
+  ```csharp
+      [Fact]
+      public async Task Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error()
+      {
+          // Arrange
+          SetupEmbeddings();
+
+          _kb.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<KnowledgeSearchResult>());
+          _leaflets.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync([]);
+
+          var handler = CreateHandler();
+          var request = new GenerateLeafletRequest { Topic = "retinol", Audience = AudienceType.EndConsumer, Length = LeafletLength.Short };
+
+          // Act
+          var response = await handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          response.Success.Should().BeFalse();
+          response.ErrorCode.Should().Be(ErrorCodes.LeafletEmptyRetrieval);
+          response.Params.Should().NotBeNull();
+          response.Params!.Should().ContainKey("detail");
+          response.Params!["detail"].Should().Contain("Knowledge Base does not yet cover this topic");
+      }
+  ```
+- [ ] Step 3: Run just this test file to confirm it fails against the current handler (still throws):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeafletHandlerTests.Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error"
+  ```
+  Expect a failure — the handler still throws `EmptyRetrievalException`, so `await handler.Handle(...)` throws instead of returning.
+- [ ] Step 4 (implementation): Open `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs`. Add the missing using directive at the top:
+  ```csharp
+  using Anela.Heblo.Application.Features.Leaflet.Contracts;
+  using Anela.Heblo.Application.Shared;
+  using Anela.Heblo.Application.Shared.Http;
+  using Anela.Heblo.Application.Shared.Rag;
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using MediatR;
+  using Microsoft.Extensions.AI;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Options;
+  ```
+  (only `using Anela.Heblo.Application.Shared;` is new).
+- [ ] Step 5: Replace lines 63-67:
+  ```csharp
+          if (kbHits.Count == 0 && leafletHits.Count == 0)
+          {
+              throw new EmptyRetrievalException(
+                  "Knowledge Base does not yet cover this topic; try a broader phrasing");
+          }
+  ```
+  with:
+  ```csharp
+          if (kbHits.Count == 0 && leafletHits.Count == 0)
+          {
+              // Params["detail"] is for API-consumer/log diagnostics only, not for direct end-user display.
+              return new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+                  new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
+          }
+  ```
+  No other line in the handler changes.
+- [ ] Step 6: Run the test again to confirm it now passes:
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeafletHandlerTests.Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error"
+  ```
+- [ ] Step 7: Run the whole `GenerateLeafletHandlerTests` class (the other tests exercise the non-empty paths and must still pass unchanged):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeafletHandlerTests"
+  ```
+- [ ] Step 8: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
+  git commit -m "#3478: GenerateLeafletHandler returns LeafletEmptyRetrieval error instead of throwing"
+  ```
+
+---
+
+### task: controller-drops-trycatch
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs:31-67`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs:42-155`
+
+Make `LeafletController.Generate` match every other action in the file: no try/catch, `return HandleResponse(result);`, return type `Task<ActionResult<GenerateLeafletResponse>>`. `EmptyRetrievalException` is still not deleted (the MCP tool still references it until the next task), but after this task nothing in `LeafletController.cs` or `LeafletControllerTests.cs` references it any more.
+
+- [ ] Step 1 (failing tests): Open `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs`. Replace the existing `Generate_returns_200_with_response_on_success` test (lines 42-72) — the assertion must change from `Assert.IsType<OkObjectResult>(result)` to `Assert.IsType<OkObjectResult>(result.Result)` because `Generate`'s return type is about to change from `Task<IActionResult>` to `Task<ActionResult<GenerateLeafletResponse>>`:
+  ```csharp
+      [Fact]
+      public async Task Generate_returns_200_with_response_on_success()
+      {
+          // Arrange
+          var request = new GenerateLeafletRequest
+          {
+              Topic = "Vitamin C serum",
+              Audience = AudienceType.EndConsumer,
+              Length = LeafletLength.Short,
+          };
+
+          var expectedResponse = new GenerateLeafletResponse
+          {
+              Success = true,
+              Content = "Vitamin C serum is great for your skin.",
+          };
+
+          _mediatorMock
+              .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(expectedResponse);
+
+          var controller = CreateController();
+
+          // Act
+          var result = await controller.Generate(request, CancellationToken.None);
+
+          // Assert
+          var okResult = Assert.IsType<OkObjectResult>(result.Result);
+          var response = Assert.IsType<GenerateLeafletResponse>(okResult.Value);
+          Assert.Equal(expectedResponse.Content, response.Content);
+      }
+  ```
+- [ ] Step 2: Replace `Generate_returns_422_on_EmptyRetrievalException` (lines 74-102) with a test asserting the response-based 422 path:
+  ```csharp
+      [Fact]
+      public async Task Generate_returns_422_on_LeafletEmptyRetrieval_error()
+      {
+          // Arrange
+          var request = new GenerateLeafletRequest
+          {
+              Topic = "Unknown topic",
+              Audience = AudienceType.EndConsumer,
+              Length = LeafletLength.Short,
+          };
+
+          var errorResponse = new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+              new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
+
+          _mediatorMock
+              .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(errorResponse);
+
+          var controller = CreateController();
+
+          // Act
+          var result = await controller.Generate(request, CancellationToken.None);
+
+          // Assert
+          var objectResult = Assert.IsType<ObjectResult>(result.Result);
+          Assert.Equal(422, objectResult.StatusCode);
+
+          var response = Assert.IsType<GenerateLeafletResponse>(objectResult.Value);
+          Assert.False(response.Success);
+          Assert.Equal(ErrorCodes.LeafletEmptyRetrieval, response.ErrorCode);
+      }
+  ```
+- [ ] Step 3: Replace `Generate_returns_502_on_unexpected_exception` (lines 104-133) with a test asserting the exception now propagates unhandled (mirroring `Generate_propagates_OperationCanceledException` immediately below it):
+  ```csharp
+      [Fact]
+      public async Task Generate_propagates_unexpected_exception()
+      {
+          // Arrange
+          var request = new GenerateLeafletRequest
+          {
+              Topic = "Retinol cream",
+              Audience = AudienceType.EndConsumer,
+              Length = LeafletLength.Short,
+          };
+
+          _mediatorMock
+              .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
+              .ThrowsAsync(new InvalidOperationException("Internal system failure with stack trace details"));
+
+          var controller = CreateController();
+
+          // Act & Assert
+          await Assert.ThrowsAsync<InvalidOperationException>(
+              () => controller.Generate(request, CancellationToken.None));
+      }
+  ```
+- [ ] Step 4: Leave `Generate_propagates_OperationCanceledException` (lines 135-155) exactly as-is — its shape (`await Assert.ThrowsAsync<OperationCanceledException>(() => controller.Generate(...))`) already matches the post-fix behavior.
+- [ ] Step 5: Run the `LeafletControllerTests` class to confirm the three edited tests fail against the current controller (it still has the try/catch and the `Task<IActionResult>` signature, so `result.Result` won't even compile yet — that's expected, it proves the test now demands the new signature):
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+  Expect a **compile error** on `result.Result` (current `Generate` returns `Task<IActionResult>`, which has no `.Result` property) — this is the "red" state proving the test drives the next step.
+- [ ] Step 6 (implementation): Open `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs`. Replace the `Generate` method and its attributes (lines 31-67):
+  ```csharp
+      [HttpPost("generate")]
+      [FeatureAuthorize(Feature.Marketing_Leaflet, AccessLevel.Write)]
+      [ProducesResponseType(typeof(GenerateLeafletResponse), 200)]
+      [ProducesResponseType(typeof(ProblemDetails), 400)]
+      [ProducesResponseType(typeof(ProblemDetails), 422)]
+      [ProducesResponseType(typeof(ProblemDetails), 502)]
+      public async Task<IActionResult> Generate([FromBody] GenerateLeafletRequest request, CancellationToken ct)
+      {
+          try
+          {
+              var response = await _mediator.Send(request, ct);
+              return Ok(response);
+          }
+          catch (EmptyRetrievalException ex)
+          {
+              return UnprocessableEntity(new ProblemDetails
+              {
+                  Status = 422,
+                  Title = "Insufficient knowledge",
+                  Detail = ex.Message,
+              });
+          }
+          catch (OperationCanceledException)
+          {
+              throw;
+          }
+          catch (Exception ex)
+          {
+              Logger.LogError(ex, "Leaflet generation failed");
+              return StatusCode(502, new ProblemDetails
+              {
+                  Status = 502,
+                  Title = "Generation failed",
+                  Detail = "Leaflet generation failed. Please try again.",
+              });
+          }
+      }
+  ```
+  with:
+  ```csharp
+      [HttpPost("generate")]
+      [FeatureAuthorize(Feature.Marketing_Leaflet, AccessLevel.Write)]
+      [ProducesResponseType(typeof(GenerateLeafletResponse), 200)]
+      [ProducesResponseType(typeof(ProblemDetails), 400)]
+      [ProducesResponseType(typeof(GenerateLeafletResponse), 422)]
+      public async Task<ActionResult<GenerateLeafletResponse>> Generate([FromBody] GenerateLeafletRequest request, CancellationToken ct)
+      {
+          var result = await _mediator.Send(request, ct);
+          return HandleResponse(result);
+      }
+  ```
+  Note what changed: the try/catch is gone; the return type changed from `Task<IActionResult>` to `Task<ActionResult<GenerateLeafletResponse>>` (matching `HandleResponse<T>`'s generic constraint and every sibling action); the `422` attribute now points at `GenerateLeafletResponse` instead of `ProblemDetails`; the `502` attribute is removed entirely (no code path produces it any more — an unexpected exception now propagates to ASP.NET's global `AddProblemDetails()` pipeline, which is already registered in `ServiceCollectionExtensions.AddCrossCuttingServices` and needs no changes here).
+- [ ] Step 7: Build, then run the `LeafletControllerTests` class:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~LeafletControllerTests"
+  ```
+  All tests in the class should now pass, including the untouched `Generate_propagates_OperationCanceledException`.
+- [ ] Step 8: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.API/Controllers/LeafletController.cs backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs
+  git commit -m "#3478: LeafletController.Generate delegates to HandleResponse, drops try/catch"
+  ```
+
+---
+
+### task: mcp-tool-inspects-response
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs:1-61`
+- Test: `backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs:1-16,62-78`
+
+`LeafletTools.GenerateLeaflet` currently catches `EmptyRetrievalException` and rethrows it as `McpException`. Since the handler no longer throws that exception (previous task), this catch is dead code, and the tool would otherwise silently return a `success: false` JSON payload instead of surfacing an MCP-level error. Replace the catch with a post-`Send` check on `response.Success`.
+
+- [ ] Step 1 (failing test): Open `backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs`. Add the missing using directive:
+  ```csharp
+  using System.Text.Json;
+  using Anela.Heblo.API.MCP.Tools;
+  using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+  using Anela.Heblo.Application.Shared;
+  using MediatR;
+  using Microsoft.Extensions.Logging;
+  using ModelContextProtocol;
+  using Moq;
+  using Xunit;
+  ```
+  (only `using Anela.Heblo.Application.Shared;` is new).
+- [ ] Step 2: Replace `GenerateLeaflet_wraps_EmptyRetrievalException_as_McpException` (lines 62-78):
+  ```csharp
+      [Fact]
+      public async Task GenerateLeaflet_wraps_EmptyRetrievalException_as_McpException()
+      {
+          // Arrange
+          const string emptyRetrievalMessage = "No relevant documents were found for the given topic.";
+
+          _mediator
+              .Setup(m => m.Send(It.IsAny<GenerateLeafletRequest>(), It.IsAny<CancellationToken>()))
+              .ThrowsAsync(new EmptyRetrievalException(emptyRetrievalMessage));
+
+          // Act
+          var exception = await Assert.ThrowsAsync<McpException>(() =>
+              CreateTools().GenerateLeaflet("Some topic", "B2B", "Medium"));
+
+          // Assert
+          Assert.Equal(emptyRetrievalMessage, exception.Message);
+      }
+  ```
+  with:
+  ```csharp
+      [Fact]
+      public async Task GenerateLeaflet_throws_McpException_on_LeafletEmptyRetrieval_response()
+      {
+          // Arrange
+          var errorResponse = new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+              new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
+
+          _mediator
+              .Setup(m => m.Send(It.IsAny<GenerateLeafletRequest>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(errorResponse);
+
+          // Act
+          var exception = await Assert.ThrowsAsync<McpException>(() =>
+              CreateTools().GenerateLeaflet("Some topic", "B2B", "Medium"));
+
+          // Assert
+          Assert.Equal("Knowledge Base does not yet cover this topic; try a broader phrasing", exception.Message);
+      }
+  ```
+- [ ] Step 3: Run this test to confirm it fails against the current tool (it currently checks a thrown `EmptyRetrievalException`, so a returned `GenerateLeafletResponse` with `Success == false` falls through to `return JsonSerializer.Serialize(response);` instead of throwing):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~GenerateLeaflet_throws_McpException_on_LeafletEmptyRetrieval_response"
+  ```
+  Expect failure (no `McpException` is thrown).
+- [ ] Step 4 (implementation): Open `backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs`. Add the missing using directive:
+  ```csharp
+  using System.ComponentModel;
+  using System.Text.Json;
+  using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+  using Anela.Heblo.Application.Shared;
+  using MediatR;
+  using Microsoft.Extensions.Logging;
+  using ModelContextProtocol;
+  using ModelContextProtocol.Server;
+  ```
+  (only `using Anela.Heblo.Application.Shared;` is new).
+- [ ] Step 5: Replace the body of `GenerateLeaflet` (lines 25-61):
+  ```csharp
+      public async Task<string> GenerateLeaflet(
+          [Description("Leaflet topic (1-200 characters), e.g. 'Bisabolol pro citlivou pleť'")] string topic,
+          [Description("Audience: 'EndConsumer' or 'B2B'")] string audience,
+          [Description("Length: 'Short', 'Medium', or 'Long'")] string length,
+          CancellationToken ct = default)
+      {
+          try
+          {
+              if (!Enum.TryParse<AudienceType>(audience, ignoreCase: true, out var audienceEnum))
+                  throw new McpException($"Invalid audience '{audience}'");
+
+              if (!Enum.TryParse<LeafletLength>(length, ignoreCase: true, out var lengthEnum))
+                  throw new McpException($"Invalid length '{length}'");
+
+              var response = await _mediator.Send(new GenerateLeafletRequest
+              {
+                  Topic = topic,
+                  Audience = audienceEnum,
+                  Length = lengthEnum
+              }, ct);
+
+              return JsonSerializer.Serialize(response);
+          }
+          catch (McpException)
+          {
+              throw;
+          }
+          catch (EmptyRetrievalException ex)
+          {
+              throw new McpException(ex.Message);
+          }
+          catch (Exception ex)
+          {
+              _logger.LogError(ex, "MCP GenerateLeaflet failed");
+              throw new McpException("Leaflet generation failed. Please try again.");
+          }
+      }
+  ```
+  with:
+  ```csharp
+      public async Task<string> GenerateLeaflet(
+          [Description("Leaflet topic (1-200 characters), e.g. 'Bisabolol pro citlivou pleť'")] string topic,
+          [Description("Audience: 'EndConsumer' or 'B2B'")] string audience,
+          [Description("Length: 'Short', 'Medium', or 'Long'")] string length,
+          CancellationToken ct = default)
+      {
+          try
+          {
+              if (!Enum.TryParse<AudienceType>(audience, ignoreCase: true, out var audienceEnum))
+                  throw new McpException($"Invalid audience '{audience}'");
+
+              if (!Enum.TryParse<LeafletLength>(length, ignoreCase: true, out var lengthEnum))
+                  throw new McpException($"Invalid length '{length}'");
+
+              var response = await _mediator.Send(new GenerateLeafletRequest
+              {
+                  Topic = topic,
+                  Audience = audienceEnum,
+                  Length = lengthEnum
+              }, ct);
+
+              if (!response.Success)
+              {
+                  var message = response.ErrorCode == ErrorCodes.LeafletEmptyRetrieval
+                      ? "Knowledge Base does not yet cover this topic; try a broader phrasing"
+                      : "Leaflet generation failed. Please try again.";
+                  throw new McpException(message);
+              }
+
+              return JsonSerializer.Serialize(response);
+          }
+          catch (McpException)
+          {
+              throw;
+          }
+          catch (Exception ex)
+          {
+              _logger.LogError(ex, "MCP GenerateLeaflet failed");
+              throw new McpException("Leaflet generation failed. Please try again.");
+          }
+      }
+  ```
+  The outer `catch (McpException)` rethrow and the generic `catch (Exception)` block are kept — they handle genuinely unexpected failures (e.g. embedding/chat client exceptions), a legitimate MCP-protocol boundary translation, not the "business logic in caller" problem this fix targets.
+- [ ] Step 6: Run the full `LeafletToolsTests` class (the success test and the two invalid-enum tests, plus the unrelated `GenerateLeaflet_wraps_unexpected_exception_with_generic_message` test, must all still pass unchanged):
+  ```bash
+  dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~LeafletToolsTests"
+  ```
+- [ ] Step 7: Commit.
+  ```bash
+  git add backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs
+  git commit -m "#3478: LeafletTools.GenerateLeaflet inspects response.Success instead of catching EmptyRetrievalException"
+  ```
+
+---
+
+### task: remove-exception-and-tests
+
+**Files:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs`
+
+After the three previous tasks, `EmptyRetrievalException` has zero remaining consumers in source or test code. Confirm that, then delete it.
+
+- [ ] Step 1: Search the whole repository for any remaining reference:
+  ```bash
+  grep -rn "EmptyRetrievalException" backend/ --include="*.cs"
+  ```
+  Expect exactly one match: the type's own definition in `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs`. If any other match appears, stop and fix it before continuing (it means an earlier task's edit was incomplete).
+- [ ] Step 2: Delete the file:
+  ```bash
+  git rm backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs
+  ```
+- [ ] Step 3: Build the backend to confirm nothing else referenced it:
+  ```bash
+  dotnet build Anela.Heblo.sln
+  ```
+- [ ] Step 4: Run the full backend test suite:
+  ```bash
+  dotnet test Anela.Heblo.sln
+  ```
+- [ ] Step 5: Re-run the grep to confirm zero remaining references anywhere in the repo (source and tests):
+  ```bash
+  grep -rn "EmptyRetrievalException" backend/ --include="*.cs"
+  ```
+  Expect no output.
+- [ ] Step 6: Commit.
+  ```bash
+  git commit -m "#3478: delete dead EmptyRetrievalException type"
+  ```
+
+---
+
+### task: frontend-error-branch-fix
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`
+- Test: `frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx` (new file)
+
+Changing the `422` `[ProducesResponseType]` from `ProblemDetails` to `GenerateLeafletResponse` (previous controller task) changes what the generated TypeScript client parses and throws on a 422 response. Regenerate the client first so the exact generated shape is known, then fix the one component that special-cased the old shape, verified with a new test file (none existed for this component before).
+
+- [ ] Step 1: Regenerate the OpenAPI TypeScript client from the now-updated backend (requires the backend to build successfully, which it does after the previous tasks):
+  ```bash
+  dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateFrontendClientManual
+  ```
+- [ ] Step 2: Confirm the regenerated `frontend/src/api/generated/api-client.ts` now has `LeafletEmptyRetrieval` in the `ErrorCodes` TS enum, and that `processLeaflet_Generate`'s `422` branch now parses the body as `GenerateLeafletResponse.fromJS(...)` instead of `ProblemDetails.fromJS(...)`:
+  ```bash
+  grep -n "LeafletEmptyRetrieval" frontend/src/api/generated/api-client.ts
+  grep -n -A6 'status === 422' frontend/src/api/generated/api-client.ts | grep -A6 "processLeaflet_Generate" -m1
+  ```
+  If the `422` branch still says `ProblemDetails.fromJS`, stop — the backend attribute change (`controller-drops-trycatch` task) or the regeneration step didn't take effect; re-run step 1 after confirming `dotnet build backend/Anela.Heblo.API` succeeds.
+- [ ] Step 3 (failing test): Create `frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx`:
+  ```tsx
+  import React from 'react';
+  import { render, screen, fireEvent } from '@testing-library/react';
+  import '@testing-library/jest-dom';
+  import LeafletGenerateTab from '../LeafletGenerateTab';
+  import { getAuthenticatedApiClient } from '../../../api/client';
+  import { ErrorCodes, GenerateLeafletResponse } from '../../../api/generated/api-client';
+
+  jest.mock('../../../api/client', () => ({
+    getAuthenticatedApiClient: jest.fn(),
+  }));
+
+  const mockGetAuthenticatedApiClient = getAuthenticatedApiClient as jest.Mock;
+
+  const fillTopicAndSubmit = () => {
+    fireEvent.change(screen.getByLabelText('Téma'), { target: { value: 'Bisabolol' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Vygenerovat leták' }));
+  };
+
+  describe('LeafletGenerateTab', () => {
+    let mockGenerate: jest.Mock;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGenerate = jest.fn();
+      mockGetAuthenticatedApiClient.mockReturnValue({ leaflet_Generate: mockGenerate });
+    });
+
+    it('shows the amber insufficient-knowledge banner when the server returns LeafletEmptyRetrieval', async () => {
+      const errorResponse = new GenerateLeafletResponse();
+      errorResponse.success = false;
+      errorResponse.errorCode = ErrorCodes.LeafletEmptyRetrieval;
+      mockGenerate.mockRejectedValue(errorResponse);
+
+      render(<LeafletGenerateTab />);
+      fillTopicAndSubmit();
+
+      const banner = await screen.findByRole('alert');
+      expect(banner).toHaveTextContent(
+        'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.'
+      );
+      expect(banner.className).toContain('bg-amber-100');
+    });
+
+    it('shows the red transient banner for any other thrown error', async () => {
+      mockGenerate.mockRejectedValue(new Error('network error'));
+
+      render(<LeafletGenerateTab />);
+      fillTopicAndSubmit();
+
+      const banner = await screen.findByRole('alert');
+      expect(banner).toHaveTextContent('Generování selhalo. Zkuste to prosím znovu.');
+      expect(banner.className).toContain('bg-red-100');
+    });
+  });
+  ```
+- [ ] Step 4: Run the new test file to confirm it fails against the current component (it still checks `isApiError(err) && err.status === 422`, and the mocked rejected `GenerateLeafletResponse` instance has no `.status` field, so both tests would currently show the red "transient" banner — the first test's assertion on `bg-amber-100` will fail):
+  ```bash
+  cd frontend && npx react-scripts test src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx --watchAll=false
+  ```
+  Expect the first test (`shows the amber insufficient-knowledge banner...`) to fail.
+- [ ] Step 5 (implementation): Open `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`. Current content:
+  ```tsx
+  import React, { useState } from 'react';
+  import LeafletForm from './LeafletForm';
+  import LeafletResult from './LeafletResult';
+  import { getAuthenticatedApiClient } from '../../api/client';
+  import { AudienceType, GenerateLeafletRequest, LeafletLength } from '../../api/generated/api-client';
+
+  interface ErrorBanner {
+    kind: 'insufficient' | 'transient';
+    message: string;
+  }
+
+  interface ApiError {
+    status: number;
+    detail?: string;
+  }
+
+  function isApiError(err: unknown): err is ApiError {
+    return typeof err === 'object' && err !== null && typeof (err as Record<string, unknown>)['status'] === 'number';
+  }
+
+  const LeafletGenerateTab: React.FC = () => {
+    const [topic, setTopic] = useState('');
+    const [audience, setAudience] = useState<AudienceType>(AudienceType.EndConsumer);
+    const [length, setLength] = useState<LeafletLength>(LeafletLength.Medium);
+    const [result, setResult] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [generationId, setGenerationId] = useState<string | null>(null);
+    const [errorBanner, setErrorBanner] = useState<ErrorBanner | null>(null);
+
+    const generate = async () => {
+      setIsLoading(true);
+      setGenerationId(null);
+      setErrorBanner(null);
+      try {
+        const client = getAuthenticatedApiClient();
+        const response = await client.leaflet_Generate(new GenerateLeafletRequest({ topic, audience, length }));
+        setResult(response.content ?? '');
+        setGenerationId((response as any).id ?? null);
+      } catch (err: unknown) {
+        if (isApiError(err) && err.status === 422) {
+          setErrorBanner({
+            kind: 'insufficient',
+            message:
+              err.detail ??
+              'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+          });
+        } else {
+          setErrorBanner({
+            kind: 'transient',
+            message: 'Generování selhalo. Zkuste to prosím znovu.',
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+  ```
+  Replace it with:
+  ```tsx
+  import React, { useState } from 'react';
+  import LeafletForm from './LeafletForm';
+  import LeafletResult from './LeafletResult';
+  import { getAuthenticatedApiClient } from '../../api/client';
+  import {
+    AudienceType,
+    ErrorCodes,
+    GenerateLeafletRequest,
+    GenerateLeafletResponse,
+    LeafletLength,
+  } from '../../api/generated/api-client';
+
+  interface ErrorBanner {
+    kind: 'insufficient' | 'transient';
+    message: string;
+  }
+
+  const LeafletGenerateTab: React.FC = () => {
+    const [topic, setTopic] = useState('');
+    const [audience, setAudience] = useState<AudienceType>(AudienceType.EndConsumer);
+    const [length, setLength] = useState<LeafletLength>(LeafletLength.Medium);
+    const [result, setResult] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [generationId, setGenerationId] = useState<string | null>(null);
+    const [errorBanner, setErrorBanner] = useState<ErrorBanner | null>(null);
+
+    const generate = async () => {
+      setIsLoading(true);
+      setGenerationId(null);
+      setErrorBanner(null);
+      try {
+        const client = getAuthenticatedApiClient();
+        const response = await client.leaflet_Generate(new GenerateLeafletRequest({ topic, audience, length }));
+        setResult(response.content ?? '');
+        setGenerationId((response as any).id ?? null);
+      } catch (err: unknown) {
+        if (err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval) {
+          setErrorBanner({
+            kind: 'insufficient',
+            message: 'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+          });
+        } else {
+          setErrorBanner({
+            kind: 'transient',
+            message: 'Generování selhalo. Zkuste to prosím znovu.',
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+  ```
+  The rest of the file (the JSX in the `return (...)` block) is unchanged. The now-unused `ApiError` interface and `isApiError` function are removed — nothing else in the file used them.
+- [ ] Step 6: Run the new test file again to confirm both tests now pass:
+  ```bash
+  cd frontend && npx react-scripts test src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx --watchAll=false
+  ```
+- [ ] Step 7: Run the full frontend test suite to confirm no regression elsewhere (in particular `LeafletGeneratorPage.test.tsx`, which mocks `LeafletGenerateTab` wholesale and is unaffected):
+  ```bash
+  cd frontend && npm test -- --watchAll=false
+  ```
+- [ ] Step 8: Run the frontend build and lint (required by this repo's validation gate):
+  ```bash
+  cd frontend && npm run build && npm run lint
+  ```
+- [ ] Step 9: Commit (include the regenerated `api-client.ts`, since the frontend build depends on it being in sync with the backend contract):
+  ```bash
+  git add frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx frontend/src/api/generated/api-client.ts
+  git commit -m "#3478: LeafletGenerateTab detects LeafletEmptyRetrieval via errorCode instead of HTTP status"
+  ```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `dotnet build Anela.Heblo.sln` and `dotnet format Anela.Heblo.sln` — both clean.
+- [ ] `dotnet test Anela.Heblo.sln` — full backend suite green.
+- [ ] `cd frontend && npm run build && npm run lint` — both clean.
+- [ ] `cd frontend && npm test -- --watchAll=false` — full frontend suite green.
+- [ ] `grep -rn "EmptyRetrievalException" backend/` returns no matches anywhere in the repository.
+- [ ] Manual sanity check of the acceptance criteria in `artifacts/feat-3478/spec.r1.md`: FR-1 (enum member + TS enum), FR-2 (response ctor), FR-3 (handler returns, doesn't throw), FR-4 (controller has no try/catch, signature matches), FR-5 (MCP tool inspects `response.Success`), FR-6 (exception type deleted), FR-7 (frontend banner logic), FR-8 (all four listed test files updated, no test deleted without a replacement) are each satisfied by the task(s) above.

--- a/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
@@ -32,38 +32,11 @@ public class LeafletController : BaseApiController
     [FeatureAuthorize(Feature.Marketing_Leaflet, AccessLevel.Write)]
     [ProducesResponseType(typeof(GenerateLeafletResponse), 200)]
     [ProducesResponseType(typeof(ProblemDetails), 400)]
-    [ProducesResponseType(typeof(ProblemDetails), 422)]
-    [ProducesResponseType(typeof(ProblemDetails), 502)]
-    public async Task<IActionResult> Generate([FromBody] GenerateLeafletRequest request, CancellationToken ct)
+    [ProducesResponseType(typeof(GenerateLeafletResponse), 422)]
+    public async Task<ActionResult<GenerateLeafletResponse>> Generate([FromBody] GenerateLeafletRequest request, CancellationToken ct)
     {
-        try
-        {
-            var response = await _mediator.Send(request, ct);
-            return Ok(response);
-        }
-        catch (EmptyRetrievalException ex)
-        {
-            return UnprocessableEntity(new ProblemDetails
-            {
-                Status = 422,
-                Title = "Insufficient knowledge",
-                Detail = ex.Message,
-            });
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Leaflet generation failed");
-            return StatusCode(502, new ProblemDetails
-            {
-                Status = 502,
-                Title = "Generation failed",
-                Detail = "Leaflet generation failed. Please try again.",
-            });
-        }
+        var result = await _mediator.Send(request, ct);
+        return HandleResponse(result);
     }
 
     [HttpGet("documents")]

--- a/backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/LeafletTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Application.Shared;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
@@ -43,15 +44,19 @@ public class LeafletTools
                 Length = lengthEnum
             }, ct);
 
+            if (!response.Success)
+            {
+                var message = response.ErrorCode == ErrorCodes.LeafletEmptyRetrieval
+                    ? "Knowledge Base does not yet cover this topic; try a broader phrasing"
+                    : "Leaflet generation failed. Please try again.";
+                throw new McpException(message);
+            }
+
             return JsonSerializer.Serialize(response);
         }
         catch (McpException)
         {
             throw;
-        }
-        catch (EmptyRetrievalException ex)
-        {
-            throw new McpException(ex.Message);
         }
         catch (Exception ex)
         {

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/EmptyRetrievalException.cs
@@ -1,8 +1,0 @@
-namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
-
-public class EmptyRetrievalException : Exception
-{
-    public EmptyRetrievalException(string message) : base(message)
-    {
-    }
-}

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.Leaflet.Contracts;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Application.Shared.Http;
 using Anela.Heblo.Application.Shared.Rag;
 using Anela.Heblo.Domain.Features.Leaflet;
@@ -62,8 +63,9 @@ public class GenerateLeafletHandler : IRequestHandler<GenerateLeafletRequest, Ge
 
         if (kbHits.Count == 0 && leafletHits.Count == 0)
         {
-            throw new EmptyRetrievalException(
-                "Knowledge Base does not yet cover this topic; try a broader phrasing");
+            // Params["detail"] is for API-consumer/log diagnostics only, not for direct end-user display.
+            return new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+                new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
         }
 
         var coldStart = leafletHits.Count == 0 ? "true" : "false";

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
@@ -5,6 +5,11 @@ namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
 
 public class GenerateLeafletResponse : BaseResponse
 {
+    public GenerateLeafletResponse() { }
+
+    public GenerateLeafletResponse(ErrorCodes errorCode, Dictionary<string, string>? details = null)
+        : base(errorCode, details) { }
+
     [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;
 

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -280,6 +280,8 @@ public enum ErrorCodes
     LeafletFeedbackNotFound = 2502,
     [HttpStatusCode(HttpStatusCode.Conflict)]
     LeafletFeedbackAlreadySubmitted = 2503,
+    [HttpStatusCode(HttpStatusCode.UnprocessableEntity)]
+    LeafletEmptyRetrieval = 2504,
 
     // Photobank errors (26XX)
     [HttpStatusCode(HttpStatusCode.NotFound)]

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletControllerTests.cs
@@ -66,13 +66,13 @@ public class LeafletControllerTests
         var result = await controller.Generate(request, CancellationToken.None);
 
         // Assert
-        var okResult = Assert.IsType<OkObjectResult>(result);
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<GenerateLeafletResponse>(okResult.Value);
         Assert.Equal(expectedResponse.Content, response.Content);
     }
 
     [Fact]
-    public async Task Generate_returns_422_on_EmptyRetrievalException()
+    public async Task Generate_returns_422_on_LeafletEmptyRetrieval_error()
     {
         // Arrange
         var request = new GenerateLeafletRequest
@@ -82,11 +82,12 @@ public class LeafletControllerTests
             Length = LeafletLength.Short,
         };
 
-        var exceptionMessage = "No relevant documents found for the given topic.";
+        var errorResponse = new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+            new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
 
         _mediatorMock
             .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new EmptyRetrievalException(exceptionMessage));
+            .ReturnsAsync(errorResponse);
 
         var controller = CreateController();
 
@@ -94,15 +95,16 @@ public class LeafletControllerTests
         var result = await controller.Generate(request, CancellationToken.None);
 
         // Assert
-        var unprocessableResult = Assert.IsType<UnprocessableEntityObjectResult>(result);
-        Assert.Equal(422, unprocessableResult.StatusCode);
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(422, objectResult.StatusCode);
 
-        var problemDetails = Assert.IsType<ProblemDetails>(unprocessableResult.Value);
-        Assert.Equal(exceptionMessage, problemDetails.Detail);
+        var response = Assert.IsType<GenerateLeafletResponse>(objectResult.Value);
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.LeafletEmptyRetrieval, response.ErrorCode);
     }
 
     [Fact]
-    public async Task Generate_returns_502_on_unexpected_exception()
+    public async Task Generate_propagates_unexpected_exception()
     {
         // Arrange
         var request = new GenerateLeafletRequest
@@ -112,24 +114,15 @@ public class LeafletControllerTests
             Length = LeafletLength.Short,
         };
 
-        var internalMessage = "Internal system failure with stack trace details";
-
         _mediatorMock
             .Setup(m => m.Send(request, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException(internalMessage));
+            .ThrowsAsync(new InvalidOperationException("Internal system failure with stack trace details"));
 
         var controller = CreateController();
 
-        // Act
-        var result = await controller.Generate(request, CancellationToken.None);
-
-        // Assert
-        var objectResult = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(502, objectResult.StatusCode);
-
-        var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
-        Assert.NotEqual(internalMessage, problemDetails.Detail);
-        Assert.DoesNotContain(internalMessage, problemDetails.Detail ?? string.Empty);
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => controller.Generate(request, CancellationToken.None));
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Features.Leaflet;
 using Anela.Heblo.Application.Features.Leaflet.Contracts;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Application.Shared.Rag;
 using Anela.Heblo.Domain.Features.Leaflet;
 using FluentAssertions;
@@ -82,7 +83,7 @@ public class GenerateLeafletHandlerTests
         (MakeLeafletChunk(content), score);
 
     [Fact]
-    public async Task Handle_dual_empty_retrieval_throws_EmptyRetrievalException()
+    public async Task Handle_dual_empty_retrieval_returns_LeafletEmptyRetrieval_error()
     {
         // Arrange
         SetupEmbeddings();
@@ -96,10 +97,14 @@ public class GenerateLeafletHandlerTests
         var request = new GenerateLeafletRequest { Topic = "retinol", Audience = AudienceType.EndConsumer, Length = LeafletLength.Short };
 
         // Act
-        var act = () => handler.Handle(request, CancellationToken.None);
+        var response = await handler.Handle(request, CancellationToken.None);
 
         // Assert
-        await act.Should().ThrowAsync<EmptyRetrievalException>();
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.LeafletEmptyRetrieval);
+        response.Params.Should().NotBeNull();
+        response.Params!.Should().ContainKey("detail");
+        response.Params!["detail"].Should().Contain("Knowledge Base does not yet cover this topic");
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/MCP/Tools/LeafletToolsTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Anela.Heblo.API.MCP.Tools;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Application.Shared;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
@@ -60,21 +61,22 @@ public class LeafletToolsTests
     }
 
     [Fact]
-    public async Task GenerateLeaflet_wraps_EmptyRetrievalException_as_McpException()
+    public async Task GenerateLeaflet_throws_McpException_on_LeafletEmptyRetrieval_response()
     {
         // Arrange
-        const string emptyRetrievalMessage = "No relevant documents were found for the given topic.";
+        var errorResponse = new GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval,
+            new() { { "detail", "Knowledge Base does not yet cover this topic; try a broader phrasing" } });
 
         _mediator
             .Setup(m => m.Send(It.IsAny<GenerateLeafletRequest>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new EmptyRetrievalException(emptyRetrievalMessage));
+            .ReturnsAsync(errorResponse);
 
         // Act
         var exception = await Assert.ThrowsAsync<McpException>(() =>
             CreateTools().GenerateLeaflet("Some topic", "B2B", "Medium"));
 
         // Assert
-        Assert.Equal(emptyRetrievalMessage, exception.Message);
+        Assert.Equal("Knowledge Base does not yet cover this topic; try a broader phrasing", exception.Message);
     }
 
     [Fact]

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -5559,15 +5559,8 @@ export class ApiClient {
             return response.text().then((_responseText) => {
             let result422: any = null;
             let resultData422 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result422 = ProblemDetails.fromJS(resultData422);
+            result422 = GenerateLeafletResponse.fromJS(resultData422);
             return throwException("A server side error occurred.", status, _responseText, _headers, result422);
-            });
-        } else if (status === 502) {
-            return response.text().then((_responseText) => {
-            let result502: any = null;
-            let resultData502 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result502 = ProblemDetails.fromJS(resultData502);
-            return throwException("A server side error occurred.", status, _responseText, _headers, result502);
             });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
@@ -8746,6 +8739,44 @@ export class ApiClient {
             });
         }
         return Promise.resolve<GetPackingDashboardResponse>(null as any);
+    }
+
+    packaging_GetStatistics(fromDate: Date | null | undefined, toDate: Date | null | undefined): Promise<GetPackingStatisticsResponse> {
+        let url_ = this.baseUrl + "/api/packaging/statistics?";
+        if (fromDate !== undefined && fromDate !== null)
+            url_ += "FromDate=" + encodeURIComponent(fromDate ? "" + fromDate.toISOString() : "") + "&";
+        if (toDate !== undefined && toDate !== null)
+            url_ += "ToDate=" + encodeURIComponent(toDate ? "" + toDate.toISOString() : "") + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackaging_GetStatistics(_response);
+        });
+    }
+
+    protected processPackaging_GetStatistics(response: Response): Promise<GetPackingStatisticsResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetPackingStatisticsResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetPackingStatisticsResponse>(null as any);
     }
 
     packaging_GetPackages(orderCode: string | null | undefined, customerName: string | null | undefined, packageNumber: string | null | undefined, carrier: Carriers | null | undefined, fromDate: Date | null | undefined, toDate: Date | null | undefined, pageNumber: number | undefined, pageSize: number | undefined, sortBy: string | undefined, sortDescending: boolean | undefined): Promise<GetPackagesResponse> {
@@ -13220,6 +13251,7 @@ export enum ErrorCodes {
     DqtRunNotFound = "DqtRunNotFound",
     DqtInvalidDateRange = "DqtInvalidDateRange",
     DqtExternalServiceError = "DqtExternalServiceError",
+    DqtUnsupportedTestType = "DqtUnsupportedTestType",
     MarketingActionNotFound = "MarketingActionNotFound",
     UnauthorizedMarketingAccess = "UnauthorizedMarketingAccess",
     MarketingCalendarAccessDenied = "MarketingCalendarAccessDenied",
@@ -13234,6 +13266,7 @@ export enum ErrorCodes {
     LeafletChunkNotFound = "LeafletChunkNotFound",
     LeafletFeedbackNotFound = "LeafletFeedbackNotFound",
     LeafletFeedbackAlreadySubmitted = "LeafletFeedbackAlreadySubmitted",
+    LeafletEmptyRetrieval = "LeafletEmptyRetrieval",
     PhotoNotFound = "PhotoNotFound",
     PhotobankRootNotFound = "PhotobankRootNotFound",
     PhotobankRuleNotFound = "PhotobankRuleNotFound",
@@ -13962,12 +13995,6 @@ export enum ArticleStatus {
     Failed = "Failed",
 }
 
-export enum ArticleGenerationStepStatus {
-    Running = "Running",
-    Succeeded = "Succeeded",
-    Failed = "Failed",
-}
-
 export class GenerateArticleRequest implements IGenerateArticleRequest {
     topic!: string;
     scope?: string;
@@ -14328,6 +14355,12 @@ export interface IArticleGenerationStepDto {
     inputJson?: string | undefined;
     outputJson?: string | undefined;
     errorMessage?: string | undefined;
+}
+
+export enum ArticleGenerationStepStatus {
+    Running = "Running",
+    Succeeded = "Succeeded",
+    Failed = "Failed",
 }
 
 export class ListArticlesResponse extends BaseResponse implements IListArticlesResponse {
@@ -16277,7 +16310,6 @@ export interface IRefreshTaskExecutionLogDto {
 export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
     taskId?: string;
     enabled?: boolean;
-    description?: string | undefined;
     refreshInterval?: string;
     lastExecution?: RefreshTaskExecutionLogDto | undefined;
 
@@ -16294,7 +16326,6 @@ export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
         if (_data) {
             this.taskId = _data["taskId"];
             this.enabled = _data["enabled"];
-            this.description = _data["description"];
             this.refreshInterval = _data["refreshInterval"];
             this.lastExecution = _data["lastExecution"] ? RefreshTaskExecutionLogDto.fromJS(_data["lastExecution"]) : <any>undefined;
         }
@@ -16311,7 +16342,6 @@ export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
         data = typeof data === 'object' ? data : {};
         data["taskId"] = this.taskId;
         data["enabled"] = this.enabled;
-        data["description"] = this.description;
         data["refreshInterval"] = this.refreshInterval;
         data["lastExecution"] = this.lastExecution ? this.lastExecution.toJSON() : <any>undefined;
         return data;
@@ -16321,7 +16351,6 @@ export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
 export interface IRefreshTaskStatusDto {
     taskId?: string;
     enabled?: boolean;
-    description?: string | undefined;
     refreshInterval?: string;
     lastExecution?: RefreshTaskExecutionLogDto | undefined;
 }
@@ -19956,6 +19985,7 @@ export interface IReprintExpeditionListRequest {
 
 export class RunExpeditionListPrintFixResponse extends BaseResponse implements IRunExpeditionListPrintFixResponse {
     totalCount?: number;
+    skippedCount?: number;
 
     constructor(data?: IRunExpeditionListPrintFixResponse) {
         super(data);
@@ -19965,6 +19995,7 @@ export class RunExpeditionListPrintFixResponse extends BaseResponse implements I
         super.init(_data);
         if (_data) {
             this.totalCount = _data["totalCount"];
+            this.skippedCount = _data["skippedCount"];
         }
     }
 
@@ -19978,6 +20009,7 @@ export class RunExpeditionListPrintFixResponse extends BaseResponse implements I
     override toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
         data["totalCount"] = this.totalCount;
+        data["skippedCount"] = this.skippedCount;
         super.toJSON(data);
         return data;
     }
@@ -19985,6 +20017,7 @@ export class RunExpeditionListPrintFixResponse extends BaseResponse implements I
 
 export interface IRunExpeditionListPrintFixResponse extends IBaseResponse {
     totalCount?: number;
+    skippedCount?: number;
 }
 
 export class PrintExpeditionOrderResponse extends BaseResponse implements IPrintExpeditionOrderResponse {
@@ -32955,6 +32988,391 @@ export class PackerStatsDto implements IPackerStatsDto {
 export interface IPackerStatsDto {
     packerId?: string | undefined;
     packerName?: string;
+    orderCount?: number;
+}
+
+export class GetPackingStatisticsResponse extends BaseResponse implements IGetPackingStatisticsResponse {
+    fromDate?: Date;
+    toDate?: Date;
+    packerAttributionSince?: Date | undefined;
+    summary?: PackingStatisticsSummaryDto;
+    throughputDaily?: DailyThroughputDto[];
+    hourHeatmap?: HourBucketDto[];
+    byPacker?: PackerThroughputDto[];
+    byCarrier?: CarrierMixDto[];
+    packagesPerOrder?: PackagesPerOrderBucketDto[];
+
+    constructor(data?: IGetPackingStatisticsResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.fromDate = _data["fromDate"] ? new Date(_data["fromDate"].toString()) : <any>undefined;
+            this.toDate = _data["toDate"] ? new Date(_data["toDate"].toString()) : <any>undefined;
+            this.packerAttributionSince = _data["packerAttributionSince"] ? new Date(_data["packerAttributionSince"].toString()) : <any>undefined;
+            this.summary = _data["summary"] ? PackingStatisticsSummaryDto.fromJS(_data["summary"]) : <any>undefined;
+            if (Array.isArray(_data["throughputDaily"])) {
+                this.throughputDaily = [] as any;
+                for (let item of _data["throughputDaily"])
+                    this.throughputDaily!.push(DailyThroughputDto.fromJS(item));
+            }
+            if (Array.isArray(_data["hourHeatmap"])) {
+                this.hourHeatmap = [] as any;
+                for (let item of _data["hourHeatmap"])
+                    this.hourHeatmap!.push(HourBucketDto.fromJS(item));
+            }
+            if (Array.isArray(_data["byPacker"])) {
+                this.byPacker = [] as any;
+                for (let item of _data["byPacker"])
+                    this.byPacker!.push(PackerThroughputDto.fromJS(item));
+            }
+            if (Array.isArray(_data["byCarrier"])) {
+                this.byCarrier = [] as any;
+                for (let item of _data["byCarrier"])
+                    this.byCarrier!.push(CarrierMixDto.fromJS(item));
+            }
+            if (Array.isArray(_data["packagesPerOrder"])) {
+                this.packagesPerOrder = [] as any;
+                for (let item of _data["packagesPerOrder"])
+                    this.packagesPerOrder!.push(PackagesPerOrderBucketDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetPackingStatisticsResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetPackingStatisticsResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["fromDate"] = this.fromDate ? this.fromDate.toISOString() : <any>undefined;
+        data["toDate"] = this.toDate ? this.toDate.toISOString() : <any>undefined;
+        data["packerAttributionSince"] = this.packerAttributionSince ? this.packerAttributionSince.toISOString() : <any>undefined;
+        data["summary"] = this.summary ? this.summary.toJSON() : <any>undefined;
+        if (Array.isArray(this.throughputDaily)) {
+            data["throughputDaily"] = [];
+            for (let item of this.throughputDaily)
+                data["throughputDaily"].push(item.toJSON());
+        }
+        if (Array.isArray(this.hourHeatmap)) {
+            data["hourHeatmap"] = [];
+            for (let item of this.hourHeatmap)
+                data["hourHeatmap"].push(item.toJSON());
+        }
+        if (Array.isArray(this.byPacker)) {
+            data["byPacker"] = [];
+            for (let item of this.byPacker)
+                data["byPacker"].push(item.toJSON());
+        }
+        if (Array.isArray(this.byCarrier)) {
+            data["byCarrier"] = [];
+            for (let item of this.byCarrier)
+                data["byCarrier"].push(item.toJSON());
+        }
+        if (Array.isArray(this.packagesPerOrder)) {
+            data["packagesPerOrder"] = [];
+            for (let item of this.packagesPerOrder)
+                data["packagesPerOrder"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetPackingStatisticsResponse extends IBaseResponse {
+    fromDate?: Date;
+    toDate?: Date;
+    packerAttributionSince?: Date | undefined;
+    summary?: PackingStatisticsSummaryDto;
+    throughputDaily?: DailyThroughputDto[];
+    hourHeatmap?: HourBucketDto[];
+    byPacker?: PackerThroughputDto[];
+    byCarrier?: CarrierMixDto[];
+    packagesPerOrder?: PackagesPerOrderBucketDto[];
+}
+
+export class PackingStatisticsSummaryDto implements IPackingStatisticsSummaryDto {
+    totalPackages?: number;
+    totalOrders?: number;
+    distinctPackers?: number;
+    averagePackagesPerOrder?: number;
+    trackingCoveragePercent?: number;
+    busiestDay?: DailyThroughputDto | undefined;
+    busiestHour?: HourBucketDto | undefined;
+
+    constructor(data?: IPackingStatisticsSummaryDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.totalPackages = _data["totalPackages"];
+            this.totalOrders = _data["totalOrders"];
+            this.distinctPackers = _data["distinctPackers"];
+            this.averagePackagesPerOrder = _data["averagePackagesPerOrder"];
+            this.trackingCoveragePercent = _data["trackingCoveragePercent"];
+            this.busiestDay = _data["busiestDay"] ? DailyThroughputDto.fromJS(_data["busiestDay"]) : <any>undefined;
+            this.busiestHour = _data["busiestHour"] ? HourBucketDto.fromJS(_data["busiestHour"]) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): PackingStatisticsSummaryDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackingStatisticsSummaryDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["totalPackages"] = this.totalPackages;
+        data["totalOrders"] = this.totalOrders;
+        data["distinctPackers"] = this.distinctPackers;
+        data["averagePackagesPerOrder"] = this.averagePackagesPerOrder;
+        data["trackingCoveragePercent"] = this.trackingCoveragePercent;
+        data["busiestDay"] = this.busiestDay ? this.busiestDay.toJSON() : <any>undefined;
+        data["busiestHour"] = this.busiestHour ? this.busiestHour.toJSON() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IPackingStatisticsSummaryDto {
+    totalPackages?: number;
+    totalOrders?: number;
+    distinctPackers?: number;
+    averagePackagesPerOrder?: number;
+    trackingCoveragePercent?: number;
+    busiestDay?: DailyThroughputDto | undefined;
+    busiestHour?: HourBucketDto | undefined;
+}
+
+export class DailyThroughputDto implements IDailyThroughputDto {
+    date?: Date;
+    orderCount?: number;
+    packageCount?: number;
+
+    constructor(data?: IDailyThroughputDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.date = _data["date"] ? new Date(_data["date"].toString()) : <any>undefined;
+            this.orderCount = _data["orderCount"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): DailyThroughputDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new DailyThroughputDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["date"] = this.date ? this.date.toISOString() : <any>undefined;
+        data["orderCount"] = this.orderCount;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface IDailyThroughputDto {
+    date?: Date;
+    orderCount?: number;
+    packageCount?: number;
+}
+
+export class HourBucketDto implements IHourBucketDto {
+    dayOfWeek?: number;
+    hour?: number;
+    packageCount?: number;
+
+    constructor(data?: IHourBucketDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.dayOfWeek = _data["dayOfWeek"];
+            this.hour = _data["hour"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): HourBucketDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new HourBucketDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["dayOfWeek"] = this.dayOfWeek;
+        data["hour"] = this.hour;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface IHourBucketDto {
+    dayOfWeek?: number;
+    hour?: number;
+    packageCount?: number;
+}
+
+export class PackerThroughputDto implements IPackerThroughputDto {
+    packerId?: string | undefined;
+    packerName?: string;
+    orderCount?: number;
+    packageCount?: number;
+
+    constructor(data?: IPackerThroughputDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.packerId = _data["packerId"];
+            this.packerName = _data["packerName"];
+            this.orderCount = _data["orderCount"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): PackerThroughputDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackerThroughputDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["packerId"] = this.packerId;
+        data["packerName"] = this.packerName;
+        data["orderCount"] = this.orderCount;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface IPackerThroughputDto {
+    packerId?: string | undefined;
+    packerName?: string;
+    orderCount?: number;
+    packageCount?: number;
+}
+
+export class CarrierMixDto implements ICarrierMixDto {
+    code?: string;
+    name?: string;
+    packageCount?: number;
+
+    constructor(data?: ICarrierMixDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.code = _data["code"];
+            this.name = _data["name"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): CarrierMixDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new CarrierMixDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["code"] = this.code;
+        data["name"] = this.name;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface ICarrierMixDto {
+    code?: string;
+    name?: string;
+    packageCount?: number;
+}
+
+export class PackagesPerOrderBucketDto implements IPackagesPerOrderBucketDto {
+    packageCount?: number;
+    orderCount?: number;
+
+    constructor(data?: IPackagesPerOrderBucketDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.packageCount = _data["packageCount"];
+            this.orderCount = _data["orderCount"];
+        }
+    }
+
+    static fromJS(data: any): PackagesPerOrderBucketDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackagesPerOrderBucketDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["packageCount"] = this.packageCount;
+        data["orderCount"] = this.orderCount;
+        return data;
+    }
+}
+
+export interface IPackagesPerOrderBucketDto {
+    packageCount?: number;
     orderCount?: number;
 }
 

--- a/frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
@@ -2,20 +2,17 @@ import React, { useState } from 'react';
 import LeafletForm from './LeafletForm';
 import LeafletResult from './LeafletResult';
 import { getAuthenticatedApiClient } from '../../api/client';
-import { AudienceType, GenerateLeafletRequest, LeafletLength } from '../../api/generated/api-client';
+import {
+  AudienceType,
+  ErrorCodes,
+  GenerateLeafletRequest,
+  GenerateLeafletResponse,
+  LeafletLength,
+} from '../../api/generated/api-client';
 
 interface ErrorBanner {
   kind: 'insufficient' | 'transient';
   message: string;
-}
-
-interface ApiError {
-  status: number;
-  detail?: string;
-}
-
-function isApiError(err: unknown): err is ApiError {
-  return typeof err === 'object' && err !== null && typeof (err as Record<string, unknown>)['status'] === 'number';
 }
 
 const LeafletGenerateTab: React.FC = () => {
@@ -37,12 +34,10 @@ const LeafletGenerateTab: React.FC = () => {
       setResult(response.content ?? '');
       setGenerationId((response as any).id ?? null);
     } catch (err: unknown) {
-      if (isApiError(err) && err.status === 422) {
+      if (err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval) {
         setErrorBanner({
           kind: 'insufficient',
-          message:
-            err.detail ??
-            'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+          message: 'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
         });
       } else {
         setErrorBanner({

--- a/frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx
+++ b/frontend/src/features/leaflet-generator/__tests__/LeafletGenerateTab.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LeafletGenerateTab from '../LeafletGenerateTab';
+import { getAuthenticatedApiClient } from '../../../api/client';
+import { ErrorCodes, GenerateLeafletResponse } from '../../../api/generated/api-client';
+
+jest.mock('../../../api/client', () => ({
+  getAuthenticatedApiClient: jest.fn(),
+}));
+
+jest.mock('../../../api/hooks/useLeaflet', () => ({
+  useSubmitLeafletFeedbackMutation: () => ({
+    mutate: jest.fn(),
+    isPending: false,
+    isError: false,
+  }),
+}));
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+let mockGenerate: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGenerate = jest.fn();
+  (getAuthenticatedApiClient as jest.Mock).mockReturnValue({
+    leaflet_Generate: mockGenerate,
+  });
+});
+
+async function fillAndSubmit() {
+  fireEvent.change(screen.getByLabelText('Téma'), { target: { value: 'Bisabolol' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Vygenerovat leták' }));
+}
+
+describe('LeafletGenerateTab', () => {
+  it('shows the insufficient knowledge banner when the API rejects with LeafletEmptyRetrieval', async () => {
+    const errorResponse = new GenerateLeafletResponse({
+      success: false,
+      errorCode: ErrorCodes.LeafletEmptyRetrieval,
+    });
+    mockGenerate.mockRejectedValue(errorResponse);
+
+    render(<LeafletGenerateTab />);
+    await fillAndSubmit();
+
+    const banner = await screen.findByRole('alert');
+    expect(banner).toHaveTextContent('Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.');
+    expect(banner.className).toContain('bg-amber-100');
+  });
+
+  it('shows the transient failure banner for a generic error', async () => {
+    mockGenerate.mockRejectedValue(new Error('network down'));
+
+    render(<LeafletGenerateTab />);
+    await fillAndSubmit();
+
+    const banner = await screen.findByRole('alert');
+    expect(banner).toHaveTextContent('Generování selhalo. Zkuste to prosím znovu.');
+    expect(banner.className).toContain('bg-red-100');
+  });
+});

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -208,6 +208,7 @@ const resources = {
         LeafletChunkNotFound: "Fragment letáku nebyl nalezen",
         LeafletFeedbackNotFound: "Zpětná vazba k letáku nebyla nalezena",
         LeafletFeedbackAlreadySubmitted: "Zpětná vazba k letáku již byla odeslána",
+        LeafletEmptyRetrieval: "Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.",
 
         // ShoptetOrders module errors
         ShoptetOrderInvalidSourceState: "Objednávku nelze zablokovat – není ve povoleném stavu",


### PR DESCRIPTION
Closes #3478

## What the issue was
`GenerateLeafletHandler` threw a domain exception (`EmptyRetrievalException`) when the knowledge base and leaflet corpus both returned zero relevant hits, forcing `LeafletController.Generate` to catch that exception (and a generic `Exception`) to decide HTTP status codes itself — business logic living in the controller, which `docs/architecture/development_guidelines.md` explicitly forbids. Every other handler in the Leaflet module already used the response-coded error pattern (`BaseResponse`/`ErrorCodes`/`HandleResponse`) instead.

## How it was fixed / handled
Replaced the thrown exception with a normal error-coded response, matching the rest of the module:

- Added `ErrorCodes.LeafletEmptyRetrieval = 2504` (422 Unprocessable Entity), and an error-constructing constructor on `GenerateLeafletResponse`.
- `GenerateLeafletHandler` now returns `GenerateLeafletResponse(ErrorCodes.LeafletEmptyRetrieval, ...)` instead of throwing.
- `LeafletController.Generate` dropped its try/catch entirely and now delegates to the shared `HandleResponse(result)` helper, like every sibling action in the controller. The former 502 safety-net catch-all is removed — this follows the issue's own suggested fix; unexpected exceptions now propagate to the app's standard exception-handling pipeline.
- `LeafletTools.GenerateLeaflet` (an MCP tool consumer not mentioned in the original issue, found during analysis) also caught this exception — updated to inspect `response.Success`/`response.ErrorCode` instead.
- Deleted the now-dead `EmptyRetrievalException` type after confirming zero remaining references.
- Regenerated the OpenAPI TypeScript client and fixed `LeafletGenerateTab.tsx` (frontend regression risk found during analysis: the component detected the old error shape via `err.status === 422` duck-typing, which would have silently broken once the 422 response body shape changed) — it now checks `err instanceof GenerateLeafletResponse && err.errorCode === ErrorCodes.LeafletEmptyRetrieval`. Added a new test file for this component (none existed before).
- Updated all affected backend tests (handler, controller, MCP tool) to match the new response-based contract.
- Added the missing Czech translation for `LeafletEmptyRetrieval` in `frontend/src/i18n.ts` (caught by CI's `LocalizationCoverageTests` after a backmerge unblocked the backend test build — see Notes below).

## Artifacts
Brief, spec, architecture review, task plan, per-task impl/review, and the final whole-branch code review are committed under `artifacts/feat-3478/` on this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

## Notes
- CI is green: Backend Tests, Frontend Tests, and Docker build all pass.
- At PR creation, the backend `Anela.Heblo.Tests` project failed to build repo-wide due to a pre-existing, unrelated compile error (`ConfigurationConstants.APP_VERSION`). That was fixed on `main` and picked up here via a backmerge, which unblocked the full test suite and surfaced one real gap in this PR — a missing i18n translation for the new error code — now fixed (see above).
- `frontend/src/api/generated/api-client.ts` includes some unrelated diff churn (e.g. `GetPackingStatisticsResponse`) — this is catch-up regeneration for an already-merged backend endpoint that hadn't been regenerated into the committed client yet, not scope creep from this change.
