### PR TITLE
#3504: implementation

### DIFF
--- a/artifacts/feat-3504/arch-review.r1.md
+++ b/artifacts/feat-3504/arch-review.r1.md
@@ -1,0 +1,128 @@
+# Architecture Review: UserStorage Test Coverage (Session Expiry, No-Session Update, Missing Last-Login)
+
+## Skip Design: true
+
+This is a test-only addition to `frontend/src/auth/userStorage.ts`. No production code, no UI components, no visual surface changes. There is nothing for a UI/UX design pass to review.
+
+## Architectural Fit Assessment
+
+This is a narrow, low-risk, test-only change and it fits the existing test architecture cleanly — with one correction to the spec's assumed file location (see Amendments).
+
+- `UserStorage` is a self-contained static utility with a single external dependency (`sessionStorage`, native in jsdom) and one internal type import (`UserInfo` from `./useAuth`). It has no React component surface, no MSAL/network dependency, and no side effects beyond `sessionStorage` and `console.log`/`console.warn`. This makes it one of the easiest modules in the codebase to unit test in isolation — no mocking framework, no fake timers, no DOM rendering.
+- The project already has an established convention for testing sibling modules in `frontend/src/auth/`: `frontend/src/auth/__tests__/authRecovery.test.ts` (and `useAuth.test.ts`, `accessMatrixConsistency.test.ts`) live under a `__tests__/` subdirectory, not as co-located `*.test.ts` files next to the module. `authRecovery.test.ts` interacts with `sessionStorage` directly (`sessionStorage.setItem`, `.getItem`, `.clear()`) with no mock/shim library — jsdom's native `sessionStorage` is used as-is. This is the pattern to replicate.
+- Test runner is CRA's `react-scripts test` (Jest + jsdom under the hood), confirmed via `frontend/package.json`. No custom jest config beyond `transformIgnorePatterns` for `date-fns`. No fake-timer convention exists elsewhere in `auth/__tests__/`, consistent with the spec's NFR-3 preference for relative `Date.now()` offsets over clock mocking.
+- No architectural risk: this change cannot affect runtime behavior (assuming the spec's out-of-scope constraint — no production code changes — is honored), and it isolates cleanly to one file addition.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+frontend/src/auth/
+├── userStorage.ts                     (unchanged — subject under test)
+├── useAuth.ts                         (unchanged — source of UserInfo type)
+└── __tests__/
+    ├── authRecovery.test.ts           (existing — pattern reference)
+    ├── useAuth.test.ts                (existing)
+    ├── accessMatrixConsistency.test.ts (existing)
+    └── userStorage.test.ts            (NEW — this feature)
+```
+
+No new components, modules, or runtime dependencies. The only artifact is one new test file exercising the existing `UserStorage` static class through its public API (`setUserInfo`, `getUserInfo`, `clearUserInfo`, `getLastLogin`, `updateUserInfo`) plus direct `sessionStorage` seeding for the two key literals.
+
+### Key Design Decisions
+
+#### Decision 1: Test file location
+**Options considered:**
+- (a) Co-located sibling file `frontend/src/auth/userStorage.test.ts`, as the spec proposes (spec explicitly flags this as unconfirmed: "no existing test file was found... confirm the project's standard... before writing").
+- (b) `frontend/src/auth/__tests__/userStorage.test.ts`, matching the three existing test files in this exact directory.
+
+**Chosen approach:** (b) — `frontend/src/auth/__tests__/userStorage.test.ts`.
+
+**Rationale:** Every existing test in `frontend/src/auth/` (and the large majority of the ~65 test files across `frontend/src/`) uses the `__tests__/` subdirectory convention, not co-location. There is no precedent anywhere in `frontend/src/auth/` for a sibling `*.test.ts` file. Deviating here would be inconsistent with zero benefit. This is a direct correction to the spec, not a judgment call — treat it as settled, not open.
+
+#### Decision 2: sessionStorage access — real jsdom storage vs. mock/shim
+**Options considered:**
+- (a) Mock `sessionStorage` with a custom in-memory shim or `jest.spyOn`.
+- (b) Use jsdom's native `sessionStorage` directly, matching `authRecovery.test.ts`.
+
+**Chosen approach:** (b).
+
+**Rationale:** `authRecovery.test.ts` already establishes this pattern in the same directory (`sessionStorage.setItem(RECOVERY_KEY, ...)`, `sessionStorage.clear()` in `beforeEach`). jsdom provides a real, spec-compliant `Storage` implementation, so there is no reason to introduce a mock layer — it would only add indirection and risk diverging from real browser behavior (e.g., `JSON.parse`/`stringify` round-tripping, `getItem` returning `string | null`).
+
+#### Decision 3: Key literals vs. exporting `USER_INFO_KEY`/`LAST_LOGIN_KEY`
+**Options considered:**
+- (a) Export the two key constants from `userStorage.ts` so tests reference them symbolically.
+- (b) Duplicate the literal strings (`"anela_heblo_user_info"`, `"anela_heblo_last_login"`) directly in the test file, as the spec directs.
+
+**Chosen approach:** (b), per spec — no production code changes.
+
+**Rationale:** The spec explicitly scopes this as test-only; exporting the constants would be a (harmless but) unrequested production change and is out of scope per the brief ("No changes to `userStorage.ts` itself are anticipated"). Duplicating the two literal strings is a minor, acceptable coupling — if they ever drift, the tests fail loudly (seeded key never read back), which is itself a useful signal. Define them as local `const` at the top of the test file (mirroring `authRecovery.test.ts`'s `const RECOVERY_KEY = "auth.recovery";`) rather than inline in every test.
+
+#### Decision 4: Clock handling for expiry tests
+**Options considered:**
+- (a) `jest.useFakeTimers()` / mock `Date.now()`.
+- (b) Relative offsets from the real `Date.now()` at test-execution time (`Date.now() - 1000`, `Date.now() + 60*60*1000`).
+
+**Chosen approach:** (b), per spec NFR-3.
+
+**Rationale:** No test in `frontend/src/auth/__tests__/` currently fakes the clock. Introducing fake timers here would be new machinery for a single test file solving a problem (flakiness) that relative real-time offsets already solve at the second/hour scale used here. Keep it simple and consistent with the rest of the auth test suite.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+Create exactly one new file:
+- `frontend/src/auth/__tests__/userStorage.test.ts`
+
+No changes to `frontend/src/auth/userStorage.ts` or any other production file.
+
+### Interfaces and Contracts
+No new interfaces. Tests exercise the existing public static API of `UserStorage` (`frontend/src/auth/userStorage.ts`):
+- `setUserInfo(userInfo: UserInfo): void` — optional seeding helper (per spec, prefer direct `sessionStorage.setItem` with a hand-built `StoredUserInfo` for expiry tests so `expiresAt` is explicit).
+- `getUserInfo(): StoredUserInfo | null` — FR-1, FR-2, FR-3.
+- `clearUserInfo(): void` — assertion target / teardown helper.
+- `getLastLogin(): Date | null` — FR-6.
+- `updateUserInfo(updates: Partial<UserInfo>): void` — FR-4, FR-5.
+
+Local test-file constants (mirroring the production module, since they aren't exported):
+```ts
+const USER_INFO_KEY = "anela_heblo_user_info";
+const LAST_LOGIN_KEY = "anela_heblo_last_login";
+```
+
+Minimal `UserInfo` fixture (matches the interface in `frontend/src/auth/useAuth.ts:8-13` — all fields optional except `name`/`email`/`initials`):
+```ts
+const baseUserInfo: UserInfo = {
+  name: "Test User",
+  email: "test@example.com",
+  initials: "TU",
+};
+```
+
+### Data Flow
+Standard AAA (arrange/act/assert) unit test flow, no async/await needed (all `UserStorage` methods are synchronous):
+1. **Arrange** — `beforeEach` calls `sessionStorage.clear()` (and `localStorage.clear()` if any shared setup does, though `UserStorage` never touches `localStorage`). Seed `sessionStorage` via `sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(storedUserInfo))` for expiry/update tests, or leave unseeded for the absent-key tests (FR-4, FR-6).
+2. **Act** — call the `UserStorage` static method under test directly (no rendering, no React Testing Library needed).
+3. **Assert** — check the method's return value and/or read back `sessionStorage.getItem(...)` to confirm persisted/cleared state.
+
+No component tree, no MSAL mocking, no `jest.mock(...)` calls are needed for this file — unlike `authRecovery.test.ts`, `userStorage.ts` has zero external module dependencies to mock (it only imports the `UserInfo` type, which is erased at compile time).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Test file placed at `frontend/src/auth/userStorage.test.ts` (co-located) instead of `__tests__/`, breaking directory convention | Low | Explicit Directory Structure guidance above; enforced in code review — only one correct path |
+| `console.log`/`console.warn` calls in `userStorage.ts` produce noisy test output | Low | Acceptable as-is; do not suppress via mocking `console` unless it already causes CI log-noise complaints elsewhere (no evidence of that convention in `authRecovery.test.ts`) |
+| Cross-test `sessionStorage` pollution (static class, shared browser storage) | Medium | `beforeEach(() => sessionStorage.clear())` per FR-7, already the established pattern in `authRecovery.test.ts` |
+| A test inadvertently encodes an inverted/incorrect expectation, defeating the purpose (pinning wrong behavior as "correct") | Medium | Explicitly assert both directions per FR-1/FR-2 (past → null + cleared; future → returned unchanged) so a single inverted comparison in production code fails at least one test, not none |
+| Coverage still short of 60% after these tests (untested paths not called out in brief, e.g. `setUserInfo`'s try/catch error branches) | Low | Out of scope per spec; if the 60% gate still fails after landing these tests, that's a follow-up coverage-gap ticket, not a blocker for this spec |
+
+## Specification Amendments
+
+1. **Test file path (correction, not open question):** The spec lists the file location as unconfirmed and suggests `frontend/src/auth/userStorage.test.ts`. Based on direct inspection of `frontend/src/auth/__tests__/` (three existing files: `authRecovery.test.ts`, `useAuth.test.ts`, `accessMatrixConsistency.test.ts`), the established and only-used convention in this directory is `frontend/src/auth/__tests__/userStorage.test.ts`. Use this path; do not create a sibling file.
+2. **sessionStorage mocking (confirmation):** Spec NFR-3 says "do not fake/mock the system clock unless an existing project convention already does so." Confirmed: no such convention exists in `frontend/src/auth/__tests__/`. Use real relative-offset timestamps as specified. Similarly, no `sessionStorage` shim/mock convention exists — use jsdom's native `sessionStorage` directly, matching `authRecovery.test.ts`.
+3. No functional requirements need to change; FR-1 through FR-7 are all implementable as written against the actual `userStorage.ts` source (confirmed lines match: expiry check at line 48, `updateUserInfo` no-op at lines 98-107, `getLastLogin` absent-key path at lines 85-93).
+
+## Prerequisites
+
+None. The test runner (`react-scripts test`, Jest + jsdom), `sessionStorage` (native in jsdom), and the `UserInfo`/`StoredUserInfo` types all already exist and require no setup, migration, or configuration change. Implementation can start immediately by creating `frontend/src/auth/__tests__/userStorage.test.ts`.

--- a/artifacts/feat-3504/brief.md
+++ b/artifacts/feat-3504/brief.md
@@ -1,0 +1,26 @@
+## Module / File
+`frontend/src/auth/userStorage.ts`
+
+## Coverage
+Line coverage: 49% (filter threshold: 60%)
+
+## What's not tested
+**`getUserInfo` — expiry check:**
+When stored user info has an `expiresAt` timestamp in the past, `getUserInfo` clears storage and returns `null`. No test verifies this expired-session path. If the comparison were accidentally inverted (`<` instead of `>`), expired sessions would be returned as valid and active sessions would be cleared — a silent auth regression.
+
+**`updateUserInfo` — silent no-op when no session:**
+`updateUserInfo` reads the current session first and only writes if something is there. If there is no current session, the update silently does nothing. No test confirms this behavior; a caller that expects an update to "create" a session would be surprised.
+
+**`getLastLogin` — null when no entry:**
+The `getLastLogin` method returns `null` when `LAST_LOGIN_KEY` is absent from sessionStorage. No test covers the absent-key path.
+
+## Why it matters
+`getUserInfo` is the auth gate — if the expiry comparison regresses, the app could serve expired credentials or log users out spuriously. The `updateUserInfo` silent-skip means callers who expect it to set initial data will find nothing persisted.
+
+## Suggested approach
+- Test `getUserInfo` with an `expiresAt` 1 second in the past: assert returns `null` and sessionStorage is cleared.
+- Test `getUserInfo` with an `expiresAt` 1 hour in the future: assert the stored info is returned unchanged.
+- Test `updateUserInfo` when no session exists: assert nothing is written to sessionStorage. ~0.5 day effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-06. Based on CI run #28716987459 (2ad2a2593e1834798a3def9ac2551b46c2e595cb)._

--- a/artifacts/feat-3504/code-review.r1.md
+++ b/artifacts/feat-3504/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3504/impl/userstorage-expiry-tests.r1.md
+++ b/artifacts/feat-3504/impl/userstorage-expiry-tests.r1.md
@@ -1,0 +1,37 @@
+# Implementation: userstorage-expiry-tests
+
+## What was implemented
+Added unit test coverage for `frontend/src/auth/userStorage.ts` (`UserStorage`), which previously had no dedicated test file. The new suite exercises the session-expiry check in `getUserInfo()`, the `updateUserInfo()` merge/no-op behavior, and the `getLastLogin()` absent-key case, following the existing `__tests__/` subdirectory convention used elsewhere under `frontend/src/auth/`.
+
+## Files created/modified
+- `frontend/src/auth/__tests__/userStorage.test.ts` — new test file, 6 tests across 3 `describe` blocks:
+  - `getUserInfo`: expired session is cleared and returns `null` (FR-1); future-expiry session is returned unchanged (FR-2); missing `expiresAt` is treated as never-expiring (FR-3).
+  - `updateUserInfo`: no-op (does not throw, does not write) when no session exists (FR-4); merges partial updates into an existing session while leaving `lastLogin`/`expiresAt` untouched (FR-5).
+  - `getLastLogin`: returns `null` when `LAST_LOGIN_KEY` is absent from `sessionStorage` (FR-6).
+
+No production code was modified in the final state — `frontend/src/auth/userStorage.ts` is unchanged from the base branch (a temporary one-character mutation flip was made and reverted twice, purely to verify the tests fail correctly; `git diff` on that file is empty).
+
+## Tests
+- `frontend/src/auth/__tests__/userStorage.test.ts` (new, 6 tests, all passing)
+- Verified regression-detection: flipping `new Date() > new Date(userInfo.expiresAt)` to `<` on line 48 of `userStorage.ts` caused both the FR-1 ("expired session") and FR-2 ("future expiry") tests to fail as expected; reverting restored all passes. Confirmed via `git diff --stat` that the source file has no residual changes.
+- Ran `src/auth/__tests__` as a group (`authRecovery.test.ts`, `useAuth.test.ts`, `accessMatrixConsistency.test.ts`, `userStorage.test.ts`) — all 4 suites / 30 tests pass together, confirming no `sessionStorage` cross-test pollution (FR-7).
+- Ran the full frontend suite with coverage scoped to `userStorage.ts`: **77.14% line coverage** (well above the 60% threshold), 90% branch, 83.33% function coverage. Remaining uncovered lines (33, 56-57, 70-79, 90-91) are the `console.warn`/catch-block error paths and `setUserInfo`/`hasValidUserInfo`, which are out of scope for this task.
+- Full suite sanity check: 286 test suites, 2347 passed / 5 skipped (pre-existing, unrelated), 0 failures.
+
+## How to verify
+```
+cd frontend
+CI=true npx react-scripts test src/auth/__tests__/userStorage.test.ts --watchAll=false
+CI=true npx react-scripts test src/auth/__tests__ --watchAll=false
+CI=true npx react-scripts test --coverage --watchAll=false --collectCoverageFrom="src/auth/userStorage.ts"
+```
+
+## Notes
+- The worktree had no `node_modules` installed. `npm ci` failed on a pre-existing peer-dependency conflict between the pinned `typescript@^4.9.5` and `react-i18next@15.7.4`'s `typescript@^5` peer requirement (unrelated to this task). Installed with `npm install --legacy-peer-deps`, consistent with how the main repo checkout's `node_modules` appears to have been resolved. This is an environment-setup detail only — no `package.json`/`package-lock.json` changes were made or committed.
+- All 4 commits landed on the current branch as instructed; no PR, merge, or branch changes were made.
+
+## PR Summary
+Adds a missing unit test file for `UserStorage` (`frontend/src/auth/__tests__/userStorage.test.ts`), closing the coverage gap on the session-expiry check and related helpers. Covers: expired-session clearing, future-expiry pass-through, missing-`expiresAt` (never-expires) handling, `updateUserInfo` no-op vs. merge semantics, and `getLastLogin` with an absent key. Verified the expiry test actually detects a regression by temporarily flipping the `>` comparison to `<` in `userStorage.ts` and confirming test failure, then reverting (no net source change). Line coverage for `userStorage.ts` is now 77.14%, comfortably above the 60% threshold. Full test suite (286 suites / 2347 tests) passes.
+
+## Status
+DONE

--- a/artifacts/feat-3504/review/userstorage-expiry-tests.r1.md
+++ b/artifacts/feat-3504/review/userstorage-expiry-tests.r1.md
@@ -1,0 +1,20 @@
+# Code Review: userstorage-expiry-tests
+
+## Summary
+The implementation creates exactly the file specified at the correct path (`frontend/src/auth/__tests__/userStorage.test.ts`), covers all seven functional requirements (FR-1 through FR-7) with tests that match the task-context's prescribed content essentially verbatim, and leaves the production file `userStorage.ts` with a confirmed zero net diff across all 5 commits. This is a clean, low-risk, spec-compliant test-only addition.
+
+## Review Result: PASS
+
+### task: userstorage-expiry-tests
+**Status:** PASS
+
+## Docs to Update
+None. This is a test-only change with no new production behavior, public API, or architectural pattern to document.
+
+## Overall Notes
+- Verified via `git diff HEAD~5 HEAD -- frontend/src/auth/userStorage.ts` that the production file has an empty diff — the temporary line-48 mutation used to validate regression-detection was reverted cleanly, consistent with the spec's "no production code changes" constraint.
+- Test file follows the `__tests__/` subdirectory convention (per arch-review Decision 1), uses jsdom-native `sessionStorage` directly with no mocking (Decision 2), duplicates the module-private key literals rather than exporting them (Decision 3), and uses relative `Date.now()` offsets with no fake timers (Decision 4) — all four architectural decisions are correctly followed.
+- All 6 tests map cleanly to FR-1 through FR-6; FR-7 (isolation) is satisfied by the `beforeEach(() => sessionStorage.clear())` at the outer `describe` level, matching the `authRecovery.test.ts` pattern.
+- The implementation summary reports the regression-detection check (flipping `>` to `<` on line 48) caused the FR-1 and FR-2 tests to fail as expected, then confirmed reversion — satisfying the acceptance criteria's mutation-testing requirement for those FRs.
+- Reported coverage (77.14% lines) comfortably clears the 60% threshold cited in the spec background.
+- No correctness issues, no architecture violations, no missing tests found.

--- a/artifacts/feat-3504/spec.r1.md
+++ b/artifacts/feat-3504/spec.r1.md
@@ -1,0 +1,111 @@
+# Specification: Test Coverage for `UserStorage` Session Expiry, No-Session Update, and Missing Last-Login Paths
+
+## Summary
+`frontend/src/auth/userStorage.ts` sits at 49% line coverage against a 60% threshold, and the untested lines are exactly the ones that decide whether a user is treated as authenticated. This spec defines unit tests for `UserStorage.getUserInfo()`'s expiry comparison, `UserStorage.updateUserInfo()`'s no-op behavior when no session exists, and `UserStorage.getLastLogin()`'s absent-key path. No production code changes are required — this is a test-only addition that pins down existing, correct behavior so future edits (e.g., an inverted comparison operator) fail CI instead of shipping a silent auth regression.
+
+## Background
+`UserStorage` is a static utility class wrapping `sessionStorage` under two keys: `anela_heblo_user_info` (`USER_INFO_KEY`) and `anela_heblo_last_login` (`LAST_LOGIN_KEY`). It backs the app's client-side session gate: `getUserInfo()` is called wherever the app decides if a user is still logged in, and its expiry check (`userInfo.expiresAt && new Date() > new Date(userInfo.expiresAt)`, line 48 of `userStorage.ts`) is the single line standing between "expired session correctly rejected" and "expired session silently accepted" (or the inverse: active sessions spuriously logged out). This logic has no direct test today. The brief additionally flags two lower-severity but still user-visible gaps: `updateUserInfo()` silently doing nothing when called with no active session (lines 98–107), and `getLastLogin()` returning `null` when `LAST_LOGIN_KEY` was never set (lines 85–93). Coverage tooling currently reports 49% line coverage for the file; adding tests for these three paths is expected to clear the 60% threshold.
+
+This is a test-authoring task only. No changes to `userStorage.ts` itself are anticipated; if a test reveals an actual defect, that must be raised as a separate finding rather than silently "fixed" to make tests pass.
+
+## Functional Requirements
+
+### FR-1: `getUserInfo()` returns `null` and clears storage when `expiresAt` is in the past
+Add a test that seeds `sessionStorage` with a `StoredUserInfo` JSON blob (matching the `StoredUserInfo` interface: base `UserInfo` fields + `lastLogin: string` + `expiresAt?: string`) under `USER_INFO_KEY`, with `expiresAt` set to a timestamp strictly in the past (e.g. `new Date(Date.now() - 1000).toISOString()`, per the brief's "1 second in the past"). Call `UserStorage.getUserInfo()` and assert:
+- The return value is `null`.
+- `sessionStorage.getItem(USER_INFO_KEY)` is `null` afterward (i.e. `clearUserInfo()` was invoked, per line 50).
+- `sessionStorage.getItem(LAST_LOGIN_KEY)` is also `null` afterward, since `clearUserInfo()` removes both keys.
+
+**Acceptance criteria:**
+- Test fails if the `>` comparison on line 48 is inverted to `<` (i.e., it would then fail to clear an expired entry and return the stale data instead of `null`).
+- Test fails if `clearUserInfo()` is not called on the expired path (storage keys remain populated).
+
+### FR-2: `getUserInfo()` returns stored info unchanged when `expiresAt` is in the future
+Add a test that seeds `sessionStorage` with a valid `StoredUserInfo` blob under `USER_INFO_KEY` with `expiresAt` set roughly one hour in the future (`new Date(Date.now() + 60 * 60 * 1000).toISOString()`, per the brief). Call `UserStorage.getUserInfo()` and assert:
+- The return value deep-equals the originally stored object (all `UserInfo` fields, `lastLogin`, and `expiresAt` preserved, no mutation).
+- `sessionStorage` still contains the entry after the call (not cleared).
+
+**Acceptance criteria:**
+- Test fails if the expiry comparison is inverted (would incorrectly treat a future-dated session as expired and return `null` / clear storage).
+- Test fails if `getUserInfo()` mutates or drops any field when passing through valid data.
+
+### FR-3: `getUserInfo()` treats a missing `expiresAt` as never-expiring
+The expiry check is short-circuited by `userInfo.expiresAt &&`, so a stored record with no `expiresAt` field must be returned as-is regardless of current time. Add a test that seeds `sessionStorage` with a `StoredUserInfo` blob that omits `expiresAt` entirely, calls `getUserInfo()`, and asserts the record is returned unchanged (not cleared).
+
+**Acceptance criteria:**
+- Test fails if the `&&` short-circuit on line 48 is removed or altered such that an absent `expiresAt` is treated as expired.
+
+### FR-4: `updateUserInfo()` is a silent no-op when no session exists
+Add a test that ensures `sessionStorage` has no entry under `USER_INFO_KEY` (either by not seeding it, or by explicitly clearing it first) and no entry under `LAST_LOGIN_KEY`. Call `UserStorage.updateUserInfo({ someField: "value" })` (using a valid partial of whatever fields `UserInfo` defines) and assert:
+- `sessionStorage.getItem(USER_INFO_KEY)` is still `null` after the call — nothing was created.
+- No exception is thrown.
+
+**Acceptance criteria:**
+- Test fails if a future change makes `updateUserInfo()` create a new session record when none existed (a behavior change that should be caught, since the brief explicitly calls out that current behavior is "silently do nothing" and callers relying on create-on-update would be surprised).
+
+### FR-5: `updateUserInfo()` merges updates into an existing session without touching `lastLogin`
+(Companion positive-path test, needed to characterize the branch alongside FR-4.) Seed `sessionStorage` with a valid, non-expired `StoredUserInfo` blob. Call `UserStorage.updateUserInfo({ ...some updated field... })` and assert:
+- The stored record now reflects the updated field(s).
+- `lastLogin` and `expiresAt` on the stored record are unchanged from the original (per the method's doc comment "Update user info without changing login timestamp").
+
+**Acceptance criteria:**
+- Test fails if `updateUserInfo()` overwrites `lastLogin` or `expiresAt` unexpectedly, or fails to persist the update via `sessionStorage.setItem`.
+
+### FR-6: `getLastLogin()` returns `null` when `LAST_LOGIN_KEY` is absent
+Add a test that ensures `sessionStorage` has no entry under `LAST_LOGIN_KEY`, calls `UserStorage.getLastLogin()`, and asserts the return value is `null`.
+
+**Acceptance criteria:**
+- Test fails if a future change causes this path to throw or return something other than `null` (e.g., `new Date(null)` / `new Date(undefined)` producing an Invalid Date object instead of `null`).
+
+### FR-7 (supporting, not in brief but needed for isolation): Test setup/teardown clears `sessionStorage`
+Each test must start from a clean `sessionStorage` (no leftover keys from a previous test) since `UserStorage` is a static class with module-level constants for keys. Use a `beforeEach`/`afterEach` (or equivalent) that calls `sessionStorage.clear()`.
+
+**Acceptance criteria:**
+- Running the full new test file in isolation and interleaved with other suites produces identical results (no cross-test pollution of `sessionStorage`).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — these are synchronous unit tests against an in-memory `sessionStorage` mock/shim (jsdom). Full suite should execute in well under 1 second.
+
+### NFR-2: Security
+No new security surface. Tests must not log or hardcode real credentials; use synthetic `UserInfo` fixture data (e.g., `{ name: "Test User", email: "test@example.com" }` or whatever minimal shape satisfies the `UserInfo` type from `./useAuth`).
+
+### NFR-3: Determinism
+Expiry tests must not be flaky due to real clock drift. Use relative offsets from `Date.now()` at test-execution time (as the brief suggests: ±1 second / ±1 hour) rather than fixed absolute timestamps, so the tests remain valid indefinitely. Do not fake/mock the system clock unless an existing project convention already does so elsewhere in the auth test suite — check for a shared test-utils pattern first.
+
+## Data Model
+No new data model. Existing types in scope:
+- `UserInfo` (imported from `./useAuth`) — the base authenticated-user shape.
+- `StoredUserInfo` (defined in `userStorage.ts`, line 6) — extends `UserInfo` with:
+  - `lastLogin: string` — ISO timestamp string.
+  - `expiresAt?: string` — optional ISO timestamp string; absence means no expiry is enforced.
+- Storage keys (module-level constants, not exported): `USER_INFO_KEY = "anela_heblo_user_info"`, `LAST_LOGIN_KEY = "anela_heblo_last_login"`. Tests must reference these via the same literal strings (or, if the module is refactored to export them, via the export) since they are not currently exported — tests will need to interact with `sessionStorage` directly using the literal key strings to seed/inspect state, mirroring what the implementation does internally.
+
+## API / Interface Design
+No public API changes. Methods under test, all static on `UserStorage`:
+- `setUserInfo(userInfo: UserInfo): void` — not the focus of this spec but may be reused as a seeding helper in place of manually constructing `sessionStorage` entries, where convenient, provided it doesn't obscure the specific `expiresAt` value under test (prefer direct `sessionStorage.setItem` with a hand-built `StoredUserInfo` for expiry tests so the exact `expiresAt` is explicit and readable).
+- `getUserInfo(): StoredUserInfo | null` — primary subject of FR-1, FR-2, FR-3.
+- `clearUserInfo(): void` — used as an assertion target (verifying it was invoked) and as a teardown helper.
+- `hasValidUserInfo(): boolean` — thin wrapper over `getUserInfo()`; already implicitly exercised by the above but not explicitly required by the brief. Optional stretch test, not required for this spec's acceptance.
+- `getLastLogin(): Date | null` — subject of FR-6.
+- `updateUserInfo(updates: Partial<UserInfo>): void` — subject of FR-4, FR-5.
+
+Test file location/naming: follow existing project convention for co-located tests — expected at `frontend/src/auth/userStorage.test.ts` (no existing test file was found in `frontend/src/auth/` at spec-writing time; confirm the project's standard test runner/config, e.g. Jest with jsdom environment, via `frontend/package.json` / `jest.config` before writing, since this repo does not yet have a sibling test file to pattern-match against for this specific module).
+
+## Dependencies
+- Test runner and DOM environment already configured for the `frontend` project (assumed Jest + jsdom, consistent with Create React App / standard React test setup — verify against `frontend/package.json`).
+- No new libraries required. `sessionStorage` is available natively in jsdom's test environment.
+- No backend, network, or other module dependencies.
+
+## Out of Scope
+- Any change to the production logic in `userStorage.ts`. If a test uncovers an actual bug (not expected, per source review — the expiry comparison, no-op update, and absent-key handling all appear correct as written), that is a separate fix to be raised, not silently patched here.
+- Testing `setUserInfo()`'s own expiry-stamping logic (the 24-hour default) as a first-class requirement — it may be exercised incidentally as a seeding helper but is not one of the three gaps called out in the brief.
+- Testing `hasValidUserInfo()` directly (thin wrapper, low risk, not flagged in the brief).
+- Broader auth-flow integration tests (e.g., `useAuth` hook behavior, login/logout UI flows) — this spec is scoped strictly to the `UserStorage` static class.
+- Raising the file's coverage threshold itself, or auditing other files' coverage — scope is limited to `userStorage.ts`.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-06T18:16:31.942612Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T18:18:12.909949Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T18:20:33.033115Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-06T18:21:13.771372Z"
+      "status": "completed",
+      "updated_at": "2026-07-06T18:28:38.453214Z"
     }
   },
   "tasks": [
     {
       "name": "userstorage-expiry-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-06T18:21:14.106330Z"
+      "updated_at": "2026-07-06T18:28:32.569683Z"
     }
   ]
 }

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "userstorage-expiry-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-06T18:18:12.909949Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T18:18:19.630557Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T18:20:33.033115Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-06T18:20:33.033115Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-06T18:21:13.771372Z"
     }
   },
   "tasks": [
     {
       "name": "userstorage-expiry-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-06T18:21:14.106330Z"
     }
   ]
 }

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-06T18:28:38.453214Z"
+    },
+    "code-review": {
+      "status": "completed",
+      "updated_at": "2026-07-06T18:29:53.850751Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3504",
+  "issue_number": 3504,
+  "created_at": "2026-07-06T18:14:27.953361Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3504/state.json
+++ b/artifacts/feat-3504/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-06T18:16:31.942612Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3504/task-context/userstorage-expiry-tests.md
+++ b/artifacts/feat-3504/task-context/userstorage-expiry-tests.md
@@ -1,0 +1,217 @@
+### task: userstorage-expiry-tests
+
+**Context for the engineer:** You have zero prior context on this codebase. Everything you need is below.
+
+**Source file under test** (do not modify): `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/userStorage.ts`
+
+Relevant excerpts already confirmed by reading the file:
+- Line 3-4: `const USER_INFO_KEY = "anela_heblo_user_info";` and `const LAST_LOGIN_KEY = "anela_heblo_last_login";` — module-private, not exported. Tests must use these literal strings directly.
+- Line 6-9: `export interface StoredUserInfo extends UserInfo { lastLogin: string; expiresAt?: string; }` — this IS exported, so tests can import and use it for typing.
+- Line 48: `if (userInfo.expiresAt && new Date() > new Date(userInfo.expiresAt)) { ... this.clearUserInfo(); return null; }` — the expiry check under test in FR-1/2/3.
+- Line 64-72: `clearUserInfo()` removes both `USER_INFO_KEY` and `LAST_LOGIN_KEY` from `sessionStorage`.
+- Line 85-93: `getLastLogin()` — `sessionStorage.getItem(LAST_LOGIN_KEY)`; returns `null` if absent, else `new Date(lastLogin)`.
+- Line 98-107: `updateUserInfo(updates)` — calls `this.getUserInfo()`; if `null` (no session), does nothing; if present, merges `updates` into the current record and calls `sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(updated))`. Does not touch `LAST_LOGIN_KEY` or the `lastLogin`/`expiresAt` fields on the merged record (they're carried over from `current` via spread, unless `updates` explicitly overrides them).
+
+`UserInfo` type (from `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/useAuth.ts` lines 8-13):
+```ts
+export interface UserInfo {
+  name: string;
+  email: string;
+  initials: string;
+  roles?: string[];
+}
+```
+
+**Pattern reference** (existing file, do not modify): `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/__tests__/authRecovery.test.ts` — shows the project convention: `__tests__/` subdirectory, direct `sessionStorage.setItem`/`.getItem`/`.clear()` calls, a local `const RECOVERY_KEY = "..."` for the storage key literal, `beforeEach(() => sessionStorage.clear())`.
+
+**File to create:** `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/__tests__/userStorage.test.ts`
+
+Do NOT create `frontend/src/auth/userStorage.test.ts` (co-located) — the architecture review confirmed the only convention used anywhere in `frontend/src/auth/` is the `__tests__/` subdirectory.
+
+**Test command:** run from the `frontend/` directory:
+```
+CI=true npx react-scripts test src/auth/__tests__/userStorage.test.ts --watchAll=false
+```
+(`CI=true` makes Jest run once and exit instead of entering watch mode.)
+
+---
+
+#### Step 1: Create the test file skeleton with fixtures and the first expiry test (FR-1)
+
+- [ ] Create `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/__tests__/userStorage.test.ts` with this content:
+
+```ts
+import { UserStorage, StoredUserInfo } from "../userStorage";
+import { UserInfo } from "../useAuth";
+
+const USER_INFO_KEY = "anela_heblo_user_info";
+const LAST_LOGIN_KEY = "anela_heblo_last_login";
+
+const baseUserInfo: UserInfo = {
+  name: "Test User",
+  email: "test@example.com",
+  initials: "TU",
+};
+
+describe("UserStorage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe("getUserInfo", () => {
+    it("returns null and clears storage when expiresAt is in the past", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+      sessionStorage.setItem(LAST_LOGIN_KEY, stored.lastLogin);
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toBeNull();
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+      expect(sessionStorage.getItem(LAST_LOGIN_KEY)).toBeNull();
+    });
+  });
+});
+```
+
+- [ ] Run the test command above. Confirm the single test passes (this pins the currently-correct behavior; there is no red phase here because the production code is not being written in this task — it already exists and is correct per the spec).
+
+- [ ] Verify the test actually detects a regression (this satisfies FR-1's acceptance criterion "Test fails if the `>` comparison on line 48 is inverted to `<`"): temporarily edit `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/userStorage.ts` line 48, changing `new Date() > new Date(userInfo.expiresAt)` to `new Date() < new Date(userInfo.expiresAt)`. Re-run the test command. Confirm the test now FAILS. Then revert the edit (change `<` back to `>`) and re-run to confirm the test passes again. Do not leave the production file modified.
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage expired-session coverage (FR-1)"`
+
+#### Step 2: Add the future-expiry and missing-expiresAt tests (FR-2, FR-3)
+
+- [ ] Add two more `it(...)` blocks inside the existing `describe("getUserInfo", ...)` block, after the FR-1 test:
+
+```ts
+    it("returns stored info unchanged when expiresAt is in the future", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toEqual(stored);
+      expect(sessionStorage.getItem(USER_INFO_KEY)).not.toBeNull();
+    });
+
+    it("treats a missing expiresAt as never-expiring", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toEqual(stored);
+      expect(sessionStorage.getItem(USER_INFO_KEY)).not.toBeNull();
+    });
+```
+
+- [ ] Run the test command. Confirm all 3 tests in `getUserInfo` pass.
+
+- [ ] Verify the future-expiry test detects a regression (FR-2's acceptance criterion): repeat the same temporary line-48 flip (`>` → `<`) used in Step 1, re-run, confirm the "returns stored info unchanged when expiresAt is in the future" test now FAILS (the future-dated session gets incorrectly treated as expired). Revert the flip, re-run, confirm all 3 tests pass again.
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage valid-session and no-expiry coverage (FR-2, FR-3)"`
+
+#### Step 3: Add the updateUserInfo no-op and merge tests (FR-4, FR-5)
+
+- [ ] Add a new `describe("updateUserInfo", ...)` block after the `getUserInfo` block closes (still inside the outer `describe("UserStorage", ...)`):
+
+```ts
+  describe("updateUserInfo", () => {
+    it("is a silent no-op when no session exists", () => {
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+
+      expect(() =>
+        UserStorage.updateUserInfo({ name: "New Name" }),
+      ).not.toThrow();
+
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+    });
+
+    it("merges updates into an existing session without touching lastLogin or expiresAt", () => {
+      const originalLastLogin = new Date(Date.now() - 60 * 1000).toISOString();
+      const originalExpiresAt = new Date(
+        Date.now() + 60 * 60 * 1000,
+      ).toISOString();
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: originalLastLogin,
+        expiresAt: originalExpiresAt,
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      UserStorage.updateUserInfo({ name: "Updated Name" });
+
+      const raw = sessionStorage.getItem(USER_INFO_KEY);
+      expect(raw).not.toBeNull();
+      const updated: StoredUserInfo = JSON.parse(raw as string);
+      expect(updated.name).toBe("Updated Name");
+      expect(updated.email).toBe(baseUserInfo.email);
+      expect(updated.lastLogin).toBe(originalLastLogin);
+      expect(updated.expiresAt).toBe(originalExpiresAt);
+    });
+  });
+```
+
+- [ ] Run the test command. Confirm both new tests pass, and the 3 `getUserInfo` tests from Steps 1-2 still pass (5 total so far).
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage updateUserInfo no-op and merge coverage (FR-4, FR-5)"`
+
+#### Step 4: Add the getLastLogin absent-key test (FR-6)
+
+- [ ] Add a new `describe("getLastLogin", ...)` block after the `updateUserInfo` block closes (still inside the outer `describe("UserStorage", ...)`):
+
+```ts
+  describe("getLastLogin", () => {
+    it("returns null when LAST_LOGIN_KEY is absent", () => {
+      expect(sessionStorage.getItem(LAST_LOGIN_KEY)).toBeNull();
+
+      const result = UserStorage.getLastLogin();
+
+      expect(result).toBeNull();
+    });
+  });
+```
+
+- [ ] Run the test command. Confirm all 6 tests pass.
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage getLastLogin absent-key coverage (FR-6)"`
+
+#### Step 5: Confirm isolation (FR-7) and check coverage impact
+
+- [ ] Run the full auth test directory together to confirm no cross-test `sessionStorage` pollution between the new file and existing sibling tests:
+```
+CI=true npx react-scripts test src/auth/__tests__ --watchAll=false
+```
+Confirm all tests across `authRecovery.test.ts`, `useAuth.test.ts`, `accessMatrixConsistency.test.ts`, and the new `userStorage.test.ts` pass together, in any run order.
+
+- [ ] Run the full frontend test suite with coverage to confirm `userStorage.ts` now clears the 60% line-coverage threshold:
+```
+CI=true npx react-scripts test --coverage --watchAll=false --collectCoverageFrom="src/auth/userStorage.ts"
+```
+Confirm the reported line coverage for `frontend/src/auth/userStorage.ts` is at or above 60%. (If it is still below 60%, that is a pre-existing gap in an out-of-scope code path per the spec's Out of Scope section — do not add further tests to force it up; report the actual number as a note rather than silently expanding scope.)
+
+- [ ] No further commit needed for this step unless the coverage run surfaces something worth noting — if so, add a one-line comment at the top of the test file only if it clarifies scope (optional, not required).
+
+**Acceptance criteria mapping (self-review):**
+- FR-1 → Step 1 test + line-48 mutation verification.
+- FR-2 → Step 2 first test + line-48 mutation verification.
+- FR-3 → Step 2 second test.
+- FR-4 → Step 3 first test.
+- FR-5 → Step 3 second test.
+- FR-6 → Step 4 test.
+- FR-7 → `beforeEach(() => sessionStorage.clear())` present from Step 1 onward; explicitly re-verified in Step 5.
+- NFR-1 (performance) → all tests synchronous, no network/timers; satisfied by construction.
+- NFR-2 (security) → fixture uses synthetic `baseUserInfo` data only, no real credentials.
+- NFR-3 (determinism) → all timestamps are relative offsets from `Date.now()` at test-execution time; no fake timers introduced, consistent with the rest of `frontend/src/auth/__tests__/`.

--- a/artifacts/feat-3504/task-plan.r1.md
+++ b/artifacts/feat-3504/task-plan.r1.md
@@ -1,0 +1,227 @@
+# UserStorage Test Coverage Implementation Plan
+
+**Goal:** Add unit tests for `UserStorage`'s session-expiry check, no-op update path, and missing-last-login path so `frontend/src/auth/userStorage.ts` clears its 60% coverage threshold, with no production code changes.
+
+**Architecture:** One new test file, `frontend/src/auth/__tests__/userStorage.test.ts`, exercising the existing static `UserStorage` class directly against jsdom's native `sessionStorage` (no mocks, no fake timers), matching the established pattern in the sibling `authRecovery.test.ts`. No changes to `userStorage.ts`, `useAuth.ts`, or any other production file.
+
+**Tech Stack:** TypeScript, Jest + jsdom (via CRA's `react-scripts test`), `@testing-library/jest-dom` matchers (already configured project-wide).
+
+---
+
+### task: userstorage-expiry-tests
+
+**Context for the engineer:** You have zero prior context on this codebase. Everything you need is below.
+
+**Source file under test** (do not modify): `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/userStorage.ts`
+
+Relevant excerpts already confirmed by reading the file:
+- Line 3-4: `const USER_INFO_KEY = "anela_heblo_user_info";` and `const LAST_LOGIN_KEY = "anela_heblo_last_login";` — module-private, not exported. Tests must use these literal strings directly.
+- Line 6-9: `export interface StoredUserInfo extends UserInfo { lastLogin: string; expiresAt?: string; }` — this IS exported, so tests can import and use it for typing.
+- Line 48: `if (userInfo.expiresAt && new Date() > new Date(userInfo.expiresAt)) { ... this.clearUserInfo(); return null; }` — the expiry check under test in FR-1/2/3.
+- Line 64-72: `clearUserInfo()` removes both `USER_INFO_KEY` and `LAST_LOGIN_KEY` from `sessionStorage`.
+- Line 85-93: `getLastLogin()` — `sessionStorage.getItem(LAST_LOGIN_KEY)`; returns `null` if absent, else `new Date(lastLogin)`.
+- Line 98-107: `updateUserInfo(updates)` — calls `this.getUserInfo()`; if `null` (no session), does nothing; if present, merges `updates` into the current record and calls `sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(updated))`. Does not touch `LAST_LOGIN_KEY` or the `lastLogin`/`expiresAt` fields on the merged record (they're carried over from `current` via spread, unless `updates` explicitly overrides them).
+
+`UserInfo` type (from `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/useAuth.ts` lines 8-13):
+```ts
+export interface UserInfo {
+  name: string;
+  email: string;
+  initials: string;
+  roles?: string[];
+}
+```
+
+**Pattern reference** (existing file, do not modify): `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/__tests__/authRecovery.test.ts` — shows the project convention: `__tests__/` subdirectory, direct `sessionStorage.setItem`/`.getItem`/`.clear()` calls, a local `const RECOVERY_KEY = "..."` for the storage key literal, `beforeEach(() => sessionStorage.clear())`.
+
+**File to create:** `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/__tests__/userStorage.test.ts`
+
+Do NOT create `frontend/src/auth/userStorage.test.ts` (co-located) — the architecture review confirmed the only convention used anywhere in `frontend/src/auth/` is the `__tests__/` subdirectory.
+
+**Test command:** run from the `frontend/` directory:
+```
+CI=true npx react-scripts test src/auth/__tests__/userStorage.test.ts --watchAll=false
+```
+(`CI=true` makes Jest run once and exit instead of entering watch mode.)
+
+---
+
+#### Step 1: Create the test file skeleton with fixtures and the first expiry test (FR-1)
+
+- [ ] Create `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/__tests__/userStorage.test.ts` with this content:
+
+```ts
+import { UserStorage, StoredUserInfo } from "../userStorage";
+import { UserInfo } from "../useAuth";
+
+const USER_INFO_KEY = "anela_heblo_user_info";
+const LAST_LOGIN_KEY = "anela_heblo_last_login";
+
+const baseUserInfo: UserInfo = {
+  name: "Test User",
+  email: "test@example.com",
+  initials: "TU",
+};
+
+describe("UserStorage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe("getUserInfo", () => {
+    it("returns null and clears storage when expiresAt is in the past", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+      sessionStorage.setItem(LAST_LOGIN_KEY, stored.lastLogin);
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toBeNull();
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+      expect(sessionStorage.getItem(LAST_LOGIN_KEY)).toBeNull();
+    });
+  });
+});
+```
+
+- [ ] Run the test command above. Confirm the single test passes (this pins the currently-correct behavior; there is no red phase here because the production code is not being written in this task — it already exists and is correct per the spec).
+
+- [ ] Verify the test actually detects a regression (this satisfies FR-1's acceptance criterion "Test fails if the `>` comparison on line 48 is inverted to `<`"): temporarily edit `/home/user/worktrees/feature-3504-Coverage-Gap-Auth-Userstorage-Session-Expiry-Check/frontend/src/auth/userStorage.ts` line 48, changing `new Date() > new Date(userInfo.expiresAt)` to `new Date() < new Date(userInfo.expiresAt)`. Re-run the test command. Confirm the test now FAILS. Then revert the edit (change `<` back to `>`) and re-run to confirm the test passes again. Do not leave the production file modified.
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage expired-session coverage (FR-1)"`
+
+#### Step 2: Add the future-expiry and missing-expiresAt tests (FR-2, FR-3)
+
+- [ ] Add two more `it(...)` blocks inside the existing `describe("getUserInfo", ...)` block, after the FR-1 test:
+
+```ts
+    it("returns stored info unchanged when expiresAt is in the future", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toEqual(stored);
+      expect(sessionStorage.getItem(USER_INFO_KEY)).not.toBeNull();
+    });
+
+    it("treats a missing expiresAt as never-expiring", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toEqual(stored);
+      expect(sessionStorage.getItem(USER_INFO_KEY)).not.toBeNull();
+    });
+```
+
+- [ ] Run the test command. Confirm all 3 tests in `getUserInfo` pass.
+
+- [ ] Verify the future-expiry test detects a regression (FR-2's acceptance criterion): repeat the same temporary line-48 flip (`>` → `<`) used in Step 1, re-run, confirm the "returns stored info unchanged when expiresAt is in the future" test now FAILS (the future-dated session gets incorrectly treated as expired). Revert the flip, re-run, confirm all 3 tests pass again.
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage valid-session and no-expiry coverage (FR-2, FR-3)"`
+
+#### Step 3: Add the updateUserInfo no-op and merge tests (FR-4, FR-5)
+
+- [ ] Add a new `describe("updateUserInfo", ...)` block after the `getUserInfo` block closes (still inside the outer `describe("UserStorage", ...)`):
+
+```ts
+  describe("updateUserInfo", () => {
+    it("is a silent no-op when no session exists", () => {
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+
+      expect(() =>
+        UserStorage.updateUserInfo({ name: "New Name" }),
+      ).not.toThrow();
+
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+    });
+
+    it("merges updates into an existing session without touching lastLogin or expiresAt", () => {
+      const originalLastLogin = new Date(Date.now() - 60 * 1000).toISOString();
+      const originalExpiresAt = new Date(
+        Date.now() + 60 * 60 * 1000,
+      ).toISOString();
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: originalLastLogin,
+        expiresAt: originalExpiresAt,
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      UserStorage.updateUserInfo({ name: "Updated Name" });
+
+      const raw = sessionStorage.getItem(USER_INFO_KEY);
+      expect(raw).not.toBeNull();
+      const updated: StoredUserInfo = JSON.parse(raw as string);
+      expect(updated.name).toBe("Updated Name");
+      expect(updated.email).toBe(baseUserInfo.email);
+      expect(updated.lastLogin).toBe(originalLastLogin);
+      expect(updated.expiresAt).toBe(originalExpiresAt);
+    });
+  });
+```
+
+- [ ] Run the test command. Confirm both new tests pass, and the 3 `getUserInfo` tests from Steps 1-2 still pass (5 total so far).
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage updateUserInfo no-op and merge coverage (FR-4, FR-5)"`
+
+#### Step 4: Add the getLastLogin absent-key test (FR-6)
+
+- [ ] Add a new `describe("getLastLogin", ...)` block after the `updateUserInfo` block closes (still inside the outer `describe("UserStorage", ...)`):
+
+```ts
+  describe("getLastLogin", () => {
+    it("returns null when LAST_LOGIN_KEY is absent", () => {
+      expect(sessionStorage.getItem(LAST_LOGIN_KEY)).toBeNull();
+
+      const result = UserStorage.getLastLogin();
+
+      expect(result).toBeNull();
+    });
+  });
+```
+
+- [ ] Run the test command. Confirm all 6 tests pass.
+
+- [ ] Commit: `git add frontend/src/auth/__tests__/userStorage.test.ts && git commit -m "test: add UserStorage getLastLogin absent-key coverage (FR-6)"`
+
+#### Step 5: Confirm isolation (FR-7) and check coverage impact
+
+- [ ] Run the full auth test directory together to confirm no cross-test `sessionStorage` pollution between the new file and existing sibling tests:
+```
+CI=true npx react-scripts test src/auth/__tests__ --watchAll=false
+```
+Confirm all tests across `authRecovery.test.ts`, `useAuth.test.ts`, `accessMatrixConsistency.test.ts`, and the new `userStorage.test.ts` pass together, in any run order.
+
+- [ ] Run the full frontend test suite with coverage to confirm `userStorage.ts` now clears the 60% line-coverage threshold:
+```
+CI=true npx react-scripts test --coverage --watchAll=false --collectCoverageFrom="src/auth/userStorage.ts"
+```
+Confirm the reported line coverage for `frontend/src/auth/userStorage.ts` is at or above 60%. (If it is still below 60%, that is a pre-existing gap in an out-of-scope code path per the spec's Out of Scope section — do not add further tests to force it up; report the actual number as a note rather than silently expanding scope.)
+
+- [ ] No further commit needed for this step unless the coverage run surfaces something worth noting — if so, add a one-line comment at the top of the test file only if it clarifies scope (optional, not required).
+
+**Acceptance criteria mapping (self-review):**
+- FR-1 → Step 1 test + line-48 mutation verification.
+- FR-2 → Step 2 first test + line-48 mutation verification.
+- FR-3 → Step 2 second test.
+- FR-4 → Step 3 first test.
+- FR-5 → Step 3 second test.
+- FR-6 → Step 4 test.
+- FR-7 → `beforeEach(() => sessionStorage.clear())` present from Step 1 onward; explicitly re-verified in Step 5.
+- NFR-1 (performance) → all tests synchronous, no network/timers; satisfied by construction.
+- NFR-2 (security) → fixture uses synthetic `baseUserInfo` data only, no real credentials.
+- NFR-3 (determinism) → all timestamps are relative offsets from `Date.now()` at test-execution time; no fake timers introduced, consistent with the rest of `frontend/src/auth/__tests__/`.

--- a/frontend/src/auth/__tests__/userStorage.test.ts
+++ b/frontend/src/auth/__tests__/userStorage.test.ts
@@ -59,4 +59,39 @@ describe("UserStorage", () => {
       expect(sessionStorage.getItem(USER_INFO_KEY)).not.toBeNull();
     });
   });
+
+  describe("updateUserInfo", () => {
+    it("is a silent no-op when no session exists", () => {
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+
+      expect(() =>
+        UserStorage.updateUserInfo({ name: "New Name" }),
+      ).not.toThrow();
+
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+    });
+
+    it("merges updates into an existing session without touching lastLogin or expiresAt", () => {
+      const originalLastLogin = new Date(Date.now() - 60 * 1000).toISOString();
+      const originalExpiresAt = new Date(
+        Date.now() + 60 * 60 * 1000,
+      ).toISOString();
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: originalLastLogin,
+        expiresAt: originalExpiresAt,
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      UserStorage.updateUserInfo({ name: "Updated Name" });
+
+      const raw = sessionStorage.getItem(USER_INFO_KEY);
+      expect(raw).not.toBeNull();
+      const updated: StoredUserInfo = JSON.parse(raw as string);
+      expect(updated.name).toBe("Updated Name");
+      expect(updated.email).toBe(baseUserInfo.email);
+      expect(updated.lastLogin).toBe(originalLastLogin);
+      expect(updated.expiresAt).toBe(originalExpiresAt);
+    });
+  });
 });

--- a/frontend/src/auth/__tests__/userStorage.test.ts
+++ b/frontend/src/auth/__tests__/userStorage.test.ts
@@ -1,0 +1,35 @@
+import { UserStorage, StoredUserInfo } from "../userStorage";
+import { UserInfo } from "../useAuth";
+
+const USER_INFO_KEY = "anela_heblo_user_info";
+const LAST_LOGIN_KEY = "anela_heblo_last_login";
+
+const baseUserInfo: UserInfo = {
+  name: "Test User",
+  email: "test@example.com",
+  initials: "TU",
+};
+
+describe("UserStorage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe("getUserInfo", () => {
+    it("returns null and clears storage when expiresAt is in the past", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+      sessionStorage.setItem(LAST_LOGIN_KEY, stored.lastLogin);
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toBeNull();
+      expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
+      expect(sessionStorage.getItem(LAST_LOGIN_KEY)).toBeNull();
+    });
+  });
+});

--- a/frontend/src/auth/__tests__/userStorage.test.ts
+++ b/frontend/src/auth/__tests__/userStorage.test.ts
@@ -94,4 +94,14 @@ describe("UserStorage", () => {
       expect(updated.expiresAt).toBe(originalExpiresAt);
     });
   });
+
+  describe("getLastLogin", () => {
+    it("returns null when LAST_LOGIN_KEY is absent", () => {
+      expect(sessionStorage.getItem(LAST_LOGIN_KEY)).toBeNull();
+
+      const result = UserStorage.getLastLogin();
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/frontend/src/auth/__tests__/userStorage.test.ts
+++ b/frontend/src/auth/__tests__/userStorage.test.ts
@@ -31,5 +31,32 @@ describe("UserStorage", () => {
       expect(sessionStorage.getItem(USER_INFO_KEY)).toBeNull();
       expect(sessionStorage.getItem(LAST_LOGIN_KEY)).toBeNull();
     });
+
+    it("returns stored info unchanged when expiresAt is in the future", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toEqual(stored);
+      expect(sessionStorage.getItem(USER_INFO_KEY)).not.toBeNull();
+    });
+
+    it("treats a missing expiresAt as never-expiring", () => {
+      const stored: StoredUserInfo = {
+        ...baseUserInfo,
+        lastLogin: new Date().toISOString(),
+      };
+      sessionStorage.setItem(USER_INFO_KEY, JSON.stringify(stored));
+
+      const result = UserStorage.getUserInfo();
+
+      expect(result).toEqual(stored);
+      expect(sessionStorage.getItem(USER_INFO_KEY)).not.toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Closes #3504

## What the issue was
`frontend/src/auth/userStorage.ts` had only 49% line coverage (below the 60% CI threshold). Three behaviors were untested:
- `getUserInfo()`'s session-expiry check (clearing storage and returning `null` when `expiresAt` is in the past) — an inverted comparison here would silently create an auth regression (serving expired sessions or logging out valid ones).
- `updateUserInfo()`'s silent no-op when there is no current session.
- `getLastLogin()` returning `null` when the last-login key is absent.

## How it was fixed / handled
Added `frontend/src/auth/__tests__/userStorage.test.ts` (following the existing `__tests__/` convention used elsewhere under `frontend/src/auth/`), with 6 tests:
- `getUserInfo`: expired session is cleared and returns `null`; future-expiry session is returned unchanged; missing `expiresAt` is treated as never-expiring.
- `updateUserInfo`: no-op when no session exists; merges partial updates into an existing session without touching `lastLogin`/`expiresAt`.
- `getLastLogin`: returns `null` when the key is absent.

No production code was changed — `userStorage.ts` is unchanged from `main`. The expiry-check tests were verified to actually catch a regression by temporarily flipping the `>` comparison to `<` on line 48, confirming the tests fail, then reverting. Line coverage for `userStorage.ts` is now 77.14% (up from 49%), comfortably above the 60% threshold. The full frontend suite (286 suites / 2347 tests) passes.

## Artifacts
- Brief, spec, architecture review, task plan, impl, and review markdown are committed under `artifacts/feat-3504/` in this branch.

## Code review

## Review Result: CLEAN

The diff is a test-only addition (`frontend/src/auth/__tests__/userStorage.test.ts`) that exactly matches the spec's FR-1 through FR-6: expiry rejection/acceptance/no-expiry paths for `getUserInfo()`, no-op and merge behavior for `updateUserInfo()`, and the absent-key path for `getLastLogin()`. All 6 tests pass against the real `userStorage.ts`. No production code was touched. No correctness bugs and no cleanup suggestions.

---
_Generated by [Claude Code](https://claude.ai/code/session_019BoHdXHNGJ5v9j9KAhmZws)_