### PR TITLE
#3503: add unit test coverage for urlUtils createFilteredUrl/isTileClickable

### DIFF
--- a/artifacts/feat-3503/arch-review.r1.md
+++ b/artifacts/feat-3503/arch-review.r1.md
@@ -1,0 +1,124 @@
+# Architecture Review: Unit test coverage for `urlUtils.ts`
+
+## Skip Design: true
+
+No UI, screen, layout, or visual component work is involved. This task adds Jest unit tests for two existing, unmodified pure functions (`createFilteredUrl`, `isTileClickable`) in `frontend/src/utils/urlUtils.ts`. There is no new or changed user-facing surface to design.
+
+## Architectural Fit Assessment
+
+This is a pure test-authoring task with zero production code impact — it fits cleanly and low-risk into the existing frontend testing setup. `frontend/src/utils/urlUtils.ts` currently has no colocated test file at all (confirmed: `frontend/src/utils/__tests__/` contains `dateUtils.test.ts`, `downloadTextFile.test.ts`, `errorHandler.test.ts`, `sharepointLink.test.ts`, but no `urlUtils.test.ts`), which is why coverage sits at 50%.
+
+The only architectural decision of substance is **where the test file goes and what conventions it follows** — the spec's suggestion (`frontend/src/utils/urlUtils.test.ts`, colocated directly beside the source) conflicts with the repository's established convention, verified by inspecting the sibling utils tests: every existing test for a file in `frontend/src/utils/` lives in the `__tests__/` subdirectory, not colocated next to the source file. This review corrects that in the Specification Amendments section below — developers should follow the existing `__tests__/` pattern, not the spec's literal path.
+
+No new dependencies, no jest config changes are needed: the project uses Create React App's built-in Jest runner (no standalone `jest.config.*` at the frontend root), invoked via `npm test`, and existing sibling tests use plain `describe`/`it`/`expect` with no additional test utilities (no RTL needed here since these are pure functions, not components).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+frontend/src/utils/
+├── urlUtils.ts                  (existing, UNMODIFIED)
+└── __tests__/
+    ├── dateUtils.test.ts         (existing, reference for conventions)
+    ├── downloadTextFile.test.ts  (existing)
+    ├── errorHandler.test.ts      (existing)
+    ├── sharepointLink.test.ts    (existing)
+    └── urlUtils.test.ts          (NEW — this task's deliverable)
+```
+
+No other components are touched. `urlUtils.test.ts` imports `createFilteredUrl` and `isTileClickable` (and, incidentally, may reference `DrillDownInfo`/`TileDataWithDrillDown` types for typed fixtures) from `../urlUtils` and exercises them in isolation — no mocks, no providers, no async handling required, since both functions are synchronous and side-effect free.
+
+### Key Design Decisions
+
+#### Decision 1: Test file location
+**Options considered:**
+- (a) Colocate as `frontend/src/utils/urlUtils.test.ts` (spec's literal suggestion, FR-1 wording).
+- (b) Place under `frontend/src/utils/__tests__/urlUtils.test.ts`, matching the four existing sibling test files.
+
+**Chosen approach:** (b) — `frontend/src/utils/__tests__/urlUtils.test.ts`.
+
+**Rationale:** Every existing unit test for a `frontend/src/utils/*.ts` file in this repository lives in the `__tests__/` subdirectory (verified by directory listing). CRA's Jest config auto-discovers both `__tests__/` folders and colocated `*.test.ts` files, so either works mechanically — but consistency with the established convention is what a reviewer and future maintainers will expect. The spec's exact filename wording is a suggestion, not a hard requirement (the spec's own acceptance criteria only describe test *behavior*, not the literal path), so this is a low-risk, appropriate deviation.
+
+#### Decision 2: Test structure and grouping
+**Options considered:**
+- One flat `describe('urlUtils', ...)` block with all tests.
+- Two top-level `describe` blocks, one per function, matching FR-1/FR-2 in the spec and mirroring `dateUtils.test.ts`'s per-function nested `describe` structure.
+
+**Chosen approach:** Two `describe` blocks — `describe('createFilteredUrl', ...)` and `describe('isTileClickable', ...)` — each with individual `it(...)` cases per acceptance criterion.
+
+**Rationale:** Matches the existing convention in `dateUtils.test.ts` (nested `describe` per function under tests), keeps failure output scoped to the specific function/scenario, and maps 1:1 to the spec's FR-1/FR-2 acceptance criteria for easy traceability.
+
+#### Decision 3: No mocking or test utilities beyond Jest globals
+**Options considered:** Use React Testing Library / MSW (per `testing-strategy.md`'s general frontend stack) vs. plain Jest.
+
+**Chosen approach:** Plain Jest (`describe`/`it`/`expect`), no RTL, no MSW, no fixtures/factories beyond inline literals.
+
+**Rationale:** Both functions are pure, synchronous, and have no React or network dependency. `testing-strategy.md`'s RTL/MSW guidance applies to component and API-integration tests; these are plain utility-function unit tests, the same category as the existing `dateUtils.test.ts`/`errorHandler.test.ts`, which also use no RTL/MSW.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create exactly one new file:
+- `frontend/src/utils/__tests__/urlUtils.test.ts`
+
+No other files are created or modified. `frontend/src/utils/urlUtils.ts` remains byte-for-byte unchanged (per spec's explicit out-of-scope statement).
+
+### Interfaces and Contracts
+
+Test against the existing, unmodified exports of `frontend/src/utils/urlUtils.ts`:
+
+```typescript
+export const createFilteredUrl = (baseUrl: string, filters: Record<string, any>): string => ...
+
+export interface DrillDownInfo {
+  filters?: Record<string, any>;
+  enabled: boolean;
+  tooltip?: string;
+}
+
+export interface TileDataWithDrillDown {
+  status?: string;
+  data?: { count?: number; [key: string]: any };
+  error?: string;
+  drillDown?: DrillDownInfo;
+  [key: string]: any;
+}
+
+export const isTileClickable = (tileData: TileDataWithDrillDown): boolean => ...
+```
+
+Import line for the new test file:
+```typescript
+import { createFilteredUrl, isTileClickable } from '../urlUtils';
+```
+
+No new interfaces, types, or contracts are introduced by this task.
+
+### Data Flow
+
+N/A in the runtime sense — these are pure functions with no I/O. The "data flow" here is purely test-input → function → assertion:
+
+1. **`createFilteredUrl(baseUrl, filters)`**: test constructs a `filters` object literal per acceptance criterion (e.g. `{ enabled: false }`, `{ page: 0 }`, `{ a: null, b: undefined, c: '' }`, mixed cases), calls the function, and asserts on the returned string (either exact equality against an expected `baseUrl?key=value&...` string, or `.toContain('key=value')` / `.not.toContain(...)` checks — prefer exact-string assertions for the single-key cases per FR-1, and `toContain`/`not.toContain` for the mixed-object case since `URLSearchParams` key order is insertion-order-stable but easiest to assert piecewise).
+2. **`isTileClickable(tileData)`**: test constructs a `TileDataWithDrillDown` (or partial) object literal per FR-2's five cases and asserts the boolean return value with `toBe(true)`/`toBe(false)`.
+
+No provider wrapping, no async/`waitFor`, no network mocking is required.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Test file placed at wrong path (`urlUtils.test.ts` colocated) diverging from repo convention, causing reviewer friction or inconsistent codebase | Low | Use `frontend/src/utils/__tests__/urlUtils.test.ts` per Decision 1 above; CI/Jest discovery is unaffected either way |
+| Assertions written against `URLSearchParams`-generated string using a brittle exact match that breaks if param order changes | Low | For single-filter cases assert exact strings (order is deterministic for one key); for the mixed-values case in FR-1, assert via `toContain`/`not.toContain` on substrings rather than one rigid full-string equality |
+| Tests inadvertently assert on `isTileClickable`'s current behavior in a way that reads as "this is definitely correct business behavior" rather than "this documents current, possibly-debatable behavior" (the `filters: {}` → clickable case) | Low | Name the test descriptively, e.g. `it('treats an empty-but-present filters object as clickable (documents current behavior)', ...)`, consistent with spec's own framing in FR-2 |
+| Coverage threshold (60%) not actually met after adding tests, if other untested branches remain in the file | Low | Out of scope per spec, but developer should run `npm test -- --coverage` on this file after implementation to confirm ≥60% is reached; if not, flag back rather than expanding scope silently |
+
+## Specification Amendments
+
+- **FR-1 file path amendment**: Replace "create `frontend/src/utils/urlUtils.test.ts` if it does not already exist" with **create `frontend/src/utils/__tests__/urlUtils.test.ts`** to match the established convention for every other test file under `frontend/src/utils/` (`dateUtils.test.ts`, `downloadTextFile.test.ts`, `errorHandler.test.ts`, `sharepointLink.test.ts` all live in `__tests__/`, none are colocated). This is a path-only correction; all acceptance criteria in FR-1 and FR-2 remain unchanged and fully apply.
+- No other amendments. The spec's functional requirements, acceptance criteria, and out-of-scope list are architecturally sound as written and require no further changes.
+
+## Prerequisites
+
+None. No migrations, config, or infrastructure changes are needed. The Jest test runner, TypeScript tooling, and `npm test` command are already fully configured in `frontend/`; the developer can start immediately by creating the single new test file described above.

--- a/artifacts/feat-3503/brief.md
+++ b/artifacts/feat-3503/brief.md
@@ -1,0 +1,22 @@
+## Module / File
+`frontend/src/utils/urlUtils.ts`
+
+## Coverage
+Line coverage: 50% (filter threshold: 60%)
+
+## What's not tested
+**`createFilteredUrl` — drops non-empty falsy values:**
+The filter condition `value !== null && value !== undefined && value !== ''` passes `false` and `0` through. However, no test verifies that `false` or `0` filter values ARE included in the query string. If the condition were widened to a simple truthiness check (`if (value)`), both `false` and `0` would be silently dropped — a common refactor mistake that would strip valid filter values (e.g. `enabled=false`, `page=0`) from API calls.
+
+**`isTileClickable` — requires both `enabled` and `filters`:**
+The function returns `true` only when `drillDown.enabled === true` AND `drillDown.filters` is truthy. An empty object `{}` evaluates as truthy, so a tile with `enabled: true, filters: {}` would be considered clickable even with no filters set. No test covers this edge case.
+
+## Why it matters
+`createFilteredUrl` is used throughout the app to build API query strings. A regression that drops `false` or `0` filter values would silently send incorrect queries — stock status `0`, boolean `false` flags, or page-zero pagination would all be omitted without any observable error.
+
+## Suggested approach
+- Unit tests for `createFilteredUrl`: assert `false` and `0` values appear in the output; assert `null`, `undefined`, and `''` do not.
+- Test `isTileClickable` with `{ enabled: true, filters: {} }`, `{ enabled: false, filters: { x: 1 } }`, and `{ enabled: true }` (no filters property). ~0.5 day effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-06. Based on CI run #28716987459 (2ad2a2593e1834798a3def9ac2551b46c2e595cb)._

--- a/artifacts/feat-3503/code-review.r1.md
+++ b/artifacts/feat-3503/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3503/design.r1.md
+++ b/artifacts/feat-3503/design.r1.md
@@ -1,0 +1,74 @@
+# Design: Unit test coverage for `urlUtils.ts` (`createFilteredUrl` and `isTileClickable`)
+
+## Component Design
+
+No production components are created or modified. The sole deliverable is one new test module.
+
+### `frontend/src/utils/__tests__/urlUtils.test.ts` (new)
+
+- **Responsibility**: Exercise the existing, unmodified pure functions `createFilteredUrl` and `isTileClickable` from `../urlUtils` against the edge cases identified in the spec, closing the coverage gap without touching source behavior.
+- **Location convention**: `__tests__/` subdirectory, matching every other sibling test in `frontend/src/utils/` (`dateUtils.test.ts`, `downloadTextFile.test.ts`, `errorHandler.test.ts`, `sharepointLink.test.ts`) — per the architecture review's Decision 1, this supersedes the spec's literal colocated-path wording.
+- **Structure**: Two top-level `describe` blocks, one per function, each containing one `it(...)` per acceptance criterion:
+  - `describe('createFilteredUrl', ...)`
+  - `describe('isTileClickable', ...)`
+- **Dependencies/imports**:
+  ```typescript
+  import { createFilteredUrl, isTileClickable } from '../urlUtils';
+  ```
+  No RTL, no MSW, no mocks, no test fixtures/factories — both functions are synchronous, side-effect-free, and take plain object literals as input.
+- **Non-goals**: No changes to `urlUtils.ts` itself; no tests added for `getTileTooltip` (out of scope per spec); no changes to CI coverage threshold configuration.
+
+### Test cases to implement
+
+**`createFilteredUrl(baseUrl, filters)`** — one `it` per case:
+1. `{ enabled: false }` → output contains `enabled=false`.
+2. `{ page: 0 }` → output contains `page=0`.
+3. `{ a: null }` → `a` excluded from output.
+4. `{ a: undefined }` → `a` excluded from output.
+5. `{ a: '' }` → `a` excluded from output.
+6. All values excluded (or empty filters object) → returns `baseUrl` unchanged, no trailing `?`.
+7. At least one valid filter present → returned string has the form `${baseUrl}?${queryString}`.
+8. Mixed object combining includable (`false`, `0`, non-empty string) and excludable (`null`, `undefined`, `''`) values → only includable ones appear in output.
+
+**`isTileClickable(tileData)`** — one `it` per case:
+1. `{ drillDown: { enabled: true, filters: {} } }` → `true` (documents current behavior: empty-but-present `filters` is truthy).
+2. `{ drillDown: { enabled: false, filters: { x: 1 } } }` → `false` (non-empty filters do not override `enabled: false`).
+3. `{ drillDown: { enabled: true } }` (no `filters`) → `false`.
+4. `{}` (no `drillDown`) → `false`.
+5. `{ drillDown: { enabled: true, filters: { x: 1 } } }` → `true` (baseline positive case).
+
+### Assertion strategy
+
+- Single-filter cases (`createFilteredUrl` cases 1–5): exact-string or `toContain`/`not.toContain` assertions against the returned string, since param order is deterministic for one key.
+- Whole-URL-shape cases (6–7): exact equality against `baseUrl` (no `?`) and a `${baseUrl}?...` pattern check, respectively.
+- Mixed case (8): `toContain` for each includable `key=value` pair, `not.toContain` for each excludable key, avoiding brittleness from `URLSearchParams` ordering assumptions across multiple keys.
+- `isTileClickable` cases: `toBe(true)` / `toBe(false)` boolean equality.
+
+## Data Schemas
+
+No database, API, or event schema changes. Tests exercise only the existing TypeScript interfaces already exported from `frontend/src/utils/urlUtils.ts`, unmodified:
+
+```typescript
+export interface DrillDownInfo {
+  filters?: Record<string, any>;
+  enabled: boolean;
+  tooltip?: string;
+}
+
+export interface TileDataWithDrillDown {
+  status?: string;
+  data?: { count?: number; [key: string]: any };
+  error?: string;
+  drillDown?: DrillDownInfo;
+  [key: string]: any;
+}
+```
+
+Function signatures under test (unmodified, referenced for contract clarity only):
+
+```typescript
+export const createFilteredUrl = (baseUrl: string, filters: Record<string, any>): string => ...
+export const isTileClickable = (tileData: TileDataWithDrillDown): boolean => ...
+```
+
+Test input fixtures are plain inline object literals conforming to the above shapes (e.g. `{ enabled: false }`, `{ page: 0 }`, `{ a: null, b: undefined, c: '' }` for `createFilteredUrl`; partial/complete `TileDataWithDrillDown` literals for `isTileClickable`) — no factory functions or shared fixture modules are introduced, consistent with sibling test files in `__tests__/`.

--- a/artifacts/feat-3503/impl/urlutils-unit-tests.r1.md
+++ b/artifacts/feat-3503/impl/urlutils-unit-tests.r1.md
@@ -1,0 +1,53 @@
+# Implementation: urlutils-unit-tests
+
+## What was implemented
+Added a new unit test file `frontend/src/utils/__tests__/urlUtils.test.ts` covering the two pure functions in `frontend/src/utils/urlUtils.ts`: `createFilteredUrl` and `isTileClickable`. No production code was changed. `getTileTooltip` was intentionally left untested per the task scope.
+
+## Files created/modified
+- `frontend/src/utils/__tests__/urlUtils.test.ts` — new test file with two `describe` blocks:
+  - `createFilteredUrl`: 9 tests covering `false`/`0` inclusion, `null`/`undefined`/`''` exclusion, all-excluded/empty-filters returning `baseUrl` unchanged (no `?`), valid-filter query string shape, and a mixed-object case asserting includable pairs are present and excludable keys are absent.
+  - `isTileClickable`: 5 tests covering `filters: {}` truthy-object behavior (documented in test name), `enabled: false`, missing `filters`, missing `drillDown`, and the baseline positive case.
+
+## Tests
+Ran from `frontend/`:
+```
+CI=true npx react-scripts test --testPathPattern=urlUtils --coverage --watchAll=false --collectCoverageFrom='src/utils/urlUtils.ts' --watchAll=false
+```
+Result:
+```
+-------------|---------|----------|---------|---------|-------------------
+File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
+-------------|---------|----------|---------|---------|-------------------
+All files    |     100 |     90.9 |     100 |     100 |
+ urlUtils.ts |     100 |     90.9 |     100 |     100 | 51
+-------------|---------|----------|---------|---------|-------------------
+
+Test Suites: 286 passed, 286 total
+Tests:       5 skipped, 2355 passed, 2360 total
+```
+(Line 51 uncovered is inside `getTileTooltip`, out of scope for this task.) All 2355 non-skipped tests across the whole suite passed, including the 14 new `urlUtils.test.ts` tests — no regressions.
+
+Note: `node_modules` was missing in this worktree and `npm install` failed with an ERESOLVE peer-dependency conflict (react-i18next requires TypeScript ^5, project pins ^4.9.5) that is pre-existing and unrelated to this change. Since `package.json`/`package-lock.json` are byte-identical to the main checkout at `/home/user/Anela.Heblo/frontend`, `node_modules` was copied from there instead of forcing an install with `--legacy-peer-deps`.
+
+## How to verify
+```
+cd frontend
+npm test -- --testPathPattern=urlUtils --coverage --watchAll=false
+```
+Confirm all `urlUtils.test.ts` tests pass and `urlUtils.ts` coverage is ≥60% (actual: 100% stmts/funcs/lines, 90.9% branch).
+
+Lint check:
+```
+npx eslint src/utils/__tests__/urlUtils.test.ts
+```
+returns no output (clean). Full `npm run lint` shows 148 pre-existing errors in unrelated test files (testing-library rule violations, import ordering, etc.) — none in the new file, confirmed baseline noise not introduced by this change.
+
+`git diff --stat -- frontend/src/utils/urlUtils.ts` is empty — source file untouched.
+
+## Notes
+- Coverage exceeds the 60% threshold (100% statements/lines/functions, 90.9% branches) using only the tests specified in the task's Steps 3 and 4 — no extra tests were added.
+- `getTileTooltip` remains untested per explicit task scope, leaving one branch (the tooltip-return line) uncovered; this does not affect the required threshold.
+- Committed only `frontend/src/utils/__tests__/urlUtils.test.ts`; `artifacts/feat-3503/state.json` was left modified/uncommitted per instructions (pipeline handles that separately).
+
+## Status
+DONE

--- a/artifacts/feat-3503/review/urlutils-unit-tests.r1.md
+++ b/artifacts/feat-3503/review/urlutils-unit-tests.r1.md
@@ -1,0 +1,19 @@
+# Code Review: urlutils-unit-tests
+
+## Summary
+This is a clean, test-only addition of `frontend/src/utils/__tests__/urlUtils.test.ts` covering `createFilteredUrl` and `isTileClickable`. All required cases from the task context are present, the source file is verified byte-identical to main, and reported coverage (100% stmts/funcs/lines, 90.9% branch) comfortably exceeds the 60% threshold.
+
+## Review Result: PASS
+
+### task: urlutils-unit-tests
+**Status:** PASS
+
+## Overall Notes
+- Verified `git diff --stat origin/main...HEAD -- frontend/src/utils/urlUtils.ts` is empty — source file is unmodified, satisfying the "test-only" constraint.
+- `describe('createFilteredUrl', ...)` and `describe('isTileClickable', ...)` blocks are both present.
+- All 8 `createFilteredUrl` cases from Step 3 are covered (the "all-excluded-or-empty-filters" bullet was split into two separate `it`s — one for all-values-excluded, one for empty-filters-object — which is a superset of what was asked, not a gap).
+- All 5 `isTileClickable` cases from Step 4 are present verbatim, including the empty-`filters`-object truthy-behavior test with a name that documents the current (possibly surprising) behavior, and the baseline positive case.
+- The mixed-object test in `createFilteredUrl` correctly uses `toContain`/`not.toContain` per the task's guidance to avoid brittle full-string equality across multiple keys.
+- Style matches the described sibling convention: plain `describe`/`it`/`expect`, inline object literals, no RTL/MSW/mocks/shared fixtures.
+- `getTileTooltip` is correctly left out of scope, matching both the task context and the acceptance criteria (only one branch, inside `getTileTooltip`, remains uncovered per the implementation summary).
+- Implementation summary reports `npm test` passing (2355 non-skipped tests, no regressions), lint clean on the new file (pre-existing unrelated lint errors elsewhere are correctly identified as baseline noise), and coverage well above the 60% threshold — all acceptance criteria appear satisfied based on the reported results.

--- a/artifacts/feat-3503/spec.r1.md
+++ b/artifacts/feat-3503/spec.r1.md
@@ -1,0 +1,67 @@
+# Specification: Unit test coverage for `urlUtils.ts` (`createFilteredUrl` and `isTileClickable`)
+
+## Summary
+`frontend/src/utils/urlUtils.ts` sits at 50% line coverage, below the 60% CI threshold. Two exported pure functions — `createFilteredUrl` and `isTileClickable` — have untested edge cases that a future refactor could silently break. This task adds targeted unit tests for both functions to close the gap and lock in their current, correct behavior.
+
+## Background
+`createFilteredUrl` builds query strings for API calls throughout the app from a filter object. Its falsy-value check (`value !== null && value !== undefined && value !== ''`) deliberately keeps `false` and `0` in the output, unlike a naive truthiness check. This distinction is not currently covered by any test, so a well-intentioned simplification (e.g. to `if (value)`) would pass existing tests while silently dropping legitimate filter values such as `enabled=false` or `page=0` from real API requests — a regression that would not throw or fail loudly, only produce wrong query results.
+
+Similarly, `isTileClickable` requires both `drillDown.enabled === true` and a truthy `drillDown.filters`. Because `{}` is truthy in JavaScript, a tile with `enabled: true, filters: {}` currently reports as clickable even though it carries no actual filters. Whether or not that is the intended behavior, it is unverified and undocumented by tests, so any change to this logic today has no safety net.
+
+This is a test-only, coverage-gap-closing task against existing, unmodified source code. No production logic changes are requested or in scope.
+
+## Functional Requirements
+
+### FR-1: Unit tests for `createFilteredUrl`
+Add unit tests in the test file colocated with `urlUtils.ts` (create `frontend/src/utils/urlUtils.test.ts` if it does not already exist) covering the function's filter/inclusion behavior.
+
+**Acceptance criteria:**
+- A test asserts that a filter value of `false` is included in the resulting query string (e.g. `{ enabled: false }` → output contains `enabled=false`).
+- A test asserts that a filter value of `0` is included in the resulting query string (e.g. `{ page: 0 }` → output contains `page=0`).
+- A test asserts that a filter value of `null` is excluded from the query string.
+- A test asserts that a filter value of `undefined` is excluded from the query string.
+- A test asserts that a filter value of empty string `''` is excluded from the query string.
+- A test asserts that when all filter values are excluded (or the filters object is empty), the function returns `baseUrl` unchanged, with no trailing `?`.
+- A test asserts that when at least one valid filter is present, the returned URL has the form `${baseUrl}?${queryString}`.
+- A test covers a mixed case: an object combining includable values (`false`, `0`, a non-empty string) and excludable values (`null`, `undefined`, `''`) in the same call, asserting only the includable ones appear in the output.
+
+### FR-2: Unit tests for `isTileClickable`
+Add unit tests covering the combinations of `enabled` and `filters` described in the brief.
+
+**Acceptance criteria:**
+- A test asserts `isTileClickable({ drillDown: { enabled: true, filters: {} } })` returns `true` (documents current behavior: an empty-but-present `filters` object is truthy).
+- A test asserts `isTileClickable({ drillDown: { enabled: false, filters: { x: 1 } } })` returns `false` (non-empty filters do not override `enabled: false`).
+- A test asserts `isTileClickable({ drillDown: { enabled: true } })` (no `filters` property at all) returns `false`.
+- A test asserts `isTileClickable({})` (no `drillDown` property at all) returns `false`.
+- A test asserts `isTileClickable({ drillDown: { enabled: true, filters: { x: 1 } } })` returns `true` (baseline positive case, for completeness alongside the edge cases).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — these are synchronous, in-memory pure-function unit tests with no I/O. No performance targets beyond keeping the suite fast (each test should run in well under a second, consistent with existing unit tests in the repo).
+
+### NFR-2: Security
+Not applicable — no authentication, authorization, or sensitive data is involved in these pure utility functions or their tests.
+
+## Data Model
+No data model changes. Tests exercise the existing `DrillDownInfo` and `TileDataWithDrillDown` interfaces already exported from `frontend/src/utils/urlUtils.ts`, and plain `Record<string, any>` filter objects for `createFilteredUrl`.
+
+## API / Interface Design
+No API or interface changes. This task adds test code only; `createFilteredUrl`, `isTileClickable`, `getTileTooltip`, `DrillDownInfo`, and `TileDataWithDrillDown` in `frontend/src/utils/urlUtils.ts` remain unmodified.
+
+## Dependencies
+- Existing frontend test tooling (Jest, per the repository's standard FE unit test setup) — no new libraries required.
+- No dependency on other in-flight features or backend changes.
+
+## Out of Scope
+- Any change to the implementation of `createFilteredUrl`, `isTileClickable`, or `getTileTooltip`.
+- Tests for `getTileTooltip` (not flagged in the coverage gap; may be incidentally exercised but is not a required deliverable).
+- Broader coverage improvements elsewhere in `frontend/src/utils/` or other modules.
+- Integration/E2E tests — this is unit-test-only work on pure functions.
+- Enforcing or changing the 60% coverage threshold itself.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-06T17:27:47.914169Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T17:27:53.879935Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T17:29:00.879813Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-06T17:27:47.914169Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-06T17:27:53.879935Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "urlutils-unit-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T17:20:55.495900Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T17:21:38.936419Z"
     }
   },
   "tasks": [
     {
       "name": "urlutils-unit-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-06T17:21:39.155866Z"
     }
   ]
 }

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T17:20:55.495900Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T17:21:38.936419Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T17:27:47.914169Z"
     }
   },
   "tasks": [
     {
       "name": "urlutils-unit-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-06T17:21:39.155866Z"
+      "updated_at": "2026-07-06T17:27:41.635127Z"
     }
   ]
 }

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-06T17:19:43.450913Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T17:20:55.495900Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-06T17:17:04.712488Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T17:18:53.564772Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3503",
+  "issue_number": 3503,
+  "created_at": "2026-07-06T17:15:43.993755Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-06T17:17:04.712488Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3503/state.json
+++ b/artifacts/feat-3503/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-06T17:18:53.564772Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T17:19:43.450913Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3503/task-context/urlutils-unit-tests.md
+++ b/artifacts/feat-3503/task-context/urlutils-unit-tests.md
@@ -1,0 +1,38 @@
+### task: urlutils-unit-tests
+
+## Goal
+Close the unit-test coverage gap for `frontend/src/utils/urlUtils.ts` by adding a new test file that covers the edge cases of the two pure functions `createFilteredUrl` and `isTileClickable`. No production code changes — this is a test-only task against existing, unmodified source.
+
+## Files
+- Create: `frontend/src/utils/__tests__/urlUtils.test.ts`
+- Reference only (read, do not modify): `frontend/src/utils/urlUtils.ts`
+- Reference only (existing convention example): `frontend/src/utils/__tests__/dateUtils.test.ts`
+
+## Steps
+1. Create `frontend/src/utils/__tests__/urlUtils.test.ts` (per the architecture review, this supersedes the spec's literal colocated-path suggestion — the repo convention places all `frontend/src/utils/*.ts` tests under the sibling `__tests__/` directory).
+2. Import the functions under test: `import { createFilteredUrl, isTileClickable } from '../urlUtils';`. Do not import or reference `getTileTooltip` — it is out of scope.
+3. Add a `describe('createFilteredUrl', ...)` block with one `it(...)` per case:
+   - `{ enabled: false }` → result contains `enabled=false`.
+   - `{ page: 0 }` → result contains `page=0`.
+   - `{ a: null }` → `a` is excluded from the result.
+   - `{ a: undefined }` → `a` is excluded from the result.
+   - `{ a: '' }` → `a` is excluded from the result.
+   - All filter values excluded (or an empty filters object) → function returns `baseUrl` unchanged with no trailing `?`.
+   - At least one valid filter present → result matches the shape `${baseUrl}?${queryString}`.
+   - Mixed object combining includable values (`false`, `0`, a non-empty string) and excludable values (`null`, `undefined`, `''`) in one call → assert only the includable key=value pairs appear (`toContain`) and the excludable keys do not (`not.toContain`), avoiding brittle full-string equality across multiple keys.
+4. Add a `describe('isTileClickable', ...)` block with one `it(...)` per case:
+   - `{ drillDown: { enabled: true, filters: {} } }` → `toBe(true)` (name the test to note it documents current behavior: an empty-but-present `filters` object is truthy).
+   - `{ drillDown: { enabled: false, filters: { x: 1 } } }` → `toBe(false)`.
+   - `{ drillDown: { enabled: true } }` (no `filters`) → `toBe(false)`.
+   - `{}` (no `drillDown`) → `toBe(false)`.
+   - `{ drillDown: { enabled: true, filters: { x: 1 } } }` → `toBe(true)` (baseline positive case).
+5. Follow the structural/style conventions of the existing sibling test files in `frontend/src/utils/__tests__/` (e.g. `dateUtils.test.ts`): plain `describe`/`it`/`expect`, no RTL, no MSW, no mocks, no shared fixture modules — inline object literals only.
+6. Run `npm test -- --coverage --watchAll=false` (or the project's standard non-watch test invocation) scoped to `urlUtils` to confirm all new tests pass and file coverage for `urlUtils.ts` reaches at least 60%. If coverage remains below 60% after implementing every acceptance criterion above, do not add tests beyond this task's scope to compensate — flag the shortfall instead.
+
+## Acceptance Criteria
+- `frontend/src/utils/__tests__/urlUtils.test.ts` exists and contains two `describe` blocks: `createFilteredUrl` and `isTileClickable`.
+- `frontend/src/utils/urlUtils.ts` is unmodified (byte-for-byte identical to before this task).
+- All 8 `createFilteredUrl` cases and all 5 `isTileClickable` cases listed in Steps 3 and 4 are present as individual `it(...)` tests and pass.
+- `npm test` (CRA/Jest runner) passes with no failing tests, including the new file.
+- `npm run build` and `npm run lint` succeed with no new errors introduced.
+- Coverage for `frontend/src/utils/urlUtils.ts` is at or above 60% after the new tests are added (verified via `npm test -- --coverage`).

--- a/artifacts/feat-3503/task-plan.r1.md
+++ b/artifacts/feat-3503/task-plan.r1.md
@@ -1,0 +1,38 @@
+### task: urlutils-unit-tests
+
+## Goal
+Close the unit-test coverage gap for `frontend/src/utils/urlUtils.ts` by adding a new test file that covers the edge cases of the two pure functions `createFilteredUrl` and `isTileClickable`. No production code changes — this is a test-only task against existing, unmodified source.
+
+## Files
+- Create: `frontend/src/utils/__tests__/urlUtils.test.ts`
+- Reference only (read, do not modify): `frontend/src/utils/urlUtils.ts`
+- Reference only (existing convention example): `frontend/src/utils/__tests__/dateUtils.test.ts`
+
+## Steps
+1. Create `frontend/src/utils/__tests__/urlUtils.test.ts` (per the architecture review, this supersedes the spec's literal colocated-path suggestion — the repo convention places all `frontend/src/utils/*.ts` tests under the sibling `__tests__/` directory).
+2. Import the functions under test: `import { createFilteredUrl, isTileClickable } from '../urlUtils';`. Do not import or reference `getTileTooltip` — it is out of scope.
+3. Add a `describe('createFilteredUrl', ...)` block with one `it(...)` per case:
+   - `{ enabled: false }` → result contains `enabled=false`.
+   - `{ page: 0 }` → result contains `page=0`.
+   - `{ a: null }` → `a` is excluded from the result.
+   - `{ a: undefined }` → `a` is excluded from the result.
+   - `{ a: '' }` → `a` is excluded from the result.
+   - All filter values excluded (or an empty filters object) → function returns `baseUrl` unchanged with no trailing `?`.
+   - At least one valid filter present → result matches the shape `${baseUrl}?${queryString}`.
+   - Mixed object combining includable values (`false`, `0`, a non-empty string) and excludable values (`null`, `undefined`, `''`) in one call → assert only the includable key=value pairs appear (`toContain`) and the excludable keys do not (`not.toContain`), avoiding brittle full-string equality across multiple keys.
+4. Add a `describe('isTileClickable', ...)` block with one `it(...)` per case:
+   - `{ drillDown: { enabled: true, filters: {} } }` → `toBe(true)` (name the test to note it documents current behavior: an empty-but-present `filters` object is truthy).
+   - `{ drillDown: { enabled: false, filters: { x: 1 } } }` → `toBe(false)`.
+   - `{ drillDown: { enabled: true } }` (no `filters`) → `toBe(false)`.
+   - `{}` (no `drillDown`) → `toBe(false)`.
+   - `{ drillDown: { enabled: true, filters: { x: 1 } } }` → `toBe(true)` (baseline positive case).
+5. Follow the structural/style conventions of the existing sibling test files in `frontend/src/utils/__tests__/` (e.g. `dateUtils.test.ts`): plain `describe`/`it`/`expect`, no RTL, no MSW, no mocks, no shared fixture modules — inline object literals only.
+6. Run `npm test -- --coverage --watchAll=false` (or the project's standard non-watch test invocation) scoped to `urlUtils` to confirm all new tests pass and file coverage for `urlUtils.ts` reaches at least 60%. If coverage remains below 60% after implementing every acceptance criterion above, do not add tests beyond this task's scope to compensate — flag the shortfall instead.
+
+## Acceptance Criteria
+- `frontend/src/utils/__tests__/urlUtils.test.ts` exists and contains two `describe` blocks: `createFilteredUrl` and `isTileClickable`.
+- `frontend/src/utils/urlUtils.ts` is unmodified (byte-for-byte identical to before this task).
+- All 8 `createFilteredUrl` cases and all 5 `isTileClickable` cases listed in Steps 3 and 4 are present as individual `it(...)` tests and pass.
+- `npm test` (CRA/Jest runner) passes with no failing tests, including the new file.
+- `npm run build` and `npm run lint` succeed with no new errors introduced.
+- Coverage for `frontend/src/utils/urlUtils.ts` is at or above 60% after the new tests are added (verified via `npm test -- --coverage`).

--- a/frontend/src/utils/__tests__/urlUtils.test.ts
+++ b/frontend/src/utils/__tests__/urlUtils.test.ts
@@ -1,0 +1,85 @@
+import { createFilteredUrl, isTileClickable } from '../urlUtils';
+
+describe('createFilteredUrl', () => {
+  it('should include a boolean false filter value', () => {
+    const result = createFilteredUrl('/api/tiles', { enabled: false });
+    expect(result).toContain('enabled=false');
+  });
+
+  it('should include a numeric zero filter value', () => {
+    const result = createFilteredUrl('/api/tiles', { page: 0 });
+    expect(result).toContain('page=0');
+  });
+
+  it('should exclude a null filter value', () => {
+    const result = createFilteredUrl('/api/tiles', { a: null });
+    expect(result).not.toContain('a=');
+  });
+
+  it('should exclude an undefined filter value', () => {
+    const result = createFilteredUrl('/api/tiles', { a: undefined });
+    expect(result).not.toContain('a=');
+  });
+
+  it('should exclude an empty string filter value', () => {
+    const result = createFilteredUrl('/api/tiles', { a: '' });
+    expect(result).not.toContain('a=');
+  });
+
+  it('should return baseUrl unchanged when all filter values are excluded', () => {
+    const result = createFilteredUrl('/api/tiles', { a: null, b: undefined, c: '' });
+    expect(result).toBe('/api/tiles');
+    expect(result).not.toContain('?');
+  });
+
+  it('should return baseUrl unchanged when filters object is empty', () => {
+    const result = createFilteredUrl('/api/tiles', {});
+    expect(result).toBe('/api/tiles');
+    expect(result).not.toContain('?');
+  });
+
+  it('should build a query string when at least one valid filter is present', () => {
+    const result = createFilteredUrl('/api/tiles', { status: 'active' });
+    expect(result).toMatch(/^\/api\/tiles\?status=active$/);
+  });
+
+  it('should include includable values and exclude excludable values in a mixed filters object', () => {
+    const result = createFilteredUrl('/api/tiles', {
+      enabled: false,
+      page: 0,
+      status: 'active',
+      a: null,
+      b: undefined,
+      c: '',
+    });
+
+    expect(result).toContain('enabled=false');
+    expect(result).toContain('page=0');
+    expect(result).toContain('status=active');
+    expect(result).not.toContain('a=');
+    expect(result).not.toContain('b=');
+    expect(result).not.toContain('c=');
+  });
+});
+
+describe('isTileClickable', () => {
+  it('should return true when enabled is true and filters is an empty object (documents current truthy-object behavior)', () => {
+    expect(isTileClickable({ drillDown: { enabled: true, filters: {} } })).toBe(true);
+  });
+
+  it('should return false when enabled is false, regardless of filters', () => {
+    expect(isTileClickable({ drillDown: { enabled: false, filters: { x: 1 } } })).toBe(false);
+  });
+
+  it('should return false when filters is missing', () => {
+    expect(isTileClickable({ drillDown: { enabled: true } })).toBe(false);
+  });
+
+  it('should return false when drillDown is missing', () => {
+    expect(isTileClickable({})).toBe(false);
+  });
+
+  it('should return true when enabled is true and filters has entries', () => {
+    expect(isTileClickable({ drillDown: { enabled: true, filters: { x: 1 } } })).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #3503

## What the issue was
`frontend/src/utils/urlUtils.ts` sat at 50% line coverage, below the 60% CI threshold. Two exported pure functions had untested edge cases with real regression risk:
- `createFilteredUrl`'s falsy-value filter (`value !== null && value !== undefined && value !== ''`) deliberately keeps `false` and `0` in the query string, unlike a naive truthiness check — but nothing verified this, so a "simplification" to `if (value)` would silently strip valid filter values like `enabled=false` or `page=0`.
- `isTileClickable` requires `drillDown.enabled === true` and a truthy `drillDown.filters`; since `{}` is truthy, a tile with `enabled: true, filters: {}` is currently considered clickable, but this edge case was unverified.

## How it was fixed / handled
- Added `frontend/src/utils/__tests__/urlUtils.test.ts` with 14 new tests:
  - `createFilteredUrl`: covers `false`/`0` inclusion, `null`/`undefined`/`''` exclusion, empty-filters/all-excluded returning the base URL unchanged (no `?`), the `baseUrl?query` shape, and a mixed-object case.
  - `isTileClickable`: covers the empty-`filters`-object truthy case, `enabled: false`, missing `filters`, missing `drillDown`, and the baseline positive case.
- No production code was changed — `urlUtils.ts` is byte-for-byte identical to `main`. This is a test-only change.
- Full frontend suite: 2355/2355 non-skipped tests pass (286 suites), no regressions. `urlUtils.ts` coverage is now 100% statements/lines/functions, 90.9% branches (only `getTileTooltip`, out of scope, remains uncovered) — well above the 60% threshold.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3503/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01DjBoYDh2tSfTWNT31e2vko)_