### PR TITLE
#3484: Relocate AzureBlobStorageService to the Azure adapter layer

### DIFF
--- a/artifacts/feat-3484/arch-review.r1.md
+++ b/artifacts/feat-3484/arch-review.r1.md
@@ -1,0 +1,312 @@
+# Architecture Review: Relocate AzureBlobStorageService to the Azure adapter layer
+
+## Skip Design: true
+
+This is a backend-only Clean Architecture compliance refactor: moving one Azure-SDK-backed
+service class and its DI wiring from the Application ring to the Azure adapter ring. There are
+no new or changed UI components, screens, layouts, or visual decisions. Behavior is unchanged.
+
+## Architectural Fit Assessment
+
+The proposed change is a **strong fit** and, in fact, corrects an existing deviation. The
+codebase already encodes the target pattern:
+
+- `filesystem.md` states the **I/O placement rule** verbatim: "Concrete `IPrintQueueSink`
+  implementations and any I/O-bound service live in adapter projects under
+  `backend/src/Adapters/`, not in `Features/{Feature}/Services/`."
+- `AzureBlobPrintQueueSink` (an Azure-SDK-backed I/O service, functionally the same shape as
+  `AzureBlobStorageService`) already lives correctly at
+  `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/ExpeditionList/`, with its DI in
+  `AzureAdapterModule.AddAzurePrintQueueSink`.
+
+`AzureBlobStorageService` is the lone outlier: it sits in the Application ring and forces
+`Anela.Heblo.Application.csproj` to reference `Azure.Storage.Blobs` (line 12). The domain
+abstraction (`IBlobStorageService`) and its DTO (`BlobItemInfo`) already live in
+`Anela.Heblo.Domain/Features/FileStorage/` with no Azure dependency, and all consumers depend
+only on the abstraction. Moving the concrete class is therefore purely mechanical from the
+consumers' perspective.
+
+**Integration points verified in the codebase:**
+
+| Concern | Current location | Verified fact |
+|---|---|---|
+| Concrete service | `Application/Features/FileStorage/Services/AzureBlobStorageService.cs` | `sealed`, ctor deps: `BlobServiceClient`, `IHttpClientFactory`, `ILogger<AzureBlobStorageService>` |
+| Abstraction | `Domain/Features/FileStorage/IBlobStorageService` | No Azure dependency; unaffected |
+| Azure DI so far | `FileStorageModule` lines 42–57 (`BlobServiceClient`), line 84 (`IBlobStorageService`) | `using Azure.Storage.Blobs;` at line 5 |
+| Adapter DI home | `AzureAdapterModule.AddAzurePrintQueueSink` | Public static extension; adapter references Application |
+| Adapter project | `Anela.Heblo.Adapters.Azure.csproj` | Already references `Azure.Storage.Blobs` 12.25.0 and `Anela.Heblo.Application` |
+| Named HTTP client constant | `FileStorageModule.FileDownloadClientName` = `"FileDownload"` | Stays in Application; adapter references it (adapter → Application ref exists) |
+| Startup composition | `ApplicationModule.AddApplicationServices` line 85 calls `AddFileStorageModule`; `Program.cs` line 103 calls `AddApplicationServices`, line 132 calls `AddPrintQueueSink` | See Decision 2 — composition constraint |
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Domain (inner ring)
+  └── Features/FileStorage/
+        ├── IBlobStorageService        (abstraction — UNCHANGED, stays)
+        └── BlobItemInfo               (DTO — UNCHANGED, stays)
+
+Application (middle ring)  — loses its Azure.Storage.Blobs dependency
+  └── Features/FileStorage/
+        ├── FileStorageModule          (KEEPS: options bind + ValidateOnStart,
+        │                                named "FileDownload" HttpClient,
+        │                                IDownloadResilienceService, FileDownloadOptions.
+        │                                LOSES: BlobServiceClient factory + IBlobStorageService bind)
+        ├── FileStorageOptions         (UNCHANGED, stays — read by adapter via IOptions<>)
+        ├── FileDownloadOptions        (UNCHANGED, stays)
+        └── Infrastructure/DownloadResilienceService (UNCHANGED, stays)
+
+Adapters.Azure (outer ring)  — sole holder of Azure.Storage.Blobs
+  ├── Features/FileStorage/
+  │     └── AzureBlobStorageService    (MOVED here; ns → Adapters.Azure.Features.FileStorage)
+  └── AzureAdapterModule
+        ├── AddAzurePrintQueueSink     (UNCHANGED)
+        └── AddAzureBlobStorageService (NEW: BlobServiceClient factory + IBlobStorageService bind)
+
+API (composition root)
+  └── Program.cs                       (NEW call: builder.Services.AddAzureBlobStorageService(builder.Environment))
+```
+
+Data-flow arrows are unchanged at runtime: consumers → `IBlobStorageService` →
+`AzureBlobStorageService` → `BlobServiceClient` → Azure. Only the *compile-time* reference graph
+changes: `Azure.Storage.Blobs` leaves the Application ring entirely.
+
+### Key Design Decisions
+
+#### Decision 1: One new adapter extension method, mirroring `AddAzurePrintQueueSink`
+
+**Options considered:**
+- (a) Add `AddAzureBlobStorageService` to `AzureAdapterModule` (mirrors the print-queue precedent).
+- (b) Fold the blob-storage registration into the existing `AddAzurePrintQueueSink`.
+- (c) Share a single `BlobServiceClient` between the print sink and the blob service.
+
+**Chosen approach:** (a) — a dedicated `AddAzureBlobStorageService` extension on
+`AzureAdapterModule`.
+
+**Rationale:** The print-queue sink registers a `BlobContainerClient` built from
+`PrintPickingListOptions`; the blob service needs a `BlobServiceClient` built from
+`FileStorageOptions`. They are different SDK client types, different options, different
+lifecycles, and are wired at different points in startup (`AddAzurePrintQueueSink` is invoked
+*conditionally* from inside `AddPrintQueueSink`'s `switch`, only for `"AzureBlob"`/`"Combined"`).
+Folding them together (b) or sharing a client (c) would couple two independent concerns and
+change behavior — both are explicitly out of scope per the spec. A separate extension keeps each
+concern self-contained and matches the one-extension-per-Azure-concern convention already present.
+
+#### Decision 2: Wire the new extension from the API composition root (`Program.cs`), unconditionally — NOT from `ApplicationModule` and NOT inside `AddPrintQueueSink`
+
+**Options considered:**
+- (a) Call `AddAzureBlobStorageService` from `ApplicationModule.AddApplicationServices` (next to `AddFileStorageModule`).
+- (b) Call it from inside `AddPrintQueueSink`'s `switch` (next to `AddAzurePrintQueueSink`).
+- (c) Call it unconditionally from `Program.cs` (the composition root), after `AddApplicationServices`.
+
+**Chosen approach:** (c).
+
+**Rationale:**
+- (a) is **impossible**: `ApplicationModule` lives in `Anela.Heblo.Application`, the middle ring.
+  The Azure adapter references Application, not the reverse — Application cannot see
+  `AzureAdapterModule`. Placing the call there would create a reference cycle and defeat the
+  entire purpose of the refactor. The daily-review "suggested fix" note in `brief.md` mentions
+  `ApplicationModule`, but that is not achievable without inverting the dependency; the spec's own
+  Open-Questions section already corrects this to "the API composition root."
+- (b) would make the `IBlobStorageService` binding **conditional** on `ExpeditionList:PrintSink`.
+  `AddAzurePrintQueueSink` runs only for `"AzureBlob"`/`"Combined"`. Blob storage is consumed by
+  `DownloadFromUrlHandler` and the `ExpeditionListArchive` handlers regardless of the print sink,
+  so the binding must always be present. Today it is unconditional (registered by
+  `FileStorageModule`, which always runs); (b) would silently regress environments using
+  `"FileSystem"`/`"Cups"`. Rejected.
+- (c) preserves "always present in every environment that had it before." `Program.cs` already
+  has `using Anela.Heblo.Adapters.Azure;` (line 5) and the API project already references the
+  adapter (`.csproj` line 68), so the call site compiles with no new wiring. Registration order
+  relative to `AddApplicationServices` is irrelevant because the `BlobServiceClient` factory
+  resolves `IOptions<FileStorageOptions>` lazily at first resolve, long after all `Add*` calls
+  complete.
+
+#### Decision 3: The new extension takes `IHostEnvironment`, not `IConfiguration`
+
+**Options considered:**
+- (a) `AddAzureBlobStorageService(this IServiceCollection, IConfiguration)` (mirrors `AddAzurePrintQueueSink`'s signature).
+- (b) `AddAzureBlobStorageService(this IServiceCollection, IHostEnvironment)`.
+- (c) Resolve `IHostEnvironment` from the provider inside the factory.
+
+**Chosen approach:** (b).
+
+**Rationale:** The `BlobServiceClient` factory must preserve its exact current behavior,
+including the Development-only warning message that interpolates `environment.EnvironmentName`
+("...is empty in {Environment}; falling back to UseDevelopmentStorage=true."). The options are
+already bound and validated by `FileStorageModule`, so the extension needs **no** `IConfiguration`
+— it only reads `IOptions<FileStorageOptions>`. It does need the environment name for the log
+message, so it must receive `IHostEnvironment`. This matches how `AddFileStorageModule` itself
+already takes `IHostEnvironment`. Option (c) (resolve from provider) works in the API host but
+forces the unit test to register a mock `IHostEnvironment`; passing it explicitly keeps the
+closure-capture pattern byte-for-byte identical to today's factory and is the smallest behavioral
+delta. This is a deliberate amendment to the spec's stated `(IServiceCollection, IConfiguration)`
+signature (see Specification Amendments).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Move (git mv to preserve history):**
+```
+FROM: backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
+TO:   backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+```
+- Change namespace to `Anela.Heblo.Adapters.Azure.Features.FileStorage`.
+- Add `using Anela.Heblo.Application.Features.FileStorage;` so the reference to
+  `FileStorageModule.FileDownloadClientName` still resolves (do **not** duplicate the `"FileDownload"`
+  literal). Keep `using Anela.Heblo.Domain.Features.FileStorage;` for `IBlobStorageService` /
+  `BlobItemInfo`. Keep the `Azure.Storage.Blobs` / `Azure.Storage.Blobs.Models` usings.
+- All method bodies, the private `BlobDownloadStream`, the `_containerExists` cache, and the two
+  content-type helper methods move **verbatim**. Do not touch logic.
+
+**Edit `backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs`:**
+- Add a second public static extension `AddAzureBlobStorageService`.
+- Add `using Anela.Heblo.Adapters.Azure.Features.FileStorage;`,
+  `using Anela.Heblo.Application.Features.FileStorage;`,
+  `using Anela.Heblo.Domain.Features.FileStorage;`,
+  `using Microsoft.Extensions.Hosting;`, `using Microsoft.Extensions.Logging;`.
+
+**Edit `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`:**
+- Remove the `BlobServiceClient` factory (lines 42–57), the
+  `AddSingleton<IBlobStorageService, AzureBlobStorageService>()` binding (line 84), the
+  `using Azure.Storage.Blobs;` (line 5), and the now-unused
+  `using ...Features.FileStorage.Services;` (line 3, unless still referenced — it will no longer be).
+- **Keep** everything else: the `FileStorageOptions` options binding, the non-Development
+  `.Validate(...).ValidateOnStart()`, the `FileDownload` named `HttpClient` with its
+  `SocketsHttpHandler`/infinite-timeout config, `IDownloadResilienceService`, and the
+  `FileDownloadOptions` binding. The `FileDownloadClientName` const stays here.
+
+**Edit `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`:**
+- Remove line 12: `<PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />`.
+
+**Edit `backend/src/Anela.Heblo.API/Program.cs`:**
+- After the `AddApplicationServices` call (line 103), add an unconditional
+  `builder.Services.AddAzureBlobStorageService(builder.Environment);`. `using Anela.Heblo.Adapters.Azure;`
+  already exists (line 5).
+
+### Interfaces and Contracts
+
+New extension method (target shape):
+
+```csharp
+// AzureAdapterModule.cs
+public static IServiceCollection AddAzureBlobStorageService(
+    this IServiceCollection services,
+    IHostEnvironment environment)
+{
+    // BlobServiceClient factory — moved verbatim from FileStorageModule lines 42–57.
+    // Reads the already-bound IOptions<FileStorageOptions> (binding + ValidateOnStart
+    // stay in FileStorageModule, which always runs before first resolve).
+    services.AddSingleton<BlobServiceClient>(provider =>
+    {
+        var opts = provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+        if (string.IsNullOrWhiteSpace(opts.BlobConnectionString))
+        {
+            var logger = provider.GetRequiredService<ILogger<AzureBlobStorageService>>();
+            logger.LogWarning(
+                "FileStorage:BlobConnectionString is empty in {Environment}; falling back to UseDevelopmentStorage=true.",
+                environment.EnvironmentName);
+            return new BlobServiceClient("UseDevelopmentStorage=true");
+        }
+        return new BlobServiceClient(opts.BlobConnectionString);
+    });
+
+    services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
+    return services;
+}
+```
+
+**Contracts that must NOT change:** `IBlobStorageService` (all eight method signatures),
+`BlobItemInfo`, `FileStorageOptions` (incl. `BlobConnectionString` and `SectionName`),
+`FileDownloadOptions`, and `FileStorageModule.FileDownloadClientName` (= `"FileDownload"`).
+
+### Data Flow
+
+Runtime path is identical before and after:
+
+1. Startup: `FileStorageModule` binds + validates `FileStorageOptions`, registers the
+   `FileDownload` `HttpClient` and `IDownloadResilienceService`.
+   `AddAzureBlobStorageService` registers the `BlobServiceClient` singleton factory and binds
+   `IBlobStorageService → AzureBlobStorageService`.
+2. First resolve of `IBlobStorageService` triggers the factory, which reads the validated
+   options (fail-fast already guaranteed by `ValidateOnStart` in non-Development).
+3. `DownloadFromUrlHandler` / `ExpeditionListArchive` handlers inject `IBlobStorageService` and
+   call it exactly as today; the service uses the named `FileDownload` client and the
+   `BlobServiceClient` as before. Singleton lifetimes (client, service, resilience) preserve the
+   `_containerExists` cache and socket pooling.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Wiring placed in `ApplicationModule`, creating an Application→Adapter reference cycle | High | Decision 2: wire from `Program.cs` (composition root) only. Application must never reference the adapter. |
+| Blob binding made conditional (e.g. added inside `AddPrintQueueSink`'s `switch`), regressing `FileSystem`/`Cups` environments | High | Decision 2: the `AddAzureBlobStorageService` call is unconditional in `Program.cs`, matching today's always-on registration by `FileStorageModule`. |
+| `FileStorageModuleTests` still assert blob/`BlobServiceClient` registration on `FileStorageModule` → compile/assert failures | Medium | Move the three affected tests to a new `AzureAdapterModule` test (see Amendment 4). The three: `RegistersBlobStorageService_AsSingleton`, `ResolvingBlobStorageServiceTwice_ReturnsSameInstance`, `DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning`. |
+| New adapter test resolves `BlobServiceClient`/`IBlobStorageService` but options binding now lives elsewhere → missing `IOptions<FileStorageOptions>` | Medium | The adapter-module test must call **both** `AddFileStorageModule(config, env)` (for the options binding + validation) **and** `AddAzureBlobStorageService(env)`. Document this coupling in the test. |
+| Warning-message text drift (`{Environment}` interpolation) breaks the dev-fallback assertion | Low | Decision 3: pass `IHostEnvironment` to the extension and keep the factory body verbatim; the log message string is unchanged. |
+| `AzureBlobStorageServiceTests` fails to compile after the type moves | Low | Only the `using`/namespace reference to the service changes (test constructs the type directly, no DI). Update `using Anela.Heblo.Application.Features.FileStorage.Services;` → `using Anela.Heblo.Adapters.Azure.Features.FileStorage;`. The test project already references the adapter (`.csproj` line 50). |
+| Stray `Azure.Storage` references left in Application after the move | Low | FR-4 acceptance: repo-wide grep for `Azure.Storage` / `BlobServiceClient` / `BlobContainerClient` under `Anela.Heblo.Application` must return nothing; `dotnet build` then proves the package removal is safe. |
+
+## Specification Amendments
+
+1. **Amend FR-2 / API-Interface-Design signature.** The new extension should be
+   `AddAzureBlobStorageService(this IServiceCollection services, IHostEnvironment environment)` —
+   **not** `(IServiceCollection, IConfiguration)`. The factory needs `environment.EnvironmentName`
+   for the fallback warning; it does **not** need `IConfiguration` because the `FileStorageOptions`
+   binding/validation stays in `FileStorageModule` and the factory reads `IOptions<FileStorageOptions>`.
+   (Rationale in Decision 3.)
+
+2. **Amend FR-3 / the `brief.md` "suggested fix" step 5.** The registration must be invoked from
+   the **API composition root (`Program.cs`)**, not from `ApplicationModule`. `ApplicationModule`
+   is in the Application ring and cannot reference the adapter without inverting the dependency —
+   the very coupling this refactor removes. Concretely: add
+   `builder.Services.AddAzureBlobStorageService(builder.Environment);` in `Program.cs` immediately
+   after the existing `AddApplicationServices(...)` call (~line 103). The spec's Open-Questions
+   already lands on "the API composition root"; this amendment makes it binding and rejects the
+   `ApplicationModule` option outright.
+
+3. **Clarify FR-3: the call is unconditional and independent of `AddPrintQueueSink`.** Do not add
+   it inside `AddPrintQueueSink`'s `switch` (that path is conditional on
+   `ExpeditionList:PrintSink`). Blob storage is consumed regardless of the print sink and must
+   always be registered.
+
+4. **Amend FR-5 with the precise test deltas discovered in the source:**
+   - `AzureBlobStorageServiceTests.cs`: update the two `using` lines (drop
+     `...Application.Features.FileStorage.Services`, add `...Adapters.Azure.Features.FileStorage`);
+     keep the reference to `FileStorageModule.FileDownloadClientName` (needs
+     `using Anela.Heblo.Application.Features.FileStorage;`, already present). No logic changes.
+   - `FileStorageModuleTests.cs`: **three** methods target the moved registrations and must be
+     relocated to a new `AzureAdapterModuleTests` (or equivalent adapter-module test):
+     `AddFileStorageModule_RegistersBlobStorageService_AsSingleton`,
+     `AddFileStorageModule_ResolvingBlobStorageServiceTwice_ReturnsSameInstance`, and
+     `AddFileStorageModule_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning` (this last
+     one resolves `BlobServiceClient` and verifies the warning). The relocated tests must call
+     **both** `AddFileStorageModule(config, env)` (for the options binding) **and**
+     `AddAzureBlobStorageService(env)`. The remaining `FileStorageModuleTests` (named `HttpClient`,
+     resilience service, options validation, constant export) stay as-is and must still pass —
+     they assert only the non-Azure registrations that remain in `FileStorageModule`.
+
+5. **Non-scope confirmation retained.** `AzureBlobConflictTelemetryFilter` references
+   `AzureBlobStorageService` only in a doc comment; per the spec no code change is required. If the
+   comment's implied namespace becomes stale, an optional one-line comment touch-up is acceptable
+   but out of scope.
+
+## Prerequisites
+
+None beyond the existing codebase. Specifically verified:
+
+- `Anela.Heblo.Adapters.Azure.csproj` **already** references `Azure.Storage.Blobs` 12.25.0 and
+  `Anela.Heblo.Application` — no new package or project references needed in the adapter.
+- `Anela.Heblo.API.csproj` (line 68) and `Program.cs` (`using`, line 5) **already** wire in the
+  Azure adapter — the new `Program.cs` call compiles without additional references.
+- `Anela.Heblo.Tests.csproj` (line 50) **already** references the Azure adapter — the relocated
+  tests need no new project reference.
+- No migrations, config keys, or Key Vault secrets are introduced. `FileStorage:BlobConnectionString`
+  already exists in all non-Development environments (documented in `environments.md`); its sourcing,
+  validation timing, and the Development fallback are all preserved unchanged.
+
+Validation gate before completion (per CLAUDE.md / NFR-3): `dotnet build` succeeds,
+`dotnet format` clean, and the full backend test suite (including the relocated FileStorage tests)
+passes.

--- a/artifacts/feat-3484/brief.md
+++ b/artifacts/feat-3484/brief.md
@@ -1,0 +1,43 @@
+## Module
+FileStorage
+
+## Finding
+`AzureBlobStorageService` lives in the Application layer at:
+
+```
+backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
+```
+
+It is an I/O-bound Azure SDK consumer — it depends directly on `Azure.Storage.Blobs.BlobServiceClient` and makes network calls to Azure Blob Storage. That makes it adapter-tier code, not Application-tier code.
+
+As a direct consequence, `FileStorageModule` also reaches into Azure-SDK territory:
+- **line 5**: `using Azure.Storage.Blobs;`
+- **lines 42–57**: registers `BlobServiceClient` as a `Singleton` via an SDK factory
+- **line 84**: `services.AddSingleton()`
+
+The codebase already demonstrates the correct approach: `AzureBlobPrintQueueSink` (functionally equivalent — an Azure-SDK-backed I/O service) is correctly placed in:
+
+```
+backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/ExpeditionList/AzureBlobPrintQueueSink.cs
+```
+
+with its `BlobContainerClient` registration and DI binding in `AzureAdapterModule.AddAzurePrintQueueSink`. `AzureBlobStorageService` is the same shape of object but skipped that placement.
+
+## Why it matters
+`filesystem.md` states the rule explicitly:
+
+> **I/O placement rule**: Concrete `IPrintQueueSink` implementations and any I/O-bound service live in adapter projects under `backend/src/Adapters/`, not in `Features/{Feature}/Services/`.
+
+With the current placement `Anela.Heblo.Application.csproj` takes a compile-time dependency on the `Azure.Storage.Blobs` NuGet package. Clean Architecture requires the Application layer to depend only on abstractions — infrastructure libraries belong in the outer ring. It also creates an inconsistency with `AzureBlobPrintQueueSink`, making the codebase harder to reason about: one Azure-blob service is in the correct place, the other is not.
+
+## Suggested fix
+1. Move `AzureBlobStorageService` to `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`.
+2. Add a new extension method (e.g. `AddAzureBlobStorageService`) to `AzureAdapterModule`, which registers `BlobServiceClient` (or reuse the one already registered by `AddAzurePrintQueueSink`) and binds `services.AddSingleton()`.
+3. Remove the `BlobServiceClient` factory and `IBlobStorageService` binding from `FileStorageModule` — keep only the `HttpClient`, `FileStorageOptions`, `FileDownloadOptions`, and `IDownloadResilienceService` registrations (none of which require the Azure SDK).
+4. Remove `using Azure.Storage.Blobs;` from `FileStorageModule`.
+5. In `ApplicationModule` (or `Program.cs`), call the new `AzureAdapterModule` extension alongside the existing `AddAzurePrintQueueSink`.
+
+`IBlobStorageService`, `BlobItemInfo`, `FileStorageOptions`, `FileDownloadOptions`, `IDownloadResilienceService`, and `DownloadFromUrlHandler` all stay where they are — none of them carry an Azure SDK dependency.
+
+---
+_Filed by daily arch-review routine on 2026-07-04._

--- a/artifacts/feat-3484/code-review.r1.md
+++ b/artifacts/feat-3484/code-review.r1.md
@@ -1,0 +1,9 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+Notes: Verified against the actual worktree (not just the pasted diff text, whose final hunk in the prompt appeared corrupted — `Times.Once):` with a stray colon and a missing class-closing brace). The real file at `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs` is syntactically correct; `dotnet build Anela.Heblo.sln` succeeds with 0 errors, and `dotnet test --filter FullyQualifiedName~FileStorage` passes 115/115. The relocation is a faithful, behavior-preserving move: `AzureBlobStorageService` and its `BlobServiceClient`/`IBlobStorageService` registrations move from `FileStorageModule` (Application) to `AzureAdapterModule.AddAzureBlobStorageService` (Azure adapter), mirroring the existing `AddAzurePrintQueueSink` pattern. `Anela.Heblo.Application.csproj` no longer references `Azure.Storage.Blobs`, no remaining `BlobServiceClient`/`Azure.Storage` references exist in the Application project, registration order in `Program.cs` is safe (options validation is deferred to first resolution, not registration time), and there is no double-registration of `IBlobStorageService`. Tests were correctly migrated: the Singleton-lifetime and Development-fallback-warning tests moved from `FileStorageModuleTests` to the new `AzureAdapterModuleTests`, with equivalent coverage.

--- a/artifacts/feat-3484/design.r1.md
+++ b/artifacts/feat-3484/design.r1.md
@@ -1,0 +1,42 @@
+# Design: Relocate AzureBlobStorageService to the Azure adapter layer
+
+## Component Design
+
+### `AzureBlobStorageService` (relocated, unchanged behavior)
+- **Old location:** `Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs`, namespace `Anela.Heblo.Application.Features.FileStorage.Services`.
+- **New location:** `Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`, namespace `Anela.Heblo.Adapters.Azure.Features.FileStorage`.
+- **Responsibility:** unchanged — the sole concrete, I/O-bound implementation of `IBlobStorageService`, backed by the Azure `BlobServiceClient` and `IHttpClientFactory` (named `FileDownload` client).
+- **Contract:** implements `Anela.Heblo.Domain.Features.FileStorage.IBlobStorageService` with identical method signatures: `DownloadFromUrlAsync`, `UploadAsync`, `DeleteAsync`, `GetBlobUrl`, `ExistsAsync`, `ListBlobsAsync`, `DownloadAsync`, `ListVirtualDirectoriesAsync`.
+- **Internals moved verbatim:** the private `BlobDownloadStream` helper, the `_containerExists` cache, and the content-type helper methods — no logic changes.
+- **Cross-ring reference:** keeps a `using Anela.Heblo.Application.Features.FileStorage;` to reach `FileStorageModule.FileDownloadClientName` (the adapter already references `Anela.Heblo.Application`, so this is a normal outer-ring→middle-ring reference, not a cycle).
+- **Constructor dependencies:** `BlobServiceClient`, `IHttpClientFactory`, `ILogger<AzureBlobStorageService>` — unchanged.
+
+### `AzureAdapterModule.AddAzureBlobStorageService` (new extension)
+- **Location:** `Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs`, alongside the existing `AddAzurePrintQueueSink`.
+- **Signature:** `public static IServiceCollection AddAzureBlobStorageService(this IServiceCollection services, IHostEnvironment environment)`.
+- **Responsibility:**
+  1. Registers `BlobServiceClient` as a `Singleton`, using the factory moved verbatim from `FileStorageModule`: reads `IOptions<FileStorageOptions>`, and if `BlobConnectionString` is blank, logs a warning interpolating `environment.EnvironmentName` and falls back to `new BlobServiceClient("UseDevelopmentStorage=true")`; otherwise constructs `new BlobServiceClient(opts.BlobConnectionString)`.
+  2. Binds `services.AddSingleton<IBlobStorageService, AzureBlobStorageService>()`.
+- **Independence from `AddAzurePrintQueueSink`:** a separate extension, not folded together and not sharing a `BlobServiceClient`/`BlobContainerClient` — different SDK client types, different options sources (`FileStorageOptions` vs `PrintPickingListOptions`), different lifecycles.
+- **Composition:** invoked unconditionally from the API composition root (`Program.cs`, `builder.Services.AddAzureBlobStorageService(builder.Environment);`, immediately after `AddApplicationServices`) — not from `ApplicationModule` (would create an Application→Adapter cycle) and not from inside `AddPrintQueueSink`'s conditional `switch` (would make the binding conditional on `ExpeditionList:PrintSink`, regressing `FileSystem`/`Cups` environments).
+
+### `FileStorageModule` (reduced responsibility)
+- **Loses:** the `BlobServiceClient` factory, the `AddSingleton<IBlobStorageService, AzureBlobStorageService>()` binding, `using Azure.Storage.Blobs;`, and the now-unused `using ...Features.FileStorage.Services;`.
+- **Keeps:** `FileStorageOptions` binding with the non-Development `.Validate(...).ValidateOnStart()`, the named `FileDownload` `HttpClient` (`SocketsHttpHandler`, timeout config), `IDownloadResilienceService` → `DownloadResilienceService`, `FileDownloadOptions` binding, and the `FileDownloadClientName` constant (remains the single source of truth referenced by the relocated service).
+- **Ordering guarantee:** `FileStorageModule` always runs during `AddApplicationServices`, so `IOptions<FileStorageOptions>` is bound and validated before `AddAzureBlobStorageService`'s factory is ever invoked (first resolve happens lazily, after all `Add*` calls complete) — registration order between the two modules is not significant.
+
+## Data Schemas
+
+No schema or contract changes; all shapes below are unchanged and listed only to confirm they are unaffected by the move.
+
+- **`IBlobStorageService`** (`Anela.Heblo.Domain/Features/FileStorage/`) — abstraction consumed by `DownloadFromUrlHandler` and the `ExpeditionListArchive` handlers. Method signatures unchanged.
+- **`BlobItemInfo`** (`Anela.Heblo.Domain/Features/FileStorage/`) — DTO fields unchanged: `Name`, `FileName`, `CreatedOn`, `ContentLength`.
+- **`FileStorageOptions`** (`Anela.Heblo.Application`) — unchanged; section name `FileStorage`; includes `BlobConnectionString`, now read by the adapter via `IOptions<FileStorageOptions>` instead of by `FileStorageModule` directly constructing `BlobServiceClient`.
+- **`FileDownloadOptions`** (`Anela.Heblo.Application`) — unchanged; bound from `FileStorage:Download`.
+- **DI surface (internal, C#-only, no HTTP/API shape change):**
+  - New: `AzureAdapterModule.AddAzureBlobStorageService(IServiceCollection, IHostEnvironment)`.
+  - Changed: `FileStorageModule.AddFileStorageModule(...)` no longer registers `BlobServiceClient` or binds `IBlobStorageService`.
+  - Changed: `AzureBlobStorageService` namespace → `Anela.Heblo.Adapters.Azure.Features.FileStorage`.
+  - Unchanged: `FileStorageModule.FileDownloadClientName` = `"FileDownload"`.
+
+No public HTTP API, request/response payload, or event schema is introduced, removed, or modified by this refactor.

--- a/artifacts/feat-3484/impl/relocate-service-and-rewire-di.r1.md
+++ b/artifacts/feat-3484/impl/relocate-service-and-rewire-di.r1.md
@@ -1,0 +1,78 @@
+# Implementation: relocate-service-and-rewire-di
+
+## What was implemented
+Moved `AzureBlobStorageService` out of the Application layer into the `Anela.Heblo.Adapters.Azure`
+project (new namespace `Anela.Heblo.Adapters.Azure.Features.FileStorage`), added a new
+`AddAzureBlobStorageService(IServiceCollection, IHostEnvironment)` extension to `AzureAdapterModule`
+that owns the `BlobServiceClient` factory (moved verbatim, including the fallback-warning log
+message) and the `IBlobStorageService` singleton binding, stripped those same registrations and the
+Azure `using`s out of `FileStorageModule`, removed the `Azure.Storage.Blobs` package reference from
+`Anela.Heblo.Application.csproj` (it was already present in `Anela.Heblo.Adapters.Azure.csproj`), and
+wired the new extension into `Program.cs` immediately after `AddApplicationServices`. Behavior is
+byte-for-byte identical — only namespace/location/DI wiring changed, no method bodies were touched.
+
+## Files created/modified
+- `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` — moved here via `git mv` from `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs`; namespace changed to `Anela.Heblo.Adapters.Azure.Features.FileStorage`, added `using Anela.Heblo.Application.Features.FileStorage;` so `FileStorageModule.FileDownloadClientName` still resolves. No method bodies changed.
+- `backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs` — added `AddAzureBlobStorageService(IServiceCollection, IHostEnvironment)` extension with the `BlobServiceClient` factory (moved verbatim from `FileStorageModule`) and the `IBlobStorageService` singleton binding; added the required `using`s (`Anela.Heblo.Adapters.Azure.Features.FileStorage`, `Anela.Heblo.Application.Features.FileStorage`, `Anela.Heblo.Domain.Features.FileStorage`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Logging`).
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs` — removed the `using Anela.Heblo.Application.Features.FileStorage.Services;` and `using Azure.Storage.Blobs;` lines, removed the `BlobServiceClient` factory registration block, and removed the `IBlobStorageService` binding + its comment. File now matches the target content specified in the task exactly (verified line-by-line).
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — removed the `<PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />` line.
+- `backend/src/Anela.Heblo.API/Program.cs` — added `builder.Services.AddAzureBlobStorageService(builder.Environment);` immediately after `AddApplicationServices(...)`, before `AddScoped<ISmartsuppWebhookMetrics, ...>()`.
+
+## Tests
+None — this task intentionally does not touch tests. Task 2 (`update-filestorage-tests`) updates the
+two test files that reference the old namespace/location; the test project (`Anela.Heblo.Tests`) does
+not compile until that task runs. Confirmed the production-only build (API project, which transitively
+builds Application and Adapters.Azure) succeeds independent of the test project.
+
+## How to verify
+```bash
+cd backend
+# 1. Moved file exists, old path gone
+ls src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+ls src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs  # expect "No such file"
+
+# 2. Production build succeeds
+dotnet build src/Anela.Heblo.API/Anela.Heblo.API.csproj   # Build succeeded, 0 Error(s)
+
+# 3. No Azure SDK references left in Application
+grep -rn "Azure.Storage\|BlobServiceClient\|BlobContainerClient" src/Anela.Heblo.Application  # empty
+
+# 4. Package reference moved correctly
+grep -n "Azure.Storage.Blobs" src/Anela.Heblo.Application/Anela.Heblo.Application.csproj  # empty
+grep -n "Azure.Storage.Blobs" src/Adapters/Anela.Heblo.Adapters.Azure/Anela.Heblo.Adapters.Azure.csproj  # one match
+
+# 5. Program.cs wiring
+grep -n "AddAzureBlobStorageService" src/Anela.Heblo.API/Program.cs  # exactly one match, right after AddApplicationServices
+
+# 6. Formatting clean (no repo-root .sln lives under backend/, so format was run per-project)
+dotnet format src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --verify-no-changes
+dotnet format src/Adapters/Anela.Heblo.Adapters.Azure/Anela.Heblo.Adapters.Azure.csproj --verify-no-changes
+dotnet format src/Anela.Heblo.API/Anela.Heblo.API.csproj --verify-no-changes
+```
+All of the above were run during implementation and passed with no findings/changes.
+
+## Notes
+- Deviation from the plan's literal verification command: the plan says to run
+  `dotnet format --verify-no-changes` "from `backend/`", but there is no `.sln`/`.csproj` directly in
+  `backend/` (the solution file `Anela.Heblo.sln` lives at the repo root and includes the
+  `Anela.Heblo.Tests` project, which does not compile until Task 2). Running `dotnet format` against
+  that solution would fail to load the workspace due to the test project's compile errors. Instead I
+  ran `dotnet format <csproj> --verify-no-changes` individually against the three touched projects
+  (`Anela.Heblo.Application`, `Anela.Heblo.Adapters.Azure`, `Anela.Heblo.API`) — all three reported no
+  changes needed, satisfying the intent of acceptance criterion 6 without requiring the test project to
+  compile.
+- The `dotnet build` output includes an unrelated warning: the post-build `AccessMatrixGen` MSBuild
+  target (`Anela.Heblo.API.csproj` line 113) exits with code 134 (MSB3073 warning, not an error). This
+  is pre-existing tooling behavior in this sandboxed environment, unrelated to this change — the build
+  still reports "Build succeeded." / "0 Error(s)".
+- `using Microsoft.Extensions.Logging;` was kept in `FileStorageModule.cs` per the task's note (still
+  potentially used elsewhere / left as-is for a surgical diff) — `dotnet format` confirmed it is not
+  flagged as an unused using, so no further removal was needed.
+- The now-empty `Services/` folder under `Anela.Heblo.Application/Features/FileStorage/` was left as-is
+  (git does not track empty directories, so there is nothing to clean up).
+- `artifacts/feat-3484/state.json` had a pre-existing unstaged modification (present before I started
+  any work) — I deliberately did not stage or commit it, per the instruction that `artifacts/` is not
+  something this task touches.
+
+## Status
+DONE

--- a/artifacts/feat-3484/impl/update-filestorage-tests.r1.md
+++ b/artifacts/feat-3484/impl/update-filestorage-tests.r1.md
@@ -1,0 +1,56 @@
+# Implementation: update-filestorage-tests
+
+## What was implemented
+Updated the two test files affected by the relocation of `AzureBlobStorageService` from
+`Anela.Heblo.Application` to `Anela.Heblo.Adapters.Azure` (task `relocate-service-and-rewire-di`),
+and added a new test file covering the relocated DI registration.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs` — swapped the
+  `using Anela.Heblo.Application.Features.FileStorage.Services;` import for
+  `using Anela.Heblo.Adapters.Azure.Features.FileStorage;` so the tests compile against the relocated
+  type. No behavioral change to the tests themselves.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs` — removed the three
+  tests that asserted `BlobServiceClient` / `IBlobStorageService` registration
+  (`AddFileStorageModule_RegistersBlobStorageService_AsSingleton`,
+  `AddFileStorageModule_ResolvingBlobStorageServiceTwice_ReturnsSameInstance`,
+  `AddFileStorageModule_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning`) since
+  `FileStorageModule` no longer owns that registration. Also dropped the now-unused
+  `Anela.Heblo.Application.Features.FileStorage.Services` and `Azure.Storage.Blobs` usings.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureAdapterModuleTests.cs` (new) — the three
+  removed tests, relocated and renamed to target `AzureAdapterModule.AddAzureBlobStorageService`
+  instead of `FileStorageModule.AddFileStorageModule`. Each test calls both `AddFileStorageModule`
+  (for `FileStorageOptions` binding/validation) and `AddAzureBlobStorageService` (for the
+  `BlobServiceClient` factory + `IBlobStorageService` binding), matching the split responsibility
+  established by task 1.
+
+## Tests
+- `AzureBlobStorageServiceTests` (10 tests, existing) — compiles against the relocated type, behavior
+  unchanged.
+- `FileStorageModuleTests` (existing, reduced by 3) — covers the options binding/validation and the
+  named `FileDownload` HTTP client; no longer asserts on Azure SDK types.
+- `AzureAdapterModuleTests` (new, 3 tests) — Singleton lifetime, same-instance resolution, and the
+  Development-environment fallback + warning log for `AddAzureBlobStorageService`.
+
+Full run: `dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.FileStorage"` from `backend/` →
+**Passed! Failed: 0, Passed: 115, Skipped: 0, Total: 115**.
+
+`dotnet format Anela.Heblo.sln --verify-no-changes --include <the three files>` from the repo root → clean (exit 0, no output).
+
+## How to verify
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.FileStorage"
+```
+Expect `Passed! Failed: 0, Passed: 115, Skipped: 0, Total: 115`.
+
+## Notes
+- The `dotnet build`/`dotnet run` step that regenerates `access-matrix.generated.json` throws an
+  unrelated `JsonException` in this environment (pre-existing tool/environment issue with the
+  `Anela.Heblo.AccessMatrixGen` tool, unrelated to this change — it reads a malformed/missing JSON
+  file). It only emits an MSBuild warning (exit code 134 from that sub-process) and does not fail the
+  build or the test run; not addressed here as it is out of scope for this task.
+- No production code was touched in this task — only test files.
+
+## Status
+DONE

--- a/artifacts/feat-3484/review/relocate-service-and-rewire-di.r1.md
+++ b/artifacts/feat-3484/review/relocate-service-and-rewire-di.r1.md
@@ -1,0 +1,35 @@
+# Code Review: relocate-service-and-rewire-di (feat-3484)
+
+## Summary
+The implementation matches the task spec precisely: `AzureBlobStorageService` was moved with `git mv`
+(confirmed as a 99%-similarity rename in the commit, preserving history) into
+`Anela.Heblo.Adapters.Azure.Features.FileStorage`, only the namespace and one `using` line changed in
+the moved file, and the new `AddAzureBlobStorageService(IServiceCollection, IHostEnvironment)`
+extension on `AzureAdapterModule` reproduces the `BlobServiceClient` factory and `IBlobStorageService`
+binding verbatim. `FileStorageModule` now matches the target content in the task context byte-for-byte.
+I independently ran the production build and it succeeds with 0 errors.
+
+## Review Result: PASS
+
+### task: relocate-service-and-rewire-di
+**Status:** PASS
+
+Verification performed directly against the worktree (not just the developer's summary):
+- Moved file exists at `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` with namespace `Anela.Heblo.Adapters.Azure.Features.FileStorage`; old path no longer exists.
+- `git log --follow` / `git show -M --summary` on the implementation commit confirm a detected rename (99% similarity), preserving history as required — only 3 lines changed (namespace + new `using Anela.Heblo.Application.Features.FileStorage;`), no method bodies touched.
+- `AzureAdapterModule.cs` contains the new `AddAzureBlobStorageService` extension with the `BlobServiceClient` factory moved verbatim (including the exact fallback-warning message) and the `IBlobStorageService` singleton binding, matching the task's target code exactly.
+- `FileStorageModule.cs` matches the task's target content exactly: Azure `using`s and registrations removed, `Microsoft.Extensions.Options`/`Microsoft.Extensions.Logging` retained as instructed.
+- `Program.cs` has exactly one `AddAzureBlobStorageService(builder.Environment)` call, immediately after `AddApplicationServices` and before the `ISmartsuppWebhookMetrics` registration — correctly placed outside the print-sink switch and outside `ApplicationModule`.
+- `Anela.Heblo.Application.csproj` no longer references `Azure.Storage.Blobs`; `Anela.Heblo.Adapters.Azure.csproj` still does (one match, version 12.25.0).
+- `grep -rn "Azure.Storage\|BlobServiceClient\|BlobContainerClient" backend/src/Anela.Heblo.Application` returns empty — no stray Azure SDK references remain in the Application layer.
+- Ran `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj` myself: **Build succeeded, 0 Error(s)** (160 pre-existing warnings unrelated to this change, plus the known non-fatal `AccessMatrixGen` post-build tool exit code 134, both pre-existing and orthogonal to this task).
+- As instructed, the test project's expected non-compilation (due to the old namespace reference, to be fixed by task 2) was not flagged as an issue here — out of scope for this task.
+
+No functional, architectural, or correctness issues found.
+
+## Docs to Update
+None.
+
+## Overall Notes
+Clean, surgical move with correct DI wiring and zero behavior change. The developer's implementation
+summary was accurate in every claim checked against the actual file contents and a live build.

--- a/artifacts/feat-3484/review/update-filestorage-tests.r1.md
+++ b/artifacts/feat-3484/review/update-filestorage-tests.r1.md
@@ -1,0 +1,38 @@
+# Code Review: update-filestorage-tests (feat-3484)
+
+## Summary
+The developer updated `AzureBlobStorageServiceTests.cs` to reference the relocated type's new
+namespace, removed the three registration tests from `FileStorageModuleTests.cs` that no longer
+apply now that `AzureBlobStorageService` lives in the Azure adapter, and created
+`AzureAdapterModuleTests.cs` with the three relocated tests targeting `AddAzureBlobStorageService`.
+Independent verification confirms the implementation matches the task context exactly, the full
+FileStorage test suite passes, and no stray references to the old namespace or type location remain
+anywhere in the repo.
+
+## Review Result: PASS
+
+### task: update-filestorage-tests
+**Status:** PASS
+
+**Verification performed:**
+- Diffed all three files against the task-context spec — content matches verbatim (imports,
+  removed tests, new `AzureAdapterModuleTests.cs` class with its three tests and doc comment).
+- Ran `dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.FileStorage"`
+  from `backend/` in the worktree: build succeeded (only pre-existing, unrelated nullable warnings
+  in other feature test files), and the run reported
+  `Passed! - Failed: 0, Passed: 115, Skipped: 0, Total: 115`.
+- `grep -rn "FileStorage.Services" backend/ --include=*.cs` — no matches; the old namespace is gone
+  repo-wide.
+- `grep -rn "AzureBlobStorageService" backend/ --include=*.cs` — all matches point to the new
+  adapter location (`Adapters/Anela.Heblo.Adapters.Azure/...`), `Program.cs` wiring, the unrelated
+  doc-comment mention in `AzureBlobConflictTelemetryFilter.cs`, and the three test files under
+  review. No lingering references to the old `Application` location.
+
+## Docs to Update
+None.
+
+## Overall Notes
+Clean, surgical test-only change. Test split correctly reflects the DI ownership split established
+in task 1 (`FileStorageModule` keeps options/HTTP/resilience; `AzureAdapterModule` owns
+`BlobServiceClient`/`IBlobStorageService`), and the relocated tests are exact behavioral analogues of
+the originals, just re-targeted at the new registration extension.

--- a/artifacts/feat-3484/spec.r1.md
+++ b/artifacts/feat-3484/spec.r1.md
@@ -1,0 +1,105 @@
+# Specification: Relocate AzureBlobStorageService to the Azure adapter layer
+
+## Summary
+`AzureBlobStorageService` — an I/O-bound Azure SDK consumer — currently lives in the Application layer, forcing `Anela.Heblo.Application` to take a compile-time dependency on the `Azure.Storage.Blobs` NuGet package and violating the project's Clean Architecture "I/O placement rule". This is an architecture-compliance refactor that moves the class (and its Azure-specific DI wiring) into `Anela.Heblo.Adapters.Azure`, mirroring the already-correct placement of `AzureBlobPrintQueueSink`. Behavior is unchanged; only the physical location and dependency graph change.
+
+## Background
+The daily arch-review routine (2026-07-04) flagged that `AzureBlobStorageService` at `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs` depends directly on `Azure.Storage.Blobs.BlobServiceClient` and performs network calls to Azure Blob Storage. Per `docs/architecture/filesystem.md`:
+
+> **I/O placement rule**: Concrete `IPrintQueueSink` implementations and any I/O-bound service live in adapter projects under `backend/src/Adapters/`, not in `Features/{Feature}/Services/`.
+
+The consequence of the current placement is that `Anela.Heblo.Application.csproj` references `Azure.Storage.Blobs` (line 12) and `FileStorageModule` reaches into the Azure SDK to register `BlobServiceClient`. The Application (inner) ring should depend only on abstractions; infrastructure libraries belong in the outer adapter ring. The codebase already has a working precedent: `AzureBlobPrintQueueSink` — a functionally equivalent Azure-SDK-backed I/O service — sits correctly in `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/ExpeditionList/` with its DI wired via `AzureAdapterModule.AddAzurePrintQueueSink`. `AzureBlobStorageService` is the same shape of object and should follow the same pattern.
+
+The domain abstraction `IBlobStorageService` and its DTO `BlobItemInfo` already live in `Anela.Heblo.Domain/Features/FileStorage/` and carry no Azure dependency. All eight `IBlobStorageService` consumers (the `ExpeditionListArchive` handlers and `DownloadFromUrlHandler`) depend only on that interface, so they are unaffected by moving the concrete implementation.
+
+## Functional Requirements
+
+### FR-1: Move the concrete service into the Azure adapter project
+Relocate `AzureBlobStorageService` from the Application layer to the Azure adapter, alongside the existing `AzureBlobPrintQueueSink`, without changing its runtime behavior.
+
+**Acceptance criteria:**
+- The file exists at `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` and no longer exists under `Anela.Heblo.Application/Features/FileStorage/Services/`.
+- Its namespace is updated to sit under `Anela.Heblo.Adapters.Azure.Features.FileStorage` (consistent with `Anela.Heblo.Adapters.Azure.Features.ExpeditionList` used by the print queue sink).
+- The class still implements `Anela.Heblo.Domain.Features.FileStorage.IBlobStorageService` and every public method retains identical logic and signatures (`DownloadFromUrlAsync`, `UploadAsync`, `DeleteAsync`, `GetBlobUrl`, `ExistsAsync`, `ListBlobsAsync`, `DownloadAsync`, `ListVirtualDirectoriesAsync`).
+- The private `BlobDownloadStream` helper, the `_containerExists` cache, and the content-type helper methods move with the class unchanged.
+- The reference to the named HTTP client constant (currently `FileStorageModule.FileDownloadClientName`) still resolves. It may remain a reference to the Application-layer constant (the adapter already references `Anela.Heblo.Application`) — no duplication of the string literal.
+
+### FR-2: Move Azure-specific DI registration out of FileStorageModule
+The `BlobServiceClient` factory registration and the `IBlobStorageService` → `AzureBlobStorageService` binding must move from `FileStorageModule` (Application layer) into a new extension method on `AzureAdapterModule` (adapter layer).
+
+**Acceptance criteria:**
+- A new extension method (e.g. `AddAzureBlobStorageService`) is added to `AzureAdapterModule` that:
+  - Registers `BlobServiceClient` as a `Singleton` using the existing factory logic, including the Development-only `UseDevelopmentStorage=true` fallback with its warning log and the reliance on the already-validated `FileStorageOptions`.
+  - Binds `services.AddSingleton<IBlobStorageService, AzureBlobStorageService>()`.
+- `FileStorageModule` no longer references `BlobServiceClient`, no longer contains `using Azure.Storage.Blobs;`, and no longer binds `IBlobStorageService`.
+- `FileStorageModule` retains all non-Azure registrations: the `FileStorageOptions` options binding and its non-Development `.Validate(...).ValidateOnStart()`, the named `FileDownload` `HttpClient` with its `SocketsHttpHandler`/timeout configuration, `IDownloadResilienceService` → `DownloadResilienceService`, and the `FileDownloadOptions` configuration binding.
+- The `FileStorageOptions` type (and its `BlobConnectionString`) remains in the Application layer; the adapter reads it via `IOptions<FileStorageOptions>` (the adapter already references Application).
+
+### FR-3: Wire the new registration into application startup
+The new adapter extension must be invoked during startup so `IBlobStorageService` resolves exactly as before.
+
+**Acceptance criteria:**
+- The new `AddAzureBlobStorageService` extension is called during service registration (in `AzureAdapterModule` composition from the API startup path — e.g. `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — or wherever `AddFileStorageModule` is composed, so the binding is always present in every environment that previously had it).
+- `IBlobStorageService` continues to resolve to `AzureBlobStorageService` at runtime with no double-registration and no missing-service regression.
+- The validation timing is preserved: `FileStorageOptions.ValidateOnStart()` still runs before any consumer resolves `BlobServiceClient` (i.e. the options validation registered by `FileStorageModule` is still in effect regardless of registration order).
+
+### FR-4: Remove the Azure SDK dependency from the Application project
+With FR-1 and FR-2 complete, the Application project no longer uses any Azure SDK type.
+
+**Acceptance criteria:**
+- The `<PackageReference Include="Azure.Storage.Blobs" ... />` line is removed from `Anela.Heblo.Application.csproj`.
+- A repository-wide search confirms no remaining `using Azure.Storage` / `BlobServiceClient` / `BlobContainerClient` references inside `Anela.Heblo.Application`.
+- `Anela.Heblo.Adapters.Azure.csproj` continues to reference `Azure.Storage.Blobs` (it already does, at version 12.25.0) — the dependency lives only in the outer ring.
+
+### FR-5: Update tests to the new location
+Existing tests that reference the concrete type or its module registration must compile and pass against the new structure.
+
+**Acceptance criteria:**
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs` compiles against the relocated type (namespace/using updated). The test project already references `Anela.Heblo.Adapters.Azure`, so no new project reference is required.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs` is updated so any assertions about `BlobServiceClient` / `IBlobStorageService` registration now target the new `AzureAdapterModule` extension rather than `FileStorageModule` (or are moved to a corresponding adapter-module test).
+- All touched tests pass; no behavioral test assertions about blob operations change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance change is intended. Singleton lifetimes are preserved for `BlobServiceClient`, `AzureBlobStorageService` (so the `_containerExists` cache survives across requests), and `IDownloadResilienceService`. HTTP client pooling (`PooledConnectionLifetime`, `AutomaticDecompression`) is unchanged.
+
+### NFR-2: Security
+No change to data sensitivity, authentication, or secret handling. The blob connection string continues to be sourced from configuration/Key Vault via `FileStorageOptions.BlobConnectionString`; the Development-only `UseDevelopmentStorage=true` fallback (with warning log) is preserved and remains unreachable in non-Development environments due to the fail-fast `ValidateOnStart()` guard.
+
+### NFR-3: Architecture compliance
+The change must satisfy the `filesystem.md` I/O placement rule and standard build/format validation: `dotnet build` succeeds, `dotnet format` reports clean, and the full backend test suite passes.
+
+## Data Model
+No data-model changes. Entities/DTOs involved (all unchanged and remaining in place):
+- `IBlobStorageService` (Domain) — the abstraction consumed by handlers.
+- `BlobItemInfo` (Domain) — `Name`, `FileName`, `CreatedOn`, `ContentLength`.
+- `FileStorageOptions` (Application) — includes `BlobConnectionString`, section name `FileStorage`.
+- `FileDownloadOptions` (Application) — bound from `FileStorage:Download`.
+
+## API / Interface Design
+No public HTTP API, contract, or UI change. The only interface-level changes are internal DI composition and C# namespaces:
+- New: `AzureAdapterModule.AddAzureBlobStorageService(IServiceCollection, IConfiguration)` (registers `BlobServiceClient` + binds `IBlobStorageService`).
+- Changed: `FileStorageModule.AddFileStorageModule(...)` loses its Azure registrations, keeps HTTP/options/resilience registrations.
+- Changed: namespace of `AzureBlobStorageService` moves to `Anela.Heblo.Adapters.Azure.Features.FileStorage`.
+- Unchanged: `FileStorageModule.FileDownloadClientName` remains the single source of the named-client string.
+
+## Dependencies
+- `Azure.Storage.Blobs` (12.25.0) — already referenced by `Anela.Heblo.Adapters.Azure`; being removed from `Anela.Heblo.Application`.
+- `Anela.Heblo.Adapters.Azure` already has a project reference to `Anela.Heblo.Application`, giving the moved service access to `FileStorageOptions` and `FileStorageModule.FileDownloadClientName`.
+- The API composition root (`Anela.Heblo.API`) already references the Azure adapter and calls `AddAzurePrintQueueSink`; it is the natural place to also invoke `AddAzureBlobStorageService`.
+
+## Out of Scope
+- Any change to blob operation behavior, error handling, logging messages, or method signatures.
+- Refactoring `AzureBlobPrintQueueSink` or the `IPrintQueueSink` print-sink selection logic (`AddPrintQueueSink`).
+- Consolidating or sharing a single `BlobServiceClient`/`BlobContainerClient` instance between the print queue sink and the blob storage service (they use different Azure SDK client types and different options; they remain independent).
+- The `AzureBlobConflictTelemetryFilter` — it only references `AzureBlobStorageService` in a doc comment, so no code change is required (an optional comment touch-up is not in scope).
+- Introducing any new configuration keys or Key Vault secrets.
+
+## Open Questions
+None. The following decisions were made as reasonable assumptions consistent with the existing precedent and the brief:
+- The `BlobServiceClient` registration is **not** shared with `AddAzurePrintQueueSink` (which registers a `BlobContainerClient` from `PrintPickingListOptions`); the blob storage service keeps its own `BlobServiceClient` built from `FileStorageOptions`, matching current behavior.
+- `AddAzureBlobStorageService` is invoked from the API composition root alongside the existing adapter wiring, ensuring the binding is present in all environments that had it before.
+- `FileStorageModule.FileDownloadClientName` remains the canonical constant; the moved service references it rather than duplicating the literal.
+
+## Status: COMPLETE

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-05T05:17:49.887939Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-05T05:17:50.142533Z"
+      "status": "completed",
+      "updated_at": "2026-07-05T05:21:31.113191Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-05T05:21:31.300146Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-05T06:44:51.079344Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-05T06:45:00.519134Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3484",
+  "issue_number": 3484,
+  "created_at": "2026-07-05T05:14:43.018476Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-05T05:17:39.041518Z"
+    },
+    "architecting": {
+      "status": "in_progress",
+      "updated_at": "2026-07-05T05:17:39.234144Z"
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-05T05:26:53.479512Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-05T05:27:14.858461Z"
+      "status": "completed",
+      "updated_at": "2026-07-05T06:44:51.079344Z"
     }
   },
   "tasks": [
@@ -34,9 +34,9 @@
     },
     {
       "name": "update-filestorage-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-05T05:35:36.114867Z"
+      "updated_at": "2026-07-05T06:44:45.360895Z"
     }
   ]
 }

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -6,11 +6,11 @@
   "phases": {
     "analyzing": {
       "status": "completed",
-      "updated_at": "2026-07-05T05:17:39.041518Z"
+      "updated_at": "2026-07-05T05:17:49.887939Z"
     },
     "architecting": {
       "status": "in_progress",
-      "updated_at": "2026-07-05T05:17:39.234144Z"
+      "updated_at": "2026-07-05T05:17:50.142533Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-05T05:21:31.113191Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-05T05:21:31.300146Z"
+      "status": "completed",
+      "updated_at": "2026-07-05T05:22:16.407694Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-05T05:22:16.668599Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -17,13 +17,26 @@
       "updated_at": "2026-07-05T05:22:16.407694Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-05T05:22:16.668599Z"
+      "status": "completed",
+      "updated_at": "2026-07-05T05:26:53.479512Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "relocate-service-and-rewire-di",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "update-filestorage-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-05T05:26:53.479512Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-05T05:27:14.858461Z"
     }
   },
   "tasks": [
     {
       "name": "relocate-service-and-rewire-di",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-05T05:27:15.045174Z"
     },
     {
       "name": "update-filestorage-tests",

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "relocate-service-and-rewire-di",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-05T05:27:15.045174Z"
+      "updated_at": "2026-07-05T05:35:32.006431Z"
     },
     {
       "name": "update-filestorage-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-05T05:35:36.114867Z"
     }
   ]
 }

--- a/artifacts/feat-3484/state.json
+++ b/artifacts/feat-3484/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-05T06:44:51.079344Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-05T06:45:00.519134Z"
+      "status": "completed",
+      "updated_at": "2026-07-05T06:48:49.447908Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3484/task-context/relocate-service-and-rewire-di.md
+++ b/artifacts/feat-3484/task-context/relocate-service-and-rewire-di.md
@@ -1,0 +1,339 @@
+### task: relocate-service-and-rewire-di
+
+**Goal**
+Move `AzureBlobStorageService` from the Application layer into `Anela.Heblo.Adapters.Azure`, add a
+new `AddAzureBlobStorageService` extension to `AzureAdapterModule` that owns the `BlobServiceClient`
+factory and the `IBlobStorageService` binding, remove those registrations (and the Azure `using`)
+from `FileStorageModule`, remove the `Azure.Storage.Blobs` package reference from the Application
+project, and wire the new extension into `Program.cs`. Behavior is byte-for-byte identical.
+
+**Files to create/modify**
+- Move (git mv to preserve history):
+  - FROM `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs`
+  - TO   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`
+- Modify `backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs`
+- Modify `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`
+- Modify `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+- Modify `backend/src/Anela.Heblo.API/Program.cs`
+
+**Implementation steps**
+
+1. **Move the service file with git so history is preserved.** From the repo root:
+   ```bash
+   git mv \
+     backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs \
+     backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+   ```
+   The `Services/` folder in the Application FileStorage feature may become empty after this — leave
+   it; do not delete other files. (There are no other files in it; git will simply stop tracking the
+   moved file at the old path.)
+
+2. **Update the namespace and usings of the moved file.** In the new file
+   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`,
+   replace the top-of-file `using` block and namespace (currently lines 1–7) with the following. The
+   only changes are: (a) the namespace, and (b) a new
+   `using Anela.Heblo.Application.Features.FileStorage;` so the reference to
+   `FileStorageModule.FileDownloadClientName` on line 38 still resolves. Do **not** touch any method
+   body, the `BlobDownloadStream` helper, the `_containerExists` cache, or the content-type helpers.
+
+   Change:
+   ```csharp
+   using System.Collections.Concurrent;
+   using Azure.Storage.Blobs;
+   using Azure.Storage.Blobs.Models;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Microsoft.Extensions.Logging;
+
+   namespace Anela.Heblo.Application.Features.FileStorage.Services;
+   ```
+   to:
+   ```csharp
+   using System.Collections.Concurrent;
+   using Azure.Storage.Blobs;
+   using Azure.Storage.Blobs.Models;
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Microsoft.Extensions.Logging;
+
+   namespace Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   ```
+   Note: the reference to the named HTTP client on line 38 stays exactly as
+   `_httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName)` — do NOT duplicate the
+   `"FileDownload"` string literal.
+
+3. **Add the `AddAzureBlobStorageService` extension to `AzureAdapterModule`.** Edit
+   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs`. Add the required `using`
+   directives and a second public static extension method. The `BlobServiceClient` factory body is
+   moved verbatim from `FileStorageModule` (old lines 42–57), including the exact warning message
+   string. The extension takes `IHostEnvironment` (not `IConfiguration`) because the options binding
+   and validation stay in `FileStorageModule`; the factory only needs `environment.EnvironmentName`
+   for the fallback warning.
+
+   Replace the whole file contents with:
+   ```csharp
+   // backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs
+   using Anela.Heblo.Adapters.Azure.Features.ExpeditionList;
+   using Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   using Anela.Heblo.Application.Features.ExpeditionList;
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Application.Shared.Printing;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Azure.Storage.Blobs;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Options;
+
+   namespace Anela.Heblo.Adapters.Azure;
+
+   public static class AzureAdapterModule
+   {
+       public static IServiceCollection AddAzurePrintQueueSink(
+           this IServiceCollection services,
+           IConfiguration configuration)
+       {
+           services.AddSingleton(provider =>
+           {
+               var options = provider.GetRequiredService<IOptions<PrintPickingListOptions>>().Value;
+               return new BlobContainerClient(options.BlobConnectionString, options.BlobContainerName);
+           });
+
+           services.AddSingleton<IPrintQueueSink, AzureBlobPrintQueueSink>();
+
+           return services;
+       }
+
+       public static IServiceCollection AddAzureBlobStorageService(
+           this IServiceCollection services,
+           IHostEnvironment environment)
+       {
+           // Register Azure Blob Storage client. The factory reads the already-validated options,
+           // so ValidateOnStart() (registered by FileStorageModule) runs before any consumer
+           // resolves the BlobServiceClient.
+           services.AddSingleton<BlobServiceClient>(provider =>
+           {
+               var opts = provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+               if (string.IsNullOrWhiteSpace(opts.BlobConnectionString))
+               {
+                   // Reachable only in Development — validation blocks the empty path elsewhere.
+                   // Log a warning so the storage-emulator fallback is never silent.
+                   var logger = provider.GetRequiredService<ILogger<AzureBlobStorageService>>();
+                   logger.LogWarning(
+                       "FileStorage:BlobConnectionString is empty in {Environment}; falling back to UseDevelopmentStorage=true.",
+                       environment.EnvironmentName);
+                   return new BlobServiceClient("UseDevelopmentStorage=true");
+               }
+
+               return new BlobServiceClient(opts.BlobConnectionString);
+           });
+
+           // Register blob storage service as Singleton so the _containerExists cache survives across requests.
+           // BlobServiceClient is already Singleton — no thread-safety concerns.
+           services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
+
+           return services;
+       }
+   }
+   ```
+   (`Microsoft.Extensions.Hosting.Abstractions` and `Microsoft.Extensions.Logging.Abstractions` are
+   available transitively — the Application project references both, the adapter references
+   Application, and the sibling `AzureBlobPrintQueueSink` already uses `Microsoft.Extensions.Logging`.
+   No new package reference is needed in `Anela.Heblo.Adapters.Azure.csproj`.)
+
+4. **Strip the Azure registrations and Azure `using`s from `FileStorageModule`.** Edit
+   `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`.
+
+   4a. Remove these two `using` lines (old lines 3 and 5):
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage.Services;
+   ...
+   using Azure.Storage.Blobs;
+   ```
+
+   4b. Remove the entire `BlobServiceClient` factory block (old lines 40–57), i.e. delete:
+   ```csharp
+           // Register Azure Blob Storage client. The factory reads the already-validated options,
+           // so ValidateOnStart() runs before any consumer resolves the BlobServiceClient.
+           services.AddSingleton<BlobServiceClient>(provider =>
+           {
+               var opts = provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+               if (string.IsNullOrWhiteSpace(opts.BlobConnectionString))
+               {
+                   // Reachable only in Development — validation blocks the empty path elsewhere.
+                   // Log a warning so the storage-emulator fallback is never silent.
+                   var logger = provider.GetRequiredService<ILogger<AzureBlobStorageService>>();
+                   logger.LogWarning(
+                       "FileStorage:BlobConnectionString is empty in {Environment}; falling back to UseDevelopmentStorage=true.",
+                       environment.EnvironmentName);
+                   return new BlobServiceClient("UseDevelopmentStorage=true");
+               }
+
+               return new BlobServiceClient(opts.BlobConnectionString);
+           });
+
+   ```
+
+   4c. Remove the `IBlobStorageService` binding and its two-line comment (old lines 82–84), i.e. delete:
+   ```csharp
+           // Register blob storage service as Singleton so the _containerExists cache survives across requests.
+           // BlobServiceClient is already Singleton — no thread-safety concerns.
+           services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
+
+   ```
+
+   After these edits the file must look exactly like this (verify against this target):
+   ```csharp
+   using System.Net;
+   using Anela.Heblo.Application.Features.FileStorage.Infrastructure;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Options;
+
+   namespace Anela.Heblo.Application.Features.FileStorage;
+
+   public static class FileStorageModule
+   {
+       public const string FileDownloadClientName = "FileDownload";
+
+       public static IServiceCollection AddFileStorageModule(
+           this IServiceCollection services,
+           IConfiguration configuration,
+           IHostEnvironment environment)
+       {
+           // MediatR handlers are automatically registered by AddMediatR scan
+
+           var optionsBuilder = services
+               .AddOptions<FileStorageOptions>()
+               .Bind(configuration.GetSection(FileStorageOptions.SectionName));
+
+           if (!environment.IsDevelopment())
+           {
+               // Fail fast in non-Development environments: missing or whitespace connection string
+               // surfaces at startup, never silently as a write to the storage emulator in production.
+               optionsBuilder
+                   .Validate(
+                       o => !string.IsNullOrWhiteSpace(o.BlobConnectionString),
+                       $"{FileStorageOptions.SectionName}:{nameof(FileStorageOptions.BlobConnectionString)} must be configured.")
+                   .ValidateOnStart();
+           }
+
+           // Register named HttpClient for product export downloads.
+           // PooledConnectionLifetime recycles sockets and refreshes DNS every 5 minutes,
+           // preventing the stale-socket and DNS-pinning problems of a long-lived singleton HttpClient.
+           // AutomaticDecompression handles gzip/brotli responses from the export URL transparently.
+           services.AddHttpClient(FileDownloadClientName)
+               .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+               {
+                   PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+                   AutomaticDecompression = DecompressionMethods.All,
+               })
+               .ConfigureHttpClient(c =>
+               {
+                   // Intentional: per-call timeout is enforced by linked CancellationTokenSource
+                   // inside DownloadResilienceService and around the HEAD probe in
+                   // DownloadFromUrlHandler. HttpClient.Timeout is left infinite so it does
+                   // not race with the linked CTS.
+                   c.Timeout = Timeout.InfiniteTimeSpan;
+               });
+
+           // Register resilience service as Singleton — it holds no request state and
+           // its internal Polly pipeline is rebuilt per-call (see BuildPipeline).
+           services.AddSingleton<IDownloadResilienceService, DownloadResilienceService>();
+
+           services.Configure<FileDownloadOptions>(configuration.GetSection("FileStorage:Download"));
+
+           return services;
+       }
+   }
+   ```
+   Note: `using Microsoft.Extensions.Options;` STAYS — it is still used by `.AddOptions<>()` /
+   `.Bind()` / `.Validate()` / `.ValidateOnStart()`. `using Microsoft.Extensions.Logging;` STAYS —
+   removing it is not required and other lines/analyzers may reference it; leave it as-is to keep the
+   diff surgical. (If `dotnet format` flags it as unused, remove it then — see acceptance.)
+
+5. **Remove the `Azure.Storage.Blobs` package reference from the Application project.** Edit
+   `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` and delete line 12:
+   ```xml
+       <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
+   ```
+   Leave every other `PackageReference` untouched.
+
+6. **Wire the new extension into the API composition root.** Edit
+   `backend/src/Anela.Heblo.API/Program.cs`. The `using Anela.Heblo.Adapters.Azure;` already exists
+   (line 5). Immediately after the existing `AddApplicationServices` call (line 103), add the
+   unconditional registration. Change:
+   ```csharp
+           builder.Services.AddApplicationServices(builder.Configuration, builder.Environment); // Vertical slice modules from Application layer
+           builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+   ```
+   to:
+   ```csharp
+           builder.Services.AddApplicationServices(builder.Configuration, builder.Environment); // Vertical slice modules from Application layer
+           builder.Services.AddAzureBlobStorageService(builder.Environment); // Azure adapter: BlobServiceClient + IBlobStorageService binding (moved out of Application ring)
+           builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+   ```
+   Do NOT place this call inside `AddPrintQueueSink`'s switch (that would make the binding
+   conditional on `ExpeditionList:PrintSink`, regressing `FileSystem`/`Cups` environments) and do NOT
+   place it in `ApplicationModule` (the Application ring cannot reference the adapter — it would
+   create a reference cycle).
+
+7. **Confirm no stray Application-layer references to the Azure SDK remain.** From `backend/`:
+   ```bash
+   grep -rn "Azure.Storage\|BlobServiceClient\|BlobContainerClient" src/Anela.Heblo.Application
+   ```
+   Expected output: no matches (empty). If anything is printed, it must be resolved before the task
+   is complete.
+
+**Tests to write/update**
+None in this task. Test-file updates are Task 2 (`update-filestorage-tests`). The test project will
+not compile until Task 2 is done — that is expected. Build only the production projects here (see
+acceptance).
+
+**Acceptance criteria**
+1. The moved file exists at
+   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`
+   with namespace `Anela.Heblo.Adapters.Azure.Features.FileStorage`, and no file exists at
+   `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs`.
+2. The production projects build. From `backend/`:
+   ```bash
+   dotnet build src/Anela.Heblo.API/Anela.Heblo.API.csproj
+   ```
+   Expected: `Build succeeded.` with `0 Error(s)`. (This transitively builds
+   `Anela.Heblo.Application` and `Anela.Heblo.Adapters.Azure`, proving the package removal is safe and
+   the move compiles. Do NOT run a full-solution build here — the test project intentionally does not
+   compile until Task 2.)
+3. The Application project no longer uses any Azure SDK type. From `backend/`:
+   ```bash
+   grep -rn "Azure.Storage\|BlobServiceClient\|BlobContainerClient" src/Anela.Heblo.Application
+   ```
+   Expected: empty output.
+4. `Anela.Heblo.Application.csproj` no longer contains `Azure.Storage.Blobs`; verify:
+   ```bash
+   grep -n "Azure.Storage.Blobs" backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+   ```
+   Expected: empty output. And `Anela.Heblo.Adapters.Azure.csproj` still contains it:
+   ```bash
+   grep -n "Azure.Storage.Blobs" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Anela.Heblo.Adapters.Azure.csproj
+   ```
+   Expected: one match (`Version="12.25.0"`).
+5. `Program.cs` contains exactly one `AddAzureBlobStorageService(builder.Environment)` call,
+   immediately after `AddApplicationServices`.
+6. Formatting is clean. From `backend/`:
+   ```bash
+   dotnet format --verify-no-changes
+   ```
+   Expected: no changes reported. (If it reports an unused `using Microsoft.Extensions.Logging;` in
+   `FileStorageModule.cs`, remove that line and re-run.)
+
+**Commit**
+```bash
+git add -A
+git commit -m "Relocate AzureBlobStorageService and its DI to the Azure adapter"
+```
+
+---
+

--- a/artifacts/feat-3484/task-context/update-filestorage-tests.md
+++ b/artifacts/feat-3484/task-context/update-filestorage-tests.md
@@ -1,0 +1,399 @@
+### task: update-filestorage-tests
+
+**Goal**
+Update the two affected test files so the test project compiles against the relocated type and the
+new adapter DI extension, and all touched tests pass. `AzureBlobStorageServiceTests` only needs a
+`using`/namespace update. Three registration tests currently in `FileStorageModuleTests` assert the
+moved registrations and must be relocated into a new `AzureAdapterModuleTests` that calls both
+`AddFileStorageModule` (for the options binding + validation) and `AddAzureBlobStorageService` (for
+the `BlobServiceClient` + `IBlobStorageService` binding).
+
+This task depends on `relocate-service-and-rewire-di` being complete.
+
+**Files to create/modify**
+- Modify `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`
+- Modify `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs`
+- Create `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureAdapterModuleTests.cs`
+
+(No project reference change is needed — `Anela.Heblo.Tests.csproj` already references
+`Anela.Heblo.Adapters.Azure`.)
+
+**Implementation steps**
+
+1. **Fix the `using`s in `AzureBlobStorageServiceTests.cs`.** Edit
+   `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`. Only the
+   type's namespace changed; the test constructs `AzureBlobStorageService` directly (no DI) and still
+   references `FileStorageModule.FileDownloadClientName`. Change the first two `using` lines:
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage.Services;
+   ```
+   to:
+   ```csharp
+   using Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage;
+   ```
+   (`using Anela.Heblo.Application.Features.FileStorage;` is retained because the test references
+   `FileStorageModule.FileDownloadClientName`; the `...Services` namespace no longer exists.) Make no
+   other changes to this file.
+
+2. **Remove the three relocated registration tests from `FileStorageModuleTests.cs`.** Edit
+   `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs`.
+
+   2a. Delete these three test methods entirely (they assert registrations that now live in the
+   adapter):
+   - `AddFileStorageModule_RegistersBlobStorageService_AsSingleton` (old lines 47–59)
+   - `AddFileStorageModule_ResolvingBlobStorageServiceTwice_ReturnsSameInstance` (old lines 61–75)
+   - `AddFileStorageModule_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning`
+     (old lines 157–193)
+
+   2b. Remove the now-unused `using` directives from the top of the file. After deleting the three
+   methods, `FileStorageModuleTests` no longer references `IBlobStorageService`, `BlobServiceClient`,
+   `AzureBlobStorageService`, or `NullLogger`/`Mock<ILogger<...>>`-of-blob-service. Delete these
+   `using` lines:
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage.Services;
+   using Azure.Storage.Blobs;
+   ```
+   Keep everything else. The remaining tests (`RegistersNamedHttpClient_FileDownload`,
+   `DoesNotRegisterTransientHttpClient`, `RegistersDownloadResilienceService_AsSingleton`,
+   `NamedClient_ConstantIsExported`, `NonDevelopmentEnvironmentWithMissingKey_FailsValidation`) all
+   reference only non-Azure registrations that still live in `FileStorageModule` and must remain
+   unchanged. `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Logging.Abstractions`
+   (NullLogger), and `Moq` `using`s STAY — `BuildBaseServices()` still registers
+   `NullLogger<>` and `Mock.Of<ITelemetryService>()`, and other retained tests use them.
+
+   After 2a/2b the file must be exactly:
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage.Infrastructure;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Anela.Heblo.Xcc.Telemetry;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Logging.Abstractions;
+   using Microsoft.Extensions.Options;
+   using Moq;
+   using Xunit;
+
+   namespace Anela.Heblo.Tests.Features.FileStorage;
+
+   public class FileStorageModuleTests
+   {
+       private static IServiceCollection BuildBaseServices()
+       {
+           var services = new ServiceCollection();
+           services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+           services.AddSingleton(Mock.Of<ITelemetryService>());
+           services.Configure<FileDownloadOptions>(opts =>
+           {
+               opts.MaxRetryAttempts = 3;
+               opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+               opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+           });
+           return services;
+       }
+
+       private static IConfiguration BuildConfiguration(string? blobConnectionString = "UseDevelopmentStorage=true")
+       {
+           var dict = new Dictionary<string, string?>();
+           if (blobConnectionString is not null)
+           {
+               dict["FileStorage:BlobConnectionString"] = blobConnectionString;
+           }
+           return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+       }
+
+       private static IHostEnvironment BuildEnvironment(string environmentName) =>
+           Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName);
+
+       [Fact]
+       public void AddFileStorageModule_RegistersNamedHttpClient_FileDownload()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+           services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
+           var provider = services.BuildServiceProvider();
+
+           // Act
+           var factory = provider.GetRequiredService<IHttpClientFactory>();
+           var client = factory.CreateClient(FileStorageModule.FileDownloadClientName);
+
+           // Assert — named client is registered and timeout is infinite (per-call CTS enforces timeout)
+           Assert.NotNull(client);
+           Assert.Equal(Timeout.InfiniteTimeSpan, client.Timeout);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_DoesNotRegisterTransientHttpClient()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+
+           // Act
+           services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
+
+           // Assert — the old services.AddTransient<HttpClient>() self-registers HttpClient with
+           // ImplementationType == typeof(HttpClient). AddHttpClient(...) registers a transient with
+           // an ImplementationFactory instead, which is the correct IHttpClientFactory pattern.
+           // We check for the explicit self-registration to confirm the bug is gone.
+           var hasBareTransientHttpClient = services.Any(d =>
+               d.ServiceType == typeof(HttpClient) &&
+               d.Lifetime == ServiceLifetime.Transient &&
+               d.ImplementationType == typeof(HttpClient));
+
+           Assert.False(hasBareTransientHttpClient);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_RegistersDownloadResilienceService_AsSingleton()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+
+           // Act
+           services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
+
+           // Assert — IDownloadResilienceService must be Singleton with the correct implementation
+           var descriptor = services.Single(d => d.ServiceType == typeof(IDownloadResilienceService));
+           Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+           Assert.Equal(typeof(DownloadResilienceService), descriptor.ImplementationType);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_NamedClient_ConstantIsExported()
+       {
+           // Assert — the constant must be stable so all consumers reference the same string
+           Assert.Equal("FileDownload", FileStorageModule.FileDownloadClientName);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_NonDevelopmentEnvironmentWithMissingKey_FailsValidation()
+       {
+           // Arrange — Production environment with no FileStorage:BlobConnectionString seeded
+           var services = BuildBaseServices();
+           var configuration = BuildConfiguration(blobConnectionString: null);
+           services.AddFileStorageModule(configuration, BuildEnvironment(Environments.Production));
+           var provider = services.BuildServiceProvider();
+
+           // Act — resolving IOptions<FileStorageOptions>.Value triggers the same .Validate pipeline
+           // that ValidateOnStart() runs at host start. This is the unit-test analogue: we want to
+           // confirm the rule fires and the message names the missing key (per spec NFR-2: no value
+           // leakage; the key name is mentioned, not the offending value).
+           var act = () => provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+
+           // Assert
+           var ex = Assert.Throws<OptionsValidationException>(act);
+           Assert.Contains("FileStorage:BlobConnectionString", ex.Message);
+       }
+   }
+   ```
+
+3. **Create `AzureAdapterModuleTests.cs` with the three relocated tests.** Create
+   `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureAdapterModuleTests.cs`. These tests
+   assert the registrations now owned by `AddAzureBlobStorageService`. Because the options binding +
+   validation stay in `FileStorageModule`, each test calls BOTH `AddFileStorageModule(config, env)`
+   AND `AddAzureBlobStorageService(env)` — this coupling is intentional and documented in the class
+   comment. The three tests are the exact analogues of the ones removed from `FileStorageModuleTests`
+   (Singleton lifetime, same-instance resolve, and the Development missing-key fallback warning),
+   updated to resolve against the adapter registration.
+
+   ```csharp
+   using Anela.Heblo.Adapters.Azure;
+   using Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Anela.Heblo.Xcc.Telemetry;
+   using Azure.Storage.Blobs;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Logging.Abstractions;
+   using Moq;
+   using Xunit;
+
+   namespace Anela.Heblo.Tests.Features.FileStorage;
+
+   /// <summary>
+   /// Tests for AzureAdapterModule.AddAzureBlobStorageService — the BlobServiceClient factory and
+   /// the IBlobStorageService binding relocated from FileStorageModule to the Azure adapter ring.
+   ///
+   /// Each test calls BOTH AddFileStorageModule (which binds and validates FileStorageOptions) and
+   /// AddAzureBlobStorageService (which registers BlobServiceClient + IBlobStorageService). The
+   /// options binding intentionally stays in FileStorageModule, so the adapter registration depends
+   /// on it being present.
+   /// </summary>
+   public class AzureAdapterModuleTests
+   {
+       private static IServiceCollection BuildBaseServices()
+       {
+           var services = new ServiceCollection();
+           services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+           services.AddSingleton(Mock.Of<ITelemetryService>());
+           services.Configure<FileDownloadOptions>(opts =>
+           {
+               opts.MaxRetryAttempts = 3;
+               opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+               opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+           });
+           return services;
+       }
+
+       private static IConfiguration BuildConfiguration(string? blobConnectionString = "UseDevelopmentStorage=true")
+       {
+           var dict = new Dictionary<string, string?>();
+           if (blobConnectionString is not null)
+           {
+               dict["FileStorage:BlobConnectionString"] = blobConnectionString;
+           }
+           return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+       }
+
+       private static IHostEnvironment BuildEnvironment(string environmentName) =>
+           Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName);
+
+       [Fact]
+       public void AddAzureBlobStorageService_RegistersBlobStorageService_AsSingleton()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+           var environment = BuildEnvironment(Environments.Development);
+
+           // Act
+           services.AddFileStorageModule(BuildConfiguration(), environment);
+           services.AddAzureBlobStorageService(environment);
+
+           // Assert — IBlobStorageService must be Singleton so _containerExists cache survives requests
+           var descriptor = services.Single(s => s.ServiceType == typeof(IBlobStorageService));
+           Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+       }
+
+       [Fact]
+       public void AddAzureBlobStorageService_ResolvingBlobStorageServiceTwice_ReturnsSameInstance()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+           var environment = BuildEnvironment(Environments.Development);
+           services.AddFileStorageModule(BuildConfiguration(), environment);
+           services.AddAzureBlobStorageService(environment);
+           var provider = services.BuildServiceProvider();
+
+           // Act
+           var first = provider.GetRequiredService<IBlobStorageService>();
+           var second = provider.GetRequiredService<IBlobStorageService>();
+
+           // Assert — same instance proves Singleton registration is working
+           Assert.Same(first, second);
+       }
+
+       [Fact]
+       public void AddAzureBlobStorageService_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning()
+       {
+           // Arrange — Development environment, no FileStorage:BlobConnectionString
+           var services = new ServiceCollection();
+           services.AddSingleton(Mock.Of<ITelemetryService>());
+           services.Configure<FileDownloadOptions>(opts =>
+           {
+               opts.MaxRetryAttempts = 3;
+               opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+               opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+           });
+
+           var warningLogger = new Mock<ILogger<AzureBlobStorageService>>();
+           services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+           // Override the AzureBlobStorageService logger so we can verify the warning was emitted.
+           services.AddSingleton(warningLogger.Object);
+
+           var environment = BuildEnvironment(Environments.Development);
+           var configuration = BuildConfiguration(blobConnectionString: null);
+           services.AddFileStorageModule(configuration, environment);
+           services.AddAzureBlobStorageService(environment);
+           var provider = services.BuildServiceProvider();
+
+           // Act — resolving the BlobServiceClient runs the factory, which emits the warning
+           // and returns a client pointed at UseDevelopmentStorage=true.
+           var client = provider.GetRequiredService<BlobServiceClient>();
+
+           // Assert — client is constructed (no throw) and the warning was logged once.
+           Assert.NotNull(client);
+           warningLogger.Verify(
+               l => l.Log(
+                   LogLevel.Warning,
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("FileStorage:BlobConnectionString")),
+                   It.IsAny<Exception?>(),
+                   It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+               Times.Once);
+       }
+   }
+   ```
+
+**Tests to write/update**
+Covered by steps 1–3 above:
+- `AzureBlobStorageServiceTests.cs` — `using`/namespace update only.
+- `FileStorageModuleTests.cs` — three registration tests removed; unused `using`s removed.
+- `AzureAdapterModuleTests.cs` — new file with the three relocated registration tests.
+
+**Acceptance criteria**
+1. The full solution builds. From `backend/`:
+   ```bash
+   dotnet build
+   ```
+   Expected: `Build succeeded.` with `0 Error(s)` (the test project now compiles).
+2. All FileStorage tests pass. From `backend/`:
+   ```bash
+   dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.FileStorage"
+   ```
+   Expected: all tests pass, `Failed: 0`. This must include:
+   - the unchanged `AzureBlobStorageServiceTests` cases,
+   - the retained `FileStorageModuleTests` cases
+     (`RegistersNamedHttpClient_FileDownload`, `DoesNotRegisterTransientHttpClient`,
+     `RegistersDownloadResilienceService_AsSingleton`, `NamedClient_ConstantIsExported`,
+     `NonDevelopmentEnvironmentWithMissingKey_FailsValidation`),
+   - the three new `AzureAdapterModuleTests` cases
+     (`RegistersBlobStorageService_AsSingleton`, `ResolvingBlobStorageServiceTwice_ReturnsSameInstance`,
+     `DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning`).
+3. Formatting is clean. From `backend/`:
+   ```bash
+   dotnet format --verify-no-changes
+   ```
+   Expected: no changes reported.
+
+**Commit**
+```bash
+git add -A
+git commit -m "Update FileStorage tests for relocated AzureBlobStorageService"
+```
+
+---
+
+## Plan self-review
+
+- **Spec requirement coverage:**
+  - FR-1 (move class, new namespace, identical logic, `FileDownloadClientName` reference intact) →
+    Task 1 steps 1–2, acceptance 1.
+  - FR-2 (move `BlobServiceClient` factory + `IBlobStorageService` bind to `AddAzureBlobStorageService`;
+    `FileStorageModule` keeps options/HTTP/resilience) → Task 1 steps 3–4, acceptance 2–3.
+  - FR-3 (wire into startup, unconditional, correct validation timing) → Task 1 step 6, acceptance 5;
+    validation timing preserved because `FileStorageModule` still owns the binding + `ValidateOnStart`.
+  - FR-4 (remove `Azure.Storage.Blobs` from Application; repo-wide grep clean) → Task 1 step 5 & 7,
+    acceptance 3–4.
+  - FR-5 (both test files compile/pass; assertions relocated to adapter test) → Task 2 (all steps),
+    acceptance 1–2.
+  - NFR-1/NFR-2 (Singleton lifetimes, dev-fallback warning verbatim) → factory moved verbatim
+    (Task 1 step 3); warning-message assertion preserved (Task 2 step 3).
+  - NFR-3 (build + format + full test suite) → Task 1 acceptance 2 & 6; Task 2 acceptance 1–3.
+- **Design amendments honored:** extension takes `IHostEnvironment` (not `IConfiguration`); wired
+  from `Program.cs` (not `ApplicationModule`, not inside `AddPrintQueueSink`); three specific tests
+  relocated to a new adapter-module test calling both modules.
+- **Out-of-scope respected:** `AzureBlobConflictTelemetryFilter` (doc-comment-only reference) is not
+  touched; no shared `BlobServiceClient`/`BlobContainerClient`; no config keys added.
+- **Placeholder scan:** no "TBD"/"similar to"/"add error handling" placeholders; all code blocks are
+  concrete and copy-ready.
+- **Type/name consistency:** `AddAzureBlobStorageService(IServiceCollection, IHostEnvironment)`,
+  namespace `Anela.Heblo.Adapters.Azure.Features.FileStorage`, and
+  `FileStorageModule.FileDownloadClientName` are used identically across both tasks and match the
+  actual source read from the repo.

--- a/artifacts/feat-3484/task-plan.r1.md
+++ b/artifacts/feat-3484/task-plan.r1.md
@@ -1,0 +1,763 @@
+# Implementation Plan: Relocate AzureBlobStorageService to the Azure adapter layer
+
+This is a Clean Architecture compliance refactor. It moves one Azure-SDK-backed service class
+(`AzureBlobStorageService`) and its DI wiring out of the Application ring into the Azure adapter
+ring, removes the `Azure.Storage.Blobs` package reference from `Anela.Heblo.Application`, and
+updates two test files. Runtime behavior is unchanged.
+
+The repo root during implementation is the feature worktree
+(`/home/user/worktrees/feature-3484-Arch-Review-Filestorage-Azureblobstorageservice-Pl`). All
+paths below are relative to that root unless stated otherwise. All backend `dotnet` commands are
+run from the `backend/` directory.
+
+There are two tasks:
+
+1. `relocate-service-and-rewire-di` — all production-code changes (move the class, add the adapter
+   DI extension, strip Azure registrations from `FileStorageModule`, remove the package reference,
+   wire the new extension into `Program.cs`). Must be applied atomically; the src builds only when
+   all of these are done together.
+2. `update-filestorage-tests` — update the two affected test files so the test project compiles and
+   all touched tests pass.
+
+Task 2 depends on Task 1. The full solution (including the test project) compiles only after Task 2.
+
+---
+
+### task: relocate-service-and-rewire-di
+
+**Goal**
+Move `AzureBlobStorageService` from the Application layer into `Anela.Heblo.Adapters.Azure`, add a
+new `AddAzureBlobStorageService` extension to `AzureAdapterModule` that owns the `BlobServiceClient`
+factory and the `IBlobStorageService` binding, remove those registrations (and the Azure `using`)
+from `FileStorageModule`, remove the `Azure.Storage.Blobs` package reference from the Application
+project, and wire the new extension into `Program.cs`. Behavior is byte-for-byte identical.
+
+**Files to create/modify**
+- Move (git mv to preserve history):
+  - FROM `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs`
+  - TO   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`
+- Modify `backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs`
+- Modify `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`
+- Modify `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+- Modify `backend/src/Anela.Heblo.API/Program.cs`
+
+**Implementation steps**
+
+1. **Move the service file with git so history is preserved.** From the repo root:
+   ```bash
+   git mv \
+     backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs \
+     backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+   ```
+   The `Services/` folder in the Application FileStorage feature may become empty after this — leave
+   it; do not delete other files. (There are no other files in it; git will simply stop tracking the
+   moved file at the old path.)
+
+2. **Update the namespace and usings of the moved file.** In the new file
+   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`,
+   replace the top-of-file `using` block and namespace (currently lines 1–7) with the following. The
+   only changes are: (a) the namespace, and (b) a new
+   `using Anela.Heblo.Application.Features.FileStorage;` so the reference to
+   `FileStorageModule.FileDownloadClientName` on line 38 still resolves. Do **not** touch any method
+   body, the `BlobDownloadStream` helper, the `_containerExists` cache, or the content-type helpers.
+
+   Change:
+   ```csharp
+   using System.Collections.Concurrent;
+   using Azure.Storage.Blobs;
+   using Azure.Storage.Blobs.Models;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Microsoft.Extensions.Logging;
+
+   namespace Anela.Heblo.Application.Features.FileStorage.Services;
+   ```
+   to:
+   ```csharp
+   using System.Collections.Concurrent;
+   using Azure.Storage.Blobs;
+   using Azure.Storage.Blobs.Models;
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Microsoft.Extensions.Logging;
+
+   namespace Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   ```
+   Note: the reference to the named HTTP client on line 38 stays exactly as
+   `_httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName)` — do NOT duplicate the
+   `"FileDownload"` string literal.
+
+3. **Add the `AddAzureBlobStorageService` extension to `AzureAdapterModule`.** Edit
+   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs`. Add the required `using`
+   directives and a second public static extension method. The `BlobServiceClient` factory body is
+   moved verbatim from `FileStorageModule` (old lines 42–57), including the exact warning message
+   string. The extension takes `IHostEnvironment` (not `IConfiguration`) because the options binding
+   and validation stay in `FileStorageModule`; the factory only needs `environment.EnvironmentName`
+   for the fallback warning.
+
+   Replace the whole file contents with:
+   ```csharp
+   // backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs
+   using Anela.Heblo.Adapters.Azure.Features.ExpeditionList;
+   using Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   using Anela.Heblo.Application.Features.ExpeditionList;
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Application.Shared.Printing;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Azure.Storage.Blobs;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Options;
+
+   namespace Anela.Heblo.Adapters.Azure;
+
+   public static class AzureAdapterModule
+   {
+       public static IServiceCollection AddAzurePrintQueueSink(
+           this IServiceCollection services,
+           IConfiguration configuration)
+       {
+           services.AddSingleton(provider =>
+           {
+               var options = provider.GetRequiredService<IOptions<PrintPickingListOptions>>().Value;
+               return new BlobContainerClient(options.BlobConnectionString, options.BlobContainerName);
+           });
+
+           services.AddSingleton<IPrintQueueSink, AzureBlobPrintQueueSink>();
+
+           return services;
+       }
+
+       public static IServiceCollection AddAzureBlobStorageService(
+           this IServiceCollection services,
+           IHostEnvironment environment)
+       {
+           // Register Azure Blob Storage client. The factory reads the already-validated options,
+           // so ValidateOnStart() (registered by FileStorageModule) runs before any consumer
+           // resolves the BlobServiceClient.
+           services.AddSingleton<BlobServiceClient>(provider =>
+           {
+               var opts = provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+               if (string.IsNullOrWhiteSpace(opts.BlobConnectionString))
+               {
+                   // Reachable only in Development — validation blocks the empty path elsewhere.
+                   // Log a warning so the storage-emulator fallback is never silent.
+                   var logger = provider.GetRequiredService<ILogger<AzureBlobStorageService>>();
+                   logger.LogWarning(
+                       "FileStorage:BlobConnectionString is empty in {Environment}; falling back to UseDevelopmentStorage=true.",
+                       environment.EnvironmentName);
+                   return new BlobServiceClient("UseDevelopmentStorage=true");
+               }
+
+               return new BlobServiceClient(opts.BlobConnectionString);
+           });
+
+           // Register blob storage service as Singleton so the _containerExists cache survives across requests.
+           // BlobServiceClient is already Singleton — no thread-safety concerns.
+           services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
+
+           return services;
+       }
+   }
+   ```
+   (`Microsoft.Extensions.Hosting.Abstractions` and `Microsoft.Extensions.Logging.Abstractions` are
+   available transitively — the Application project references both, the adapter references
+   Application, and the sibling `AzureBlobPrintQueueSink` already uses `Microsoft.Extensions.Logging`.
+   No new package reference is needed in `Anela.Heblo.Adapters.Azure.csproj`.)
+
+4. **Strip the Azure registrations and Azure `using`s from `FileStorageModule`.** Edit
+   `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`.
+
+   4a. Remove these two `using` lines (old lines 3 and 5):
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage.Services;
+   ...
+   using Azure.Storage.Blobs;
+   ```
+
+   4b. Remove the entire `BlobServiceClient` factory block (old lines 40–57), i.e. delete:
+   ```csharp
+           // Register Azure Blob Storage client. The factory reads the already-validated options,
+           // so ValidateOnStart() runs before any consumer resolves the BlobServiceClient.
+           services.AddSingleton<BlobServiceClient>(provider =>
+           {
+               var opts = provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+               if (string.IsNullOrWhiteSpace(opts.BlobConnectionString))
+               {
+                   // Reachable only in Development — validation blocks the empty path elsewhere.
+                   // Log a warning so the storage-emulator fallback is never silent.
+                   var logger = provider.GetRequiredService<ILogger<AzureBlobStorageService>>();
+                   logger.LogWarning(
+                       "FileStorage:BlobConnectionString is empty in {Environment}; falling back to UseDevelopmentStorage=true.",
+                       environment.EnvironmentName);
+                   return new BlobServiceClient("UseDevelopmentStorage=true");
+               }
+
+               return new BlobServiceClient(opts.BlobConnectionString);
+           });
+
+   ```
+
+   4c. Remove the `IBlobStorageService` binding and its two-line comment (old lines 82–84), i.e. delete:
+   ```csharp
+           // Register blob storage service as Singleton so the _containerExists cache survives across requests.
+           // BlobServiceClient is already Singleton — no thread-safety concerns.
+           services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
+
+   ```
+
+   After these edits the file must look exactly like this (verify against this target):
+   ```csharp
+   using System.Net;
+   using Anela.Heblo.Application.Features.FileStorage.Infrastructure;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Options;
+
+   namespace Anela.Heblo.Application.Features.FileStorage;
+
+   public static class FileStorageModule
+   {
+       public const string FileDownloadClientName = "FileDownload";
+
+       public static IServiceCollection AddFileStorageModule(
+           this IServiceCollection services,
+           IConfiguration configuration,
+           IHostEnvironment environment)
+       {
+           // MediatR handlers are automatically registered by AddMediatR scan
+
+           var optionsBuilder = services
+               .AddOptions<FileStorageOptions>()
+               .Bind(configuration.GetSection(FileStorageOptions.SectionName));
+
+           if (!environment.IsDevelopment())
+           {
+               // Fail fast in non-Development environments: missing or whitespace connection string
+               // surfaces at startup, never silently as a write to the storage emulator in production.
+               optionsBuilder
+                   .Validate(
+                       o => !string.IsNullOrWhiteSpace(o.BlobConnectionString),
+                       $"{FileStorageOptions.SectionName}:{nameof(FileStorageOptions.BlobConnectionString)} must be configured.")
+                   .ValidateOnStart();
+           }
+
+           // Register named HttpClient for product export downloads.
+           // PooledConnectionLifetime recycles sockets and refreshes DNS every 5 minutes,
+           // preventing the stale-socket and DNS-pinning problems of a long-lived singleton HttpClient.
+           // AutomaticDecompression handles gzip/brotli responses from the export URL transparently.
+           services.AddHttpClient(FileDownloadClientName)
+               .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+               {
+                   PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+                   AutomaticDecompression = DecompressionMethods.All,
+               })
+               .ConfigureHttpClient(c =>
+               {
+                   // Intentional: per-call timeout is enforced by linked CancellationTokenSource
+                   // inside DownloadResilienceService and around the HEAD probe in
+                   // DownloadFromUrlHandler. HttpClient.Timeout is left infinite so it does
+                   // not race with the linked CTS.
+                   c.Timeout = Timeout.InfiniteTimeSpan;
+               });
+
+           // Register resilience service as Singleton — it holds no request state and
+           // its internal Polly pipeline is rebuilt per-call (see BuildPipeline).
+           services.AddSingleton<IDownloadResilienceService, DownloadResilienceService>();
+
+           services.Configure<FileDownloadOptions>(configuration.GetSection("FileStorage:Download"));
+
+           return services;
+       }
+   }
+   ```
+   Note: `using Microsoft.Extensions.Options;` STAYS — it is still used by `.AddOptions<>()` /
+   `.Bind()` / `.Validate()` / `.ValidateOnStart()`. `using Microsoft.Extensions.Logging;` STAYS —
+   removing it is not required and other lines/analyzers may reference it; leave it as-is to keep the
+   diff surgical. (If `dotnet format` flags it as unused, remove it then — see acceptance.)
+
+5. **Remove the `Azure.Storage.Blobs` package reference from the Application project.** Edit
+   `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` and delete line 12:
+   ```xml
+       <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
+   ```
+   Leave every other `PackageReference` untouched.
+
+6. **Wire the new extension into the API composition root.** Edit
+   `backend/src/Anela.Heblo.API/Program.cs`. The `using Anela.Heblo.Adapters.Azure;` already exists
+   (line 5). Immediately after the existing `AddApplicationServices` call (line 103), add the
+   unconditional registration. Change:
+   ```csharp
+           builder.Services.AddApplicationServices(builder.Configuration, builder.Environment); // Vertical slice modules from Application layer
+           builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+   ```
+   to:
+   ```csharp
+           builder.Services.AddApplicationServices(builder.Configuration, builder.Environment); // Vertical slice modules from Application layer
+           builder.Services.AddAzureBlobStorageService(builder.Environment); // Azure adapter: BlobServiceClient + IBlobStorageService binding (moved out of Application ring)
+           builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+   ```
+   Do NOT place this call inside `AddPrintQueueSink`'s switch (that would make the binding
+   conditional on `ExpeditionList:PrintSink`, regressing `FileSystem`/`Cups` environments) and do NOT
+   place it in `ApplicationModule` (the Application ring cannot reference the adapter — it would
+   create a reference cycle).
+
+7. **Confirm no stray Application-layer references to the Azure SDK remain.** From `backend/`:
+   ```bash
+   grep -rn "Azure.Storage\|BlobServiceClient\|BlobContainerClient" src/Anela.Heblo.Application
+   ```
+   Expected output: no matches (empty). If anything is printed, it must be resolved before the task
+   is complete.
+
+**Tests to write/update**
+None in this task. Test-file updates are Task 2 (`update-filestorage-tests`). The test project will
+not compile until Task 2 is done — that is expected. Build only the production projects here (see
+acceptance).
+
+**Acceptance criteria**
+1. The moved file exists at
+   `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`
+   with namespace `Anela.Heblo.Adapters.Azure.Features.FileStorage`, and no file exists at
+   `backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs`.
+2. The production projects build. From `backend/`:
+   ```bash
+   dotnet build src/Anela.Heblo.API/Anela.Heblo.API.csproj
+   ```
+   Expected: `Build succeeded.` with `0 Error(s)`. (This transitively builds
+   `Anela.Heblo.Application` and `Anela.Heblo.Adapters.Azure`, proving the package removal is safe and
+   the move compiles. Do NOT run a full-solution build here — the test project intentionally does not
+   compile until Task 2.)
+3. The Application project no longer uses any Azure SDK type. From `backend/`:
+   ```bash
+   grep -rn "Azure.Storage\|BlobServiceClient\|BlobContainerClient" src/Anela.Heblo.Application
+   ```
+   Expected: empty output.
+4. `Anela.Heblo.Application.csproj` no longer contains `Azure.Storage.Blobs`; verify:
+   ```bash
+   grep -n "Azure.Storage.Blobs" backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+   ```
+   Expected: empty output. And `Anela.Heblo.Adapters.Azure.csproj` still contains it:
+   ```bash
+   grep -n "Azure.Storage.Blobs" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Anela.Heblo.Adapters.Azure.csproj
+   ```
+   Expected: one match (`Version="12.25.0"`).
+5. `Program.cs` contains exactly one `AddAzureBlobStorageService(builder.Environment)` call,
+   immediately after `AddApplicationServices`.
+6. Formatting is clean. From `backend/`:
+   ```bash
+   dotnet format --verify-no-changes
+   ```
+   Expected: no changes reported. (If it reports an unused `using Microsoft.Extensions.Logging;` in
+   `FileStorageModule.cs`, remove that line and re-run.)
+
+**Commit**
+```bash
+git add -A
+git commit -m "Relocate AzureBlobStorageService and its DI to the Azure adapter"
+```
+
+---
+
+### task: update-filestorage-tests
+
+**Goal**
+Update the two affected test files so the test project compiles against the relocated type and the
+new adapter DI extension, and all touched tests pass. `AzureBlobStorageServiceTests` only needs a
+`using`/namespace update. Three registration tests currently in `FileStorageModuleTests` assert the
+moved registrations and must be relocated into a new `AzureAdapterModuleTests` that calls both
+`AddFileStorageModule` (for the options binding + validation) and `AddAzureBlobStorageService` (for
+the `BlobServiceClient` + `IBlobStorageService` binding).
+
+This task depends on `relocate-service-and-rewire-di` being complete.
+
+**Files to create/modify**
+- Modify `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`
+- Modify `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs`
+- Create `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureAdapterModuleTests.cs`
+
+(No project reference change is needed — `Anela.Heblo.Tests.csproj` already references
+`Anela.Heblo.Adapters.Azure`.)
+
+**Implementation steps**
+
+1. **Fix the `using`s in `AzureBlobStorageServiceTests.cs`.** Edit
+   `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`. Only the
+   type's namespace changed; the test constructs `AzureBlobStorageService` directly (no DI) and still
+   references `FileStorageModule.FileDownloadClientName`. Change the first two `using` lines:
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage.Services;
+   ```
+   to:
+   ```csharp
+   using Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage;
+   ```
+   (`using Anela.Heblo.Application.Features.FileStorage;` is retained because the test references
+   `FileStorageModule.FileDownloadClientName`; the `...Services` namespace no longer exists.) Make no
+   other changes to this file.
+
+2. **Remove the three relocated registration tests from `FileStorageModuleTests.cs`.** Edit
+   `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs`.
+
+   2a. Delete these three test methods entirely (they assert registrations that now live in the
+   adapter):
+   - `AddFileStorageModule_RegistersBlobStorageService_AsSingleton` (old lines 47–59)
+   - `AddFileStorageModule_ResolvingBlobStorageServiceTwice_ReturnsSameInstance` (old lines 61–75)
+   - `AddFileStorageModule_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning`
+     (old lines 157–193)
+
+   2b. Remove the now-unused `using` directives from the top of the file. After deleting the three
+   methods, `FileStorageModuleTests` no longer references `IBlobStorageService`, `BlobServiceClient`,
+   `AzureBlobStorageService`, or `NullLogger`/`Mock<ILogger<...>>`-of-blob-service. Delete these
+   `using` lines:
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage.Services;
+   using Azure.Storage.Blobs;
+   ```
+   Keep everything else. The remaining tests (`RegistersNamedHttpClient_FileDownload`,
+   `DoesNotRegisterTransientHttpClient`, `RegistersDownloadResilienceService_AsSingleton`,
+   `NamedClient_ConstantIsExported`, `NonDevelopmentEnvironmentWithMissingKey_FailsValidation`) all
+   reference only non-Azure registrations that still live in `FileStorageModule` and must remain
+   unchanged. `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Logging.Abstractions`
+   (NullLogger), and `Moq` `using`s STAY — `BuildBaseServices()` still registers
+   `NullLogger<>` and `Mock.Of<ITelemetryService>()`, and other retained tests use them.
+
+   After 2a/2b the file must be exactly:
+   ```csharp
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage.Infrastructure;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Anela.Heblo.Xcc.Telemetry;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Logging.Abstractions;
+   using Microsoft.Extensions.Options;
+   using Moq;
+   using Xunit;
+
+   namespace Anela.Heblo.Tests.Features.FileStorage;
+
+   public class FileStorageModuleTests
+   {
+       private static IServiceCollection BuildBaseServices()
+       {
+           var services = new ServiceCollection();
+           services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+           services.AddSingleton(Mock.Of<ITelemetryService>());
+           services.Configure<FileDownloadOptions>(opts =>
+           {
+               opts.MaxRetryAttempts = 3;
+               opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+               opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+           });
+           return services;
+       }
+
+       private static IConfiguration BuildConfiguration(string? blobConnectionString = "UseDevelopmentStorage=true")
+       {
+           var dict = new Dictionary<string, string?>();
+           if (blobConnectionString is not null)
+           {
+               dict["FileStorage:BlobConnectionString"] = blobConnectionString;
+           }
+           return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+       }
+
+       private static IHostEnvironment BuildEnvironment(string environmentName) =>
+           Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName);
+
+       [Fact]
+       public void AddFileStorageModule_RegistersNamedHttpClient_FileDownload()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+           services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
+           var provider = services.BuildServiceProvider();
+
+           // Act
+           var factory = provider.GetRequiredService<IHttpClientFactory>();
+           var client = factory.CreateClient(FileStorageModule.FileDownloadClientName);
+
+           // Assert — named client is registered and timeout is infinite (per-call CTS enforces timeout)
+           Assert.NotNull(client);
+           Assert.Equal(Timeout.InfiniteTimeSpan, client.Timeout);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_DoesNotRegisterTransientHttpClient()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+
+           // Act
+           services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
+
+           // Assert — the old services.AddTransient<HttpClient>() self-registers HttpClient with
+           // ImplementationType == typeof(HttpClient). AddHttpClient(...) registers a transient with
+           // an ImplementationFactory instead, which is the correct IHttpClientFactory pattern.
+           // We check for the explicit self-registration to confirm the bug is gone.
+           var hasBareTransientHttpClient = services.Any(d =>
+               d.ServiceType == typeof(HttpClient) &&
+               d.Lifetime == ServiceLifetime.Transient &&
+               d.ImplementationType == typeof(HttpClient));
+
+           Assert.False(hasBareTransientHttpClient);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_RegistersDownloadResilienceService_AsSingleton()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+
+           // Act
+           services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
+
+           // Assert — IDownloadResilienceService must be Singleton with the correct implementation
+           var descriptor = services.Single(d => d.ServiceType == typeof(IDownloadResilienceService));
+           Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+           Assert.Equal(typeof(DownloadResilienceService), descriptor.ImplementationType);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_NamedClient_ConstantIsExported()
+       {
+           // Assert — the constant must be stable so all consumers reference the same string
+           Assert.Equal("FileDownload", FileStorageModule.FileDownloadClientName);
+       }
+
+       [Fact]
+       public void AddFileStorageModule_NonDevelopmentEnvironmentWithMissingKey_FailsValidation()
+       {
+           // Arrange — Production environment with no FileStorage:BlobConnectionString seeded
+           var services = BuildBaseServices();
+           var configuration = BuildConfiguration(blobConnectionString: null);
+           services.AddFileStorageModule(configuration, BuildEnvironment(Environments.Production));
+           var provider = services.BuildServiceProvider();
+
+           // Act — resolving IOptions<FileStorageOptions>.Value triggers the same .Validate pipeline
+           // that ValidateOnStart() runs at host start. This is the unit-test analogue: we want to
+           // confirm the rule fires and the message names the missing key (per spec NFR-2: no value
+           // leakage; the key name is mentioned, not the offending value).
+           var act = () => provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+
+           // Assert
+           var ex = Assert.Throws<OptionsValidationException>(act);
+           Assert.Contains("FileStorage:BlobConnectionString", ex.Message);
+       }
+   }
+   ```
+
+3. **Create `AzureAdapterModuleTests.cs` with the three relocated tests.** Create
+   `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureAdapterModuleTests.cs`. These tests
+   assert the registrations now owned by `AddAzureBlobStorageService`. Because the options binding +
+   validation stay in `FileStorageModule`, each test calls BOTH `AddFileStorageModule(config, env)`
+   AND `AddAzureBlobStorageService(env)` — this coupling is intentional and documented in the class
+   comment. The three tests are the exact analogues of the ones removed from `FileStorageModuleTests`
+   (Singleton lifetime, same-instance resolve, and the Development missing-key fallback warning),
+   updated to resolve against the adapter registration.
+
+   ```csharp
+   using Anela.Heblo.Adapters.Azure;
+   using Anela.Heblo.Adapters.Azure.Features.FileStorage;
+   using Anela.Heblo.Application.Features.FileStorage;
+   using Anela.Heblo.Domain.Features.FileStorage;
+   using Anela.Heblo.Xcc.Telemetry;
+   using Azure.Storage.Blobs;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Hosting;
+   using Microsoft.Extensions.Logging;
+   using Microsoft.Extensions.Logging.Abstractions;
+   using Moq;
+   using Xunit;
+
+   namespace Anela.Heblo.Tests.Features.FileStorage;
+
+   /// <summary>
+   /// Tests for AzureAdapterModule.AddAzureBlobStorageService — the BlobServiceClient factory and
+   /// the IBlobStorageService binding relocated from FileStorageModule to the Azure adapter ring.
+   ///
+   /// Each test calls BOTH AddFileStorageModule (which binds and validates FileStorageOptions) and
+   /// AddAzureBlobStorageService (which registers BlobServiceClient + IBlobStorageService). The
+   /// options binding intentionally stays in FileStorageModule, so the adapter registration depends
+   /// on it being present.
+   /// </summary>
+   public class AzureAdapterModuleTests
+   {
+       private static IServiceCollection BuildBaseServices()
+       {
+           var services = new ServiceCollection();
+           services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+           services.AddSingleton(Mock.Of<ITelemetryService>());
+           services.Configure<FileDownloadOptions>(opts =>
+           {
+               opts.MaxRetryAttempts = 3;
+               opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+               opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+           });
+           return services;
+       }
+
+       private static IConfiguration BuildConfiguration(string? blobConnectionString = "UseDevelopmentStorage=true")
+       {
+           var dict = new Dictionary<string, string?>();
+           if (blobConnectionString is not null)
+           {
+               dict["FileStorage:BlobConnectionString"] = blobConnectionString;
+           }
+           return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+       }
+
+       private static IHostEnvironment BuildEnvironment(string environmentName) =>
+           Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName);
+
+       [Fact]
+       public void AddAzureBlobStorageService_RegistersBlobStorageService_AsSingleton()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+           var environment = BuildEnvironment(Environments.Development);
+
+           // Act
+           services.AddFileStorageModule(BuildConfiguration(), environment);
+           services.AddAzureBlobStorageService(environment);
+
+           // Assert — IBlobStorageService must be Singleton so _containerExists cache survives requests
+           var descriptor = services.Single(s => s.ServiceType == typeof(IBlobStorageService));
+           Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+       }
+
+       [Fact]
+       public void AddAzureBlobStorageService_ResolvingBlobStorageServiceTwice_ReturnsSameInstance()
+       {
+           // Arrange
+           var services = BuildBaseServices();
+           var environment = BuildEnvironment(Environments.Development);
+           services.AddFileStorageModule(BuildConfiguration(), environment);
+           services.AddAzureBlobStorageService(environment);
+           var provider = services.BuildServiceProvider();
+
+           // Act
+           var first = provider.GetRequiredService<IBlobStorageService>();
+           var second = provider.GetRequiredService<IBlobStorageService>();
+
+           // Assert — same instance proves Singleton registration is working
+           Assert.Same(first, second);
+       }
+
+       [Fact]
+       public void AddAzureBlobStorageService_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning()
+       {
+           // Arrange — Development environment, no FileStorage:BlobConnectionString
+           var services = new ServiceCollection();
+           services.AddSingleton(Mock.Of<ITelemetryService>());
+           services.Configure<FileDownloadOptions>(opts =>
+           {
+               opts.MaxRetryAttempts = 3;
+               opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+               opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+           });
+
+           var warningLogger = new Mock<ILogger<AzureBlobStorageService>>();
+           services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+           // Override the AzureBlobStorageService logger so we can verify the warning was emitted.
+           services.AddSingleton(warningLogger.Object);
+
+           var environment = BuildEnvironment(Environments.Development);
+           var configuration = BuildConfiguration(blobConnectionString: null);
+           services.AddFileStorageModule(configuration, environment);
+           services.AddAzureBlobStorageService(environment);
+           var provider = services.BuildServiceProvider();
+
+           // Act — resolving the BlobServiceClient runs the factory, which emits the warning
+           // and returns a client pointed at UseDevelopmentStorage=true.
+           var client = provider.GetRequiredService<BlobServiceClient>();
+
+           // Assert — client is constructed (no throw) and the warning was logged once.
+           Assert.NotNull(client);
+           warningLogger.Verify(
+               l => l.Log(
+                   LogLevel.Warning,
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("FileStorage:BlobConnectionString")),
+                   It.IsAny<Exception?>(),
+                   It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+               Times.Once);
+       }
+   }
+   ```
+
+**Tests to write/update**
+Covered by steps 1–3 above:
+- `AzureBlobStorageServiceTests.cs` — `using`/namespace update only.
+- `FileStorageModuleTests.cs` — three registration tests removed; unused `using`s removed.
+- `AzureAdapterModuleTests.cs` — new file with the three relocated registration tests.
+
+**Acceptance criteria**
+1. The full solution builds. From `backend/`:
+   ```bash
+   dotnet build
+   ```
+   Expected: `Build succeeded.` with `0 Error(s)` (the test project now compiles).
+2. All FileStorage tests pass. From `backend/`:
+   ```bash
+   dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.FileStorage"
+   ```
+   Expected: all tests pass, `Failed: 0`. This must include:
+   - the unchanged `AzureBlobStorageServiceTests` cases,
+   - the retained `FileStorageModuleTests` cases
+     (`RegistersNamedHttpClient_FileDownload`, `DoesNotRegisterTransientHttpClient`,
+     `RegistersDownloadResilienceService_AsSingleton`, `NamedClient_ConstantIsExported`,
+     `NonDevelopmentEnvironmentWithMissingKey_FailsValidation`),
+   - the three new `AzureAdapterModuleTests` cases
+     (`RegistersBlobStorageService_AsSingleton`, `ResolvingBlobStorageServiceTwice_ReturnsSameInstance`,
+     `DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning`).
+3. Formatting is clean. From `backend/`:
+   ```bash
+   dotnet format --verify-no-changes
+   ```
+   Expected: no changes reported.
+
+**Commit**
+```bash
+git add -A
+git commit -m "Update FileStorage tests for relocated AzureBlobStorageService"
+```
+
+---
+
+## Plan self-review
+
+- **Spec requirement coverage:**
+  - FR-1 (move class, new namespace, identical logic, `FileDownloadClientName` reference intact) →
+    Task 1 steps 1–2, acceptance 1.
+  - FR-2 (move `BlobServiceClient` factory + `IBlobStorageService` bind to `AddAzureBlobStorageService`;
+    `FileStorageModule` keeps options/HTTP/resilience) → Task 1 steps 3–4, acceptance 2–3.
+  - FR-3 (wire into startup, unconditional, correct validation timing) → Task 1 step 6, acceptance 5;
+    validation timing preserved because `FileStorageModule` still owns the binding + `ValidateOnStart`.
+  - FR-4 (remove `Azure.Storage.Blobs` from Application; repo-wide grep clean) → Task 1 step 5 & 7,
+    acceptance 3–4.
+  - FR-5 (both test files compile/pass; assertions relocated to adapter test) → Task 2 (all steps),
+    acceptance 1–2.
+  - NFR-1/NFR-2 (Singleton lifetimes, dev-fallback warning verbatim) → factory moved verbatim
+    (Task 1 step 3); warning-message assertion preserved (Task 2 step 3).
+  - NFR-3 (build + format + full test suite) → Task 1 acceptance 2 & 6; Task 2 acceptance 1–3.
+- **Design amendments honored:** extension takes `IHostEnvironment` (not `IConfiguration`); wired
+  from `Program.cs` (not `ApplicationModule`, not inside `AddPrintQueueSink`); three specific tests
+  relocated to a new adapter-module test calling both modules.
+- **Out-of-scope respected:** `AzureBlobConflictTelemetryFilter` (doc-comment-only reference) is not
+  touched; no shared `BlobServiceClient`/`BlobContainerClient`; no config keys added.
+- **Placeholder scan:** no "TBD"/"similar to"/"add error handling" placeholders; all code blocks are
+  concrete and copy-ready.
+- **Type/name consistency:** `AddAzureBlobStorageService(IServiceCollection, IHostEnvironment)`,
+  namespace `Anela.Heblo.Adapters.Azure.Features.FileStorage`, and
+  `FileStorageModule.FileDownloadClientName` are used identically across both tasks and match the
+  actual source read from the repo.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs
@@ -1,10 +1,15 @@
 // backend/src/Adapters/Anela.Heblo.Adapters.Azure/AzureAdapterModule.cs
 using Anela.Heblo.Adapters.Azure.Features.ExpeditionList;
+using Anela.Heblo.Adapters.Azure.Features.FileStorage;
 using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.FileStorage;
 using Anela.Heblo.Application.Shared.Printing;
+using Anela.Heblo.Domain.Features.FileStorage;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Adapters.Azure;
@@ -22,6 +27,37 @@ public static class AzureAdapterModule
         });
 
         services.AddSingleton<IPrintQueueSink, AzureBlobPrintQueueSink>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddAzureBlobStorageService(
+        this IServiceCollection services,
+        IHostEnvironment environment)
+    {
+        // Register Azure Blob Storage client. The factory reads the already-validated options,
+        // so ValidateOnStart() (registered by FileStorageModule) runs before any consumer
+        // resolves the BlobServiceClient.
+        services.AddSingleton<BlobServiceClient>(provider =>
+        {
+            var opts = provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
+            if (string.IsNullOrWhiteSpace(opts.BlobConnectionString))
+            {
+                // Reachable only in Development — validation blocks the empty path elsewhere.
+                // Log a warning so the storage-emulator fallback is never silent.
+                var logger = provider.GetRequiredService<ILogger<AzureBlobStorageService>>();
+                logger.LogWarning(
+                    "FileStorage:BlobConnectionString is empty in {Environment}; falling back to UseDevelopmentStorage=true.",
+                    environment.EnvironmentName);
+                return new BlobServiceClient("UseDevelopmentStorage=true");
+            }
+
+            return new BlobServiceClient(opts.BlobConnectionString);
+        });
+
+        // Register blob storage service as Singleton so the _containerExists cache survives across requests.
+        // BlobServiceClient is already Singleton — no thread-safety concerns.
+        services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
 
         return services;
     }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
@@ -1,10 +1,11 @@
 using System.Collections.Concurrent;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Anela.Heblo.Application.Features.FileStorage;
 using Anela.Heblo.Domain.Features.FileStorage;
 using Microsoft.Extensions.Logging;
 
-namespace Anela.Heblo.Application.Features.FileStorage.Services;
+namespace Anela.Heblo.Adapters.Azure.Features.FileStorage;
 
 /// <summary>
 /// Azure Blob Storage implementation of IBlobStorageService

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -101,6 +101,7 @@ public partial class Program
         // Add new architecture services
         builder.Services.AddPersistenceServices(builder.Configuration, builder.Environment);
         builder.Services.AddApplicationServices(builder.Configuration, builder.Environment); // Vertical slice modules from Application layer
+        builder.Services.AddAzureBlobStorageService(builder.Environment); // Azure adapter: BlobServiceClient + IBlobStorageService binding (moved out of Application ring)
         builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
         builder.Services.AddXccServices(builder.Configuration); // Cross-cutting concerns (audit, telemetry, etc.)
         builder.Services.AddUsersModule(); // Users feature composition root (API-layer adapter for ICurrentUserService)

--- a/backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+++ b/backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.1.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
     <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
@@ -1,8 +1,6 @@
 using System.Net;
 using Anela.Heblo.Application.Features.FileStorage.Infrastructure;
-using Anela.Heblo.Application.Features.FileStorage.Services;
 using Anela.Heblo.Domain.Features.FileStorage;
-using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -37,25 +35,6 @@ public static class FileStorageModule
                 .ValidateOnStart();
         }
 
-        // Register Azure Blob Storage client. The factory reads the already-validated options,
-        // so ValidateOnStart() runs before any consumer resolves the BlobServiceClient.
-        services.AddSingleton<BlobServiceClient>(provider =>
-        {
-            var opts = provider.GetRequiredService<IOptions<FileStorageOptions>>().Value;
-            if (string.IsNullOrWhiteSpace(opts.BlobConnectionString))
-            {
-                // Reachable only in Development — validation blocks the empty path elsewhere.
-                // Log a warning so the storage-emulator fallback is never silent.
-                var logger = provider.GetRequiredService<ILogger<AzureBlobStorageService>>();
-                logger.LogWarning(
-                    "FileStorage:BlobConnectionString is empty in {Environment}; falling back to UseDevelopmentStorage=true.",
-                    environment.EnvironmentName);
-                return new BlobServiceClient("UseDevelopmentStorage=true");
-            }
-
-            return new BlobServiceClient(opts.BlobConnectionString);
-        });
-
         // Register named HttpClient for product export downloads.
         // PooledConnectionLifetime recycles sockets and refreshes DNS every 5 minutes,
         // preventing the stale-socket and DNS-pinning problems of a long-lived singleton HttpClient.
@@ -78,10 +57,6 @@ public static class FileStorageModule
         // Register resilience service as Singleton — it holds no request state and
         // its internal Polly pipeline is rebuilt per-call (see BuildPipeline).
         services.AddSingleton<IDownloadResilienceService, DownloadResilienceService>();
-
-        // Register blob storage service as Singleton so the _containerExists cache survives across requests.
-        // BlobServiceClient is already Singleton — no thread-safety concerns.
-        services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
 
         services.Configure<FileDownloadOptions>(configuration.GetSection("FileStorage:Download"));
 

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureAdapterModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureAdapterModuleTests.cs
@@ -1,0 +1,128 @@
+using Anela.Heblo.Adapters.Azure;
+using Anela.Heblo.Adapters.Azure.Features.FileStorage;
+using Anela.Heblo.Application.Features.FileStorage;
+using Anela.Heblo.Domain.Features.FileStorage;
+using Anela.Heblo.Xcc.Telemetry;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.FileStorage;
+
+/// <summary>
+/// Tests for AzureAdapterModule.AddAzureBlobStorageService — the BlobServiceClient factory and
+/// the IBlobStorageService binding relocated from FileStorageModule to the Azure adapter ring.
+///
+/// Each test calls BOTH AddFileStorageModule (which binds and validates FileStorageOptions) and
+/// AddAzureBlobStorageService (which registers BlobServiceClient + IBlobStorageService). The
+/// options binding intentionally stays in FileStorageModule, so the adapter registration depends
+/// on it being present.
+/// </summary>
+public class AzureAdapterModuleTests
+{
+    private static IServiceCollection BuildBaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton(Mock.Of<ITelemetryService>());
+        services.Configure<FileDownloadOptions>(opts =>
+        {
+            opts.MaxRetryAttempts = 3;
+            opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+            opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+        });
+        return services;
+    }
+
+    private static IConfiguration BuildConfiguration(string? blobConnectionString = "UseDevelopmentStorage=true")
+    {
+        var dict = new Dictionary<string, string?>();
+        if (blobConnectionString is not null)
+        {
+            dict["FileStorage:BlobConnectionString"] = blobConnectionString;
+        }
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    private static IHostEnvironment BuildEnvironment(string environmentName) =>
+        Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName);
+
+    [Fact]
+    public void AddAzureBlobStorageService_RegistersBlobStorageService_AsSingleton()
+    {
+        // Arrange
+        var services = BuildBaseServices();
+        var environment = BuildEnvironment(Environments.Development);
+
+        // Act
+        services.AddFileStorageModule(BuildConfiguration(), environment);
+        services.AddAzureBlobStorageService(environment);
+
+        // Assert — IBlobStorageService must be Singleton so _containerExists cache survives requests
+        var descriptor = services.Single(s => s.ServiceType == typeof(IBlobStorageService));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddAzureBlobStorageService_ResolvingBlobStorageServiceTwice_ReturnsSameInstance()
+    {
+        // Arrange
+        var services = BuildBaseServices();
+        var environment = BuildEnvironment(Environments.Development);
+        services.AddFileStorageModule(BuildConfiguration(), environment);
+        services.AddAzureBlobStorageService(environment);
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var first = provider.GetRequiredService<IBlobStorageService>();
+        var second = provider.GetRequiredService<IBlobStorageService>();
+
+        // Assert — same instance proves Singleton registration is working
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void AddAzureBlobStorageService_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning()
+    {
+        // Arrange — Development environment, no FileStorage:BlobConnectionString
+        var services = new ServiceCollection();
+        services.AddSingleton(Mock.Of<ITelemetryService>());
+        services.Configure<FileDownloadOptions>(opts =>
+        {
+            opts.MaxRetryAttempts = 3;
+            opts.DownloadTimeout = TimeSpan.FromSeconds(120);
+            opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
+        });
+
+        var warningLogger = new Mock<ILogger<AzureBlobStorageService>>();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        // Override the AzureBlobStorageService logger so we can verify the warning was emitted.
+        services.AddSingleton(warningLogger.Object);
+
+        var environment = BuildEnvironment(Environments.Development);
+        var configuration = BuildConfiguration(blobConnectionString: null);
+        services.AddFileStorageModule(configuration, environment);
+        services.AddAzureBlobStorageService(environment);
+        var provider = services.BuildServiceProvider();
+
+        // Act — resolving the BlobServiceClient runs the factory, which emits the warning
+        // and returns a client pointed at UseDevelopmentStorage=true.
+        var client = provider.GetRequiredService<BlobServiceClient>();
+
+        // Assert — client is constructed (no throw) and the warning was logged once.
+        Assert.NotNull(client);
+        warningLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("FileStorage:BlobConnectionString")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
@@ -1,5 +1,5 @@
+using Anela.Heblo.Adapters.Azure.Features.FileStorage;
 using Anela.Heblo.Application.Features.FileStorage;
-using Anela.Heblo.Application.Features.FileStorage.Services;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
@@ -1,9 +1,7 @@
 using Anela.Heblo.Application.Features.FileStorage;
 using Anela.Heblo.Application.Features.FileStorage.Infrastructure;
-using Anela.Heblo.Application.Features.FileStorage.Services;
 using Anela.Heblo.Domain.Features.FileStorage;
 using Anela.Heblo.Xcc.Telemetry;
-using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -43,36 +41,6 @@ public class FileStorageModuleTests
 
     private static IHostEnvironment BuildEnvironment(string environmentName) =>
         Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName);
-
-    [Fact]
-    public void AddFileStorageModule_RegistersBlobStorageService_AsSingleton()
-    {
-        // Arrange
-        var services = BuildBaseServices();
-
-        // Act
-        services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
-
-        // Assert — IBlobStorageService must be Singleton so _containerExists cache survives requests
-        var descriptor = services.Single(s => s.ServiceType == typeof(IBlobStorageService));
-        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
-    }
-
-    [Fact]
-    public void AddFileStorageModule_ResolvingBlobStorageServiceTwice_ReturnsSameInstance()
-    {
-        // Arrange
-        var services = BuildBaseServices();
-        services.AddFileStorageModule(BuildConfiguration(), BuildEnvironment(Environments.Development));
-        var provider = services.BuildServiceProvider();
-
-        // Act
-        var first = provider.GetRequiredService<IBlobStorageService>();
-        var second = provider.GetRequiredService<IBlobStorageService>();
-
-        // Assert — same instance proves Singleton registration is working
-        Assert.Same(first, second);
-    }
 
     [Fact]
     public void AddFileStorageModule_RegistersNamedHttpClient_FileDownload()
@@ -152,43 +120,5 @@ public class FileStorageModuleTests
         // Assert
         var ex = Assert.Throws<OptionsValidationException>(act);
         Assert.Contains("FileStorage:BlobConnectionString", ex.Message);
-    }
-
-    [Fact]
-    public void AddFileStorageModule_DevelopmentEnvironmentWithMissingKey_FallsBackAndLogsWarning()
-    {
-        // Arrange — Development environment, no FileStorage:BlobConnectionString
-        var services = new ServiceCollection();
-        services.AddSingleton(Mock.Of<ITelemetryService>());
-        services.Configure<FileDownloadOptions>(opts =>
-        {
-            opts.MaxRetryAttempts = 3;
-            opts.DownloadTimeout = TimeSpan.FromSeconds(120);
-            opts.RetryBaseDelay = TimeSpan.FromSeconds(2);
-        });
-
-        var warningLogger = new Mock<ILogger<AzureBlobStorageService>>();
-        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
-        // Override the AzureBlobStorageService logger so we can verify the warning was emitted.
-        services.AddSingleton(warningLogger.Object);
-
-        var configuration = BuildConfiguration(blobConnectionString: null);
-        services.AddFileStorageModule(configuration, BuildEnvironment(Environments.Development));
-        var provider = services.BuildServiceProvider();
-
-        // Act — resolving the BlobServiceClient runs the factory, which emits the warning
-        // and returns a client pointed at UseDevelopmentStorage=true.
-        var client = provider.GetRequiredService<BlobServiceClient>();
-
-        // Assert — client is constructed (no throw) and the warning was logged once.
-        Assert.NotNull(client);
-        warningLogger.Verify(
-            l => l.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("FileStorage:BlobConnectionString")),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
     }
 }


### PR DESCRIPTION
Closes #3484

## What the issue was
`AzureBlobStorageService` — an I/O-bound Azure SDK consumer using `BlobServiceClient` — lived in the Application layer (`Anela.Heblo.Application/Features/FileStorage/Services/`), violating the project's Clean Architecture I/O placement rule (`docs/architecture/filesystem.md`): concrete Azure-SDK-backed services belong in the adapter ring, not `Features/{Feature}/Services/`. This forced `Anela.Heblo.Application.csproj` to reference the `Azure.Storage.Blobs` NuGet package directly, and left the codebase inconsistent — the functionally equivalent `AzureBlobPrintQueueSink` was already correctly placed under `backend/src/Adapters/Anela.Heblo.Adapters.Azure/`.

## How it was fixed / handled
- Moved `AzureBlobStorageService` to `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/`, updating its namespace to `Anela.Heblo.Adapters.Azure.Features.FileStorage` (git-tracked as a rename, 99% similarity — only the namespace/using changed).
- Added `AzureAdapterModule.AddAzureBlobStorageService(IServiceCollection, IHostEnvironment)`, which now owns the `BlobServiceClient` singleton factory (including the Development-only `UseDevelopmentStorage=true` fallback with its warning log) and the `IBlobStorageService` → `AzureBlobStorageService` binding.
- Stripped those registrations and the `Azure.Storage.Blobs`/service usings out of `FileStorageModule`, which now only owns `FileStorageOptions` binding/validation, the named `FileDownload` HTTP client, and `IDownloadResilienceService`.
- Wired the new extension into the composition root (`Program.cs`, unconditionally, alongside the existing `AddApplicationServices`/`AddAzurePrintQueueSink` calls) rather than from `ApplicationModule`, since the Application layer cannot reference the adapter without recreating the dependency it's removing.
- Removed the `Azure.Storage.Blobs` package reference from `Anela.Heblo.Application.csproj` — confirmed via repo-wide grep that no Azure SDK types remain referenced from the Application project.
- Updated the two affected test files: `AzureBlobStorageServiceTests` (namespace/using swap only) and `FileStorageModuleTests` (registration-assertion tests relocated to a new `AzureAdapterModuleTests`, which now exercises both `AddFileStorageModule` + `AddAzureBlobStorageService` together).

No behavior change — this is a pure architecture-compliance refactor (Clean Architecture layering), verified by the full existing test suite passing and a whole-branch code review.

## Artifacts
Full pipeline artifacts (brief, spec, arch review, design, task plan, per-task impl/review, and this whole-branch code review) are committed under `artifacts/feat-3484/` on this branch.

## Validation
- `dotnet build Anela.Heblo.sln` — 0 errors.
- `dotnet test` (full backend suite) — 5414 passed, 0 relevant failures (64 pre-existing failures are unrelated Postgres/Testcontainers integration tests that require Docker, unavailable in this sandbox; none touch FileStorage).
- `dotnet format --verify-no-changes` on all touched files — clean.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

Verified against the actual worktree: the relocation is a faithful, behavior-preserving move mirroring the existing `AddAzurePrintQueueSink` pattern. No remaining Azure SDK references in the Application project, no double-registration of `IBlobStorageService`, DI registration order in `Program.cs` is safe, and tests were correctly migrated with equivalent coverage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WoqjoVZSnwKy6GsPXaNakG)_