### PR TITLE
#3486: remove dead TopProductCount parameter from GetProductMarginSummary

### DIFF
--- a/artifacts/feat-3486/arch-review.r1.md
+++ b/artifacts/feat-3486/arch-review.r1.md
@@ -1,0 +1,120 @@
+# Architecture Review: Fix dead `TopProductCount` parameter in GetProductMarginSummary
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a narrow, internal API-surface cleanup inside an existing vertical slice (`Analytics/UseCases/GetProductMarginSummary`). It touches one MediatR request DTO, one handler (read-only, no logic change needed), one frontend hook, and the generated OpenAPI client. There is no new component, no new module boundary, and no UI change — the frontend already renders from the full `topProducts` list today, so removing a parameter nobody reads changes nothing observable.
+
+I independently verified the facts the spec relies on:
+- `GetProductMarginSummaryRequest.TopProductCount` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs:9`) exists but `GetProductMarginSummaryHandler.Handle` (same folder) never reads `request.TopProductCount` — `GenerateTopProducts` builds `topProductsWithData` from `calculationResult.GroupTotals` with no `Take`/limit anywhere in its body.
+- The controller binds the whole request via `[FromQuery] GetProductMarginSummaryRequest request` (`backend/src/Anela.Heblo.API/Controllers/AnalyticsController.cs:32`), so removing a property is a pure DTO change — no controller signature edit needed.
+- `useProductMarginSummary.ts:27` calls the generated client with a hardcoded `0, // topProductCount = 0 means no limit` positional argument.
+- `ProductMarginSummary.tsx` (lines ~66-167) does its own client-side top-N bucketing: it sorts `data.topProducts` by `totalMargin`, takes `TOP_CHART_PRODUCTS = 15` for the chart series, and buckets everything else into an "Ostatní produkty" (Other) series computed from the full remainder of the list. The table (`tableData`, lines ~170+) is built from every entry in `data.topProducts`, not a truncated subset.
+- No backend test references `TopProductCount` (`backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` — zero matches).
+- `docs/architecture/development_guidelines.md` / `docs/development/api-client-generation.md` mandate DTOs-as-classes (already satisfied — `GetProductMarginSummaryRequest` is a class) and require the OpenAPI client to be regenerated whenever a request/response contract changes.
+
+Given this, the parameter is unambiguously dead on the server, and the one real caller structurally depends on receiving the *complete* group list to do its own top-15/Other split and full-table rendering. There is no plan, ticket, or code path anywhere in this repo that wants a truncated response.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. Existing flow, unchanged shape, one property removed from the contract:
+
+```
+ProductMarginSummary.tsx
+        │ (reads data.topProducts — full list; does its own top-15/Other split)
+        ▼
+useProductMarginSummaryQuery (useProductMarginSummary.ts)
+        │ calls analytics_GetProductMarginSummary(timeWindow, groupingMode, marginLevel, sortBy, sortDescending)
+        ▼
+AnalyticsController.GetProductMarginSummary([FromQuery] GetProductMarginSummaryRequest)
+        │
+        ▼
+GetProductMarginSummaryHandler.Handle
+        │ streams products → IMarginCalculator → GenerateTopProducts (no limit, returns all groups)
+        ▼
+GetProductMarginSummaryResponse { TopProducts: List<TopProductDto> (full), MonthlyData, TotalMargin, ... }
+```
+
+### Key Design Decisions
+
+#### Decision 1: Remove `TopProductCount` vs. implement server-side truncation
+
+**Options considered:**
+- **Option 1 — Remove the parameter.** Delete `TopProductCount` from `GetProductMarginSummaryRequest`; handler is already unaffected. Update the frontend call site to drop the argument. Regenerate the OpenAPI client.
+- **Option 2 — Implement the limit.** Add `.Take(request.TopProductCount > 0 ? request.TopProductCount : int.MaxValue)` in `GenerateTopProducts` after sorting, and have the frontend pass a real value.
+
+**Chosen approach: Option 1 — remove the parameter.** This is the final, binding decision for this change.
+
+**Rationale:**
+1. **The only consumer needs the untruncated list, structurally, not incidentally.** `ProductMarginSummary.tsx` computes its own top-15 + "Other" chart bucket and renders a full data table plus a total-group count (`data.topProducts.length`) from the complete set. If the backend truncated to N, the "Other" bucket and the total-group count would silently become wrong or would require a second, unbounded endpoint call anyway — defeating the purpose of truncating in the first place. Implementing Option 2 today would produce a parameter that is technically "wired up" but that no caller could safely use above `0` (no-limit) without a separate frontend rework that is out of scope and unspecified.
+2. **YAGNI.** There is no present requirement, ticket, or planned feature that needs the server to truncate this list. Speculative truncation is exactly the kind of unused-but-plausible-looking parameter that created this bug report in the first place (the arch-review routine flagged it precisely because a documented-but-inert parameter is worse than no parameter).
+3. **Lower risk, smaller diff.** Option 1 is a subtractive, behavior-preserving change: no handler logic changes, no new sorting/ranking edge cases (Option 2 would need to re-verify that `Rank` stays contiguous 1..N after truncation, per the spec's own FR-2 caveat). Option 1 has nothing new to get wrong.
+4. **Contract honesty.** The project's dev guidelines already require DTOs to accurately reflect behavior (classes-not-records DTOs, `[Required]`/validation attributes, etc.) — a parameter that is accepted, documented with a default, and silently ignored is itself a violation of that spirit. Removing it directly resolves the arch-review finding; keeping-but-implementing it defers the real fix to a future, currently-unplanned frontend change.
+5. **Reversible later.** If a genuine need for server-side pagination/top-N emerges (e.g., the results table grows large enough to need real pagination — explicitly called out as future, out-of-scope work in the spec), that should be designed as its own feature with its own contract (e.g., a proper `PageSize`/`Take` combined with a documented "does this affect the chart Other-bucket and total count" answer) rather than resurrecting a parameter whose semantics were never fully thought through.
+
+No further clarification round-trip exists after this review — Option 1 is final.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files or directories. Edit in place, within the existing `Analytics` vertical slice:
+
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs`
+- `frontend/src/api/hooks/useProductMarginSummary.ts`
+- `frontend/src/api/generated/api-client.ts` (regenerated, not hand-edited)
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` (only if it constructs `GetProductMarginSummaryRequest` with `TopProductCount` set anywhere — grep found none, but re-check at implementation time in case object initializers set it without using the property name in a way grep missed, e.g. via reflection/AutoFixture)
+
+### Interfaces and Contracts
+
+**Backend — `GetProductMarginSummaryRequest.cs`:** delete the line:
+```csharp
+public int TopProductCount { get; set; } = 15; // Configurable, default 15
+```
+Leave every other property (`TimeWindow`, `GroupingMode`, `MarginLevel`, `SortBy`, `SortDescending`) untouched. `GetProductMarginSummaryHandler.Handle` requires **no changes** — it never referenced `request.TopProductCount`. `GetProductMarginSummaryResponse` and `TopProductDto` are unaffected.
+
+**Controller:** `AnalyticsController.GetProductMarginSummary([FromQuery] GetProductMarginSummaryRequest request)` binds the whole DTO — no signature change needed; the query string simply gains one fewer recognized parameter (`TopProductCount`/`topProductCount`).
+
+**OpenAPI client regeneration is required** per `docs/development/api-client-generation.md` (any request/response contract change must regenerate both clients). Run:
+```bash
+dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateFrontendClientManual
+```
+(or let the Debug-mode PostBuild / frontend `prebuild` script do it automatically). After regeneration, `frontend/src/api/generated/api-client.ts`'s `analytics_GetProductMarginSummary` method signature loses its `topProductCount` positional parameter — this is a generated file; do not hand-edit it, just regenerate and commit the diff.
+
+**Frontend — `useProductMarginSummary.ts`:** update the call to match the new (regenerated) positional signature by removing the `0, // topProductCount = 0 means no limit` argument:
+```typescript
+return apiClient.analytics_GetProductMarginSummary(
+  timeWindow,
+  groupingMode,
+  marginLevel,
+  sortBy,
+  true // sortDescending = true
+);
+```
+No other frontend file needs to change — `ProductMarginSummary.tsx`'s chart bucketing, table rendering, and "Celkem skupin" total-group count already consume the full `topProducts` array and require no rework, since the response shape (`TopProducts: List<TopProductDto>`) does not change at all, only the request's query parameters shrink by one.
+
+### Data Flow
+
+Unchanged. Request → `TimeWindowParser` → streamed product margin calculation → `GenerateTopProducts` (all groups, ranked) → `GetProductMarginSummaryResponse.TopProducts` (full list) → frontend hook → `ProductMarginSummary.tsx` (client-side top-15 + Other bucketing for the chart; full list for the table and group count). The only thing removed from this flow is an inert query parameter that never influenced any step.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Stale/uncommitted generated client leaves `topProductCount` in `api-client.ts` after backend change, causing a TS compile mismatch or a silently-passed dead arg | Low | Regenerate via `dotnet msbuild ... -t:GenerateFrontendClientManual` (or `npm run generate-client`) as part of the same commit; `npm run build`'s prebuild step will also catch drift |
+| Hidden caller of `TopProductCount` elsewhere in the codebase (e.g. a script, Postman collection, or forgotten test) breaks after removal | Low | Grep across the full repo found only: the property declaration itself, the frontend hook's `0` argument, the generated client, and the old pre-refactor doc (`docs/features/product-margin-summary.md`, historical/inactive). No test or other caller references it. |
+| Future request to add real server-side pagination/top-N reintroduces the same "documented but unused" trap if rushed | Low | When that need arises, design it as a dedicated change that also updates `ProductMarginSummary.tsx`'s chart Other-bucket and total-group-count logic in the same PR — do not add a parameter without a consumer exercising it with a non-default value, per FR-3's acceptance criterion |
+
+## Specification Amendments
+
+- The spec's **Open Question** is resolved: **Option 1 is chosen, final, and binding.** FR-2 (the "alternative" implement-the-limit path) should be treated as rejected/out of scope for this change, not merely "not recommended." Remove or mark FR-2 as rejected in the spec status so implementers don't accidentally build it.
+- FR-1's acceptance criteria are confirmed accurate as written and require no changes.
+- Clarify in FR-1 (or FR-3) explicitly that **no controller code changes** are needed beyond the DTO edit, since `[FromQuery]` binds the whole request object — this review confirms that explicitly so implementers don't go looking for a controller parameter list to edit.
+- Add to FR-1's acceptance criteria: after regenerating `frontend/src/api/generated/api-client.ts`, update the positional call in `useProductMarginSummary.ts` to the new 5-argument signature (`timeWindow, groupingMode, marginLevel, sortBy, sortDescending`) — the exact ordering must be re-checked against whatever NSwag actually emits (positional args are ordered by property declaration order in the request class), not assumed.
+
+## Prerequisites
+
+- None. No migrations, no config, no new infrastructure. This can be implemented immediately: edit the DTO, regenerate both OpenAPI clients (backend C# client and frontend TypeScript client), update the one frontend call site, run `dotnet build` + `dotnet format` and `npm run build` + `npm run lint` per the repo's standard validation gate, and re-run `ProductMarginSummary.test.tsx` plus a manual smoke check of the Analytics page.

--- a/artifacts/feat-3486/brief.md
+++ b/artifacts/feat-3486/brief.md
@@ -1,0 +1,28 @@
+# [arch-review] Analytics: GetProductMarginSummaryRequest.TopProductCount accepted but silently ignored
+
+## Module
+Analytics
+
+## Finding
+`GetProductMarginSummaryRequest.TopProductCount` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs:9`) is declared as a public API parameter:
+
+```csharp
+public int TopProductCount { get; set; } = 15; // Configurable, default 15
+```
+
+`GetProductMarginSummaryHandler.Handle` never reads `request.TopProductCount`. The `GenerateTopProducts` method (lines 69–117) returns all groups without any limit. The frontend workaround confirms this: it passes `topProductCount: 0` explicitly, relying on the backend ignoring the value.
+
+Because the TypeScript client is auto-generated from the OpenAPI spec, `topProductCount` appears as a documented query parameter with a default of 15, but it has no effect on the response.
+
+## Why it matters
+The public API lies: callers who pass `topProductCount=5` expecting a shorter, faster response receive the full dataset. This is a contract violation and will mislead anyone integrating against the spec. It also creates confusion whenever the parameter is "discovered" in the source — it looks like a feature but is dead code.
+
+## Suggested fix
+Pick one option:
+1. **Remove the parameter** from `GetProductMarginSummaryRequest` and update `GetProductMarginSummaryHandler` (no behaviour change; cleans up the API surface).
+2. **Implement the limit** — after sorting in `GenerateTopProducts`, truncate: `return sortedProducts.Take(request.TopProductCount > 0 ? request.TopProductCount : int.MaxValue).ToList();`.
+
+Option 2 honours the documented intent. Update the frontend to pass a meaningful value instead of `0`.
+
+---
+_Filed by daily arch-review routine on 2026-07-05._

--- a/artifacts/feat-3486/code-review.r1.md
+++ b/artifacts/feat-3486/code-review.r1.md
@@ -1,0 +1,11 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `docs/features/product-margin-summary.md` — still documents the old, pre-refactor `TopProductCount`/"top N" behavior now that the parameter has been removed; not required by the spec (explicitly Out of Scope) but worth a follow-up doc pass.
+- `frontend/src/api/generated/api-client.ts` — this regeneration also picked up unrelated pre-existing drift between the checked-in client and the current backend OpenAPI surface (`packaging_GetStatistics`, `DqtUnsupportedTestType`, `RunExpeditionListPrintFixResponse.skippedCount`, `RefreshTaskStatusDto.description` removal, `ArticleGenerationStepStatus` relocation). Verified via `git diff origin/main -- frontend/src/api/generated/api-client.ts` that this drift already existed on `main` before this branch — none of it was introduced by this change, and it is an unavoidable side effect of the mandatory "regenerate, don't hand-edit" workflow. No action needed for this PR; flagging only so a future generated-client refresh isn't mistaken for scope creep.
+
+## Notes
+Diff reviewed: `backend/.../GetProductMarginSummaryRequest.cs` (removes unused `TopProductCount` property), `frontend/src/api/hooks/useProductMarginSummary.ts` (drops the now-invalid positional argument), and the regenerated `frontend/src/api/generated/api-client.ts`. `GetProductMarginSummaryHandler`, `GenerateTopProducts`, the controller, and all existing tests are untouched, matching the architect's binding decision (Option 1: remove the dead parameter) and the task context's explicit statement that the handler requires zero changes. Confirmed via repo-wide grep that no reference to `TopProductCount`/`topProductCount` remains in any `.cs`/`.ts`/`.tsx` file. This is a pure, behavior-preserving dead-code removal — no correctness risk.

--- a/artifacts/feat-3486/design.r1.md
+++ b/artifacts/feat-3486/design.r1.md
@@ -1,0 +1,68 @@
+# Design: Fix dead `TopProductCount` parameter in GetProductMarginSummary
+
+## Component Design
+
+No new components. This is a subtractive edit to an existing vertical slice — one request DTO property is removed, the generated OpenAPI client is regenerated, and the one frontend caller drops the corresponding argument. No component boundaries change.
+
+```
+ProductMarginSummary.tsx
+        │ (reads data.topProducts — full list; does its own top-15/Other split;
+        │  no changes required — response shape is unaffected)
+        ▼
+useProductMarginSummaryQuery (useProductMarginSummary.ts)
+        │ calls analytics_GetProductMarginSummary(timeWindow, groupingMode,
+        │                                          marginLevel, sortBy, sortDescending)
+        │ — drops the `0 /* topProductCount */` positional argument
+        ▼
+AnalyticsController.GetProductMarginSummary([FromQuery] GetProductMarginSummaryRequest)
+        │ — no signature change; [FromQuery] binds the whole DTO
+        ▼
+GetProductMarginSummaryHandler.Handle
+        │ streams products → IMarginCalculator → GenerateTopProducts
+        │ (no limit, returns all groups — never read TopProductCount, so no
+        │  behavior change)
+        ▼
+GetProductMarginSummaryResponse { TopProducts: List<TopProductDto> (full), ... }
+```
+
+### Responsibilities and interface changes
+
+- **`GetProductMarginSummaryRequest`** (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs`): drop the `TopProductCount` property. Remains a plain class (per project DTO convention — never a record). All other properties (`TimeWindow`, `GroupingMode`, `MarginLevel`, `SortBy`, `SortDescending`) are unchanged.
+- **`AnalyticsController.GetProductMarginSummary`**: no code change. It binds the entire request object via `[FromQuery]`, so the query string simply loses one recognized parameter.
+- **`GetProductMarginSummaryHandler.Handle` / `GenerateTopProducts`**: no code change. Neither method ever read `request.TopProductCount`; ranking and grouping logic is untouched.
+- **`useProductMarginSummaryQuery`** (`frontend/src/api/hooks/useProductMarginSummary.ts`): update the call to the regenerated client method, removing the `0, // topProductCount = 0 means no limit` positional argument. The exact resulting argument order must match whatever the regenerated client emits (NSwag orders positional args by request-class property declaration order) — expected to become `(timeWindow, groupingMode, marginLevel, sortBy, sortDescending)`.
+- **`ProductMarginSummary.tsx`**: no code change. Its client-side top-15/"Other" chart bucketing, full results table, and "Celkem skupin" total-group count already consume the complete `topProducts` array and are unaffected because the response shape does not change.
+- **Generated client** (`frontend/src/api/generated/api-client.ts`): regenerated, not hand-edited, via the project's standard client-generation step (`docs/development/api-client-generation.md`). `analytics_GetProductMarginSummary` loses its `topProductCount` parameter.
+
+## Data Schemas
+
+### Request (query parameters)
+
+Before:
+
+| Param | Type | Notes |
+|---|---|---|
+| `timeWindow` | `string` | |
+| `groupingMode` | `ProductGroupingMode` | |
+| `marginLevel` | `MarginLevel` | |
+| `sortBy` | `string?` | |
+| `sortDescending` | `bool` | |
+| `topProductCount` | `int` | **Removed** — accepted by the contract but never read by the handler |
+
+After:
+
+| Param | Type | Notes |
+|---|---|---|
+| `timeWindow` | `string` | unchanged |
+| `groupingMode` | `ProductGroupingMode` | unchanged |
+| `marginLevel` | `MarginLevel` | unchanged |
+| `sortBy` | `string?` | unchanged |
+| `sortDescending` | `bool` | unchanged |
+
+### Response — `GetProductMarginSummaryResponse`
+
+No change. `TopProducts: List<TopProductDto>` continues to carry the full, untruncated group list; `TopProductDto` fields are unaffected: `GroupKey`, `DisplayName`, `TotalMargin`, `ColorCode`, `M0Amount`/`M1Amount`/`M2Amount`, `M0Percentage`/`M1Percentage`/`M2Percentage`, `SellingPrice`, `PurchasePrice`, `Rank`.
+
+### Persistence / events
+
+None. No database schema, migration, or event payload is affected by this change.

--- a/artifacts/feat-3486/impl/remove-dead-top-product-count-parameter.r1.md
+++ b/artifacts/feat-3486/impl/remove-dead-top-product-count-parameter.r1.md
@@ -1,0 +1,68 @@
+# Implementation: remove-dead-top-product-count-parameter
+
+## What was implemented
+
+Removed the unused `TopProductCount` property from `GetProductMarginSummaryRequest`
+(never read by `GetProductMarginSummaryHandler.Handle` or `GenerateTopProducts` — the
+streaming refactor already returns the full `TopProducts` list). Regenerated the
+frontend OpenAPI TypeScript client so `analytics_GetProductMarginSummary` no longer
+takes a `topProductCount` argument, and updated the only caller
+(`useProductMarginSummaryQuery`) to drop the now-removed `0, // topProductCount = 0
+means no limit` positional argument. No behavior change anywhere — this is a pure
+subtractive/dead-code removal.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs` — deleted the `public int TopProductCount { get; set; } = 15;` line.
+- `frontend/src/api/generated/api-client.ts` — regenerated via `dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateFrontendClientManual` (not hand-edited). `analytics_GetProductMarginSummary` signature now: `(timeWindow, groupingMode, marginLevel, sortBy, sortDescending)`. Regeneration also picked up unrelated backend surface that had drifted out of sync with the previously-committed client (e.g. a `packaging_GetStatistics` method, a `DqtUnsupportedTestType` enum value, and reordering that made `ArticleGenerationStepStatus` appear removed-then-readded in the diff — verified byte-for-byte identical, just relocated). No actually-used exported type was removed; confirmed no frontend code broke (`npm run build` compiled successfully).
+- `frontend/src/api/hooks/useProductMarginSummary.ts` — removed the `0, // topProductCount = 0 means no limit` argument from the `analytics_GetProductMarginSummary(...)` call. No other line changed.
+
+## Tests
+
+No new tests were written per the task's explicit instruction (subtractive, behavior-preserving change to a parameter with zero effect on any code path — testing "absence of a property" would just test the compiler). Existing suites were re-run as regression checks:
+
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` — all 6 test methods (8 total cases counting the `[Theory]`'s 3 inline-data rows) pass unchanged.
+- `frontend/src/components/pages/__tests__/ProductMarginSummary.test.tsx` — passes unchanged (mocks the hook module directly, never referenced `topProductCount`).
+
+## How to verify
+
+```bash
+# Acceptance-criteria greps (all pass — no matches)
+grep -n "TopProductCount" backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs
+grep -n "topProductCount" frontend/src/api/generated/api-client.ts
+grep -n "topProductCount" frontend/src/api/hooks/useProductMarginSummary.ts
+
+# Backend
+dotnet build Anela.Heblo.sln                                   # from repo root; see Notes on path
+dotnet format Anela.Heblo.sln --verify-no-changes               # from repo root; see Notes on path
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+
+# Frontend
+cd frontend
+npm run build
+npm run lint
+CI=true npm test -- --testPathPattern=ProductMarginSummary
+```
+
+## Actual verification results (this run)
+
+- `grep TopProductCount` (backend DTO): **no matches** — PASS
+- `grep topProductCount` (generated client): **no matches** — PASS
+- `grep topProductCount` (hook): **no matches** — PASS
+- `dotnet build Anela.Heblo.sln`: **Build succeeded, 0 Errors** (52 pre-existing warnings, all unrelated to this change — same `MarginData.M1`/nullable-reference warnings present before this change)
+- `dotnet format Anela.Heblo.sln --verify-no-changes`: **exit code 0, no output** — no formatting diffs
+- `dotnet test ... --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"`: **Passed! Failed: 0, Passed: 8, Skipped: 0, Total: 8**
+- `npm run build`: **"Compiled successfully."** — no TypeScript errors
+- `npm run lint`: **exit code 1, 148 errors / 14 warnings** — verified pre-existing and unchanged: ran lint again after `git stash`-ing this task's 3 changed files, got the identical 148 errors / 14 warnings / exit 1, and none of the reported error lines reference any file this task touched. Per acceptance criterion ("no *new* errors"), this passes.
+- `CI=true npm test -- --testPathPattern=ProductMarginSummary`: react-scripts' `--testPathPattern` flag is not honored by this project's Jest/react-scripts version — it ran the entire suite instead of filtering (confirmed via `--listTests`, which showed unrelated files). Within that full run: `PASS src/components/pages/__tests__/ProductMarginSummary.test.tsx`; overall `Test Suites: 285 passed, 285 total`, `Tests: 5 skipped, 2341 passed, 2346 total`, `Snapshots: 2 passed, 2 total`. Target file passes; no regressions anywhere else either.
+- Manual smoke check (start app, navigate to Analytics → Product Margin Summary, visually confirm chart/table/count): **not performed** — no live app instance / authenticated browser session available in this non-interactive execution environment. Confidence substitute: `npm run build` type-checks the hook's call site against the regenerated client (this is exactly the check the task context calls out as the one that "would catch any remaining topProductCount argument-count mismatch"), and it compiled cleanly.
+
+## Notes
+
+- **Solution path deviation**: the task's example commands use `backend/Anela.Heblo.sln`, but this checkout's solution file lives at the repo root (`Anela.Heblo.sln`) — there is no `backend/Anela.Heblo.sln`. Ran `dotnet build Anela.Heblo.sln` / `dotnet format Anela.Heblo.sln --verify-no-changes` from the repo root instead; same solution, same result.
+- **Frontend environment**: this worktree had no `node_modules` installed. Plain `npm ci`/`npm install` failed with an ERESOLVE peer-dependency conflict (`react-i18next` wants TypeScript `^5`, project pins `^4.9.5`) — pre-existing repo state, unrelated to this change. Installed with `npm install --legacy-peer-deps` to unblock verification; `package.json`/`package-lock.json` were not modified (confirmed via `git status`).
+- **Concurrent session in same worktree**: during this run, another Claude session was observed running commands (`dotnet format`, `dotnet test`) in this exact same worktree directory, apparently also assigned this task. I sent it a status message asking it to stand down; the tool couldn't resolve its address by the generic name, so it may not have been delivered, but it never modified any files beyond what I already had staged (verified via repeated `git status --short` checks — never any unexpected file appeared). Final `git status` immediately before commit showed exactly the 3 intended files plus `artifacts/feat-3486/state.json` (untouched by me, correctly excluded from the commit).
+- The generated `api-client.ts` diff is larger than the minimal `topProductCount` removal because the checked-in file was already stale relative to the current backend (unrelated endpoints/enum values added by prior work not yet regenerated). This is an expected consequence of the task's explicit "regenerate, do not hand-edit" instruction; verified no actually-used exported symbol was lost (`npm run build` compiled cleanly, and the one `-`/`+` pair for `ArticleGenerationStepStatus` in the diff is an identical re-add at a shifted line, not a real removal).
+
+## Status
+DONE

--- a/artifacts/feat-3486/review/remove-dead-top-product-count-parameter.r1.md
+++ b/artifacts/feat-3486/review/remove-dead-top-product-count-parameter.r1.md
@@ -1,0 +1,26 @@
+# Code Review: Fix dead `TopProductCount` parameter in GetProductMarginSummary (feat-3486)
+
+## Summary
+The implementation matches the task context exactly: the dead `TopProductCount` property is removed from `GetProductMarginSummaryRequest`, the frontend OpenAPI client was regenerated (not hand-edited) so `analytics_GetProductMarginSummary` drops the corresponding argument, and the sole caller (`useProductMarginSummaryQuery`) was updated to match. Verified against the actual commit diff (`6ed83a2`) and a repo-wide grep — no remaining references to `TopProductCount`/`topProductCount` in any `.cs`/`.ts`/`.tsx` file. All required verification commands were run and reported with real output, not assumed.
+
+## Review Result: PASS
+
+### task: remove-dead-top-product-count-parameter
+**Status:** PASS
+
+Verification performed independently for this review:
+- `git show 6ed83a2` — diff is exactly the two intended one-line deletions (DTO property, hook call-site argument) plus the regenerated `api-client.ts`. No changes to `GetProductMarginSummaryHandler`, `GenerateTopProducts`, the controller, or any test file — matches the task context's explicit statement that the handler needs zero changes.
+- Repo-wide grep for `TopProductCount`/`topProductCount` across `backend/` and `frontend/` (`.cs`, `.ts`, `.tsx`): no matches — confirms all acceptance-criteria greps from the task context pass.
+- Backend: `dotnet build Anela.Heblo.sln` succeeds (0 errors); `dotnet format --verify-no-changes` reports no diffs; `GetProductMarginSummaryHandlerTests` — 8/8 pass.
+- Frontend: `npm run build` compiles; `ProductMarginSummary.test.tsx` passes within the full suite run (real `--testPathPattern` filtering isn't supported by this project's react-scripts version, correctly identified and worked around by running the full suite and confirming the target file passes with no regressions elsewhere — 285/285 suites, 2341/2346 tests passing, 5 pre-existing skips).
+- `npm run lint`: pre-existing 148 errors/14 warnings, verified unchanged via git-stash diff-check — none attributable to this change.
+- Manual browser smoke check was not performed (no live/authenticated browser available in this non-interactive environment) — acceptable given `npm run build` type-checks the exact call-site/client-signature mismatch this task is meant to guard against, and no runtime behavior changed (subtractive-only change to a parameter that was never read).
+
+No functional requirement is unmet, no architecture guidance is contradicted (Option 1 removal, as bindingly decided by the architect, was followed exactly), and no test coverage gap exists — the task context explicitly and correctly called for no new tests since this is a pure dead-parameter removal with no new behavior to cover.
+
+## Docs to Update
+- `docs/features/product-margin-summary.md` — still documents the old pre-refactor top-N design referencing `TopProductCount`; stale relative to the removed parameter. The spec (`spec.r1.md`, Out of Scope) explicitly deferred this cleanup, so it is not a blocker for this task, but should be tracked separately.
+- `docs/superpowers/plans/2026-06-10-analytics-margin-level-enum.md` — historical plan document mentioning `topProductCount`; purely historical record, no action needed.
+
+## Overall Notes
+The larger-than-minimal diff in `frontend/src/api/generated/api-client.ts` (unrelated `packaging_GetStatistics`, `DqtUnsupportedTestType`, `RefreshTaskStatusDto.description`, etc.) is pre-existing drift between the backend's current OpenAPI surface and the last-committed generated client — confirmed by diffing `origin/main`'s copy of the file against this branch's pre-change copy (identical), so none of that drift was introduced by this task. It is an unavoidable side effect of running the documented, mandatory regeneration command (`dotnet msbuild ... -t:GenerateFrontendClientManual`) rather than hand-editing generated code, which the task context explicitly required. `npm run build` compiling cleanly confirms no consumer of the regenerated client broke.

--- a/artifacts/feat-3486/spec.r1.md
+++ b/artifacts/feat-3486/spec.r1.md
@@ -1,0 +1,86 @@
+# Specification: Fix dead `TopProductCount` parameter in GetProductMarginSummary
+
+## Summary
+`GetProductMarginSummaryRequest.TopProductCount` is a documented API parameter (default `15`) that the handler never reads, so it has zero effect on the response — a contract violation flagged by the arch-review routine. The frontend's only caller already works around this by hard-coding `topProductCount: 0`, because it needs the *full* unfiltered group list to build its own "top 15 + Other" chart bucketing and a complete results table. This spec recommends **removing the parameter** (Option 1) rather than implementing server-side truncation (Option 2), because truncation would work against the frontend's actual, current data needs.
+
+## Background
+`GetProductMarginSummary` used to be a simple top-N report: the original design (`docs/features/product-margin-summary.md`) had the handler itself select the top N products by margin and build monthly segments only for those, with everything else implicitly excluded.
+
+The feature was since refactored for performance (see `GetProductMarginSummaryHandler`, header comment "🔒 PERFORMANCE FIX: Refactored handler using streaming architecture"). The current handler streams all products, computes margin data for **every** group (`GenerateTopProducts`, lines 69–117), and returns the complete list in `TopProducts` — `TopProductCount` is left over from the old design and is never referenced in `Handle` or `GenerateTopProducts`.
+
+The frontend evolved alongside this: `frontend/src/components/pages/ProductMarginSummary.tsx` now does its own client-side top-N logic:
+- It sorts `data.topProducts` and takes the top 15 for the stacked chart (`TOP_CHART_PRODUCTS = 15`), bucketing everything else into an "Ostatní produkty" ("Other products") series (lines 72–131).
+- It renders a full data table from **all** entries in `data.topProducts`, not just the top 15 (lines 169–200+).
+- It displays a total group count, "Celkem skupin" ("Total groups"), driven by `data.topProducts.length` (line 462).
+
+To make all three behaviors work, the frontend genuinely needs the complete, untruncated group list — which is exactly what `useProductMarginSummary.ts` requests by passing `topProductCount: 0` with the comment `// topProductCount = 0 means no limit` (line 27). This is not an accidental workaround for a bug; it reflects an actual, current product requirement: the UI wants everything and does its own top-N/aggregation client-side.
+
+## Functional Requirements
+
+### FR-1: Remove the dead `TopProductCount` parameter (recommended fix)
+Remove `TopProductCount` from `GetProductMarginSummaryRequest` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs:9`). No handler behavior changes, since the value was never consumed.
+
+**Acceptance criteria:**
+- `GetProductMarginSummaryRequest` no longer declares a `TopProductCount` property.
+- `GetProductMarginSummaryHandler` compiles and behaves identically (it never referenced the property, so no logic changes are needed there).
+- The OpenAPI spec / generated TypeScript client (`frontend/src/api/generated/api-client.ts`) is regenerated and no longer exposes `topProductCount` as a parameter of `analytics_GetProductMarginSummary`.
+- `useProductMarginSummary.ts` (line 25–32) is updated to call `analytics_GetProductMarginSummary` without the `topProductCount` argument, removing the `0, // topProductCount = 0 means no limit` line and the now-obsolete comment.
+- Any existing backend tests referencing `TopProductCount` are updated or removed; no test asserts a truncation behavior that no longer exists (there currently is none — grep found no test coverage for this field).
+- Full response payload (`TopProducts`, chart data, table, total group count) is unchanged for the one existing caller (`ProductMarginSummary.tsx`) after the change — verified by running the existing component test suite (`frontend/src/components/pages/__tests__/ProductMarginSummary.test.tsx`) and manual smoke-check of the Analytics page.
+
+### FR-2: (Alternative, not recommended) Implement the limit server-side
+For completeness, if the architect prefers Option 2 instead: implement truncation in `GenerateTopProducts` by taking `request.TopProductCount` items after sorting (treating `<= 0` as "no limit", per the brief's suggested `sortedProducts.Take(request.TopProductCount > 0 ? request.TopProductCount : int.MaxValue).ToList()`), and update `useProductMarginSummary.ts` to pass a meaningful positive value (or continue passing `0` for "no limit", which would leave today's dead-code smell mostly resolved but the parameter effectively unused by the only caller).
+
+**Acceptance criteria (only if this option is chosen instead of FR-1):**
+- `GenerateTopProducts` truncates the sorted group list to `request.TopProductCount` when it is a positive integer, and returns all groups when it is `0` or negative.
+- `Rank` values (assigned after sorting, lines 111–114) are computed on the truncated list, i.e., `Rank` still starts at 1 and is contiguous.
+- Because the frontend chart (top-15 + "Other" bucket) and table (all groups) both depend on receiving the complete group list today, the frontend must **not** switch to passing a small `topProductCount` (e.g. `15`) without also reworking the "Other" aggregation and the "Celkem skupin" total-group-count display, since both currently assume they receive every group. If this option is chosen, that frontend rework is in scope and must be specified before implementation — it is not a drop-in one-line change.
+
+### FR-3: Keep OpenAPI contract and generated client in sync
+Whichever option is chosen, regenerate the backend-driven OpenAPI spec and the frontend TypeScript client (per `docs/development/api-client-generation.md`) as part of the same change, so the public contract accurately reflects the implementation.
+
+**Acceptance criteria:**
+- No parameter appears in the generated client that has no effect on the server (Option 1), or every parameter that appears has real effect and is exercised by at least one caller with a non-default value (Option 2).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance regression. Option 1 is a no-op change on the hot path (removes an unused field). Option 2, if chosen, must not change algorithmic complexity — truncation is an O(1) `Take` after the existing `O(n log n)` sort in `ApplySorting`, so no meaningful performance impact either way. This fix is not motivated by a performance problem; the streaming refactor already addressed memory/perf concerns for large group counts.
+
+### NFR-2: Security
+No security-relevant surface. This is an internal analytics query with no PII sensitivity beyond what's already returned by the endpoint today.
+
+### NFR-3: Backward compatibility
+This is an internal API consumed by exactly one known caller in this codebase (`useProductMarginSummaryQuery`). No external/public consumers were found (grep across the repo found only the generated client, the hook, and documentation references). Removing the parameter (Option 1) is therefore a safe, low-risk breaking change to the OpenAPI contract, contained entirely within this repository and released in one atomic change (backend + regenerated client + frontend caller).
+
+## Data Model
+No data model changes. Affected types:
+- `GetProductMarginSummaryRequest` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs`): loses the `TopProductCount` property under Option 1; unchanged under Option 2.
+- `GetProductMarginSummaryResponse` and `TopProductDto`: unaffected by either option — the response always carries `TopProducts: List<TopProductDto>` (fields: `GroupKey`, `DisplayName`, `TotalMargin`, `ColorCode`, `M0Amount`/`M1Amount`/`M2Amount`, `M0Percentage`/`M1Percentage`/`M2Percentage`, `SellingPrice`, `PurchasePrice`, `Rank`).
+
+## API / Interface Design
+Endpoint: `GET /analytics/product-margin-summary` (via `analytics_GetProductMarginSummary` in the generated client), backed by `GetProductMarginSummaryRequest` → `GetProductMarginSummaryHandler` → `GetProductMarginSummaryResponse`.
+
+Under the recommended Option 1, the query parameters become:
+- `timeWindow: string`
+- `groupingMode: ProductGroupingMode`
+- `marginLevel: MarginLevel`
+- `sortBy?: string`
+- `sortDescending: bool`
+
+(`topProductCount` removed.) `useProductMarginSummaryQuery` (`frontend/src/api/hooks/useProductMarginSummary.ts`) calls this with one fewer positional argument; downstream consumption in `ProductMarginSummary.tsx` (chart top-15/"Other" split, full table, total group count) is unaffected because it already relies on receiving the complete group list.
+
+## Dependencies
+- OpenAPI client regeneration tooling (`docs/development/api-client-generation.md`) must be run after the backend change so `frontend/src/api/generated/api-client.ts` stays in sync.
+- No external services or new libraries required.
+
+## Out of Scope
+- Any change to the actual margin calculation logic in `GetProductMarginSummaryHandler`, `IMarginCalculator`, or `IMonthlyBreakdownGenerator`.
+- Adding pagination or a genuine server-side "top N with real limit" feature for the results table (would be a separate, larger UX change to `ProductMarginSummary.tsx`, since the table and "Celkem skupin" count currently assume the full list).
+- Reworking the frontend's chart "top 15 + Other" bucketing logic.
+- Updating `docs/features/product-margin-summary.md`, which still describes the old (pre-refactor) top-N design — left as-is unless the architect wants documentation cleanup bundled in.
+
+## Open Questions
+- **Confirm the recommended direction with the architect:** this spec recommends **Option 1 (remove `TopProductCount`)** because the only real caller (`ProductMarginSummary.tsx`) needs the full, untruncated group list for its client-side "top 15 + Other" chart bucketing and its full results table with a total-group count — implementing server-side truncation (Option 2) would work against that existing behavior rather than serve it, and would require additional frontend rework (not specified here) to remain useful. Please confirm Option 1 is acceptable before implementation proceeds, or direct that Option 2 be pursued along with the additional frontend rework it would require.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-05T06:20:33.113874Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-05T06:22:28.497918Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-05T06:27:35.789722Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-05T06:28:09.930589Z"
+      "status": "completed",
+      "updated_at": "2026-07-05T06:57:47.641675Z"
     }
   },
   "tasks": [
     {
       "name": "remove-dead-top-product-count-parameter",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-05T06:28:10.172043Z"
+      "updated_at": "2026-07-05T06:57:36.140211Z"
     }
   ]
 }

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "remove-dead-top-product-count-parameter",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-05T06:27:35.789722Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-05T06:28:09.930589Z"
     }
   },
   "tasks": [
     {
       "name": "remove-dead-top-product-count-parameter",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-05T06:28:10.172043Z"
     }
   ]
 }

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-05T06:57:47.641675Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-05T06:57:57.650531Z"
+      "status": "completed",
+      "updated_at": "2026-07-05T06:58:36.515249Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3486",
+  "issue_number": 3486,
+  "created_at": "2026-07-05T06:17:16.903066Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-05T06:20:33.113874Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-05T06:22:28.497918Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-05T06:23:16.752066Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-05T06:57:47.641675Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-05T06:57:57.650531Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3486/state.json
+++ b/artifacts/feat-3486/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-05T06:23:16.752066Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-05T06:27:35.789722Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3486/task-context/remove-dead-top-product-count-parameter.md
+++ b/artifacts/feat-3486/task-context/remove-dead-top-product-count-parameter.md
@@ -1,0 +1,224 @@
+### task: remove-dead-top-product-count-parameter
+
+**Goal**
+Delete the unused `TopProductCount` property from `GetProductMarginSummaryRequest`, regenerate the frontend OpenAPI TypeScript client, and update the frontend hook call site to match the new (shorter) generated method signature — with no behavior change anywhere, since the property was never read by the handler.
+
+**Context** (self-contained — read this fully; you will not see the spec/arch-review/design docs)
+
+This is an internal analytics endpoint: `GET /api/analytics/GetProductMarginSummary` (via `AnalyticsController.GetProductMarginSummary`), backed by MediatR request `GetProductMarginSummaryRequest` → `GetProductMarginSummaryHandler` → `GetProductMarginSummaryResponse`.
+
+`GetProductMarginSummaryRequest.TopProductCount` is a documented "top N" parameter (default `15`) left over from an older, pre-refactor version of the handler. The current handler (header comment: "🔒 PERFORMANCE FIX: Refactored handler using streaming architecture") streams **all** matching products, computes margin data for **every** group in `GenerateTopProducts`, and returns the complete list in `TopProducts`. `TopProductCount` is never referenced anywhere in `GetProductMarginSummaryHandler.Handle` or `GenerateTopProducts` — it has zero effect on the response. Verified by reading the full handler file: no `Take(...)`, no `request.TopProductCount` reference anywhere.
+
+The only caller, `useProductMarginSummaryQuery` (`frontend/src/api/hooks/useProductMarginSummary.ts`), already works around this by hard-coding `0` for this argument with the comment `// topProductCount = 0 means no limit` — because `ProductMarginSummary.tsx` needs the complete, untruncated group list to do its own client-side "top 15 + Other" chart bucketing, its full results table, and its "Celkem skupin" (total groups) count. This is not a bug workaround; the frontend genuinely needs the full list, so **removing** the parameter (rather than implementing real server-side truncation) is the correct, final, binding decision — already made by the architect. Do not implement truncation.
+
+Current state of the request DTO (confirmed by reading the file), property declaration order matters because NSwag generates **positional** TypeScript method arguments in this exact order:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
+
+public class GetProductMarginSummaryRequest : IRequest<GetProductMarginSummaryResponse>
+{
+    public string TimeWindow { get; set; } = "current-year"; // current-year, current-and-previous-year, last-6-months, last-12-months, last-24-months
+    public int TopProductCount { get; set; } = 15; // Configurable, default 15
+    public ProductGroupingMode GroupingMode { get; set; } = ProductGroupingMode.Products; // Products, ProductFamily, ProductType
+
+    // Margin level for display (determines which margin values to show)
+    public MarginLevel MarginLevel { get; set; } = MarginLevel.M2;
+
+    // Sorting parameters
+    public string? SortBy { get; set; } // Column to sort by (m0percentage, m1amount, totalmargin, etc.)
+    public bool SortDescending { get; set; } = true; // Default descending for margin sorting
+}
+```
+
+After deleting the `TopProductCount` line, the remaining property order is `TimeWindow, GroupingMode, MarginLevel, SortBy, SortDescending` — so the regenerated TypeScript method `analytics_GetProductMarginSummary` will take exactly these 5 parameters, in this order (confirmed: current generated signature is `analytics_GetProductMarginSummary(timeWindow, topProductCount, groupingMode, marginLevel, sortBy, sortDescending)` in `frontend/src/api/generated/api-client.ts:51` — removing the DTO property removes only the `topProductCount` argument, all other positions/types are unchanged).
+
+The controller does **not** need any change:
+```csharp
+// backend/src/Anela.Heblo.API/Controllers/AnalyticsController.cs:32
+public async Task<ActionResult<GetProductMarginSummaryResponse>> GetProductMarginSummary([FromQuery] GetProductMarginSummaryRequest request)
+```
+`[FromQuery]` binds the whole DTO — the query string simply loses one recognized parameter (`TopProductCount`).
+
+`GetProductMarginSummaryHandler.Handle` and `GenerateTopProducts` require **zero** code changes — confirmed by reading the full handler file, neither method references `request.TopProductCount`.
+
+Current state of the frontend hook (confirmed by reading the file):
+
+```typescript
+// frontend/src/api/hooks/useProductMarginSummary.ts
+import { useQuery } from "@tanstack/react-query";
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+import {
+  GetProductMarginSummaryResponse,
+  ProductGroupingMode,
+  MarginLevel,
+} from "../generated/api-client";
+
+// Re-export the generated types for convenience
+export { GetProductMarginSummaryResponse, ProductGroupingMode, MarginLevel };
+
+export const useProductMarginSummaryQuery = (
+  timeWindow: string = "current-year",
+  groupingMode: ProductGroupingMode = ProductGroupingMode.Products,
+  marginLevel: MarginLevel = MarginLevel.M2,
+) => {
+  return useQuery<GetProductMarginSummaryResponse, Error>({
+    queryKey: [...QUERY_KEYS.productMarginSummary, timeWindow, groupingMode, marginLevel],
+    queryFn: async () => {
+      const apiClient = await getAuthenticatedApiClient();
+      // Use sortBy parameter to sort by the selected margin level percentage (descending)
+      const sortBy = `totalmargin`;
+
+      // Use generated API client method with proper parameters
+      return apiClient.analytics_GetProductMarginSummary(
+        timeWindow,
+        0, // topProductCount = 0 means no limit
+        groupingMode,
+        marginLevel,
+        sortBy,
+        true // sortDescending = true
+      );
+    },
+    staleTime: 5 * 60 * 1000, // Consider data stale after 5 minutes
+    gcTime: 10 * 60 * 1000, // Keep cache for 10 minutes
+  });
+};
+```
+
+Only the `0, // topProductCount = 0 means no limit` line needs to be deleted here — nothing else in this file changes.
+
+`ProductMarginSummary.tsx` (the component consuming this hook) needs **no changes at all** — it already consumes the full `data.topProducts` array for its client-side top-15/"Other" chart bucketing, full table, and total-group count. The response shape (`GetProductMarginSummaryResponse.TopProducts: List<TopProductDto>`) is completely unaffected by this change.
+
+`frontend/src/components/pages/__tests__/ProductMarginSummary.test.tsx` mocks the hook module itself (`jest.mock("../../../api/hooks/useProductMarginSummary")`), not the underlying generated client call — confirmed by reading the test file. It does not reference `topProductCount` anywhere, so it needs no changes and should continue to pass unmodified.
+
+`backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` was checked in full: none of its test cases set or assert `TopProductCount` on any `GetProductMarginSummaryRequest` instance anywhere. No test changes are needed there.
+
+A repo-wide grep for `TopProductCount`/`topProductCount` found exactly these matches, all of which are handled by this task:
+1. `frontend/src/api/hooks/useProductMarginSummary.ts` — the `0, // topProductCount...` argument (removed in this task)
+2. `frontend/src/api/generated/api-client.ts` — generated file (regenerated in this task, not hand-edited)
+3. `docs/superpowers/plans/2026-06-10-analytics-margin-level-enum.md` — historical plan document, out of scope, leave as-is
+4. `docs/features/product-margin-summary.md` — historical pre-refactor feature doc, out of scope per this feature's spec, leave as-is
+5. `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs` — the property declaration (removed in this task)
+
+The frontend client is regenerated via an MSBuild target defined in `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`:
+```xml
+<Target Name="GenerateFrontendClientManual">
+    <Message Text="Generating TypeScript API client for frontend..." Importance="high" />
+    <Exec Command="dotnet nswag run nswag.frontend.json" ContinueOnError="true" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+    <Message Text="Frontend API client generation completed." Importance="high" />
+</Target>
+```
+Note: this repository's `frontend/package.json` does **not** currently have a `generate-client`/`prebuild` npm script (checked directly — only `start`, `start:automation`, `start:conductor`, `build`, `test`, `test:playwright`, `eject`, `lint`, `lint:fix`, `prepare` exist). The only reliable way to regenerate the client is the `dotnet msbuild` command below; do not rely on an npm script that doesn't exist in this checkout.
+
+**Files to create/modify**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs`
+- Regenerate (do not hand-edit): `frontend/src/api/generated/api-client.ts`
+- Modify: `frontend/src/api/hooks/useProductMarginSummary.ts`
+
+**Implementation steps**
+
+1. Open `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs` and delete the `TopProductCount` line, leaving:
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
+
+public class GetProductMarginSummaryRequest : IRequest<GetProductMarginSummaryResponse>
+{
+    public string TimeWindow { get; set; } = "current-year"; // current-year, current-and-previous-year, last-6-months, last-12-months, last-24-months
+    public ProductGroupingMode GroupingMode { get; set; } = ProductGroupingMode.Products; // Products, ProductFamily, ProductType
+
+    // Margin level for display (determines which margin values to show)
+    public MarginLevel MarginLevel { get; set; } = MarginLevel.M2;
+
+    // Sorting parameters
+    public string? SortBy { get; set; } // Column to sort by (m0percentage, m1amount, totalmargin, etc.)
+    public bool SortDescending { get; set; } = true; // Default descending for margin sorting
+}
+```
+
+2. Build the backend to confirm the DTO change compiles cleanly (no other code references `TopProductCount`):
+```bash
+dotnet build backend/src/Anela.Heblo.Application
+```
+Expected: `Build succeeded.` with 0 errors.
+
+3. Build the API project in Debug configuration so the OpenAPI spec used for client generation reflects the change, then regenerate the frontend TypeScript client:
+```bash
+dotnet build backend/src/Anela.Heblo.API
+dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateFrontendClientManual
+```
+Expected: both commands complete without errors; the second prints `Generating TypeScript API client for frontend...` followed by `Frontend API client generation completed.`
+
+4. Open `frontend/src/api/generated/api-client.ts` and confirm the `analytics_GetProductMarginSummary` method signature no longer has a `topProductCount` parameter — it should now read (order per remaining DTO property order `TimeWindow, GroupingMode, MarginLevel, SortBy, SortDescending`):
+```typescript
+analytics_GetProductMarginSummary(timeWindow: string | undefined, groupingMode: ProductGroupingMode | undefined, marginLevel: MarginLevel | undefined, sortBy: string | null | undefined, sortDescending: boolean | undefined): Promise<GetProductMarginSummaryResponse> {
+```
+Do not hand-edit this file — it must come from the regeneration step above. If the signature still contains `topProductCount`, re-run step 3; do not proceed until the generated file reflects the DTO change.
+
+5. Open `frontend/src/api/hooks/useProductMarginSummary.ts` and remove the `0, // topProductCount = 0 means no limit` line from the `analytics_GetProductMarginSummary` call, so the `queryFn` body becomes:
+```typescript
+    queryFn: async () => {
+      const apiClient = await getAuthenticatedApiClient();
+      // Use sortBy parameter to sort by the selected margin level percentage (descending)
+      const sortBy = `totalmargin`;
+
+      // Use generated API client method with proper parameters
+      return apiClient.analytics_GetProductMarginSummary(
+        timeWindow,
+        groupingMode,
+        marginLevel,
+        sortBy,
+        true // sortDescending = true
+      );
+    },
+```
+Leave every other line in the file (imports, exports, function signature, `queryKey`, `staleTime`, `gcTime`) exactly as-is.
+
+6. Run the backend test suite for this feature to confirm no regressions:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+Expected: all existing tests pass (`Handle_ValidRequest_ReturnsCorrectResponse`, `Handle_DifferentTimeWindows_ParsesCorrectly`, `Handle_EmptyProductList_ReturnsZeroMargin`, `Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator`, `GetMarginAmountForLevel_WithUndefinedEnumValue_ThrowsArgumentOutOfRangeException`, `ParseTimeWindow_UnknownValue_ThrowsArgumentException`) — none of them reference `TopProductCount`, so no test code changes are required; this step is verification only.
+
+7. Run the full backend build and formatting check per the repo's standard validation gate:
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+Expected: build succeeds with 0 errors; `dotnet format` reports no changes needed (if it reports changes, run `dotnet format backend/Anela.Heblo.sln` to apply them and re-verify).
+
+8. Run the frontend test suite for the affected component to confirm no regressions:
+```bash
+cd frontend
+CI=true npm test -- --testPathPattern=ProductMarginSummary
+```
+Expected: `ProductMarginSummary.test.tsx` passes unchanged — it mocks the hook module directly and never asserted on `topProductCount`.
+
+9. Run the full frontend build and lint per the repo's standard validation gate:
+```bash
+cd frontend
+npm run build
+npm run lint
+```
+Expected: `npm run build` completes with no TypeScript errors (this is the step that would catch any remaining `topProductCount` argument-count mismatch between the hook and the regenerated client); `npm run lint` reports no new errors.
+
+**Tests to write**
+No new tests are required. This is a subtractive, behavior-preserving change to a parameter that was never read by any code path, so there is no new behavior to cover. The existing backend test suite (`GetProductMarginSummaryHandlerTests.cs`) and frontend test suite (`ProductMarginSummary.test.tsx`) already provide regression coverage for the unchanged behavior and are re-run as verification in steps 6 and 8 above — do not add tests asserting the absence of a property or a parameter, as that would be testing the compiler/type system rather than behavior.
+
+**Acceptance criteria**
+- `grep -n "TopProductCount" backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs` returns no matches.
+- `grep -n "topProductCount" frontend/src/api/generated/api-client.ts` returns no matches (confirms regeneration succeeded).
+- `grep -n "topProductCount" frontend/src/api/hooks/useProductMarginSummary.ts` returns no matches.
+- `dotnet build backend/Anela.Heblo.sln` succeeds with 0 errors.
+- `dotnet format backend/Anela.Heblo.sln --verify-no-changes` reports no formatting diffs.
+- `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"` — all tests pass.
+- `cd frontend && npm run build` succeeds with no TypeScript errors.
+- `cd frontend && npm run lint` reports no new errors.
+- `cd frontend && CI=true npm test -- --testPathPattern=ProductMarginSummary` passes.
+- Manual smoke check: start the app, navigate to the Analytics → Product Margin Summary page, and confirm the chart (top 15 + "Ostatní produkty"), the full results table, and the "Celkem skupin" total-group count all render identically to before the change (same data, since the handler's behavior is unchanged).

--- a/artifacts/feat-3486/task-plan.r1.md
+++ b/artifacts/feat-3486/task-plan.r1.md
@@ -1,0 +1,230 @@
+# Task Plan: Fix dead `TopProductCount` parameter in GetProductMarginSummary (feat-3486)
+
+Removes the dead `TopProductCount` property from `GetProductMarginSummaryRequest` (never read by the handler), regenerates the OpenAPI-derived TypeScript client so `analytics_GetProductMarginSummary` drops the corresponding argument, and updates the one caller (`useProductMarginSummary.ts`) to match. This is a single cohesive, behavior-preserving change — one task covers it end to end.
+
+---
+
+### task: remove-dead-top-product-count-parameter
+
+**Goal**
+Delete the unused `TopProductCount` property from `GetProductMarginSummaryRequest`, regenerate the frontend OpenAPI TypeScript client, and update the frontend hook call site to match the new (shorter) generated method signature — with no behavior change anywhere, since the property was never read by the handler.
+
+**Context** (self-contained — read this fully; you will not see the spec/arch-review/design docs)
+
+This is an internal analytics endpoint: `GET /api/analytics/GetProductMarginSummary` (via `AnalyticsController.GetProductMarginSummary`), backed by MediatR request `GetProductMarginSummaryRequest` → `GetProductMarginSummaryHandler` → `GetProductMarginSummaryResponse`.
+
+`GetProductMarginSummaryRequest.TopProductCount` is a documented "top N" parameter (default `15`) left over from an older, pre-refactor version of the handler. The current handler (header comment: "🔒 PERFORMANCE FIX: Refactored handler using streaming architecture") streams **all** matching products, computes margin data for **every** group in `GenerateTopProducts`, and returns the complete list in `TopProducts`. `TopProductCount` is never referenced anywhere in `GetProductMarginSummaryHandler.Handle` or `GenerateTopProducts` — it has zero effect on the response. Verified by reading the full handler file: no `Take(...)`, no `request.TopProductCount` reference anywhere.
+
+The only caller, `useProductMarginSummaryQuery` (`frontend/src/api/hooks/useProductMarginSummary.ts`), already works around this by hard-coding `0` for this argument with the comment `// topProductCount = 0 means no limit` — because `ProductMarginSummary.tsx` needs the complete, untruncated group list to do its own client-side "top 15 + Other" chart bucketing, its full results table, and its "Celkem skupin" (total groups) count. This is not a bug workaround; the frontend genuinely needs the full list, so **removing** the parameter (rather than implementing real server-side truncation) is the correct, final, binding decision — already made by the architect. Do not implement truncation.
+
+Current state of the request DTO (confirmed by reading the file), property declaration order matters because NSwag generates **positional** TypeScript method arguments in this exact order:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
+
+public class GetProductMarginSummaryRequest : IRequest<GetProductMarginSummaryResponse>
+{
+    public string TimeWindow { get; set; } = "current-year"; // current-year, current-and-previous-year, last-6-months, last-12-months, last-24-months
+    public int TopProductCount { get; set; } = 15; // Configurable, default 15
+    public ProductGroupingMode GroupingMode { get; set; } = ProductGroupingMode.Products; // Products, ProductFamily, ProductType
+
+    // Margin level for display (determines which margin values to show)
+    public MarginLevel MarginLevel { get; set; } = MarginLevel.M2;
+
+    // Sorting parameters
+    public string? SortBy { get; set; } // Column to sort by (m0percentage, m1amount, totalmargin, etc.)
+    public bool SortDescending { get; set; } = true; // Default descending for margin sorting
+}
+```
+
+After deleting the `TopProductCount` line, the remaining property order is `TimeWindow, GroupingMode, MarginLevel, SortBy, SortDescending` — so the regenerated TypeScript method `analytics_GetProductMarginSummary` will take exactly these 5 parameters, in this order (confirmed: current generated signature is `analytics_GetProductMarginSummary(timeWindow, topProductCount, groupingMode, marginLevel, sortBy, sortDescending)` in `frontend/src/api/generated/api-client.ts:51` — removing the DTO property removes only the `topProductCount` argument, all other positions/types are unchanged).
+
+The controller does **not** need any change:
+```csharp
+// backend/src/Anela.Heblo.API/Controllers/AnalyticsController.cs:32
+public async Task<ActionResult<GetProductMarginSummaryResponse>> GetProductMarginSummary([FromQuery] GetProductMarginSummaryRequest request)
+```
+`[FromQuery]` binds the whole DTO — the query string simply loses one recognized parameter (`TopProductCount`).
+
+`GetProductMarginSummaryHandler.Handle` and `GenerateTopProducts` require **zero** code changes — confirmed by reading the full handler file, neither method references `request.TopProductCount`.
+
+Current state of the frontend hook (confirmed by reading the file):
+
+```typescript
+// frontend/src/api/hooks/useProductMarginSummary.ts
+import { useQuery } from "@tanstack/react-query";
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+import {
+  GetProductMarginSummaryResponse,
+  ProductGroupingMode,
+  MarginLevel,
+} from "../generated/api-client";
+
+// Re-export the generated types for convenience
+export { GetProductMarginSummaryResponse, ProductGroupingMode, MarginLevel };
+
+export const useProductMarginSummaryQuery = (
+  timeWindow: string = "current-year",
+  groupingMode: ProductGroupingMode = ProductGroupingMode.Products,
+  marginLevel: MarginLevel = MarginLevel.M2,
+) => {
+  return useQuery<GetProductMarginSummaryResponse, Error>({
+    queryKey: [...QUERY_KEYS.productMarginSummary, timeWindow, groupingMode, marginLevel],
+    queryFn: async () => {
+      const apiClient = await getAuthenticatedApiClient();
+      // Use sortBy parameter to sort by the selected margin level percentage (descending)
+      const sortBy = `totalmargin`;
+
+      // Use generated API client method with proper parameters
+      return apiClient.analytics_GetProductMarginSummary(
+        timeWindow,
+        0, // topProductCount = 0 means no limit
+        groupingMode,
+        marginLevel,
+        sortBy,
+        true // sortDescending = true
+      );
+    },
+    staleTime: 5 * 60 * 1000, // Consider data stale after 5 minutes
+    gcTime: 10 * 60 * 1000, // Keep cache for 10 minutes
+  });
+};
+```
+
+Only the `0, // topProductCount = 0 means no limit` line needs to be deleted here — nothing else in this file changes.
+
+`ProductMarginSummary.tsx` (the component consuming this hook) needs **no changes at all** — it already consumes the full `data.topProducts` array for its client-side top-15/"Other" chart bucketing, full table, and total-group count. The response shape (`GetProductMarginSummaryResponse.TopProducts: List<TopProductDto>`) is completely unaffected by this change.
+
+`frontend/src/components/pages/__tests__/ProductMarginSummary.test.tsx` mocks the hook module itself (`jest.mock("../../../api/hooks/useProductMarginSummary")`), not the underlying generated client call — confirmed by reading the test file. It does not reference `topProductCount` anywhere, so it needs no changes and should continue to pass unmodified.
+
+`backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` was checked in full: none of its test cases set or assert `TopProductCount` on any `GetProductMarginSummaryRequest` instance anywhere. No test changes are needed there.
+
+A repo-wide grep for `TopProductCount`/`topProductCount` found exactly these matches, all of which are handled by this task:
+1. `frontend/src/api/hooks/useProductMarginSummary.ts` — the `0, // topProductCount...` argument (removed in this task)
+2. `frontend/src/api/generated/api-client.ts` — generated file (regenerated in this task, not hand-edited)
+3. `docs/superpowers/plans/2026-06-10-analytics-margin-level-enum.md` — historical plan document, out of scope, leave as-is
+4. `docs/features/product-margin-summary.md` — historical pre-refactor feature doc, out of scope per this feature's spec, leave as-is
+5. `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs` — the property declaration (removed in this task)
+
+The frontend client is regenerated via an MSBuild target defined in `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`:
+```xml
+<Target Name="GenerateFrontendClientManual">
+    <Message Text="Generating TypeScript API client for frontend..." Importance="high" />
+    <Exec Command="dotnet nswag run nswag.frontend.json" ContinueOnError="true" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+    <Message Text="Frontend API client generation completed." Importance="high" />
+</Target>
+```
+Note: this repository's `frontend/package.json` does **not** currently have a `generate-client`/`prebuild` npm script (checked directly — only `start`, `start:automation`, `start:conductor`, `build`, `test`, `test:playwright`, `eject`, `lint`, `lint:fix`, `prepare` exist). The only reliable way to regenerate the client is the `dotnet msbuild` command below; do not rely on an npm script that doesn't exist in this checkout.
+
+**Files to create/modify**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs`
+- Regenerate (do not hand-edit): `frontend/src/api/generated/api-client.ts`
+- Modify: `frontend/src/api/hooks/useProductMarginSummary.ts`
+
+**Implementation steps**
+
+1. Open `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs` and delete the `TopProductCount` line, leaving:
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
+
+public class GetProductMarginSummaryRequest : IRequest<GetProductMarginSummaryResponse>
+{
+    public string TimeWindow { get; set; } = "current-year"; // current-year, current-and-previous-year, last-6-months, last-12-months, last-24-months
+    public ProductGroupingMode GroupingMode { get; set; } = ProductGroupingMode.Products; // Products, ProductFamily, ProductType
+
+    // Margin level for display (determines which margin values to show)
+    public MarginLevel MarginLevel { get; set; } = MarginLevel.M2;
+
+    // Sorting parameters
+    public string? SortBy { get; set; } // Column to sort by (m0percentage, m1amount, totalmargin, etc.)
+    public bool SortDescending { get; set; } = true; // Default descending for margin sorting
+}
+```
+
+2. Build the backend to confirm the DTO change compiles cleanly (no other code references `TopProductCount`):
+```bash
+dotnet build backend/src/Anela.Heblo.Application
+```
+Expected: `Build succeeded.` with 0 errors.
+
+3. Build the API project in Debug configuration so the OpenAPI spec used for client generation reflects the change, then regenerate the frontend TypeScript client:
+```bash
+dotnet build backend/src/Anela.Heblo.API
+dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateFrontendClientManual
+```
+Expected: both commands complete without errors; the second prints `Generating TypeScript API client for frontend...` followed by `Frontend API client generation completed.`
+
+4. Open `frontend/src/api/generated/api-client.ts` and confirm the `analytics_GetProductMarginSummary` method signature no longer has a `topProductCount` parameter — it should now read (order per remaining DTO property order `TimeWindow, GroupingMode, MarginLevel, SortBy, SortDescending`):
+```typescript
+analytics_GetProductMarginSummary(timeWindow: string | undefined, groupingMode: ProductGroupingMode | undefined, marginLevel: MarginLevel | undefined, sortBy: string | null | undefined, sortDescending: boolean | undefined): Promise<GetProductMarginSummaryResponse> {
+```
+Do not hand-edit this file — it must come from the regeneration step above. If the signature still contains `topProductCount`, re-run step 3; do not proceed until the generated file reflects the DTO change.
+
+5. Open `frontend/src/api/hooks/useProductMarginSummary.ts` and remove the `0, // topProductCount = 0 means no limit` line from the `analytics_GetProductMarginSummary` call, so the `queryFn` body becomes:
+```typescript
+    queryFn: async () => {
+      const apiClient = await getAuthenticatedApiClient();
+      // Use sortBy parameter to sort by the selected margin level percentage (descending)
+      const sortBy = `totalmargin`;
+
+      // Use generated API client method with proper parameters
+      return apiClient.analytics_GetProductMarginSummary(
+        timeWindow,
+        groupingMode,
+        marginLevel,
+        sortBy,
+        true // sortDescending = true
+      );
+    },
+```
+Leave every other line in the file (imports, exports, function signature, `queryKey`, `staleTime`, `gcTime`) exactly as-is.
+
+6. Run the backend test suite for this feature to confirm no regressions:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+Expected: all existing tests pass (`Handle_ValidRequest_ReturnsCorrectResponse`, `Handle_DifferentTimeWindows_ParsesCorrectly`, `Handle_EmptyProductList_ReturnsZeroMargin`, `Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator`, `GetMarginAmountForLevel_WithUndefinedEnumValue_ThrowsArgumentOutOfRangeException`, `ParseTimeWindow_UnknownValue_ThrowsArgumentException`) — none of them reference `TopProductCount`, so no test code changes are required; this step is verification only.
+
+7. Run the full backend build and formatting check per the repo's standard validation gate:
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+Expected: build succeeds with 0 errors; `dotnet format` reports no changes needed (if it reports changes, run `dotnet format backend/Anela.Heblo.sln` to apply them and re-verify).
+
+8. Run the frontend test suite for the affected component to confirm no regressions:
+```bash
+cd frontend
+CI=true npm test -- --testPathPattern=ProductMarginSummary
+```
+Expected: `ProductMarginSummary.test.tsx` passes unchanged — it mocks the hook module directly and never asserted on `topProductCount`.
+
+9. Run the full frontend build and lint per the repo's standard validation gate:
+```bash
+cd frontend
+npm run build
+npm run lint
+```
+Expected: `npm run build` completes with no TypeScript errors (this is the step that would catch any remaining `topProductCount` argument-count mismatch between the hook and the regenerated client); `npm run lint` reports no new errors.
+
+**Tests to write**
+No new tests are required. This is a subtractive, behavior-preserving change to a parameter that was never read by any code path, so there is no new behavior to cover. The existing backend test suite (`GetProductMarginSummaryHandlerTests.cs`) and frontend test suite (`ProductMarginSummary.test.tsx`) already provide regression coverage for the unchanged behavior and are re-run as verification in steps 6 and 8 above — do not add tests asserting the absence of a property or a parameter, as that would be testing the compiler/type system rather than behavior.
+
+**Acceptance criteria**
+- `grep -n "TopProductCount" backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs` returns no matches.
+- `grep -n "topProductCount" frontend/src/api/generated/api-client.ts` returns no matches (confirms regeneration succeeded).
+- `grep -n "topProductCount" frontend/src/api/hooks/useProductMarginSummary.ts` returns no matches.
+- `dotnet build backend/Anela.Heblo.sln` succeeds with 0 errors.
+- `dotnet format backend/Anela.Heblo.sln --verify-no-changes` reports no formatting diffs.
+- `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"` — all tests pass.
+- `cd frontend && npm run build` succeeds with no TypeScript errors.
+- `cd frontend && npm run lint` reports no new errors.
+- `cd frontend && CI=true npm test -- --testPathPattern=ProductMarginSummary` passes.
+- Manual smoke check: start the app, navigate to the Analytics → Product Margin Summary page, and confirm the chart (top 15 + "Ostatní produkty"), the full results table, and the "Celkem skupin" total-group count all render identically to before the change (same data, since the handler's behavior is unchanged).

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryRequest.cs
@@ -6,7 +6,6 @@ namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSu
 public class GetProductMarginSummaryRequest : IRequest<GetProductMarginSummaryResponse>
 {
     public string TimeWindow { get; set; } = "current-year"; // current-year, current-and-previous-year, last-6-months, last-12-months, last-24-months
-    public int TopProductCount { get; set; } = 15; // Configurable, default 15
     public ProductGroupingMode GroupingMode { get; set; } = ProductGroupingMode.Products; // Products, ProductFamily, ProductType
 
     // Margin level for display (determines which margin values to show)

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -48,16 +48,12 @@ export class ApiClient {
         return Promise.resolve<void>(null as any);
     }
 
-    analytics_GetProductMarginSummary(timeWindow: string | undefined, topProductCount: number | undefined, groupingMode: ProductGroupingMode | undefined, marginLevel: MarginLevel | undefined, sortBy: string | null | undefined, sortDescending: boolean | undefined): Promise<GetProductMarginSummaryResponse> {
+    analytics_GetProductMarginSummary(timeWindow: string | undefined, groupingMode: ProductGroupingMode | undefined, marginLevel: MarginLevel | undefined, sortBy: string | null | undefined, sortDescending: boolean | undefined): Promise<GetProductMarginSummaryResponse> {
         let url_ = this.baseUrl + "/api/Analytics/product-margin-summary?";
         if (timeWindow === null)
             throw new Error("The parameter 'timeWindow' cannot be null.");
         else if (timeWindow !== undefined)
             url_ += "TimeWindow=" + encodeURIComponent("" + timeWindow) + "&";
-        if (topProductCount === null)
-            throw new Error("The parameter 'topProductCount' cannot be null.");
-        else if (topProductCount !== undefined)
-            url_ += "TopProductCount=" + encodeURIComponent("" + topProductCount) + "&";
         if (groupingMode === null)
             throw new Error("The parameter 'groupingMode' cannot be null.");
         else if (groupingMode !== undefined)
@@ -8748,6 +8744,44 @@ export class ApiClient {
         return Promise.resolve<GetPackingDashboardResponse>(null as any);
     }
 
+    packaging_GetStatistics(fromDate: Date | null | undefined, toDate: Date | null | undefined): Promise<GetPackingStatisticsResponse> {
+        let url_ = this.baseUrl + "/api/packaging/statistics?";
+        if (fromDate !== undefined && fromDate !== null)
+            url_ += "FromDate=" + encodeURIComponent(fromDate ? "" + fromDate.toISOString() : "") + "&";
+        if (toDate !== undefined && toDate !== null)
+            url_ += "ToDate=" + encodeURIComponent(toDate ? "" + toDate.toISOString() : "") + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackaging_GetStatistics(_response);
+        });
+    }
+
+    protected processPackaging_GetStatistics(response: Response): Promise<GetPackingStatisticsResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetPackingStatisticsResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetPackingStatisticsResponse>(null as any);
+    }
+
     packaging_GetPackages(orderCode: string | null | undefined, customerName: string | null | undefined, packageNumber: string | null | undefined, carrier: Carriers | null | undefined, fromDate: Date | null | undefined, toDate: Date | null | undefined, pageNumber: number | undefined, pageSize: number | undefined, sortBy: string | undefined, sortDescending: boolean | undefined): Promise<GetPackagesResponse> {
         let url_ = this.baseUrl + "/api/packaging/packages?";
         if (orderCode !== undefined && orderCode !== null)
@@ -13220,6 +13254,7 @@ export enum ErrorCodes {
     DqtRunNotFound = "DqtRunNotFound",
     DqtInvalidDateRange = "DqtInvalidDateRange",
     DqtExternalServiceError = "DqtExternalServiceError",
+    DqtUnsupportedTestType = "DqtUnsupportedTestType",
     MarketingActionNotFound = "MarketingActionNotFound",
     UnauthorizedMarketingAccess = "UnauthorizedMarketingAccess",
     MarketingCalendarAccessDenied = "MarketingCalendarAccessDenied",
@@ -13962,12 +13997,6 @@ export enum ArticleStatus {
     Failed = "Failed",
 }
 
-export enum ArticleGenerationStepStatus {
-    Running = "Running",
-    Succeeded = "Succeeded",
-    Failed = "Failed",
-}
-
 export class GenerateArticleRequest implements IGenerateArticleRequest {
     topic!: string;
     scope?: string;
@@ -14328,6 +14357,12 @@ export interface IArticleGenerationStepDto {
     inputJson?: string | undefined;
     outputJson?: string | undefined;
     errorMessage?: string | undefined;
+}
+
+export enum ArticleGenerationStepStatus {
+    Running = "Running",
+    Succeeded = "Succeeded",
+    Failed = "Failed",
 }
 
 export class ListArticlesResponse extends BaseResponse implements IListArticlesResponse {
@@ -16277,7 +16312,6 @@ export interface IRefreshTaskExecutionLogDto {
 export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
     taskId?: string;
     enabled?: boolean;
-    description?: string | undefined;
     refreshInterval?: string;
     lastExecution?: RefreshTaskExecutionLogDto | undefined;
 
@@ -16294,7 +16328,6 @@ export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
         if (_data) {
             this.taskId = _data["taskId"];
             this.enabled = _data["enabled"];
-            this.description = _data["description"];
             this.refreshInterval = _data["refreshInterval"];
             this.lastExecution = _data["lastExecution"] ? RefreshTaskExecutionLogDto.fromJS(_data["lastExecution"]) : <any>undefined;
         }
@@ -16311,7 +16344,6 @@ export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
         data = typeof data === 'object' ? data : {};
         data["taskId"] = this.taskId;
         data["enabled"] = this.enabled;
-        data["description"] = this.description;
         data["refreshInterval"] = this.refreshInterval;
         data["lastExecution"] = this.lastExecution ? this.lastExecution.toJSON() : <any>undefined;
         return data;
@@ -16321,7 +16353,6 @@ export class RefreshTaskStatusDto implements IRefreshTaskStatusDto {
 export interface IRefreshTaskStatusDto {
     taskId?: string;
     enabled?: boolean;
-    description?: string | undefined;
     refreshInterval?: string;
     lastExecution?: RefreshTaskExecutionLogDto | undefined;
 }
@@ -19956,6 +19987,7 @@ export interface IReprintExpeditionListRequest {
 
 export class RunExpeditionListPrintFixResponse extends BaseResponse implements IRunExpeditionListPrintFixResponse {
     totalCount?: number;
+    skippedCount?: number;
 
     constructor(data?: IRunExpeditionListPrintFixResponse) {
         super(data);
@@ -19965,6 +19997,7 @@ export class RunExpeditionListPrintFixResponse extends BaseResponse implements I
         super.init(_data);
         if (_data) {
             this.totalCount = _data["totalCount"];
+            this.skippedCount = _data["skippedCount"];
         }
     }
 
@@ -19978,6 +20011,7 @@ export class RunExpeditionListPrintFixResponse extends BaseResponse implements I
     override toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
         data["totalCount"] = this.totalCount;
+        data["skippedCount"] = this.skippedCount;
         super.toJSON(data);
         return data;
     }
@@ -19985,6 +20019,7 @@ export class RunExpeditionListPrintFixResponse extends BaseResponse implements I
 
 export interface IRunExpeditionListPrintFixResponse extends IBaseResponse {
     totalCount?: number;
+    skippedCount?: number;
 }
 
 export class PrintExpeditionOrderResponse extends BaseResponse implements IPrintExpeditionOrderResponse {
@@ -32955,6 +32990,391 @@ export class PackerStatsDto implements IPackerStatsDto {
 export interface IPackerStatsDto {
     packerId?: string | undefined;
     packerName?: string;
+    orderCount?: number;
+}
+
+export class GetPackingStatisticsResponse extends BaseResponse implements IGetPackingStatisticsResponse {
+    fromDate?: Date;
+    toDate?: Date;
+    packerAttributionSince?: Date | undefined;
+    summary?: PackingStatisticsSummaryDto;
+    throughputDaily?: DailyThroughputDto[];
+    hourHeatmap?: HourBucketDto[];
+    byPacker?: PackerThroughputDto[];
+    byCarrier?: CarrierMixDto[];
+    packagesPerOrder?: PackagesPerOrderBucketDto[];
+
+    constructor(data?: IGetPackingStatisticsResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.fromDate = _data["fromDate"] ? new Date(_data["fromDate"].toString()) : <any>undefined;
+            this.toDate = _data["toDate"] ? new Date(_data["toDate"].toString()) : <any>undefined;
+            this.packerAttributionSince = _data["packerAttributionSince"] ? new Date(_data["packerAttributionSince"].toString()) : <any>undefined;
+            this.summary = _data["summary"] ? PackingStatisticsSummaryDto.fromJS(_data["summary"]) : <any>undefined;
+            if (Array.isArray(_data["throughputDaily"])) {
+                this.throughputDaily = [] as any;
+                for (let item of _data["throughputDaily"])
+                    this.throughputDaily!.push(DailyThroughputDto.fromJS(item));
+            }
+            if (Array.isArray(_data["hourHeatmap"])) {
+                this.hourHeatmap = [] as any;
+                for (let item of _data["hourHeatmap"])
+                    this.hourHeatmap!.push(HourBucketDto.fromJS(item));
+            }
+            if (Array.isArray(_data["byPacker"])) {
+                this.byPacker = [] as any;
+                for (let item of _data["byPacker"])
+                    this.byPacker!.push(PackerThroughputDto.fromJS(item));
+            }
+            if (Array.isArray(_data["byCarrier"])) {
+                this.byCarrier = [] as any;
+                for (let item of _data["byCarrier"])
+                    this.byCarrier!.push(CarrierMixDto.fromJS(item));
+            }
+            if (Array.isArray(_data["packagesPerOrder"])) {
+                this.packagesPerOrder = [] as any;
+                for (let item of _data["packagesPerOrder"])
+                    this.packagesPerOrder!.push(PackagesPerOrderBucketDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetPackingStatisticsResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetPackingStatisticsResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["fromDate"] = this.fromDate ? this.fromDate.toISOString() : <any>undefined;
+        data["toDate"] = this.toDate ? this.toDate.toISOString() : <any>undefined;
+        data["packerAttributionSince"] = this.packerAttributionSince ? this.packerAttributionSince.toISOString() : <any>undefined;
+        data["summary"] = this.summary ? this.summary.toJSON() : <any>undefined;
+        if (Array.isArray(this.throughputDaily)) {
+            data["throughputDaily"] = [];
+            for (let item of this.throughputDaily)
+                data["throughputDaily"].push(item.toJSON());
+        }
+        if (Array.isArray(this.hourHeatmap)) {
+            data["hourHeatmap"] = [];
+            for (let item of this.hourHeatmap)
+                data["hourHeatmap"].push(item.toJSON());
+        }
+        if (Array.isArray(this.byPacker)) {
+            data["byPacker"] = [];
+            for (let item of this.byPacker)
+                data["byPacker"].push(item.toJSON());
+        }
+        if (Array.isArray(this.byCarrier)) {
+            data["byCarrier"] = [];
+            for (let item of this.byCarrier)
+                data["byCarrier"].push(item.toJSON());
+        }
+        if (Array.isArray(this.packagesPerOrder)) {
+            data["packagesPerOrder"] = [];
+            for (let item of this.packagesPerOrder)
+                data["packagesPerOrder"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetPackingStatisticsResponse extends IBaseResponse {
+    fromDate?: Date;
+    toDate?: Date;
+    packerAttributionSince?: Date | undefined;
+    summary?: PackingStatisticsSummaryDto;
+    throughputDaily?: DailyThroughputDto[];
+    hourHeatmap?: HourBucketDto[];
+    byPacker?: PackerThroughputDto[];
+    byCarrier?: CarrierMixDto[];
+    packagesPerOrder?: PackagesPerOrderBucketDto[];
+}
+
+export class PackingStatisticsSummaryDto implements IPackingStatisticsSummaryDto {
+    totalPackages?: number;
+    totalOrders?: number;
+    distinctPackers?: number;
+    averagePackagesPerOrder?: number;
+    trackingCoveragePercent?: number;
+    busiestDay?: DailyThroughputDto | undefined;
+    busiestHour?: HourBucketDto | undefined;
+
+    constructor(data?: IPackingStatisticsSummaryDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.totalPackages = _data["totalPackages"];
+            this.totalOrders = _data["totalOrders"];
+            this.distinctPackers = _data["distinctPackers"];
+            this.averagePackagesPerOrder = _data["averagePackagesPerOrder"];
+            this.trackingCoveragePercent = _data["trackingCoveragePercent"];
+            this.busiestDay = _data["busiestDay"] ? DailyThroughputDto.fromJS(_data["busiestDay"]) : <any>undefined;
+            this.busiestHour = _data["busiestHour"] ? HourBucketDto.fromJS(_data["busiestHour"]) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): PackingStatisticsSummaryDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackingStatisticsSummaryDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["totalPackages"] = this.totalPackages;
+        data["totalOrders"] = this.totalOrders;
+        data["distinctPackers"] = this.distinctPackers;
+        data["averagePackagesPerOrder"] = this.averagePackagesPerOrder;
+        data["trackingCoveragePercent"] = this.trackingCoveragePercent;
+        data["busiestDay"] = this.busiestDay ? this.busiestDay.toJSON() : <any>undefined;
+        data["busiestHour"] = this.busiestHour ? this.busiestHour.toJSON() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IPackingStatisticsSummaryDto {
+    totalPackages?: number;
+    totalOrders?: number;
+    distinctPackers?: number;
+    averagePackagesPerOrder?: number;
+    trackingCoveragePercent?: number;
+    busiestDay?: DailyThroughputDto | undefined;
+    busiestHour?: HourBucketDto | undefined;
+}
+
+export class DailyThroughputDto implements IDailyThroughputDto {
+    date?: Date;
+    orderCount?: number;
+    packageCount?: number;
+
+    constructor(data?: IDailyThroughputDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.date = _data["date"] ? new Date(_data["date"].toString()) : <any>undefined;
+            this.orderCount = _data["orderCount"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): DailyThroughputDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new DailyThroughputDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["date"] = this.date ? this.date.toISOString() : <any>undefined;
+        data["orderCount"] = this.orderCount;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface IDailyThroughputDto {
+    date?: Date;
+    orderCount?: number;
+    packageCount?: number;
+}
+
+export class HourBucketDto implements IHourBucketDto {
+    dayOfWeek?: number;
+    hour?: number;
+    packageCount?: number;
+
+    constructor(data?: IHourBucketDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.dayOfWeek = _data["dayOfWeek"];
+            this.hour = _data["hour"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): HourBucketDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new HourBucketDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["dayOfWeek"] = this.dayOfWeek;
+        data["hour"] = this.hour;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface IHourBucketDto {
+    dayOfWeek?: number;
+    hour?: number;
+    packageCount?: number;
+}
+
+export class PackerThroughputDto implements IPackerThroughputDto {
+    packerId?: string | undefined;
+    packerName?: string;
+    orderCount?: number;
+    packageCount?: number;
+
+    constructor(data?: IPackerThroughputDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.packerId = _data["packerId"];
+            this.packerName = _data["packerName"];
+            this.orderCount = _data["orderCount"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): PackerThroughputDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackerThroughputDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["packerId"] = this.packerId;
+        data["packerName"] = this.packerName;
+        data["orderCount"] = this.orderCount;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface IPackerThroughputDto {
+    packerId?: string | undefined;
+    packerName?: string;
+    orderCount?: number;
+    packageCount?: number;
+}
+
+export class CarrierMixDto implements ICarrierMixDto {
+    code?: string;
+    name?: string;
+    packageCount?: number;
+
+    constructor(data?: ICarrierMixDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.code = _data["code"];
+            this.name = _data["name"];
+            this.packageCount = _data["packageCount"];
+        }
+    }
+
+    static fromJS(data: any): CarrierMixDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new CarrierMixDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["code"] = this.code;
+        data["name"] = this.name;
+        data["packageCount"] = this.packageCount;
+        return data;
+    }
+}
+
+export interface ICarrierMixDto {
+    code?: string;
+    name?: string;
+    packageCount?: number;
+}
+
+export class PackagesPerOrderBucketDto implements IPackagesPerOrderBucketDto {
+    packageCount?: number;
+    orderCount?: number;
+
+    constructor(data?: IPackagesPerOrderBucketDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.packageCount = _data["packageCount"];
+            this.orderCount = _data["orderCount"];
+        }
+    }
+
+    static fromJS(data: any): PackagesPerOrderBucketDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackagesPerOrderBucketDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["packageCount"] = this.packageCount;
+        data["orderCount"] = this.orderCount;
+        return data;
+    }
+}
+
+export interface IPackagesPerOrderBucketDto {
+    packageCount?: number;
     orderCount?: number;
 }
 

--- a/frontend/src/api/hooks/useProductMarginSummary.ts
+++ b/frontend/src/api/hooks/useProductMarginSummary.ts
@@ -24,7 +24,6 @@ export const useProductMarginSummaryQuery = (
       // Use generated API client method with proper parameters
       return apiClient.analytics_GetProductMarginSummary(
         timeWindow,
-        0, // topProductCount = 0 means no limit
         groupingMode,
         marginLevel,
         sortBy,


### PR DESCRIPTION
Closes #3486

## What the issue was
`GetProductMarginSummaryRequest.TopProductCount` was a public API parameter (default 15) that `GetProductMarginSummaryHandler` never read — `GenerateTopProducts` always returned the full, unlimited result set regardless of the value passed. The frontend already worked around this by always passing `topProductCount: 0`. Because the TypeScript client is auto-generated from the OpenAPI spec, the parameter looked like a real, documented feature but had no effect — a contract violation that would mislead any integrator relying on the spec.

## How it was fixed
The pipeline's architect/planner phase chose **Option 1** from the issue (remove the dead parameter, since nothing else in the handler needed it):
- Removed `TopProductCount` from `GetProductMarginSummaryRequest` (backend).
- Removed the now-invalid `topProductCount: 0` argument from the `useProductMarginSummaryQuery` hook call (frontend).
- Regenerated `frontend/src/api/generated/api-client.ts` to match the updated OpenAPI surface.

`GetProductMarginSummaryHandler`, `GenerateTopProducts`, the controller, and all existing tests were left untouched — this is a pure, behavior-preserving removal of dead API surface.

## Verification
- `dotnet build` — 0 errors
- `dotnet format --verify-no-changes` — no diffs
- `dotnet test --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"` — 8/8 passed
- `npm run build` — compiled successfully, no TypeScript errors
- `npm run lint` — no new lint errors (byte-identical to pre-change baseline)
- Full frontend test suite — 2341/2346 passed (5 pre-existing skips, 0 failures), including `ProductMarginSummary.test.tsx`
- Repo-wide grep confirms no remaining reference to `TopProductCount`/`topProductCount` in any `.cs`/`.ts`/`.tsx` file

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3486/` in this branch.

## Code review

Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `docs/features/product-margin-summary.md` still documents the old, pre-refactor `TopProductCount`/"top N" behavior; explicitly out of scope for this fix but worth a follow-up doc pass.
- The regenerated `frontend/src/api/generated/api-client.ts` also picked up unrelated pre-existing drift between the checked-in client and the current backend OpenAPI surface (verified via diff against `main` that this drift predates this branch and was not introduced by this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fcb177mTWHRXYLKsktKBrU)_