### PR TITLE
#3497: implementation

### DIFF
--- a/artifacts/feat-3497/arch-review.r1.md
+++ b/artifacts/feat-3497/arch-review.r1.md
@@ -1,0 +1,107 @@
+# Architecture Review: Unit test coverage for InventorySummaryTileBase age-bucket logic
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure test-addition task with zero production code changes, confirmed by reading `backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs`. The class is a straightforward `ITile` implementation: it pulls `ICatalogRepository.GetAllAsync`, filters via an abstract `ItemFilter`, buckets by `(DateTime.UtcNow - item.LastStockTaking.Value).TotalDays` against two `const double` thresholds (`ThresholdCritical = 180`, `ThresholdWarning = 365`), and returns an anonymous-object JSON payload wrapped in a try/catch. This matches exactly the shape already covered by the sibling test `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/LowStockAlertTileTests.cs`, which tests `LowStockAlertTile` (a different concrete `ITile`) using `Mock<ICatalogRepository>` + `JsonSerializer`/`JsonDocument` round-tripping to assert on the anonymous response shape. No new abstractions, interfaces, or test infrastructure are needed — this fits the existing test conventions in the repo directly.
+
+One material difference from the sibling class: `LowStockAlertTile` takes an injected `TimeProvider` (mockable, fixed `_fixedDateTime`), but `InventorySummaryTileBase` calls `DateTime.UtcNow` directly with no seam. The spec correctly identifies this — production code is out of scope, so tests must anchor to real-world `DateTime.UtcNow` at Arrange time.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. Tests exercise the existing `InventorySummaryTileBase.LoadDataAsync` through one of its existing concrete subclasses in `backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/` (`ProductInventorySummaryTile`, `MaterialWithExpirationInventorySummaryTile`, `MaterialWithoutExpirationInventorySummaryTile`) — no test double or new subclass is required.
+
+### Key Design Decisions
+
+#### Decision 1: Which concrete tile to instantiate
+**Options considered:**
+- Write a private test-only subclass of `InventorySummaryTileBase` inline in the test file (mirrors nothing in the codebase today; adds a throwaway type).
+- Instantiate an existing production subclass, e.g. `ProductInventorySummaryTile`.
+
+**Chosen approach:** Use `ProductInventorySummaryTile` (`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/ProductInventorySummaryTile.cs`). Its constructor is `ProductInventorySummaryTile(ICatalogRepository catalogRepository)` — no `TimeProvider` or other dependency to fake, so setup is a single `Mock<ICatalogRepository>`. Its `ItemFilter` is `c => c.Type == ProductType.Product || c.Type == ProductType.Goods`, which conveniently gives a natural "excluded" type to use for FR-4 (`ProductType.Material` or `ProductType.SemiProduct` items are filtered out, exactly as `LowStockAlertTileTests` already does with `MAT001`/`SEMI001`).
+
+**Rationale:** Reusing a real, already-registered subclass keeps the test honest (it exercises the actual composition the app ships, including the `[TileId(...)]` attribute path) and avoids introducing a new type purely for test convenience, consistent with "no production code changes" and "surgical changes" guidance.
+
+#### Decision 2: How to set `LastStockTaking` on `CatalogAggregate`
+**Options considered:**
+- Look for a settable `LastStockTaking` property on `CatalogAggregate` and assign it directly.
+- Populate `StockTakingHistory` with a `StockTakingRecord`.
+
+**Chosen approach:** `CatalogAggregate.LastStockTaking` (`backend/src/Anela.Heblo.Domain/Features/Catalog/CatalogAggregate.cs:158`) is a **computed, get-only** property: `=> StockTakingHistory.OrderByDescending(o => o.Date).FirstOrDefault()?.Date`. It cannot be assigned directly. Tests must populate `StockTakingHistory` (a `List<StockTakingRecord>`, `backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockTakingRecord.cs`) with one record whose `Date` is the desired offset from `DateTime.UtcNow`. For the "never" bucket (FR-3), leave `StockTakingHistory` empty (default `new()`), which makes `LastStockTaking` return `null`.
+
+**Rationale:** This is a hard fact about the domain model that the spec's "Data Model note" doesn't call out; getting it wrong (e.g. trying to set a nonexistent `LastStockTaking` setter) would make the tests fail to compile.
+
+#### Decision 3: Boundary date construction without a mockable clock
+**Options considered:**
+- Assert exact fractional-day boundaries (e.g. exactly 180.000 days) — infeasible and flaky, since `LoadDataAsync` captures its own `DateTime.UtcNow` at Act time, a few milliseconds after the test's Arrange-time `DateTime.UtcNow`.
+- Use whole-day offsets one day off the threshold in each direction, matching the FR wording itself ("179→recent, 180→medium").
+
+**Chosen approach:** Capture `var now = DateTime.UtcNow;` once at the top of each boundary test, then set `StockTakingHistory` dates as `now.AddDays(-179)` / `now.AddDays(-180)` / `now.AddDays(-365)` / `now.AddDays(-366)`. Because production code's internal `now` is always fractionally later than the test's captured `now`, a `-180` day offset always evaluates to slightly *more* than 180.0 elapsed days by the time `LoadDataAsync` runs (correctly landing in `medium`, since the comparison is `>= ThresholdCritical`), and a `-179` day offset always evaluates to comfortably less than 180 days (correctly landing in `recent`). This gives deterministic, non-flaky tests without needing to touch production code to inject a clock.
+
+**Rationale:** Matches the spec's own FR wording (which already builds in a 1-day margin rather than demanding sub-second precision) and avoids the false step of trying to freeze `DateTime.UtcNow` globally (e.g. via `Microsoft.Extensions.Time.Testing.FakeTimeProvider` or shims), which isn't wired into this class and is explicitly out of scope.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New file only:
+```
+backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs
+```
+Namespace: `Anela.Heblo.Tests.Features.Catalog.DashboardTiles` (matches `LowStockAlertTileTests.cs` in the same directory).
+
+### Interfaces and Contracts
+
+No new interfaces. Reuse exactly what `LowStockAlertTileTests` uses:
+- `Anela.Heblo.Application.Features.Catalog.DashboardTiles` (for `ProductInventorySummaryTile`)
+- `Anela.Heblo.Domain.Features.Catalog` (for `CatalogAggregate`, `ICatalogRepository`, `ProductType`)
+- `Anela.Heblo.Domain.Features.Catalog.Stock` (for `StockTakingRecord`)
+- `Moq`, `FluentAssertions`, `System.Text.Json`, `Xunit`
+
+Suggested private fixture helper, mirroring `CreateProductWithStock` in the sibling file:
+```csharp
+private CatalogAggregate CreateItem(string code, ProductType type, DateTime? lastStockTaking)
+{
+    var item = new CatalogAggregate { ProductCode = code, Type = type };
+    if (lastStockTaking.HasValue)
+    {
+        item.StockTakingHistory.Add(new StockTakingRecord { Date = lastStockTaking.Value });
+    }
+    return item;
+}
+```
+(`StockTakingRecord.Code`/`AmountNew`/`AmountOld` are irrelevant to this logic and can be left at defaults — only `Date` matters for bucket assignment.)
+
+### Data Flow
+
+Test → `Mock<ICatalogRepository>.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(items)` → `new ProductInventorySummaryTile(catalogRepositoryMock.Object)` → `await tile.LoadDataAsync()` → serialize result via `JsonSerializer.Serialize` + `JsonDocument.Parse`, exactly as `LowStockAlertTileTests` does, then assert on `data.recent` / `data.medium` / `data.old` / `data.never` / `data.total` ints and `status` string.
+
+Recommended test cases (one `[Fact]` each, or a `[Theory]` with `[InlineData]` for the four boundary directions if preferred — sibling file uses discrete `[Fact]`s, so match that):
+1. `LoadDataAsync_ItemAt179Days_CountsAsRecent`
+2. `LoadDataAsync_ItemAt180Days_CountsAsMedium` (FR-1)
+3. `LoadDataAsync_ItemAt365Days_CountsAsMedium`
+4. `LoadDataAsync_ItemAt366Days_CountsAsOld` (FR-2)
+5. `LoadDataAsync_ItemWithNullLastStockTaking_CountsAsNever` (FR-3)
+6. `LoadDataAsync_MixedItemsWithFilteredOutType_TotalExcludesFilteredItems` (FR-4) — include e.g. one `recent`, one `medium`, one `Material`-type item (excluded by `ItemFilter`), assert `total == recent+medium+old+never` and the Material item isn't counted anywhere.
+7. `LoadDataAsync_HappyPath_ReturnsSuccessStatusAndExpectedShape` (FR-5) — assert `status == "success"` and that `data` has all five keys with sane values for a small mixed set.
+8. Optionally, one exception-path test mirroring `LoadDataAsync_HandlesExceptions_ReturnsErrorStatus` from the sibling file (incidental coverage per the spec's "no exhaustive exception-path testing beyond incidental" note) — cheap to add since the try/catch is already generic and untested for this class.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Real-clock (`DateTime.UtcNow`) boundary tests could theoretically flake if a test runs exactly at a day-rollover instant | Low | Use whole-day offsets one day away from each threshold (179/180, 365/366) as designed in Decision 3 — margin comfortably absorbs sub-second test execution time |
+| Choosing `ProductInventorySummaryTile` ties these "base class" tests to one concrete subclass's `ItemFilter`, slightly obscuring that the behavior under test is really in the base class | Low | Add a class-level XML doc comment on the test class stating it exercises `InventorySummaryTileBase.LoadDataAsync` via `ProductInventorySummaryTile` as a representative concrete instance |
+| Future contributors might duplicate these bucket tests again per-subclass (`MaterialWithExpirationInventorySummaryTile`, etc.), inflating redundant coverage | Low | The doc comment above also signals "don't re-test bucket math per subclass" — only subclass-specific `ItemFilter`/`GenerateDrillDownFilters` differences warrant their own tests |
+
+## Specification Amendments
+
+None required — the spec is accurate and implementable as written. Two clarifications worth folding into the spec text (non-blocking, just so an implementer doesn't have to re-derive them):
+- `CatalogAggregate.LastStockTaking` is a computed property backed by `StockTakingHistory` (`List<StockTakingRecord>`); it has no setter, so fixtures must add a `StockTakingRecord` with the desired `Date` rather than assigning `LastStockTaking` directly.
+- Use `ProductInventorySummaryTile` (concrete, single-dependency constructor) as the test host — no new test double needed.
+
+## Prerequisites
+
+None. All required packages (Moq, FluentAssertions, System.Text.Json, Xunit) are already referenced by the test project (confirmed via `LowStockAlertTileTests.cs`), and no other files need to change before this test file can be added.

--- a/artifacts/feat-3497/brief.md
+++ b/artifacts/feat-3497/brief.md
@@ -1,0 +1,27 @@
+# [coverage-gap] Catalog/InventorySummaryTileBase: age-bucket thresholds and never-inventoried count untested
+
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs`
+
+## Coverage
+Line coverage: 0% (filter threshold: 60%)
+
+## What's not tested
+The `LoadDataAsync` method computes four inventory-age buckets using two hardcoded thresholds (`ThresholdCritical = 180` days, `ThresholdWarning = 365` days):
+
+- **Recent**: `LastStockTaking` < 180 days ago
+- **Medium**: 180–365 days ago
+- **Old**: > 365 days ago
+- **Never**: `!LastStockTaking.HasValue`
+
+No test verifies that items land in the correct bucket, that boundary values (exactly 180 or 365 days) are assigned correctly, or that items with a null `LastStockTaking` are counted in `never` rather than silently dropped from all buckets.
+
+## Why it matters
+These buckets drive the warehouse dashboard display. If the threshold comparison direction flips, or a null check is wrong, items migrate between buckets silently. The 180/365-day boundaries are business-defined constants that could be refactored without an obvious test failure.
+
+## Suggested approach
+- Unit-test `LoadDataAsync` with a mock `ICatalogRepository` returning items whose `LastStockTaking` is set to exactly the boundary values (180 days, 365 days, 179 days, 366 days) and one with `null`. Assert each item lands in the expected bucket.
+- Verify that `total` equals the sum of all four bucket counts. ~0.5 day effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-06. Based on CI run #28716987459 (2ad2a2593e1834798a3def9ac2551b46c2e595cb)._

--- a/artifacts/feat-3497/code-review.r1.md
+++ b/artifacts/feat-3497/code-review.r1.md
@@ -1,0 +1,19 @@
+## Review Result: CLEAN
+
+### Blocking
+- None
+
+### Advisory
+- None
+
+**Verification performed:**
+- Traced every threshold in `InventorySummaryTileBase.LoadDataAsync` (`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs:42-52`) against the new tests: `recent` is `< 180`, `medium` is `>=180 && <=365`, `old` is `> 365`, `never` is `!HasValue`. The 179/180/365(+1s nudge)/366-day test cases and the null-`LastStockTaking` case all land in the bucket the production comparison operators actually produce.
+- Confirmed `LastStockTaking` (`CatalogAggregate.cs:158`) derives from `StockTakingHistory.OrderByDescending(Date).FirstOrDefault()`, matching the `CreateItem` helper's use of a single `StockTakingRecord`.
+- Confirmed `ProductInventorySummaryTile.ItemFilter` (`Product`/`Goods` only) matches the `Material`-filtered-out assertion in `LoadDataAsync_MixedItemsWithFilteredOutType_TotalExcludesFilteredItems`.
+- Confirmed the `total` invariant test and happy-path shape assertions match the anonymous response shape (`status`, `data.{recent,medium,old,never,total}`).
+- Compared style against the existing sibling test `LowStockAlertTileTests.cs` in the same folder — same `JsonSerializer`/`JsonDocument` assertion pattern, same Moq usage, consistent with codebase conventions.
+- `git log` on the branch confirms only test-file commits, matching the "no production code changes" intent.
+
+The prior-round accepted limitation (no injectable clock, so the exact strict-vs-inclusive operator can't be mutation-tested right at the boundary) is documented accurately in the class-level comment; nothing found indicating that documented rationale is wrong.
+
+No other correctness, reuse, or quality issues found. The new file `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` is ready as-is.

--- a/artifacts/feat-3497/design.r1.md
+++ b/artifacts/feat-3497/design.r1.md
@@ -1,0 +1,19 @@
+# Design: Unit test coverage for InventorySummaryTileBase age-bucket logic
+
+No UI/UX component — this is a backend-only unit test addition (per Architecture Review: `Skip Design: true`).
+
+## Component Design
+
+No new components. Tests exercise the existing `InventorySummaryTileBase.LoadDataAsync` via the existing concrete subclass `ProductInventorySummaryTile` (`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/ProductInventorySummaryTile.cs`), constructed with a mocked `ICatalogRepository`. New test file only:
+
+```
+backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs
+```
+
+## Data Schemas
+
+No schema changes. Test fixtures construct `CatalogAggregate` instances with `StockTakingHistory` (`List<StockTakingRecord>`) populated to control the derived `LastStockTaking` property:
+- Boundary cases: `StockTakingHistory` = one record with `Date = now.AddDays(-N)` for N in {179, 180, 365, 366}.
+- "Never" bucket case: `StockTakingHistory` left empty, so `LastStockTaking == null`.
+
+`LoadDataAsync`'s existing JSON response shape (`status`, `data.recent`, `data.medium`, `data.old`, `data.never`, `data.total`) is unchanged and asserted via `JsonSerializer`/`JsonDocument`, matching the pattern in `LowStockAlertTileTests`.

--- a/artifacts/feat-3497/impl/add-inventory-summary-tile-tests.r1.md
+++ b/artifacts/feat-3497/impl/add-inventory-summary-tile-tests.r1.md
@@ -1,0 +1,34 @@
+# Implementation: add-inventory-summary-tile-tests
+
+## What was implemented
+Added a new unit test class covering `InventorySummaryTileBase.LoadDataAsync`'s age-bucket logic: the 180-day and 365-day thresholds (both directions), the null-`LastStockTaking` "never" bucket, the `total` sum invariant with a filtered-out item type, and the happy-path response shape. No production code was changed.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` — new file, 7 test methods, exercising the base class via the concrete `ProductInventorySummaryTile` subclass with a mocked `ICatalogRepository`, following the `LowStockAlertTileTests` JSON-assertion convention.
+
+## Tests
+- `LoadDataAsync_ItemAt179Days_CountsAsRecent` — 179 days elapsed lands in `recent`.
+- `LoadDataAsync_ItemAt180Days_CountsAsMedium` — 180 days elapsed lands in `medium` (lower inclusive bound).
+- `LoadDataAsync_ItemAt365Days_CountsAsMedium` — 365 days elapsed lands in `medium` (upper inclusive bound).
+- `LoadDataAsync_ItemAt366Days_CountsAsOld` — 366 days elapsed lands in `old`.
+- `LoadDataAsync_ItemWithNullLastStockTaking_CountsAsNever` — no stock-taking history lands in `never`, not silently dropped.
+- `LoadDataAsync_MixedItemsWithFilteredOutType_TotalExcludesFilteredItems` — a `Material`-type item is excluded by `ItemFilter`; `total` reflects only filtered-in items and equals the bucket sum.
+- `LoadDataAsync_HappyPath_ReturnsSuccessStatusAndExpectedShape` — one item per bucket; asserts `status == "success"` and `total == 4 == recent+medium+old+never`.
+
+## How to verify
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InventorySummaryTileBaseTests"
+```
+Result: `Passed! - Failed: 0, Passed: 7, Skipped: 0, Total: 7`.
+
+## Notes
+The initial implementation set `LastStockTaking = now.AddDays(-365)` for the 365-day boundary case, using the test's own `DateTime.UtcNow` snapshot. Because production code (`InventorySummaryTileBase.LoadDataAsync`) captures its own, slightly later `DateTime.UtcNow` at Act time, the elapsed time as measured by production code was fractionally *more* than 365.0 days — pushing the item past the inclusive `<= ThresholdWarning` (365) comparison into the `old` bucket instead of `medium`, failing the test on first run. Fixed by nudging the fixture 1 second closer to "now" (`now.AddDays(-365).AddSeconds(1)`) so elapsed time stays at/under the 365-day inclusive boundary regardless of test/production clock drift. The other three boundary tests (179, 180, 366 days) were unaffected because their comparisons (`< 180`, `>= 180`, `> 365`) tolerate the same forward clock drift in the correct direction.
+
+## PR Summary
+Added `InventorySummaryTileBaseTests.cs` with 7 unit tests covering the age-bucket boundary logic (180/365-day thresholds in both directions), the null-`LastStockTaking` "never" bucket, the `total` invariant with a filtered-out item, and the happy-path response shape for `InventorySummaryTileBase.LoadDataAsync`. No production code changes.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` — new test file, 7 `[Fact]` tests
+
+## Status
+DONE

--- a/artifacts/feat-3497/impl/add-inventory-summary-tile-tests.r2.md
+++ b/artifacts/feat-3497/impl/add-inventory-summary-tile-tests.r2.md
@@ -1,0 +1,28 @@
+# Implementation: add-inventory-summary-tile-tests (revision 2)
+
+## What was implemented
+Addressed reviewer feedback on `review/add-inventory-summary-tile-tests.r1.md` by adding a class-level doc comment to `InventorySummaryTileBaseTests.cs` explaining a structural limitation: the exact strict-vs-inclusive comparison operator at each day boundary (`<` vs `<=` at 180 days, `<=` vs `<` at 365 days) cannot be distinguished by any black-box test against this production code, because `LoadDataAsync` calls `DateTime.UtcNow` directly with no injectable clock, and nonzero wall-clock time between test Arrange and production Act always drifts the measured elapsed time away from the exact integer-day boundary. No production code was changed — injecting a clock would be the only way to close this specific gap, and that is explicitly out of scope for this coverage-gap task.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` — added an explanatory comment above the test class; no test logic changed.
+
+## Tests
+Same 7 tests as revision 1 (see `impl/add-inventory-summary-tile-tests.r1.md`); all still pass.
+
+## How to verify
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InventorySummaryTileBaseTests"
+```
+Result: `Passed! - Failed: 0, Passed: 7, Skipped: 0, Total: 7`.
+
+## Notes
+This is a documented, accepted limitation rather than a fixed defect: the reviewer's mutation-testing finding is correct, but fully resolving it would require adding an injectable clock (e.g. `TimeProvider`) to `InventorySummaryTileBase`, which is a production code change explicitly out of scope per the task brief and specification. The tests do correctly verify bucket assignment to within one day of each threshold, catch gross regressions (e.g. threshold constants changed by more than a few hours, null-handling removed, filter/total logic broken), and match the original coverage-gap issue's suggested approach (boundary values at 179/180/365/366 days).
+
+## PR Summary
+Added `InventorySummaryTileBaseTests.cs` (7 unit tests) covering `InventorySummaryTileBase.LoadDataAsync`'s age-bucket logic: the 180/365-day thresholds, the null-`LastStockTaking` "never" bucket, the `total` invariant with a filtered-out item, and the happy-path response shape. No production code changes. A code review identified that the exact strict-vs-inclusive boundary operators can't be mutation-tested without an injectable clock (out of scope); this is documented in a comment on the test class.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` — new test file, 7 `[Fact]` tests, plus a doc comment on the clock-drift/boundary-precision limitation
+
+## Status
+DONE_WITH_CONCERNS

--- a/artifacts/feat-3497/review/add-inventory-summary-tile-tests.r1.md
+++ b/artifacts/feat-3497/review/add-inventory-summary-tile-tests.r1.md
@@ -1,0 +1,29 @@
+# Code Review: Unit test coverage for InventorySummaryTileBase age-bucket logic
+
+## Summary
+All 7 required test methods exist with the correct names in `InventorySummaryTileBaseTests.cs`, currently pass (7/7, confirmed via `dotnet test`), and no production file was modified (confirmed via `git diff origin/main...HEAD` and a byte-for-byte restore check after mutation testing). However, empirical mutation testing on the actual production comparison operators shows the suite does **not** satisfy the acceptance criterion "fail if any bucket comparison operator... is reverted/mutated": two of the four operators can be flipped without any test failing.
+
+## Review Result: REVISION_NEEDED
+
+### task: add-inventory-summary-tile-tests
+**Status:** REVISION_NEEDED
+**Issues:**
+- Mutation of the `recent` bucket's `<` to `<=` (line 43, `TotalDays < ThresholdCritical`) is not caught by any test. Production code captures its own `DateTime.UtcNow` at Act time, always fractionally later than the test's Arrange-time `now`, so an item created at `now.AddDays(-180)` is always measured as slightly more than 180.000 days elapsed — never exactly 180. `LoadDataAsync_ItemAt180Days_CountsAsMedium` never actually exercises the boundary value from the "recent" side.
+- Mutation of the `medium` bucket's upper bound `<=` to `<` (line 47, `TotalDays <= ThresholdWarning`) is also not caught. The flakiness fix (nudging the `-365 days` fixture by `+1 second`) pushes the tested elapsed time to roughly 364.99999 days, comfortably inside `<365` too, so it can no longer distinguish `<=365` from `<365`.
+- Both gaps stem from the same structural issue: with no injectable clock in `InventorySummaryTileBase.LoadDataAsync` (it calls `DateTime.UtcNow` directly), it is not possible to reliably land exactly on an integer-day boundary from a test — the elapsed value always drifts forward by whatever wall-clock time passes between Arrange and Act.
+
+## Docs to Update
+None.
+
+## Overall Notes
+- Confirmed via `git diff origin/main...HEAD -- . ':(exclude)artifacts'`: only the new test file was added; no production file was touched.
+- `ProductInventorySummaryTile.ItemFilter`, the null/`never` bucket test, and the happy-path shape test all hold up under inspection and are not tautological.
+- `dotnet build`/`dotnet format` were not independently re-verified in this review due to long build times in the sandbox; secondary check, doesn't change the verdict.
+
+---
+
+## Resolution (round 2)
+
+Confirmed by direct inspection: this specific mutation (exact strict-vs-inclusive comparison operator at the day boundary, e.g. `<` vs `<=` at exactly 180.000 elapsed days) is **structurally unreachable** from a black-box test given the current production code, for any fixture construction — not just the ones used here. `InventorySummaryTileBase.LoadDataAsync` calls `DateTime.UtcNow` directly with no injectable clock, and any nonzero wall-clock time between a test's Arrange step and the production Act step guarantees the measured elapsed time is *never* exactly on an integer-day boundary; it always drifts by a small positive epsilon. Because `<` and `<=` (or `>` and `>=`) only differ in behavior at that exact point, no black-box test can distinguish them without either (a) injecting a controllable clock into `InventorySummaryTileBase` — a production code change explicitly out of scope for this coverage-gap task — or (b) a global time-freezing mechanism not present in this codebase's test toolchain.
+
+Given this constraint, a clarifying comment was added directly above the test class documenting the limitation, so future readers understand why the boundary tests verify "correct bucket to within one day" rather than "exact single-ULP operator." This is the practical ceiling of coverage achievable without expanding scope to include a production clock-injection change, which this task's brief and specification explicitly rule out. All other review findings (test authenticity, no production changes, correct bucket/null/total/shape behavior) hold.

--- a/artifacts/feat-3497/review/add-inventory-summary-tile-tests.r2.md
+++ b/artifacts/feat-3497/review/add-inventory-summary-tile-tests.r2.md
@@ -1,0 +1,26 @@
+# Code Review: Unit test coverage for InventorySummaryTileBase age-bucket logic (round 2)
+
+## Summary
+
+Independently verified all four items in scope.
+
+**1. Mathematical claim (confirmed).** `InventorySummaryTileBase.cs` line 35 shows `LoadDataAsync` captures `var now = DateTime.UtcNow;` itself, with no constructor parameter, no `TimeProvider`, no static/injectable clock of any kind — `now` is a fully local variable computed at Act time inside the method under test. There is no seam a test can use to freeze or control this value. Sibling classes in the same directory (`InventoryCountTileBase.cs`, `LowStockAlertTile.cs`, etc.) do take a `TimeProvider` via DI, but `InventorySummaryTileBase` itself was never wired to it — using that pattern here would require a production code change, explicitly out of scope. Conclusion: the round-1 finding is confirmed correct — the exact `<` vs `<=` boundary at 180.000/365.000 days is structurally unreachable from a black-box test against this production code, for any fixture construction, without touching the file.
+
+**2. New comment (confirmed accurate).** The comment above the test class correctly states that production captures its own (later) `UtcNow` at Act time, that arrange-time offsets therefore always drift to slightly more than the nominal day count, and that this makes the strict-vs-inclusive distinction unreachable without an injectable clock (correctly scoped as out-of-scope here).
+
+**3. Tests pass.** Confirmed 7/7 passing in this worktree in prior verification runs (`dotnet test ... --filter "FullyQualifiedName~InventorySummaryTileBaseTests"` → `Passed! - Failed: 0, Passed: 7, Skipped: 0, Total: 7`).
+
+**4. No production file changed (confirmed).** The round-2 commit touched only `InventorySummaryTileBaseTests.cs` (+8 lines, the class-level comment). No production code was modified in this revision.
+
+## Review Result: PASS
+
+### task: add-inventory-summary-tile-tests
+**Status:** PASS
+
+## Docs to Update
+(none)
+
+## Overall Notes
+
+- The documented limitation is real, correctly explained, and does not represent a fixable-in-scope gap: closing it requires either an injectable clock (explicitly out of scope per the task brief) or a global time-freezing mechanism not present in this toolchain.
+- Noted purely for a future ticket, not this review: `InventoryCountTileBase.cs` (sibling class, same directory) already receives an injected `TimeProvider` but still uses raw `DateTime.UtcNow.AddDays(...)` for its actual cutoff comparison rather than `_timeProvider.GetUtcNow()`. If `InventorySummaryTileBase` is ever refactored to add a clock seam, it would be worth fixing that inconsistency in the sibling at the same time.

--- a/artifacts/feat-3497/spec.r1.md
+++ b/artifacts/feat-3497/spec.r1.md
@@ -1,0 +1,78 @@
+# Specification: Unit test coverage for InventorySummaryTileBase age-bucket logic
+
+## Summary
+`InventorySummaryTileBase.LoadDataAsync` (`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs`) currently has 0% line coverage. This task adds unit tests that pin down the existing behavior of the four inventory-age buckets (`recent`, `medium`, `old`, `never`), including the exact boundary conditions at the `ThresholdCritical` (180 days) and `ThresholdWarning` (365 days) constants. No production code changes are required or expected.
+
+## Background
+`InventorySummaryTileBase` is an abstract dashboard tile base class used by concrete warehouse tiles to summarize how long it has been since each catalog item was last inventoried. It buckets filtered catalog items into four counts based on `CatalogAggregate.LastStockTaking` (a derived, nullable `DateTime` computed from the item's `StockTakingHistory`) and returns them alongside a `total` and drill-down metadata.
+
+Because the bucket boundaries are business-defined constants (180/365 days) embedded directly in comparison expressions, a future refactor (e.g., changing `<` to `<=`, or inverting a null check) could silently reassign items between buckets or drop never-inventoried items entirely, with no test to catch the regression. This task closes that gap by adding tests against the existing behavior — it does not change bucket definitions, thresholds, or output shape.
+
+## Functional Requirements
+
+### FR-1: Test bucket assignment at and around the critical threshold (180 days)
+Verify that an item whose `LastStockTaking` is exactly 180 days before "now" is **not** counted in `recent`, and is counted in `medium`; an item at 179 days is counted in `recent`.
+
+**Acceptance criteria:**
+- An item with `LastStockTaking` = now − 179 days is counted in `recent`, not in `medium` or `old`.
+- An item with `LastStockTaking` = now − 180 days is counted in `medium`, not in `recent`.
+
+### FR-2: Test bucket assignment at and around the warning threshold (365 days)
+Verify that an item whose `LastStockTaking` is exactly 365 days before "now" is counted in `medium` (inclusive upper bound), and an item at 366 days is counted in `old`.
+
+**Acceptance criteria:**
+- An item with `LastStockTaking` = now − 365 days is counted in `medium`, not in `old`.
+- An item with `LastStockTaking` = now − 366 days is counted in `old`, not in `medium`.
+
+### FR-3: Test that items with a null `LastStockTaking` land in `never`
+Verify an item that has no stock-taking history at all (empty `StockTakingHistory`, so `LastStockTaking` is `null`) is counted in `never` and not silently excluded from every bucket.
+
+**Acceptance criteria:**
+- An item with an empty `StockTakingHistory` (`LastStockTaking == null`) is counted in `never`.
+- That item is not counted in `recent`, `medium`, or `old`.
+
+### FR-4: Test that `total` equals the sum of all four buckets
+Verify that for a mixed set of items spanning all four buckets, `total` equals `recent + medium + old + never`, and equals the count of items passing `ItemFilter`.
+
+**Acceptance criteria:**
+- Given one item in each of `recent`, `medium`, `old`, and `never`, `total == 4` and `total == recent + medium + old + never`.
+- Items excluded by `ItemFilter` are not counted in `total` or any bucket (use a minimal test-only subclass or an existing concrete tile with a known filter, consistent with the pattern in `LowStockAlertTileTests`).
+
+### FR-5: Preserve existing success/error response shape checks
+Add coverage confirming the method returns `status: "success"` with the bucket data on the happy path, consistent with existing tile test conventions (e.g. `LowStockAlertTileTests.LoadDataAsync_HandlesExceptions_ReturnsErrorStatus`). This is incidental coverage gained naturally from exercising `LoadDataAsync`, not a new requirement to test exception handling in depth beyond what falls out of the happy-path tests.
+
+**Acceptance criteria:**
+- `result` deserializes with `status == "success"` and `data.recent`, `data.medium`, `data.old`, `data.never`, `data.total` present and correct for the arranged input.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+N/A — this is a unit test addition with no runtime performance impact.
+
+### NFR-2: Security
+N/A — no auth, permissions, or sensitive data handling involved.
+
+## Data Model
+No schema changes. Tests construct `CatalogAggregate` instances with a `StockTakingHistory` (`List<StockTakingRecord>`) populated so that the derived `LastStockTaking` property (`StockTakingHistory.OrderByDescending(o => o.Date).FirstOrDefault()?.Date`) yields the desired boundary date, or left empty to yield `null`. A minimal `StockTakingRecord` needs at least `Date` set (other fields such as `Type`, `Code`, `AmountNew`, `AmountOld` can take arbitrary/default test values).
+
+Note for implementation: `LoadDataAsync` computes `now` via `DateTime.UtcNow` directly (no injected `TimeProvider`, unlike some sibling tiles such as `LowStockAlertTile`). Tests must compute each item's `LastStockTaking` relative to `DateTime.UtcNow` at test-execution time (e.g., `DateTime.UtcNow.AddDays(-180)`) rather than using a fixed calendar date, to avoid flakiness from the immutable threshold constants combined with a moving "now".
+
+## API / Interface Design
+N/A — no interface or contract changes. Tests exercise the existing `ITile.LoadDataAsync(Dictionary<string,string>?, CancellationToken)` method via a concrete subclass (or a minimal test double subclass of `InventorySummaryTileBase` implementing `Title`, `Description`, `ItemFilter`, and `GenerateDrillDownFilters`) with a mocked `ICatalogRepository.GetAllAsync`.
+
+## Dependencies
+- `Moq` for mocking `ICatalogRepository` (already used in sibling tests, e.g. `LowStockAlertTileTests`).
+- `FluentAssertions` for assertions (existing convention).
+- `System.Text.Json` for parsing the anonymous-object result, following the `JsonSerializer.Serialize` / `JsonDocument.Parse` pattern used in `LowStockAlertTileTests`.
+- No new NuGet packages or test infrastructure required.
+
+## Out of Scope
+- Any change to `InventorySummaryTileBase.cs` production logic, thresholds, or output shape.
+- Testing concrete subclasses of `InventorySummaryTileBase` beyond what's needed to exercise the shared bucket logic (e.g., no requirement to add tests for every concrete tile that derives from this base, unless one is reused merely as a vehicle to invoke `LoadDataAsync`).
+- Testing the exception-handling branch (`catch (Exception ex)`) beyond incidental coverage; this brief is scoped to bucket/threshold/null-handling correctness, not exhaustive error-path testing.
+- Testing `ItemFilter` implementations of concrete tiles — only enough filtering behavior to confirm filtered-out items don't pollute the buckets/total (FR-4).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T11:21:22.332739Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T11:21:41.173932Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T13:30:52.076848Z"
     }
   },
   "tasks": [
     {
       "name": "add-inventory-summary-tile-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 2,
-      "updated_at": "2026-07-06T13:15:35.480629Z"
+      "updated_at": "2026-07-06T13:30:46.388274Z"
     }
   ]
 }

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T11:21:22.332739Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T11:21:41.173932Z"
     }
   },
   "tasks": [
     {
       "name": "add-inventory-summary-tile-tests",
-      "status": "pending",
-      "revision": 1,
-      "updated_at": null
+      "status": "in_progress",
+      "revision": 2,
+      "updated_at": "2026-07-06T13:15:35.480629Z"
     }
   ]
 }

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-06T11:17:54.129254Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T11:20:35.595904Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-inventory-summary-tile-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-06T13:30:52.076848Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T13:30:52.411662Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T13:37:24.455305Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T11:17:54.129254Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3497",
+  "issue_number": 3497,
+  "created_at": "2026-07-06T11:15:25.564269Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-06T13:30:52.076848Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-06T13:30:52.411662Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-06T11:20:35.595904Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T11:20:52.902649Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3497/state.json
+++ b/artifacts/feat-3497/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-06T11:20:52.902649Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T11:21:22.332739Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3497/task-context/add-inventory-summary-tile-tests.md
+++ b/artifacts/feat-3497/task-context/add-inventory-summary-tile-tests.md
@@ -1,0 +1,49 @@
+# Task Plan: Unit test coverage for InventorySummaryTileBase age-bucket logic
+
+Single-task plan — this is a small, self-contained test-addition with no production code changes and no cross-cutting dependencies.
+
+### task: add-inventory-summary-tile-tests
+
+## Goal
+Add unit tests for `InventorySummaryTileBase.LoadDataAsync` covering the age-bucket boundary logic (180-day and 365-day thresholds), the null-`LastStockTaking` "never" bucket, the `total` sum invariant, and the happy-path response shape. No production code changes.
+
+## Context
+- Target file under test: `backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs`
+- `LoadDataAsync` buckets items by `(DateTime.UtcNow - item.LastStockTaking.Value).TotalDays` against `const double ThresholdCritical = 180` and `ThresholdWarning = 365`; items with `LastStockTaking == null` go to `never`.
+- `CatalogAggregate.LastStockTaking` (`backend/src/Anela.Heblo.Domain/Features/Catalog/CatalogAggregate.cs`) is a computed, get-only property derived from `StockTakingHistory` (`List<StockTakingRecord>`, ordered by `Date` descending, first-or-default). It has no setter — fixtures must add a `StockTakingRecord` with the desired `Date`, or leave the list empty for `null`.
+- Sibling reference test: `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/LowStockAlertTileTests.cs` — mirrors the `Mock<ICatalogRepository>` + `JsonSerializer`/`JsonDocument` assertion pattern to follow.
+- Host subclass to exercise the base class logic: `ProductInventorySummaryTile` (`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/ProductInventorySummaryTile.cs`), constructor `ProductInventorySummaryTile(ICatalogRepository catalogRepository)`. Its `ItemFilter` accepts `ProductType.Product`/`ProductType.Goods` and excludes other types (e.g. `ProductType.Material`), which is useful for the total/filter test.
+
+## Files to create/modify
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` — new file, namespace `Anela.Heblo.Tests.Features.Catalog.DashboardTiles`.
+
+## Implementation steps
+1. Create the test class with a private fixture helper:
+   ```csharp
+   private CatalogAggregate CreateItem(string code, ProductType type, DateTime? lastStockTaking)
+   {
+       var item = new CatalogAggregate { ProductCode = code, Type = type };
+       if (lastStockTaking.HasValue)
+       {
+           item.StockTakingHistory.Add(new StockTakingRecord { Date = lastStockTaking.Value });
+       }
+       return item;
+   }
+   ```
+2. In each test, `Mock<ICatalogRepository>` with `Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(items)`, construct `new ProductInventorySummaryTile(repoMock.Object)`, call `await tile.LoadDataAsync()`.
+3. Parse the result via `JsonSerializer.Serialize(result)` then `JsonDocument.Parse(...)`, and assert on `data.GetProperty("recent"|"medium"|"old"|"never"|"total").GetInt32()` and `status.GetString()`, following the exact pattern already used in `LowStockAlertTileTests`.
+4. Capture `var now = DateTime.UtcNow;` once per test before building fixtures, and use `now.AddDays(-N)` offsets for boundary dates.
+
+## Tests to write
+1. `LoadDataAsync_ItemAt179Days_CountsAsRecent` — one item, `LastStockTaking = now.AddDays(-179)` → `recent == 1`, `medium == 0`, `old == 0`, `never == 0`.
+2. `LoadDataAsync_ItemAt180Days_CountsAsMedium` — one item, `LastStockTaking = now.AddDays(-180)` → `medium == 1`, `recent == 0`.
+3. `LoadDataAsync_ItemAt365Days_CountsAsMedium` — one item, `LastStockTaking = now.AddDays(-365)` → `medium == 1`, `old == 0`.
+4. `LoadDataAsync_ItemAt366Days_CountsAsOld` — one item, `LastStockTaking = now.AddDays(-366)` → `old == 1`, `medium == 0`.
+5. `LoadDataAsync_ItemWithNullLastStockTaking_CountsAsNever` — one item, no `StockTakingHistory` → `never == 1`, all other buckets `0`.
+6. `LoadDataAsync_MixedItemsWithFilteredOutType_TotalExcludesFilteredItems` — one `recent`-bucket `Product`, one `medium`-bucket `Product`, one `Material`-type item (any age) → `total == 2` (excludes the Material item), and `total == recent + medium + old + never`.
+7. `LoadDataAsync_HappyPath_ReturnsSuccessStatusAndExpectedShape` — small mixed set covering all four buckets (one item each) → `status == "success"`, `total == 4 == recent+medium+old+never`.
+
+## Acceptance criteria
+- All 7 tests above exist in `InventorySummaryTileBaseTests.cs`, pass, and fail if any bucket comparison operator or null-check in `InventorySummaryTileBase.LoadDataAsync` is reverted/mutated.
+- No changes to any production (non-test) file.
+- Full backend test suite passes (`dotnet test`), and `dotnet build` / `dotnet format` are clean.

--- a/artifacts/feat-3497/task-plan.r1.md
+++ b/artifacts/feat-3497/task-plan.r1.md
@@ -1,0 +1,49 @@
+# Task Plan: Unit test coverage for InventorySummaryTileBase age-bucket logic
+
+Single-task plan — this is a small, self-contained test-addition with no production code changes and no cross-cutting dependencies.
+
+### task: add-inventory-summary-tile-tests
+
+## Goal
+Add unit tests for `InventorySummaryTileBase.LoadDataAsync` covering the age-bucket boundary logic (180-day and 365-day thresholds), the null-`LastStockTaking` "never" bucket, the `total` sum invariant, and the happy-path response shape. No production code changes.
+
+## Context
+- Target file under test: `backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs`
+- `LoadDataAsync` buckets items by `(DateTime.UtcNow - item.LastStockTaking.Value).TotalDays` against `const double ThresholdCritical = 180` and `ThresholdWarning = 365`; items with `LastStockTaking == null` go to `never`.
+- `CatalogAggregate.LastStockTaking` (`backend/src/Anela.Heblo.Domain/Features/Catalog/CatalogAggregate.cs`) is a computed, get-only property derived from `StockTakingHistory` (`List<StockTakingRecord>`, ordered by `Date` descending, first-or-default). It has no setter — fixtures must add a `StockTakingRecord` with the desired `Date`, or leave the list empty for `null`.
+- Sibling reference test: `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/LowStockAlertTileTests.cs` — mirrors the `Mock<ICatalogRepository>` + `JsonSerializer`/`JsonDocument` assertion pattern to follow.
+- Host subclass to exercise the base class logic: `ProductInventorySummaryTile` (`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/ProductInventorySummaryTile.cs`), constructor `ProductInventorySummaryTile(ICatalogRepository catalogRepository)`. Its `ItemFilter` accepts `ProductType.Product`/`ProductType.Goods` and excludes other types (e.g. `ProductType.Material`), which is useful for the total/filter test.
+
+## Files to create/modify
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` — new file, namespace `Anela.Heblo.Tests.Features.Catalog.DashboardTiles`.
+
+## Implementation steps
+1. Create the test class with a private fixture helper:
+   ```csharp
+   private CatalogAggregate CreateItem(string code, ProductType type, DateTime? lastStockTaking)
+   {
+       var item = new CatalogAggregate { ProductCode = code, Type = type };
+       if (lastStockTaking.HasValue)
+       {
+           item.StockTakingHistory.Add(new StockTakingRecord { Date = lastStockTaking.Value });
+       }
+       return item;
+   }
+   ```
+2. In each test, `Mock<ICatalogRepository>` with `Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(items)`, construct `new ProductInventorySummaryTile(repoMock.Object)`, call `await tile.LoadDataAsync()`.
+3. Parse the result via `JsonSerializer.Serialize(result)` then `JsonDocument.Parse(...)`, and assert on `data.GetProperty("recent"|"medium"|"old"|"never"|"total").GetInt32()` and `status.GetString()`, following the exact pattern already used in `LowStockAlertTileTests`.
+4. Capture `var now = DateTime.UtcNow;` once per test before building fixtures, and use `now.AddDays(-N)` offsets for boundary dates.
+
+## Tests to write
+1. `LoadDataAsync_ItemAt179Days_CountsAsRecent` — one item, `LastStockTaking = now.AddDays(-179)` → `recent == 1`, `medium == 0`, `old == 0`, `never == 0`.
+2. `LoadDataAsync_ItemAt180Days_CountsAsMedium` — one item, `LastStockTaking = now.AddDays(-180)` → `medium == 1`, `recent == 0`.
+3. `LoadDataAsync_ItemAt365Days_CountsAsMedium` — one item, `LastStockTaking = now.AddDays(-365)` → `medium == 1`, `old == 0`.
+4. `LoadDataAsync_ItemAt366Days_CountsAsOld` — one item, `LastStockTaking = now.AddDays(-366)` → `old == 1`, `medium == 0`.
+5. `LoadDataAsync_ItemWithNullLastStockTaking_CountsAsNever` — one item, no `StockTakingHistory` → `never == 1`, all other buckets `0`.
+6. `LoadDataAsync_MixedItemsWithFilteredOutType_TotalExcludesFilteredItems` — one `recent`-bucket `Product`, one `medium`-bucket `Product`, one `Material`-type item (any age) → `total == 2` (excludes the Material item), and `total == recent + medium + old + never`.
+7. `LoadDataAsync_HappyPath_ReturnsSuccessStatusAndExpectedShape` — small mixed set covering all four buckets (one item each) → `status == "success"`, `total == 4 == recent+medium+old+never`.
+
+## Acceptance criteria
+- All 7 tests above exist in `InventorySummaryTileBaseTests.cs`, pass, and fail if any bucket comparison operator or null-check in `InventorySummaryTileBase.LoadDataAsync` is reverted/mutated.
+- No changes to any production (non-test) file.
+- Full backend test suite passes (`dotnet test`), and `dotnet build` / `dotnet format` are clean.

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs
@@ -8,6 +8,14 @@ using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Catalog.DashboardTiles;
 
+// Note on boundary precision: LoadDataAsync captures its own DateTime.UtcNow at Act time,
+// which is always fractionally later than the Arrange-time `now` these tests capture. So an
+// item built at `now.AddDays(-180)` is always measured as slightly MORE than 180.000 elapsed
+// days by production code - never exactly 180.000. Without an injectable clock in
+// InventorySummaryTileBase (out of scope to add - see task brief), these tests cannot
+// distinguish a strict (`<`/`>`) from an inclusive (`<=`/`>=`) comparison operator exactly at
+// the threshold value; they do verify the threshold is in the right place to within one day
+// and that same-side values land in the correct bucket.
 public class InventorySummaryTileBaseTests
 {
     private readonly Mock<ICatalogRepository> _catalogRepositoryMock;

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs
@@ -1,0 +1,240 @@
+using Anela.Heblo.Application.Features.Catalog.DashboardTiles;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Moq;
+using System.Text.Json;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.DashboardTiles;
+
+public class InventorySummaryTileBaseTests
+{
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly ProductInventorySummaryTile _tile;
+
+    public InventorySummaryTileBaseTests()
+    {
+        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _tile = new ProductInventorySummaryTile(_catalogRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_ItemAt179Days_CountsAsRecent()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var items = new List<CatalogAggregate>
+        {
+            CreateItem("PROD001", ProductType.Product, now.AddDays(-179))
+        };
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+
+        var data = doc.RootElement.GetProperty("data");
+        data.GetProperty("recent").GetInt32().Should().Be(1);
+        data.GetProperty("medium").GetInt32().Should().Be(0);
+        data.GetProperty("old").GetInt32().Should().Be(0);
+        data.GetProperty("never").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_ItemAt180Days_CountsAsMedium()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var items = new List<CatalogAggregate>
+        {
+            CreateItem("PROD001", ProductType.Product, now.AddDays(-180))
+        };
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+
+        var data = doc.RootElement.GetProperty("data");
+        data.GetProperty("medium").GetInt32().Should().Be(1);
+        data.GetProperty("recent").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_ItemAt365Days_CountsAsMedium()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        // The production code captures its own (slightly later) "now" at Act time, so an
+        // offset of exactly -365 days would drift to just over 365 elapsed days by the time
+        // LoadDataAsync runs. Nudge 1 second closer to keep elapsed time at/under the
+        // inclusive upper bound of the "medium" bucket.
+        var items = new List<CatalogAggregate>
+        {
+            CreateItem("PROD001", ProductType.Product, now.AddDays(-365).AddSeconds(1))
+        };
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+
+        var data = doc.RootElement.GetProperty("data");
+        data.GetProperty("medium").GetInt32().Should().Be(1);
+        data.GetProperty("old").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_ItemAt366Days_CountsAsOld()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var items = new List<CatalogAggregate>
+        {
+            CreateItem("PROD001", ProductType.Product, now.AddDays(-366))
+        };
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+
+        var data = doc.RootElement.GetProperty("data");
+        data.GetProperty("old").GetInt32().Should().Be(1);
+        data.GetProperty("medium").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_ItemWithNullLastStockTaking_CountsAsNever()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var items = new List<CatalogAggregate>
+        {
+            CreateItem("PROD001", ProductType.Product, null)
+        };
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+
+        var data = doc.RootElement.GetProperty("data");
+        data.GetProperty("never").GetInt32().Should().Be(1);
+        data.GetProperty("recent").GetInt32().Should().Be(0);
+        data.GetProperty("medium").GetInt32().Should().Be(0);
+        data.GetProperty("old").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_MixedItemsWithFilteredOutType_TotalExcludesFilteredItems()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var items = new List<CatalogAggregate>
+        {
+            CreateItem("PROD001", ProductType.Product, now.AddDays(-10)),   // recent
+            CreateItem("PROD002", ProductType.Product, now.AddDays(-200)),  // medium
+            CreateItem("MAT001", ProductType.Material, now.AddDays(-10))    // filtered out
+        };
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+
+        var data = doc.RootElement.GetProperty("data");
+        var recent = data.GetProperty("recent").GetInt32();
+        var medium = data.GetProperty("medium").GetInt32();
+        var old = data.GetProperty("old").GetInt32();
+        var never = data.GetProperty("never").GetInt32();
+        var total = data.GetProperty("total").GetInt32();
+
+        total.Should().Be(2);
+        total.Should().Be(recent + medium + old + never);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_HappyPath_ReturnsSuccessStatusAndExpectedShape()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var items = new List<CatalogAggregate>
+        {
+            CreateItem("PROD001", ProductType.Product, now.AddDays(-10)),   // recent
+            CreateItem("PROD002", ProductType.Product, now.AddDays(-200)),  // medium
+            CreateItem("PROD003", ProductType.Product, now.AddDays(-400)),  // old
+            CreateItem("PROD004", ProductType.Product, null)                // never
+        };
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.Serialize(result);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+
+        var data = doc.RootElement.GetProperty("data");
+        var recent = data.GetProperty("recent").GetInt32();
+        var medium = data.GetProperty("medium").GetInt32();
+        var old = data.GetProperty("old").GetInt32();
+        var never = data.GetProperty("never").GetInt32();
+        var total = data.GetProperty("total").GetInt32();
+
+        total.Should().Be(4);
+        total.Should().Be(recent + medium + old + never);
+    }
+
+    private CatalogAggregate CreateItem(string code, ProductType type, DateTime? lastStockTaking)
+    {
+        var item = new CatalogAggregate { ProductCode = code, Type = type };
+        if (lastStockTaking.HasValue)
+        {
+            item.StockTakingHistory.Add(new StockTakingRecord { Date = lastStockTaking.Value });
+        }
+        return item;
+    }
+}


### PR DESCRIPTION
Closes #3497

## What the issue was
`InventorySummaryTileBase.LoadDataAsync` (`backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs`) had 0% line coverage. This method buckets catalog items by inventory age into `recent` (<180 days), `medium` (180–365 days), `old` (>365 days), and `never` (no stock-taking history) using two hardcoded thresholds, but no test verified the boundary behavior, the null-handling for never-inventoried items, or the `total` sum invariant.

## How it was fixed / handled
Added `backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/InventorySummaryTileBaseTests.cs` with 7 unit tests exercising `InventorySummaryTileBase.LoadDataAsync` via the existing concrete subclass `ProductInventorySummaryTile`, mocking `ICatalogRepository`, following the same `JsonSerializer`/`JsonDocument` assertion pattern already used in the sibling `LowStockAlertTileTests`:

- Boundary tests at 179/180/365/366 elapsed days confirming correct bucket assignment.
- Null `LastStockTaking` (no stock-taking history) correctly counted in `never`.
- `total` invariant test with a filtered-out item type, confirming `total == recent + medium + old + never`.
- Happy-path test confirming the `status: "success"` response shape.

No production code was changed — this is a pure test-addition task. A two-round review process identified and accepted one structural limitation: because `LoadDataAsync` calls `DateTime.UtcNow` directly with no injectable clock, the exact strict-vs-inclusive comparison operator at a boundary (e.g. `<` vs `<=` at exactly 180.000 days) can't be distinguished by a black-box test — any wall-clock time between test Arrange and production Act always drifts the measured elapsed time past the exact integer-day point. This is documented in a comment on the test class; closing it fully would require adding an injectable clock to production code, which is out of scope for this coverage-gap task.

All 7 new tests pass locally (`dotnet test ... --filter "FullyQualifiedName~InventorySummaryTileBaseTests"` → 7/7 passed).

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3497/`.

## Code review

Final whole-branch code review result: **CLEAN** — no blocking or advisory findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JeTioCB2pH3MmruaFAKjMP)_