### PR TITLE
#3498: implementation

### DIFF
--- a/artifacts/feat-3498/arch-review.r1.md
+++ b/artifacts/feat-3498/arch-review.r1.md
@@ -1,0 +1,101 @@
+# Architecture Review: Catalog/StockUpOperationResult unit test coverage
+
+## Skip Design: true
+
+This is a pure test-authoring task against an existing, unmodified production class (`StockUpOperationResult.cs`). There is no UI, no API surface, and no visual component involved — Skip Design is set per the standing rule for backend-only, non-behavioral changes.
+
+## Architectural Fit Assessment
+
+This is a coverage-gap remediation, not a feature. It fits cleanly into the existing test project without requiring any new infrastructure:
+
+- `StockUpOperationResult` is a self-contained result/value object in `Anela.Heblo.Application/Features/Catalog/Services/`, with no DI dependencies, no I/O, and a private parameterless constructor that forces construction through its own static factories.
+- The test project `backend/test/Anela.Heblo.Tests` already has a matching directory `Features/Catalog/Services/` containing sibling test files for other classes in the same production folder (`MarginCalculationServiceTests.cs`, `ProductWeightRecalculationServiceTests.cs`, `ProductCatalogQueryServiceTests.cs`, `SalesCostCalculationServiceTests.cs`), all namespaced `Anela.Heblo.Tests.Features.Catalog.Services`. The new test class fits this directory/namespace with zero structural changes.
+- Confirmed stack from `docs/architecture/testing-strategy.md` and the sibling test file: **xUnit** (`[Fact]`/`[Theory]`), **FluentAssertions** (`.Should()`), **Moq** for mocking (not needed here — no dependencies to mock). No new packages, no new test project.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/test/Anela.Heblo.Tests/
+└── Features/Catalog/Services/
+    ├── MarginCalculationServiceTests.cs        (existing, sibling pattern)
+    ├── ProductWeightRecalculationServiceTests.cs (existing)
+    └── StockUpOperationResultTests.cs           <-- NEW (this task)
+```
+
+No components are added or wired together; this is a leaf addition to the existing test tree. The class under test has exactly one production dependency: `StockUpOperation` (`Anela.Heblo.Domain.Features.Catalog.Stock`), which is constructed directly (no mock) since it is a plain entity with a public constructor.
+
+### Key Design Decisions
+
+#### Decision 1: How to reach all six `StockUpResultStatus` values given the private constructor
+**Options considered:**
+1. Reflection / `Activator.CreateInstance` with non-public constructor + property injection to bypass the factories entirely.
+2. Use only the seven public static factory methods, since together they produce all six enum values (`Success`, `AlreadyCompleted`, `AlreadyInShoptet`, `InProgress`, `PreviouslyFailed`, and `Failed` — the latter reachable via `SubmitFailed`, `VerificationFailed`, or `VerificationError`).
+
+**Chosen approach:** Option 2 — factory methods only, no reflection.
+
+**Rationale:** The spec's "Open Question" flags this as needing a decision; the answer is unambiguous once you enumerate the factories against the enum: every value of `StockUpResultStatus` is produced by at least one factory. Reflection would test an implementation detail (the private constructor exists for encapsulation, e.g. to prevent inconsistent states) and adds no verification value the factory methods don't already provide — it would also break if the constructor signature ever changes, for no benefit. Testing through the public factory API is strictly better: it exercises real call paths and doubles as the factory-method coverage required by FR-2–FR-9. Resolve the spec's open question this way; no implementer decision needed.
+
+#### Decision 2: Building `StockUpOperation` test instances
+**Options considered:**
+1. Add a test builder/helper class.
+2. Construct `StockUpOperation` directly via its public constructor per test.
+
+**Chosen approach:** Option 2 — direct construction, no builder.
+
+**Rationale:** `StockUpOperation`'s public constructor (`documentNumber, productCode, amount, sourceType, sourceId`) has no invalid-value traps for this task (avoid empty strings for `documentNumber`/`productCode` and a non-zero `amount`, since the constructor validates these) and needs only two additional method calls to set the two fields the factories consume:
+- `PreviouslyFailed` reads `operation.ErrorMessage` → call `operation.MarkAsFailed(timestamp, "some error")` to populate it (there is no other way to set `ErrorMessage`; it has a private setter).
+- `InProgress` reads `operation.State` → the default post-construction state is `StockUpOperationState.Pending`, which is already a "known value" satisfying FR-5; no extra call needed unless the test wants to show a different state (optional, not required).
+
+A dedicated builder/helper is unwarranted for a single test file exercising one type with a two-argument construction path; it would add indirection without reducing duplication meaningfully. No existing test helper for `StockUpOperation` was found in the repo (checked `Domain/Catalog` test tree) — none needs to be introduced for this scope.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+- **New file:** `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs`
+- **Namespace:** `Anela.Heblo.Tests.Features.Catalog.Services` (matches sibling files in the same directory)
+- **No `.csproj` changes** — the file lands inside the existing `Anela.Heblo.Tests` project and is picked up automatically (no explicit `<Compile>` globs to edit; the project uses default SDK-style globbing, confirmed by the presence of the four sibling files already compiling in that folder).
+
+### Interfaces and Contracts
+
+No new interfaces or contracts. Test surface is entirely the existing public API of `StockUpOperationResult`:
+```csharp
+StockUpOperationResult.Success(StockUpOperation operation)
+StockUpOperationResult.AlreadyCompleted(StockUpOperation operation)
+StockUpOperationResult.PreviouslyFailed(StockUpOperation operation)
+StockUpOperationResult.InProgress(StockUpOperation? operation)
+StockUpOperationResult.AlreadyInShoptet(StockUpOperation operation)
+StockUpOperationResult.SubmitFailed(StockUpOperation operation, Exception ex)
+StockUpOperationResult.VerificationFailed(StockUpOperation operation)
+StockUpOperationResult.VerificationError(StockUpOperation operation, Exception ex)
+```
+plus the `IsSuccess`, `Status`, `Message`, `Operation`, `Exception` properties read back on the result.
+
+Recommended test shape (xUnit + FluentAssertions, matching sibling conventions):
+- One `[Fact]` per factory method (FR-2 through FR-9), asserting `Status`, `Message`, `Operation` (reference equality via `.Should().BeSameAs(operation)`), `Exception`, and `IsSuccess` in a single test body each — this mirrors the "one test per factory method" guidance in the brief and is more readable than a single mega-theory for methods with differing signatures (some take an `Exception`, `InProgress` takes a nullable operand).
+- One additional `[Theory]`/`[InlineData]`-free or table-driven test dedicated to `IsSuccess`, built by calling the relevant factory for each of the six statuses and asserting the boolean — this satisfies FR-1's ask for a single self-contained place that pins "the current set of success statuses," even though the per-factory tests already cover the same assertions individually. Keep this as a distinct test (not a refactor of the per-factory tests) so the intent ("this is the list of success statuses, on purpose") reads clearly to a future maintainer.
+- Cover both branches of `InProgress` per FR-5: non-null operation with a known `State`, and `InProgress(null)` asserting `Operation` is `null` and the literal message `"Operation already in progress (state: )"`.
+
+### Data Flow
+
+N/A beyond in-memory construction → factory call → assertion. No async, no I/O, no DI container involved. Each test is fully self-contained (arrange operation/exception → act via factory → assert on returned `StockUpOperationResult`).
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Reflection-based test bypassing the private constructor, testing an implementation detail instead of real usage | Low | Explicitly resolved in this review (Decision 1) — use only the public factory methods; do not use `Activator.CreateInstance` or reflection. |
+| Test asserts derived/re-computed expected strings (e.g. re-implementing the interpolation) instead of literal pinned strings, weakening regression value | Low | Spec already flags this (FR-5); assert literal expected strings, not re-derived logic, especially for the `InProgress(null)` case. |
+| Constructing `StockUpOperation` with invalid arguments (empty `documentNumber`/`productCode`, zero `amount`) throws `ValidationException` and breaks unrelated tests | Low | Use simple non-empty test values, e.g. `"DOC-1"`, `"PROD-1"`, `amount: 1`; not a design concern, just an implementation note. |
+| Adding this file to the wrong namespace/folder breaks the "mirrors production namespace" convention used elsewhere in the test project | Low | Directory (`Features/Catalog/Services/`) and namespace (`Anela.Heblo.Tests.Features.Catalog.Services`) are already established by four sibling files; simply follow the pattern. |
+
+## Specification Amendments
+
+- **Resolve Open Question 1** (private constructor / `IsSuccess` coverage strategy): confirmed — use only the seven public static factories to reach all six `StockUpResultStatus` values; no reflection, no test-internal factory. FR-1 is satisfied by a dedicated `IsSuccess`-focused test built from factory calls, in addition to the `IsSuccess` assertions embedded in each per-factory test (FR-2–FR-9).
+- **Resolve Open Question 2** (test framework/assertions): confirmed by inspecting `MarginCalculationServiceTests.cs` — **xUnit** + **FluentAssertions**, in `backend/test/Anela.Heblo.Tests`. No Moq needed for this specific test class (no dependencies to mock).
+- **Minor addition to spec:** note that `StockUpOperation.ErrorMessage` can only be populated via `MarkAsFailed(DateTime timestamp, string errorMessage)` (private setter), so the `PreviouslyFailed` test (FR-4) must call `MarkAsFailed` on the constructed operation before invoking `StockUpOperationResult.PreviouslyFailed(operation)`.
+
+## Prerequisites
+
+None. No migrations, no config, no new packages, no new test project. Implementation can start immediately by adding the single new test file.

--- a/artifacts/feat-3498/brief.md
+++ b/artifacts/feat-3498/brief.md
@@ -1,0 +1,22 @@
+# [coverage-gap] Catalog/StockUpOperationResult: IsSuccess predicate and factory methods untested
+
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs`
+
+## Coverage
+Line coverage: 0% (filter threshold: 60%)
+
+## What's not tested
+The `IsSuccess` computed property returns `true` for exactly three statuses — `Success`, `AlreadyCompleted`, and `AlreadyInShoptet` — and `false` for the remaining ones (`InProgress`, `PreviouslyFailed`, `Failed`). No test exercises this predicate.
+
+There are also seven static factory methods (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress`, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`). None are tested for the shape of the result they produce.
+
+## Why it matters
+`IsSuccess` is used by callers to decide whether a stock-up operation succeeded. If a new `StockUpResultStatus` value is added later (e.g. a new retry-eligible state), it will default to `false` in `IsSuccess` — which may or may not be correct. Without a test pinning the current set of success statuses, a refactor that restructures the enum could silently change which operations the caller treats as successful.
+
+## Suggested approach
+- Parameterized test over all `StockUpResultStatus` values asserting that `IsSuccess` returns `true` for `Success`, `AlreadyCompleted`, `AlreadyInShoptet` and `false` for all others.
+- One test per factory method asserting the `Status`, `Message`, and `Operation`/`Exception` fields are populated correctly. ~0.5 day effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-06. Based on CI run #28716987459 (2ad2a2593e1834798a3def9ac2551b46c2e595cb)._

--- a/artifacts/feat-3498/code-review.r1.md
+++ b/artifacts/feat-3498/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs:180` — `IsSuccess_ReturnsExpectedValue_ForEachStatus` reuses `SubmitFailed` for the `Failed` status case but doesn't include `VerificationFailed`/`VerificationError`; not a bug (all three produce `Status.Failed` and are already asserted individually in FR-7/8/9), but could be a `[Theory]`/`[InlineData]` instead of a manually-built tuple array for slightly less boilerplate.

--- a/artifacts/feat-3498/design.r1.md
+++ b/artifacts/feat-3498/design.r1.md
@@ -1,0 +1,30 @@
+# Design: Unit test coverage for `StockUpOperationResult`
+
+## Component Design
+
+No production components are added or modified — this is a single new test class added to the existing test tree, with zero wiring changes.
+
+### `StockUpOperationResultTests` (new)
+- **Location:** `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs`
+- **Namespace:** `Anela.Heblo.Tests.Features.Catalog.Services` (matches sibling files `MarginCalculationServiceTests.cs`, `ProductWeightRecalculationServiceTests.cs`, `ProductCatalogQueryServiceTests.cs`, `SalesCostCalculationServiceTests.cs` in the same directory)
+- **Framework:** xUnit (`[Fact]`, `[Theory]`) + FluentAssertions (`.Should()`), matching existing conventions in the same test project. No Moq — no dependencies to mock.
+- **Responsibility:** Exercises the public surface of `StockUpOperationResult` (`Features/Catalog/Services/StockUpOperationResult.cs`) — its seven static factory methods and the `IsSuccess` computed property — without touching or duplicating production code.
+- **Construction strategy:** `StockUpOperation` test instances are built directly via its public constructor (`documentNumber, productCode, amount, sourceType, sourceId`) using simple non-empty values (e.g. `"DOC-1"`, `"PROD-1"`, amount `1`) — no test builder/helper is introduced, since a single call site with two fixed arguments doesn't warrant one. Where a test needs `ErrorMessage` populated (the `PreviouslyFailed` case), it calls `operation.MarkAsFailed(timestamp, "some error")` after construction, since `ErrorMessage` has a private setter reachable only through that method.
+- **Construction of `StockUpOperationResult` itself:** exclusively through its own public static factories (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress`, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`) — no reflection, no `Activator.CreateInstance` against the private parameterless constructor. Together these seven factories reach all six `StockUpResultStatus` values, which is what makes the `IsSuccess` predicate fully coverable without bypassing encapsulation.
+
+### Test case shape
+- One `[Fact]` per factory method (covers FR-2 through FR-9), each asserting in a single test body: `Status`, `Message` (exact literal or exact interpolated string — never re-derived), `Operation` (reference identity via `.Should().BeSameAs(operation)`), `Exception` (identity where applicable, else null), and `IsSuccess`.
+- `InProgress` gets two `[Fact]`s (per FR-5): one with a non-null operation and a known `State`, one with `InProgress(null)` asserting `Operation` is `null` and `Message` equals the literal pinned string `"Operation already in progress (state: )"`.
+- One additional dedicated test (table-driven `[Theory]` or equivalent) built from factory calls across all six `StockUpResultStatus` values, asserting `IsSuccess` true for `Success`/`AlreadyCompleted`/`AlreadyInShoptet` and false for `InProgress`/`PreviouslyFailed`/`Failed` — kept distinct from the per-factory tests so the "current set of success statuses" is pinned in one self-contained, readable place (FR-1).
+
+No `.csproj` changes are needed — the test project uses default SDK-style globbing and already compiles sibling files from the same folder.
+
+## Data Schemas
+
+No new or changed data schemas, DTOs, or API contracts. This task only reads the existing shapes below to construct test fixtures and assertions:
+
+- **`StockUpOperationResult`** (class, `Features/Catalog/Services/StockUpOperationResult.cs`) — properties: `Status` (`StockUpResultStatus`), `Message` (`string`, default `""`), `Operation` (`StockUpOperation?`), `Exception` (`Exception?`), computed `IsSuccess` (`bool`, true only for `Success`/`AlreadyCompleted`/`AlreadyInShoptet`).
+- **`StockUpResultStatus`** (enum, same file) — `Success`, `AlreadyCompleted`, `AlreadyInShoptet`, `InProgress`, `PreviouslyFailed`, `Failed`.
+- **`StockUpOperation`** (domain type, `Anela.Heblo.Domain.Features.Catalog.Stock`) — fields consumed by the factories under test: `ErrorMessage` (populated only via `MarkAsFailed(DateTime, string)`) and `State` (defaults to `StockUpOperationState.Pending` post-construction).
+
+No API endpoints, controllers, or event payloads are introduced or affected.

--- a/artifacts/feat-3498/impl/add-issuccess-predicate-theory-test.r1.md
+++ b/artifacts/feat-3498/impl/add-issuccess-predicate-theory-test.r1.md
@@ -1,0 +1,29 @@
+# Implementation: add-issuccess-predicate-theory-test
+
+## What was implemented
+Added `IsSuccess_ReturnsExpectedValue_ForEachStatus`, a single test method appended to the existing `StockUpOperationResultTests` class, that builds one `StockUpOperationResult` per representative `StockUpResultStatus` value via the existing factories and asserts `IsSuccess` for each: `Success`→true, `AlreadyCompleted`→true, `AlreadyInShoptet`→true, `InProgress`→false, `PreviouslyFailed`→false, `SubmitFailed` (representing `Failed`)→false.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs` — added one `[Fact]` method (no other changes).
+
+## Tests
+Filtered run (old 9 + new 1):
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+Passed!  - Failed:     0, Passed:    10, Skipped:     0, Total:    10, Duration: 36 ms - Anela.Heblo.Tests.dll (net8.0)
+```
+Full project sanity run:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+Failed!  - Failed:    64, Passed:  5424, Skipped:     4, Total:  5492, Duration: 20 s - Anela.Heblo.Tests.dll (net8.0)
+```
+All 64 failures are pre-existing Docker/Testcontainers-dependent integration tests (`PostgresSharedContainerFixture` construction throws `Docker is either not running or misconfigured` in this sandbox — no Docker daemon available). None involve `StockUpOperationResultTests` or `StockUpOperationResult`. This is an environment limitation, not a regression introduced by this change.
+
+## How to verify
+Run the filtered command above from the worktree root; expect 10/10 passing.
+
+## Notes
+No deviations from the plan; the real source matched the pinned facts exactly.
+
+## Status
+DONE

--- a/artifacts/feat-3498/impl/create-stockupoperationresult-test-file-with-factory-tests.r1.md
+++ b/artifacts/feat-3498/impl/create-stockupoperationresult-test-file-with-factory-tests.r1.md
@@ -1,0 +1,26 @@
+# Implementation: create-stockupoperationresult-test-file-with-factory-tests
+
+## What was implemented
+Added a new xUnit + FluentAssertions test file covering all seven static factory methods on `StockUpOperationResult` (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress` (both non-null and null operand), `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`), asserting `Status`, `Message`, `Operation`, `Exception`, and `IsSuccess` for each.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs` — new file, 9 `[Fact]` tests, no production code changes.
+
+## Tests
+9 tests, all passing:
+```
+Passed!  - Failed:     0, Passed:     9, Skipped:     0, Total:     9, Duration: 6 ms - Anela.Heblo.Tests.dll (net8.0)
+```
+Verified with:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+
+## How to verify
+Run the command above from the worktree root; expect 9/9 passing with no build errors.
+
+## Notes
+Test code matched the task-plan verbatim; cross-checked against the real source files (`StockUpOperationResult.cs`, `StockUpOperation.cs`) and found no discrepancies with the pinned facts in the plan.
+
+## Status
+DONE

--- a/artifacts/feat-3498/review/add-issuccess-predicate-theory-test.r1.md
+++ b/artifacts/feat-3498/review/add-issuccess-predicate-theory-test.r1.md
@@ -1,0 +1,19 @@
+# Code Review: StockUpOperationResult IsSuccess predicate test
+
+## Summary
+The new `IsSuccess_ReturnsExpectedValue_ForEachStatus` test was added exactly as planned, as the tenth and final `[Fact]` in `StockUpOperationResultTests.cs`. It builds one `StockUpOperationResult` per representative `StockUpResultStatus` value via the existing public factories and asserts the boolean outcome of `IsSuccess`. Every assertion in the method was independently checked against the real `IsSuccess` implementation in `StockUpOperationResult.cs` and is correct.
+
+## Review Result: PASS
+
+### task: add-issuccess-predicate-theory-test
+**Status:** PASS
+
+## Docs to Update
+(none)
+
+## Overall Notes
+- **FR-1 compliance:** `IsSuccess` is `Status == Success || Status == AlreadyCompleted || Status == AlreadyInShoptet` (source lines 11-13). The test's six cases map to all six `StockUpResultStatus` values (`Success`, `AlreadyCompleted`, `AlreadyInShoptet` → `true`; `InProgress`, `PreviouslyFailed`, `Failed` via `SubmitFailed` → `false`), and each expected boolean matches the real predicate exactly. `Failed` is represented once (via `SubmitFailed`) rather than three times (`SubmitFailed`/`VerificationFailed`/`VerificationError`), which is correct since all three produce the same `Status` value and the per-factory tests (FR-2–FR-9, already in the file) independently cover those other two call sites' `IsSuccess` assertions.
+- **Architecture adherence:** `arch-review.r1.md` Decision 1 explicitly resolves the private-constructor open question in favor of factory-methods-only (no reflection) — followed exactly. The "Test case shape" section explicitly recommends "One additional `[Theory]`/`[InlineData]`-free or table-driven test dedicated to `IsSuccess`" as a distinct test kept separate from the per-factory tests — the implementation matches this precisely (a `[Fact]` iterating a tuple array, not an xUnit `[Theory]`), so the spec's looser wording ("parameterized (theory-style)" in FR-1) is satisfied per the architecture review's explicit resolution.
+- **Correctness detail checked:** the test reuses a single `operation` instance (via `CreateOperation()`) across all six factory calls, including `PreviouslyFailed(operation)` on an operation that was never `MarkAsFailed`'d. This is safe here — `PreviouslyFailed`'s message interpolates `operation.ErrorMessage` (null-safe string interpolation, no exception), and this test asserts only `IsSuccess`, not `Message`, so the un-set `ErrorMessage` has no effect on the assertions made. The message-content assertion for `PreviouslyFailed` is separately and correctly covered by the earlier `PreviouslyFailed_WithFailedOperation_ReturnsPreviouslyFailedResult` test, which does call `MarkAsFailed` first.
+- **Completeness:** file now has 10 `[Fact]` methods total (9 per-factory/edge-case tests + 1 dedicated `IsSuccess` test), matching the impl artifact's reported count and the task's Step 2 expectation. No production code was touched, consistent with the coverage-only scope.
+- No style, correctness, or spec-compliance issues found. No changes requested.

--- a/artifacts/feat-3498/review/create-stockupoperationresult-test-file-with-factory-tests.r1.md
+++ b/artifacts/feat-3498/review/create-stockupoperationresult-test-file-with-factory-tests.r1.md
@@ -1,0 +1,27 @@
+# Code Review: StockUpOperationResult test coverage
+
+## Summary
+The new test file adds one `[Fact]` per `StockUpOperationResult` factory method (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress` x2, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`) exactly as specified in the task plan, and every assertion (`Status`, `Message`, `Operation`, `Exception`, `IsSuccess`) was independently traced against the real `StockUpOperationResult.cs` and `StockUpOperation.cs` source and found correct. No production code was touched, matching the coverage-only scope.
+
+## Review Result: PASS
+
+### task: create-stockupoperationresult-test-file-with-factory-tests
+**Status:** PASS
+
+Verification detail (source-level cross-check, not just trusting the plan):
+- `Success`/`AlreadyCompleted`/`AlreadyInShoptet`: message strings and `IsSuccess == true` match `StockUpOperationResult.cs` lines 11-13 (allow-list includes exactly these three statuses) and the corresponding factory bodies (lines 17-25, 27-35, 57-65).
+- `PreviouslyFailed`: test calls `operation.MarkAsFailed(DateTime.UtcNow, "Test error message")` before invoking the factory — this is required because `StockUpOperation.ErrorMessage` has a private setter only reachable via `MarkAsFailed` (`StockUpOperation.cs` lines 68-76). Resulting message `"Operation previously failed: Test error message"` matches the factory's `$"Operation previously failed: {operation.ErrorMessage}"` (line 42). `IsSuccess == false` correctly reflects that `PreviouslyFailed` is not in the success allow-list.
+- `InProgress` (non-null operand): default post-construction `State` is `Pending` (`StockUpOperation.cs` line 45, `StockUpOperationState.cs`), so `"Operation already in progress (state: Pending)"` is correct against `$"Operation already in progress (state: {operation?.State})"` (line 52).
+- `InProgress(null)`: `operation?.State` on a null operand interpolates as empty string, matching the asserted `"Operation already in progress (state: )"`.
+- `SubmitFailed`/`VerificationError`: both set `Status = Failed`, propagate the same `Exception` instance, and interpolate `ex.Message` into the message string — matches lines 67-76 and 88-97 exactly, including `.BeSameAs(ex)` for reference equality.
+- `VerificationFailed`: literal message matches line 83 verbatim.
+- `CreateOperation()` helper uses valid non-empty `documentNumber`/`productCode` and non-zero `amount`, avoiding the `ValidationException` guards in the `StockUpOperation` constructor.
+
+Architecture adherence: matches `arch-review.r1.md` exactly — direct construction of `StockUpOperation` (no builder, no reflection), factory-methods-only approach, xUnit + FluentAssertions, correct namespace (`Anela.Heblo.Tests.Features.Catalog.Services`) and directory (`Features/Catalog/Services/`) mirroring the production path and sibling test files.
+
+Scope note: FR-1 (the dedicated `IsSuccess` theory test enumerating all six `StockUpResultStatus` values) is correctly out of scope for this task — it is handled by the separate task `add-issuccess-predicate-theory-test.md`, confirmed present in `task-context/`. This task's own plan only requires FR-2 through FR-9, which are all fully and correctly covered.
+
+The implementation file is a verbatim match to the task plan's prescribed content (Step 1), so there is no deviation to flag. The developer's reported test run (`Passed! - Failed: 0, Passed: 9, Skipped: 0, Total: 9`) is consistent with the independent source-level verification performed here.
+
+## Overall Notes
+No issues found. This is a clean, correctly-scoped, coverage-only test addition with no production code changes.

--- a/artifacts/feat-3498/spec.r1.md
+++ b/artifacts/feat-3498/spec.r1.md
@@ -1,0 +1,134 @@
+# Specification: Unit test coverage for `StockUpOperationResult`
+
+## Summary
+`backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs` currently has 0% line coverage. This work adds a focused unit test suite covering the `IsSuccess` computed property and all seven static factory methods (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress`, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`), pinning current behavior so future refactors of `StockUpResultStatus` or the factory methods are caught by regression tests.
+
+## Background
+`StockUpOperationResult` is a plain result-object class (not a record, per project convention) representing the outcome of a stock-up operation against Shoptet. Callers branch on `IsSuccess` to decide whether an operation succeeded. `IsSuccess` returns `true` for exactly three of the six `StockUpResultStatus` enum values (`Success`, `AlreadyCompleted`, `AlreadyInShoptet`) and `false` for the other three (`InProgress`, `PreviouslyFailed`, `Failed`). Because `IsSuccess` is an explicit allow-list rather than a deny-list, adding a new enum value in the future will silently default to `false` — this is very likely correct behavior, but currently unverified by any test. This is a coverage-gap remediation task (filed by the weekly coverage-gap routine on 2026-07-06), not a behavior change: no production code should be modified.
+
+## Functional Requirements
+
+### FR-1: `IsSuccess` predicate coverage
+Add a parameterized (theory-style) test that exercises `IsSuccess` for every value currently defined in `StockUpResultStatus`.
+
+**Acceptance criteria:**
+- A test constructs (or otherwise obtains) a `StockUpOperationResult` with `Status` set to each of the six enum values: `Success`, `AlreadyCompleted`, `AlreadyInShoptet`, `InProgress`, `PreviouslyFailed`, `Failed`.
+- Asserts `IsSuccess == true` for `Success`, `AlreadyCompleted`, `AlreadyInShoptet`.
+- Asserts `IsSuccess == false` for `InProgress`, `PreviouslyFailed`, `Failed`.
+- Because the class has a private parameterless constructor, tests must set `Status` either via one of the existing static factory methods (preferred, since it also validates factory behavior) or via object initializer syntax using the `init`-scoped `Status` property from within the test project (the constructor is private, but properties are `init`-settable, which C# permits via object initializers even with a private constructor called from a factory the type itself defines — note: the private constructor prevents `new StockUpOperationResult { ... }` from a test outside the class; see Open Questions).
+
+### FR-2: `Success` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.Success(operation)` with a non-null `StockUpOperation` returns a result where:
+  - `Status == StockUpResultStatus.Success`
+  - `Message == "Stock up operation completed successfully"`
+  - `Operation` is the same instance passed in
+  - `Exception` is `null`
+  - `IsSuccess == true`
+
+### FR-3: `AlreadyCompleted` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.AlreadyCompleted(operation)` returns a result where:
+  - `Status == StockUpResultStatus.AlreadyCompleted`
+  - `Message == "Operation already completed"`
+  - `Operation` is the same instance passed in
+  - `Exception` is `null`
+  - `IsSuccess == true`
+
+### FR-4: `PreviouslyFailed` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.PreviouslyFailed(operation)` where `operation.ErrorMessage` is set to a known test string returns a result where:
+  - `Status == StockUpResultStatus.PreviouslyFailed`
+  - `Message == $"Operation previously failed: {operation.ErrorMessage}"` (verify the exact interpolated value appears in the message)
+  - `Operation` is the same instance passed in
+  - `Exception` is `null`
+  - `IsSuccess == false`
+
+### FR-5: `InProgress` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.InProgress(operation)` with a non-null `operation` whose `State` is set to a known value returns a result where:
+  - `Status == StockUpResultStatus.InProgress`
+  - `Message == $"Operation already in progress (state: {operation.State})"`
+  - `Operation` is the same instance passed in
+  - `Exception` is `null`
+  - `IsSuccess == false`
+- A second case calls `StockUpOperationResult.InProgress(null)` (the parameter is nullable) and asserts:
+  - `Operation` is `null`
+  - `Message` contains the rendered form of `null` state (i.e. `"Operation already in progress (state: )"`, since `operation?.State` on a null operation evaluates to `null` and interpolates as empty string) — the test should assert the literal expected string rather than re-deriving the interpolation logic, to genuinely pin behavior.
+  - `IsSuccess == false`
+
+### FR-6: `AlreadyInShoptet` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.AlreadyInShoptet(operation)` returns a result where:
+  - `Status == StockUpResultStatus.AlreadyInShoptet`
+  - `Message == "Document already exists in Shoptet history"`
+  - `Operation` is the same instance passed in
+  - `Exception` is `null`
+  - `IsSuccess == true`
+
+### FR-7: `SubmitFailed` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.SubmitFailed(operation, ex)` with a non-null `Exception` (e.g. `new InvalidOperationException("boom")`) returns a result where:
+  - `Status == StockUpResultStatus.Failed`
+  - `Message == $"Submit failed: {ex.Message}"`
+  - `Operation` is the same instance passed in
+  - `Exception` is the same instance passed in
+  - `IsSuccess == false`
+
+### FR-8: `VerificationFailed` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.VerificationFailed(operation)` returns a result where:
+  - `Status == StockUpResultStatus.Failed`
+  - `Message == "Verification failed: Record not found in Shoptet history after submission"`
+  - `Operation` is the same instance passed in
+  - `Exception` is `null`
+  - `IsSuccess == false`
+
+### FR-9: `VerificationError` factory method coverage
+**Acceptance criteria:**
+- Calling `StockUpOperationResult.VerificationError(operation, ex)` with a non-null `Exception` returns a result where:
+  - `Status == StockUpResultStatus.Failed`
+  - `Message == $"Verification error: {ex.Message}"`
+  - `Operation` is the same instance passed in
+  - `Exception` is the same instance passed in
+  - `IsSuccess == false`
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+N/A — pure unit tests over an in-memory value object; no I/O, no async, expected to run in milliseconds each.
+
+### NFR-2: Security
+N/A — no auth, no sensitive data, no external calls involved in this type or its tests.
+
+### NFR-3: Test isolation and conventions
+- Tests must not require a database, HTTP server, or any mocked infrastructure — `StockUpOperationResult` and `StockUpOperation` are plain in-memory types.
+- Follow the existing test project conventions in the repository (test framework — likely xUnit based on typical .NET conventions in this repo; confirm by inspecting an existing test file in the same test project before authoring, e.g. under `backend/test/.../Catalog/` or equivalent).
+- New test file should be named consistently with existing conventions, e.g. `StockUpOperationResultTests.cs`, placed in the test project mirroring the production namespace path `Features/Catalog/Services/`.
+- Use a minimal valid `StockUpOperation` test fixture/builder (constructed directly or via existing test helpers if any exist in the codebase) rather than mocking, since it is a plain domain object.
+
+## Data Model
+No new or changed data model. Existing types referenced:
+- `StockUpOperationResult` (class, `Features/Catalog/Services/StockUpOperationResult.cs`): properties `Status` (`StockUpResultStatus`), `Message` (`string`, defaults to `""`), `Operation` (`StockUpOperation?`), `Exception` (`Exception?`), and computed `IsSuccess` (`bool`).
+- `StockUpResultStatus` (enum, same file): `Success`, `AlreadyCompleted`, `AlreadyInShoptet`, `InProgress`, `PreviouslyFailed`, `Failed`.
+- `StockUpOperation` (domain type, `Anela.Heblo.Domain.Features.Catalog.Stock`): referenced fields used by the factories are `ErrorMessage` (used in `PreviouslyFailed`'s message) and `State` (used in `InProgress`'s message). Tests should inspect this type's actual definition before constructing instances, to use real property names and any required constructor arguments.
+
+## API / Interface Design
+N/A — this is a test-only change; no public API, controller, or UI surface is added or modified.
+
+## Dependencies
+- Existing test project for the `Anela.Heblo.Application` layer (locate the project covering `Features/Catalog/Services/*`; do not create a new test project if one already exists).
+- `StockUpOperation` domain type (read-only dependency — must inspect its actual shape in `Anela.Heblo.Domain.Features.Catalog.Stock` to construct valid test instances; do not invent properties).
+- Standard .NET test framework and assertion library already in use elsewhere in the test suite (match existing patterns — do not introduce a new test framework).
+
+## Out of Scope
+- Any change to production code in `StockUpOperationResult.cs` (this is a coverage-only task).
+- Testing the callers/consumers of `StockUpOperationResult` (e.g. the service(s) that invoke these factory methods) — only the result type itself is in scope.
+- Testing `StockUpOperation` itself, beyond what's needed to construct instances for these tests.
+- Behavioral changes to `IsSuccess`, such as switching it from an allow-list to a deny-list, or adding new `StockUpResultStatus` values.
+
+## Open Questions
+- `StockUpOperationResult` has a `private` parameterless constructor, so it can only be instantiated via its own static factory methods from outside the class (object-initializer syntax like `new StockUpOperationResult { Status = ... }` is not accessible from the test project since the constructor is private). FR-1's `IsSuccess` coverage should therefore be validated indirectly through the existing factory methods, which between them exercise all six `StockUpResultStatus` values (`Success`→Success, `AlreadyCompleted`→AlreadyCompleted, `AlreadyInShoptet`→AlreadyInShoptet, `InProgress`→InProgress, `PreviouslyFailed`→PreviouslyFailed, `SubmitFailed`/`VerificationFailed`/`VerificationError`→Failed) rather than via direct object construction. Confirm this approach is acceptable, or confirm whether a test-internal factory/reflection-based approach is preferred — this spec assumes the factory-method-only approach and considers FR-1 satisfied by the combination of FR-2 through FR-9 assertions on `IsSuccess`, plus an explicit dedicated theory test for clarity and to make the "current set of success statuses" assertion self-contained and readable in one place.
+- Exact test framework/assertion library in use in the target test project (xUnit/NUnit/MSTest, FluentAssertions or plain `Assert`) was not verified against the actual test project structure. The implementer should inspect a neighboring test file in the same project before authoring to match conventions exactly.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-06T12:18:29.003435Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T12:19:11.605344Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "create-stockupoperationresult-test-file-with-factory-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-06T12:22:06.381153Z"
+      "updated_at": "2026-07-06T12:54:40.107841Z"
     },
     {
       "name": "add-issuccess-predicate-theory-test",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-06T12:54:43.596526Z"
     }
   ]
 }

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-06T12:21:33.905834Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T12:22:06.166926Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T13:52:15.138969Z"
     }
   },
   "tasks": [
@@ -34,9 +34,9 @@
     },
     {
       "name": "add-issuccess-predicate-theory-test",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-06T12:54:43.596526Z"
+      "updated_at": "2026-07-06T13:52:07.132001Z"
     }
   ]
 }

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3498",
+  "issue_number": 3498,
+  "created_at": "2026-07-06T12:14:55.226720Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T12:21:33.905834Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T12:22:06.166926Z"
     }
   },
   "tasks": [
     {
       "name": "create-stockupoperationresult-test-file-with-factory-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-06T12:22:06.381153Z"
     },
     {
       "name": "add-issuccess-predicate-theory-test",

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-06T13:52:15.138969Z"
+    },
+    "code-review": {
+      "status": "completed",
+      "updated_at": "2026-07-06T13:53:14.042662Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-06T12:19:11.605344Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T12:21:33.905834Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T12:16:41.882742Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -25,5 +25,18 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "create-stockupoperationresult-test-file-with-factory-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "add-issuccess-predicate-theory-test",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3498/state.json
+++ b/artifacts/feat-3498/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-06T12:16:41.882742Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T12:18:29.003435Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3498/task-context/add-issuccess-predicate-theory-test.md
+++ b/artifacts/feat-3498/task-context/add-issuccess-predicate-theory-test.md
@@ -1,0 +1,92 @@
+# Task Plan: Unit test coverage for `StockUpOperationResult`
+
+**Goal:** Add a focused xUnit + FluentAssertions test suite for `backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs`, covering all seven static factory methods and the `IsSuccess` computed property. This is a coverage-only change — no production code is modified.
+
+**Tech stack:** xUnit (`[Fact]`), FluentAssertions (`.Should()`). No Moq needed (no dependencies to mock). `Xunit` is globally usable in the test project (`<Using Include="Xunit" />` in `Anela.Heblo.Tests.csproj`), so no `using Xunit;` line is required, but sibling files include it explicitly for clarity — this plan follows that same convention.
+
+**New file:** `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs`
+**Namespace:** `Anela.Heblo.Tests.Features.Catalog.Services`
+**Test command (run from repo root of the worktree):**
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+
+**Key facts pinned from source inspection (do not re-derive, use verbatim):**
+- `StockUpOperationResult` (`backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs`): properties `Status` (`StockUpResultStatus`), `Message` (`string`), `Operation` (`StockUpOperation?`), `Exception` (`Exception?`), computed `IsSuccess` (true only for `Success`, `AlreadyCompleted`, `AlreadyInShoptet`).
+- `StockUpOperation` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperation.cs`): public constructor `StockUpOperation(string documentNumber, string productCode, int amount, StockUpSourceType sourceType, int sourceId)`. Throws `ValidationException` if `documentNumber`/`productCode` empty or `amount == 0`. Default post-construction `State` is `StockUpOperationState.Pending`. `ErrorMessage` has a private setter, populated only via `MarkAsFailed(DateTime timestamp, string errorMessage)`.
+- `StockUpSourceType` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpSourceType.cs`): enum values `TransportBox = 0`, `GiftPackageManufacture = 1`.
+- `StockUpOperationState` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperationState.cs`): `Pending`, `Submitted`, `Completed`, `Failed`.
+- Exact factory message strings (verified from source):
+  - `Success` → `"Stock up operation completed successfully"`
+  - `AlreadyCompleted` → `"Operation already completed"`
+  - `PreviouslyFailed` → `$"Operation previously failed: {operation.ErrorMessage}"`
+  - `InProgress` → `$"Operation already in progress (state: {operation?.State})"`
+  - `AlreadyInShoptet` → `"Document already exists in Shoptet history"`
+  - `SubmitFailed` → `$"Submit failed: {ex.Message}"`
+  - `VerificationFailed` → `"Verification failed: Record not found in Shoptet history after submission"`
+  - `VerificationError` → `$"Verification error: {ex.Message}"`
+
+---
+
+---
+
+### task: add-issuccess-predicate-theory-test
+
+Add a dedicated test (FR-1) that pins, in one self-contained place, which `StockUpResultStatus` values make `IsSuccess` true vs. false — built from the same factory methods used in the previous task, kept as a distinct test so the "current set of success statuses" reads clearly to a future maintainer (per the architecture review's Decision 1 and the design doc's "Test case shape" section).
+
+**Step 1 — Add the test method**
+
+Edit `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs` and add the following method as the last member of the `StockUpOperationResultTests` class (insert immediately before the closing `}` of the class, after `VerificationError_WithOperationAndException_ReturnsFailedResult`):
+
+```csharp
+
+    [Fact]
+    public void IsSuccess_ReturnsExpectedValue_ForEachStatus()
+    {
+        // Arrange: one factory call per StockUpResultStatus value, paired with the
+        // expected IsSuccess outcome. This is the single place that pins "the current
+        // set of success statuses" (Success, AlreadyCompleted, AlreadyInShoptet).
+        var operation = CreateOperation();
+        var cases = new (StockUpOperationResult Result, bool ExpectedIsSuccess)[]
+        {
+            (StockUpOperationResult.Success(operation), true),
+            (StockUpOperationResult.AlreadyCompleted(operation), true),
+            (StockUpOperationResult.AlreadyInShoptet(operation), true),
+            (StockUpOperationResult.InProgress(operation), false),
+            (StockUpOperationResult.PreviouslyFailed(operation), false),
+            (StockUpOperationResult.SubmitFailed(operation, new InvalidOperationException("boom")), false),
+        };
+
+        // Act & Assert
+        foreach (var (result, expectedIsSuccess) in cases)
+        {
+            result.IsSuccess.Should().Be(expectedIsSuccess,
+                $"because Status={result.Status} should yield IsSuccess={expectedIsSuccess}");
+        }
+    }
+```
+
+Note: `cases` covers all six `StockUpResultStatus` enum values (`Success`, `AlreadyCompleted`, `AlreadyInShoptet`, `InProgress`, `PreviouslyFailed`, and `Failed` via `SubmitFailed`) exactly as required by FR-1 — `SubmitFailed` is used as the representative `Failed`-status case since `VerificationFailed`/`VerificationError` already cover the same `Status` value in the per-factory tests from the previous task.
+
+**Step 2 — Run the full test file and confirm all tests pass**
+
+Run:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+Expected: build succeeds, 10 tests discovered and passed (the 9 from the previous task plus `IsSuccess_ReturnsExpectedValue_ForEachStatus`).
+
+**Step 3 — Run the full test project as a final sanity check**
+
+Run:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: no regressions — all previously-passing tests in the project still pass; the new file only adds tests, it does not touch any shared fixtures or production code.
+
+**Step 4 — Commit**
+
+```
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
+git commit -m "test: pin IsSuccess predicate coverage across all StockUpResultStatus values"
+```

--- a/artifacts/feat-3498/task-context/create-stockupoperationresult-test-file-with-factory-tests.md
+++ b/artifacts/feat-3498/task-context/create-stockupoperationresult-test-file-with-factory-tests.md
@@ -1,0 +1,231 @@
+# Task Plan: Unit test coverage for `StockUpOperationResult`
+
+**Goal:** Add a focused xUnit + FluentAssertions test suite for `backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs`, covering all seven static factory methods and the `IsSuccess` computed property. This is a coverage-only change — no production code is modified.
+
+**Tech stack:** xUnit (`[Fact]`), FluentAssertions (`.Should()`). No Moq needed (no dependencies to mock). `Xunit` is globally usable in the test project (`<Using Include="Xunit" />` in `Anela.Heblo.Tests.csproj`), so no `using Xunit;` line is required, but sibling files include it explicitly for clarity — this plan follows that same convention.
+
+**New file:** `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs`
+**Namespace:** `Anela.Heblo.Tests.Features.Catalog.Services`
+**Test command (run from repo root of the worktree):**
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+
+**Key facts pinned from source inspection (do not re-derive, use verbatim):**
+- `StockUpOperationResult` (`backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs`): properties `Status` (`StockUpResultStatus`), `Message` (`string`), `Operation` (`StockUpOperation?`), `Exception` (`Exception?`), computed `IsSuccess` (true only for `Success`, `AlreadyCompleted`, `AlreadyInShoptet`).
+- `StockUpOperation` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperation.cs`): public constructor `StockUpOperation(string documentNumber, string productCode, int amount, StockUpSourceType sourceType, int sourceId)`. Throws `ValidationException` if `documentNumber`/`productCode` empty or `amount == 0`. Default post-construction `State` is `StockUpOperationState.Pending`. `ErrorMessage` has a private setter, populated only via `MarkAsFailed(DateTime timestamp, string errorMessage)`.
+- `StockUpSourceType` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpSourceType.cs`): enum values `TransportBox = 0`, `GiftPackageManufacture = 1`.
+- `StockUpOperationState` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperationState.cs`): `Pending`, `Submitted`, `Completed`, `Failed`.
+- Exact factory message strings (verified from source):
+  - `Success` → `"Stock up operation completed successfully"`
+  - `AlreadyCompleted` → `"Operation already completed"`
+  - `PreviouslyFailed` → `$"Operation previously failed: {operation.ErrorMessage}"`
+  - `InProgress` → `$"Operation already in progress (state: {operation?.State})"`
+  - `AlreadyInShoptet` → `"Document already exists in Shoptet history"`
+  - `SubmitFailed` → `$"Submit failed: {ex.Message}"`
+  - `VerificationFailed` → `"Verification failed: Record not found in Shoptet history after submission"`
+  - `VerificationError` → `$"Verification error: {ex.Message}"`
+
+---
+
+---
+
+### task: create-stockupoperationresult-test-file-with-factory-tests
+
+Create the new test file with one `[Fact]` per factory method (FR-2 through FR-9 in the spec), plus the two required `InProgress` cases (non-null operand and `null` operand). This is the bulk of the coverage.
+
+**Step 1 — Create the file**
+
+Write `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs` with the following complete content:
+
+```csharp
+using System;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Services;
+
+/// <summary>
+/// Unit tests for StockUpOperationResult factory methods and the IsSuccess predicate.
+/// Coverage-only test suite: pins current behavior, does not change production code.
+/// </summary>
+public class StockUpOperationResultTests
+{
+    private static StockUpOperation CreateOperation()
+    {
+        return new StockUpOperation("DOC-1", "PROD-1", 1, StockUpSourceType.TransportBox, 1);
+    }
+
+    [Fact]
+    public void Success_WithOperation_ReturnsSuccessResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.Success(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Success);
+        result.Message.Should().Be("Stock up operation completed successfully");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AlreadyCompleted_WithOperation_ReturnsAlreadyCompletedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.AlreadyCompleted(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.AlreadyCompleted);
+        result.Message.Should().Be("Operation already completed");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreviouslyFailed_WithFailedOperation_ReturnsPreviouslyFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        operation.MarkAsFailed(DateTime.UtcNow, "Test error message");
+
+        // Act
+        var result = StockUpOperationResult.PreviouslyFailed(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.PreviouslyFailed);
+        result.Message.Should().Be("Operation previously failed: Test error message");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InProgress_WithOperation_ReturnsInProgressResultWithState()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.InProgress(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.InProgress);
+        result.Message.Should().Be("Operation already in progress (state: Pending)");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InProgress_WithNullOperation_ReturnsInProgressResultWithEmptyState()
+    {
+        // Act
+        var result = StockUpOperationResult.InProgress(null);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.InProgress);
+        result.Message.Should().Be("Operation already in progress (state: )");
+        result.Operation.Should().BeNull();
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AlreadyInShoptet_WithOperation_ReturnsAlreadyInShoptetResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.AlreadyInShoptet(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.AlreadyInShoptet);
+        result.Message.Should().Be("Document already exists in Shoptet history");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SubmitFailed_WithOperationAndException_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        var ex = new InvalidOperationException("boom");
+
+        // Act
+        var result = StockUpOperationResult.SubmitFailed(operation, ex);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Submit failed: boom");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeSameAs(ex);
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerificationFailed_WithOperation_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.VerificationFailed(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Verification failed: Record not found in Shoptet history after submission");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerificationError_WithOperationAndException_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        var ex = new InvalidOperationException("boom");
+
+        // Act
+        var result = StockUpOperationResult.VerificationError(operation, ex);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Verification error: boom");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeSameAs(ex);
+        result.IsSuccess.Should().BeFalse();
+    }
+}
+```
+
+**Step 2 — Run the new tests and confirm they pass**
+
+Run:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+Expected: build succeeds, 9 tests discovered and passed (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress` x2, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`). Since no production code changed and the assertions were derived directly from reading `StockUpOperationResult.cs`, these tests should be green on the first run — there is no red/green cycle here (this is coverage-of-existing-behavior, not TDD-driven new behavior). If any test fails, re-check the exact string/property against the source file before changing the test (never change production code for this task).
+
+**Step 3 — Commit**
+
+```
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
+git commit -m "test: add factory method coverage for StockUpOperationResult"
+```
+
+---

--- a/artifacts/feat-3498/task-plan.r1.md
+++ b/artifacts/feat-3498/task-plan.r1.md
@@ -1,0 +1,290 @@
+# Task Plan: Unit test coverage for `StockUpOperationResult`
+
+**Goal:** Add a focused xUnit + FluentAssertions test suite for `backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs`, covering all seven static factory methods and the `IsSuccess` computed property. This is a coverage-only change — no production code is modified.
+
+**Tech stack:** xUnit (`[Fact]`), FluentAssertions (`.Should()`). No Moq needed (no dependencies to mock). `Xunit` is globally usable in the test project (`<Using Include="Xunit" />` in `Anela.Heblo.Tests.csproj`), so no `using Xunit;` line is required, but sibling files include it explicitly for clarity — this plan follows that same convention.
+
+**New file:** `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs`
+**Namespace:** `Anela.Heblo.Tests.Features.Catalog.Services`
+**Test command (run from repo root of the worktree):**
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+
+**Key facts pinned from source inspection (do not re-derive, use verbatim):**
+- `StockUpOperationResult` (`backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs`): properties `Status` (`StockUpResultStatus`), `Message` (`string`), `Operation` (`StockUpOperation?`), `Exception` (`Exception?`), computed `IsSuccess` (true only for `Success`, `AlreadyCompleted`, `AlreadyInShoptet`).
+- `StockUpOperation` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperation.cs`): public constructor `StockUpOperation(string documentNumber, string productCode, int amount, StockUpSourceType sourceType, int sourceId)`. Throws `ValidationException` if `documentNumber`/`productCode` empty or `amount == 0`. Default post-construction `State` is `StockUpOperationState.Pending`. `ErrorMessage` has a private setter, populated only via `MarkAsFailed(DateTime timestamp, string errorMessage)`.
+- `StockUpSourceType` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpSourceType.cs`): enum values `TransportBox = 0`, `GiftPackageManufacture = 1`.
+- `StockUpOperationState` (`backend/src/Anela.Heblo.Domain/Features/Catalog/Stock/StockUpOperationState.cs`): `Pending`, `Submitted`, `Completed`, `Failed`.
+- Exact factory message strings (verified from source):
+  - `Success` → `"Stock up operation completed successfully"`
+  - `AlreadyCompleted` → `"Operation already completed"`
+  - `PreviouslyFailed` → `$"Operation previously failed: {operation.ErrorMessage}"`
+  - `InProgress` → `$"Operation already in progress (state: {operation?.State})"`
+  - `AlreadyInShoptet` → `"Document already exists in Shoptet history"`
+  - `SubmitFailed` → `$"Submit failed: {ex.Message}"`
+  - `VerificationFailed` → `"Verification failed: Record not found in Shoptet history after submission"`
+  - `VerificationError` → `$"Verification error: {ex.Message}"`
+
+---
+
+### task: create-stockupoperationresult-test-file-with-factory-tests
+
+Create the new test file with one `[Fact]` per factory method (FR-2 through FR-9 in the spec), plus the two required `InProgress` cases (non-null operand and `null` operand). This is the bulk of the coverage.
+
+**Step 1 — Create the file**
+
+Write `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs` with the following complete content:
+
+```csharp
+using System;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Services;
+
+/// <summary>
+/// Unit tests for StockUpOperationResult factory methods and the IsSuccess predicate.
+/// Coverage-only test suite: pins current behavior, does not change production code.
+/// </summary>
+public class StockUpOperationResultTests
+{
+    private static StockUpOperation CreateOperation()
+    {
+        return new StockUpOperation("DOC-1", "PROD-1", 1, StockUpSourceType.TransportBox, 1);
+    }
+
+    [Fact]
+    public void Success_WithOperation_ReturnsSuccessResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.Success(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Success);
+        result.Message.Should().Be("Stock up operation completed successfully");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AlreadyCompleted_WithOperation_ReturnsAlreadyCompletedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.AlreadyCompleted(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.AlreadyCompleted);
+        result.Message.Should().Be("Operation already completed");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreviouslyFailed_WithFailedOperation_ReturnsPreviouslyFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        operation.MarkAsFailed(DateTime.UtcNow, "Test error message");
+
+        // Act
+        var result = StockUpOperationResult.PreviouslyFailed(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.PreviouslyFailed);
+        result.Message.Should().Be("Operation previously failed: Test error message");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InProgress_WithOperation_ReturnsInProgressResultWithState()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.InProgress(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.InProgress);
+        result.Message.Should().Be("Operation already in progress (state: Pending)");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InProgress_WithNullOperation_ReturnsInProgressResultWithEmptyState()
+    {
+        // Act
+        var result = StockUpOperationResult.InProgress(null);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.InProgress);
+        result.Message.Should().Be("Operation already in progress (state: )");
+        result.Operation.Should().BeNull();
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AlreadyInShoptet_WithOperation_ReturnsAlreadyInShoptetResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.AlreadyInShoptet(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.AlreadyInShoptet);
+        result.Message.Should().Be("Document already exists in Shoptet history");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SubmitFailed_WithOperationAndException_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        var ex = new InvalidOperationException("boom");
+
+        // Act
+        var result = StockUpOperationResult.SubmitFailed(operation, ex);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Submit failed: boom");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeSameAs(ex);
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerificationFailed_WithOperation_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.VerificationFailed(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Verification failed: Record not found in Shoptet history after submission");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerificationError_WithOperationAndException_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        var ex = new InvalidOperationException("boom");
+
+        // Act
+        var result = StockUpOperationResult.VerificationError(operation, ex);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Verification error: boom");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeSameAs(ex);
+        result.IsSuccess.Should().BeFalse();
+    }
+}
+```
+
+**Step 2 — Run the new tests and confirm they pass**
+
+Run:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+Expected: build succeeds, 9 tests discovered and passed (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress` x2, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`). Since no production code changed and the assertions were derived directly from reading `StockUpOperationResult.cs`, these tests should be green on the first run — there is no red/green cycle here (this is coverage-of-existing-behavior, not TDD-driven new behavior). If any test fails, re-check the exact string/property against the source file before changing the test (never change production code for this task).
+
+**Step 3 — Commit**
+
+```
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
+git commit -m "test: add factory method coverage for StockUpOperationResult"
+```
+
+---
+
+### task: add-issuccess-predicate-theory-test
+
+Add a dedicated test (FR-1) that pins, in one self-contained place, which `StockUpResultStatus` values make `IsSuccess` true vs. false — built from the same factory methods used in the previous task, kept as a distinct test so the "current set of success statuses" reads clearly to a future maintainer (per the architecture review's Decision 1 and the design doc's "Test case shape" section).
+
+**Step 1 — Add the test method**
+
+Edit `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs` and add the following method as the last member of the `StockUpOperationResultTests` class (insert immediately before the closing `}` of the class, after `VerificationError_WithOperationAndException_ReturnsFailedResult`):
+
+```csharp
+
+    [Fact]
+    public void IsSuccess_ReturnsExpectedValue_ForEachStatus()
+    {
+        // Arrange: one factory call per StockUpResultStatus value, paired with the
+        // expected IsSuccess outcome. This is the single place that pins "the current
+        // set of success statuses" (Success, AlreadyCompleted, AlreadyInShoptet).
+        var operation = CreateOperation();
+        var cases = new (StockUpOperationResult Result, bool ExpectedIsSuccess)[]
+        {
+            (StockUpOperationResult.Success(operation), true),
+            (StockUpOperationResult.AlreadyCompleted(operation), true),
+            (StockUpOperationResult.AlreadyInShoptet(operation), true),
+            (StockUpOperationResult.InProgress(operation), false),
+            (StockUpOperationResult.PreviouslyFailed(operation), false),
+            (StockUpOperationResult.SubmitFailed(operation, new InvalidOperationException("boom")), false),
+        };
+
+        // Act & Assert
+        foreach (var (result, expectedIsSuccess) in cases)
+        {
+            result.IsSuccess.Should().Be(expectedIsSuccess,
+                $"because Status={result.Status} should yield IsSuccess={expectedIsSuccess}");
+        }
+    }
+```
+
+Note: `cases` covers all six `StockUpResultStatus` enum values (`Success`, `AlreadyCompleted`, `AlreadyInShoptet`, `InProgress`, `PreviouslyFailed`, and `Failed` via `SubmitFailed`) exactly as required by FR-1 — `SubmitFailed` is used as the representative `Failed`-status case since `VerificationFailed`/`VerificationError` already cover the same `Status` value in the per-factory tests from the previous task.
+
+**Step 2 — Run the full test file and confirm all tests pass**
+
+Run:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~StockUpOperationResultTests"
+```
+Expected: build succeeds, 10 tests discovered and passed (the 9 from the previous task plus `IsSuccess_ReturnsExpectedValue_ForEachStatus`).
+
+**Step 3 — Run the full test project as a final sanity check**
+
+Run:
+```
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: no regressions — all previously-passing tests in the project still pass; the new file only adds tests, it does not touch any shared fixtures or production code.
+
+**Step 4 — Commit**
+
+```
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
+git commit -m "test: pin IsSuccess predicate coverage across all StockUpResultStatus values"
+```

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
@@ -1,0 +1,172 @@
+using System;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Services;
+
+/// <summary>
+/// Unit tests for StockUpOperationResult factory methods and the IsSuccess predicate.
+/// Coverage-only test suite: pins current behavior, does not change production code.
+/// </summary>
+public class StockUpOperationResultTests
+{
+    private static StockUpOperation CreateOperation()
+    {
+        return new StockUpOperation("DOC-1", "PROD-1", 1, StockUpSourceType.TransportBox, 1);
+    }
+
+    [Fact]
+    public void Success_WithOperation_ReturnsSuccessResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.Success(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Success);
+        result.Message.Should().Be("Stock up operation completed successfully");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AlreadyCompleted_WithOperation_ReturnsAlreadyCompletedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.AlreadyCompleted(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.AlreadyCompleted);
+        result.Message.Should().Be("Operation already completed");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PreviouslyFailed_WithFailedOperation_ReturnsPreviouslyFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        operation.MarkAsFailed(DateTime.UtcNow, "Test error message");
+
+        // Act
+        var result = StockUpOperationResult.PreviouslyFailed(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.PreviouslyFailed);
+        result.Message.Should().Be("Operation previously failed: Test error message");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InProgress_WithOperation_ReturnsInProgressResultWithState()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.InProgress(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.InProgress);
+        result.Message.Should().Be("Operation already in progress (state: Pending)");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InProgress_WithNullOperation_ReturnsInProgressResultWithEmptyState()
+    {
+        // Act
+        var result = StockUpOperationResult.InProgress(null);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.InProgress);
+        result.Message.Should().Be("Operation already in progress (state: )");
+        result.Operation.Should().BeNull();
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AlreadyInShoptet_WithOperation_ReturnsAlreadyInShoptetResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.AlreadyInShoptet(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.AlreadyInShoptet);
+        result.Message.Should().Be("Document already exists in Shoptet history");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SubmitFailed_WithOperationAndException_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        var ex = new InvalidOperationException("boom");
+
+        // Act
+        var result = StockUpOperationResult.SubmitFailed(operation, ex);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Submit failed: boom");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeSameAs(ex);
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerificationFailed_WithOperation_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+
+        // Act
+        var result = StockUpOperationResult.VerificationFailed(operation);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Verification failed: Record not found in Shoptet history after submission");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeNull();
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerificationError_WithOperationAndException_ReturnsFailedResult()
+    {
+        // Arrange
+        var operation = CreateOperation();
+        var ex = new InvalidOperationException("boom");
+
+        // Act
+        var result = StockUpOperationResult.VerificationError(operation, ex);
+
+        // Assert
+        result.Status.Should().Be(StockUpResultStatus.Failed);
+        result.Message.Should().Be("Verification error: boom");
+        result.Operation.Should().BeSameAs(operation);
+        result.Exception.Should().BeSameAs(ex);
+        result.IsSuccess.Should().BeFalse();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs
@@ -169,4 +169,29 @@ public class StockUpOperationResultTests
         result.Exception.Should().BeSameAs(ex);
         result.IsSuccess.Should().BeFalse();
     }
+
+    [Fact]
+    public void IsSuccess_ReturnsExpectedValue_ForEachStatus()
+    {
+        // Arrange: one factory call per StockUpResultStatus value, paired with the
+        // expected IsSuccess outcome. This is the single place that pins "the current
+        // set of success statuses" (Success, AlreadyCompleted, AlreadyInShoptet).
+        var operation = CreateOperation();
+        var cases = new (StockUpOperationResult Result, bool ExpectedIsSuccess)[]
+        {
+            (StockUpOperationResult.Success(operation), true),
+            (StockUpOperationResult.AlreadyCompleted(operation), true),
+            (StockUpOperationResult.AlreadyInShoptet(operation), true),
+            (StockUpOperationResult.InProgress(operation), false),
+            (StockUpOperationResult.PreviouslyFailed(operation), false),
+            (StockUpOperationResult.SubmitFailed(operation, new InvalidOperationException("boom")), false),
+        };
+
+        // Act & Assert
+        foreach (var (result, expectedIsSuccess) in cases)
+        {
+            result.IsSuccess.Should().Be(expectedIsSuccess,
+                $"because Status={result.Status} should yield IsSuccess={expectedIsSuccess}");
+        }
+    }
 }


### PR DESCRIPTION
Closes #3498

## What the issue was
`backend/src/Anela.Heblo.Application/Features/Catalog/Services/StockUpOperationResult.cs` had 0% line coverage. Neither the `IsSuccess` computed property (true only for `Success`, `AlreadyCompleted`, `AlreadyInShoptet`) nor any of the seven static factory methods (`Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress`, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`) had any test pinning their current behavior — a future enum/refactor change could silently alter which operations are treated as successful.

## How it was fixed / handled
Added a new xUnit + FluentAssertions test file, `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs`, following the conventions of sibling test files in the same directory:
- One `[Fact]` per factory method (9 tests covering `Success`, `AlreadyCompleted`, `PreviouslyFailed`, `InProgress` for both a real and a `null` operation, `AlreadyInShoptet`, `SubmitFailed`, `VerificationFailed`, `VerificationError`), asserting `Status`, `Message`, `Operation`, and `Exception`.
- One dedicated `[Fact]` (`IsSuccess_ReturnsExpectedValue_ForEachStatus`) pinning the `IsSuccess` predicate across all six `StockUpResultStatus` values in a single, table-driven place, exactly as requested in the issue.

No production code was changed — this is a coverage-only change. All 10 new tests pass (`dotnet test ... --filter "FullyQualifiedName~StockUpOperationResultTests"` → 10/10). A full-project sanity run showed 64 pre-existing failures, all unrelated `Testcontainers`/Postgres integration tests failing due to no Docker daemon in this sandbox — not a regression from this change.

## Artifacts
Brief, spec, architecture review, design, task plan, per-task impl/review, and the final whole-branch code review are committed under `artifacts/feat-3498/` on this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/StockUpOperationResultTests.cs:180` — `IsSuccess_ReturnsExpectedValue_ForEachStatus` reuses `SubmitFailed` for the `Failed` status case but doesn't include `VerificationFailed`/`VerificationError`; not a bug (all three produce `Status.Failed` and are already asserted individually), but could be a `[Theory]`/`[InlineData]` instead of a manually-built tuple array for slightly less boilerplate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PznR4krH3xMya3gYjsXM6M)_