### PR TITLE
#3517: remove dead GridLayoutPersistencePayload record

### DIFF
--- a/artifacts/feat-3517/arch-review.r1.md
+++ b/artifacts/feat-3517/arch-review.r1.md
@@ -1,0 +1,121 @@
+# Architecture Review: Remove dead `GridLayoutPersistencePayload` type
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure dead-code removal in the `GridLayouts` vertical slice
+(`backend/src/Anela.Heblo.Application/Features/GridLayouts/`). I inspected the
+three files in question directly:
+
+- `GridLayoutPersistencePayload.cs` defines `internal sealed record
+  GridLayoutPersistencePayload(List<GridColumnStateDto> Columns)`. It has a
+  `[JsonPropertyName("columns")]` attribute but is never constructed,
+  deserialized into, or passed as a parameter/return type anywhere.
+- The actual persistence path already exists and is in active use:
+  `GridLayoutStoredMapper` (in `Features/GridLayouts/Infrastructure/`) maps
+  `GridColumnStateDto` ⇄ `StoredGridLayout`/`StoredColumnState`, and the
+  save/get handlers work with `Dictionary<string, JsonElement>` for the raw
+  JSON round-trip in tests. `GridLayoutPersistencePayload` sits alongside this
+  as an orphaned, unused parallel shape.
+- A repo-wide grep for `GridLayoutPersistencePayload` (backend `**/*.cs` and
+  frontend `**/*.ts(x)`) returns exactly two hits: the type's own definition
+  file, and a doc comment on `SaveGridLayoutHandlerPayloadTests` (lines 14–16)
+  in `GridLayoutHandlerTests.cs`. No production code, DI registration,
+  MediatR handler, controller, or frontend generated client references it —
+  it's `internal`, so it was never exposed via the OpenAPI contract either.
+
+There is no architectural decision to make here beyond "delete it and fix the
+comment." No module boundary, DTO contract, or persistence format changes as
+a result — `StoredGridLayout`/`StoredColumnState`/`GridLayoutStoredMapper`
+remain exactly as they are today.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new or changed components. This removes one unreferenced internal type
+and corrects a stale XML doc comment on an existing test class. The
+`GridLayouts` feature's public shape (handlers, DTOs, repository,
+`GridLayoutStoredMapper`) is untouched.
+
+### Key Design Decisions
+
+#### Decision 1: Delete outright vs. deprecate/mark obsolete
+**Options considered:**
+1. Delete the file entirely.
+2. Mark the type `[Obsolete]` and leave it for a deprecation window.
+
+**Chosen approach:** Delete the file entirely (option 1).
+
+**Rationale:** The type is `internal`, has no external consumers by
+construction (nothing outside this assembly could reference it), and has
+zero in-repo references outside its own file. There is no deprecation
+audience — `[Obsolete]` exists to warn external/future callers, and there
+are none. Per the spec's YAGNI framing, keeping it around (even flagged)
+just perpetuates the "is this a future replacement?" ambiguity the finding
+called out.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+1. **Delete** `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` in full (all 7 lines — the entire file).
+2. **Edit** `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs`, lines 14–17 (the XML doc comment on `SaveGridLayoutHandlerPayloadTests`):
+
+   Current:
+   ```csharp
+   /// <summary>
+   /// Tests for the slim persistence payload refactor.
+   /// These tests verify that GridLayoutPersistencePayload contains only columns,
+   /// and that GridLayoutDto is assembled from payload + entity.GridKey + entity.LastModified.
+   /// </summary>
+   ```
+
+   Replace with wording that keeps the same intent but drops the type name,
+   e.g.:
+   ```csharp
+   /// <summary>
+   /// Tests for the slim persistence payload refactor.
+   /// These tests verify that the persisted JSON payload contains only columns,
+   /// and that GridLayoutDto is assembled from that payload + entity.GridKey + entity.LastModified.
+   /// </summary>
+   ```
+   No other lines in this file change — test bodies, assertions, and the
+   `SaveGridLayoutHandlerPayloadTests` class name stay as-is (confirmed by
+   reading the test file: it already asserts against
+   `JsonSerializer.Deserialize<Dictionary<string, JsonElement>>`, not against
+   the deleted type).
+
+No other files need to change. `GridLayoutStoredMapper.cs` and
+`GridColumnStateDto`/`StoredGridLayout`/`StoredColumnState` are unaffected —
+do not touch them.
+
+### Interfaces and Contracts
+
+N/A — `GridLayoutPersistencePayload` was `internal` and never part of any
+MediatR request/response, controller contract, or the generated OpenAPI
+client.
+
+### Data Flow
+
+N/A — no runtime data flow references this type; its removal has no effect
+on the save/get grid layout request path.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Hidden reflection-based usage (e.g. via `JsonSerializer` polymorphism or DI scanning) that grep wouldn't catch | Low | `dotnet build` will fail loudly if any compiled reference exists, since the type is only usable via direct C# reference (no interface, no attribute-based registration found). Acceptance criteria already require a clean build. |
+| Doc comment edit accidentally changes test semantics | Low | Restrict the edit strictly to the XML comment text (lines 14–17); do not touch method bodies or assertions. |
+
+## Specification Amendments
+
+None. The spec (`spec.r1.md`) is accurate and directly verified against the
+working tree: file paths, line numbers, and current file contents all match
+what I found. FR-1 and FR-2 are implementable exactly as written.
+
+## Prerequisites
+
+None — this change has no dependencies on other in-flight work and can be
+implemented immediately.

--- a/artifacts/feat-3517/brief.md
+++ b/artifacts/feat-3517/brief.md
@@ -1,0 +1,24 @@
+# [arch-review] GridLayouts: GridLayoutPersistencePayload.cs is dead code
+
+## Module
+GridLayouts
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` defines `internal sealed record GridLayoutPersistencePayload` but this type is **never referenced in any production source file**.
+
+```csharp
+// GridLayoutPersistencePayload.cs (lines 1–7) — defined but unused
+internal sealed record GridLayoutPersistencePayload(
+    [property: JsonPropertyName("columns")] List<StoredColumnState> Columns);
+```
+
+The actual persistence serialization path uses `StoredGridLayout` / `StoredColumnState` via `GridLayoutStoredMapper` (`Infrastructure/GridLayoutStoredMapper.cs`). The only reference to `GridLayoutPersistencePayload` outside its own definition file is a comment in a test class description — it is not imported or instantiated anywhere.
+
+## Why it matters
+A dangling type with the same conceptual role as `StoredGridLayout` creates confusion: a reader must determine whether it is a future replacement, a legacy artifact, or an alternative code path. YAGNI — unused code has maintenance cost with zero benefit.
+
+## Suggested fix
+Delete `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs`. Update the comment in `GridLayoutHandlerTests.cs` (line 14–17) to remove the reference if needed.
+
+---
+_Filed by daily arch-review routine on 2026-07-06._

--- a/artifacts/feat-3517/code-review.r1.md
+++ b/artifacts/feat-3517/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3517/design.r1.md
+++ b/artifacts/feat-3517/design.r1.md
@@ -1,0 +1,17 @@
+# Design: Remove dead `GridLayoutPersistencePayload` type
+
+## Component Design
+No new or changed components. This change deletes one unreferenced internal
+type — `GridLayoutPersistencePayload` (in
+`backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs`)
+— and corrects a stale XML doc comment on `SaveGridLayoutHandlerPayloadTests`
+in `GridLayoutHandlerTests.cs` so it no longer names the deleted type. The
+`GridLayouts` feature's active components (handlers, `GridLayoutStoredMapper`,
+`StoredGridLayout`/`StoredColumnState`) are untouched and keep their existing
+responsibilities and interfaces.
+
+## Data Schemas
+N/A, no schema changes. `GridLayoutPersistencePayload` was unused, `internal`,
+and never part of the persisted JSON format, any MediatR contract, or the
+OpenAPI surface; the active persistence shape (`StoredGridLayout` /
+`StoredColumnState` via `GridLayoutStoredMapper`) is unaffected.

--- a/artifacts/feat-3517/impl/remove-dead-grid-layout-persistence-payload.r1.md
+++ b/artifacts/feat-3517/impl/remove-dead-grid-layout-persistence-payload.r1.md
@@ -1,0 +1,41 @@
+# Implementation: remove-dead-grid-layout-persistence-payload
+
+## What was implemented
+Deleted the unused `GridLayoutPersistencePayload` record (never referenced anywhere in
+production code — the active persistence path is `StoredGridLayout`/`StoredColumnState`
+via `GridLayoutStoredMapper`), and corrected the stale XML doc comment on
+`SaveGridLayoutHandlerPayloadTests` that named the deleted type. No behavioral change.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` — deleted (via `git rm`).
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs` — updated the XML doc
+  comment (lines 14-18) on `SaveGridLayoutHandlerPayloadTests` to no longer name the deleted type
+  ("These tests verify that the persisted JSON payload contains only columns, and that GridLayoutDto
+  is assembled from that payload + entity.GridKey + entity.LastModified."). No other lines touched.
+
+## Tests
+- Repo-wide grep for `GridLayoutPersistencePayload`: only remaining hit is the historical plan doc
+  `docs/superpowers/plans/2026-06-08-gridlayouts-slim-persistence-payload.md` (out of scope, expected).
+- `dotnet build Anela.Heblo.sln` (from repo root): succeeded, 0 errors, 254 pre-existing warnings
+  (none related to this change).
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GridLayouts&FullyQualifiedName!~IntegrationTests" --no-build`:
+  Passed - 35/35 (all unit tests, including `SaveGridLayoutHandlerPayloadTests`).
+- Note: `--filter FullyQualifiedName~GridLayouts` alone shows 7 additional failures in
+  `GridLayoutRepositoryUpsertIntegrationTests`, but these fail because Docker is unavailable in this
+  sandbox (Testcontainers Postgres fixture throws "Docker is either not running or misconfigured") —
+  confirmed unrelated to this change and pre-existing environment limitation, not a regression.
+
+## How to verify
+1. `grep -r "GridLayoutPersistencePayload" backend/` → no matches.
+2. `dotnet build Anela.Heblo.sln` from repo root → 0 errors.
+3. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GridLayouts&FullyQualifiedName!~IntegrationTests"` → all pass.
+4. `git show --stat HEAD` → confirms only the two intended files changed.
+
+## Notes
+Integration tests under `GridLayoutRepositoryUpsertIntegrationTests` could not be executed in this
+sandbox due to no Docker daemon being available for the Postgres Testcontainer fixture; this is an
+environmental limitation unrelated to the change (those tests don't reference the deleted type or the
+edited doc comment).
+
+## Status
+DONE

--- a/artifacts/feat-3517/review/remove-dead-grid-layout-persistence-payload.r1.md
+++ b/artifacts/feat-3517/review/remove-dead-grid-layout-persistence-payload.r1.md
@@ -1,0 +1,35 @@
+# Code Review: Remove dead GridLayoutPersistencePayload
+
+## Summary
+The commit `9947d6a` deletes the unused `GridLayoutPersistencePayload.cs` file and corrects the stale
+XML doc comment on `SaveGridLayoutHandlerPayloadTests` exactly as specified, touching only the two
+intended files. Independent verification (grep, build, targeted test run) confirms the change is
+complete, correct, and behaviorally neutral.
+
+## Review Result: PASS
+
+### task: remove-dead-grid-layout-persistence-payload
+**Status:** PASS
+
+## Docs to Update
+None.
+
+## Overall Notes
+- `git show 9947d6a --stat` confirms exactly two files changed: the deleted
+  `GridLayoutPersistencePayload.cs` (7 lines removed) and `GridLayoutHandlerTests.cs` (2 lines changed,
+  doc comment only, lines 14-18 as specified). No other lines touched — matches the "deletion only, no
+  other changes" architecture guidance.
+- `grep -rn "GridLayoutPersistencePayload" backend/` returns zero matches — acceptance criterion met.
+  A repo-wide grep shows the only remaining hits are in `docs/superpowers/plans/...` and the
+  `artifacts/feat-3517/**` pipeline artifacts (spec/arch-review/task-context/impl docs), which are
+  explicitly out of scope per the task spec.
+- The updated doc comment accurately describes the test intent without naming the deleted type:
+  "the persisted JSON payload contains only columns, and that GridLayoutDto is assembled from that
+  payload + entity.GridKey + entity.LastModified" — matches acceptance criteria wording.
+- `dotnet build Anela.Heblo.sln` succeeds with 0 errors (254 pre-existing warnings, none related to
+  this change) — reproduced independently.
+- `dotnet test ... --filter "FullyQualifiedName~GridLayouts&FullyQualifiedName!~IntegrationTests" --no-build`:
+  35/35 passed, including `SaveGridLayoutHandlerPayloadTests` — reproduced independently, no regressions.
+- Integration tests requiring Docker/Testcontainers were not run (environment limitation, consistent
+  with the impl summary); they don't reference the deleted type or edited comment, so this does not
+  affect the review outcome.

--- a/artifacts/feat-3517/spec.r1.md
+++ b/artifacts/feat-3517/spec.r1.md
@@ -1,0 +1,74 @@
+# Specification: Remove dead `GridLayoutPersistencePayload` type
+
+## Summary
+An arch-review finding identified `GridLayoutPersistencePayload.cs` in the `GridLayouts` feature as dead code: it is defined but never referenced by any production code path. This change deletes the unused file and corrects a stale doc-comment reference to it in the test suite, with no behavioral impact.
+
+## Background
+`GridLayoutPersistencePayload` is an `internal sealed record` in `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs`. A prior refactor plan (`docs/superpowers/plans/2026-06-08-gridlayouts-slim-persistence-payload.md`) proposed introducing this type as the on-disk JSON persistence shape for grid layouts, decoupling it from `GridLayoutDto`. The plan document describes `GridLayoutPersistencePayload` as "used by both save and get handlers," but the codebase as it exists today does not use it that way: the actual persistence serialization path uses `StoredGridLayout` / `StoredColumnState` via `GridLayoutStoredMapper` (`Infrastructure/GridLayoutStoredMapper.cs`), and the save/get handlers work directly with `Dictionary<string, JsonElement>`-shaped JSON, not `GridLayoutPersistencePayload`.
+
+The only trace of `GridLayoutPersistencePayload` outside its own definition file is a doc comment on the test class `SaveGridLayoutHandlerPayloadTests` in `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs`, which describes the tests as verifying properties of `GridLayoutPersistencePayload`. The tests themselves do not import, instantiate, or otherwise reference the type — they assert against parsed `JsonElement` dictionaries.
+
+Leaving an unreferenced type with the same conceptual role as `StoredGridLayout` in the codebase creates ambiguity for future readers (is it a planned replacement? a leftover from an abandoned refactor? a parallel code path?). Per YAGNI, it should be removed.
+
+## Functional Requirements
+
+### FR-1: Delete the unused `GridLayoutPersistencePayload` type
+Delete the file `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` in its entirety. This file currently contains (verified in the working tree):
+
+```csharp
+using System.Text.Json.Serialization;
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+
+namespace Anela.Heblo.Application.Features.GridLayouts;
+
+internal sealed record GridLayoutPersistencePayload(
+    [property: JsonPropertyName("columns")] List<GridColumnStateDto> Columns);
+```
+
+(Note: the type parameter is `List<GridColumnStateDto>`, not `List<StoredColumnState>` as an earlier description of this finding assumed — this does not change the disposition, since the type is unreferenced regardless of its member types.)
+
+**Acceptance criteria:**
+- The file `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` no longer exists in the repository.
+- A repository-wide search for the identifier `GridLayoutPersistencePayload` in `backend/src/**` returns zero matches.
+- `dotnet build` succeeds with no new errors or warnings introduced by the deletion.
+
+### FR-2: Correct the stale doc comment in the test file
+Update the XML doc comment on the `SaveGridLayoutHandlerPayloadTests` class in `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs` (verified at lines 14–18 in the current working tree) so it no longer references the now-deleted `GridLayoutPersistencePayload` type by name. The comment currently reads:
+
+```csharp
+/// <summary>
+/// Tests for the slim persistence payload refactor.
+/// These tests verify that GridLayoutPersistencePayload contains only columns,
+/// and that GridLayoutDto is assembled from payload + entity.GridKey + entity.LastModified.
+/// </summary>
+```
+
+The reference to `GridLayoutPersistencePayload` is on line 16. Reword lines 14–18 to describe the same test intent (that the serialized persistence JSON contains only `columns`, and that `GridLayoutDto` is assembled from the payload plus `entity.GridKey` and `entity.LastModified`) without naming the deleted type — e.g. referring to "the persisted JSON payload" or "the on-disk payload shape" instead. The test class name (`SaveGridLayoutHandlerPayloadTests`), method bodies, and assertions are unaffected — this is a comment-only edit; no test logic reference to the type was found to require updating.
+
+**Acceptance criteria:**
+- The string `GridLayoutPersistencePayload` no longer appears anywhere in `GridLayoutHandlerTests.cs`.
+- The doc comment still accurately describes what the test class verifies (slim JSON payload containing only `columns`; `GridLayoutDto` reconstructed from payload + `GridKey` + `LastModified`).
+- All existing tests in `GridLayoutHandlerTests.cs` continue to pass unmodified (no assertion or setup logic is changed).
+
+## Non-Functional Requirements
+N/A — this is a dead-code removal and comment correction with no behavioral, performance, or security surface.
+
+## Data Model
+N/A — `GridLayoutPersistencePayload` was unused; no data model, serialization contract, or storage format is affected by its removal. The active persistence shape (`StoredGridLayout` / `StoredColumnState`, mapped via `GridLayoutStoredMapper`) is unchanged.
+
+## API / Interface Design
+N/A — the type is `internal` and was never exposed via any public API, controller, or MediatR contract.
+
+## Dependencies
+N/A — no other production files reference `GridLayoutPersistencePayload`. The stale plan document `docs/superpowers/plans/2026-06-08-gridlayouts-slim-persistence-payload.md` also mentions the type extensively, but historical plan documents are not in scope for this change and should not be edited.
+
+## Out of Scope
+- Any change to the actual persistence path (`StoredGridLayout`, `StoredColumnState`, `GridLayoutStoredMapper`).
+- Any change to test assertions or behavior in `GridLayoutHandlerTests.cs` beyond the doc comment wording.
+- Editing or removing the historical plan document `docs/superpowers/plans/2026-06-08-gridlayouts-slim-persistence-payload.md`.
+- Any broader refactor of the `GridLayouts` feature's persistence contracts.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3517",
+  "issue_number": 3517,
+  "created_at": "2026-07-07T05:15:02.713473Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-07T05:17:01.716611Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-07T05:17:26.167326Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T05:19:13.583833Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T05:20:26.391843Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T05:20:39.654592Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T05:27:37.242396Z"
     }
   },
   "tasks": [
     {
       "name": "remove-dead-grid-layout-persistence-payload",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-07T05:20:39.970061Z"
+      "updated_at": "2026-07-07T05:27:32.198436Z"
     }
   ]
 }

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -6,7 +6,7 @@
   "phases": {
     "analyzing": {
       "status": "completed",
-      "updated_at": "2026-07-07T05:17:01.716611Z"
+      "updated_at": "2026-07-07T05:17:26.167326Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-07T05:19:44.756436Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T05:20:26.391843Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "remove-dead-grid-layout-persistence-payload",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T05:20:26.391843Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T05:20:39.654592Z"
     }
   },
   "tasks": [
     {
       "name": "remove-dead-grid-layout-persistence-payload",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-07T05:20:39.970061Z"
     }
   ]
 }

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-07T05:27:37.242396Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-07T05:27:41.963459Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3517/state.json
+++ b/artifacts/feat-3517/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-07T05:19:13.583833Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T05:19:44.756436Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3517/task-context/remove-dead-grid-layout-persistence-payload.md
+++ b/artifacts/feat-3517/task-context/remove-dead-grid-layout-persistence-payload.md
@@ -1,0 +1,68 @@
+### task: remove-dead-grid-layout-persistence-payload
+
+**Goal:** Delete the unused `GridLayoutPersistencePayload` type and correct the stale doc comment
+that references it, with no behavioral change to the `GridLayouts` feature.
+
+**Context (from spec.r1.md / arch-review.r1.md):**
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` defines
+  an `internal sealed record GridLayoutPersistencePayload(List<GridColumnStateDto> Columns)` that is
+  never referenced anywhere in production code. The active persistence path is
+  `StoredGridLayout`/`StoredColumnState` via `GridLayoutStoredMapper`
+  (`Features/GridLayouts/Infrastructure/GridLayoutStoredMapper.cs`), which is untouched by this change.
+- The only other reference to the type's name in the repo is a stale XML doc comment (lines 14–18) on
+  `SaveGridLayoutHandlerPayloadTests` in
+  `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs`. This was confirmed
+  by reading the file directly — the comment reads:
+  ```csharp
+  /// <summary>
+  /// Tests for the slim persistence payload refactor.
+  /// These tests verify that GridLayoutPersistencePayload contains only columns,
+  /// and that GridLayoutDto is assembled from payload + entity.GridKey + entity.LastModified.
+  /// </summary>
+  ```
+  The test bodies themselves assert against `JsonSerializer.Deserialize<Dictionary<string, JsonElement>>`
+  and do not reference the type — this is a comment-only fix.
+- Out of scope (per spec): any change to `StoredGridLayout`, `StoredColumnState`,
+  `GridLayoutStoredMapper`, any test assertion/logic, or the historical plan document
+  `docs/superpowers/plans/2026-06-08-gridlayouts-slim-persistence-payload.md`.
+
+**Files to create/modify:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs` (doc comment
+  on `SaveGridLayoutHandlerPayloadTests`, lines 14–18 only)
+
+**Implementation steps:**
+1. Delete the file `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs`
+   in its entirety (e.g. `git rm`).
+2. In `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs`, replace the XML
+   doc comment on `SaveGridLayoutHandlerPayloadTests` (currently lines 14–18) with wording that keeps
+   the same intent but does not name the deleted type, e.g.:
+   ```csharp
+   /// <summary>
+   /// Tests for the slim persistence payload refactor.
+   /// These tests verify that the persisted JSON payload contains only columns,
+   /// and that GridLayoutDto is assembled from that payload + entity.GridKey + entity.LastModified.
+   /// </summary>
+   ```
+   Do not touch any other lines in this file — no method bodies, assertions, setup code, or the class
+   name change.
+3. Run a repository-wide search for the identifier `GridLayoutPersistencePayload` under `backend/`
+   (excluding `docs/`) to confirm zero remaining references outside the historical plan document.
+4. Build the backend solution and run the `GridLayouts` test suite to confirm no regressions.
+
+**Tests to write:**
+- No new tests are required — this is a dead-code deletion and comment-only edit with no behavioral
+  change (per spec FR-1/FR-2 acceptance criteria).
+- Existing tests in `GridLayoutHandlerTests.cs` must continue to pass unmodified; do not alter any
+  assertion or setup logic while editing the doc comment.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` no longer
+  exists in the repository.
+- A repository-wide search for `GridLayoutPersistencePayload` under `backend/**` returns zero matches.
+- The string `GridLayoutPersistencePayload` no longer appears anywhere in `GridLayoutHandlerTests.cs`.
+- The updated doc comment still accurately describes the test class's intent (persisted JSON payload
+  contains only `columns`; `GridLayoutDto` is assembled from that payload plus `entity.GridKey` and
+  `entity.LastModified`).
+- `dotnet build` succeeds with no new errors or warnings introduced by the deletion.
+- All tests in `GridLayoutHandlerTests.cs` (and the broader `GridLayouts` test suite) pass unmodified.

--- a/artifacts/feat-3517/task-plan.r1.md
+++ b/artifacts/feat-3517/task-plan.r1.md
@@ -1,0 +1,78 @@
+# Task Plan: Remove dead `GridLayoutPersistencePayload` type
+
+## Overview
+This is a small, self-contained dead-code removal identified by the arch review: delete an unused
+internal record and correct a stale doc comment that names it. Both the spec (`spec.r1.md`) and the
+arch review (`arch-review.r1.md`, `Skip Design: true`) agree there is a single unit of work with no
+architectural decisions left to make. A single task is appropriate — do not split further.
+
+---
+
+### task: remove-dead-grid-layout-persistence-payload
+
+**Goal:** Delete the unused `GridLayoutPersistencePayload` type and correct the stale doc comment
+that references it, with no behavioral change to the `GridLayouts` feature.
+
+**Context (from spec.r1.md / arch-review.r1.md):**
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` defines
+  an `internal sealed record GridLayoutPersistencePayload(List<GridColumnStateDto> Columns)` that is
+  never referenced anywhere in production code. The active persistence path is
+  `StoredGridLayout`/`StoredColumnState` via `GridLayoutStoredMapper`
+  (`Features/GridLayouts/Infrastructure/GridLayoutStoredMapper.cs`), which is untouched by this change.
+- The only other reference to the type's name in the repo is a stale XML doc comment (lines 14–18) on
+  `SaveGridLayoutHandlerPayloadTests` in
+  `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs`. This was confirmed
+  by reading the file directly — the comment reads:
+  ```csharp
+  /// <summary>
+  /// Tests for the slim persistence payload refactor.
+  /// These tests verify that GridLayoutPersistencePayload contains only columns,
+  /// and that GridLayoutDto is assembled from payload + entity.GridKey + entity.LastModified.
+  /// </summary>
+  ```
+  The test bodies themselves assert against `JsonSerializer.Deserialize<Dictionary<string, JsonElement>>`
+  and do not reference the type — this is a comment-only fix.
+- Out of scope (per spec): any change to `StoredGridLayout`, `StoredColumnState`,
+  `GridLayoutStoredMapper`, any test assertion/logic, or the historical plan document
+  `docs/superpowers/plans/2026-06-08-gridlayouts-slim-persistence-payload.md`.
+
+**Files to create/modify:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs` (doc comment
+  on `SaveGridLayoutHandlerPayloadTests`, lines 14–18 only)
+
+**Implementation steps:**
+1. Delete the file `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs`
+   in its entirety (e.g. `git rm`).
+2. In `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs`, replace the XML
+   doc comment on `SaveGridLayoutHandlerPayloadTests` (currently lines 14–18) with wording that keeps
+   the same intent but does not name the deleted type, e.g.:
+   ```csharp
+   /// <summary>
+   /// Tests for the slim persistence payload refactor.
+   /// These tests verify that the persisted JSON payload contains only columns,
+   /// and that GridLayoutDto is assembled from that payload + entity.GridKey + entity.LastModified.
+   /// </summary>
+   ```
+   Do not touch any other lines in this file — no method bodies, assertions, setup code, or the class
+   name change.
+3. Run a repository-wide search for the identifier `GridLayoutPersistencePayload` under `backend/`
+   (excluding `docs/`) to confirm zero remaining references outside the historical plan document.
+4. Build the backend solution and run the `GridLayouts` test suite to confirm no regressions.
+
+**Tests to write:**
+- No new tests are required — this is a dead-code deletion and comment-only edit with no behavioral
+  change (per spec FR-1/FR-2 acceptance criteria).
+- Existing tests in `GridLayoutHandlerTests.cs` must continue to pass unmodified; do not alter any
+  assertion or setup logic while editing the doc comment.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` no longer
+  exists in the repository.
+- A repository-wide search for `GridLayoutPersistencePayload` under `backend/**` returns zero matches.
+- The string `GridLayoutPersistencePayload` no longer appears anywhere in `GridLayoutHandlerTests.cs`.
+- The updated doc comment still accurately describes the test class's intent (persisted JSON payload
+  contains only `columns`; `GridLayoutDto` is assembled from that payload plus `entity.GridKey` and
+  `entity.LastModified`).
+- `dotnet build` succeeds with no new errors or warnings introduced by the deletion.
+- All tests in `GridLayoutHandlerTests.cs` (and the broader `GridLayouts` test suite) pass unmodified.

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs
@@ -1,7 +1,0 @@
-using System.Text.Json.Serialization;
-using Anela.Heblo.Application.Features.GridLayouts.Contracts;
-
-namespace Anela.Heblo.Application.Features.GridLayouts;
-
-internal sealed record GridLayoutPersistencePayload(
-    [property: JsonPropertyName("columns")] List<GridColumnStateDto> Columns);

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GridLayoutHandlerTests.cs
@@ -13,8 +13,8 @@ namespace Anela.Heblo.Tests.Features.GridLayouts;
 
 /// <summary>
 /// Tests for the slim persistence payload refactor.
-/// These tests verify that GridLayoutPersistencePayload contains only columns,
-/// and that GridLayoutDto is assembled from payload + entity.GridKey + entity.LastModified.
+/// These tests verify that the persisted JSON payload contains only columns,
+/// and that GridLayoutDto is assembled from that payload + entity.GridKey + entity.LastModified.
 /// </summary>
 public class SaveGridLayoutHandlerPayloadTests
 {


### PR DESCRIPTION
Closes #3517

## What the issue was
`backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutPersistencePayload.cs` defined an `internal sealed record GridLayoutPersistencePayload` that was never referenced anywhere in production code. The actual persistence serialization path uses `StoredGridLayout` / `StoredColumnState` via `GridLayoutStoredMapper`. The only other mention of the type was a stale XML doc comment on `SaveGridLayoutHandlerPayloadTests` in `GridLayoutHandlerTests.cs`, which described tests in terms of the now-nonexistent type.

## How it was fixed / handled
- Deleted `GridLayoutPersistencePayload.cs` in its entirety.
- Reworded the doc comment on `SaveGridLayoutHandlerPayloadTests` so it describes the test intent (persisted JSON payload contains only `columns`; `GridLayoutDto` assembled from that payload + `entity.GridKey` + `entity.LastModified`) without naming the deleted type. No test logic/assertions were touched.
- Confirmed via repo-wide grep that `GridLayoutPersistencePayload` has zero remaining references outside the historical plan doc under `docs/`.
- `dotnet build` succeeds with 0 errors; all 35 `GridLayouts` unit tests pass unmodified.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3517/` in this branch.

## Code review

The pipeline's whole-branch code review came back **CLEAN** — no correctness findings, no advisory cleanups. Full report in `artifacts/feat-3517/code-review.r1.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz2ajz77jKBoqWQai1YfKC)_