### PR TITLE
#3496: implementation

### DIFF
--- a/artifacts/feat-3496/arch-review.r1.md
+++ b/artifacts/feat-3496/arch-review.r1.md
@@ -1,0 +1,95 @@
+# Architecture Review: Extract duplicated `HasSalesInPeriod` logic into a shared `AnalyticsProduct` extension
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a textbook-clean refactor with an exact precedent already in the codebase. Verified against actual source:
+
+- `GetMarginReportHandler.cs:125-128` and `GetProductMarginAnalysisHandler.cs:71-74` both define `private static bool HasSalesInPeriod(...)` with an identical body (`product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate)`), differing only in parameter name (`product` vs `productData`). Call sites are `GetMarginReportHandler.cs:95` and `GetProductMarginAnalysisHandler.cs:51`, exactly as the spec states.
+- `AnalyticsProduct` and `SalesDataPoint` (`backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs`) are plain, behavior-free data classes populated by the repository layer — no EF mapping, no persistence concerns, no invariants to protect. Attaching a pure, stateless predicate to them via an extension method is a natural fit, not a stretch.
+- The Domain layer already has exactly this pattern in three places: `CarrierExtensions.cs` (Logistics), `CurrentUserExtensions.cs` (Users), `ManufactureOrderExtensions.cs` (Manufacture) — all static `{Entity}Extensions` classes co-located with the entity they extend, in the entity's own feature namespace. `AnalyticsProductExtensions` in `Domain/Features/Analytics/` is consistent with this established convention, not a new one.
+- Both handlers already `using Anela.Heblo.Domain.Features.Analytics;` and already reference `AnalyticsProduct` by its Domain-layer type, so no new project reference or using statement beyond what's already present is required (Application → Domain dependency already exists per `docs/architecture/filesystem.md`'s layering).
+- The Analytics module's existing "extract shared logic into a named service" pattern (`IMarginCalculator`, `IProductFilterService`, `IReportBuilderService`) is Application-layer and DI-injected — appropriate for logic with dependencies or that needs mocking in isolation. `HasSalesInPeriod` has neither: it's a pure, dependency-free one-liner over data already in memory. Promoting it to an injectable service would be over-engineering for a boolean predicate; a Domain extension method is the right-sized abstraction, matching the spec's explicit choice (see Out of Scope) and the codebase's own precedent for this exact shape of logic.
+
+No conflicts with `development_guidelines.md`: this introduces no new DTO (the DTO-classes-not-records rule doesn't apply — `AnalyticsProductExtensions` is a static method container, not a data-transfer type), no new module boundary crossing, no new controller/API surface, and no persistence change.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Domain
+└── Features/Analytics/
+    ├── AnalyticsProduct.cs                 (existing, unchanged)
+    └── AnalyticsProductExtensions.cs        (NEW — static extension class)
+
+Anela.Heblo.Application
+└── Features/Analytics/UseCases/
+    ├── GetMarginReport/GetMarginReportHandler.cs
+    │     — private HasSalesInPeriod REMOVED, call site now `product.HasSalesInPeriod(startDate, endDate)`
+    └── GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs
+          — private HasSalesInPeriod REMOVED, call site now `productData.HasSalesInPeriod(request.StartDate, request.EndDate)`
+```
+
+No new dependency edges are introduced: Application already depends on Domain (that's where `AnalyticsProduct` itself lives). This is purely a "move a method one layer down and rename its call sites" change.
+
+### Key Design Decisions
+
+#### Decision 1: Static Domain extension method vs. injectable Application service
+**Options considered:**
+1. Static extension method on `AnalyticsProduct` in Domain (as specced).
+2. New injectable service (`ISalesPeriodChecker` or folded into `IMarginCalculator`/`IProductFilterService`), following the module's DI-service pattern.
+3. Instance method directly on `AnalyticsProduct` (`product.HasSalesInPeriod(...)` as a member, not an extension).
+
+**Chosen approach:** Option 1, per spec.
+
+**Rationale:** The logic is pure, stateless, and has zero dependencies (no repository, no config, no logging) — nothing to inject or mock. Options 2 would add DI ceremony and a test double for a one-line predicate, which is disproportionate and inconsistent with how trivial extensions are already handled elsewhere (`CarrierExtensions`, `CurrentUserExtensions`, `ManufactureOrderExtensions` are all static, non-DI). Option 3 (instance method) is rejected because `AnalyticsProduct` is explicitly documented as a "lightweight … model" built by the repository for read purposes (see its XML doc comment); keeping query/filter behavior as extension methods rather than instance methods keeps the entity itself a narrow data holder, matching the existing convention where behavior is layered on via `*Extensions` rather than added directly to the class body.
+
+#### Decision 2: Placement — Domain layer vs. Application-layer shared helper
+**Options considered:**
+1. `Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs` (Domain layer, as specced).
+2. A shared static helper class in `Anela.Heblo.Application/Features/Analytics/` (e.g. under a `Shared/` or `Services/` folder), since both consuming handlers are Application-layer.
+
+**Chosen approach:** Option 1, per spec.
+
+**Rationale:** The method operates exclusively on `AnalyticsProduct`/`SalesDataPoint`, both Domain types, with no Application-layer dependency (no MediatR, no contracts, no repository). Clean Architecture places entity-scoped behavior with the entity's layer whenever it doesn't need outer-ring services — this is exactly the precedent set by `ManufactureOrderExtensions` (extends `ManufactureOrder`/`ManufactureOrderProduct`, lives in `Domain/Features/Manufacture/`) and `CarrierExtensions`. Placing it in Application would create an inconsistency the next reviewer would have to explain, for no benefit.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+- **New file:** `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs` — single `public static class AnalyticsProductExtensions` containing only `HasSalesInPeriod`. No new folder needed.
+- **No `{Feature}Module.cs` change** — static extension methods require no DI registration.
+- **No new test project/module** — this stays inside the existing `Anela.Heblo.Domain`/`Anela.Heblo.Application` structure.
+
+### Interfaces and Contracts
+- New public surface (exact signature, per spec):
+  ```csharp
+  namespace Anela.Heblo.Domain.Features.Analytics;
+
+  public static class AnalyticsProductExtensions
+  {
+      public static bool HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)
+          => product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+  }
+  ```
+- `GetMarginReportHandler.cs`: delete the `private static bool HasSalesInPeriod(...)` method at lines 125-128; change the call at line 95 from `HasSalesInPeriod(product, startDate, endDate)` to `product.HasSalesInPeriod(startDate, endDate)`.
+- `GetProductMarginAnalysisHandler.cs`: delete the `private static bool HasSalesInPeriod(...)` method at lines 71-74; change the call at line 51 from `HasSalesInPeriod(productData, request.StartDate, request.EndDate)` to `productData.HasSalesInPeriod(request.StartDate, request.EndDate)`.
+- Both files already have `using Anela.Heblo.Domain.Features.Analytics;` (confirmed at line 5 of `GetMarginReportHandler.cs` and line 4 of `GetProductMarginAnalysisHandler.cs`) — no using-statement changes needed.
+- No changes to any MediatR `Request`/`Response` DTO, no changes to `IMarginCalculator`, `IProductFilterService`, `IReportBuilderService`, or any other interface.
+
+### Data Flow
+Unchanged. `IAnalyticsRepository` still builds `AnalyticsProduct` instances (with pre-filtered `SalesHistory`); handlers still call the period check before proceeding to margin calculation. The only change is *where* the check's implementation is defined and *how* it's invoked (extension-method syntax on the Domain type instead of a handler-private static method) — the runtime call graph and IL are effectively identical (C# extension methods compile to ordinary static method calls).
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Accidental behavior drift while moving the method (e.g., swapping `>=`/`<=` for `>`/`<`) | Low | Copy the body verbatim as specified in FR-1; rely on the existing handler test suites (`GetMarginReportHandlerTests.cs`, `GetProductMarginAnalysisHandlerTests.cs`) to catch any regression — they exercise boundary dates indirectly and must pass unmodified. |
+| Leaving a stray unused `using` or now-unreachable helper class member behind after deleting the private methods | Low | `dotnet build`/`dotnet format` (required by this repo's validation step) will flag unused usings/dead code; verify no other private members in either handler referenced only by the deleted method. |
+| Namespace collision / ambiguity between `Anela.Heblo.Domain.Features.Analytics.AnalyticsProduct` and any Application-layer type of the same short name | Very Low | Not applicable here — both handlers already fully qualify or alias `AnalyticsProduct` from the Domain namespace today; no new ambiguity is introduced. |
+
+## Specification Amendments
+None. The spec is precise, fully verified against the current source (file paths, line numbers, and method bodies all match exactly), and requires no architectural correction. The extension-class-in-Domain pattern it specifies is not just reasonable but already the established convention in this codebase (`CarrierExtensions`, `CurrentUserExtensions`, `ManufactureOrderExtensions`), which strengthens confidence this is a safe, idiomatic move.
+
+## Prerequisites
+None. No migrations, no config, no new infrastructure, no DI wiring. Implementation can start immediately: add the new Domain file, then update the two handlers in the same change.

--- a/artifacts/feat-3496/brief.md
+++ b/artifacts/feat-3496/brief.md
@@ -1,0 +1,49 @@
+## Module
+Analytics
+
+## Finding
+The private static method `HasSalesInPeriod` is copy-pasted identically into two handlers:
+
+**`GetMarginReportHandler.cs:125-128`**
+```csharp
+private static bool HasSalesInPeriod(Domain.Features.Analytics.AnalyticsProduct product, DateTime startDate, DateTime endDate)
+{
+    return product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+}
+```
+
+**`GetProductMarginAnalysisHandler.cs:71-74`**
+```csharp
+private static bool HasSalesInPeriod(AnalyticsProduct productData, DateTime startDate, DateTime endDate)
+{
+    return productData.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+}
+```
+
+The method bodies are bit-for-bit identical. The only difference is the parameter name (`product` vs `productData`).
+
+## Why it matters
+If the date-range semantics ever change (e.g., exclusive end date, UTC normalisation), the fix must be applied in two places. Because both methods are private, the duplication is invisible to consumers and easy to miss in a PR review. It is also inconsistent with the module's pattern of extracting shared logic into named services (`IMarginCalculator`, `IProductFilterService`, etc.).
+
+## Suggested fix
+Add an extension method on `AnalyticsProduct` in the Domain layer (or as a static helper in the Analytics application layer):
+
+```csharp
+// Domain/Features/Analytics/AnalyticsProductExtensions.cs
+public static class AnalyticsProductExtensions
+{
+    public static bool HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)
+        => product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+}
+```
+
+Both handlers then become:
+```csharp
+if (!product.HasSalesInPeriod(startDate, endDate))
+    continue; // or return error
+```
+
+No behaviour change; one canonical implementation.
+
+---
+_Filed by daily arch-review routine on 2026-07-06._

--- a/artifacts/feat-3496/code-review.r1.md
+++ b/artifacts/feat-3496/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3496/design.r1.md
+++ b/artifacts/feat-3496/design.r1.md
@@ -1,0 +1,42 @@
+# Design: Extract duplicated `HasSalesInPeriod` logic into a shared `AnalyticsProduct` extension
+
+## Component Design
+
+### `AnalyticsProductExtensions` (new — Domain layer)
+- **File:** `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs`
+- **Namespace:** `Anela.Heblo.Domain.Features.Analytics`
+- **Responsibility:** Single canonical, stateless predicate for whether an `AnalyticsProduct` has any sales activity within an inclusive date range. Co-located with `AnalyticsProduct.cs`, following the existing `{Entity}Extensions` convention already used by `CarrierExtensions`, `CurrentUserExtensions`, and `ManufactureOrderExtensions`.
+- **Interface:**
+  ```csharp
+  public static class AnalyticsProductExtensions
+  {
+      public static bool HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)
+          => product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+  }
+  ```
+- **Contract:** Pure function, no side effects, no dependencies (no repository, no config, no logging). Given `product.SalesHistory`, returns `true` if at least one `SalesDataPoint.Date` falls within `[startDate, endDate]` inclusive; `false` otherwise (including when `SalesHistory` is empty). Logically identical to the two existing private implementations being replaced — no change to comparison operators or date normalization.
+
+### `GetMarginReportHandler` (Application layer — modified)
+- **File:** `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+- **Change:** Remove the private `static bool HasSalesInPeriod(...)` method (lines 125-128). `ProcessProductsForReport` now calls `product.HasSalesInPeriod(startDate, endDate)` (extension-method syntax) at the existing call site (line 95) instead of the removed private method.
+- **Dependency:** Consumes `AnalyticsProductExtensions` via the existing `using Anela.Heblo.Domain.Features.Analytics;` import — no new using statement or project reference required.
+
+### `GetProductMarginAnalysisHandler` (Application layer — modified)
+- **File:** `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`
+- **Change:** Remove the private `static bool HasSalesInPeriod(...)` method (lines 71-74). `Handle` now calls `productData.HasSalesInPeriod(request.StartDate, request.EndDate)` (extension-method syntax) at the existing call site (line 51) instead of the removed private method.
+- **Dependency:** Same as above — existing `using Anela.Heblo.Domain.Features.Analytics;` import already brings the extension method into scope.
+
+### Unaffected components
+`IMarginCalculator`, `IProductFilterService`, `IReportBuilderService`, `IAnalyticsRepository`, and all MediatR request/response contracts are unchanged. No DI registration is needed for the new static extension class.
+
+## Data Schemas
+
+No data model, database schema, or API request/response shape changes.
+
+- `AnalyticsProduct` and `SalesDataPoint` (`backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs`) are unmodified.
+- No changes to `GetMarginReportRequest` / `GetMarginReportResponse` or `GetProductMarginAnalysisRequest` / `GetProductMarginAnalysisResponse`.
+- New public surface is limited to the method signature below (Domain project); no DTO or wire-format is introduced:
+  ```
+  Anela.Heblo.Domain.Features.Analytics.AnalyticsProductExtensions
+      .HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate) : bool
+  ```

--- a/artifacts/feat-3496/impl/extract-has-sales-in-period-extension.r1.md
+++ b/artifacts/feat-3496/impl/extract-has-sales-in-period-extension.r1.md
@@ -1,0 +1,40 @@
+# Implementation: extract-has-sales-in-period-extension
+
+## What was implemented
+Extracted the duplicated private `HasSalesInPeriod` method from `GetMarginReportHandler` and `GetProductMarginAnalysisHandler` into a single public extension method `AnalyticsProductExtensions.HasSalesInPeriod` on `AnalyticsProduct`, in the Domain layer, following the existing `*Extensions` convention (`CarrierExtensions`, `CurrentUserExtensions`, `ManufactureOrderExtensions`). Both handlers now call `product.HasSalesInPeriod(...)` via extension-method syntax and no longer define their own copy of the check. No behavior change — the body is logically identical to both removed private methods.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs` — new file, single static extension method `HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)`.
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs` — new file, 7 unit tests covering in-range, boundary (start/end inclusive), before-range, after-range, empty history, and mixed-history cases.
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs` — call site updated to `product.HasSalesInPeriod(startDate, endDate)`; private `HasSalesInPeriod` method removed.
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs` — call site updated to `productData.HasSalesInPeriod(request.StartDate, request.EndDate)`; private `HasSalesInPeriod` method removed.
+
+## Tests
+- `AnalyticsProductExtensionsTests` (7 new tests) — exercises the extension method directly, including both inclusive boundaries.
+- `GetMarginReportHandlerTests` and `GetProductMarginAnalysisHandlerTests` — existing tests, unmodified, still pass (confirms no behavior regression from the refactor).
+
+## How to verify
+```bash
+cd backend
+dotnet build Anela.Heblo.sln
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Analytics"
+dotnet format Anela.Heblo.sln --verify-no-changes
+```
+Build succeeds with 0 errors (pre-existing unrelated warnings only). All 104 tests under `Features.Analytics` pass, including the 7 new extension tests. `dotnet format --verify-no-changes` reports no changes needed.
+
+## Notes
+No deviations from the task plan. No `using` statement changes were needed in either handler — both already imported `Anela.Heblo.Domain.Features.Analytics`.
+
+## PR Summary
+Two handlers in the Analytics module (`GetMarginReportHandler` and `GetProductMarginAnalysisHandler`) each defined a bit-for-bit identical private `HasSalesInPeriod` method, differing only in a parameter name. This duplication was invisible to any consumer (both methods were private) and risked silent divergence if date-range semantics ever changed in one handler but not the other.
+
+The fix extracts the shared logic into a new `AnalyticsProductExtensions.HasSalesInPeriod` static extension method on `AnalyticsProduct` in the Domain layer — matching an existing codebase convention (`CarrierExtensions`, `CurrentUserExtensions`, `ManufactureOrderExtensions`). Both handlers now call the extension method and no longer carry their own copy. This is a pure refactor: no behavior change, verified by the existing handler test suites passing unmodified plus 7 new direct unit tests on the extension method covering inclusive boundary dates and edge cases.
+
+### Changes
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs` — new extension method
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs` — new unit tests
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs` — use extension, remove duplicate
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs` — use extension, remove duplicate
+
+## Status
+DONE

--- a/artifacts/feat-3496/review/extract-has-sales-in-period-extension.r1.md
+++ b/artifacts/feat-3496/review/extract-has-sales-in-period-extension.r1.md
@@ -1,0 +1,24 @@
+# Code Review: extract-has-sales-in-period-extension
+
+## Summary
+The implementation exactly matches the task spec: the duplicated private `HasSalesInPeriod` methods in `GetMarginReportHandler` and `GetProductMarginAnalysisHandler` were removed and replaced with calls to a new `AnalyticsProductExtensions.HasSalesInPeriod` extension method in the Domain layer, with identical inclusive-boundary semantics. All 7 new unit tests plus the full pre-existing Analytics test suite pass, and the build/format checks are clean.
+
+## Review Result: PASS
+
+### task: extract-has-sales-in-period-extension
+**Status:** PASS
+
+## Docs to Update
+None.
+
+## Overall Notes
+Independently verified (not just from the developer summary):
+- `AnalyticsProductExtensions.cs` contains exactly the specified extension method (`product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate)`), matching the semantics of both removed private methods.
+- `AnalyticsProductExtensionsTests.cs` contains all 7 specified test cases (in-range, inclusive start boundary, inclusive end boundary, before-range, after-range, empty history, mixed history).
+- `GetMarginReportHandler.cs`: call site at line 95 now reads `if (!product.HasSalesInPeriod(startDate, endDate))`; the old private `HasSalesInPeriod` method (previously at lines 125-128) is fully removed — confirmed via grep, no stray occurrences remain in `backend/src`.
+- `GetProductMarginAnalysisHandler.cs`: call site at line 51 now reads `if (!productData.HasSalesInPeriod(request.StartDate, request.EndDate))`; the old private method is fully removed.
+- Ran `dotnet build Anela.Heblo.sln` from the worktree root — build succeeded with 0 errors (254 pre-existing nullable-reference warnings unrelated to this change, none introduced by it).
+- Ran `dotnet test .../Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Analytics"` — 104/104 tests passed, including the 7 new extension tests and the unmodified `GetMarginReportHandlerTests` / `GetProductMarginAnalysisHandlerTests` suites (confirming no behavior regression).
+- Ran `dotnet format Anela.Heblo.sln --verify-no-changes` — exit code 0, no formatting issues.
+
+No issues found. This is a clean, low-risk refactor with correct spec compliance and full test coverage.

--- a/artifacts/feat-3496/spec.r1.md
+++ b/artifacts/feat-3496/spec.r1.md
@@ -1,0 +1,91 @@
+# Specification: Extract duplicated `HasSalesInPeriod` logic into a shared `AnalyticsProduct` extension
+
+## Summary
+`GetMarginReportHandler` and `GetProductMarginAnalysisHandler` (Analytics module) each define a private, bit-for-bit identical `HasSalesInPeriod` method that checks whether an `AnalyticsProduct` has any `SalesDataPoint` within a date range. This spec covers extracting that logic into a single public extension method on `AnalyticsProduct`, and updating both handlers to call it, with no change in behavior.
+
+## Background
+The Analytics module already follows a pattern of extracting shared calculation/filtering logic into named, injectable services (`IMarginCalculator`, `IProductFilterService`, `IReportBuilderService`). `HasSalesInPeriod`, however, is duplicated as a private static method in two handlers:
+
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs:125-128`
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs:71-74`
+
+Both implementations are:
+```csharp
+return product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+```
+differing only in the parameter name (`product` vs. `productData`). Because the method is `private`, this duplication is invisible to any consumer and easy for a reviewer to miss; if the date-range semantics ever change (e.g., exclusive end date, UTC normalization, timezone handling), a fix applied to one handler and not the other would silently produce inconsistent results between the margin report and the single-product margin analysis endpoints. Consolidating into one canonical implementation removes this risk and aligns the code with the module's existing pattern of factoring out shared logic.
+
+`AnalyticsProduct` and `SalesDataPoint` are defined in `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs`. This is a plain domain model (not persisted directly, built by the repository layer for analytics reads), making it a natural extension-method target.
+
+## Functional Requirements
+
+### FR-1: Single canonical `HasSalesInPeriod` implementation
+Add a new static class `AnalyticsProductExtensions` in the Domain layer, in namespace `Anela.Heblo.Domain.Features.Analytics`, file `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs`, containing:
+
+```csharp
+public static class AnalyticsProductExtensions
+{
+    public static bool HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)
+        => product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+}
+```
+
+The method body must be logically identical to the two existing private implementations (same inclusive `>=` / `<=` comparison, same `SalesHistory.Any` predicate). No date-range semantics change (no exclusive end date, no UTC normalization) — this is a pure move, not a behavior fix.
+
+**Acceptance criteria:**
+- `AnalyticsProductExtensions.HasSalesInPeriod` exists as a public static extension method on `AnalyticsProduct` in the Domain project, in the `Anela.Heblo.Domain.Features.Analytics` namespace.
+- Given a product whose `SalesHistory` contains at least one `SalesDataPoint` with `Date` between `startDate` and `endDate` inclusive, the method returns `true`.
+- Given a product whose `SalesHistory` is empty, or contains only dates strictly before `startDate` or strictly after `endDate`, the method returns `false`.
+- Boundary dates (`Date == startDate`, `Date == endDate`) are treated as in-period (inclusive), matching current behavior.
+
+### FR-2: Remove duplicate private methods and call the extension instead
+Update both handlers to remove their private `HasSalesInPeriod` method and call the new extension method instead.
+
+- In `GetMarginReportHandler.cs`, `ProcessProductsForReport` currently calls `HasSalesInPeriod(product, startDate, endDate)` (line 95) against the private static method (lines 125-128). Replace the private method with a call to the extension: `product.HasSalesInPeriod(startDate, endDate)` (or the existing static-call syntax `AnalyticsProductExtensions.HasSalesInPeriod(product, startDate, endDate)` — extension-method call syntax is preferred per FR-3), and delete the private method.
+- In `GetProductMarginAnalysisHandler.cs`, `Handle` currently calls `HasSalesInPeriod(productData, request.StartDate, request.EndDate)` (line 51) against the private static method (lines 71-74). Replace with `productData.HasSalesInPeriod(request.StartDate, request.EndDate)`, and delete the private method.
+- Both handlers need a `using Anela.Heblo.Domain.Features.Analytics;` import to bring the extension method into scope (already present as a `using` in both files, since both already reference `AnalyticsProduct` / `Domain.Features.Analytics.AnalyticsProduct`).
+
+**Acceptance criteria:**
+- No `HasSalesInPeriod` method remains defined in either `GetMarginReportHandler.cs` or `GetProductMarginAnalysisHandler.cs`.
+- Both handlers compile and call `AnalyticsProductExtensions.HasSalesInPeriod` (via extension-method syntax) at their existing call sites.
+- Existing unit tests in `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs` and `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs` continue to pass unmodified (no behavior change means no test assertions should need updating).
+
+### FR-3: Extension-method call style
+Both call sites should use C# extension-method invocation syntax (`product.HasSalesInPeriod(...)`) rather than static-method invocation syntax (`AnalyticsProductExtensions.HasSalesInPeriod(product, ...)`), for readability and to match the idiomatic style suggested in the brief.
+
+**Acceptance criteria:**
+- Call sites read as `product.HasSalesInPeriod(startDate, endDate)` / `productData.HasSalesInPeriod(request.StartDate, request.EndDate)`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. The extension method compiles to the same static method call as before (C# extension methods are syntactic sugar); `SalesHistory.Any(...)` short-circuits on first match exactly as today.
+
+### NFR-2: Security
+Not applicable. This is a private-method-to-extension-method refactor of existing pure logic with no new data exposure, no new inputs from outside the process, and no change to authorization/validation.
+
+## Data Model
+No data model changes. `AnalyticsProduct` and `SalesDataPoint` (`backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs`) are unchanged. This refactor only adds a stateless extension method operating on the existing `AnalyticsProduct.SalesHistory` collection.
+
+## API / Interface Design
+No public API (controller/endpoint) changes. This is an internal code-organization change:
+
+- New public surface: `Anela.Heblo.Domain.Features.Analytics.AnalyticsProductExtensions.HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate) : bool`, in the Domain project.
+- Removed: two private static methods, one each in `GetMarginReportHandler` and `GetProductMarginAnalysisHandler` (Application project).
+- No changes to `GetMarginReportRequest`/`GetMarginReportResponse`, `GetProductMarginAnalysisRequest`/`GetProductMarginAnalysisResponse`, or any MediatR request/response contracts.
+
+## Dependencies
+- Domain project (`Anela.Heblo.Domain`) must be referenced by the Application project (`Anela.Heblo.Application`) — already the case, since both handlers already use `Anela.Heblo.Domain.Features.Analytics.AnalyticsProduct`.
+- No new external library or service dependency introduced.
+- No dependency on `IMarginCalculator` or `IProductFilterService` — those are unaffected by this change; they are referenced in the brief only as examples of the module's existing "extract shared logic" pattern.
+
+## Out of Scope
+- Any change to date-range comparison semantics (e.g., switching to exclusive end date, half-open intervals, or UTC/timezone normalization). This refactor is a pure code move; any semantic change is a separate, follow-up piece of work.
+- Adding new unit tests specifically for `AnalyticsProductExtensions.HasSalesInPeriod` beyond what's needed to confirm existing handler tests still pass — recommended as a fast-follow, but not required to satisfy this spec's acceptance criteria (existing handler-level tests already exercise the boundary/inclusive-date behavior indirectly).
+- Any other duplicated logic in the Analytics module not called out in the brief (e.g., other private helpers in these or other handlers).
+- Converting `IMarginCalculator` or `IProductFilterService` to also expose this logic as an injectable service — the brief explicitly proposes a static extension method, not a new DI service, and this spec follows that direction.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-06T10:18:46.532017Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T10:20:59.019010Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T10:20:59.019010Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T10:21:17.701890Z"
     }
   },
   "tasks": [
     {
       "name": "extract-has-sales-in-period-extension",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-06T10:21:17.898681Z"
     }
   ]
 }

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T10:20:59.019010Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T10:21:17.701890Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T10:40:53.014501Z"
     }
   },
   "tasks": [
     {
       "name": "extract-has-sales-in-period-extension",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-06T10:21:17.898681Z"
+      "updated_at": "2026-07-06T10:40:48.534568Z"
     }
   ]
 }

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-06T10:16:23.132853Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T10:17:56.330169Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-06T10:40:53.014501Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-06T10:41:00.876701Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "extract-has-sales-in-period-extension",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T10:16:23.132853Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-06T10:17:56.330169Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T10:18:46.532017Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-06T10:40:53.014501Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T10:41:00.876701Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T10:41:54.556065Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3496/state.json
+++ b/artifacts/feat-3496/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3496",
+  "issue_number": 3496,
+  "created_at": "2026-07-06T10:14:40.208925Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3496/task-context/extract-has-sales-in-period-extension.md
+++ b/artifacts/feat-3496/task-context/extract-has-sales-in-period-extension.md
@@ -1,0 +1,238 @@
+### task: extract-has-sales-in-period-extension
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`
+- Test (must still pass unmodified): `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs`
+- Test (must still pass unmodified): `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing unit test for `AnalyticsProductExtensions.HasSalesInPeriod`**
+
+  Create `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs` with the following content:
+
+  ```csharp
+  using System;
+  using System.Collections.Generic;
+  using Anela.Heblo.Domain.Features.Analytics;
+  using FluentAssertions;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Features.Analytics;
+
+  public class AnalyticsProductExtensionsTests
+  {
+      private static AnalyticsProduct CreateProduct(List<SalesDataPoint> salesHistory)
+      {
+          return new AnalyticsProduct
+          {
+              ProductCode = "PROD001",
+              ProductName = "Test Product",
+              Type = AnalyticsProductType.Product,
+              MarginAmount = 0m,
+              SalesHistory = salesHistory
+          };
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleWithinRange_ReturnsTrue()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2024, 6, 15), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeTrue();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleExactlyOnStartDate_ReturnsTrue()
+      {
+          var startDate = new DateTime(2024, 1, 1);
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = startDate, AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(startDate, new DateTime(2024, 12, 31));
+
+          result.Should().BeTrue();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleExactlyOnEndDate_ReturnsTrue()
+      {
+          var endDate = new DateTime(2024, 12, 31);
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = endDate, AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), endDate);
+
+          result.Should().BeTrue();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleBeforeStartDate_ReturnsFalse()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2023, 12, 31), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeFalse();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleAfterEndDate_ReturnsFalse()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2025, 1, 1), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeFalse();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_EmptySalesHistory_ReturnsFalse()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>());
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeFalse();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_OneSaleInRangeAmongOthersOutOfRange_ReturnsTrue()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2023, 5, 1), AmountB2B = 1, AmountB2C = 0 },
+              new() { Date = new DateTime(2024, 6, 1), AmountB2B = 1, AmountB2C = 0 },
+              new() { Date = new DateTime(2025, 5, 1), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeTrue();
+      }
+  }
+  ```
+
+  Run:
+  ```bash
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~AnalyticsProductExtensionsTests"
+  ```
+
+  **Confirm fail:** the build fails with a compiler error (`CS1061: 'AnalyticsProduct' does not contain a definition for 'HasSalesInPeriod'`) because the extension method does not exist yet.
+
+- [ ] **Step 2: Create the `AnalyticsProductExtensions` class**
+
+  Create `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs`:
+
+  ```csharp
+  namespace Anela.Heblo.Domain.Features.Analytics;
+
+  public static class AnalyticsProductExtensions
+  {
+      public static bool HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)
+          => product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+  }
+  ```
+
+  Run:
+  ```bash
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~AnalyticsProductExtensionsTests"
+  ```
+
+  **Confirm pass:** all 7 tests in `AnalyticsProductExtensionsTests` pass.
+
+- [ ] **Step 3: Commit the new extension and its tests**
+
+  ```bash
+  git add backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs
+  git commit -m "Add AnalyticsProductExtensions.HasSalesInPeriod with unit tests"
+  ```
+
+- [ ] **Step 4: Update `GetMarginReportHandler.cs` to call the extension and delete its private duplicate**
+
+  In `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`:
+
+  Change line 95 from:
+  ```csharp
+              if (!HasSalesInPeriod(product, startDate, endDate))
+  ```
+  to:
+  ```csharp
+              if (!product.HasSalesInPeriod(startDate, endDate))
+  ```
+
+  Delete lines 125-128 (the private method):
+  ```csharp
+      private static bool HasSalesInPeriod(Domain.Features.Analytics.AnalyticsProduct product, DateTime startDate, DateTime endDate)
+      {
+          return product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+      }
+
+  ```
+  (remove the entire method including its trailing blank line, so `AccumulateCategoryTotals` follows directly after `ProcessProductsForReport`'s closing brace with the same blank-line spacing as the rest of the file).
+
+  No `using` changes needed — `using Anela.Heblo.Domain.Features.Analytics;` is already present at line 5.
+
+- [ ] **Step 5: Update `GetProductMarginAnalysisHandler.cs` to call the extension and delete its private duplicate**
+
+  In `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`:
+
+  Change line 51 from:
+  ```csharp
+              if (!HasSalesInPeriod(productData, request.StartDate, request.EndDate))
+  ```
+  to:
+  ```csharp
+              if (!productData.HasSalesInPeriod(request.StartDate, request.EndDate))
+  ```
+
+  Delete lines 71-74 (the private method):
+  ```csharp
+      private static bool HasSalesInPeriod(AnalyticsProduct productData, DateTime startDate, DateTime endDate)
+      {
+          return productData.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+      }
+
+  ```
+  (remove the entire method including its trailing blank line, so `BuildSuccessResponse` follows directly after `Handle`'s closing brace with the same blank-line spacing as the rest of the file).
+
+  No `using` changes needed — `using Anela.Heblo.Domain.Features.Analytics;` is already present at line 4.
+
+- [ ] **Step 6: Run the full Analytics test suite to confirm no regression**
+
+  ```bash
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Analytics"
+  ```
+
+  **Confirm pass:** `GetMarginReportHandlerTests`, `GetProductMarginAnalysisHandlerTests`, and `AnalyticsProductExtensionsTests` all pass unmodified — no assertions needed to change since `HasSalesInPeriod`'s behavior is identical to the removed private methods.
+
+- [ ] **Step 7: Build and format the whole solution**
+
+  ```bash
+  cd backend && dotnet build && dotnet format --verify-no-changes
+  ```
+
+  **Confirm pass:** build succeeds with no errors/warnings about unused usings or dead code, and `dotnet format` reports no changes needed (or run `dotnet format` without `--verify-no-changes` and re-check `git diff` only touches intended lines if it reformats anything).
+
+- [ ] **Step 8: Commit the handler changes**
+
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs
+  git commit -m "Replace duplicated private HasSalesInPeriod methods with AnalyticsProductExtensions call"
+  ```

--- a/artifacts/feat-3496/task-plan.r1.md
+++ b/artifacts/feat-3496/task-plan.r1.md
@@ -1,0 +1,255 @@
+# Implementation Plan: Extract duplicated `HasSalesInPeriod` logic into a shared `AnalyticsProduct` extension
+
+## Context
+
+`GetMarginReportHandler.cs` and `GetProductMarginAnalysisHandler.cs` each define a private, bit-for-bit identical `HasSalesInPeriod` method. This plan extracts the logic into a single public extension method `AnalyticsProductExtensions.HasSalesInPeriod` in the Domain layer (`backend/src/Anela.Heblo.Domain/Features/Analytics/`), following the existing `{Entity}Extensions` convention (`CarrierExtensions`, `CurrentUserExtensions`, `ManufactureOrderExtensions`), and updates both handlers to call it via extension-method syntax, deleting the private duplicates. Pure refactor — no behavior change.
+
+Verified against current source:
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs` — call site at line 95 (`HasSalesInPeriod(product, startDate, endDate)`), private method at lines 125-128, `using Anela.Heblo.Domain.Features.Analytics;` already present at line 5.
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs` — call site at line 51 (`HasSalesInPeriod(productData, request.StartDate, request.EndDate)`), private method at lines 71-74, `using Anela.Heblo.Domain.Features.Analytics;` already present at line 4.
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs` — `AnalyticsProduct.SalesHistory` is `required List<SalesDataPoint>`; `SalesDataPoint.Date` is `required DateTime`.
+- Existing extension-class + test precedent confirmed: `backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrderExtensions.cs` (file-scoped namespace, no leading `using`, static class body only) paired with `backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderExtensionsTests.cs` (xUnit `[Theory]`/`[Fact]` + FluentAssertions `.Should()`, namespace `Anela.Heblo.Tests.Features.<Module>`). The test project (`backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`) already references xunit, FluentAssertions, and the Domain project (used today by `GetMarginReportHandlerTests.cs` / `GetProductMarginAnalysisHandlerTests.cs`, both of which already `using Anela.Heblo.Domain.Features.Analytics;`).
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs` and `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs` exercise the handlers end-to-end (including sales-in-period filtering) through mocked repository/service data — they call the real, unmodified date-range logic indirectly and require no changes since the extracted method's behavior is identical.
+
+This is one tightly-scoped task: add the extension + its unit tests (TDD), then update both handlers to use it and delete the duplicates.
+
+---
+
+### task: extract-has-sales-in-period-extension
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`
+- Test (must still pass unmodified): `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs`
+- Test (must still pass unmodified): `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing unit test for `AnalyticsProductExtensions.HasSalesInPeriod`**
+
+  Create `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs` with the following content:
+
+  ```csharp
+  using System;
+  using System.Collections.Generic;
+  using Anela.Heblo.Domain.Features.Analytics;
+  using FluentAssertions;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Features.Analytics;
+
+  public class AnalyticsProductExtensionsTests
+  {
+      private static AnalyticsProduct CreateProduct(List<SalesDataPoint> salesHistory)
+      {
+          return new AnalyticsProduct
+          {
+              ProductCode = "PROD001",
+              ProductName = "Test Product",
+              Type = AnalyticsProductType.Product,
+              MarginAmount = 0m,
+              SalesHistory = salesHistory
+          };
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleWithinRange_ReturnsTrue()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2024, 6, 15), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeTrue();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleExactlyOnStartDate_ReturnsTrue()
+      {
+          var startDate = new DateTime(2024, 1, 1);
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = startDate, AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(startDate, new DateTime(2024, 12, 31));
+
+          result.Should().BeTrue();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleExactlyOnEndDate_ReturnsTrue()
+      {
+          var endDate = new DateTime(2024, 12, 31);
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = endDate, AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), endDate);
+
+          result.Should().BeTrue();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleBeforeStartDate_ReturnsFalse()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2023, 12, 31), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeFalse();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_SaleAfterEndDate_ReturnsFalse()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2025, 1, 1), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeFalse();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_EmptySalesHistory_ReturnsFalse()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>());
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeFalse();
+      }
+
+      [Fact]
+      public void HasSalesInPeriod_OneSaleInRangeAmongOthersOutOfRange_ReturnsTrue()
+      {
+          var product = CreateProduct(new List<SalesDataPoint>
+          {
+              new() { Date = new DateTime(2023, 5, 1), AmountB2B = 1, AmountB2C = 0 },
+              new() { Date = new DateTime(2024, 6, 1), AmountB2B = 1, AmountB2C = 0 },
+              new() { Date = new DateTime(2025, 5, 1), AmountB2B = 1, AmountB2C = 0 }
+          });
+
+          var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+          result.Should().BeTrue();
+      }
+  }
+  ```
+
+  Run:
+  ```bash
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~AnalyticsProductExtensionsTests"
+  ```
+
+  **Confirm fail:** the build fails with a compiler error (`CS1061: 'AnalyticsProduct' does not contain a definition for 'HasSalesInPeriod'`) because the extension method does not exist yet.
+
+- [ ] **Step 2: Create the `AnalyticsProductExtensions` class**
+
+  Create `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs`:
+
+  ```csharp
+  namespace Anela.Heblo.Domain.Features.Analytics;
+
+  public static class AnalyticsProductExtensions
+  {
+      public static bool HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)
+          => product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+  }
+  ```
+
+  Run:
+  ```bash
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~AnalyticsProductExtensionsTests"
+  ```
+
+  **Confirm pass:** all 7 tests in `AnalyticsProductExtensionsTests` pass.
+
+- [ ] **Step 3: Commit the new extension and its tests**
+
+  ```bash
+  git add backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs
+  git commit -m "Add AnalyticsProductExtensions.HasSalesInPeriod with unit tests"
+  ```
+
+- [ ] **Step 4: Update `GetMarginReportHandler.cs` to call the extension and delete its private duplicate**
+
+  In `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`:
+
+  Change line 95 from:
+  ```csharp
+              if (!HasSalesInPeriod(product, startDate, endDate))
+  ```
+  to:
+  ```csharp
+              if (!product.HasSalesInPeriod(startDate, endDate))
+  ```
+
+  Delete lines 125-128 (the private method):
+  ```csharp
+      private static bool HasSalesInPeriod(Domain.Features.Analytics.AnalyticsProduct product, DateTime startDate, DateTime endDate)
+      {
+          return product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+      }
+
+  ```
+  (remove the entire method including its trailing blank line, so `AccumulateCategoryTotals` follows directly after `ProcessProductsForReport`'s closing brace with the same blank-line spacing as the rest of the file).
+
+  No `using` changes needed — `using Anela.Heblo.Domain.Features.Analytics;` is already present at line 5.
+
+- [ ] **Step 5: Update `GetProductMarginAnalysisHandler.cs` to call the extension and delete its private duplicate**
+
+  In `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs`:
+
+  Change line 51 from:
+  ```csharp
+              if (!HasSalesInPeriod(productData, request.StartDate, request.EndDate))
+  ```
+  to:
+  ```csharp
+              if (!productData.HasSalesInPeriod(request.StartDate, request.EndDate))
+  ```
+
+  Delete lines 71-74 (the private method):
+  ```csharp
+      private static bool HasSalesInPeriod(AnalyticsProduct productData, DateTime startDate, DateTime endDate)
+      {
+          return productData.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+      }
+
+  ```
+  (remove the entire method including its trailing blank line, so `BuildSuccessResponse` follows directly after `Handle`'s closing brace with the same blank-line spacing as the rest of the file).
+
+  No `using` changes needed — `using Anela.Heblo.Domain.Features.Analytics;` is already present at line 4.
+
+- [ ] **Step 6: Run the full Analytics test suite to confirm no regression**
+
+  ```bash
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Analytics"
+  ```
+
+  **Confirm pass:** `GetMarginReportHandlerTests`, `GetProductMarginAnalysisHandlerTests`, and `AnalyticsProductExtensionsTests` all pass unmodified — no assertions needed to change since `HasSalesInPeriod`'s behavior is identical to the removed private methods.
+
+- [ ] **Step 7: Build and format the whole solution**
+
+  ```bash
+  cd backend && dotnet build && dotnet format --verify-no-changes
+  ```
+
+  **Confirm pass:** build succeeds with no errors/warnings about unused usings or dead code, and `dotnet format` reports no changes needed (or run `dotnet format` without `--verify-no-changes` and re-check `git diff` only touches intended lines if it reformats anything).
+
+- [ ] **Step 8: Commit the handler changes**
+
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs
+  git commit -m "Replace duplicated private HasSalesInPeriod methods with AnalyticsProductExtensions call"
+  ```

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs
@@ -92,7 +92,7 @@ public class GetMarginReportHandler : IRequestHandler<GetMarginReportRequest, Ge
         foreach (var product in products)
         {
             // Check if product has sales data in the period
-            if (!HasSalesInPeriod(product, startDate, endDate))
+            if (!product.HasSalesInPeriod(startDate, endDate))
                 continue;
 
             var marginData = _marginCalculator.CalculateForProduct(product, product.SalesHistory);
@@ -120,11 +120,6 @@ public class GetMarginReportHandler : IRequestHandler<GetMarginReportRequest, Ge
             CategorySummaries = categorySummaries,
             OverallTotals = overallTotals
         };
-    }
-
-    private static bool HasSalesInPeriod(Domain.Features.Analytics.AnalyticsProduct product, DateTime startDate, DateTime endDate)
-    {
-        return product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
     }
 
     private static void AccumulateCategoryTotals(

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginAnalysis/GetProductMarginAnalysisHandler.cs
@@ -48,7 +48,7 @@ public class GetProductMarginAnalysisHandler : IRequestHandler<GetProductMarginA
             }
 
             // Check if we have sales data for the period
-            if (!HasSalesInPeriod(productData, request.StartDate, request.EndDate))
+            if (!productData.HasSalesInPeriod(request.StartDate, request.EndDate))
             {
                 return CreateErrorResponse(ErrorCodes.AnalysisDataNotAvailable,
                     ("product", productData.ProductName),
@@ -66,11 +66,6 @@ public class GetProductMarginAnalysisHandler : IRequestHandler<GetProductMarginA
             _logger.LogError(ex, "Unhandled exception in GetProductMarginAnalysisHandler");
             return CreateErrorResponse(ErrorCodes.InternalServerError);
         }
-    }
-
-    private static bool HasSalesInPeriod(AnalyticsProduct productData, DateTime startDate, DateTime endDate)
-    {
-        return productData.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
     }
 
     private GetProductMarginAnalysisResponse BuildSuccessResponse(

--- a/backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Domain.Features.Analytics;
+
+public static class AnalyticsProductExtensions
+{
+    public static bool HasSalesInPeriod(this AnalyticsProduct product, DateTime startDate, DateTime endDate)
+        => product.SalesHistory.Any(s => s.Date >= startDate && s.Date <= endDate);
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsProductExtensionsTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Anela.Heblo.Domain.Features.Analytics;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+public class AnalyticsProductExtensionsTests
+{
+    private static AnalyticsProduct CreateProduct(List<SalesDataPoint> salesHistory)
+    {
+        return new AnalyticsProduct
+        {
+            ProductCode = "PROD001",
+            ProductName = "Test Product",
+            Type = AnalyticsProductType.Product,
+            MarginAmount = 0m,
+            SalesHistory = salesHistory
+        };
+    }
+
+    [Fact]
+    public void HasSalesInPeriod_SaleWithinRange_ReturnsTrue()
+    {
+        var product = CreateProduct(new List<SalesDataPoint>
+        {
+            new() { Date = new DateTime(2024, 6, 15), AmountB2B = 1, AmountB2C = 0 }
+        });
+
+        var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSalesInPeriod_SaleExactlyOnStartDate_ReturnsTrue()
+    {
+        var startDate = new DateTime(2024, 1, 1);
+        var product = CreateProduct(new List<SalesDataPoint>
+        {
+            new() { Date = startDate, AmountB2B = 1, AmountB2C = 0 }
+        });
+
+        var result = product.HasSalesInPeriod(startDate, new DateTime(2024, 12, 31));
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSalesInPeriod_SaleExactlyOnEndDate_ReturnsTrue()
+    {
+        var endDate = new DateTime(2024, 12, 31);
+        var product = CreateProduct(new List<SalesDataPoint>
+        {
+            new() { Date = endDate, AmountB2B = 1, AmountB2C = 0 }
+        });
+
+        var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), endDate);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSalesInPeriod_SaleBeforeStartDate_ReturnsFalse()
+    {
+        var product = CreateProduct(new List<SalesDataPoint>
+        {
+            new() { Date = new DateTime(2023, 12, 31), AmountB2B = 1, AmountB2C = 0 }
+        });
+
+        var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSalesInPeriod_SaleAfterEndDate_ReturnsFalse()
+    {
+        var product = CreateProduct(new List<SalesDataPoint>
+        {
+            new() { Date = new DateTime(2025, 1, 1), AmountB2B = 1, AmountB2C = 0 }
+        });
+
+        var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSalesInPeriod_EmptySalesHistory_ReturnsFalse()
+    {
+        var product = CreateProduct(new List<SalesDataPoint>());
+
+        var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSalesInPeriod_OneSaleInRangeAmongOthersOutOfRange_ReturnsTrue()
+    {
+        var product = CreateProduct(new List<SalesDataPoint>
+        {
+            new() { Date = new DateTime(2023, 5, 1), AmountB2B = 1, AmountB2C = 0 },
+            new() { Date = new DateTime(2024, 6, 1), AmountB2B = 1, AmountB2C = 0 },
+            new() { Date = new DateTime(2025, 5, 1), AmountB2B = 1, AmountB2C = 0 }
+        });
+
+        var result = product.HasSalesInPeriod(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31));
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Closes #3496

## What the issue was
`GetMarginReportHandler` and `GetProductMarginAnalysisHandler` in the Analytics module each defined a private, bit-for-bit identical `HasSalesInPeriod` method (differing only in a parameter name). Because both were private, the duplication was invisible to any consumer — if date-range semantics ever changed in one handler but not the other, the two endpoints would silently diverge.

## How it was fixed / handled
Extracted the shared logic into a new `AnalyticsProductExtensions.HasSalesInPeriod` static extension method on `AnalyticsProduct`, in the Domain layer (`backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductExtensions.cs`). This matches an existing codebase convention (`CarrierExtensions`, `CurrentUserExtensions`, `ManufactureOrderExtensions`) for pure, dependency-free predicates on Domain entities.

Both handlers now call `product.HasSalesInPeriod(...)` via extension-method syntax; their private duplicate methods were removed. This is a pure refactor — no behavior change, no new dependencies, no API/contract changes.

Added 7 new unit tests (`AnalyticsProductExtensionsTests`) covering in-range, inclusive start/end boundaries, before-range, after-range, empty history, and mixed-history cases. All 104 tests under the Analytics feature area pass, including the pre-existing `GetMarginReportHandlerTests` and `GetProductMarginAnalysisHandlerTests` suites, unmodified.

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3496/`.

## Code review

Final whole-branch code review result: **CLEAN** — no blocking or advisory findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AvdDmHf1uuSaW5nEmLUup5)_