### PR TITLE
#3500: implementation

### DIFF
--- a/artifacts/feat-3500/arch-review.r1.md
+++ b/artifacts/feat-3500/arch-review.r1.md
@@ -1,0 +1,124 @@
+# Architecture Review: Close Coverage Gap in GraphCatalogDocumentsStorage
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a test-only tech-debt task with zero production surface. There is no new component, no new interface, no new module — the deliverable is exclusively additional `[Fact]`/`[Theory]` methods (plus one small test-only helper `Stream`) appended to an existing, already-conventional test file:
+
+`backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs`
+
+I read the production file (`backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/GraphCatalogDocumentsStorage.cs`), the existing test file, the model/contract types it depends on (`CatalogGraphModels.cs`, `FolderSearchResult.cs`, `Contracts/FolderStatus.cs`), and `GraphApiHelpers.cs`. The spec's description of the production code and the existing test harness is accurate — no amendments needed there. The stack matches `docs/architecture/testing-strategy.md`: xUnit + Moq + FluentAssertions, `HttpMessageHandler` faking rather than a real Graph sandbox (there is precedent for this exact pattern in `Features/KnowledgeBase/Services/GraphDriveItem.cs`'s sibling models, confirming Graph-via-fake-handler is the established convention for this codebase, not something invented for this file).
+
+The existing `CreateStorage(responder)` / `RecordingHandler` harness is sufficient for every scenario in the spec — including multi-request sequences (upload-session-then-chunks, paginated folder listing) — provided the `responder` lambda closes over local state (a counter, or branches on `request.RequestUri`/`request.Method`). No harness changes are required. This keeps risk to shared test infrastructure at zero, which matters because other tests in the same file already depend on `RecordingHandler`'s current (simple) behavior.
+
+## Proposed Architecture
+
+### Component Overview
+
+No architectural components change. For completeness, this is what's under test and how the new tests plug into it:
+
+```
+GraphCatalogDocumentsStorageTests.cs   (existing file — ONLY file touched)
+│
+├── CreateStorage(responder)  ─────────► GraphCatalogDocumentsStorage (SUT, unchanged)
+│     • Mock<ITokenAcquisition>                │
+│     • Mock<IHttpClientFactory>               ├─ FindFolderAsync(...)      [app token]
+│     • RecordingHandler(responder)            ├─ UploadFileAsync(...)      [delegated token]
+│                                               │    ├─ UploadSmallFileAsync   (≤ 4 MB)
+│                                               │    └─ UploadLargeFileAsync  (> 4 MB, chunked)
+├── RecordingHandler : HttpMessageHandler
+│     • Requests: List<HttpRequestMessage>   ◄──── new tests assert against this
+│     • responder: Func<HttpRequestMessage, HttpResponseMessage>
+│                                                    (existing tests use `_ =>` ignoring input;
+│                                                     new tests use closures/counters — no class change)
+│
+└── NEW: ThrottledReadStream (private nested helper, test-only)
+      • wraps a MemoryStream/byte[], caps bytes returned per ReadAsync call
+      • used only by the FR-2 "multi-read fill" scenario
+```
+
+### Key Design Decisions
+
+#### Decision 1: How to make `RecordingHandler` answer multi-request sequences
+
+**Options considered:**
+- (a) Extend `RecordingHandler` itself with built-in URL-routing / sequencing support (e.g. a `Dictionary<Predicate, HttpResponseMessage>` table).
+- (b) Keep `RecordingHandler` exactly as-is; do all branching inside each test's `responder` lambda via closures (a local counter, or pattern-matching on `request.RequestUri!.ToString()` / `request.Method`).
+
+**Chosen approach:** (b).
+
+**Rationale:** `RecordingHandler` is shared by all tests in the file, including the three existing ones. Option (a) would require touching code the passing tests already rely on, for a benefit only the new tests need. Closures are sufficient — C# lambdas can trivially maintain a mutable counter or switch on `request.RequestUri.ToString().Contains(...)`. This matches the spec's own recommendation and keeps the blast radius of this change to "new test methods only," consistent with the "surgical changes" principle for this repo.
+
+#### Decision 2: Individual `[Fact]`s vs. `[Theory]` for the threshold routing cases (FR-1)
+
+**Options considered:**
+- (a) Three separate `[Fact]` methods for `threshold`, `threshold+1`, `threshold-1`.
+- (b) A single `[Theory]` with `[InlineData]` for the three sizes, asserting a shared "path taken" outcome.
+
+**Chosen approach:** (a) for FR-1, but only because the *arrange* step differs by branch (the small path needs one mocked response; the large path needs a `createUploadSession` response plus at least one chunk response) — a `[Theory]` would need internal branching in the test body to set up different responders per size, which defeats the readability benefit of `[Theory]`. Where the spec's own open question suggests `[Theory]` is acceptable, apply it narrowly: e.g. a `[Theory]` is fine for asserting "is small-file path taken?" (`threshold` and `threshold-1` share identical arrange/responder), with the `threshold+1` (large-path) case kept as its own `[Fact]`.
+
+**Rationale:** Optimize for the assertions being self-evidently correct at a glance, per `docs/architecture/testing-strategy.md`'s "Maintainability Over Coverage" principle, over minimizing method count. Do not force a shared theory body across branches whose fixtures genuinely differ.
+
+#### Decision 3: New helper `Stream` for short/partial reads (FR-2)
+
+**Options considered:**
+- (a) A one-off `Stream` subclass added inline to the test file.
+- (b) A shared test-utilities project/class if one already exists for stream fakes.
+
+**Chosen approach:** (a) — add a small private nested class (e.g. `ThrottledReadStream : Stream`) directly in `GraphCatalogDocumentsStorageTests.cs`, under a `// ─── Recording infrastructure ───` banner alongside `RecordingHandler`, matching the file's existing convention of colocating test infrastructure with the tests that use it.
+
+**Rationale:** I found no shared "fake stream" utility elsewhere in `backend/test/Anela.Heblo.Tests` worth reusing (confirmed by inspecting the test file's own structure) and this stream is single-purpose (cap bytes per `ReadAsync`, backed by a `MemoryStream`/`byte[]`). Introducing a shared abstraction for one caller would be premature generalization; keep it local per the "surgical changes" rule.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files, no new folders. All new test code goes into the existing file:
+
+`backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs`
+
+Add three new region banners after the existing `// ─── UploadFileAsync — delegated token ───` block and before `// ─── Recording infrastructure ───`:
+- `// ─── UploadFileAsync — size routing ───`
+- `// ─── UploadLargeFileAsync — chunk loop ───`
+- `// ─── FindFolderAsync — pagination & matching ───`
+
+Add the `ThrottledReadStream` helper class inside the existing `// ─── Recording infrastructure ───` region, next to `RecordingHandler`.
+
+### Interfaces and Contracts
+
+No new interfaces or contracts. Tests exercise only the existing public members of `ICatalogDocumentsStorage` (`UploadFileAsync`, `FindFolderAsync`) through the existing `GraphCatalogDocumentsStorage` concrete type (constructed via `CreateStorage`, same as today). Response bodies must be raw JSON string literals matching the internal Graph model shapes already used by the existing tests (`CatalogGraphDriveItem`, `CatalogGraphDriveItemCollection` with `"value"` / `"@odata.nextLink"`, `CatalogGraphUploadSession` with `"uploadUrl"`) — these types are `internal` to the Application assembly and are never referenced directly from the test project; tests only ever produce/consume their JSON wire shape, exactly as the current three tests do. Do not attempt to instantiate them directly.
+
+Two contract details developers must get exactly right, since they're easy to get subtly wrong:
+- **`Content-Range` assertions**: read `request.Content!.Headers.ContentRange` (an `System.Net.Http.Headers.ContentRangeHeaderValue`) and assert on its `.From`, `.To`, `.Length` properties — not by string-parsing the header. `From`/`To` are inclusive byte offsets; `Length` is the *total* `sizeBytes`, not the chunk length.
+- **`FolderSearchResult` on `MultipleMatches`**: per current code, `FolderId`/`FolderName` are left at their default (`string.Empty`) on this branch — assert emptiness explicitly if the test wants to pin that, per FR-3's acceptance criteria.
+
+### Data Flow
+
+For the two multi-request scenarios, the `responder` lambda must branch on the *outgoing* request, not just return a fixed value:
+
+- **FR-1/FR-2 (large upload):** request #1 is `POST .../createUploadSession` → respond with a JSON body containing an arbitrary `"uploadUrl"` (e.g. `"https://graph.microsoft.com/upload-session/abc"`). Every subsequent request is `PUT` to that exact `uploadUrl` string (the production code constructs `new HttpRequestMessage(HttpMethod.Put, session.UploadUrl)` directly, bypassing `GraphApiHelpers.CreateRequest`, so these chunk requests carry **no Authorization header** — do not assert one on them). Branch the responder by request count (a closure-local counter) or by checking `request.Method == HttpMethod.Post` vs `Put`.
+- **FR-3 (pagination):** page 1 response body must include a `"@odata.nextLink"` whose value the test controls (e.g. `"https://graph.microsoft.com/v1.0/next-page-2"`); the responder must recognize a subsequent request whose `RequestUri.ToString()` equals that exact string and return the page-2 body with `"@odata.nextLink": null` (or the property omitted). Branch on `request.RequestUri` equality/`Contains`, not on call order, since this most directly mirrors what the production code actually does (`GET nextLink` verbatim).
+
+Content streams for upload tests must have a `Length`/readable size matching the declared `sizeBytes` argument; for the "multi-read fill" scenario, back `ThrottledReadStream` with exactly `chunkSize` (10 MB) or `chunkSize + remainder` bytes of arbitrary content (e.g. all zeros) — the test only needs to assert on request shape (`Content-Range`, request count), never on byte content.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| 10–20 MB `byte[]`/`MemoryStream` allocations per chunk test slow the suite or bloat CI memory | Low | Acceptable one-off per test; avoid allocating in a loop across many `[Theory]` cases. Keep the "two full chunks" (20 MB) case to a single test, not parameterized. |
+| Chunk-response `Content-Range` assertions are brittle if written as raw string comparisons | Medium | Assert via `ContentRangeHeaderValue.From/To/Length` (typed), not string matching, per guidance above. |
+| Branching responder logic (counters/URL matching) silently matches the wrong request if closures share mutable state incorrectly across parallel test execution | Low | xUnit test classes are not shared instances across parallel test methods by default in this project (each `[Fact]` calls `CreateStorage` fresh); no shared mutable state risk as long as counters are declared inside each test method, not as class fields. |
+| Asserting on chunk requests' Authorization header (there isn't one — see Data Flow) leads to a false-negative test if a developer assumes `GraphApiHelpers.CreateRequest` was used | Medium | Explicitly call out in test comments that `UploadLargeFileAsync`'s chunk `PUT`s bypass `CreateRequest` and carry no Bearer header — do not assert on it for those requests. |
+| Pre-existing correctness gap noted in spec's Open Questions (outer loop exits early on partial final read without validating total bytes == `sizeBytes`) gets "fixed" accidentally by an over-eager implementer | Low | Explicitly out of scope (per spec); the "pin current behavior" test (no exception, early stop) should be added, but no production code changed. Flag as a candidate follow-up bug ticket, not addressed here. |
+
+## Specification Amendments
+
+None required to the functional requirements — the spec accurately reflects the source file's structure (verified line-by-line against `GraphCatalogDocumentsStorage.cs`), the existing test harness, and the model/contract shapes. Two clarifications for the implementer, not spec changes:
+
+1. Chunk `PUT` requests in `UploadLargeFileAsync` are constructed via `new HttpRequestMessage(HttpMethod.Put, session.UploadUrl)` directly — they do **not** go through `GraphApiHelpers.CreateRequest` and therefore carry no `Authorization` header. Tests must not assert a Bearer token on these requests (only on the initial `createUploadSession` POST and the small-file PUT, both of which do use `CreateRequest`).
+2. Resolve the spec's two "Open Questions" before writing tests, per its own recommendations: (a) add one test pinning the early-stream-exhaustion behavior as a documentation test, filed separately as a follow-up bug candidate rather than fixed here; (b) keep `RecordingHandler` unchanged, do all branching via per-test closures (Decision 1 above formalizes this).
+
+## Prerequisites
+
+None. No migrations, no config, no new infrastructure. The existing test project (`backend/test/Anela.Heblo.Tests`, already referencing xUnit/Moq/FluentAssertions) is sufficient. Implementation can start immediately.

--- a/artifacts/feat-3500/brief.md
+++ b/artifacts/feat-3500/brief.md
@@ -1,0 +1,26 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/GraphCatalogDocumentsStorage.cs`
+
+## Coverage
+Line coverage: 43% (filter threshold: 60%)
+
+## What's not tested
+**`UploadFileAsync` — small vs large routing:**
+Files ≤ 4 MB use a single-PUT upload; files > 4 MB use a chunked upload session. No test verifies that the size threshold routes to the correct upload path. A change to the 4 MB constant (or an off-by-one) would silently mis-route uploads without a failing test.
+
+**`UploadLargeFileAsync` — chunk loop:**
+The chunked upload loop reads the stream in 10 MB increments and sends `Content-Range` headers. No test covers what happens when the last chunk is smaller than the buffer, or when the stream requires multiple reads to fill a single chunk (`totalRead < chunkSize` inner loop). A bug in the offset tracking would produce a corrupt upload with no observable error until the file is opened.
+
+**`FindFolderAsync` — pagination and multi-match:**
+The folder search follows `@odata.nextLink` pages. No test exercises the multi-page case. The multiple-match branch (`matches.Count > 1 && !allowMultiple` → `MultipleMatches`) and the `allowMultiple` path (picks alphabetically first) are also untested.
+
+## Why it matters
+This is the integration point for uploading PIF documents to SharePoint/OneDrive via the Graph API. A routing bug silently selects the wrong upload path; a chunk-loop offset bug corrupts the uploaded file; a multi-match bug either rejects a valid folder or picks the wrong one.
+
+## Suggested approach
+- Unit-test `UploadFileAsync` with mocked `IHttpClientFactory` at sizeBytes = threshold, threshold+1, threshold−1.
+- Test `FindFolderAsync` with a mock returning two pages of results and assert all items from both pages are considered.
+- Test the multi-match path with `allowMultiple = false` and assert `MultipleMatches` is returned. ~1.5 day effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-06. Based on CI run #28716987459 (2ad2a2593e1834798a3def9ac2551b46c2e595cb)._

--- a/artifacts/feat-3500/code-review.r1.md
+++ b/artifacts/feat-3500/code-review.r1.md
@@ -1,0 +1,15 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs:190-207,232-249,279-296,328-346,373-390` — the `createUploadSession`/chunk-response `responder` lambda (branch on `HttpMethod.Post` → session JSON, else → `{"id":"item-1","name":"final.pdf"}`) is duplicated near-verbatim across five large-file tests. Extracting a small `CreateLargeUploadResponder(...)` helper (optionally parameterized by chunk response name) would remove the repetition without changing behavior.
+- `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs:140,164,188,229,276,319,369` — `const long threshold = 4 * 1024 * 1024` and `const long chunkSize = 10 * 1024 * 1024` are re-declared locally in nearly every new test instead of being hoisted to shared `private const` fields on the test class (mirroring the production constants), which would also make the threshold/chunk-size relationship to the SUT more visually explicit.
+
+### Verification performed
+- Read the full diff; confirmed the only non-artifact change is `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs` (14 new `[Fact]` tests + `ThrottledReadStream` helper), no production code touched.
+- Cross-checked every new test's arrange/act/assert against the actual production logic in `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/GraphCatalogDocumentsStorage.cs` (threshold `<=` boundary, chunk `Content-Range` offset math, `uploadedName` update-from-last-chunk, early-EOF pre-existing behavior, `FindFolderAsync` pagination/matching/`allowMultiple` ordering, 404 short-circuit) — all assertions match actual behavior, no tautological checks.
+- Confirmed `ThrottledReadStream` overriding only the `byte[]`-based `ReadAsync` override is sufficient: production calls `content.ReadAsync(buffer.AsMemory(totalRead), ct)`, and `Stream`'s default `ReadAsync(Memory<byte>, ...)` delegates to the array-based overload when the destination memory is array-backed (it is, since `buffer` is a `byte[]`), so the throttling logic is actually exercised.
+- Ran `dotnet build test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — 0 errors (pre-existing unrelated warnings only).
+- Ran `dotnet test --filter "FullyQualifiedName~GraphCatalogDocumentsStorageTests"` — 17/17 passed (3 pre-existing + 14 new).

--- a/artifacts/feat-3500/design.r1.md
+++ b/artifacts/feat-3500/design.r1.md
@@ -1,0 +1,101 @@
+# Design: Close Coverage Gap in GraphCatalogDocumentsStorage
+
+## Component Design
+
+No production components are added or changed. This section covers the test-only doubles that the new tests will introduce or extend inside `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs`.
+
+### `CreateStorage(responder)` (existing, reused as-is)
+Factory used by every test to build a `GraphCatalogDocumentsStorage` wired to:
+- `Mock<ITokenAcquisition>` returning fixed `"app-token"` / `"delegated-token"` strings.
+- `Mock<IHttpClientFactory>` returning an `HttpClient` backed by `RecordingHandler`.
+
+No changes to this helper's signature or internals are needed. New tests call it exactly as existing tests do; all new behavior (multi-request sequencing, URL branching) lives in the `responder` argument each test supplies, not in the factory.
+
+### `RecordingHandler` (existing, unchanged)
+Fake `HttpMessageHandler` that appends every outgoing `HttpRequestMessage` to an ordered `List<HttpRequestMessage> Requests` and returns `responder(request)` as the `HttpResponseMessage`.
+
+- **Contract:** one handler instance per test (fresh via `CreateStorage`), so `Requests` accumulates only the calls made within that single test — no shared state across tests, no thread-safety concerns since each `[Fact]` builds its own instance.
+- **New usage pattern (not a class change):** tests that need multi-request sequencing (upload-session-then-chunks, paginated folder search) implement `responder` as a closure that branches on the incoming request rather than ignoring it:
+  - By call count: a local `int callCount` mutated on each invocation, first call returns the `createUploadSession` body, subsequent calls return chunk-response bodies.
+  - By request shape: `request.Method == HttpMethod.Post` vs `HttpMethod.Put`, or `request.RequestUri!.ToString().Contains("createUploadSession")` / `.Contains("next-page-2")` / equality against a mocked `@odata.nextLink` URL.
+- Assertions read `Requests[i].Method`, `Requests[i].RequestUri`, and `Requests[i].Content!.Headers.ContentRange` (typed `ContentRangeHeaderValue`, not string-parsed) to pin routing, pagination, and chunk-offset behavior.
+
+### `ThrottledReadStream` (new, test-only, private nested class)
+A minimal `Stream` subclass added under the existing `// ─── Recording infrastructure ───` region, alongside `RecordingHandler`. Used only by the FR-2 "multi-read fill of a single chunk" scenario, where the production `ReadAsync` inner-fill loop must be exercised against a source that deliberately under-fills the caller's buffer.
+
+**Contract:**
+- Constructed from a backing byte source (e.g. `byte[]` or wraps a `MemoryStream`) plus a `maxBytesPerRead` cap (an int much smaller than `chunkSize`, e.g. 64 KB).
+- `ReadAsync(buffer, offset, count, ...)` returns `min(count, maxBytesPerRead, remainingBytes)` bytes per call — i.e., it must never fill the caller's full request in one call while bytes remain, forcing the production code's `while (totalRead < chunkSize)` fill loop to execute multiple iterations.
+- Returns `0` once the backing content is exhausted (standard EOF contract), so the production code's outer `while (offset < sizeBytes)` loop terminates correctly.
+- `Length` must reflect the total declared size the test passes as `sizeBytes` to `UploadFileAsync`, since the production code does not re-derive size from the stream independently in the paths under test.
+- Only `Read`/`ReadAsync`, `Length`, and `Position` need real behavior; `Write`/`Seek`/`CanWrite` etc. can throw `NotSupportedException` or be no-ops, since production code never calls them on the upload content stream.
+
+No other test doubles are required: `FindFolderAsync` tests use the existing `CreateStorage`/`RecordingHandler` pair with URL-branching responders (no new stream double needed, since folder-search responses are JSON bodies, not content streams).
+
+## Data Schemas
+
+All schemas below are wire-shape JSON string literals the tests fabricate as mocked Graph API HTTP response bodies (via the `responder` callback), matching the internal shapes already consumed by `GraphCatalogDocumentsStorage.cs` (`CatalogGraphDriveItem`, `CatalogGraphDriveItemCollection`, `CatalogGraphUploadSession`, folder/file facets). Tests never instantiate these C# types directly — they are `internal` to the Application assembly and are only ever produced/consumed as raw JSON across the fake HTTP boundary.
+
+### Small-file upload response (single `PUT .../content?...`)
+```json
+{
+  "id": "item-id-small-1",
+  "name": "uploaded-file.pdf",
+  "folder": null
+}
+```
+Returned once, `200 OK`, in response to the single `PUT` issued by `UploadSmallFileAsync`.
+
+### `createUploadSession` response (large-file path, first request)
+```json
+{
+  "uploadUrl": "https://graph.microsoft.com/upload-session/abc"
+}
+```
+Returned `200 OK` in response to `POST .../createUploadSession`. All subsequent chunk `PUT`s in the test must target this exact `uploadUrl` string verbatim (production code issues `new HttpRequestMessage(HttpMethod.Put, session.UploadUrl)` directly — no `Authorization` header on these requests; tests must not assert one).
+
+### Chunk upload response (large-file path, each chunk `PUT`)
+```json
+{
+  "id": "item-id-chunk-final",
+  "name": "uploaded-file.pdf",
+  "folder": null
+}
+```
+Returned `200 OK` (or `201 Created`) for each chunk `PUT`. Tests assert the method's returned filename equals the `name` from the **last** chunk response (confirms `uploadedName` is updated from the final chunk, not a stale first-chunk value) — so intermediate chunk responses may use a distinguishable `name` (e.g. `"chunk-1-name"`) versus the final chunk's `name` (e.g. `"final-name.pdf"`) to make the assertion meaningful.
+
+Chunk request assertions read `Content-Range` via `request.Content!.Headers.ContentRange` (typed `ContentRangeHeaderValue`):
+- `.From` / `.To` — inclusive byte offsets of the chunk within the file.
+- `.Length` — the **total** declared `sizeBytes`, not the chunk's own length.
+
+### Folder listing page response (`FindFolderAsync`, `CatalogGraphDriveItemCollection`)
+```json
+{
+  "value": [
+    {
+      "id": "folder-id-1",
+      "name": "PIF-2024",
+      "folder": { "childCount": 0 }
+    },
+    {
+      "id": "file-id-1",
+      "name": "PIF-2024-notes.txt",
+      "folder": null,
+      "file": { "mimeType": "text/plain" }
+    }
+  ],
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/next-page-2"
+}
+```
+- Items with a non-null `folder` facet are folder candidates; items with `folder: null` (and typically a `file` facet present) are excluded from match consideration regardless of name match, per FR-3's "non-folder items excluded" case.
+- `@odata.nextLink`, when present and non-null, is followed verbatim: the responder must recognize a subsequent request whose `RequestUri` equals this exact string and return the next page.
+- Second/last page omits `@odata.nextLink` (or sets it to `null`) to terminate pagination.
+
+### Folder listing — 404 short-circuit response
+An `HttpResponseMessage` with `StatusCode = HttpStatusCode.NotFound` and no body (or an empty JSON object), returned for the first-page request only, to assert `FolderStatus.NotFound` without any pagination attempt.
+
+### `FolderSearchResult` shapes under test (existing type, not redefined; assertions target these field combinations)
+- No matches → `{ Status: FolderStatus.NotFound }` (`FolderId`/`FolderName` default/empty).
+- Exactly one match → `{ Status: FolderStatus.Found, FolderId: "<matching id>", FolderName: "<matching name>" }`.
+- Multiple matches, `allowMultiple: false` → `{ Status: FolderStatus.MultipleMatches, FolderId: string.Empty, FolderName: string.Empty }`.
+- Multiple matches, `allowMultiple: true` → `{ Status: FolderStatus.Found, FolderId/FolderName: <alphabetically-first match by StringComparer.OrdinalIgnoreCase> }`.

--- a/artifacts/feat-3500/impl/add-graph-catalog-documents-storage-coverage-tests.r1.md
+++ b/artifacts/feat-3500/impl/add-graph-catalog-documents-storage-coverage-tests.r1.md
@@ -1,0 +1,52 @@
+# Implementation: add-graph-catalog-documents-storage-coverage-tests
+
+## What was implemented
+
+Added 15 new unit tests to the existing `GraphCatalogDocumentsStorageTests.cs` covering the three coverage gaps identified in the brief:
+
+1. **`UploadFileAsync` size-threshold routing** — tests at `threshold` (small-file path, since the production check is `<=`), `threshold - 1` (small-file path), and `threshold + 1` (large-file session path).
+2. **`UploadLargeFileAsync` chunk-loop offset tracking** — a partial-final-chunk case (asserts two chunk PUTs with correct `Content-Range` headers and offsets), a throttled/short-read stream that requires multiple `ReadAsync` calls to fill one chunk buffer, a stream size that's an exact multiple of the chunk size (asserts no trailing empty request), and a stream that ends earlier than the declared size (asserts the loop stops without throwing).
+3. **`FindFolderAsync` pagination and multi-match** — no-match → `NotFound`, exactly one match → `Found`, non-folder items matching the prefix are excluded, multiple matches with `allowMultiple: false` → `MultipleMatches` (with empty `FolderId`/`FolderName`), multiple matches with `allowMultiple: true` → alphabetically-first match returned, multi-page `@odata.nextLink` pagination (items from both pages considered), and a first-page 404 short-circuiting to `NotFound` without following pagination.
+
+No production code was modified — this is a test-only change. The existing `CreateStorage`/`RecordingHandler` test harness in the file was reused as-is.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs` — added 15 new `[Fact]` tests (471 lines added), including a small throttled-stream test double (`ThrottledReadStream`) used only for the multi-read-per-chunk case.
+
+## Tests
+- `UploadFileAsync_SizeEqualsThreshold_UsesSmallFilePath`
+- `UploadFileAsync_SizeOneBelowThreshold_UsesSmallFilePath`
+- `UploadFileAsync_SizeOneAboveThreshold_UsesLargeFileSessionPath`
+- `UploadFileAsync_LargeFileWithPartialFinalChunk_SendsTwoChunksWithCorrectContentRange`
+- `UploadFileAsync_LargeFileWithThrottledStream_AssemblesFullChunkFromShortReads`
+- `UploadFileAsync_LargeFileExactMultipleOfChunkSize_SendsExactlyTwoChunksNoTrailingRequest`
+- `UploadFileAsync_StreamExhaustedBeforeDeclaredSize_StopsEarlyWithoutThrowing`
+- `FindFolderAsync_NoMatchingItems_ReturnsNotFound`
+- `FindFolderAsync_ExactlyOneMatch_ReturnsFoundWithMatchedFolder`
+- `FindFolderAsync_ExcludesNonFolderItemsMatchingPrefix`
+- `FindFolderAsync_MultipleMatches_AllowMultipleFalse_ReturnsMultipleMatchesWithEmptyFolder`
+- `FindFolderAsync_MultipleMatches_AllowMultipleTrue_ReturnsAlphabeticallyFirstMatch`
+- `FindFolderAsync_MultiPagePagination_ConsidersMatchesFromBothPages`
+- `FindFolderAsync_FirstPage404_ReturnsNotFoundWithoutPagination`
+
+(Plus the 3 pre-existing tests in the file, for 17 total.)
+
+## How to verify
+```bash
+cd backend
+dotnet build test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build --filter "FullyQualifiedName~GraphCatalogDocumentsStorageTests"
+```
+Result: `Passed! - Failed: 0, Passed: 17, Skipped: 0, Total: 17`.
+
+## Notes
+No bug was found in the production code during this work — all behavior confirmed by direct reading of `GraphCatalogDocumentsStorage.cs` matched the task-context's description (including the `<=` threshold boundary and the chunk-PUT requests bypassing the standard `Authorization`-header helper, which is existing behavior, not something introduced by this change). No production code was touched.
+
+## PR Summary
+Closes the coverage gap on `GraphCatalogDocumentsStorage.UploadFileAsync`/`UploadLargeFileAsync`/`FindFolderAsync` by adding 15 targeted unit tests for the small/large upload routing threshold, chunked-upload offset tracking (partial final chunk, throttled short-reads, exact-multiple size, early stream exhaustion), and folder search pagination/multi-match handling (`MultipleMatches` vs. `allowMultiple` alphabetical pick, multi-page `@odata.nextLink` traversal, and the first-page-404 short circuit). Test-only change; no production code modified.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs` — 15 new tests added, reusing the existing `CreateStorage`/`RecordingHandler` mock harness
+
+## Status
+DONE

--- a/artifacts/feat-3500/review/add-graph-catalog-documents-storage-coverage-tests.r1.md
+++ b/artifacts/feat-3500/review/add-graph-catalog-documents-storage-coverage-tests.r1.md
@@ -1,0 +1,19 @@
+# Code Review: GraphCatalogDocumentsStorage coverage tests
+
+## Summary
+The diff (`c3f8e1a`) adds 14 new `[Fact]` tests to the existing `GraphCatalogDocumentsStorageTests.cs`, touching only the test file (471 insertions, no production code changed). All three named coverage gaps — upload size-threshold routing, chunk-loop offset/Content-Range tracking, and folder pagination/multi-match — are exercised with assertions tied to concrete request shapes (method, URL, Content-Range bounds, header presence, dequeued response ordering) rather than tautological checks.
+
+## Review Result: PASS
+
+### task: add-graph-catalog-documents-storage-coverage-tests
+**Status:** PASS
+
+## Docs to Update
+(none)
+
+## Overall Notes
+- Verified against production source (`GraphCatalogDocumentsStorage.cs`): the `<=` threshold boundary (`UploadFileAsync_SizeEqualsThreshold_UsesSmallFilePath` vs. `_SizeOneAboveThreshold_...`), the inner fill-loop/outer offset loop in `UploadLargeFileAsync` (partial final chunk, throttled short-reads via a custom `ThrottledReadStream`, exact-chunk-multiple with no trailing request, early-EOF-before-declared-size), and `FindFolderAsync`'s pagination (`@odata.nextLink` traversal, first-page-404 short circuit) and matching (`MultipleMatches` with empty `FolderId`/`FolderName`, `allowMultiple: true` alphabetical pick using deliberately out-of-order input, non-folder items excluded) are all faithfully modeled in the new tests.
+- Ran `dotnet build` (0 errors) then `dotnet test --filter "FullyQualifiedName~GraphCatalogDocumentsStorageTests"`: 17/17 passed (3 pre-existing + 14 new), consistent with both the diff and the implementation summary.
+- Ran the full test project as a regression check: 5428 passed, 64 failed — all 64 failures are pre-existing `Testcontainers`/PostgreSQL integration tests failing because Docker is unavailable in this sandbox (`KnowledgeBaseRepositoryIntegrationTests`, etc.), unrelated to this change and not present in the `GraphCatalogDocumentsStorageTests` filter run.
+- Minor, non-blocking nit: the implementation summary's "What was implemented" section says "Added 15 new unit tests" but its own "Tests" list and the actual diff show 14 new tests (17 total including the 3 pre-existing) — a documentation miscount only, not a code issue.
+- No production code was touched, satisfying the test-only constraint.

--- a/artifacts/feat-3500/spec.r1.md
+++ b/artifacts/feat-3500/spec.r1.md
@@ -1,0 +1,105 @@
+# Specification: Close Coverage Gap in GraphCatalogDocumentsStorage
+
+## Summary
+`GraphCatalogDocumentsStorage` (the Microsoft Graph integration used to upload PIF/material documents to SharePoint/OneDrive) sits at 43% line coverage against a 60% gate. Three code paths are entirely untested: the small-vs-large upload routing decision in `UploadFileAsync`, the chunked-upload offset/read-loop in `UploadLargeFileAsync`, and the pagination / multi-match logic in `FindFolderAsync`. This is a test-only tech-debt task — no production code in `GraphCatalogDocumentsStorage.cs` is expected to change; the deliverable is a set of targeted unit tests added to the existing `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs` file that exercise these paths and would fail if the underlying logic regressed.
+
+## Background
+`GraphCatalogDocumentsStorage` implements `ICatalogDocumentsStorage` and is the sole production adapter to Microsoft Graph for catalog document storage (there is also a `NoOpCatalogDocumentsStorage` used presumably for local/dev). It is consumed by `UploadPifDocumentHandler` and `UploadMaterialDocumentHandler` to place uploaded files into the correct SharePoint/OneDrive folder.
+
+A test file already exists for this class and establishes the mocking pattern to reuse:
+- `CreateStorage(Func<HttpRequestMessage, HttpResponseMessage> responder)` — builds a `GraphCatalogDocumentsStorage` wired to a mocked `ITokenAcquisition` (app token `"app-token"`, delegated token `"delegated-token"`) and a `RecordingHandler` (a fake `HttpMessageHandler`) that records every outgoing `HttpRequestMessage` and answers via the supplied `responder` callback.
+- `RecordingHandler` — captures requests in an ordered `List<HttpRequestMessage>` for later assertion (URL, method, headers) and returns whatever `HttpResponseMessage` the test's responder function produces, keyed however the test wants (e.g., by inspecting `request.RequestUri`).
+
+The existing three tests cover token selection (`UploadFileAsync` uses the delegated token, `FindFolderAsync` uses the app token) and the consent-missing failure path. They do not touch the three gaps this ticket targets. The new tests must be added to this same file, following its established patterns, rather than introducing a parallel test harness.
+
+Relevant production code (read in full from `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/GraphCatalogDocumentsStorage.cs`):
+- `UploadSessionThresholdBytes = 4 * 1024 * 1024` (4 MB). `UploadFileAsync` routes to `UploadSmallFileAsync` when `sizeBytes <= UploadSessionThresholdBytes`, and to `UploadLargeFileAsync` when `sizeBytes > UploadSessionThresholdBytes`.
+- `UploadSmallFileAsync` issues a single `PUT` to `.../items/{folderId}:/{encodedName}:/content?@microsoft.graph.conflictBehavior=rename`.
+- `UploadLargeFileAsync` first `POST`s to `.../createUploadSession` to obtain an `uploadUrl`, then loops: for each iteration it fills a 10 MB (`chunkSize = 10 * 1024 * 1024`) buffer via a nested `while (totalRead < chunkSize)` loop that calls `content.ReadAsync` repeatedly until the buffer is full or the stream returns `0` (EOF), sends a `PUT` with a `Content-Range` header covering `[offset, offset + totalRead - 1]` of `sizeBytes`, and advances `offset += totalRead`. The outer loop continues `while (offset < sizeBytes)`.
+- `FindFolderAsync` lists the immediate children of `basePath` via Graph, following `@odata.nextLink` across pages into a single accumulated list, filters to folder items whose name starts with `prefix` (ordinal, case-insensitive), and then: returns `NotFound` if there are no matches; returns `MultipleMatches` if there is more than one match and `allowMultiple` is `false`; otherwise returns `Found` with the alphabetically-first match (by `StringComparer.OrdinalIgnoreCase`) — this alphabetical-first selection also applies when `allowMultiple` is `true` and there are multiple matches.
+
+## Functional Requirements
+
+### FR-1: `UploadFileAsync` routing tests (small vs. large upload path)
+Add tests that pin the size-threshold routing decision in `UploadFileAsync` so a future change to `UploadSessionThresholdBytes` (or an off-by-one in the comparison) fails a test instead of silently mis-routing uploads.
+
+Use the existing `CreateStorage` helper. Distinguish which path was taken by asserting on the recorded request(s) in `RecordingHandler.Requests`:
+- Small-file path: exactly one request is sent, and its `RequestUri` matches the single-PUT `.../content?@microsoft.graph.conflictBehavior=rename` pattern (method `PUT`).
+- Large-file path: at least two requests are sent, the first being a `POST` to a URL containing `/createUploadSession`, and subsequent request(s) being `PUT`s to the mocked session `uploadUrl`.
+
+**Acceptance criteria:**
+- A test calling `UploadFileAsync` with `sizeBytes == UploadSessionThresholdBytes` (4 MB exactly) asserts the small-file (single-PUT) path is used.
+- A test calling `UploadFileAsync` with `sizeBytes == UploadSessionThresholdBytes + 1` asserts the large-file (chunked/session) path is used.
+- A test calling `UploadFileAsync` with `sizeBytes == UploadSessionThresholdBytes - 1` asserts the small-file path is used.
+- Each test supplies a content `Stream` whose length matches its declared `sizeBytes` and a mocked Graph response sequence sufficient for that path to complete without error (small: one `200 OK` item response; large: a `createUploadSession` response plus one or more chunk `200/201` responses).
+- Tests assert on recorded request shape (method + URL pattern and/or request count), not on internal/private method calls.
+
+### FR-2: `UploadLargeFileAsync` chunk-loop offset-tracking tests
+Add tests that exercise the chunked-upload read/offset loop, reachable only through the public `UploadFileAsync` entry point with `sizeBytes > UploadSessionThresholdBytes`.
+
+**Acceptance criteria:**
+- **Final partial chunk:** a test uploads a file whose size is larger than one chunk (10 MB) but not an exact multiple of the chunk size (e.g., 10 MB + 2 MB = 12 MB), using a content stream that yields data on each `ReadAsync` call up to the requested amount. The test asserts:
+  - Two chunk `PUT` requests are sent to the upload-session URL.
+  - The first chunk's `Content-Range` header covers bytes `0` through `chunkSize - 1` of the total `sizeBytes`.
+  - The second (final) chunk's `Content-Range` header covers bytes `chunkSize` through `sizeBytes - 1` (i.e., its length is the remainder, not a full chunk) of the total `sizeBytes`.
+- **Multi-read fill of a single chunk:** a test uses a custom/fake `Stream` whose `ReadAsync` deliberately returns fewer bytes than requested on at least one call (e.g., returns at most N bytes per call, where N is much smaller than `chunkSize`), for a total file size of exactly one chunk (10 MB) or a bit more. The test asserts:
+  - The inner fill loop correctly assembles a full chunk from multiple short reads before sending the `PUT` (i.e., the `Content-Range` header for the chunk reflects the full expected chunk length, not the length of a single short read).
+  - `Content-Range` offsets remain correct across chunks when short reads are involved (no double-counting or gap in `offset`).
+- **Two full chunks + exact-multiple boundary:** a test with `sizeBytes` an exact multiple of `chunkSize` (e.g., 20 MB) asserts exactly two chunk requests are sent (no trailing empty/zero-length final chunk request), verifying the outer `while (offset < sizeBytes)` loop terminates correctly at the boundary.
+- Each chunk `PUT` response in these tests should return `200 OK` (or `201 Created`) with a valid `CatalogGraphDriveItem` JSON body so the loop's status-code branch is exercised on the success path; the method's returned filename should be asserted to equal the name from the **last** chunk response (confirming `uploadedName` is updated from the final chunk, not a stale first-chunk value).
+
+### FR-3: `FindFolderAsync` pagination and multi-match tests
+Add tests covering the `@odata.nextLink` pagination loop and the match-count branching (`NotFound` / `MultipleMatches` / `Found` with alphabetical selection), reusing the `CreateStorage` responder pattern by branching the mocked response on the requested URL.
+
+**Acceptance criteria:**
+- **Multi-page pagination:** a test mocks a first-page response containing one or more items plus a non-null `@odata.nextLink`, and a second-page response (returned when the handler receives a request to that `nextLink` URL) containing additional items and no `@odata.nextLink`. The test asserts the method considers items from **both** pages when computing matches (e.g., a matching folder that exists only on page two is still found/returned, or a multi-match spanning both pages still yields `MultipleMatches`).
+- **No matches:** a test with zero items matching `prefix` (either because the folder listing is empty or no name starts with `prefix`) asserts `FolderStatus.NotFound` is returned.
+- **Single match:** a test with exactly one folder item whose name starts with `prefix` asserts `FolderStatus.Found` is returned with the matching `FolderId`/`FolderName` populated.
+- **Multiple matches, `allowMultiple = false`:** a test with two or more folder items matching `prefix` and `allowMultiple: false` asserts `FolderStatus.MultipleMatches` is returned (and that no `FolderId`/`FolderName` is populated, per current `FolderSearchResult` construction for that branch).
+- **Multiple matches, `allowMultiple = true`:** a test with two or more matching folder items in non-alphabetical order and `allowMultiple: true` asserts `FolderStatus.Found` is returned with the **alphabetically first** match's `FolderId`/`FolderName` (ordinal, case-insensitive comparison), confirming the `OrderBy(..., StringComparer.OrdinalIgnoreCase).First()` selection.
+- **Non-folder items excluded:** a test includes at least one item whose name matches `prefix` but which has a `null` `folder` facet (i.e., a file, not a folder) and asserts it is excluded from match consideration (does not count toward `Found`/`MultipleMatches`).
+- **404 short-circuit (existing behavior, not currently asserted at this level — optional but recommended):** a test where the first-page request returns HTTP 404 asserts `FolderStatus.NotFound` is returned without attempting pagination.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — this is a unit-test-only change with no runtime/production code path affected. Tests must run fast (no real network calls; `RecordingHandler` fully substitutes for the Graph HTTP endpoint) and complete within the existing test suite's normal execution budget (sub-second per test).
+
+### NFR-2: Security
+Not applicable in the sense of introducing new security surface. Tests must not weaken or bypass any authentication/token-acquisition logic under test — they mock `ITokenAcquisition` exactly as the existing tests do (app token vs. delegated token), and must continue to assert the correct token is used for each call path where relevant (already covered by existing tests; new tests are not required to re-assert token selection unless it's incidental to the scenario).
+
+## Data Model
+No new or changed data model. Tests operate against existing types already defined in the codebase:
+- `FolderSearchResult` (`Status`, `FolderId`, `FolderName`) and `FolderStatus` enum (`NotFound`, `MultipleMatches`, `Found`) — `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/FolderSearchResult.cs`, `Contracts/FolderStatus.cs`.
+- `CatalogGraphDriveItem`, `CatalogGraphDriveItemCollection` (`Value`, `NextLink`), `CatalogGraphFolderFacet`, `CatalogGraphFileFacet`, `CatalogGraphUploadSession` (`UploadUrl`) — `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/CatalogGraphModels.cs`. These are the exact JSON shapes new tests must construct as mocked Graph API response bodies.
+- `CatalogDocumentDto` — not directly exercised by the three gaps in scope but present in the same file; no changes needed.
+
+## API / Interface Design
+No API or interface changes. This ticket only adds test methods to `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs`, following the existing `CreateStorage` / `RecordingHandler` pattern already defined in that file. New tests should be grouped under clear region/comment banners consistent with the existing `// ─── UploadFileAsync — delegated token ───` style, e.g.:
+- `// ─── UploadFileAsync — size routing ───`
+- `// ─── UploadLargeFileAsync — chunk loop ───`
+- `// ─── FindFolderAsync — pagination & matching ───`
+
+For the multi-read/short-read scenario in FR-2, a small private helper `Stream` subclass (or a wrapper around `MemoryStream` that caps bytes returned per `ReadAsync` call) will need to be added to the test file's "Recording infrastructure" section, alongside the existing `RecordingHandler`.
+
+For branching mock responses by request URL/method (needed for FR-1's session-then-chunk sequence and FR-3's pagination), the `responder` callback passed to `CreateStorage` should pattern-match on `request.RequestUri` (e.g., `Contains("createUploadSession")`, equality with the mocked `nextLink` URL) and/or a call counter, consistent with how a `Func<HttpRequestMessage, HttpResponseMessage>` is already used in the existing tests (each existing test currently ignores the input and returns a fixed response, since none of them yet needs multi-request branching — this ticket is the first to require it).
+
+## Dependencies
+- Existing test project `backend/test/Anela.Heblo.Tests` (xUnit, Moq, FluentAssertions — already referenced by the current test file).
+- No new NuGet packages required. No production dependency changes.
+- Depends on the current shape of `GraphCatalogDocumentsStorage.cs`, `CatalogGraphModels.cs`, `FolderSearchResult.cs`, and `Contracts/FolderStatus.cs` remaining as read for this spec; if the file changes before implementation, the spec's line-level references should be re-verified.
+
+## Out of Scope
+- Any change to production code in `GraphCatalogDocumentsStorage.cs`, `CatalogGraphModels.cs`, `ICatalogDocumentsStorage.cs`, or related contracts. This is a test-only coverage-gap fix.
+- Testing `ListFilesAsync` (not called out in the brief; also uses pagination but is not part of the identified coverage gap).
+- Testing `GetDelegatedTokenAsync` / `AcquireDelegatedTokenAsync` single-flight caching behavior beyond what the existing consent-failure test already covers.
+- Integration or end-to-end tests against a real/sandboxed Microsoft Graph endpoint — this remains pure unit testing with a fake `HttpMessageHandler`.
+- Retry/resume behavior for interrupted chunked uploads (the production code has no retry logic to test).
+- Raising line coverage anywhere else in the codebase; this ticket targets only the three named gaps in this one file.
+
+## Open Questions
+- **Potential pre-existing correctness gap (not to be fixed under this ticket):** `UploadLargeFileAsync`'s outer loop (`while (offset < sizeBytes)`) exits as soon as the inner read loop reads `0` bytes (stream EOF), even if `offset` has not yet reached `sizeBytes`. There is no post-loop check that the total bytes uploaded equals the declared `sizeBytes`; if a caller passes a `sizeBytes` larger than the actual stream content, the method would silently return a "success" filename after uploading fewer bytes than declared, rather than throwing. Should a test merely document this current behavior (i.e., assert it does *not* throw and stops early — pinning the existing behavior), or should this be filed as a separate bug ticket for the production code? Recommend: add one test that pins current behavior (no exception, loop stops when stream is exhausted early) and separately flag this to the architect as a candidate follow-up bug ticket — do not change production code in this pass.
+- Should the `RecordingHandler` change (URL/count-based branching) be made generic/reusable in the test file's "Recording infrastructure" section for future tests, or kept as small inline anonymous responders per new test? Recommend: keep the existing `RecordingHandler` class unchanged and do all branching inside each test's `responder` lambda (using closures/counters), to minimize risk of touching shared test infrastructure that other tests already depend on.
+- The brief's suggested effort (~1.5 day) and the FR-2/FR-3 acceptance criteria above imply roughly 8-10 new test methods. Confirm this granularity is acceptable versus a more consolidated set of parameterized (`[Theory]`) tests for the threshold cases in FR-1 — no strong preference from this spec; either satisfies the acceptance criteria as written.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-06T14:19:06.651777Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T14:20:04.099225Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T14:23:36.192650Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T14:23:50.405565Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T14:50:45.116399Z"
     }
   },
   "tasks": [
     {
       "name": "add-graph-catalog-documents-storage-coverage-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-06T14:23:50.594956Z"
+      "updated_at": "2026-07-06T14:50:37.933977Z"
     }
   ]
 }

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-graph-catalog-documents-storage-coverage-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T14:23:36.192650Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T14:23:50.405565Z"
     }
   },
   "tasks": [
     {
       "name": "add-graph-catalog-documents-storage-coverage-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-06T14:23:50.594956Z"
     }
   ]
 }

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3500",
+  "issue_number": 3500,
+  "created_at": "2026-07-06T14:13:54.321977Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-06T14:16:50.979205Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-06T14:20:04.099225Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T14:23:36.192650Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-06T14:50:45.116399Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-06T14:50:45.431072Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-06T14:16:50.979205Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T14:19:06.651777Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3500/state.json
+++ b/artifacts/feat-3500/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-06T14:50:45.116399Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T14:50:45.431072Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T14:53:42.601448Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3500/task-context/add-graph-catalog-documents-storage-coverage-tests.md
+++ b/artifacts/feat-3500/task-context/add-graph-catalog-documents-storage-coverage-tests.md
@@ -1,0 +1,604 @@
+### task: add-graph-catalog-documents-storage-coverage-tests
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs`
+
+**Reference — production code under test** (`backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/GraphCatalogDocumentsStorage.cs`), confirmed by direct read as of this plan:
+- `private const long UploadSessionThresholdBytes = 4 * 1024 * 1024;` — `UploadFileAsync` routes via `if (sizeBytes <= UploadSessionThresholdBytes) return UploadSmallFileAsync(...); return UploadLargeFileAsync(...);` (line 135-138). **Note the boundary: `<=` routes to the small path, so `sizeBytes == threshold` is small-path, not large-path.**
+- `UploadSmallFileAsync` (private static): single `PUT` to `.../items/{folderId}:/{encodedName}:/content?@microsoft.graph.conflictBehavior=rename`, returns `item.Name` from the JSON body.
+- `UploadLargeFileAsync` (private static, reached only via `UploadFileAsync`): `POST .../items/{folderId}:/{encodedName}:/createUploadSession` → deserializes `CatalogGraphUploadSession.UploadUrl` → `const int chunkSize = 10 * 1024 * 1024;` → outer `while (offset < sizeBytes)`, inner `while (totalRead < chunkSize) { read = await content.ReadAsync(buffer.AsMemory(totalRead), ct); if (read == 0) break; totalRead += read; }`, then `if (totalRead == 0) break;` (outer loop exit for early EOF) → builds `ByteArrayContent(buffer, 0, totalRead)` with `Headers.ContentRange = new ContentRangeHeaderValue(offset, offset + totalRead - 1, sizeBytes)` → sends `new HttpRequestMessage(HttpMethod.Put, session.UploadUrl)` **directly (bypasses `GraphApiHelpers.CreateRequest`, so no `Authorization` header on chunk PUTs)** → on `200`/`201` response, deserializes `CatalogGraphDriveItem` and sets `uploadedName = item.Name`; on any other status except `202`, calls `EnsureSuccessAsync` (which throws) → `offset += totalRead`. Returns `uploadedName` (initially `filename`, only updated by a successful chunk response).
+- `FindFolderAsync`: `GET {GraphBaseUrl}/drives/{driveId}/root:/{encodedPath}:/children` using **app token** (`GetAccessTokenForAppAsync`). If first response is `404`, returns `FolderStatus.NotFound` immediately (no pagination attempted). Otherwise deserializes `CatalogGraphDriveItemCollection` (`Value: List<CatalogGraphDriveItem>`, `NextLink: string?` from `@odata.nextLink`), accumulates `Value` into `allFolderItems`, and while `nextLink != null`, issues `GET nextLink` (via `GraphApiHelpers.CreateRequest`, same app token) and appends that page's `Value`, updating `nextLink` each time. After accumulating all pages: `matches = allFolderItems.Where(i => i.Folder is not null && i.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();`. Then: `matches.Count == 0` → `NotFound`; `matches.Count > 1 && !allowMultiple` → `MultipleMatches` (with `FolderId`/`FolderName` left at their class defaults, i.e. `string.Empty`, since the object initializer only sets `Status`); otherwise `chosen = matches.OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase).First();` → returns `Found` with `chosen.Id`/`chosen.Name` (this "pick alphabetically first" path is taken both for the single-match case and the `allowMultiple: true` multi-match case).
+
+**Reference — wire model shapes** (`backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/CatalogGraphModels.cs`, all `internal`, never referenced directly from tests — fabricate as raw JSON only):
+- `CatalogGraphDriveItem`: `id`, `name`, `webUrl`, `size`, `lastModifiedDateTime`, `file` (nullable `{mimeType}`), `folder` (nullable `{childCount}`).
+- `CatalogGraphDriveItemCollection`: `value: CatalogGraphDriveItem[]`, `@odata.nextLink: string?`.
+- `CatalogGraphUploadSession`: `uploadUrl`.
+- `FolderSearchResult` (`backend/.../FolderSearchResult.cs`): `Status`, `FolderId = string.Empty` (default), `FolderName = string.Empty` (default). `FolderStatus` enum (`backend/.../Contracts/FolderStatus.cs`): `Found`, `NotFound`, `MultipleMatches`.
+
+**Reference — existing test harness** (already in the file, do not modify):
+- `CreateStorage(Func<HttpRequestMessage, HttpResponseMessage> responder)` returns `(GraphCatalogDocumentsStorage Storage, Mock<ITokenAcquisition> TokenAcquisition, RecordingHandler Handler)`. Mocks `GetAccessTokenForAppAsync` → `"app-token"`, `GetAccessTokenForUserAsync` → `"delegated-token"`. Wires an `HttpClient(handler)` returned by `IHttpClientFactory.CreateClient("MicrosoftGraph")`.
+- `RecordingHandler(responder)` : `HttpMessageHandler` — appends every request to `List<HttpRequestMessage> Requests`, returns `responder(request)`. One fresh instance per `CreateStorage` call; safe to close over local mutable state (counters) inside a test's `responder` lambda since each `[Fact]` builds its own handler.
+- Namespace: `Anela.Heblo.Tests.Application.CatalogDocuments`. Class: `public sealed class GraphCatalogDocumentsStorageTests`. Framework: xUnit (`[Fact]`), FluentAssertions (`.Should()`), Moq. `NullLogger<GraphCatalogDocumentsStorage>.Instance` for the logger arg.
+
+⚠️ Before transcribing any test below, re-open the production file and re-diff signatures/constants against what's written here — this plan was written from a point-in-time read and has not been compiled.
+
+---
+
+- [ ] **Step 1: Add region banners and the `ThrottledReadStream` helper.**
+
+  In `GraphCatalogDocumentsStorageTests.cs`, after the existing `// ─── UploadFileAsync — delegated token ───` block (i.e. after the three existing `[Fact]` methods, before `// ─── Recording infrastructure ───`), add three new banners (empty for now, tests fill them in in later steps):
+  ```csharp
+  // ─── UploadFileAsync — size routing ──────────────────────────────────────
+
+  // ─── UploadLargeFileAsync — chunk loop ───────────────────────────────────
+
+  // ─── FindFolderAsync — pagination & matching ─────────────────────────────
+  ```
+
+  Inside the existing `// ─── Recording infrastructure ───` region, alongside `RecordingHandler`, add a private nested `Stream` that caps bytes returned per `ReadAsync` call, to force the production inner fill loop (`while (totalRead < chunkSize)`) through multiple reads:
+
+  ```csharp
+  /// Wraps an in-memory byte source but returns at most <see cref="_maxBytesPerRead"/>
+  /// bytes per ReadAsync call, forcing callers with a larger buffer to loop.
+  private sealed class ThrottledReadStream : Stream
+  {
+      private readonly byte[] _data;
+      private readonly int _maxBytesPerRead;
+      private int _position;
+
+      public ThrottledReadStream(long totalBytes, int maxBytesPerRead)
+      {
+          _data = new byte[totalBytes]; // zero-filled content; tests assert on request shape, not bytes
+          _maxBytesPerRead = maxBytesPerRead;
+      }
+
+      public override int Read(byte[] buffer, int offset, int count)
+          => ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+      public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+      {
+          var remaining = _data.Length - _position;
+          var toCopy = Math.Min(Math.Min(count, _maxBytesPerRead), remaining);
+          if (toCopy > 0)
+              Array.Copy(_data, _position, buffer, offset, toCopy);
+          _position += toCopy;
+          return Task.FromResult(toCopy);
+      }
+
+      public override bool CanRead => true;
+      public override bool CanSeek => false;
+      public override bool CanWrite => false;
+      public override long Length => _data.Length;
+      public override long Position
+      {
+          get => _position;
+          set => throw new NotSupportedException();
+      }
+      public override void Flush() { }
+      public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+      public override void SetLength(long value) => throw new NotSupportedException();
+      public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+  }
+  ```
+
+  Verify against the real `Stream.ReadAsync` overload actually invoked by production code: production calls `content.ReadAsync(buffer.AsMemory(totalRead), ct)` — the `Memory<byte>`-based overload, not the `byte[]` overload. `Stream` provides a default `ReadAsync(Memory<byte>, ...)` implementation that delegates to `ReadAsync(byte[], int, int, ...)` via `ArrayPool` when not overridden directly — overriding the `byte[]`-based `ReadAsync` above is sufficient and is the simpler override surface; confirm this still triggers correctly (i.e. that overriding only the array-based overload actually gets hit) by running Step 8's tests — if the `Memory<byte>` entry point does not route through the overridden method in practice, override `ReadAsync(Memory<byte> buffer, CancellationToken)` directly instead, matching the exact signature used in production.
+
+- [ ] **Step 2 (FR-1): `UploadFileAsync` size-threshold routing — small path at/below threshold.**
+
+  Add two `[Fact]`s under `// ─── UploadFileAsync — size routing ───`:
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_SizeEqualsThreshold_UsesSmallFilePath()
+  {
+      // Arrange — 4 MB exactly; UploadFileAsync uses `<=` so this must take the small-file path
+      const long threshold = 4 * 1024 * 1024;
+      var (storage, _, handler) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"test.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      using var stream = new MemoryStream(new byte[threshold]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", threshold);
+
+      // Assert — exactly one PUT to the .../content endpoint, no createUploadSession call
+      handler.Requests.Should().HaveCount(1);
+      handler.Requests[0].Method.Should().Be(HttpMethod.Put);
+      handler.Requests[0].RequestUri!.ToString().Should().Contain("/content?@microsoft.graph.conflictBehavior=rename");
+  }
+
+  [Fact]
+  public async Task UploadFileAsync_SizeOneBelowThreshold_UsesSmallFilePath()
+  {
+      // Arrange
+      const long threshold = 4 * 1024 * 1024;
+      var (storage, _, handler) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"test.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      using var stream = new MemoryStream(new byte[threshold - 1]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", threshold - 1);
+
+      // Assert
+      handler.Requests.Should().HaveCount(1);
+      handler.Requests[0].Method.Should().Be(HttpMethod.Put);
+      handler.Requests[0].RequestUri!.ToString().Should().Contain("/content?@microsoft.graph.conflictBehavior=rename");
+  }
+  ```
+
+  Do not allocate the full 4 MB `byte[]` unnecessarily large in a loop across many cases — these are two one-off `[Fact]`s, acceptable per the arch review's risk table.
+
+- [ ] **Step 3 (FR-1): `UploadFileAsync` size-threshold routing — large path one above threshold.**
+
+  Add under the same banner:
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_SizeOneAboveThreshold_UsesLargeFileSessionPath()
+  {
+      // Arrange
+      const long threshold = 4 * 1024 * 1024;
+      const long size = threshold + 1;
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[size]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+      // Assert — createUploadSession POST, then chunk PUT(s) to the session's uploadUrl
+      handler.Requests.Should().HaveCountGreaterOrEqualTo(2);
+      handler.Requests[0].Method.Should().Be(HttpMethod.Post);
+      handler.Requests[0].RequestUri!.ToString().Should().Contain("/createUploadSession");
+      handler.Requests.Skip(1).Should().OnlyContain(r =>
+          r.Method == HttpMethod.Put &&
+          r.RequestUri!.ToString() == "https://graph.microsoft.com/upload-session/abc");
+  }
+  ```
+
+  Note: with `size = threshold + 1` (one byte over 4 MB, well under the 10 MB chunk size), the outer chunk loop runs exactly once, so this also incidentally exercises "one small partial chunk" — that's fine, FR-2 below adds the dedicated multi-chunk/boundary cases.
+
+- [ ] **Step 4 (FR-2): Final partial chunk (12 MB: one full 10 MB chunk + 2 MB remainder).**
+
+  Add under `// ─── UploadLargeFileAsync — chunk loop ───`:
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_LargeFileWithPartialFinalChunk_SendsTwoChunksWithCorrectContentRange()
+  {
+      // Arrange — 12 MB: chunk 1 = full 10 MB, chunk 2 = remaining 2 MB
+      const long chunkSize = 10 * 1024 * 1024;
+      const long size = chunkSize + 2 * 1024 * 1024;
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[size]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+      // Assert
+      var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+      chunkRequests.Should().HaveCount(2);
+
+      var range1 = chunkRequests[0].Content!.Headers.ContentRange!;
+      range1.From.Should().Be(0);
+      range1.To.Should().Be(chunkSize - 1);
+      range1.Length.Should().Be(size);
+
+      var range2 = chunkRequests[1].Content!.Headers.ContentRange!;
+      range2.From.Should().Be(chunkSize);
+      range2.To.Should().Be(size - 1);
+      range2.Length.Should().Be(size);
+  }
+  ```
+
+- [ ] **Step 5 (FR-2): Multi-read fill of a single chunk, using `ThrottledReadStream`.**
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_LargeFileWithThrottledStream_AssemblesFullChunkFromShortReads()
+  {
+      // Arrange — exactly one chunk (10 MB), but the stream only yields 64 KB per ReadAsync call,
+      // forcing UploadLargeFileAsync's inner fill loop to run many iterations before sending the PUT.
+      const long chunkSize = 10 * 1024 * 1024;
+      const int maxBytesPerRead = 64 * 1024;
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new ThrottledReadStream(chunkSize, maxBytesPerRead);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", chunkSize);
+
+      // Assert — exactly one chunk PUT, whose Content-Range reflects the FULL chunk length,
+      // not the length of a single short read
+      var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+      chunkRequests.Should().HaveCount(1);
+
+      var range = chunkRequests[0].Content!.Headers.ContentRange!;
+      range.From.Should().Be(0);
+      range.To.Should().Be(chunkSize - 1);
+      range.Length.Should().Be(chunkSize);
+  }
+  ```
+
+- [ ] **Step 6 (FR-2): Two full chunks, exact multiple boundary (20 MB) — verifies outer loop termination and last-chunk-wins naming.**
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_LargeFileExactMultipleOfChunkSize_SendsExactlyTwoChunksNoTrailingRequest()
+  {
+      // Arrange — 20 MB = exactly two 10 MB chunks; outer `while (offset < sizeBytes)` must
+      // stop after the second chunk with no trailing empty/zero-length request.
+      const long chunkSize = 10 * 1024 * 1024;
+      const long size = 2 * chunkSize;
+
+      var responses = new Queue<string>(new[]
+      {
+          "chunk-1-name",
+          "final-name.pdf"
+      });
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          var name = responses.Dequeue();
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  $$"""{"id":"item-1","name":"{{name}}"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[size]);
+
+      // Act
+      var result = await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+      // Assert — exactly two chunk PUTs, no trailing third request
+      var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+      chunkRequests.Should().HaveCount(2);
+
+      // Returned filename comes from the LAST chunk response, not the first
+      result.Should().Be("final-name.pdf");
+
+      // No Authorization header on chunk PUTs (bypass GraphApiHelpers.CreateRequest)
+      chunkRequests.Should().OnlyContain(r => r.Headers.Authorization == null);
+  }
+  ```
+
+  Verify the `$$"""..."""` raw-string-with-interpolation syntax compiles against this project's configured C# language version (check `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` / `Directory.Build.props` for `<LangVersion>`); if not supported, replace with plain string concatenation/`string.Format`.
+
+- [ ] **Step 7 (FR-2, Open Question): Pin early-stream-exhaustion behavior (documentation test, not a bug fix).**
+
+  Per the spec's Open Questions and the arch review's recommendation, add one test pinning current (arguably questionable) behavior: if the content stream returns EOF before `sizeBytes` is reached, `UploadLargeFileAsync`'s outer loop exits early without error.
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_StreamExhaustedBeforeDeclaredSize_StopsEarlyWithoutThrowing()
+  {
+      // Documents existing (pre-existing, out-of-scope-to-fix) behavior: UploadLargeFileAsync's
+      // outer loop exits as soon as the stream returns 0 bytes, even if offset < sizeBytes.
+      // See spec Open Questions — flagged as a candidate follow-up bug ticket, not fixed here.
+      const long chunkSize = 10 * 1024 * 1024;
+      const long declaredSize = 3 * chunkSize; // 30 MB declared
+      const long actualStreamBytes = chunkSize; // but stream only has 10 MB
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[actualStreamBytes]);
+
+      // Act
+      var act = () => storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", declaredSize);
+
+      // Assert — no exception; loop stops after the one chunk the stream actually had
+      await act.Should().NotThrowAsync();
+      handler.Requests.Count(r => r.Method == HttpMethod.Put).Should().Be(1);
+  }
+  ```
+
+- [ ] **Step 8: Run and verify FR-1/FR-2 tests before moving on.**
+
+  ```bash
+  cd backend
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~GraphCatalogDocumentsStorageTests" \
+    -v normal
+  ```
+
+  Expected: all tests in the file pass, including the 3 pre-existing tests plus the 6 added so far in this step range (Steps 2-7) — 9 total. If `ThrottledReadStream`'s overridden `ReadAsync(byte[], ...)` is not actually invoked (i.e. the `Memory<byte>`-based call in production routes elsewhere), Step 5's test will show a Content-Range shorter than expected or a hang — fix by overriding `ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)` directly with the equivalent logic, matching the exact overload used at the call site (`content.ReadAsync(buffer.AsMemory(totalRead), ct)`).
+
+- [ ] **Step 9 (FR-3): `FindFolderAsync` — no matches, single match, non-folder exclusion.**
+
+  Add under `// ─── FindFolderAsync — pagination & matching ───`:
+
+  ```csharp
+  [Fact]
+  public async Task FindFolderAsync_NoMatchingItems_ReturnsNotFound()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"value":[]}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "MAT001__", false);
+
+      result.Status.Should().Be(FolderStatus.NotFound);
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_ExactlyOneMatch_ReturnsFoundWithMatchedFolder()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"value":[{"id":"folder-id-1","name":"PIF-2024","folder":{"childCount":0}}]}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.Found);
+      result.FolderId.Should().Be("folder-id-1");
+      result.FolderName.Should().Be("PIF-2024");
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_ExcludesNonFolderItemsMatchingPrefix()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """
+                  {
+                    "value": [
+                      { "id": "file-id-1", "name": "PIF-2024-notes.txt", "folder": null, "file": { "mimeType": "text/plain" } }
+                    ]
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.NotFound);
+  }
+  ```
+
+- [ ] **Step 10 (FR-3): Multiple matches — `allowMultiple: false` and `allowMultiple: true` (alphabetical pick).**
+
+  ```csharp
+  [Fact]
+  public async Task FindFolderAsync_MultipleMatches_AllowMultipleFalse_ReturnsMultipleMatchesWithEmptyFolder()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """
+                  {
+                    "value": [
+                      { "id": "folder-id-2", "name": "PIF-2024-B", "folder": {"childCount":0} },
+                      { "id": "folder-id-1", "name": "PIF-2024-A", "folder": {"childCount":0} }
+                    ]
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.MultipleMatches);
+      result.FolderId.Should().BeEmpty();
+      result.FolderName.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_MultipleMatches_AllowMultipleTrue_ReturnsAlphabeticallyFirstMatch()
+  {
+      // Items deliberately in non-alphabetical order in the response
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """
+                  {
+                    "value": [
+                      { "id": "folder-id-2", "name": "PIF-2024-B", "folder": {"childCount":0} },
+                      { "id": "folder-id-1", "name": "PIF-2024-A", "folder": {"childCount":0} }
+                    ]
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", true);
+
+      result.Status.Should().Be(FolderStatus.Found);
+      result.FolderId.Should().Be("folder-id-1");
+      result.FolderName.Should().Be("PIF-2024-A");
+  }
+  ```
+
+- [ ] **Step 11 (FR-3): Multi-page pagination — a match only on page two, and a 404 short-circuit.**
+
+  ```csharp
+  [Fact]
+  public async Task FindFolderAsync_MultiPagePagination_ConsidersMatchesFromBothPages()
+  {
+      const string nextLinkUrl = "https://graph.microsoft.com/v1.0/next-page-2";
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.RequestUri!.ToString() == nextLinkUrl)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"value":[{"id":"folder-id-page2","name":"PIF-2024-Page2","folder":{"childCount":0}}]}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  $$"""
+                  {
+                    "value": [
+                      { "id": "file-id-1", "name": "PIF-2024-notes.txt", "folder": null, "file": {"mimeType":"text/plain"} }
+                    ],
+                    "@odata.nextLink": "{{nextLinkUrl}}"
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      // Only page 2 has a matching folder item; page 1's item is a file (excluded), not a folder.
+      result.Status.Should().Be(FolderStatus.Found);
+      result.FolderId.Should().Be("folder-id-page2");
+      handler.Requests.Should().Contain(r => r.RequestUri!.ToString() == nextLinkUrl);
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_FirstPage404_ReturnsNotFoundWithoutPagination()
+  {
+      var (storage, _, handler) = CreateStorage(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.NotFound);
+      handler.Requests.Should().HaveCount(1);
+  }
+  ```
+
+  Verify the exact `basePath`/`encodedPath` URL construction is irrelevant to these assertions (they only check `nextLink`/count), so no need to match the first-page URL precisely — the responder branches on the `nextLinkUrl` value only, falling back to the default response for every other request (including the very first request), which is correct here since there is exactly one "other" request per test.
+
+- [ ] **Step 12: Run the full new test file and verify final counts.**
+
+  ```bash
+  cd backend
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~GraphCatalogDocumentsStorageTests" \
+    -v normal
+  ```
+
+  Expected: 3 (pre-existing) + 6 (Steps 2-7) + 3 (Step 9) + 2 (Step 10) + 2 (Step 11) = 16 tests, all passing. If any count mismatches (developer added/omitted a `[Fact]` during implementation), reconcile the count rather than treating it as acceptable drift — but do not chase an exact number if a genuinely better test shape (e.g. consolidating two `[Fact]`s into a `[Theory]`) was used; confirm intent against the FRs in `artifacts/feat-3500/spec.r1.md` instead.
+
+  Also run the full test project to confirm no regressions elsewhere:
+  ```bash
+  cd backend
+  dotnet build && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+  ```
+
+- [ ] **Step 13: Commit.**
+
+  ```bash
+  git add backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs
+  git commit -m "$(cat <<'EOF'
+  Add coverage for GraphCatalogDocumentsStorage upload routing, chunk loop, and folder pagination
+
+  Closes the coverage gap on GraphCatalogDocumentsStorage's three untested
+  paths: UploadFileAsync size-threshold routing, UploadLargeFileAsync's
+  chunked offset/read loop, and FindFolderAsync's pagination and
+  multi-match logic. Test-only change, no production code touched.
+  EOF
+  )"
+  ```

--- a/artifacts/feat-3500/task-plan.r1.md
+++ b/artifacts/feat-3500/task-plan.r1.md
@@ -1,0 +1,612 @@
+# Close Coverage Gap in GraphCatalogDocumentsStorage Implementation Plan
+
+**Goal:** Add unit tests to the existing `GraphCatalogDocumentsStorageTests.cs` file that exercise the three untested code paths in `GraphCatalogDocumentsStorage` — `UploadFileAsync` size-threshold routing, `UploadLargeFileAsync`'s chunked offset/read loop, and `FindFolderAsync`'s pagination and multi-match logic — with no production code changes.
+
+**Architecture:** All new tests are appended to the single existing file `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs`, reusing the existing `CreateStorage(responder)` factory and `RecordingHandler` fake `HttpMessageHandler` exactly as today's three tests do. One new test-only helper class (`ThrottledReadStream`) is added alongside `RecordingHandler` under the `// ─── Recording infrastructure ───` region to force the production chunk-fill loop through multiple `ReadAsync` iterations. No production file changes.
+
+---
+
+### task: add-graph-catalog-documents-storage-coverage-tests
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs`
+
+**Reference — production code under test** (`backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/GraphCatalogDocumentsStorage.cs`), confirmed by direct read as of this plan:
+- `private const long UploadSessionThresholdBytes = 4 * 1024 * 1024;` — `UploadFileAsync` routes via `if (sizeBytes <= UploadSessionThresholdBytes) return UploadSmallFileAsync(...); return UploadLargeFileAsync(...);` (line 135-138). **Note the boundary: `<=` routes to the small path, so `sizeBytes == threshold` is small-path, not large-path.**
+- `UploadSmallFileAsync` (private static): single `PUT` to `.../items/{folderId}:/{encodedName}:/content?@microsoft.graph.conflictBehavior=rename`, returns `item.Name` from the JSON body.
+- `UploadLargeFileAsync` (private static, reached only via `UploadFileAsync`): `POST .../items/{folderId}:/{encodedName}:/createUploadSession` → deserializes `CatalogGraphUploadSession.UploadUrl` → `const int chunkSize = 10 * 1024 * 1024;` → outer `while (offset < sizeBytes)`, inner `while (totalRead < chunkSize) { read = await content.ReadAsync(buffer.AsMemory(totalRead), ct); if (read == 0) break; totalRead += read; }`, then `if (totalRead == 0) break;` (outer loop exit for early EOF) → builds `ByteArrayContent(buffer, 0, totalRead)` with `Headers.ContentRange = new ContentRangeHeaderValue(offset, offset + totalRead - 1, sizeBytes)` → sends `new HttpRequestMessage(HttpMethod.Put, session.UploadUrl)` **directly (bypasses `GraphApiHelpers.CreateRequest`, so no `Authorization` header on chunk PUTs)** → on `200`/`201` response, deserializes `CatalogGraphDriveItem` and sets `uploadedName = item.Name`; on any other status except `202`, calls `EnsureSuccessAsync` (which throws) → `offset += totalRead`. Returns `uploadedName` (initially `filename`, only updated by a successful chunk response).
+- `FindFolderAsync`: `GET {GraphBaseUrl}/drives/{driveId}/root:/{encodedPath}:/children` using **app token** (`GetAccessTokenForAppAsync`). If first response is `404`, returns `FolderStatus.NotFound` immediately (no pagination attempted). Otherwise deserializes `CatalogGraphDriveItemCollection` (`Value: List<CatalogGraphDriveItem>`, `NextLink: string?` from `@odata.nextLink`), accumulates `Value` into `allFolderItems`, and while `nextLink != null`, issues `GET nextLink` (via `GraphApiHelpers.CreateRequest`, same app token) and appends that page's `Value`, updating `nextLink` each time. After accumulating all pages: `matches = allFolderItems.Where(i => i.Folder is not null && i.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();`. Then: `matches.Count == 0` → `NotFound`; `matches.Count > 1 && !allowMultiple` → `MultipleMatches` (with `FolderId`/`FolderName` left at their class defaults, i.e. `string.Empty`, since the object initializer only sets `Status`); otherwise `chosen = matches.OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase).First();` → returns `Found` with `chosen.Id`/`chosen.Name` (this "pick alphabetically first" path is taken both for the single-match case and the `allowMultiple: true` multi-match case).
+
+**Reference — wire model shapes** (`backend/src/Anela.Heblo.Application/Features/CatalogDocuments/Services/CatalogGraphModels.cs`, all `internal`, never referenced directly from tests — fabricate as raw JSON only):
+- `CatalogGraphDriveItem`: `id`, `name`, `webUrl`, `size`, `lastModifiedDateTime`, `file` (nullable `{mimeType}`), `folder` (nullable `{childCount}`).
+- `CatalogGraphDriveItemCollection`: `value: CatalogGraphDriveItem[]`, `@odata.nextLink: string?`.
+- `CatalogGraphUploadSession`: `uploadUrl`.
+- `FolderSearchResult` (`backend/.../FolderSearchResult.cs`): `Status`, `FolderId = string.Empty` (default), `FolderName = string.Empty` (default). `FolderStatus` enum (`backend/.../Contracts/FolderStatus.cs`): `Found`, `NotFound`, `MultipleMatches`.
+
+**Reference — existing test harness** (already in the file, do not modify):
+- `CreateStorage(Func<HttpRequestMessage, HttpResponseMessage> responder)` returns `(GraphCatalogDocumentsStorage Storage, Mock<ITokenAcquisition> TokenAcquisition, RecordingHandler Handler)`. Mocks `GetAccessTokenForAppAsync` → `"app-token"`, `GetAccessTokenForUserAsync` → `"delegated-token"`. Wires an `HttpClient(handler)` returned by `IHttpClientFactory.CreateClient("MicrosoftGraph")`.
+- `RecordingHandler(responder)` : `HttpMessageHandler` — appends every request to `List<HttpRequestMessage> Requests`, returns `responder(request)`. One fresh instance per `CreateStorage` call; safe to close over local mutable state (counters) inside a test's `responder` lambda since each `[Fact]` builds its own handler.
+- Namespace: `Anela.Heblo.Tests.Application.CatalogDocuments`. Class: `public sealed class GraphCatalogDocumentsStorageTests`. Framework: xUnit (`[Fact]`), FluentAssertions (`.Should()`), Moq. `NullLogger<GraphCatalogDocumentsStorage>.Instance` for the logger arg.
+
+⚠️ Before transcribing any test below, re-open the production file and re-diff signatures/constants against what's written here — this plan was written from a point-in-time read and has not been compiled.
+
+---
+
+- [ ] **Step 1: Add region banners and the `ThrottledReadStream` helper.**
+
+  In `GraphCatalogDocumentsStorageTests.cs`, after the existing `// ─── UploadFileAsync — delegated token ───` block (i.e. after the three existing `[Fact]` methods, before `// ─── Recording infrastructure ───`), add three new banners (empty for now, tests fill them in in later steps):
+  ```csharp
+  // ─── UploadFileAsync — size routing ──────────────────────────────────────
+
+  // ─── UploadLargeFileAsync — chunk loop ───────────────────────────────────
+
+  // ─── FindFolderAsync — pagination & matching ─────────────────────────────
+  ```
+
+  Inside the existing `// ─── Recording infrastructure ───` region, alongside `RecordingHandler`, add a private nested `Stream` that caps bytes returned per `ReadAsync` call, to force the production inner fill loop (`while (totalRead < chunkSize)`) through multiple reads:
+
+  ```csharp
+  /// Wraps an in-memory byte source but returns at most <see cref="_maxBytesPerRead"/>
+  /// bytes per ReadAsync call, forcing callers with a larger buffer to loop.
+  private sealed class ThrottledReadStream : Stream
+  {
+      private readonly byte[] _data;
+      private readonly int _maxBytesPerRead;
+      private int _position;
+
+      public ThrottledReadStream(long totalBytes, int maxBytesPerRead)
+      {
+          _data = new byte[totalBytes]; // zero-filled content; tests assert on request shape, not bytes
+          _maxBytesPerRead = maxBytesPerRead;
+      }
+
+      public override int Read(byte[] buffer, int offset, int count)
+          => ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+      public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+      {
+          var remaining = _data.Length - _position;
+          var toCopy = Math.Min(Math.Min(count, _maxBytesPerRead), remaining);
+          if (toCopy > 0)
+              Array.Copy(_data, _position, buffer, offset, toCopy);
+          _position += toCopy;
+          return Task.FromResult(toCopy);
+      }
+
+      public override bool CanRead => true;
+      public override bool CanSeek => false;
+      public override bool CanWrite => false;
+      public override long Length => _data.Length;
+      public override long Position
+      {
+          get => _position;
+          set => throw new NotSupportedException();
+      }
+      public override void Flush() { }
+      public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+      public override void SetLength(long value) => throw new NotSupportedException();
+      public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+  }
+  ```
+
+  Verify against the real `Stream.ReadAsync` overload actually invoked by production code: production calls `content.ReadAsync(buffer.AsMemory(totalRead), ct)` — the `Memory<byte>`-based overload, not the `byte[]` overload. `Stream` provides a default `ReadAsync(Memory<byte>, ...)` implementation that delegates to `ReadAsync(byte[], int, int, ...)` via `ArrayPool` when not overridden directly — overriding the `byte[]`-based `ReadAsync` above is sufficient and is the simpler override surface; confirm this still triggers correctly (i.e. that overriding only the array-based overload actually gets hit) by running Step 8's tests — if the `Memory<byte>` entry point does not route through the overridden method in practice, override `ReadAsync(Memory<byte> buffer, CancellationToken)` directly instead, matching the exact signature used in production.
+
+- [ ] **Step 2 (FR-1): `UploadFileAsync` size-threshold routing — small path at/below threshold.**
+
+  Add two `[Fact]`s under `// ─── UploadFileAsync — size routing ───`:
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_SizeEqualsThreshold_UsesSmallFilePath()
+  {
+      // Arrange — 4 MB exactly; UploadFileAsync uses `<=` so this must take the small-file path
+      const long threshold = 4 * 1024 * 1024;
+      var (storage, _, handler) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"test.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      using var stream = new MemoryStream(new byte[threshold]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", threshold);
+
+      // Assert — exactly one PUT to the .../content endpoint, no createUploadSession call
+      handler.Requests.Should().HaveCount(1);
+      handler.Requests[0].Method.Should().Be(HttpMethod.Put);
+      handler.Requests[0].RequestUri!.ToString().Should().Contain("/content?@microsoft.graph.conflictBehavior=rename");
+  }
+
+  [Fact]
+  public async Task UploadFileAsync_SizeOneBelowThreshold_UsesSmallFilePath()
+  {
+      // Arrange
+      const long threshold = 4 * 1024 * 1024;
+      var (storage, _, handler) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"test.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      using var stream = new MemoryStream(new byte[threshold - 1]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", threshold - 1);
+
+      // Assert
+      handler.Requests.Should().HaveCount(1);
+      handler.Requests[0].Method.Should().Be(HttpMethod.Put);
+      handler.Requests[0].RequestUri!.ToString().Should().Contain("/content?@microsoft.graph.conflictBehavior=rename");
+  }
+  ```
+
+  Do not allocate the full 4 MB `byte[]` unnecessarily large in a loop across many cases — these are two one-off `[Fact]`s, acceptable per the arch review's risk table.
+
+- [ ] **Step 3 (FR-1): `UploadFileAsync` size-threshold routing — large path one above threshold.**
+
+  Add under the same banner:
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_SizeOneAboveThreshold_UsesLargeFileSessionPath()
+  {
+      // Arrange
+      const long threshold = 4 * 1024 * 1024;
+      const long size = threshold + 1;
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[size]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+      // Assert — createUploadSession POST, then chunk PUT(s) to the session's uploadUrl
+      handler.Requests.Should().HaveCountGreaterOrEqualTo(2);
+      handler.Requests[0].Method.Should().Be(HttpMethod.Post);
+      handler.Requests[0].RequestUri!.ToString().Should().Contain("/createUploadSession");
+      handler.Requests.Skip(1).Should().OnlyContain(r =>
+          r.Method == HttpMethod.Put &&
+          r.RequestUri!.ToString() == "https://graph.microsoft.com/upload-session/abc");
+  }
+  ```
+
+  Note: with `size = threshold + 1` (one byte over 4 MB, well under the 10 MB chunk size), the outer chunk loop runs exactly once, so this also incidentally exercises "one small partial chunk" — that's fine, FR-2 below adds the dedicated multi-chunk/boundary cases.
+
+- [ ] **Step 4 (FR-2): Final partial chunk (12 MB: one full 10 MB chunk + 2 MB remainder).**
+
+  Add under `// ─── UploadLargeFileAsync — chunk loop ───`:
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_LargeFileWithPartialFinalChunk_SendsTwoChunksWithCorrectContentRange()
+  {
+      // Arrange — 12 MB: chunk 1 = full 10 MB, chunk 2 = remaining 2 MB
+      const long chunkSize = 10 * 1024 * 1024;
+      const long size = chunkSize + 2 * 1024 * 1024;
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[size]);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+      // Assert
+      var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+      chunkRequests.Should().HaveCount(2);
+
+      var range1 = chunkRequests[0].Content!.Headers.ContentRange!;
+      range1.From.Should().Be(0);
+      range1.To.Should().Be(chunkSize - 1);
+      range1.Length.Should().Be(size);
+
+      var range2 = chunkRequests[1].Content!.Headers.ContentRange!;
+      range2.From.Should().Be(chunkSize);
+      range2.To.Should().Be(size - 1);
+      range2.Length.Should().Be(size);
+  }
+  ```
+
+- [ ] **Step 5 (FR-2): Multi-read fill of a single chunk, using `ThrottledReadStream`.**
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_LargeFileWithThrottledStream_AssemblesFullChunkFromShortReads()
+  {
+      // Arrange — exactly one chunk (10 MB), but the stream only yields 64 KB per ReadAsync call,
+      // forcing UploadLargeFileAsync's inner fill loop to run many iterations before sending the PUT.
+      const long chunkSize = 10 * 1024 * 1024;
+      const int maxBytesPerRead = 64 * 1024;
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new ThrottledReadStream(chunkSize, maxBytesPerRead);
+
+      // Act
+      await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", chunkSize);
+
+      // Assert — exactly one chunk PUT, whose Content-Range reflects the FULL chunk length,
+      // not the length of a single short read
+      var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+      chunkRequests.Should().HaveCount(1);
+
+      var range = chunkRequests[0].Content!.Headers.ContentRange!;
+      range.From.Should().Be(0);
+      range.To.Should().Be(chunkSize - 1);
+      range.Length.Should().Be(chunkSize);
+  }
+  ```
+
+- [ ] **Step 6 (FR-2): Two full chunks, exact multiple boundary (20 MB) — verifies outer loop termination and last-chunk-wins naming.**
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_LargeFileExactMultipleOfChunkSize_SendsExactlyTwoChunksNoTrailingRequest()
+  {
+      // Arrange — 20 MB = exactly two 10 MB chunks; outer `while (offset < sizeBytes)` must
+      // stop after the second chunk with no trailing empty/zero-length request.
+      const long chunkSize = 10 * 1024 * 1024;
+      const long size = 2 * chunkSize;
+
+      var responses = new Queue<string>(new[]
+      {
+          "chunk-1-name",
+          "final-name.pdf"
+      });
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          var name = responses.Dequeue();
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  $$"""{"id":"item-1","name":"{{name}}"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[size]);
+
+      // Act
+      var result = await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+      // Assert — exactly two chunk PUTs, no trailing third request
+      var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+      chunkRequests.Should().HaveCount(2);
+
+      // Returned filename comes from the LAST chunk response, not the first
+      result.Should().Be("final-name.pdf");
+
+      // No Authorization header on chunk PUTs (bypass GraphApiHelpers.CreateRequest)
+      chunkRequests.Should().OnlyContain(r => r.Headers.Authorization == null);
+  }
+  ```
+
+  Verify the `$$"""..."""` raw-string-with-interpolation syntax compiles against this project's configured C# language version (check `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` / `Directory.Build.props` for `<LangVersion>`); if not supported, replace with plain string concatenation/`string.Format`.
+
+- [ ] **Step 7 (FR-2, Open Question): Pin early-stream-exhaustion behavior (documentation test, not a bug fix).**
+
+  Per the spec's Open Questions and the arch review's recommendation, add one test pinning current (arguably questionable) behavior: if the content stream returns EOF before `sizeBytes` is reached, `UploadLargeFileAsync`'s outer loop exits early without error.
+
+  ```csharp
+  [Fact]
+  public async Task UploadFileAsync_StreamExhaustedBeforeDeclaredSize_StopsEarlyWithoutThrowing()
+  {
+      // Documents existing (pre-existing, out-of-scope-to-fix) behavior: UploadLargeFileAsync's
+      // outer loop exits as soon as the stream returns 0 bytes, even if offset < sizeBytes.
+      // See spec Open Questions — flagged as a candidate follow-up bug ticket, not fixed here.
+      const long chunkSize = 10 * 1024 * 1024;
+      const long declaredSize = 3 * chunkSize; // 30 MB declared
+      const long actualStreamBytes = chunkSize; // but stream only has 10 MB
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.Method == HttpMethod.Post)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"id":"item-1","name":"final.pdf"}""",
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      using var stream = new MemoryStream(new byte[actualStreamBytes]);
+
+      // Act
+      var act = () => storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", declaredSize);
+
+      // Assert — no exception; loop stops after the one chunk the stream actually had
+      await act.Should().NotThrowAsync();
+      handler.Requests.Count(r => r.Method == HttpMethod.Put).Should().Be(1);
+  }
+  ```
+
+- [ ] **Step 8: Run and verify FR-1/FR-2 tests before moving on.**
+
+  ```bash
+  cd backend
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~GraphCatalogDocumentsStorageTests" \
+    -v normal
+  ```
+
+  Expected: all tests in the file pass, including the 3 pre-existing tests plus the 6 added so far in this step range (Steps 2-7) — 9 total. If `ThrottledReadStream`'s overridden `ReadAsync(byte[], ...)` is not actually invoked (i.e. the `Memory<byte>`-based call in production routes elsewhere), Step 5's test will show a Content-Range shorter than expected or a hang — fix by overriding `ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)` directly with the equivalent logic, matching the exact overload used at the call site (`content.ReadAsync(buffer.AsMemory(totalRead), ct)`).
+
+- [ ] **Step 9 (FR-3): `FindFolderAsync` — no matches, single match, non-folder exclusion.**
+
+  Add under `// ─── FindFolderAsync — pagination & matching ───`:
+
+  ```csharp
+  [Fact]
+  public async Task FindFolderAsync_NoMatchingItems_ReturnsNotFound()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"value":[]}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "MAT001__", false);
+
+      result.Status.Should().Be(FolderStatus.NotFound);
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_ExactlyOneMatch_ReturnsFoundWithMatchedFolder()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """{"value":[{"id":"folder-id-1","name":"PIF-2024","folder":{"childCount":0}}]}""",
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.Found);
+      result.FolderId.Should().Be("folder-id-1");
+      result.FolderName.Should().Be("PIF-2024");
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_ExcludesNonFolderItemsMatchingPrefix()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """
+                  {
+                    "value": [
+                      { "id": "file-id-1", "name": "PIF-2024-notes.txt", "folder": null, "file": { "mimeType": "text/plain" } }
+                    ]
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.NotFound);
+  }
+  ```
+
+- [ ] **Step 10 (FR-3): Multiple matches — `allowMultiple: false` and `allowMultiple: true` (alphabetical pick).**
+
+  ```csharp
+  [Fact]
+  public async Task FindFolderAsync_MultipleMatches_AllowMultipleFalse_ReturnsMultipleMatchesWithEmptyFolder()
+  {
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """
+                  {
+                    "value": [
+                      { "id": "folder-id-2", "name": "PIF-2024-B", "folder": {"childCount":0} },
+                      { "id": "folder-id-1", "name": "PIF-2024-A", "folder": {"childCount":0} }
+                    ]
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.MultipleMatches);
+      result.FolderId.Should().BeEmpty();
+      result.FolderName.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_MultipleMatches_AllowMultipleTrue_ReturnsAlphabeticallyFirstMatch()
+  {
+      // Items deliberately in non-alphabetical order in the response
+      var (storage, _, _) = CreateStorage(_ =>
+          new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  """
+                  {
+                    "value": [
+                      { "id": "folder-id-2", "name": "PIF-2024-B", "folder": {"childCount":0} },
+                      { "id": "folder-id-1", "name": "PIF-2024-A", "folder": {"childCount":0} }
+                    ]
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", true);
+
+      result.Status.Should().Be(FolderStatus.Found);
+      result.FolderId.Should().Be("folder-id-1");
+      result.FolderName.Should().Be("PIF-2024-A");
+  }
+  ```
+
+- [ ] **Step 11 (FR-3): Multi-page pagination — a match only on page two, and a 404 short-circuit.**
+
+  ```csharp
+  [Fact]
+  public async Task FindFolderAsync_MultiPagePagination_ConsidersMatchesFromBothPages()
+  {
+      const string nextLinkUrl = "https://graph.microsoft.com/v1.0/next-page-2";
+
+      var (storage, _, handler) = CreateStorage(request =>
+      {
+          if (request.RequestUri!.ToString() == nextLinkUrl)
+          {
+              return new HttpResponseMessage(HttpStatusCode.OK)
+              {
+                  Content = new StringContent(
+                      """{"value":[{"id":"folder-id-page2","name":"PIF-2024-Page2","folder":{"childCount":0}}]}""",
+                      Encoding.UTF8, "application/json")
+              };
+          }
+
+          return new HttpResponseMessage(HttpStatusCode.OK)
+          {
+              Content = new StringContent(
+                  $$"""
+                  {
+                    "value": [
+                      { "id": "file-id-1", "name": "PIF-2024-notes.txt", "folder": null, "file": {"mimeType":"text/plain"} }
+                    ],
+                    "@odata.nextLink": "{{nextLinkUrl}}"
+                  }
+                  """,
+                  Encoding.UTF8, "application/json")
+          };
+      });
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      // Only page 2 has a matching folder item; page 1's item is a file (excluded), not a folder.
+      result.Status.Should().Be(FolderStatus.Found);
+      result.FolderId.Should().Be("folder-id-page2");
+      handler.Requests.Should().Contain(r => r.RequestUri!.ToString() == nextLinkUrl);
+  }
+
+  [Fact]
+  public async Task FindFolderAsync_FirstPage404_ReturnsNotFoundWithoutPagination()
+  {
+      var (storage, _, handler) = CreateStorage(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+      var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+      result.Status.Should().Be(FolderStatus.NotFound);
+      handler.Requests.Should().HaveCount(1);
+  }
+  ```
+
+  Verify the exact `basePath`/`encodedPath` URL construction is irrelevant to these assertions (they only check `nextLink`/count), so no need to match the first-page URL precisely — the responder branches on the `nextLinkUrl` value only, falling back to the default response for every other request (including the very first request), which is correct here since there is exactly one "other" request per test.
+
+- [ ] **Step 12: Run the full new test file and verify final counts.**
+
+  ```bash
+  cd backend
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~GraphCatalogDocumentsStorageTests" \
+    -v normal
+  ```
+
+  Expected: 3 (pre-existing) + 6 (Steps 2-7) + 3 (Step 9) + 2 (Step 10) + 2 (Step 11) = 16 tests, all passing. If any count mismatches (developer added/omitted a `[Fact]` during implementation), reconcile the count rather than treating it as acceptable drift — but do not chase an exact number if a genuinely better test shape (e.g. consolidating two `[Fact]`s into a `[Theory]`) was used; confirm intent against the FRs in `artifacts/feat-3500/spec.r1.md` instead.
+
+  Also run the full test project to confirm no regressions elsewhere:
+  ```bash
+  cd backend
+  dotnet build && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+  ```
+
+- [ ] **Step 13: Commit.**
+
+  ```bash
+  git add backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs
+  git commit -m "$(cat <<'EOF'
+  Add coverage for GraphCatalogDocumentsStorage upload routing, chunk loop, and folder pagination
+
+  Closes the coverage gap on GraphCatalogDocumentsStorage's three untested
+  paths: UploadFileAsync size-threshold routing, UploadLargeFileAsync's
+  chunked offset/read loop, and FindFolderAsync's pagination and
+  multi-match logic. Test-only change, no production code touched.
+  EOF
+  )"
+  ```

--- a/backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/CatalogDocuments/GraphCatalogDocumentsStorageTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using Anela.Heblo.Application.Features.CatalogDocuments.Contracts;
 using Anela.Heblo.Application.Features.CatalogDocuments.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -130,6 +131,434 @@ public sealed class GraphCatalogDocumentsStorageTests
         ex.And.InnerException.Should().BeOfType<MsalUiRequiredException>();
     }
 
+    // ─── UploadFileAsync — size routing ──────────────────────────────────────
+
+    [Fact]
+    public async Task UploadFileAsync_SizeEqualsThreshold_UsesSmallFilePath()
+    {
+        // Arrange — 4 MB exactly; UploadFileAsync uses `<=` so this must take the small-file path
+        const long threshold = 4 * 1024 * 1024;
+        var (storage, _, handler) = CreateStorage(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"id":"item-1","name":"test.pdf"}""",
+                    Encoding.UTF8, "application/json")
+            });
+
+        using var stream = new MemoryStream(new byte[threshold]);
+
+        // Act
+        await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", threshold);
+
+        // Assert — exactly one PUT to the .../content endpoint, no createUploadSession call
+        handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].Method.Should().Be(HttpMethod.Put);
+        handler.Requests[0].RequestUri!.ToString().Should().Contain("/content?@microsoft.graph.conflictBehavior=rename");
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_SizeOneBelowThreshold_UsesSmallFilePath()
+    {
+        // Arrange
+        const long threshold = 4 * 1024 * 1024;
+        var (storage, _, handler) = CreateStorage(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"id":"item-1","name":"test.pdf"}""",
+                    Encoding.UTF8, "application/json")
+            });
+
+        using var stream = new MemoryStream(new byte[threshold - 1]);
+
+        // Act
+        await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", threshold - 1);
+
+        // Assert
+        handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].Method.Should().Be(HttpMethod.Put);
+        handler.Requests[0].RequestUri!.ToString().Should().Contain("/content?@microsoft.graph.conflictBehavior=rename");
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_SizeOneAboveThreshold_UsesLargeFileSessionPath()
+    {
+        // Arrange
+        const long threshold = 4 * 1024 * 1024;
+        const long size = threshold + 1;
+        var (storage, _, handler) = CreateStorage(request =>
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                        Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"id":"item-1","name":"final.pdf"}""",
+                    Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var stream = new MemoryStream(new byte[size]);
+
+        // Act
+        await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+        // Assert — createUploadSession POST, then chunk PUT(s) to the session's uploadUrl
+        handler.Requests.Should().HaveCountGreaterOrEqualTo(2);
+        handler.Requests[0].Method.Should().Be(HttpMethod.Post);
+        handler.Requests[0].RequestUri!.ToString().Should().Contain("/createUploadSession");
+        handler.Requests.Skip(1).Should().OnlyContain(r =>
+            r.Method == HttpMethod.Put &&
+            r.RequestUri!.ToString() == "https://graph.microsoft.com/upload-session/abc");
+    }
+
+    // ─── UploadLargeFileAsync — chunk loop ───────────────────────────────────
+
+    [Fact]
+    public async Task UploadFileAsync_LargeFileWithPartialFinalChunk_SendsTwoChunksWithCorrectContentRange()
+    {
+        // Arrange — 12 MB: chunk 1 = full 10 MB, chunk 2 = remaining 2 MB
+        const long chunkSize = 10 * 1024 * 1024;
+        const long size = chunkSize + 2 * 1024 * 1024;
+
+        var (storage, _, handler) = CreateStorage(request =>
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                        Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"id":"item-1","name":"final.pdf"}""",
+                    Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var stream = new MemoryStream(new byte[size]);
+
+        // Act
+        await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+        // Assert
+        var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+        chunkRequests.Should().HaveCount(2);
+
+        var range1 = chunkRequests[0].Content!.Headers.ContentRange!;
+        range1.From.Should().Be(0);
+        range1.To.Should().Be(chunkSize - 1);
+        range1.Length.Should().Be(size);
+
+        var range2 = chunkRequests[1].Content!.Headers.ContentRange!;
+        range2.From.Should().Be(chunkSize);
+        range2.To.Should().Be(size - 1);
+        range2.Length.Should().Be(size);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_LargeFileWithThrottledStream_AssemblesFullChunkFromShortReads()
+    {
+        // Arrange — exactly one chunk (10 MB), but the stream only yields 64 KB per ReadAsync call,
+        // forcing UploadLargeFileAsync's inner fill loop to run many iterations before sending the PUT.
+        const long chunkSize = 10 * 1024 * 1024;
+        const int maxBytesPerRead = 64 * 1024;
+
+        var (storage, _, handler) = CreateStorage(request =>
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                        Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"id":"item-1","name":"final.pdf"}""",
+                    Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var stream = new ThrottledReadStream(chunkSize, maxBytesPerRead);
+
+        // Act
+        await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", chunkSize);
+
+        // Assert — exactly one chunk PUT, whose Content-Range reflects the FULL chunk length,
+        // not the length of a single short read
+        var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+        chunkRequests.Should().HaveCount(1);
+
+        var range = chunkRequests[0].Content!.Headers.ContentRange!;
+        range.From.Should().Be(0);
+        range.To.Should().Be(chunkSize - 1);
+        range.Length.Should().Be(chunkSize);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_LargeFileExactMultipleOfChunkSize_SendsExactlyTwoChunksNoTrailingRequest()
+    {
+        // Arrange — 20 MB = exactly two 10 MB chunks; outer `while (offset < sizeBytes)` must
+        // stop after the second chunk with no trailing empty/zero-length request.
+        const long chunkSize = 10 * 1024 * 1024;
+        const long size = 2 * chunkSize;
+
+        var responses = new Queue<string>(new[]
+        {
+            "chunk-1-name",
+            "final-name.pdf"
+        });
+
+        var (storage, _, handler) = CreateStorage(request =>
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                        Encoding.UTF8, "application/json")
+                };
+            }
+            var name = responses.Dequeue();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    $$"""{"id":"item-1","name":"{{name}}"}""",
+                    Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var stream = new MemoryStream(new byte[size]);
+
+        // Act
+        var result = await storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", size);
+
+        // Assert — exactly two chunk PUTs, no trailing third request
+        var chunkRequests = handler.Requests.Where(r => r.Method == HttpMethod.Put).ToList();
+        chunkRequests.Should().HaveCount(2);
+
+        // Returned filename comes from the LAST chunk response, not the first
+        result.Should().Be("final-name.pdf");
+
+        // No Authorization header on chunk PUTs (bypass GraphApiHelpers.CreateRequest)
+        chunkRequests.Should().OnlyContain(r => r.Headers.Authorization == null);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_StreamExhaustedBeforeDeclaredSize_StopsEarlyWithoutThrowing()
+    {
+        // Documents existing (pre-existing, out-of-scope-to-fix) behavior: UploadLargeFileAsync's
+        // outer loop exits as soon as the stream returns 0 bytes, even if offset < sizeBytes.
+        const long chunkSize = 10 * 1024 * 1024;
+        const long declaredSize = 3 * chunkSize; // 30 MB declared
+        const long actualStreamBytes = chunkSize; // but stream only has 10 MB
+
+        var (storage, _, handler) = CreateStorage(request =>
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"uploadUrl":"https://graph.microsoft.com/upload-session/abc"}""",
+                        Encoding.UTF8, "application/json")
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"id":"item-1","name":"final.pdf"}""",
+                    Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var stream = new MemoryStream(new byte[actualStreamBytes]);
+
+        // Act
+        var act = () => storage.UploadFileAsync("drive-1", "folder-1", "test.pdf", stream, "application/pdf", declaredSize);
+
+        // Assert — no exception; loop stops after the one chunk the stream actually had
+        await act.Should().NotThrowAsync();
+        handler.Requests.Count(r => r.Method == HttpMethod.Put).Should().Be(1);
+    }
+
+    // ─── FindFolderAsync — pagination & matching ─────────────────────────────
+
+    [Fact]
+    public async Task FindFolderAsync_NoMatchingItems_ReturnsNotFound()
+    {
+        var (storage, _, _) = CreateStorage(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"value":[]}""",
+                    Encoding.UTF8, "application/json")
+            });
+
+        var result = await storage.FindFolderAsync("drive-1", "/Materials", "MAT001__", false);
+
+        result.Status.Should().Be(FolderStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task FindFolderAsync_ExactlyOneMatch_ReturnsFoundWithMatchedFolder()
+    {
+        var (storage, _, _) = CreateStorage(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"value":[{"id":"folder-id-1","name":"PIF-2024","folder":{"childCount":0}}]}""",
+                    Encoding.UTF8, "application/json")
+            });
+
+        var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+        result.Status.Should().Be(FolderStatus.Found);
+        result.FolderId.Should().Be("folder-id-1");
+        result.FolderName.Should().Be("PIF-2024");
+    }
+
+    [Fact]
+    public async Task FindFolderAsync_ExcludesNonFolderItemsMatchingPrefix()
+    {
+        var (storage, _, _) = CreateStorage(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "value": [
+                        { "id": "file-id-1", "name": "PIF-2024-notes.txt", "folder": null, "file": { "mimeType": "text/plain" } }
+                      ]
+                    }
+                    """,
+                    Encoding.UTF8, "application/json")
+            });
+
+        var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+        result.Status.Should().Be(FolderStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task FindFolderAsync_MultipleMatches_AllowMultipleFalse_ReturnsMultipleMatchesWithEmptyFolder()
+    {
+        var (storage, _, _) = CreateStorage(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "value": [
+                        { "id": "folder-id-2", "name": "PIF-2024-B", "folder": {"childCount":0} },
+                        { "id": "folder-id-1", "name": "PIF-2024-A", "folder": {"childCount":0} }
+                      ]
+                    }
+                    """,
+                    Encoding.UTF8, "application/json")
+            });
+
+        var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+        result.Status.Should().Be(FolderStatus.MultipleMatches);
+        result.FolderId.Should().BeEmpty();
+        result.FolderName.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FindFolderAsync_MultipleMatches_AllowMultipleTrue_ReturnsAlphabeticallyFirstMatch()
+    {
+        // Items deliberately in non-alphabetical order in the response
+        var (storage, _, _) = CreateStorage(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "value": [
+                        { "id": "folder-id-2", "name": "PIF-2024-B", "folder": {"childCount":0} },
+                        { "id": "folder-id-1", "name": "PIF-2024-A", "folder": {"childCount":0} }
+                      ]
+                    }
+                    """,
+                    Encoding.UTF8, "application/json")
+            });
+
+        var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", true);
+
+        result.Status.Should().Be(FolderStatus.Found);
+        result.FolderId.Should().Be("folder-id-1");
+        result.FolderName.Should().Be("PIF-2024-A");
+    }
+
+    [Fact]
+    public async Task FindFolderAsync_MultiPagePagination_ConsidersMatchesFromBothPages()
+    {
+        const string nextLinkUrl = "https://graph.microsoft.com/v1.0/next-page-2";
+
+        var (storage, _, handler) = CreateStorage(request =>
+        {
+            if (request.RequestUri!.ToString() == nextLinkUrl)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"value":[{"id":"folder-id-page2","name":"PIF-2024-Page2","folder":{"childCount":0}}]}""",
+                        Encoding.UTF8, "application/json")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    $$"""
+                    {
+                      "value": [
+                        { "id": "file-id-1", "name": "PIF-2024-notes.txt", "folder": null, "file": {"mimeType":"text/plain"} }
+                      ],
+                      "@odata.nextLink": "{{nextLinkUrl}}"
+                    }
+                    """,
+                    Encoding.UTF8, "application/json")
+            };
+        });
+
+        var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+        // Only page 2 has a matching folder item; page 1's item is a file (excluded), not a folder.
+        result.Status.Should().Be(FolderStatus.Found);
+        result.FolderId.Should().Be("folder-id-page2");
+        handler.Requests.Should().Contain(r => r.RequestUri!.ToString() == nextLinkUrl);
+    }
+
+    [Fact]
+    public async Task FindFolderAsync_FirstPage404_ReturnsNotFoundWithoutPagination()
+    {
+        var (storage, _, handler) = CreateStorage(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var result = await storage.FindFolderAsync("drive-1", "/Materials", "PIF-2024", false);
+
+        result.Status.Should().Be(FolderStatus.NotFound);
+        handler.Requests.Should().HaveCount(1);
+    }
+
     // ─── Recording infrastructure ─────────────────────────────────────────────
 
     private sealed class RecordingHandler : HttpMessageHandler
@@ -146,5 +575,47 @@ public sealed class GraphCatalogDocumentsStorageTests
             Requests.Add(request);
             return Task.FromResult(_responder(request));
         }
+    }
+
+    /// Wraps an in-memory byte source but returns at most <see cref="_maxBytesPerRead"/>
+    /// bytes per ReadAsync call, forcing callers with a larger buffer to loop.
+    private sealed class ThrottledReadStream : Stream
+    {
+        private readonly byte[] _data;
+        private readonly int _maxBytesPerRead;
+        private int _position;
+
+        public ThrottledReadStream(long totalBytes, int maxBytesPerRead)
+        {
+            _data = new byte[totalBytes]; // zero-filled content; tests assert on request shape, not bytes
+            _maxBytesPerRead = maxBytesPerRead;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var remaining = _data.Length - _position;
+            var toCopy = Math.Min(Math.Min(count, _maxBytesPerRead), remaining);
+            if (toCopy > 0)
+                Array.Copy(_data, _position, buffer, offset, toCopy);
+            _position += toCopy;
+            return Task.FromResult(toCopy);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _data.Length;
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
Closes #3500

## What the issue was
`GraphCatalogDocumentsStorage.cs` (the Graph API integration for uploading PIF documents to SharePoint/OneDrive) had only 43% line coverage. Three areas were completely untested: the small-vs-large upload routing threshold in `UploadFileAsync`, the chunked-upload offset tracking loop in `UploadLargeFileAsync`, and the `@odata.nextLink` pagination / multi-match conflict handling in `FindFolderAsync`. A regression in any of these (an off-by-one on the 4 MB threshold, a chunk-offset bug corrupting uploads, or a folder-matching bug) would have gone unnoticed.

## How it was fixed / handled
Added 14 new unit tests to the existing `GraphCatalogDocumentsStorageTests.cs`, reusing the existing `CreateStorage`/`RecordingHandler` mock harness (mocked `IHttpClientFactory`/`HttpMessageHandler`, no real HTTP calls):
- **Threshold routing**: tests at `threshold`, `threshold - 1`, and `threshold + 1` confirm the `<=` boundary routes to the small-file path and anything larger to the chunked-session path.
- **Chunk-loop offsets**: partial final chunk, a throttled stream requiring multiple short `ReadAsync` calls to fill one chunk buffer, an exact-multiple-of-chunk-size stream (no trailing empty request), and early stream exhaustion before the declared size — each asserts the actual `Content-Range` headers and request count sent.
- **Folder pagination/multi-match**: no-match, single-match, non-folder items excluded, multi-match with `allowMultiple: false` (→ `MultipleMatches`), multi-match with `allowMultiple: true` (→ alphabetically-first pick), multi-page `@odata.nextLink` traversal, and a first-page-404 short circuit.

This is a test-only change — no production code was modified. All 17 tests in the class (3 pre-existing + 14 new) pass.

## Artifacts
Brief, spec, arch-review, design, task plan, task-context, impl, and review markdown are committed under `artifacts/feat-3500/` in this branch.

## Code review

The pipeline's whole-branch code review came back **CLEAN** (no blocking correctness findings). Two advisory (non-blocking) cleanup suggestions were raised:
- Extract a shared `CreateLargeUploadResponder(...)` helper — the createUploadSession/chunk-response responder lambda is duplicated near-verbatim across five large-file tests.
- Hoist the locally-redeclared `threshold`/`chunkSize` constants in each test to shared `private const` fields on the test class.

Neither affects correctness; left as follow-up cleanup opportunities rather than blocking this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016HXSxLMcic4RR6YE7tUuLG)_