### PR TITLE
#3495: implementation

### DIFF
--- a/artifacts/feat-3495/arch-review.r1.md
+++ b/artifacts/feat-3495/arch-review.r1.md
@@ -1,0 +1,92 @@
+# Architecture Review: Inject `TimeProvider` into `GetBankStatementImportStatisticsHandler`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure hygiene fix that brings one outlier handler in line with a pattern the Analytics module has already established twice over. Verified directly in the codebase:
+
+- `InvoiceImportStatisticsTile.cs` (`backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs:10-11,22-29`) takes `TimeProvider` as a constructor dependency alongside `IAnalyticsRepository` and calls `_timeProvider.GetUtcNow().Date` at line 46.
+- `TimeWindowParser.cs` (`backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs`) does the same via `_timeProvider.GetLocalNow().Date`.
+- `GetBankStatementImportStatisticsHandler.cs:13-16,23` is the odd one out: constructor takes only `IAnalyticsRepository`, and line 23 calls `DateTime.UtcNow.Date` directly.
+- DI registration is confirmed at `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131` — `services.AddSingleton(TimeProvider.System);` inside `AddCrossCuttingServices()`. This is a single, application-wide registration; **no new registration is needed**, MediatR's container will resolve the added constructor parameter automatically.
+
+There is no architectural decision to make here — the pattern, the DI wiring, and the test-mocking convention all already exist and are used verbatim elsewhere in the same module. The only job of this review is to confirm there's no reason to deviate, and there isn't.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+GetBankStatementImportStatisticsHandler : IRequestHandler<Request, Response>
+ ├── IAnalyticsRepository   (existing dependency, unchanged)
+ └── TimeProvider           (new dependency — resolves to TimeProvider.System via
+                              existing singleton registration in
+                              ServiceCollectionExtensions.cs:131)
+```
+
+No new components, no new interfaces, no new registrations. The change is confined to one handler's constructor and one line of its `Handle` method.
+
+### Key Design Decisions
+
+#### Decision 1: Reuse `TimeProvider` exactly as done in `InvoiceImportStatisticsTile`
+**Options considered:**
+- (a) Inject `TimeProvider` via constructor, matching `InvoiceImportStatisticsTile` / `TimeWindowParser`.
+- (b) Introduce a module-level `IClock`/`INowProvider` abstraction.
+- (c) Leave as-is and accept the untestable branch.
+
+**Chosen approach:** (a).
+
+**Rationale:** `TimeProvider` (BCL, .NET 8) is already the module's standardized abstraction, already registered once as a singleton, and already has an established mocking convention in tests (`Mock<TimeProvider>` + `.Setup(x => x.GetUtcNow())`). Introducing a second abstraction (b) would create inconsistency within the same module for no benefit. Leaving it as-is (c) is what the brief explicitly asks to fix.
+
+#### Decision 2: No behavior change, testability-only
+**Options considered:** Rewrite the default-window logic (e.g., extract to a shared helper shared with `GetInvoiceImportStatisticsHandler`) vs. minimal in-place swap.
+
+**Chosen approach:** Minimal in-place swap of `DateTime.UtcNow.Date` → `_timeProvider.GetUtcNow().Date`. Everything else (the `??` fallback chain, the `DateTimeKind` normalization block at lines 26-30) stays untouched.
+
+**Rationale:** The sibling handler (`GetInvoiceImportStatisticsHandler`) has the identical gap but is tracked separately under issue #3488. Unifying the two into a shared helper now would silently expand scope and couple two independently-tracked fixes. Keep this PR small and reviewable.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files or directories except the test file. Everything lives in its existing location:
+
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`
+- Add: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs` (confirmed this file does not exist today — `GetInvoiceImportStatisticsHandlerTests.cs` exists as a sibling in the same folder and is a reasonable structural neighbor, though `InvoiceImportStatisticsTileTests.cs` in `Features/Analytics/DashboardTiles/` is the closer *behavioral* template for the `Mock<TimeProvider>` setup).
+
+### Interfaces and Contracts
+
+Constructor signature changes from:
+```csharp
+public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository)
+```
+to:
+```csharp
+public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository, TimeProvider timeProvider)
+```
+with a new `private readonly TimeProvider _timeProvider;` field assigned in the body, matching the existing `_analyticsRepository` field style (confirmed at lines 11, 15 of the current handler).
+
+No MediatR request/response contract changes. No controller changes. No new interfaces.
+
+### Data Flow
+
+Unchanged. `request.EndDate` (nullable) still short-circuits the clock call via `??`. When null, `_timeProvider.GetUtcNow().Date` supplies today's UTC date instead of `DateTime.UtcNow.Date` — same effective value in production (`TimeProvider.System` wraps the real system clock), but now substitutable with a `FakeTimeProvider`/`Mock<TimeProvider>` in tests. `startDate`'s derivation and the subsequent `DateTimeKind.Utc` normalization block (lines 26-30) are untouched and continue to run exactly as before, since `GetUtcNow().Date` produces the same `Unspecified`-kind `DateTime` that `DateTime.UtcNow.Date` did.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Constructor signature change breaks any manual (non-DI-container) instantiation of the handler | Low | Grep confirms the only production instantiation is via MediatR/DI, which resolves `TimeProvider` automatically from the existing singleton — no call-site changes needed. Test file is the only place explicitly constructing the handler, and it's being added, not modified. |
+| Divergence between this fix and the still-open sibling gap in `GetInvoiceImportStatisticsHandler` (#3488) | Low | Explicitly out of scope per spec; no shared helper is introduced that would need to track both. Flagged here only so the reviewer doesn't expect this PR to also close #3488. |
+| Test asserts on wrong date semantics (e.g., off-by-one from `.Date` truncation) | Low | Mirror the exact fixed-`DateTimeOffset` mocking pattern already proven in `InvoiceImportStatisticsTileTests.cs` (`_fixedDateTime` = `2025-10-14T10:00:00Z`), which already exercises this same `.GetUtcNow().Date` truncation correctly. |
+
+## Specification Amendments
+
+None. The spec (`spec.r1.md`) is accurate against the current codebase in every claim I verified: the handler's current constructor/line-23 content, the `InvoiceImportStatisticsTile`/`TimeWindowParser` reference patterns, and the DI registration at `ServiceCollectionExtensions.cs:131`. No changes needed.
+
+One implementation-guidance note (not a spec defect, just for the developer): FR-3's acceptance criteria reference `GetInvoiceImportStatisticsHandlerTests`-style `Verify(...)` assertions for structure, but the closer template for the `Mock<TimeProvider>` setup itself is `InvoiceImportStatisticsTileTests.cs` (confirmed pattern: `Mock<TimeProvider>` + `.Setup(x => x.GetUtcNow()).Returns(fixedDateTime)`). Use that file as the primary reference for the mock setup, and `GetInvoiceImportStatisticsHandlerTests.cs` as the reference for handler-level `Handle(...)` + repository-verification structure.
+
+## Prerequisites
+
+None. No migrations, no config, no infrastructure changes. `TimeProvider.System` singleton registration already exists; `Moq` is already a test-project dependency. Implementation can start immediately.

--- a/artifacts/feat-3495/brief.md
+++ b/artifacts/feat-3495/brief.md
@@ -1,0 +1,33 @@
+## Module
+Analytics
+
+## Finding
+`GetBankStatementImportStatisticsHandler` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs:23`) accesses system time directly:
+
+```csharp
+var endDate = request.EndDate ?? DateTime.UtcNow.Date;
+```
+
+The module already established the correct pattern: `InvoiceImportStatisticsTile` (line 46) and `TimeWindowParser` both inject `TimeProvider` and call `_timeProvider.GetUtcNow()`. Issue #3488 filed the same finding for `GetInvoiceImportStatisticsHandler` — this is its sibling handler with an identical gap.
+
+## Why it matters
+When `request.EndDate` is null (the common path — the frontend does not pass explicit end dates for this endpoint), the handler falls back to `DateTime.UtcNow.Date`. Unit tests cannot control "today" without static shims, making the default-date branch untestable in isolation. It is also inconsistent with the established module pattern.
+
+## Suggested fix
+Inject `TimeProvider` (no DI registration change needed — it is already in the container):
+
+```csharp
+public GetBankStatementImportStatisticsHandler(
+    IAnalyticsRepository analyticsRepository,
+    TimeProvider timeProvider)               // ← add this
+{
+    _analyticsRepository = analyticsRepository;
+    _timeProvider = timeProvider;
+}
+
+// In Handle():
+var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date;
+```
+
+---
+_Filed by daily arch-review routine on 2026-07-06._

--- a/artifacts/feat-3495/code-review.r1.md
+++ b/artifacts/feat-3495/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3495/design.r1.md
+++ b/artifacts/feat-3495/design.r1.md
@@ -1,0 +1,56 @@
+# Design: Inject `TimeProvider` into `GetBankStatementImportStatisticsHandler`
+
+## Component Design
+
+### `GetBankStatementImportStatisticsHandler`
+Location: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`
+
+Responsibility: `IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>` — resolves the effective `startDate`/`endDate` window (defaulting to "today minus 30 days" through "today" when not supplied in the request) and delegates to `IAnalyticsRepository` to fetch bank statement import statistics.
+
+Change: add `TimeProvider` as a second constructor dependency, alongside the existing `IAnalyticsRepository`, and use it to resolve "now" instead of calling the static `DateTime.UtcNow` directly. This brings the handler in line with the pattern already used by `InvoiceImportStatisticsTile` and `TimeWindowParser` in the same module.
+
+```csharp
+public class GetBankStatementImportStatisticsHandler
+    : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
+{
+    private readonly IAnalyticsRepository _analyticsRepository;   // existing, unchanged
+    private readonly TimeProvider _timeProvider;                  // new
+
+    public GetBankStatementImportStatisticsHandler(
+        IAnalyticsRepository analyticsRepository,
+        TimeProvider timeProvider)
+    {
+        _analyticsRepository = analyticsRepository;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<GetBankStatementImportStatisticsResponse> Handle(
+        GetBankStatementImportStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date; // was: DateTime.UtcNow.Date
+        var startDate = request.StartDate ?? endDate.AddDays(-30);       // unchanged
+
+        // DateTimeKind normalization block (unchanged) — still required, since
+        // GetUtcNow().Date yields Kind == Unspecified, same as UtcNow.Date did.
+        ...
+    }
+}
+```
+
+No new interfaces, no new abstractions. `TimeProvider` resolves via the existing application-wide singleton registration (`services.AddSingleton(TimeProvider.System)` in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131`) — no DI registration changes required.
+
+### `GetBankStatementImportStatisticsHandlerTests` (new)
+Location: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs`
+
+Responsibility: unit-test coverage for the handler's date-resolution logic, using the mocking pattern from `InvoiceImportStatisticsTileTests.cs` (`Mock<TimeProvider>` + `.Setup(x => x.GetUtcNow()).Returns(fixedDateTimeOffset)`) for the clock, and the `Handle(...)` + `_mockRepository.Verify(...)` structure from `GetInvoiceImportStatisticsHandlerTests.cs` for handler-level assertions.
+
+Test cases:
+1. `EndDate == null` and `StartDate == null` → `IAnalyticsRepository.GetBankStatementImportStatisticsAsync` is invoked with `endDate` equal to the mocked fixed date and `startDate` equal to `fixedDate.AddDays(-30)`, proving the branch is driven by the injected `TimeProvider` rather than the real wall clock.
+2. `EndDate` (and/or `StartDate`) explicitly supplied → the mocked `TimeProvider.GetUtcNow()` is not what drives the resulting dates; repository is called with the supplied values (pass-through behavior unchanged).
+
+No other components are added, removed, or restructured. `IAnalyticsRepository`, the MediatR request/response contract, and the controller endpoint are all unaffected.
+
+## Data Schemas
+
+No schema changes. `GetBankStatementImportStatisticsRequest`, `GetBankStatementImportStatisticsResponse`, and `DailyBankStatementStatistics` are unchanged — this is purely a constructor-dependency and internal-logic change inside the handler. No database, API contract, or event-payload changes are introduced.

--- a/artifacts/feat-3495/impl/inject-timeprovider-bank-statement-handler.r1.md
+++ b/artifacts/feat-3495/impl/inject-timeprovider-bank-statement-handler.r1.md
@@ -1,0 +1,38 @@
+# Implementation: inject-timeprovider-bank-statement-handler
+
+## What was implemented
+`GetBankStatementImportStatisticsHandler` now takes a `TimeProvider` constructor dependency and uses `_timeProvider.GetUtcNow().Date` instead of calling `DateTime.UtcNow.Date` directly, matching the established pattern in `InvoiceImportStatisticsTile` and `TimeWindowParser`. No DI registration changes were needed since `TimeProvider.System` is already registered as a singleton. Added unit test coverage proving the default-date branch is now deterministically testable via a mocked `TimeProvider`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs` — added `TimeProvider` constructor parameter and `_timeProvider` field; replaced `DateTime.UtcNow.Date` with `_timeProvider.GetUtcNow().Date`. No other lines changed.
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs` — new test file (none existed before) with two tests: default-date-range resolution via mocked `TimeProvider`, and pass-through behavior confirming the provider is not consulted when explicit dates are supplied.
+
+## Tests
+- `GetBankStatementImportStatisticsHandlerTests.Handle_WithNoDatesProvided_UsesInjectedTimeProviderForDefaultRange` — passes.
+- `GetBankStatementImportStatisticsHandlerTests.Handle_WithExplicitDatesProvided_DoesNotConsultTimeProvider` — passes.
+- Full `Features.Analytics` test folder (99 tests, including sibling `GetInvoiceImportStatisticsHandlerTests` and `InvoiceImportStatisticsTileTests`) — all pass, no regressions.
+- `dotnet build` on `Anela.Heblo.sln` — 0 errors (13 pre-existing warnings in unrelated Flexi adapter test files, not touched by this change).
+- `dotnet format` on the two changed files — no formatting changes required.
+
+## How to verify
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetBankStatementImportStatisticsHandlerTests"
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Analytics"
+dotnet build ../Anela.Heblo.sln
+```
+
+## Notes
+No deviations from the plan. The DI container resolves the new `TimeProvider` constructor parameter automatically via the existing `services.AddSingleton(TimeProvider.System)` registration — confirmed no other callers of this handler needed changes.
+
+## PR Summary
+`GetBankStatementImportStatisticsHandler` called `DateTime.UtcNow.Date` directly to compute its default end-date, unlike its sibling module code (`InvoiceImportStatisticsTile`, `TimeWindowParser`) which already inject `TimeProvider`. This made the default-date branch — the common real-world path, since the frontend doesn't pass an explicit end date — untestable without a time-freezing shim.
+
+This change injects `TimeProvider` via the constructor (no DI registration change needed) and swaps the direct clock call for `_timeProvider.GetUtcNow().Date`. Behavior is unchanged in production (`TimeProvider.System` wraps the real clock). A new test file adds coverage for both the default-date branch (via a mocked fixed time) and the explicit-date pass-through path.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs` — inject `TimeProvider`, replace `DateTime.UtcNow.Date` with `_timeProvider.GetUtcNow().Date`.
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs` — new test file covering both the default-date and explicit-date paths.
+
+## Status
+DONE

--- a/artifacts/feat-3495/review/inject-timeprovider-bank-statement-handler.r1.md
+++ b/artifacts/feat-3495/review/inject-timeprovider-bank-statement-handler.r1.md
@@ -1,0 +1,19 @@
+# Code Review: Inject TimeProvider into GetBankStatementImportStatisticsHandler
+
+## Summary
+The implementation matches the task spec exactly: `GetBankStatementImportStatisticsHandler` now takes an injected `TimeProvider` and uses `_timeProvider.GetUtcNow().Date` instead of `DateTime.UtcNow.Date`, with the rest of the method body byte-for-byte unchanged. The new test file matches the spec's prescribed content verbatim and covers both the default-date and explicit-date branches. DI registration was correctly left untouched, verified against `ServiceCollectionExtensions.cs:131` which already registers `TimeProvider.System` as a singleton.
+
+## Review Result: PASS
+
+### task: inject-timeprovider-bank-statement-handler
+**Status:** PASS
+
+## Docs to Update
+None. This is an internal refactor (constructor dependency swap) with no API, contract, or architectural documentation impact.
+
+## Overall Notes
+- Verified the actual handler file (`GetBankStatementImportStatisticsHandler.cs`) matches the spec's "full resulting file" exactly, including the unchanged date-normalization block, repository call, and response construction.
+- Verified the test file matches the spec's prescribed content exactly (constructor injection of `Mock<TimeProvider>`, fixed-date setup, `Times.Once`/`Times.Never` verification of `GetUtcNow()` for the two branches).
+- Confirmed via grep that `TimeProvider.System` is already registered as a singleton in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131`, substantiating the implementation summary's claim that no DI registration change was required.
+- No logic errors, no missing error handling introduced or removed — the change is a pure dependency-injection swap with no behavioral change in production (TimeProvider.System wraps the real clock).
+- Test coverage appropriately isolates both the previously-untestable default-date branch and the explicit-date pass-through path, consistent with FR-3 in the spec.

--- a/artifacts/feat-3495/spec.r1.md
+++ b/artifacts/feat-3495/spec.r1.md
@@ -1,0 +1,79 @@
+# Specification: Inject `TimeProvider` into `GetBankStatementImportStatisticsHandler`
+
+## Summary
+`GetBankStatementImportStatisticsHandler` computes its default end-date by calling `DateTime.UtcNow.Date` directly instead of using the module's established `TimeProvider` abstraction. This is a small architectural-hygiene fix: inject `TimeProvider` via constructor DI (already registered in the container as `TimeProvider.System`), replace the direct system-clock call with `_timeProvider.GetUtcNow().Date`, and add a unit test that proves the default-date branch is now controllable in tests. No behavior change is intended for production; the fix is testability and consistency only.
+
+## Background
+The Analytics module has already standardized on constructor-injected `TimeProvider` for anything that needs "now": `InvoiceImportStatisticsTile` (`backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs`) injects `TimeProvider` and calls `_timeProvider.GetUtcNow().Date`, and `TimeWindowParser` (`backend/src/Anela.Heblo.Application/Features/Analytics/Services/TimeWindowParser.cs`) does the same via `GetLocalNow()`. `TimeProvider` is registered once, application-wide, as a singleton (`services.AddSingleton(TimeProvider.System)` in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131`), so no DI registration changes are needed for this fix — the type is already resolvable everywhere.
+
+`GetBankStatementImportStatisticsHandler` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs:23`) does not follow this pattern:
+
+```csharp
+var endDate = request.EndDate ?? DateTime.UtcNow.Date;
+```
+
+`request.EndDate` (`GetBankStatementImportStatisticsRequest.EndDate`) is a nullable, optional field, and the frontend does not currently pass an explicit end date for this endpoint — meaning the `DateTime.UtcNow.Date` branch is the common, real-world code path, not an edge case. Because it calls the static system clock directly, this branch cannot be exercised deterministically in a unit test without a time-freezing shim (e.g. Microsoft.Extensions.Time.Testing `FakeTimeProvider` or a hand-rolled mock), and today there is no such test for it at all (there is no existing `GetBankStatementImportStatisticsHandlerTests` file in `backend/test/Anela.Heblo.Tests/Features/Analytics/`).
+
+A sibling issue (#3488) flags the identical gap in `GetInvoiceImportStatisticsHandler` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs:36`), which as of this writing also still calls `DateTime.UtcNow.Date` directly and is out of scope here — it is tracked and fixed independently. This spec covers only `GetBankStatementImportStatisticsHandler`.
+
+## Functional Requirements
+
+### FR-1: Handler must resolve "now" via injected `TimeProvider`
+`GetBankStatementImportStatisticsHandler` must take a `TimeProvider` as a constructor dependency (in addition to its existing `IAnalyticsRepository` dependency) and store it in a private readonly field, following the exact pattern already used by `InvoiceImportStatisticsTile`.
+
+**Acceptance criteria:**
+- The constructor signature becomes `GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository, TimeProvider timeProvider)`.
+- A private readonly field `_timeProvider` is assigned from the constructor parameter, matching the existing `_analyticsRepository` field style.
+- No changes are made to DI registration (`ServiceCollectionExtensions.cs` or elsewhere) — `TimeProvider.System` is already registered as a singleton and MediatR/the DI container will resolve it automatically for the handler's added constructor parameter.
+
+### FR-2: Default end-date must come from the injected clock, not the static system clock
+Line 23's `var endDate = request.EndDate ?? DateTime.UtcNow.Date;` must become `var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date;`. No other line in the method changes.
+
+**Acceptance criteria:**
+- The only occurrence of `DateTime.UtcNow` in `GetBankStatementImportStatisticsHandler.cs` is removed and replaced with `_timeProvider.GetUtcNow().Date`.
+- Behavior when `request.EndDate` is supplied is unchanged (the `??` fallback is untouched other than its right-hand side).
+- The subsequent `DateTimeKind` normalization logic (lines 26–30: `DateTime.SpecifyKind(...)` for both `startDate` and `endDate`) is left exactly as-is — `GetUtcNow().Date` already yields a `DateTime` whose `.Kind` may be `Unspecified` after `.Date`, so the existing normalization block continues to guarantee UTC kind and must not be removed or altered.
+- `startDate`'s derivation (`request.StartDate ?? endDate.AddDays(-30)`) is unchanged and continues to depend on the (now provider-sourced) `endDate`.
+
+### FR-3: Unit test coverage for the default-date branch
+A new test file `GetBankStatementImportStatisticsHandlerTests.cs` must be added under `backend/test/Anela.Heblo.Tests/Features/Analytics/` (none exists today), following the mocking pattern established in `InvoiceImportStatisticsTileTests.cs` (`Mock<TimeProvider>` with `.Setup(x => x.GetUtcNow()).Returns(fixedDateTime)`).
+
+**Acceptance criteria:**
+- A test constructs the handler with a mocked `IAnalyticsRepository` and a mocked `TimeProvider` whose `GetUtcNow()` returns a fixed, arbitrary `DateTimeOffset` (e.g. `2025-10-14T10:00:00Z`).
+- A test calls `Handle` with a request that has `EndDate == null` (and, per current default behavior, `StartDate == null` too) and verifies that `IAnalyticsRepository.GetBankStatementImportStatisticsAsync` is invoked with `startDate`/`endDate` derived deterministically from the fixed mocked time (i.e. `endDate == fixedDate`, `startDate == fixedDate.AddDays(-30)`), not from the real wall clock.
+- At least one test also verifies the pass-through behavior when `request.EndDate` (and/or `request.StartDate`) is explicitly supplied, confirming the injected `TimeProvider` is not consulted in that case (mirrors existing sibling-handler test coverage style, e.g. `GetInvoiceImportStatisticsHandlerTests.Handle_ShouldPassCorrectDateTypeToRepository`-style verification via `_mockRepository.Verify(...)`).
+- All new and existing tests in the Analytics test folder pass under `dotnet test`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. `TimeProvider.GetUtcNow()` is a trivial call equivalent in cost to `DateTime.UtcNow`; no additional I/O, allocation of note, or async work is introduced.
+
+### NFR-2: Security
+Not applicable — this change touches only internal date-computation logic and does not affect authentication, authorization, or data exposure. No new external inputs or trust boundaries are introduced.
+
+### NFR-3: Backward compatibility
+The change must be behavior-preserving for all production and existing-test scenarios: given the same wall-clock time, `_timeProvider.GetUtcNow().Date` must produce the same effective date as `DateTime.UtcNow.Date` did (since `TimeProvider.System`, the only production registration, wraps the real system clock). Any existing caller relying on the endpoint's current default-date behavior sees no observable difference in production.
+
+## Data Model
+No data model changes. `GetBankStatementImportStatisticsRequest`, `GetBankStatementImportStatisticsResponse`, and `DailyBankStatementStatistics` are unaffected — this is a pure implementation-detail change inside the handler's constructor and `Handle` method.
+
+## API / Interface Design
+No public API surface changes. The MediatR request/response contract (`GetBankStatementImportStatisticsRequest` → `GetBankStatementImportStatisticsResponse`) and the controller endpoint that dispatches it are untouched. Only the handler's internal constructor dependency list changes (adding `TimeProvider`), which is resolved transparently by the existing DI container — no callers or consumers need to change.
+
+## Dependencies
+- `TimeProvider` (BCL type, .NET 8) — already registered as a singleton (`TimeProvider.System`) in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131`. No new package or registration dependency.
+- Existing `IAnalyticsRepository` dependency is unchanged.
+- Test project already references `Moq` and the `Mock<TimeProvider>` pattern (see `InvoiceImportStatisticsTileTests.cs`), so no new test dependency is required.
+
+## Out of Scope
+- `GetInvoiceImportStatisticsHandler` (tracked separately under issue #3488) — not touched by this change.
+- Any change to the 30-day default window, the `DateTimeKind` normalization logic, or the repository query signature.
+- Any change to `TimeWindowParser` or `InvoiceImportStatisticsTile` — both already follow the correct pattern and serve only as reference implementations here.
+- Any DI registration changes — `TimeProvider.System` registration already exists and is reused as-is.
+- Any frontend changes — the frontend does not pass explicit end dates for this endpoint today, and that is not altered by this fix.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3495",
+  "issue_number": 3495,
+  "created_at": "2026-07-06T09:15:19.509327Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T09:16:21.040171Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T09:18:07.147361Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T09:18:16.672871Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-06T09:18:07.147361Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T09:18:16.672871Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T09:19:46.013222Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T09:20:39.759359Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T09:16:21.040171Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-06T09:20:40.181330Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T09:21:16.400107Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T09:23:09.521533Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "inject-timeprovider-bank-statement-handler",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T09:23:09.521533Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T09:23:39.532956Z"
     }
   },
   "tasks": [
     {
       "name": "inject-timeprovider-bank-statement-handler",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-06T09:23:39.735959Z"
     }
   ]
 }

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-06T09:19:46.013222Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T09:20:39.759359Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T09:20:40.181330Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T09:21:16.400107Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-06T10:27:26.526992Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-06T10:27:32.091017Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3495/state.json
+++ b/artifacts/feat-3495/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T09:23:09.521533Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T09:23:39.532956Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T10:27:26.526992Z"
     }
   },
   "tasks": [
     {
       "name": "inject-timeprovider-bank-statement-handler",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-06T09:23:39.735959Z"
+      "updated_at": "2026-07-06T10:27:20.552222Z"
     }
   ]
 }

--- a/artifacts/feat-3495/task-context/inject-timeprovider-bank-statement-handler.md
+++ b/artifacts/feat-3495/task-context/inject-timeprovider-bank-statement-handler.md
@@ -1,0 +1,254 @@
+### task: inject-timeprovider-bank-statement-handler
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs:9-23`
+- Create: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs` with the following complete content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+  using Anela.Heblo.Domain.Features.Analytics;
+  using FluentAssertions;
+  using Moq;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Features.Analytics;
+
+  public class GetBankStatementImportStatisticsHandlerTests
+  {
+      private readonly Mock<IAnalyticsRepository> _mockRepository;
+      private readonly Mock<TimeProvider> _timeProviderMock;
+      private readonly GetBankStatementImportStatisticsHandler _handler;
+      private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);
+
+      public GetBankStatementImportStatisticsHandlerTests()
+      {
+          _mockRepository = new Mock<IAnalyticsRepository>();
+          _timeProviderMock = new Mock<TimeProvider>();
+          _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
+          _handler = new GetBankStatementImportStatisticsHandler(_mockRepository.Object, _timeProviderMock.Object);
+      }
+
+      [Fact]
+      public async Task Handle_WithNoDatesProvided_UsesInjectedTimeProviderForDefaultRange()
+      {
+          // Arrange
+          var request = new GetBankStatementImportStatisticsRequest();
+          var expectedEndDate = DateTime.SpecifyKind(_fixedDateTime.Date, DateTimeKind.Utc);
+          var expectedStartDate = DateTime.SpecifyKind(_fixedDateTime.Date.AddDays(-30), DateTimeKind.Utc);
+
+          _mockRepository
+              .Setup(r => r.GetBankStatementImportStatisticsAsync(
+                  It.IsAny<DateTime>(),
+                  It.IsAny<DateTime>(),
+                  It.IsAny<BankStatementDateType>(),
+                  It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<DailyBankStatementStatistics>());
+
+          // Act
+          var result = await _handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          result.Should().NotBeNull();
+          result.Success.Should().BeTrue();
+
+          _timeProviderMock.Verify(x => x.GetUtcNow(), Times.Once);
+          _mockRepository.Verify(r => r.GetBankStatementImportStatisticsAsync(
+              expectedStartDate,
+              expectedEndDate,
+              request.DateType,
+              It.IsAny<CancellationToken>()), Times.Once);
+      }
+
+      [Fact]
+      public async Task Handle_WithExplicitDatesProvided_DoesNotConsultTimeProvider()
+      {
+          // Arrange
+          var suppliedStartDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+          var suppliedEndDate = new DateTime(2024, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+          var request = new GetBankStatementImportStatisticsRequest
+          {
+              StartDate = suppliedStartDate,
+              EndDate = suppliedEndDate,
+              DateType = BankStatementDateType.ImportDate
+          };
+
+          _mockRepository
+              .Setup(r => r.GetBankStatementImportStatisticsAsync(
+                  It.IsAny<DateTime>(),
+                  It.IsAny<DateTime>(),
+                  It.IsAny<BankStatementDateType>(),
+                  It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<DailyBankStatementStatistics>());
+
+          // Act
+          var result = await _handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          result.Should().NotBeNull();
+          result.Success.Should().BeTrue();
+
+          _timeProviderMock.Verify(x => x.GetUtcNow(), Times.Never);
+          _mockRepository.Verify(r => r.GetBankStatementImportStatisticsAsync(
+              suppliedStartDate,
+              suppliedEndDate,
+              BankStatementDateType.ImportDate,
+              It.IsAny<CancellationToken>()), Times.Once);
+      }
+  }
+  ```
+
+  This will not compile/pass yet: `GetBankStatementImportStatisticsHandler` does not currently have a constructor overload accepting `TimeProvider`, so `new GetBankStatementImportStatisticsHandler(_mockRepository.Object, _timeProviderMock.Object)` fails to compile against the current single-argument constructor.
+
+- [ ] **Step 2: Confirm the test fails**
+
+  Run:
+  ```
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetBankStatementImportStatisticsHandlerTests"
+  ```
+  Expected outcome: build failure (CS1729 or similar — "does not contain a constructor that takes 2 arguments"), confirming the test currently fails because the production code has not yet been changed.
+
+- [ ] **Step 3: Modify `GetBankStatementImportStatisticsHandler.cs`**
+
+  In `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`, replace lines 9-23:
+
+  ```csharp
+  public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
+  {
+      private readonly IAnalyticsRepository _analyticsRepository;
+
+      public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository)
+      {
+          _analyticsRepository = analyticsRepository;
+      }
+
+      public async Task<GetBankStatementImportStatisticsResponse> Handle(
+          GetBankStatementImportStatisticsRequest request,
+          CancellationToken cancellationToken)
+      {
+          // Set default date range if not provided (last 30 days)
+          var endDate = request.EndDate ?? DateTime.UtcNow.Date;
+  ```
+
+  with:
+
+  ```csharp
+  public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
+  {
+      private readonly IAnalyticsRepository _analyticsRepository;
+      private readonly TimeProvider _timeProvider;
+
+      public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository, TimeProvider timeProvider)
+      {
+          _analyticsRepository = analyticsRepository;
+          _timeProvider = timeProvider;
+      }
+
+      public async Task<GetBankStatementImportStatisticsResponse> Handle(
+          GetBankStatementImportStatisticsRequest request,
+          CancellationToken cancellationToken)
+      {
+          // Set default date range if not provided (last 30 days)
+          var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date;
+  ```
+
+  The rest of the file (lines 24-44: `startDate` derivation, the `DateTimeKind` normalization block, the repository call, and the response construction) remains exactly as-is — no other lines change. The full resulting file is:
+
+  ```csharp
+  using Anela.Heblo.Domain.Features.Analytics;
+  using MediatR;
+
+  namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+
+  /// <summary>
+  /// Handler for getting bank statement import statistics for monitoring purposes
+  /// </summary>
+  public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
+  {
+      private readonly IAnalyticsRepository _analyticsRepository;
+      private readonly TimeProvider _timeProvider;
+
+      public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository, TimeProvider timeProvider)
+      {
+          _analyticsRepository = analyticsRepository;
+          _timeProvider = timeProvider;
+      }
+
+      public async Task<GetBankStatementImportStatisticsResponse> Handle(
+          GetBankStatementImportStatisticsRequest request,
+          CancellationToken cancellationToken)
+      {
+          // Set default date range if not provided (last 30 days)
+          var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date;
+          var startDate = request.StartDate ?? endDate.AddDays(-30);
+
+          // Ensure dates are UTC for consistency
+          if (startDate.Kind != DateTimeKind.Utc)
+              startDate = DateTime.SpecifyKind(startDate.Date, DateTimeKind.Utc);
+          if (endDate.Kind != DateTimeKind.Utc)
+              endDate = DateTime.SpecifyKind(endDate.Date, DateTimeKind.Utc);
+
+          // Get daily bank statement statistics from repository
+          var dailyStatistics = await _analyticsRepository.GetBankStatementImportStatisticsAsync(
+              startDate,
+              endDate,
+              request.DateType,
+              cancellationToken);
+
+          return new GetBankStatementImportStatisticsResponse
+          {
+              Statistics = dailyStatistics
+          };
+      }
+  }
+  ```
+
+- [ ] **Step 4: Confirm the tests pass**
+
+  Run:
+  ```
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetBankStatementImportStatisticsHandlerTests"
+  ```
+  Expected outcome: both `Handle_WithNoDatesProvided_UsesInjectedTimeProviderForDefaultRange` and `Handle_WithExplicitDatesProvided_DoesNotConsultTimeProvider` pass.
+
+  Also run the full Analytics test folder to confirm no regressions among sibling tests (e.g. `GetInvoiceImportStatisticsHandlerTests`, `InvoiceImportStatisticsTileTests`):
+  ```
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Analytics"
+  ```
+
+- [ ] **Step 5: Final validation**
+
+  Run, from `backend/`:
+  ```
+  dotnet build
+  dotnet format
+  ```
+  Confirm `dotnet build` succeeds with no new errors/warnings, and `dotnet format` reports no unformatted files (or applies only whitespace formatting with no semantic changes) in the two touched files.
+
+- [ ] **Step 6: Commit**
+
+  Stage exactly the two touched files and commit:
+  ```
+  git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs
+  git commit -m "Inject TimeProvider into GetBankStatementImportStatisticsHandler
+
+  Replaces the direct DateTime.UtcNow.Date call with the module's
+  standard injected TimeProvider abstraction, matching the pattern
+  already used by InvoiceImportStatisticsTile and TimeWindowParser.
+  No behavior change in production; adds unit test coverage for the
+  default-date branch.
+
+  Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+  ```
+
+## Spec Coverage Self-Review
+
+- FR-1 (constructor takes `TimeProvider`, private readonly field, no DI registration changes) — covered by Step 3; DI registration untouched (no changes made to `ServiceCollectionExtensions.cs`).
+- FR-2 (line 23 default-date swap only, `DateTimeKind` normalization and `startDate` derivation untouched) — covered by Step 3; diff is limited to the constructor and the single `endDate` assignment line.
+- FR-3 (new test file, `Mock<TimeProvider>` pattern, fixed-date + pass-through test cases, all Analytics tests pass) — covered by Step 1 (test creation) and Step 4 (running the new tests plus the full Analytics folder).
+- NFR-1/NFR-2/NFR-3 (no perf/security impact, behavior-preserving in production) — no additional code introduced beyond the swap; `TimeProvider.System` wraps the real clock, so production behavior is identical.
+- Data Model / API sections (no changes) — confirmed no changes made to `GetBankStatementImportStatisticsRequest`, `GetBankStatementImportStatisticsResponse`, `DailyBankStatementStatistics`, or the controller.
+- Out of Scope items (`GetInvoiceImportStatisticsHandler`, 30-day window, normalization logic, repository signature, `TimeWindowParser`/`InvoiceImportStatisticsTile`, DI registration, frontend) — none touched by this plan.

--- a/artifacts/feat-3495/task-plan.r1.md
+++ b/artifacts/feat-3495/task-plan.r1.md
@@ -1,0 +1,274 @@
+# Task Plan: Inject `TimeProvider` into `GetBankStatementImportStatisticsHandler`
+
+## Feature Name
+Inject `TimeProvider` into `GetBankStatementImportStatisticsHandler`
+
+## Goal
+Replace the direct `DateTime.UtcNow.Date` call in `GetBankStatementImportStatisticsHandler.Handle` with the module's standard injected `TimeProvider` abstraction (`_timeProvider.GetUtcNow().Date`), matching the pattern already used by `InvoiceImportStatisticsTile` and `TimeWindowParser`. This is a testability/consistency-only change — no production behavior change, no DI registration change (the `TimeProvider.System` singleton is already registered), no API/contract change. Add unit test coverage proving the default-date branch is now deterministically testable.
+
+## Architecture
+- `GetBankStatementImportStatisticsHandler` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`) implements `IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>`.
+- Currently depends only on `IAnalyticsRepository`. Gains a second constructor dependency: `TimeProvider` (BCL, .NET 8), resolved automatically by the DI container from the existing `services.AddSingleton(TimeProvider.System)` registration in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131`. No registration changes needed.
+- `request.EndDate ?? DateTime.UtcNow.Date` becomes `request.EndDate ?? _timeProvider.GetUtcNow().Date`. Everything else in `Handle` (the `startDate` derivation, the `DateTimeKind` normalization block, the repository call, the response construction) is untouched.
+- New test file `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs` follows the `Mock<TimeProvider>` pattern from `backend/test/Anela.Heblo.Tests/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTileTests.cs`.
+
+## Tech Stack
+- .NET 8, MediatR, xUnit, Moq, FluentAssertions (available in the test project; plain xUnit `Assert` is also used elsewhere in the same folder — either is acceptable, this plan uses FluentAssertions to match the closer `InvoiceImportStatisticsTileTests.cs` template).
+- BCL `TimeProvider` / `Mock<TimeProvider>`.
+
+---
+
+### task: inject-timeprovider-bank-statement-handler
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs:9-23`
+- Create: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs` with the following complete content:
+
+  ```csharp
+  using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+  using Anela.Heblo.Domain.Features.Analytics;
+  using FluentAssertions;
+  using Moq;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Features.Analytics;
+
+  public class GetBankStatementImportStatisticsHandlerTests
+  {
+      private readonly Mock<IAnalyticsRepository> _mockRepository;
+      private readonly Mock<TimeProvider> _timeProviderMock;
+      private readonly GetBankStatementImportStatisticsHandler _handler;
+      private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);
+
+      public GetBankStatementImportStatisticsHandlerTests()
+      {
+          _mockRepository = new Mock<IAnalyticsRepository>();
+          _timeProviderMock = new Mock<TimeProvider>();
+          _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
+          _handler = new GetBankStatementImportStatisticsHandler(_mockRepository.Object, _timeProviderMock.Object);
+      }
+
+      [Fact]
+      public async Task Handle_WithNoDatesProvided_UsesInjectedTimeProviderForDefaultRange()
+      {
+          // Arrange
+          var request = new GetBankStatementImportStatisticsRequest();
+          var expectedEndDate = DateTime.SpecifyKind(_fixedDateTime.Date, DateTimeKind.Utc);
+          var expectedStartDate = DateTime.SpecifyKind(_fixedDateTime.Date.AddDays(-30), DateTimeKind.Utc);
+
+          _mockRepository
+              .Setup(r => r.GetBankStatementImportStatisticsAsync(
+                  It.IsAny<DateTime>(),
+                  It.IsAny<DateTime>(),
+                  It.IsAny<BankStatementDateType>(),
+                  It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<DailyBankStatementStatistics>());
+
+          // Act
+          var result = await _handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          result.Should().NotBeNull();
+          result.Success.Should().BeTrue();
+
+          _timeProviderMock.Verify(x => x.GetUtcNow(), Times.Once);
+          _mockRepository.Verify(r => r.GetBankStatementImportStatisticsAsync(
+              expectedStartDate,
+              expectedEndDate,
+              request.DateType,
+              It.IsAny<CancellationToken>()), Times.Once);
+      }
+
+      [Fact]
+      public async Task Handle_WithExplicitDatesProvided_DoesNotConsultTimeProvider()
+      {
+          // Arrange
+          var suppliedStartDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+          var suppliedEndDate = new DateTime(2024, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+          var request = new GetBankStatementImportStatisticsRequest
+          {
+              StartDate = suppliedStartDate,
+              EndDate = suppliedEndDate,
+              DateType = BankStatementDateType.ImportDate
+          };
+
+          _mockRepository
+              .Setup(r => r.GetBankStatementImportStatisticsAsync(
+                  It.IsAny<DateTime>(),
+                  It.IsAny<DateTime>(),
+                  It.IsAny<BankStatementDateType>(),
+                  It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new List<DailyBankStatementStatistics>());
+
+          // Act
+          var result = await _handler.Handle(request, CancellationToken.None);
+
+          // Assert
+          result.Should().NotBeNull();
+          result.Success.Should().BeTrue();
+
+          _timeProviderMock.Verify(x => x.GetUtcNow(), Times.Never);
+          _mockRepository.Verify(r => r.GetBankStatementImportStatisticsAsync(
+              suppliedStartDate,
+              suppliedEndDate,
+              BankStatementDateType.ImportDate,
+              It.IsAny<CancellationToken>()), Times.Once);
+      }
+  }
+  ```
+
+  This will not compile/pass yet: `GetBankStatementImportStatisticsHandler` does not currently have a constructor overload accepting `TimeProvider`, so `new GetBankStatementImportStatisticsHandler(_mockRepository.Object, _timeProviderMock.Object)` fails to compile against the current single-argument constructor.
+
+- [ ] **Step 2: Confirm the test fails**
+
+  Run:
+  ```
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetBankStatementImportStatisticsHandlerTests"
+  ```
+  Expected outcome: build failure (CS1729 or similar — "does not contain a constructor that takes 2 arguments"), confirming the test currently fails because the production code has not yet been changed.
+
+- [ ] **Step 3: Modify `GetBankStatementImportStatisticsHandler.cs`**
+
+  In `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`, replace lines 9-23:
+
+  ```csharp
+  public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
+  {
+      private readonly IAnalyticsRepository _analyticsRepository;
+
+      public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository)
+      {
+          _analyticsRepository = analyticsRepository;
+      }
+
+      public async Task<GetBankStatementImportStatisticsResponse> Handle(
+          GetBankStatementImportStatisticsRequest request,
+          CancellationToken cancellationToken)
+      {
+          // Set default date range if not provided (last 30 days)
+          var endDate = request.EndDate ?? DateTime.UtcNow.Date;
+  ```
+
+  with:
+
+  ```csharp
+  public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
+  {
+      private readonly IAnalyticsRepository _analyticsRepository;
+      private readonly TimeProvider _timeProvider;
+
+      public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository, TimeProvider timeProvider)
+      {
+          _analyticsRepository = analyticsRepository;
+          _timeProvider = timeProvider;
+      }
+
+      public async Task<GetBankStatementImportStatisticsResponse> Handle(
+          GetBankStatementImportStatisticsRequest request,
+          CancellationToken cancellationToken)
+      {
+          // Set default date range if not provided (last 30 days)
+          var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date;
+  ```
+
+  The rest of the file (lines 24-44: `startDate` derivation, the `DateTimeKind` normalization block, the repository call, and the response construction) remains exactly as-is — no other lines change. The full resulting file is:
+
+  ```csharp
+  using Anela.Heblo.Domain.Features.Analytics;
+  using MediatR;
+
+  namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+
+  /// <summary>
+  /// Handler for getting bank statement import statistics for monitoring purposes
+  /// </summary>
+  public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
+  {
+      private readonly IAnalyticsRepository _analyticsRepository;
+      private readonly TimeProvider _timeProvider;
+
+      public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository, TimeProvider timeProvider)
+      {
+          _analyticsRepository = analyticsRepository;
+          _timeProvider = timeProvider;
+      }
+
+      public async Task<GetBankStatementImportStatisticsResponse> Handle(
+          GetBankStatementImportStatisticsRequest request,
+          CancellationToken cancellationToken)
+      {
+          // Set default date range if not provided (last 30 days)
+          var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date;
+          var startDate = request.StartDate ?? endDate.AddDays(-30);
+
+          // Ensure dates are UTC for consistency
+          if (startDate.Kind != DateTimeKind.Utc)
+              startDate = DateTime.SpecifyKind(startDate.Date, DateTimeKind.Utc);
+          if (endDate.Kind != DateTimeKind.Utc)
+              endDate = DateTime.SpecifyKind(endDate.Date, DateTimeKind.Utc);
+
+          // Get daily bank statement statistics from repository
+          var dailyStatistics = await _analyticsRepository.GetBankStatementImportStatisticsAsync(
+              startDate,
+              endDate,
+              request.DateType,
+              cancellationToken);
+
+          return new GetBankStatementImportStatisticsResponse
+          {
+              Statistics = dailyStatistics
+          };
+      }
+  }
+  ```
+
+- [ ] **Step 4: Confirm the tests pass**
+
+  Run:
+  ```
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetBankStatementImportStatisticsHandlerTests"
+  ```
+  Expected outcome: both `Handle_WithNoDatesProvided_UsesInjectedTimeProviderForDefaultRange` and `Handle_WithExplicitDatesProvided_DoesNotConsultTimeProvider` pass.
+
+  Also run the full Analytics test folder to confirm no regressions among sibling tests (e.g. `GetInvoiceImportStatisticsHandlerTests`, `InvoiceImportStatisticsTileTests`):
+  ```
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Analytics"
+  ```
+
+- [ ] **Step 5: Final validation**
+
+  Run, from `backend/`:
+  ```
+  dotnet build
+  dotnet format
+  ```
+  Confirm `dotnet build` succeeds with no new errors/warnings, and `dotnet format` reports no unformatted files (or applies only whitespace formatting with no semantic changes) in the two touched files.
+
+- [ ] **Step 6: Commit**
+
+  Stage exactly the two touched files and commit:
+  ```
+  git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs
+  git commit -m "Inject TimeProvider into GetBankStatementImportStatisticsHandler
+
+  Replaces the direct DateTime.UtcNow.Date call with the module's
+  standard injected TimeProvider abstraction, matching the pattern
+  already used by InvoiceImportStatisticsTile and TimeWindowParser.
+  No behavior change in production; adds unit test coverage for the
+  default-date branch.
+
+  Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+  ```
+
+## Spec Coverage Self-Review
+
+- FR-1 (constructor takes `TimeProvider`, private readonly field, no DI registration changes) — covered by Step 3; DI registration untouched (no changes made to `ServiceCollectionExtensions.cs`).
+- FR-2 (line 23 default-date swap only, `DateTimeKind` normalization and `startDate` derivation untouched) — covered by Step 3; diff is limited to the constructor and the single `endDate` assignment line.
+- FR-3 (new test file, `Mock<TimeProvider>` pattern, fixed-date + pass-through test cases, all Analytics tests pass) — covered by Step 1 (test creation) and Step 4 (running the new tests plus the full Analytics folder).
+- NFR-1/NFR-2/NFR-3 (no perf/security impact, behavior-preserving in production) — no additional code introduced beyond the swap; `TimeProvider.System` wraps the real clock, so production behavior is identical.
+- Data Model / API sections (no changes) — confirmed no changes made to `GetBankStatementImportStatisticsRequest`, `GetBankStatementImportStatisticsResponse`, `DailyBankStatementStatistics`, or the controller.
+- Out of Scope items (`GetInvoiceImportStatisticsHandler`, 30-day window, normalization logic, repository signature, `TimeWindowParser`/`InvoiceImportStatisticsTile`, DI registration, frontend) — none touched by this plan.

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs
@@ -9,10 +9,12 @@ namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementIm
 public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankStatementImportStatisticsRequest, GetBankStatementImportStatisticsResponse>
 {
     private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly TimeProvider _timeProvider;
 
-    public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository)
+    public GetBankStatementImportStatisticsHandler(IAnalyticsRepository analyticsRepository, TimeProvider timeProvider)
     {
         _analyticsRepository = analyticsRepository;
+        _timeProvider = timeProvider;
     }
 
     public async Task<GetBankStatementImportStatisticsResponse> Handle(
@@ -20,7 +22,7 @@ public class GetBankStatementImportStatisticsHandler : IRequestHandler<GetBankSt
         CancellationToken cancellationToken)
     {
         // Set default date range if not provided (last 30 days)
-        var endDate = request.EndDate ?? DateTime.UtcNow.Date;
+        var endDate = request.EndDate ?? _timeProvider.GetUtcNow().Date;
         var startDate = request.StartDate ?? endDate.AddDays(-30);
 
         // Ensure dates are UTC for consistency

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetBankStatementImportStatisticsHandlerTests.cs
@@ -1,0 +1,90 @@
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+using Anela.Heblo.Domain.Features.Analytics;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+public class GetBankStatementImportStatisticsHandlerTests
+{
+    private readonly Mock<IAnalyticsRepository> _mockRepository;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly GetBankStatementImportStatisticsHandler _handler;
+    private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);
+
+    public GetBankStatementImportStatisticsHandlerTests()
+    {
+        _mockRepository = new Mock<IAnalyticsRepository>();
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
+        _handler = new GetBankStatementImportStatisticsHandler(_mockRepository.Object, _timeProviderMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithNoDatesProvided_UsesInjectedTimeProviderForDefaultRange()
+    {
+        // Arrange
+        var request = new GetBankStatementImportStatisticsRequest();
+        var expectedEndDate = DateTime.SpecifyKind(_fixedDateTime.Date, DateTimeKind.Utc);
+        var expectedStartDate = DateTime.SpecifyKind(_fixedDateTime.Date.AddDays(-30), DateTimeKind.Utc);
+
+        _mockRepository
+            .Setup(r => r.GetBankStatementImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<BankStatementDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DailyBankStatementStatistics>());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+
+        _timeProviderMock.Verify(x => x.GetUtcNow(), Times.Once);
+        _mockRepository.Verify(r => r.GetBankStatementImportStatisticsAsync(
+            expectedStartDate,
+            expectedEndDate,
+            request.DateType,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithExplicitDatesProvided_DoesNotConsultTimeProvider()
+    {
+        // Arrange
+        var suppliedStartDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var suppliedEndDate = new DateTime(2024, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+        var request = new GetBankStatementImportStatisticsRequest
+        {
+            StartDate = suppliedStartDate,
+            EndDate = suppliedEndDate,
+            DateType = BankStatementDateType.ImportDate
+        };
+
+        _mockRepository
+            .Setup(r => r.GetBankStatementImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<BankStatementDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DailyBankStatementStatistics>());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+
+        _timeProviderMock.Verify(x => x.GetUtcNow(), Times.Never);
+        _mockRepository.Verify(r => r.GetBankStatementImportStatisticsAsync(
+            suppliedStartDate,
+            suppliedEndDate,
+            BankStatementDateType.ImportDate,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #3495

## What the issue was
`GetBankStatementImportStatisticsHandler` computed its default end-date by calling `DateTime.UtcNow.Date` directly, unlike its sibling module code (`InvoiceImportStatisticsTile`, `TimeWindowParser`) which already inject `TimeProvider`. Since the frontend doesn't pass an explicit end date for this endpoint, the `DateTime.UtcNow.Date` fallback was the common real-world path — but it was untestable without a time-freezing shim, and inconsistent with the module's established pattern.

## How it was fixed / handled
- Injected `TimeProvider` into `GetBankStatementImportStatisticsHandler`'s constructor (no DI registration change needed — `TimeProvider.System` is already registered as a singleton in `ServiceCollectionExtensions.cs`).
- Replaced `request.EndDate ?? DateTime.UtcNow.Date` with `request.EndDate ?? _timeProvider.GetUtcNow().Date`. No other line in the handler changed — behavior is identical in production.
- Added `GetBankStatementImportStatisticsHandlerTests.cs` (no test file existed for this handler before), covering the default-date branch via a mocked fixed `TimeProvider`, and the explicit-date pass-through path confirming the provider is not consulted when dates are supplied.
- Verified: the new tests pass, the full `Features.Analytics` test folder (99 tests) passes with no regressions, and `dotnet build`/`dotnet format` are clean.

## Artifacts
Full pipeline artifacts (brief, spec, architecture review, design, task plan, implementation summary, review, whole-branch code review) are committed under `artifacts/feat-3495/` on this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01VQnPmHvH3q55kuzM86STaU)_