### PR TITLE
#3521: implementation

### DIFF
--- a/artifacts/feat-3521/arch-review.r1.md
+++ b/artifacts/feat-3521/arch-review.r1.md
@@ -1,0 +1,105 @@
+# Architecture Review: InvoiceClassification ADR-005 Identity-Resolution Fix
+
+## Skip Design: true
+
+No UI, contract (`Contracts/`), controller, or HTTP-facing type changes. `IInvoiceClassificationService` is an internal application-layer interface not exposed via OpenAPI; `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse` (the public MediatR contract) are explicitly unchanged per the spec. This is a pure internal signature change plus a call-site move, confirmed against both the spec's "API / Interface Design" section and the actual code below.
+
+## Architectural Fit Assessment
+
+This is a textbook ADR-005 convergence fix, not a new pattern. The codebase already has two correct reference implementations in the same module — `CreateClassificationRuleHandler` and `UpdateClassificationRuleHandler` — both of which inject `ICurrentUserService`, call `GetCurrentUser()` once in `Handle`, and pass `currentUser.Name` down into domain/service calls. `ClassifyInvoicesHandler` and `InvoiceClassificationService` are the only two files in this vertical slice that deviate from that shape.
+
+Verified in code:
+- `InvoiceClassificationService.cs:13,21,28,34` — constructor takes `ICurrentUserService currentUserService`, and `ClassifyInvoiceAsync` (line 34) calls `_currentUserService.GetCurrentUser()` once per invoice, inside the service.
+- `ClassifyInvoicesHandler.cs` — no `ICurrentUserService` dependency at all today; `Handle` calls `_classificationService.ClassifyInvoiceAsync(invoice)` per invoice in a `foreach` loop (line 72) with no identity passed.
+- `InvoiceClassificationJob.cs` sends `ClassifyInvoicesRequest` via `IMediator` on an hourly cron (`"0 * * * *"`) with no HTTP request in flight, confirming the runtime-bug half of the finding.
+- `InvoiceClassificationModule.cs` registers `IInvoiceClassificationService` but never registers `ICurrentUserService` itself (it's registered once, module-wide, by `UsersModule.AddUsersModule()` at the API composition root) — so removing the dependency from `InvoiceClassificationService` requires no DI registration change in this module, only removal of the constructor parameter.
+
+No new components, no new module boundaries, no schema changes. The fix is a mechanical application of an already-accepted, already-precedented pattern.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before:
+  ClassifyInvoicesHandler.Handle
+      └─> IInvoiceClassificationService.ClassifyInvoiceAsync(invoice)
+              └─> ICurrentUserService.GetCurrentUser()   [WRONG LAYER: called from job with no HttpContext]
+              └─> RecordClassificationHistory(..., currentUser.Name)
+
+After:
+  ClassifyInvoicesHandler.Handle
+      ├─> ICurrentUserService.GetCurrentUser()           [resolved ONCE, in the handler]
+      ├─> compute processedBy ("system" if unauthenticated, else Name)
+      └─> IInvoiceClassificationService.ClassifyInvoiceAsync(invoice, processedBy)   [per invoice, in the loop]
+              └─> RecordClassificationHistory(..., processedBy)
+```
+
+This mirrors `CreateClassificationRuleHandler.Handle` / `UpdateClassificationRuleHandler.Handle`, which resolve `currentUser` once at the top of `Handle` and pass `currentUser.Name` into the domain call.
+
+### Key Design Decisions
+
+#### Decision 1: Resolve identity once per `Handle` call, not per invoice
+**Options considered:**
+- (a) Resolve `GetCurrentUser()` inside the `foreach` loop, once per invoice.
+- (b) Resolve it once before the loop and reuse the same value for every invoice in the batch.
+
+**Chosen approach:** (b), per spec FR-3.
+
+**Rationale:** The caller identity cannot change mid-`Handle` (it's fixed by the inbound HTTP request or the fact that there is none). Resolving once avoids redundant `IHttpContextAccessor`/claims-chain work per invoice and matches the existing single-resolution pattern in `CreateClassificationRuleHandler`/`UpdateClassificationRuleHandler`. It's also a net reduction in `ICurrentUserService` calls versus today (was 1/invoice inside the service; becomes 1/batch inside the handler).
+
+#### Decision 2: Explicit `processedBy` parameter vs. threading identity through the request DTO
+**Options considered:**
+- (a) Add a `CallerName`/`ProcessedBy` field to `ClassifyInvoicesRequest` and have `InvoiceClassificationJob`/controllers populate it.
+- (b) Keep `ClassifyInvoicesRequest` untouched; resolve identity fully inside `ClassifyInvoicesHandler.Handle` via DI, and pass the resolved string as an explicit method parameter to `IInvoiceClassificationService.ClassifyInvoiceAsync`.
+
+**Chosen approach:** (b), per spec FR-1/FR-3 and the "API / Interface Design" section.
+
+**Rationale:** Option (a) would violate ADR-005's spoofing-hole rule ("Request DTOs must not carry client-settable `UserId`/`ModifiedBy`") and would force `InvoiceClassificationJob` to know about identity resolution, which it correctly does not today. The handler already has direct DI access to `ICurrentUserService`; there is no reason to route identity through the MediatR request payload.
+
+#### Decision 3: Fallback string for unauthenticated/background callers
+**Options considered:**
+- (a) Let `ProcessedBy` be empty/null when there's no HTTP context (today's de facto behavior, modulo the "Anonymous" string produced by `CurrentUserService`'s null-`HttpContext` fallback).
+- (b) Use a fixed literal `"system"` whenever `IsAuthenticated == false`, and also fall back to `"system"` if `IsAuthenticated == true` but `Name` is unexpectedly empty.
+
+**Chosen approach:** (b), per spec FR-3.
+
+**Rationale:** `"system"` is self-describing in audit history (distinguishes automated runs from a blank/misleading "Anonymous"), and the double fallback (`IsAuthenticated == true` + empty `Name`) closes a latent null-string edge case that would otherwise resurface as a future arch-review finding. This is a value/interface-layer decision, not an architectural one — flagged here only because it affects the `IInvoiceClassificationService` contract's implicit guarantee ("caller always gets a non-empty `processedBy`").
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files or folders. All changes are edits to existing files, all within the `InvoiceClassification` module:
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/IInvoiceClassificationService.cs` — signature change.
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs` — remove `ICurrentUserService` field/ctor param/call; use the new `processedBy` parameter at all four `RecordClassificationHistory` call sites (lines 44-45, 60-61, 74-75, 89-90).
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs` — add `ICurrentUserService` ctor param; resolve `currentUser`/`processedBy` once before the `foreach` (before line 68); pass `processedBy` into the `ClassifyInvoiceAsync` call (line 72).
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs` — no change expected (confirmed: it does not register `ICurrentUserService` today, so nothing to remove there); verify at implementation time that this stays true.
+- Test files: `InvoiceClassificationServiceTests` and `ClassifyInvoicesHandlerTests` (exact paths under `backend/test/Anela.Heblo.Tests/...InvoiceClassification/...` — not read in this review; locate via the existing test project structure mirrored from `Application/Features/InvoiceClassification`).
+
+### Interfaces and Contracts
+```csharp
+// IInvoiceClassificationService.cs — changed
+Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy);
+```
+No other public interface changes. `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse` (the MediatR contract used by controllers and `InvoiceClassificationJob`) are unchanged — confirmed no controller or job code needs to change.
+
+### Data Flow
+1. HTTP request (authenticated) or `InvoiceClassificationJob` (hourly, unauthenticated) → `IMediator.Send(ClassifyInvoicesRequest)`.
+2. `ClassifyInvoicesHandler.Handle` resolves `currentUser = _currentUserService.GetCurrentUser()` exactly once.
+3. Handler computes `processedBy`: `currentUser.IsAuthenticated ? (currentUser.Name ?? "system") : "system"`.
+4. For each invoice in the batch, handler calls `_classificationService.ClassifyInvoiceAsync(invoice, processedBy)` — same `processedBy` value for every invoice in the run.
+5. `InvoiceClassificationService.ClassifyInvoiceAsync` uses the passed-in `processedBy` at all four `RecordClassificationHistory` call sites (no-match, success, ABRA-failure, exception-catch branches) — no other logic changes.
+6. `ClassificationHistory.ProcessedBy` is persisted with either the real authenticated user's name or the literal `"system"`.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missed call site: one of the four `RecordClassificationHistory` calls in `InvoiceClassificationService` still references a removed `currentUser` variable, causing a compile error (not a silent bug, since it won't build) | Low | Compile immediately after edit; `dotnet build` will catch any stale reference — no `currentUser` local should remain in the file. |
+| Existing unit tests fail to compile because `ClassifyInvoicesHandlerTests`/`InvoiceClassificationServiceTests` construct the handlers/services with the old constructor signatures | Medium | Update both test files in the same change per spec FR-4; this is required for the build to pass, not optional follow-up. |
+| Historical `ClassificationHistory` rows already have `ProcessedBy = "Anonymous"` from prior scheduled runs, and a reviewer might expect a backfill | Low | Explicitly out of scope per spec — no data migration needed; call this out in the PR description so it isn't mistaken for a partial fix. |
+
+## Specification Amendments
+None. The specification is implementation-ready as written: FR-1 through FR-4 fully cover the interface change, the dependency removal, the handler-side resolution, and the required test updates, and they match the actual code read during this review (line numbers, call-site count, module registration state, and the `CurrentUser` record shape — `Id`/`Name`/`Email`/`IsAuthenticated` — all verified).
+
+## Prerequisites
+None. No migrations, no config, no infrastructure changes, no other module needs to change first. This can be implemented directly against `main`/the current branch.

--- a/artifacts/feat-3521/brief.md
+++ b/artifacts/feat-3521/brief.md
@@ -1,0 +1,26 @@
+# Issue #3521: [arch-review] InvoiceClassification: InvoiceClassificationService resolves user identity, causing a latent bug in the scheduled job (ADR-005 violation)
+
+## Module
+InvoiceClassification
+
+## Finding
+`InvoiceClassificationService` injects `ICurrentUserService` and calls `_currentUserService.GetCurrentUser()` at line 34 of `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs` to populate the `processedBy` field in classification history records.
+
+ADR-005 mandates that user identity is resolved **inside MediatR handlers**, not in application services. The `ClassifyInvoicesHandler` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`) is the correct location for identity resolution — it currently delegates to `IInvoiceClassificationService` without passing a caller identity.
+
+Beyond the architectural violation, this creates a concrete runtime bug: `InvoiceClassificationJob` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Infrastructure/Jobs/InvoiceClassificationJob.cs`) triggers `ClassifyInvoicesHandler` on a schedule, with no HTTP request context. `ICurrentUserService` depends on `IHttpContextAccessor`; called from a background thread, `HttpContext` is `null`, so either the service throws or returns empty/null user data, meaning every scheduled classification run records an empty `ProcessedBy` in history.
+
+## Why it matters
+- Violates ADR-005 (accepted decision: identity in handlers only).
+- Produces silent data corruption: history records written by the hourly job will have `ProcessedBy = ""` (or throw), making audit history unreliable for automated runs.
+- `IInvoiceClassificationService`'s dependency on `ICurrentUserService` is invisible to callers — nothing in the interface signature indicates that an HTTP context is required.
+
+## Suggested fix
+1. Add a `string processedBy` parameter to `IInvoiceClassificationService.ClassifyInvoiceAsync` (and the concrete implementation).
+2. In `ClassifyInvoicesHandler.Handle`, resolve identity via injected `ICurrentUserService` and pass `currentUser.Name` (or `"system"` when `currentUser` is anonymous/null) to `ClassifyInvoiceAsync`.
+3. Remove `ICurrentUserService` from `InvoiceClassificationService`'s constructor and the DI registration.
+
+This is the same pattern already used correctly in `CreateClassificationRuleHandler` and `UpdateClassificationRuleHandler`.
+
+---
+_Filed by daily arch-review routine on 2026-07-07._

--- a/artifacts/feat-3521/code-review.r1.md
+++ b/artifacts/feat-3521/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs:73-75` — This inline `IsAuthenticated ? (Name-or-fallback) : "system"` ternary duplicates the intent of the existing `CurrentUser.GetDisplayName()` extension (`backend/src/Anela.Heblo.Domain/Features/Users/CurrentUserExtensions.cs`), which is already used by several other handlers (e.g. `UpdateManufactureOrderStatusHandler`, `DuplicateManufactureOrderHandler`) for the same "resolve a display name for an audit field" purpose. It can't be swapped in as-is because `GetDisplayName()` returns `"System"`/`"Unknown User"` rather than the lowercase `"system"` this spec and its tests require, so this isn't a drop-in duplicate — but the divergence in fallback casing/wording between two near-identical "who performed this action" helpers is worth a follow-up (e.g. reconciling `GetDisplayName()` to use `"system"` everywhere, or documenting why `InvoiceClassification` needs a different convention) rather than leaving two parallel conventions in the codebase.

--- a/artifacts/feat-3521/design.r1.md
+++ b/artifacts/feat-3521/design.r1.md
@@ -1,0 +1,23 @@
+# Design: Move user-identity resolution out of InvoiceClassificationService (ADR-005 compliance)
+
+## Component Design
+
+**`IInvoiceClassificationService` / `InvoiceClassificationService`**
+- Signature change: `ClassifyInvoiceAsync(ReceivedInvoice invoice)` → `ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)`.
+- Service becomes context-agnostic: no `ICurrentUserService` field, constructor parameter, or `GetCurrentUser()` call. The caller-supplied `processedBy` is used verbatim at all four existing `RecordClassificationHistory` call sites (no-match, success, ABRA-update-failure, catch block). No other logic changes.
+
+**`ClassifyInvoicesHandler`**
+- Identity resolution moves here, per ADR-005 (MediatR handlers are the only layer allowed to consume `ICurrentUserService`). New constructor dependency on `ICurrentUserService`, mirroring `CreateClassificationRuleHandler` / `UpdateClassificationRuleHandler`.
+- `Handle` calls `_currentUserService.GetCurrentUser()` exactly once (before the `foreach`, not per invoice) and derives:
+  - `processedBy = currentUser.IsAuthenticated ? (currentUser.Name is not null/empty ? currentUser.Name : "system") : "system"`
+- The same `processedBy` value is passed into every `_classificationService.ClassifyInvoiceAsync(invoice, processedBy)` call within the batch.
+
+**Callers unaffected**: `InvoiceClassificationJob` (hourly, no HTTP context) and any controller triggering `ClassifyInvoicesRequest` require no changes — they only interact with the unchanged `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse` MediatR contract; the handler resolves identity internally via DI.
+
+## Data Schemas
+
+No schema or contract changes.
+- `ClassificationHistory.ProcessedBy` — existing `string` column/property, unchanged shape. Only the source of the value changes (handler-resolved string instead of a service-internal lookup); scheduled-job runs now write `"system"` instead of the misleading `"Anonymous"`.
+- `ClassifyInvoicesRequest` / `ClassifyInvoicesResponse` (public MediatR contract) — unchanged.
+- `IInvoiceClassificationService.ClassifyInvoiceAsync` — internal application-layer interface, not exposed via HTTP/OpenAPI; no client regeneration needed.
+- No database migration required.

--- a/artifacts/feat-3521/impl/move-identity-resolution-to-classify-invoices-handler.r1.md
+++ b/artifacts/feat-3521/impl/move-identity-resolution-to-classify-invoices-handler.r1.md
@@ -1,0 +1,37 @@
+# Implementation: move-identity-resolution-to-classify-invoices-handler
+
+## What was implemented
+Moved `ICurrentUserService` resolution out of `InvoiceClassificationService` and into `ClassifyInvoicesHandler`, per ADR-005 (identity resolution belongs in MediatR handlers, not application services). `IInvoiceClassificationService.ClassifyInvoiceAsync` now takes an explicit `string processedBy` parameter instead of resolving the current user internally. `ClassifyInvoicesHandler` now injects `ICurrentUserService`, resolves identity exactly once per `Handle` invocation before the `foreach` loop, applies the fallback rule (`IsAuthenticated` false, or `Name` null/empty, → `"system"`; otherwise `currentUser.Name`), and passes that single `processedBy` value into every `ClassifyInvoiceAsync` call in the batch. This fixes the latent bug where the hourly scheduled `InvoiceClassificationJob` (no HTTP context) previously wrote `ProcessedBy = "Anonymous"` into classification history.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/IInvoiceClassificationService.cs` — changed `ClassifyInvoiceAsync(ReceivedInvoice invoice)` signature to `ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)`.
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs` — removed `ICurrentUserService _currentUserService` field, constructor parameter, and the `using Anela.Heblo.Domain.Features.Users;` import; removed the internal `GetCurrentUser()` call; all four `RecordClassificationHistory` call sites now use the `processedBy` parameter instead of `currentUser.Name`.
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs` — added `ICurrentUserService` field/constructor parameter (after `IClassificationRuleRepository`, before `logger`) and `using Anela.Heblo.Domain.Features.Users;`; resolves `currentUser`/`processedBy` once before the `foreach` loop using the specified fallback rule; passes `processedBy` into `ClassifyInvoiceAsync`.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs` — removed `Mock<ICurrentUserService>` field/usage and the `Anela.Heblo.Domain.Features.Users` import; each of the four tests now defines an explicit `processedBy` literal, calls `ClassifyInvoiceAsync(invoice, processedBy)`, and asserts `capturedHistory.ProcessedBy.Should().Be(processedBy)`.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs` — added `Mock<ICurrentUserService>` field wired into the handler constructor (with a default authenticated `"test-user"` setup applied in the test constructor so the three pre-existing tests keep passing unmodified in behavior); updated the three existing `ClassifyInvoiceAsync` mock setups to the two-argument overload; added two new tests: `Handle_WhenCurrentUserIsUnauthenticated_PassesSystemAsProcessedBy` and `Handle_WhenCurrentUserIsAuthenticated_PassesUserNameAsProcessedBy`, verifying the `"system"` fallback and the authenticated `"jane.doe"` pass-through respectively.
+
+`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs` was verified (not modified) — it registers `IInvoiceClassificationService`, `IRuleEvaluationEngine`, repositories, and rule implementations only; no `ICurrentUserService` registration existed or was needed there.
+
+## Tests
+- `InvoiceClassificationServiceTests.cs` — all 4 tests updated and passing (no-match, ABRA success, ABRA failure, exception-thrown paths), asserting `ProcessedBy` equals the explicitly passed-in value.
+- `ClassifyInvoicesHandlerTests.cs` — 3 pre-existing tests (parallel fetch, missing-invoice error counting, batch-mode fetch) updated to the new two-arg mock signature; 2 new tests added covering the unauthenticated (`"system"`) and authenticated (`currentUser.Name`) identity-resolution paths.
+
+## How to verify
+```
+cd backend
+dotnet build Anela.Heblo.sln
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"
+dotnet test Anela.Heblo.sln   # full suite
+dotnet format Anela.Heblo.sln --verify-no-changes
+```
+Build: 0 errors (250 pre-existing warnings, unrelated to this change).
+Scoped test run: 88/88 InvoiceClassification tests passed.
+Full suite: 5416 passed, 64 failed, 4 skipped — all 64 failures are pre-existing `Docker is either not running or misconfigured` Testcontainers errors (Leaflet/Article persistence integration tests requiring a Postgres container), unrelated to this change and present regardless of it; no InvoiceClassification test failed.
+`dotnet format --verify-no-changes` on the touched files: clean, no formatting changes needed.
+
+## Notes
+- Kept a default `GetCurrentUser()` setup in the `ClassifyInvoicesHandlerTests` constructor (returns an authenticated `"test-user"`) rather than duplicating an identical setup into each of the three pre-existing tests individually — functionally equivalent to what the task context describes, just centralized to avoid repetition, and it does not weaken the new dedicated tests which each override the setup explicitly for their scenario.
+- `artifacts/feat-3521/state.json` had an unstaged modification (pipeline bookkeeping, updated by the orchestrator to `in_progress`) that was present in the working tree but was deliberately left out of the commit per the instruction not to touch anything under `artifacts/`.
+
+## Status
+DONE

--- a/artifacts/feat-3521/review/move-identity-resolution-to-classify-invoices-handler.r1.md
+++ b/artifacts/feat-3521/review/move-identity-resolution-to-classify-invoices-handler.r1.md
@@ -1,0 +1,23 @@
+# Code Review: move-identity-resolution-to-classify-invoices-handler
+
+## Summary
+The implementation exactly matches the task spec: `ICurrentUserService` resolution was removed from `InvoiceClassificationService` and moved into `ClassifyInvoicesHandler`, with `processedBy` now an explicit parameter threaded through all four `RecordClassificationHistory` call sites. Verified directly against the diff (commit `d4eef9f`), the current file contents, and a live `dotnet build` + scoped `dotnet test` run — build succeeds with 0 errors and all 88 InvoiceClassification tests pass.
+
+## Review Result: PASS
+
+### task: move-identity-resolution-to-classify-invoices-handler
+**Status:** PASS
+
+## Docs to Update
+No documentation changes required. This is an internal bugfix to an existing, undocumented-in-detail identity-resolution flow (ADR-005 already codifies the "resolve identity in handlers, not services" pattern per `docs/architecture/development_guidelines.md`); no new public behavior, endpoint, or operational concept was introduced, and `InvoiceClassificationModule.cs` DI registration is unchanged.
+
+## Overall Notes
+Verification performed beyond reading the summaries:
+- `IInvoiceClassificationService.cs`: signature is now `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)` — matches FR-1.
+- `InvoiceClassificationService.cs`: `ICurrentUserService` field, constructor parameter, `using Anela.Heblo.Domain.Features.Users;`, and the internal `GetCurrentUser()` call are all gone (confirmed via `grep`); all four `RecordClassificationHistory` calls (no-match, success, ABRA-failure, catch block) now pass the `processedBy` parameter — matches FR-2.
+- `ClassifyInvoicesHandler.cs`: `ICurrentUserService` injected in the correct parameter position (after `IClassificationRuleRepository`, before `logger`); `Handle` resolves `currentUser`/`processedBy` exactly once, immediately after `response.TotalInvoicesProcessed = invoicesToClassify.Count;` and before the `foreach` loop, using the exact fallback expression from the task context (`IsAuthenticated ? (string.IsNullOrEmpty(Name) ? "system" : Name) : "system"`); the same `processedBy` value is passed into every `ClassifyInvoiceAsync` call in the batch — matches FR-3.
+- Test coverage: `InvoiceClassificationServiceTests.cs` updated across all 4 tests to pass an explicit `processedBy` literal and assert `ProcessedBy` equals it (no more `ICurrentUserService` mock). `ClassifyInvoicesHandlerTests.cs` adds `Handle_WhenCurrentUserIsUnauthenticated_PassesSystemAsProcessedBy` (verifies `"system"` fallback for `IsAuthenticated == false`) and `Handle_WhenCurrentUserIsAuthenticated_PassesUserNameAsProcessedBy` (verifies `currentUser.Name` pass-through, e.g. `"jane.doe"`) — both the authenticated and unauthenticated/background-job paths are covered, satisfying FR-4.
+- `InvoiceClassificationModule.cs` was confirmed unchanged and still has no `ICurrentUserService` registration, as expected (it's registered at the composition root).
+- Ran `dotnet build Anela.Heblo.sln` from repo root: 0 errors, 250 warnings (pre-existing, unrelated to this change — consistent with the impl summary's claim).
+- Ran `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"`: 88/88 passed, confirming the impl summary's scoped test-run claim.
+- No stray references to `currentUser`/`_currentUserService`/`ICurrentUserService` remain in `InvoiceClassificationService.cs`.

--- a/artifacts/feat-3521/spec.r1.md
+++ b/artifacts/feat-3521/spec.r1.md
@@ -1,0 +1,93 @@
+# Specification: Move user-identity resolution out of InvoiceClassificationService (ADR-005 compliance)
+
+## Summary
+`InvoiceClassificationService` currently resolves the caller's identity itself (via `ICurrentUserService`) to stamp `ProcessedBy` on classification history records. This violates ADR-005, which mandates that identity resolution happens only inside MediatR handlers, and it causes the hourly `InvoiceClassificationJob` — which runs with no HTTP context — to write history records with a misleading `ProcessedBy` value instead of a real caller name. This spec moves identity resolution into `ClassifyInvoicesHandler` and makes `ProcessedBy` an explicit, required input to the service.
+
+## Background
+`ClassifyInvoicesHandler.Handle` calls `IInvoiceClassificationService.ClassifyInvoiceAsync(invoice)` for each invoice. Inside that service, `ClassifyInvoiceAsync` calls `_currentUserService.GetCurrentUser()` (line 34 of `InvoiceClassificationService.cs`) purely to obtain a display name for the `processedBy` field passed into `RecordClassificationHistory`.
+
+Two problems result:
+1. **Architectural**: `ICurrentUserService` is an HTTP-request-scoped concern. ADR-005 requires it be consumed only in MediatR handlers, not in application services further down the call stack, so that services remain context-agnostic and testable without HTTP concerns. `CreateClassificationRuleHandler` and `UpdateClassificationRuleHandler` already follow the correct pattern (resolve `currentUser` in the handler, pass the resolved name into the aggregate/service call).
+2. **Runtime bug**: `InvoiceClassificationJob` is a scheduled `IRecurringJob` invoked hourly by the job scheduler, with no HTTP request in flight. It calls `_mediator.Send(new ClassifyInvoicesRequest(...))`, which reaches `ClassifyInvoicesHandler` and then `InvoiceClassificationService.ClassifyInvoiceAsync`. At that point `IHttpContextAccessor.HttpContext` is `null`. Per the concrete `CurrentUserService.GetCurrentUser()` implementation (`backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs`), a null `HttpContext` does not throw — it falls through to `user = null`, `isAuthenticated = false`, and `name = "Anonymous"`. So in practice every hourly job run writes `ClassificationHistory.ProcessedBy = "Anonymous"` rather than throwing or leaving it empty; the brief's characterization of the symptom (empty/throwing) does not exactly match the current fallback string, but the underlying defect — audit history for automated runs never reflects that the job (not a person) performed the classification — is confirmed and is exactly the bug this fix addresses.
+
+Fixing this also removes a hidden dependency: `IInvoiceClassificationService`'s interface gives no indication that an HTTP context is required to call it, which makes it easy for future callers (e.g., other background jobs) to hit the same bug.
+
+## Functional Requirements
+
+### FR-1: `IInvoiceClassificationService.ClassifyInvoiceAsync` takes an explicit `processedBy` parameter
+Change the interface signature from:
+```csharp
+Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice);
+```
+to:
+```csharp
+Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy);
+```
+Update `InvoiceClassificationService.ClassifyInvoiceAsync` to use the passed-in `processedBy` parameter (instead of `_currentUserService.GetCurrentUser().Name`) everywhere it currently passes `currentUser.Name` into `RecordClassificationHistory` (the "no matching rule" branch, the success branch, the ABRA-update-failure branch, and the catch block).
+
+**Acceptance criteria:**
+- `IInvoiceClassificationService.ClassifyInvoiceAsync` has signature `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)`.
+- All four `RecordClassificationHistory` call sites in `InvoiceClassificationService` pass the `processedBy` parameter value as the `processedBy`/`currentUser.Name` argument.
+- No behavior other than the source of the `processedBy` value changes (matching logic, ABRA update calls, exception handling, and returned `InvoiceClassificationResult` are unchanged).
+
+### FR-2: `InvoiceClassificationService` no longer depends on `ICurrentUserService`
+Remove the `ICurrentUserService _currentUserService` field, the constructor parameter, and the `_currentUserService.GetCurrentUser()` call from `InvoiceClassificationService`.
+
+**Acceptance criteria:**
+- `InvoiceClassificationService`'s constructor no longer accepts `ICurrentUserService`.
+- `InvoiceClassificationService.cs` no longer references `ICurrentUserService`, `_currentUserService`, or `Anela.Heblo.Domain.Features.Users` (unless still needed for another type — verify and remove the `using` if unused).
+- `InvoiceClassificationModule.AddInvoiceClassificationModule` requires no change for `ICurrentUserService` registration (it was never registered there — `ICurrentUserService` is registered at the API composition-root level and continues to be used by other handlers); confirm no dangling/unused registration exists for this service that was specific to `InvoiceClassificationService`.
+
+### FR-3: `ClassifyInvoicesHandler` resolves identity and passes it down
+Inject `ICurrentUserService` into `ClassifyInvoicesHandler`. In `Handle`, resolve `var currentUser = _currentUserService.GetCurrentUser();` once per `Handle` invocation (not once per invoice), and compute a `processedBy` string:
+- If `currentUser.IsAuthenticated` is `true`, use `currentUser.Name` (falling back to `"system"` if `Name` is null or empty even though authenticated, to avoid ever writing a null/empty `ProcessedBy`).
+- If `currentUser.IsAuthenticated` is `false` (the case for the scheduled job, since there is no HTTP context), use the literal string `"system"`.
+
+Pass this single `processedBy` value into every `_classificationService.ClassifyInvoiceAsync(invoice, processedBy)` call inside the `foreach` loop.
+
+**Acceptance criteria:**
+- `ClassifyInvoicesHandler`'s constructor accepts `ICurrentUserService` (added as a new constructor parameter, following the same DI pattern as `CreateClassificationRuleHandler`).
+- `Handle` calls `_currentUserService.GetCurrentUser()` exactly once per invocation, not inside the per-invoice loop.
+- When invoked with no HTTP context (`IsAuthenticated == false`, as happens for `InvoiceClassificationJob`), every `ClassificationHistory` row written during that run has `ProcessedBy == "system"`.
+- When invoked from an authenticated HTTP request (e.g., a manual "reclassify" trigger from the UI, if one exists, or any future authenticated caller), `ProcessedBy` is set to the authenticated user's `Name`.
+- All invoices processed within a single `Handle` call receive the same `processedBy` value (it is not re-resolved per invoice).
+
+### FR-4: Update existing unit tests to match the new signatures
+`ClassifyInvoicesHandlerTests` and `InvoiceClassificationServiceTests` currently construct `ClassifyInvoicesHandler` without `ICurrentUserService` and `InvoiceClassificationService` with `ICurrentUserService`; both must be updated to compile and to verify the new behavior.
+
+**Acceptance criteria:**
+- `InvoiceClassificationServiceTests`: `InvoiceClassificationService` is constructed without a `ICurrentUserService` mock; each test calls `_sut.ClassifyInvoiceAsync(invoice, processedBy)` with an explicit `processedBy` test value and asserts `capturedHistory.ProcessedBy` equals that value (replacing the current `currentUser.Name` assertions).
+- `ClassifyInvoicesHandlerTests`: `ClassifyInvoicesHandler` is constructed with a `Mock<ICurrentUserService>`. At least one test asserts that when the mocked `GetCurrentUser()` returns `IsAuthenticated == false` (simulating the background-job scenario), `_classificationServiceMock` receives `ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "system")`. At least one test covers the authenticated case, asserting `ClassifyInvoiceAsync` is called with the authenticated user's `Name`.
+- All existing assertions unrelated to identity resolution (invoice fetching, parallelism, error counting) continue to pass unmodified.
+- `dotnet build` and the full `Anela.Heblo.Tests` suite (at minimum the `InvoiceClassification` test files) pass after the change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+N/A — this change replaces one `GetCurrentUser()` call per invoice (inside the service, in the per-invoice path) with one `GetCurrentUser()` call per `Handle` invocation (in the handler, outside the per-invoice loop). This is a net reduction in calls to `ICurrentUserService`, not a regression.
+
+### NFR-2: Security
+No change to authentication/authorization. `ICurrentUserService` continues to be resolved only where an `IHttpContextAccessor`-backed implementation is meaningful (inside the MediatR handler, which is invoked either from an authenticated HTTP request or from the internal scheduler). No new identity data is exposed; the fix makes an existing audit field (`ProcessedBy`) more accurate, which is a net data-integrity improvement for audit history.
+
+## Data Model
+No schema changes. `ClassificationHistory.ProcessedBy` (existing `string` field) continues to be populated the same way structurally; only the source of the value changes (handler-resolved `processedBy` string instead of a service-internal `ICurrentUserService` lookup). No migration required.
+
+## API / Interface Design
+- **Changed internal interface**: `IInvoiceClassificationService.ClassifyInvoiceAsync(ReceivedInvoice invoice)` → `IInvoiceClassificationService.ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)`. This is an internal application-layer interface (not exposed via HTTP/OpenAPI), so no client regeneration or contract-versioning concerns apply.
+- No changes to `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse` (the public MediatR contract used by controllers and `InvoiceClassificationJob`) — identity resolution stays fully internal to `ClassifyInvoicesHandler.Handle` and does not need to be threaded through the request DTO.
+- No HTTP endpoint, route, or UI changes.
+
+## Dependencies
+- `ICurrentUserService` (`Anela.Heblo.Domain.Features.Users`) — already registered at the API composition root; only the consumer moves from `InvoiceClassificationService` to `ClassifyInvoicesHandler`.
+- No new external dependencies.
+
+## Out of Scope
+- Changing `ADR-005` itself or auditing other modules for the same violation (this fix addresses only the `InvoiceClassification` module, per the filed issue).
+- Adding a caller-identity parameter to `ClassifyInvoicesRequest` (unnecessary — the handler already has direct access to `ICurrentUserService` via DI).
+- Backfilling or correcting historical `ClassificationHistory` rows that already have `ProcessedBy = "Anonymous"` from prior scheduled runs.
+- Any change to `InvoiceClassificationJob` itself — it is already correctly context-agnostic; the fix is entirely within the handler/service layer it calls into.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3521",
+  "issue_number": 3521,
+  "created_at": "2026-07-07T09:15:46.500168Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T09:18:38.974225Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-07T09:37:15.480933Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T09:37:26.713181Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T09:39:23.768024Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "move-identity-resolution-to-classify-invoices-handler",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T09:23:42.269441Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T09:24:08.079211Z"
     }
   },
   "tasks": [
     {
       "name": "move-identity-resolution-to-classify-invoices-handler",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-07T09:24:08.393835Z"
     }
   ]
 }

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-07T09:18:38.974225Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T09:20:23.640677Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-07T09:37:15.480933Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-07T09:37:26.713181Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-07T09:21:20.697260Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T09:23:42.269441Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T09:23:42.269441Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T09:24:08.079211Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T09:37:15.480933Z"
     }
   },
   "tasks": [
     {
       "name": "move-identity-resolution-to-classify-invoices-handler",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-07T09:24:08.393835Z"
+      "updated_at": "2026-07-07T09:37:09.649333Z"
     }
   ]
 }

--- a/artifacts/feat-3521/state.json
+++ b/artifacts/feat-3521/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-07T09:20:23.640677Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T09:21:20.697260Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3521/task-context/move-identity-resolution-to-classify-invoices-handler.md
+++ b/artifacts/feat-3521/task-context/move-identity-resolution-to-classify-invoices-handler.md
@@ -1,0 +1,64 @@
+### task: move-identity-resolution-to-classify-invoices-handler
+
+**Goal:** Move `ICurrentUserService` resolution out of `InvoiceClassificationService` and into `ClassifyInvoicesHandler`, making `processedBy` an explicit parameter, so that scheduled (non-HTTP) classification runs write an accurate `ProcessedBy` value instead of relying on a service-internal HTTP-context-dependent lookup.
+
+**Context (from spec.r1.md / arch-review.r1.md):**
+- `InvoiceClassificationService.cs:13,21,28,34` — constructor takes `ICurrentUserService currentUserService` (field `_currentUserService`); `ClassifyInvoiceAsync` (line 32) calls `_currentUserService.GetCurrentUser()` at line 34 and uses `currentUser.Name` at four `RecordClassificationHistory` call sites: line 45 (no-match branch), line 61 (success branch), line 75 (ABRA-update-failure branch), line 90 (catch block).
+- `IInvoiceClassificationService.cs:7` — signature is `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice);` and must become `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy);`.
+- `ClassifyInvoicesHandler.cs` — currently has no `ICurrentUserService` dependency; `Handle` calls `_classificationService.ClassifyInvoiceAsync(invoice)` at line 72 inside the `foreach` loop starting at line 68, with no identity resolution anywhere.
+- Runtime bug being fixed: `InvoiceClassificationJob` invokes `IMediator.Send(ClassifyInvoicesRequest)` hourly with no HTTP context, so today's `_currentUserService.GetCurrentUser()` call (inside the service) returns `IsAuthenticated == false`, `Name == null`, and the concrete `CurrentUserService.GetCurrentUser()` implementation falls through to `Name = "Anonymous"` — misleading audit history for automated runs.
+- Precedent pattern (already correct, do not modify): `CreateClassificationRuleHandler.cs:12,14-22,26` — injects `ICurrentUserService _currentUserService` via constructor, calls `var currentUser = _currentUserService.GetCurrentUser();` once at the top of `Handle` (line 26), and passes `currentUser.Name` into the domain constructor call (line 38). `UpdateClassificationRuleHandler` follows the identical shape. `ClassifyInvoicesHandler` must mirror this.
+- `CurrentUser` is `public record CurrentUser(string? Id, string? Name, string? Email, bool IsAuthenticated);` (`backend/src/Anela.Heblo.Domain/Features/Users/CurrentUser.cs`). `ICurrentUserService` (`backend/src/Anela.Heblo.Domain/Features/Users/ICurrentUserService.cs`) exposes `CurrentUser GetCurrentUser()` and `bool IsInRole(string role)`.
+- Fallback rule (spec FR-3 / design.r1.md): `processedBy = currentUser.IsAuthenticated ? (string.IsNullOrEmpty(currentUser.Name) ? "system" : currentUser.Name) : "system"`. Must be computed exactly once per `Handle` invocation, before the `foreach` loop, and the same value passed into every `ClassifyInvoiceAsync` call in that batch.
+- `InvoiceClassificationModule.cs` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs`) does **not** register `ICurrentUserService` today (confirmed by reading the file — it registers `IInvoiceClassificationService`, `IRuleEvaluationEngine`, repositories, and rule implementations only) — no change needed there; `ICurrentUserService` is registered once at the API composition root by `UsersModule.AddUsersModule()` and resolved via standard constructor injection in both `InvoiceClassificationService` (removed by this task) and `ClassifyInvoicesHandler` (added by this task).
+- Out of scope (per spec): changing `ADR-005` itself, auditing other modules, adding identity to `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse`, modifying `InvoiceClassificationJob`, or backfilling historical `ClassificationHistory.ProcessedBy = "Anonymous"` rows.
+
+**Files to create/modify:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/IInvoiceClassificationService.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+- No change (verify only): `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs`
+
+**Implementation steps:**
+1. In `IInvoiceClassificationService.cs`, change the method signature to `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy);`.
+2. In `InvoiceClassificationService.cs`:
+   - Remove the `ICurrentUserService _currentUserService` field (line 13), the `currentUserService` constructor parameter (line 21) and its assignment (line 28).
+   - Remove the `using Anela.Heblo.Domain.Features.Users;` line (line 3) since `ICurrentUserService`/`CurrentUser` will no longer be referenced (verify no other type from that namespace is used in the file before removing).
+   - Change `ClassifyInvoiceAsync(ReceivedInvoice invoice)` to `ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)` and delete the `var currentUser = _currentUserService.GetCurrentUser();` line (line 34).
+   - Replace `currentUser.Name` with `processedBy` at all four call sites (lines 45, 61, 75, 90).
+3. In `ClassifyInvoicesHandler.cs`:
+   - Add `using Anela.Heblo.Domain.Features.Users;`.
+   - Add `private readonly ICurrentUserService _currentUserService;` field, add `ICurrentUserService currentUserService` constructor parameter (after `IClassificationRuleRepository ruleRepository`, before `logger`, matching the existing parameter-then-logger ordering convention), and assign it in the constructor body.
+   - At the top of `Handle`, immediately after `response.TotalInvoicesProcessed = invoicesToClassify.Count;` (line 66) and before the `foreach` loop (line 68), add:
+     ```csharp
+     var currentUser = _currentUserService.GetCurrentUser();
+     var processedBy = currentUser.IsAuthenticated
+         ? (string.IsNullOrEmpty(currentUser.Name) ? "system" : currentUser.Name)
+         : "system";
+     ```
+   - Change the call at line 72 from `_classificationService.ClassifyInvoiceAsync(invoice)` to `_classificationService.ClassifyInvoiceAsync(invoice, processedBy)`.
+4. Open `InvoiceClassificationModule.cs` and confirm it still has no `ICurrentUserService` registration (it shouldn't need one — `ICurrentUserService` is registered at the API composition root). No edit expected; if a registration is somehow found, leave a note rather than removing it silently, since spec/arch-review both assert none exists.
+5. Run `dotnet build` to catch any stale `currentUser`/`_currentUserService` references left in `InvoiceClassificationService.cs` per arch-review's identified risk.
+
+**Testing:**
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`:
+  - Remove `Mock<ICurrentUserService> _currentUserServiceMock` field and its argument from the `_sut = new InvoiceClassificationService(...)` construction (drop the `_currentUserServiceMock.Object` argument at line 28).
+  - In each of the four tests (`ClassifyInvoiceAsync_NoMatchingRule_MarksForManualReviewAndRecordsHistory`, `ClassifyInvoiceAsync_RuleMatchedAndAbraSucceeds_RecordsSuccessAndReturnsRuleResult`, `ClassifyInvoiceAsync_RuleMatchedAndAbraFails_RecordsErrorAndReturnsRuleIdForDisplay`, `ClassifyInvoiceAsync_ExceptionThrown_RecordsErrorWithMessageAndReturnsErrorResult`): remove the `var currentUser = new CurrentUser(...)` arrangement and the `_currentUserServiceMock.Setup(x => x.GetCurrentUser()).Returns(currentUser);` setup; introduce an explicit `var processedBy = "test-user";` (or reuse a similarly named literal per test) and call `await _sut.ClassifyInvoiceAsync(invoice, processedBy)`; change each `capturedHistory.ProcessedBy.Should().Be(currentUser.Name);` assertion to `capturedHistory.ProcessedBy.Should().Be(processedBy);`. Remove the now-unused `using Anela.Heblo.Domain.Features.Users;` import only if `CurrentUser`/`ICurrentUserService` are no longer referenced anywhere in the file.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`:
+  - Add `Mock<ICurrentUserService> _currentUserServiceMock` field, instantiate it in the constructor, and pass `_currentUserServiceMock.Object` into the `ClassifyInvoicesHandler` construction (matching the new constructor parameter order). Add `using Anela.Heblo.Domain.Features.Users;`.
+  - Update all three existing tests' `_classificationServiceMock.Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>()))` setups to `ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>())` (new signature), and set up `_currentUserServiceMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("id", "test-user", "test@test.com", true));` (or similar) in each so they keep passing.
+  - Add a new test asserting the unauthenticated/background-job path: mock `GetCurrentUser()` to return a `CurrentUser` with `IsAuthenticated == false`, run `Handle`, and verify `_classificationServiceMock.Verify(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "system"), Times.Once)` (or `Times.AtLeastOnce` depending on invoice count in that test's fixture).
+  - Add a new test asserting the authenticated path: mock `GetCurrentUser()` to return `IsAuthenticated == true` with a concrete `Name` (e.g., `"jane.doe"`), run `Handle`, and verify `_classificationServiceMock.Verify(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "jane.doe"), Times.Once)`.
+  - Leave the existing parallelism/error-counting/fetch assertions (`Handle_WithMultipleInvoiceIds_FetchesAllInvoicesInParallel`, `Handle_WhenSomeInvoicesNotFound_CountsThemAsErrors`, `Handle_WithNoInvoiceIds_FetchesAllUnclassifiedInvoices`) otherwise unmodified aside from the mock setup/signature updates above.
+- Run: `dotnet build` (from `backend/`) followed by `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"` to scope to this module's tests; then the full suite (`dotnet test`) to confirm no other module referenced the old `ClassifyInvoiceAsync(ReceivedInvoice)` overload.
+
+**Acceptance criteria:**
+- `IInvoiceClassificationService.ClassifyInvoiceAsync` has signature `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)` (FR-1).
+- `InvoiceClassificationService` no longer has an `ICurrentUserService` constructor parameter, field, or `GetCurrentUser()` call anywhere in the file (FR-2).
+- `ClassifyInvoicesHandler`'s constructor accepts `ICurrentUserService`; `Handle` calls `_currentUserService.GetCurrentUser()` exactly once per invocation, outside the `foreach` loop, and the resulting `processedBy` value is passed unchanged into every `ClassifyInvoiceAsync` call in that batch (FR-3).
+- When `IsAuthenticated == false` (background-job scenario), `processedBy == "system"`; when `IsAuthenticated == true` with a non-empty `Name`, `processedBy == currentUser.Name`; when `IsAuthenticated == true` with a null/empty `Name`, `processedBy == "system"` (FR-3).
+- `InvoiceClassificationServiceTests` and `ClassifyInvoicesHandlerTests` are updated to the new signatures and pass, including the two new handler tests covering the authenticated and unauthenticated identity-resolution paths (FR-4).
+- `InvoiceClassificationModule.cs` requires no edit (confirmed no `ICurrentUserService` registration exists there before or after the change).
+- `dotnet build` succeeds and the full `Anela.Heblo.Tests` suite passes.

--- a/artifacts/feat-3521/task-plan.r1.md
+++ b/artifacts/feat-3521/task-plan.r1.md
@@ -1,0 +1,71 @@
+# Task Plan: Move user-identity resolution out of InvoiceClassificationService (ADR-005 compliance)
+
+## Overview
+This is a small, mechanical ADR-005 convergence fix confined to three source files and two test files, all within the `InvoiceClassification` vertical slice, with no schema, contract, controller, or UI changes (per arch-review's `Skip Design: true`). The interface signature change, the service-side removal of `ICurrentUserService`, and the handler-side identity resolution are tightly coupled — the interface change breaks the service until the handler is updated to match, and vice versa — so splitting them into separate tasks would leave the codebase non-compiling between steps. This is one task.
+
+---
+
+### task: move-identity-resolution-to-classify-invoices-handler
+
+**Goal:** Move `ICurrentUserService` resolution out of `InvoiceClassificationService` and into `ClassifyInvoicesHandler`, making `processedBy` an explicit parameter, so that scheduled (non-HTTP) classification runs write an accurate `ProcessedBy` value instead of relying on a service-internal HTTP-context-dependent lookup.
+
+**Context (from spec.r1.md / arch-review.r1.md):**
+- `InvoiceClassificationService.cs:13,21,28,34` — constructor takes `ICurrentUserService currentUserService` (field `_currentUserService`); `ClassifyInvoiceAsync` (line 32) calls `_currentUserService.GetCurrentUser()` at line 34 and uses `currentUser.Name` at four `RecordClassificationHistory` call sites: line 45 (no-match branch), line 61 (success branch), line 75 (ABRA-update-failure branch), line 90 (catch block).
+- `IInvoiceClassificationService.cs:7` — signature is `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice);` and must become `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy);`.
+- `ClassifyInvoicesHandler.cs` — currently has no `ICurrentUserService` dependency; `Handle` calls `_classificationService.ClassifyInvoiceAsync(invoice)` at line 72 inside the `foreach` loop starting at line 68, with no identity resolution anywhere.
+- Runtime bug being fixed: `InvoiceClassificationJob` invokes `IMediator.Send(ClassifyInvoicesRequest)` hourly with no HTTP context, so today's `_currentUserService.GetCurrentUser()` call (inside the service) returns `IsAuthenticated == false`, `Name == null`, and the concrete `CurrentUserService.GetCurrentUser()` implementation falls through to `Name = "Anonymous"` — misleading audit history for automated runs.
+- Precedent pattern (already correct, do not modify): `CreateClassificationRuleHandler.cs:12,14-22,26` — injects `ICurrentUserService _currentUserService` via constructor, calls `var currentUser = _currentUserService.GetCurrentUser();` once at the top of `Handle` (line 26), and passes `currentUser.Name` into the domain constructor call (line 38). `UpdateClassificationRuleHandler` follows the identical shape. `ClassifyInvoicesHandler` must mirror this.
+- `CurrentUser` is `public record CurrentUser(string? Id, string? Name, string? Email, bool IsAuthenticated);` (`backend/src/Anela.Heblo.Domain/Features/Users/CurrentUser.cs`). `ICurrentUserService` (`backend/src/Anela.Heblo.Domain/Features/Users/ICurrentUserService.cs`) exposes `CurrentUser GetCurrentUser()` and `bool IsInRole(string role)`.
+- Fallback rule (spec FR-3 / design.r1.md): `processedBy = currentUser.IsAuthenticated ? (string.IsNullOrEmpty(currentUser.Name) ? "system" : currentUser.Name) : "system"`. Must be computed exactly once per `Handle` invocation, before the `foreach` loop, and the same value passed into every `ClassifyInvoiceAsync` call in that batch.
+- `InvoiceClassificationModule.cs` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs`) does **not** register `ICurrentUserService` today (confirmed by reading the file — it registers `IInvoiceClassificationService`, `IRuleEvaluationEngine`, repositories, and rule implementations only) — no change needed there; `ICurrentUserService` is registered once at the API composition root by `UsersModule.AddUsersModule()` and resolved via standard constructor injection in both `InvoiceClassificationService` (removed by this task) and `ClassifyInvoicesHandler` (added by this task).
+- Out of scope (per spec): changing `ADR-005` itself, auditing other modules, adding identity to `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse`, modifying `InvoiceClassificationJob`, or backfilling historical `ClassificationHistory.ProcessedBy = "Anonymous"` rows.
+
+**Files to create/modify:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/IInvoiceClassificationService.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+- No change (verify only): `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationModule.cs`
+
+**Implementation steps:**
+1. In `IInvoiceClassificationService.cs`, change the method signature to `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy);`.
+2. In `InvoiceClassificationService.cs`:
+   - Remove the `ICurrentUserService _currentUserService` field (line 13), the `currentUserService` constructor parameter (line 21) and its assignment (line 28).
+   - Remove the `using Anela.Heblo.Domain.Features.Users;` line (line 3) since `ICurrentUserService`/`CurrentUser` will no longer be referenced (verify no other type from that namespace is used in the file before removing).
+   - Change `ClassifyInvoiceAsync(ReceivedInvoice invoice)` to `ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)` and delete the `var currentUser = _currentUserService.GetCurrentUser();` line (line 34).
+   - Replace `currentUser.Name` with `processedBy` at all four call sites (lines 45, 61, 75, 90).
+3. In `ClassifyInvoicesHandler.cs`:
+   - Add `using Anela.Heblo.Domain.Features.Users;`.
+   - Add `private readonly ICurrentUserService _currentUserService;` field, add `ICurrentUserService currentUserService` constructor parameter (after `IClassificationRuleRepository ruleRepository`, before `logger`, matching the existing parameter-then-logger ordering convention), and assign it in the constructor body.
+   - At the top of `Handle`, immediately after `response.TotalInvoicesProcessed = invoicesToClassify.Count;` (line 66) and before the `foreach` loop (line 68), add:
+     ```csharp
+     var currentUser = _currentUserService.GetCurrentUser();
+     var processedBy = currentUser.IsAuthenticated
+         ? (string.IsNullOrEmpty(currentUser.Name) ? "system" : currentUser.Name)
+         : "system";
+     ```
+   - Change the call at line 72 from `_classificationService.ClassifyInvoiceAsync(invoice)` to `_classificationService.ClassifyInvoiceAsync(invoice, processedBy)`.
+4. Open `InvoiceClassificationModule.cs` and confirm it still has no `ICurrentUserService` registration (it shouldn't need one — `ICurrentUserService` is registered at the API composition root). No edit expected; if a registration is somehow found, leave a note rather than removing it silently, since spec/arch-review both assert none exists.
+5. Run `dotnet build` to catch any stale `currentUser`/`_currentUserService` references left in `InvoiceClassificationService.cs` per arch-review's identified risk.
+
+**Testing:**
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`:
+  - Remove `Mock<ICurrentUserService> _currentUserServiceMock` field and its argument from the `_sut = new InvoiceClassificationService(...)` construction (drop the `_currentUserServiceMock.Object` argument at line 28).
+  - In each of the four tests (`ClassifyInvoiceAsync_NoMatchingRule_MarksForManualReviewAndRecordsHistory`, `ClassifyInvoiceAsync_RuleMatchedAndAbraSucceeds_RecordsSuccessAndReturnsRuleResult`, `ClassifyInvoiceAsync_RuleMatchedAndAbraFails_RecordsErrorAndReturnsRuleIdForDisplay`, `ClassifyInvoiceAsync_ExceptionThrown_RecordsErrorWithMessageAndReturnsErrorResult`): remove the `var currentUser = new CurrentUser(...)` arrangement and the `_currentUserServiceMock.Setup(x => x.GetCurrentUser()).Returns(currentUser);` setup; introduce an explicit `var processedBy = "test-user";` (or reuse a similarly named literal per test) and call `await _sut.ClassifyInvoiceAsync(invoice, processedBy)`; change each `capturedHistory.ProcessedBy.Should().Be(currentUser.Name);` assertion to `capturedHistory.ProcessedBy.Should().Be(processedBy);`. Remove the now-unused `using Anela.Heblo.Domain.Features.Users;` import only if `CurrentUser`/`ICurrentUserService` are no longer referenced anywhere in the file.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`:
+  - Add `Mock<ICurrentUserService> _currentUserServiceMock` field, instantiate it in the constructor, and pass `_currentUserServiceMock.Object` into the `ClassifyInvoicesHandler` construction (matching the new constructor parameter order). Add `using Anela.Heblo.Domain.Features.Users;`.
+  - Update all three existing tests' `_classificationServiceMock.Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>()))` setups to `ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>())` (new signature), and set up `_currentUserServiceMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("id", "test-user", "test@test.com", true));` (or similar) in each so they keep passing.
+  - Add a new test asserting the unauthenticated/background-job path: mock `GetCurrentUser()` to return a `CurrentUser` with `IsAuthenticated == false`, run `Handle`, and verify `_classificationServiceMock.Verify(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "system"), Times.Once)` (or `Times.AtLeastOnce` depending on invoice count in that test's fixture).
+  - Add a new test asserting the authenticated path: mock `GetCurrentUser()` to return `IsAuthenticated == true` with a concrete `Name` (e.g., `"jane.doe"`), run `Handle`, and verify `_classificationServiceMock.Verify(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "jane.doe"), Times.Once)`.
+  - Leave the existing parallelism/error-counting/fetch assertions (`Handle_WithMultipleInvoiceIds_FetchesAllInvoicesInParallel`, `Handle_WhenSomeInvoicesNotFound_CountsThemAsErrors`, `Handle_WithNoInvoiceIds_FetchesAllUnclassifiedInvoices`) otherwise unmodified aside from the mock setup/signature updates above.
+- Run: `dotnet build` (from `backend/`) followed by `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"` to scope to this module's tests; then the full suite (`dotnet test`) to confirm no other module referenced the old `ClassifyInvoiceAsync(ReceivedInvoice)` overload.
+
+**Acceptance criteria:**
+- `IInvoiceClassificationService.ClassifyInvoiceAsync` has signature `Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)` (FR-1).
+- `InvoiceClassificationService` no longer has an `ICurrentUserService` constructor parameter, field, or `GetCurrentUser()` call anywhere in the file (FR-2).
+- `ClassifyInvoicesHandler`'s constructor accepts `ICurrentUserService`; `Handle` calls `_currentUserService.GetCurrentUser()` exactly once per invocation, outside the `foreach` loop, and the resulting `processedBy` value is passed unchanged into every `ClassifyInvoiceAsync` call in that batch (FR-3).
+- When `IsAuthenticated == false` (background-job scenario), `processedBy == "system"`; when `IsAuthenticated == true` with a non-empty `Name`, `processedBy == currentUser.Name`; when `IsAuthenticated == true` with a null/empty `Name`, `processedBy == "system"` (FR-3).
+- `InvoiceClassificationServiceTests` and `ClassifyInvoicesHandlerTests` are updated to the new signatures and pass, including the two new handler tests covering the authenticated and unauthenticated identity-resolution paths (FR-4).
+- `InvoiceClassificationModule.cs` requires no edit (confirmed no `ICurrentUserService` registration exists there before or after the change).
+- `dotnet build` succeeds and the full `Anela.Heblo.Tests` suite passes.

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/IInvoiceClassificationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/IInvoiceClassificationService.cs
@@ -4,5 +4,5 @@ namespace Anela.Heblo.Application.Features.InvoiceClassification.Services;
 
 public interface IInvoiceClassificationService
 {
-    Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice);
+    Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy);
 }

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
-using Anela.Heblo.Domain.Features.Users;
 
 namespace Anela.Heblo.Application.Features.InvoiceClassification.Services;
 
@@ -10,7 +9,6 @@ public class InvoiceClassificationService : IInvoiceClassificationService
     private readonly IClassificationHistoryRepository _historyRepository;
     private readonly IInvoiceClassificationsClient _classificationsClient;
     private readonly IRuleEvaluationEngine _ruleEngine;
-    private readonly ICurrentUserService _currentUserService;
     private readonly ILogger<InvoiceClassificationService> _logger;
 
     public InvoiceClassificationService(
@@ -18,21 +16,17 @@ public class InvoiceClassificationService : IInvoiceClassificationService
         IClassificationHistoryRepository historyRepository,
         IInvoiceClassificationsClient classificationsClient,
         IRuleEvaluationEngine ruleEngine,
-        ICurrentUserService currentUserService,
         ILogger<InvoiceClassificationService> logger)
     {
         _ruleRepository = ruleRepository;
         _historyRepository = historyRepository;
         _classificationsClient = classificationsClient;
         _ruleEngine = ruleEngine;
-        _currentUserService = currentUserService;
         _logger = logger;
     }
 
-    public async Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice)
+    public async Task<InvoiceClassificationResult> ClassifyInvoiceAsync(ReceivedInvoice invoice, string processedBy)
     {
-        var currentUser = _currentUserService.GetCurrentUser();
-
         try
         {
             var rules = await _ruleRepository.GetActiveRulesOrderedAsync();
@@ -42,7 +36,7 @@ public class InvoiceClassificationService : IInvoiceClassificationService
             if (matchedRule == null)
             {
                 await RecordClassificationHistory(invoice, null, ClassificationResult.ManualReviewRequired,
-                    null, null, "No matching rule found", currentUser.Name);
+                    null, null, "No matching rule found", processedBy);
 
                 await _classificationsClient.MarkInvoiceForManualReviewAsync(invoice.InvoiceNumber, "No matching classification rule");
 
@@ -58,7 +52,7 @@ public class InvoiceClassificationService : IInvoiceClassificationService
             if (success)
             {
                 await RecordClassificationHistory(invoice, matchedRule.Id, ClassificationResult.Success,
-                    matchedRule.AccountingTemplateCode, matchedRule.Department, null, currentUser.Name);
+                    matchedRule.AccountingTemplateCode, matchedRule.Department, null, processedBy);
 
                 return new InvoiceClassificationResult
                 {
@@ -72,7 +66,7 @@ public class InvoiceClassificationService : IInvoiceClassificationService
             {
                 var errorMessage = "Failed to update invoice classification in ABRA";
                 await RecordClassificationHistory(invoice, matchedRule.Id, ClassificationResult.Error,
-                    matchedRule.AccountingTemplateCode, matchedRule.Department, errorMessage, currentUser.Name);
+                    matchedRule.AccountingTemplateCode, matchedRule.Department, errorMessage, processedBy);
 
                 return new InvoiceClassificationResult
                 {
@@ -87,7 +81,7 @@ public class InvoiceClassificationService : IInvoiceClassificationService
         {
             var errorMessage = $"Exception during classification: {ex.Message}";
             await RecordClassificationHistory(invoice, null, ClassificationResult.Error,
-                null, null, errorMessage, currentUser.Name);
+                null, null, errorMessage, processedBy);
 
             _logger.LogError(ex, "Error classifying invoice {InvoiceId}", invoice.InvoiceNumber);
 

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Domain.Features.Users;
 using Anela.Heblo.Application.Features.InvoiceClassification.Services;
 
 namespace Anela.Heblo.Application.Features.InvoiceClassification.UseCases.ClassifyInvoices;
@@ -10,17 +11,20 @@ public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, 
     private readonly IReceivedInvoicesClient _invoicesClient;
     private readonly IInvoiceClassificationService _classificationService;
     private readonly IClassificationRuleRepository _ruleRepository;
+    private readonly ICurrentUserService _currentUserService;
     private readonly ILogger<ClassifyInvoicesHandler> _logger;
 
     public ClassifyInvoicesHandler(
         IReceivedInvoicesClient invoicesClient,
         IInvoiceClassificationService classificationService,
         IClassificationRuleRepository ruleRepository,
+        ICurrentUserService currentUserService,
         ILogger<ClassifyInvoicesHandler> logger)
     {
         _invoicesClient = invoicesClient;
         _classificationService = classificationService;
         _ruleRepository = ruleRepository;
+        _currentUserService = currentUserService;
         _logger = logger;
     }
 
@@ -65,11 +69,16 @@ public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, 
 
             response.TotalInvoicesProcessed = invoicesToClassify.Count;
 
+            var currentUser = _currentUserService.GetCurrentUser();
+            var processedBy = currentUser.IsAuthenticated
+                ? (string.IsNullOrEmpty(currentUser.Name) ? "system" : currentUser.Name)
+                : "system";
+
             foreach (var invoice in invoicesToClassify)
             {
                 try
                 {
-                    var result = await _classificationService.ClassifyInvoiceAsync(invoice);
+                    var result = await _classificationService.ClassifyInvoiceAsync(invoice, processedBy);
 
                     switch (result.Result)
                     {

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Features.InvoiceClassification.Services;
 using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.ClassifyInvoices;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Domain.Features.Users;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -13,6 +14,7 @@ public class ClassifyInvoicesHandlerTests
     private readonly Mock<IReceivedInvoicesClient> _invoicesClientMock;
     private readonly Mock<IInvoiceClassificationService> _classificationServiceMock;
     private readonly Mock<IClassificationRuleRepository> _ruleRepositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<ILogger<ClassifyInvoicesHandler>> _loggerMock;
     private readonly ClassifyInvoicesHandler _handler;
 
@@ -21,12 +23,18 @@ public class ClassifyInvoicesHandlerTests
         _invoicesClientMock = new Mock<IReceivedInvoicesClient>();
         _classificationServiceMock = new Mock<IInvoiceClassificationService>();
         _ruleRepositoryMock = new Mock<IClassificationRuleRepository>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
         _loggerMock = new Mock<ILogger<ClassifyInvoicesHandler>>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("id", "test-user", "test@test.com", true));
 
         _handler = new ClassifyInvoicesHandler(
             _invoicesClientMock.Object,
             _classificationServiceMock.Object,
             _ruleRepositoryMock.Object,
+            _currentUserServiceMock.Object,
             _loggerMock.Object);
     }
 
@@ -51,7 +59,7 @@ public class ClassifyInvoicesHandlerTests
             .ReturnsAsync(new ReceivedInvoice { InvoiceNumber = invoiceId3, Labels = Array.Empty<string>() });
 
         _classificationServiceMock
-            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>()))
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()))
             .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
 
         var request = new ClassifyInvoicesRequest
@@ -85,7 +93,7 @@ public class ClassifyInvoicesHandlerTests
             .ReturnsAsync((ReceivedInvoice?)null);
 
         _classificationServiceMock
-            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>()))
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()))
             .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
 
         var request = new ClassifyInvoicesRequest
@@ -114,7 +122,7 @@ public class ClassifyInvoicesHandlerTests
             .ReturnsAsync(unclassifiedInvoices);
 
         _classificationServiceMock
-            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>()))
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()))
             .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
 
         var request = new ClassifyInvoicesRequest { InvoiceIds = null };
@@ -124,5 +132,63 @@ public class ClassifyInvoicesHandlerTests
         response.TotalInvoicesProcessed.Should().Be(1);
         response.SuccessfulClassifications.Should().Be(1);
         _invoicesClientMock.Verify(x => x.GetUnclassifiedInvoicesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCurrentUserIsUnauthenticated_PassesSystemAsProcessedBy()
+    {
+        var unclassifiedInvoices = new List<ReceivedInvoice>
+        {
+            new() { InvoiceNumber = "UNCLASSIFIED-001", Labels = Array.Empty<string>() }
+        };
+
+        _invoicesClientMock
+            .Setup(x => x.GetUnclassifiedInvoicesAsync())
+            .ReturnsAsync(unclassifiedInvoices);
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(null, null, null, false));
+
+        _classificationServiceMock
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()))
+            .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
+
+        var request = new ClassifyInvoicesRequest { InvoiceIds = null };
+
+        await _handler.Handle(request, CancellationToken.None);
+
+        _classificationServiceMock.Verify(
+            x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "system"),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCurrentUserIsAuthenticated_PassesUserNameAsProcessedBy()
+    {
+        var unclassifiedInvoices = new List<ReceivedInvoice>
+        {
+            new() { InvoiceNumber = "UNCLASSIFIED-001", Labels = Array.Empty<string>() }
+        };
+
+        _invoicesClientMock
+            .Setup(x => x.GetUnclassifiedInvoicesAsync())
+            .ReturnsAsync(unclassifiedInvoices);
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("id", "jane.doe", "jane.doe@test.com", true));
+
+        _classificationServiceMock
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()))
+            .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
+
+        var request = new ClassifyInvoicesRequest { InvoiceIds = null };
+
+        await _handler.Handle(request, CancellationToken.None);
+
+        _classificationServiceMock.Verify(
+            x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "jane.doe"),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs
@@ -1,6 +1,5 @@
 using Anela.Heblo.Application.Features.InvoiceClassification.Services;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
-using Anela.Heblo.Domain.Features.Users;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -14,7 +13,6 @@ public class InvoiceClassificationServiceTests
     private readonly Mock<IClassificationHistoryRepository> _historyRepositoryMock = new();
     private readonly Mock<IInvoiceClassificationsClient> _classificationsClientMock = new();
     private readonly Mock<IRuleEvaluationEngine> _ruleEngineMock = new();
-    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
     private readonly Mock<ILogger<InvoiceClassificationService>> _loggerMock = new();
     private readonly InvoiceClassificationService _sut;
 
@@ -25,7 +23,6 @@ public class InvoiceClassificationServiceTests
             _historyRepositoryMock.Object,
             _classificationsClientMock.Object,
             _ruleEngineMock.Object,
-            _currentUserServiceMock.Object,
             _loggerMock.Object);
     }
 
@@ -41,12 +38,8 @@ public class InvoiceClassificationServiceTests
             Description = "Test Invoice"
         };
 
-        var currentUser = new CurrentUser("user-1", "test-user", "test@test.com", true);
+        var processedBy = "test-user";
         ClassificationHistory? capturedHistory = null;
-
-        _currentUserServiceMock
-            .Setup(x => x.GetCurrentUser())
-            .Returns(currentUser);
 
         _ruleRepositoryMock
             .Setup(x => x.GetActiveRulesOrderedAsync())
@@ -69,7 +62,7 @@ public class InvoiceClassificationServiceTests
             .ReturnsAsync((ClassificationHistory h) => h);
 
         // Act
-        var result = await _sut.ClassifyInvoiceAsync(invoice);
+        var result = await _sut.ClassifyInvoiceAsync(invoice, processedBy);
 
         // Assert
         result.Result.Should().Be(ClassificationResult.ManualReviewRequired);
@@ -85,7 +78,7 @@ public class InvoiceClassificationServiceTests
         capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
         capturedHistory.Description.Should().Be(invoice.Description);
         capturedHistory.Result.Should().Be(ClassificationResult.ManualReviewRequired);
-        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ProcessedBy.Should().Be(processedBy);
         capturedHistory.ClassificationRuleId.Should().BeNull();
         capturedHistory.AccountingTemplateCode.Should().BeNull();
         capturedHistory.Department.Should().BeNull();
@@ -123,12 +116,8 @@ public class InvoiceClassificationServiceTests
             "Sales",
             "admin-user");
 
-        var currentUser = new CurrentUser("user-1", "test-user", "test@test.com", true);
+        var processedBy = "test-user";
         ClassificationHistory? capturedHistory = null;
-
-        _currentUserServiceMock
-            .Setup(x => x.GetCurrentUser())
-            .Returns(currentUser);
 
         _ruleRepositoryMock
             .Setup(x => x.GetActiveRulesOrderedAsync())
@@ -152,7 +141,7 @@ public class InvoiceClassificationServiceTests
             .ReturnsAsync((ClassificationHistory h) => h);
 
         // Act
-        var result = await _sut.ClassifyInvoiceAsync(invoice);
+        var result = await _sut.ClassifyInvoiceAsync(invoice, processedBy);
 
         // Assert
         result.Result.Should().Be(ClassificationResult.Success);
@@ -168,7 +157,7 @@ public class InvoiceClassificationServiceTests
         capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
         capturedHistory.Description.Should().Be(invoice.Description);
         capturedHistory.Result.Should().Be(ClassificationResult.Success);
-        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ProcessedBy.Should().Be(processedBy);
         capturedHistory.ClassificationRuleId.Should().Be(ruleWithId.Id);
         capturedHistory.AccountingTemplateCode.Should().Be("TEMPLATE_001");
         capturedHistory.Department.Should().Be("Sales");
@@ -207,12 +196,8 @@ public class InvoiceClassificationServiceTests
             "Purchases",
             "admin-user");
 
-        var currentUser = new CurrentUser("user-2", "another-user", "another@test.com", true);
+        var processedBy = "another-user";
         ClassificationHistory? capturedHistory = null;
-
-        _currentUserServiceMock
-            .Setup(x => x.GetCurrentUser())
-            .Returns(currentUser);
 
         _ruleRepositoryMock
             .Setup(x => x.GetActiveRulesOrderedAsync())
@@ -236,7 +221,7 @@ public class InvoiceClassificationServiceTests
             .ReturnsAsync((ClassificationHistory h) => h);
 
         // Act
-        var result = await _sut.ClassifyInvoiceAsync(invoice);
+        var result = await _sut.ClassifyInvoiceAsync(invoice, processedBy);
 
         // Assert
         result.Result.Should().Be(ClassificationResult.Error);
@@ -252,7 +237,7 @@ public class InvoiceClassificationServiceTests
         capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
         capturedHistory.Description.Should().Be(invoice.Description);
         capturedHistory.Result.Should().Be(ClassificationResult.Error);
-        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ProcessedBy.Should().Be(processedBy);
         capturedHistory.ClassificationRuleId.Should().Be(matchedRule.Id);
         capturedHistory.AccountingTemplateCode.Should().Be("TEMPLATE_002");
         capturedHistory.Department.Should().Be("Purchases");
@@ -283,12 +268,8 @@ public class InvoiceClassificationServiceTests
             Description = "Test Invoice with Exception"
         };
 
-        var currentUser = new CurrentUser("user-3", "error-user", "error@test.com", true);
+        var processedBy = "error-user";
         ClassificationHistory? capturedHistory = null;
-
-        _currentUserServiceMock
-            .Setup(x => x.GetCurrentUser())
-            .Returns(currentUser);
 
         _ruleRepositoryMock
             .Setup(x => x.GetActiveRulesOrderedAsync())
@@ -300,7 +281,7 @@ public class InvoiceClassificationServiceTests
             .ReturnsAsync((ClassificationHistory h) => h);
 
         // Act
-        var result = await _sut.ClassifyInvoiceAsync(invoice);
+        var result = await _sut.ClassifyInvoiceAsync(invoice, processedBy);
 
         // Assert
         result.Result.Should().Be(ClassificationResult.Error);
@@ -317,7 +298,7 @@ public class InvoiceClassificationServiceTests
         capturedHistory.CompanyName.Should().Be(invoice.CompanyName);
         capturedHistory.Description.Should().Be(invoice.Description);
         capturedHistory.Result.Should().Be(ClassificationResult.Error);
-        capturedHistory.ProcessedBy.Should().Be(currentUser.Name);
+        capturedHistory.ProcessedBy.Should().Be(processedBy);
         capturedHistory.ClassificationRuleId.Should().BeNull();
         capturedHistory.AccountingTemplateCode.Should().BeNull();
         capturedHistory.Department.Should().BeNull();


### PR DESCRIPTION
Closes #3521

## What the issue was
`InvoiceClassificationService` resolved the current user's identity internally via `ICurrentUserService` to populate the `ProcessedBy` field on classification history records — a violation of ADR-005, which mandates that identity resolution happen inside MediatR handlers, not application services. This was also a latent runtime bug: `InvoiceClassificationJob` triggers `ClassifyInvoicesHandler` on a schedule with no HTTP request context, so `ICurrentUserService` (which depends on `IHttpContextAccessor`) produced an unauthenticated/empty user on every scheduled run, corrupting the `ProcessedBy` audit trail for automated classifications.

## How it was fixed / handled
- `IInvoiceClassificationService.ClassifyInvoiceAsync` now takes an explicit `string processedBy` parameter instead of resolving identity itself.
- `InvoiceClassificationService` no longer depends on `ICurrentUserService` — it uses the passed-in `processedBy` at all four `RecordClassificationHistory` call sites.
- `ClassifyInvoicesHandler` now injects `ICurrentUserService`, resolves the current user once before its per-invoice loop, and applies the fallback rule `processedBy = currentUser.IsAuthenticated ? (name-or-"system") : "system"` — mirroring the existing pattern in `CreateClassificationRuleHandler`/`UpdateClassificationRuleHandler`. Scheduled runs now consistently record `"system"` instead of a misleading anonymous/empty value.
- Updated `InvoiceClassificationServiceTests` and `ClassifyInvoicesHandlerTests` for the new signature, and added two new handler tests covering the authenticated and unauthenticated identity-resolution paths.

Verified: `dotnet build` (0 errors), scoped `dotnet test --filter "FullyQualifiedName~InvoiceClassification"` (88/88 passed), `dotnet format --verify-no-changes` (clean).

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3521/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- The handler's inline `processedBy` fallback ternary duplicates the intent of the existing `CurrentUser.GetDisplayName()` extension used elsewhere in the codebase, but with different casing/fallback text (`"system"` vs `"System"`/`"Unknown User"`). Flagged for future reconciliation — not required for this fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RPS3kZTaj6nHm93CBF7Rgh)_