### PR TITLE
#3522: Use IMapper in GetClassificationHistoryHandler instead of manual projection

### DIFF
--- a/artifacts/feat-3522/arch-review.r1.md
+++ b/artifacts/feat-3522/arch-review.r1.md
@@ -1,0 +1,72 @@
+# Architecture Review: Refactor GetClassificationHistoryHandler to Use IMapper
+
+## Skip Design: true
+Backend-only, behavior-preserving internal refactor. No new or changed UI components, screens, or visual decisions.
+
+## Architectural Fit Assessment
+This refactor increases alignment with existing patterns rather than introducing anything new. The sibling `GetClassificationRulesHandler` in the same module already injects `IMapper` and calls `_mapper.Map<List<...Dto>>(...)`, and `InvoiceClassificationMappingProfile` already defines `CreateMap<ClassificationHistory, ClassificationHistoryDto>()` in full — including the two non-conventional members (`InvoiceId ← AbraInvoiceId`, `RuleName ← ClassificationRule.Name`) that the manual projection replicates. The handler is currently the sole consumer of that map that bypasses it. The change removes duplicated mapping logic and consolidates it in the one place the guidelines and existing code already treat as authoritative (development_guidelines.md lists AutoMapper as the mechanism for DTO↔Domain mapping). Integration points are minimal: DI (IMapper already registered and resolved elsewhere), the mapping profile (unchanged), and the repository call (unchanged).
+
+## Proposed Architecture
+
+### Component Overview
+```
+GetClassificationHistoryRequest
+        │
+        ▼
+GetClassificationHistoryHandler
+   ├── IClassificationHistoryRepository ──> (historyItems, totalCount)
+   ├── IMapper ──> Map<List<ClassificationHistoryDto>>(historyItems)   [NEW dependency]
+   └── ILogger
+        │
+        ▼
+GetClassificationHistoryResponse { Items, TotalCount, Page, PageSize }
+
+InvoiceClassificationMappingProfile
+   └── CreateMap<ClassificationHistory, ClassificationHistoryDto>()  [reused, unchanged]
+```
+
+### Key Design Decisions
+
+#### Decision 1: Reuse the existing profile map via IMapper, do not add a projection map
+**Options considered:**
+(a) Inject `IMapper` and call `_mapper.Map<List<ClassificationHistoryDto>>(historyItems)`.
+(b) Use `_mapper.ProjectTo<ClassificationHistoryDto>` for IQueryable server-side projection.
+**Chosen approach:** (a).
+**Rationale:** The repository returns already-materialized items (`(historyItems, totalCount)` from `GetPagedHistoryAsync`), not an `IQueryable`, so `ProjectTo` does not apply. Option (a) matches the exact pattern of `GetClassificationRulesHandler` (`_mapper.Map<List<...Dto>>(...)`), keeping the module internally consistent. Scope stays surgical — the profile is untouched.
+
+#### Decision 2: Keep constructor parameter ordering per spec, not per sibling
+**Options considered:** Match sibling's `(repository, mapper)` order vs. spec's `(historyRepository, mapper, logger)`.
+**Chosen approach:** Follow the spec: `(IClassificationHistoryRepository historyRepository, IMapper mapper, ILogger<GetClassificationHistoryHandler> logger)`.
+**Rationale:** Constructor parameter order is irrelevant to DI resolution (resolved by type), and the spec's ordering preserves the existing `logger`-last convention in this handler. No behavioral difference.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Single file edited:
+`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs`
+
+### Interfaces and Contracts
+- Constructor becomes `(IClassificationHistoryRepository historyRepository, IMapper mapper, ILogger<GetClassificationHistoryHandler> logger)`; add `private readonly IMapper _mapper;`.
+- Add `using AutoMapper;`.
+- `ClassificationHistoryDto` and the `CreateMap<ClassificationHistory, ClassificationHistoryDto>()` configuration are the contract of record — do not change either. The DTO stays a class per the project rule; unaffected here.
+- HTTP contract (`GetClassificationHistoryResponse` envelope) is untouched.
+
+### Data Flow
+1. Handler calls `_historyRepository.GetPagedHistoryAsync(...)` → `(historyItems, totalCount)`. **Unchanged.**
+2. Replace the 17-line `Select(... new ClassificationHistoryDto { ... }).ToList()` with:
+   `var historyDtos = _mapper.Map<List<ClassificationHistoryDto>>(historyItems);`
+3. AutoMapper populates the 14 properties: 12 by name convention, plus `InvoiceId ← AbraInvoiceId` and `RuleName ← ClassificationRule?.Name` (null-safe) from the profile's explicit `ForMember` rules.
+4. Response envelope assembled identically.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Silent output drift — an AutoMapper convention maps a property differently than the manual code, or leaves a field default | Low | Confirm the profile map is validated (`configuration.AssertConfigurationIsValid()`); add/keep a handler or profile unit test asserting all 14 fields, especially `InvoiceId` and null `RuleName` when `ClassificationRule` is null |
+| `ClassificationRule` navigation not loaded, causing `RuleName` to differ from manual `?.` behavior | Low | Behavior is identical — profile uses `src.ClassificationRule != null ? ... : null`, matching the manual `?.`; no repository/include change is in scope |
+| Empty `historyItems` handling | Low | `_mapper.Map<List<...>>` on an empty enumerable returns an empty list — equivalent to `.Select().ToList()` |
+
+## Specification Amendments
+None required. The spec is accurate and complete. One clarification worth capturing during implementation: the two explicit `ForMember` rules in `InvoiceClassificationMappingProfile` (`InvoiceId`, `RuleName`) are what guarantee FR-2 equivalence — the reviewer should verify these against the manual assignments as the equivalence proof, since the other 12 properties rely on name-convention mapping.
+
+## Prerequisites
+None. `IMapper` is already registered in DI (consumed by `GetClassificationRulesHandler` and others) and the `ClassificationHistory → ClassificationHistoryDto` map already exists in `InvoiceClassificationMappingProfile`. No migration, config, or infrastructure change is needed.

--- a/artifacts/feat-3522/brief.md
+++ b/artifacts/feat-3522/brief.md
@@ -1,0 +1,28 @@
+## Module
+InvoiceClassification
+
+## Finding
+`GetClassificationHistoryHandler.Handle` (lines 31–47 of `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs`) manually projects `ClassificationHistory → ClassificationHistoryDto` using a `Select` lambda, including explicit member assignments for all 14 properties.
+
+`InvoiceClassificationMappingProfile` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/InvoiceClassificationMappingProfile.cs`, line 16) already defines this exact mapping:
+```csharp
+CreateMap<ClassificationHistory, ClassificationHistoryDto>()
+    .ForMember(dest => dest.InvoiceId, opt => opt.MapFrom(src => src.AbraInvoiceId))
+    .ForMember(dest => dest.RuleName, opt => opt.MapFrom(src => src.ClassificationRule != null ? src.ClassificationRule.Name : null));
+```
+
+The handler does not inject `IMapper`, despite every sibling handler in the same module (`GetClassificationRulesHandler`, `GetInvoiceDetailsHandler`, `CreateClassificationRuleHandler`, `UpdateClassificationRuleHandler`) doing so.
+
+## Why it matters
+Adding or renaming a field in `ClassificationHistory` or `ClassificationHistoryDto` now requires updating two places — the mapping profile and the handler's manual projection — with no compiler enforcement to remind a developer of the second site. The mapping profile exists precisely to prevent this duplication.
+
+## Suggested fix
+Inject `IMapper` into `GetClassificationHistoryHandler` and replace lines 31–47 with:
+```csharp
+var historyDtos = _mapper.Map<List<ClassificationHistoryDto>>(historyItems);
+```
+
+This is a one-line change that removes ~17 lines of manual boilerplate and brings the handler in line with all its siblings.
+
+---
+_Filed by daily arch-review routine on 2026-07-07._

--- a/artifacts/feat-3522/code-review.r1.md
+++ b/artifacts/feat-3522/code-review.r1.md
@@ -1,0 +1,10 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+## Notes
+AutoMapper scans the whole `Anela.Heblo.Application` assembly, so `InvoiceClassificationMappingProfile` (already existing, pre-dating this branch) is auto-registered; no DI change needed. Confirmed the profile's explicit mappings for `InvoiceId ← AbraInvoiceId` and null-safe `RuleName ← ClassificationRule?.Name` exactly match the removed manual projection, and all other DTO properties match domain property names 1:1 for AutoMapper's convention-based mapping. New tests cover both the rule-present and rule-null branches. Handler change mirrors the sibling `GetClassificationRulesHandler` pattern precisely.

--- a/artifacts/feat-3522/impl/use-imapper-in-classification-history-handler.r1.md
+++ b/artifacts/feat-3522/impl/use-imapper-in-classification-history-handler.r1.md
@@ -1,0 +1,32 @@
+# Implementation: use-imapper-in-classification-history-handler
+
+## What was implemented
+Replaced the 17-line manual `Select` projection in `GetClassificationHistoryHandler.Handle` with a single `_mapper.Map<List<ClassificationHistoryDto>>(historyItems)` call, injecting `IMapper` via the constructor (matching the sibling `GetClassificationRulesHandler`). The existing `InvoiceClassificationMappingProfile` already fully covers the `ClassificationHistory` → `ClassificationHistoryDto` mapping (including `InvoiceId ← AbraInvoiceId` and null-safe `RuleName ← ClassificationRule?.Name`), so no profile changes were needed.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs` — added `using AutoMapper;`, added `private readonly IMapper _mapper;` field, updated constructor to accept and assign `IMapper mapper` (order: repository, mapper, logger), replaced the manual projection with `_mapper.Map<List<ClassificationHistoryDto>>(historyItems)`. Response envelope and repository call untouched.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationMappingProfileTests.cs` — added two tests: `Map_ClassificationHistory_To_Dto_WithClassificationRule_MapsInvoiceIdAndRuleName` (non-null `ClassificationRule`, set via reflection since the navigation property has a private setter — consistent with the existing pattern used in `ClassificationHistoryRepositoryTests.cs`) and `Map_ClassificationHistory_To_Dto_WithoutClassificationRule_RuleNameIsNull` (no rule set). Both assert `InvoiceId` comes from `AbraInvoiceId` and `RuleName` behaves correctly (populated vs. null).
+
+## Tests
+- `InvoiceClassificationMappingProfileTests.cs` — added the two new `ClassificationHistory` mapping tests described above, exercising the exact mapping now used by the handler.
+- Full InvoiceClassification test suite run: `dotnet test --filter "FullyQualifiedName~InvoiceClassification"` → 88 passed, 0 failed.
+
+## How to verify
+1. `cd backend && dotnet build ../Anela.Heblo.sln` (or from repo root: `dotnet build Anela.Heblo.sln`) — succeeds, 0 errors.
+2. `dotnet format Anela.Heblo.sln --include backend/src/.../GetClassificationHistoryHandler.cs backend/test/.../InvoiceClassificationMappingProfileTests.cs --verify-no-changes` — reports no changes (clean).
+3. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"` — 88/88 pass.
+
+## Notes
+- `ClassificationHistory.ClassificationRule` has a private setter (EF navigation property); the new tests set it via reflection, mirroring the existing convention already used in `ClassificationHistoryRepositoryTests.cs` for `Timestamp`.
+- No changes made to `InvoiceClassificationMappingProfile`, `ClassificationHistoryDto`, the domain entity, repository, contracts, controller, or DI registration, per scope constraints.
+- `artifacts/` directory left untouched (not staged/committed) by the developer subagent.
+
+## PR Summary
+`GetClassificationHistoryHandler` now delegates its DTO mapping to `IMapper` instead of hand-rolling a 17-line `Select` projection, bringing it in line with its sibling `GetClassificationRulesHandler` and eliminating a duplicate of the mapping logic already defined in `InvoiceClassificationMappingProfile`. Added unit test coverage in `InvoiceClassificationMappingProfileTests` for both the rule-present and rule-null cases to lock in the null-safe `RuleName` behavior and the `InvoiceId ← AbraInvoiceId` rename.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs` — inject `IMapper`, replace manual projection with `_mapper.Map<List<ClassificationHistoryDto>>(...)`.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationMappingProfileTests.cs` — add two tests covering `ClassificationHistory` → `ClassificationHistoryDto` mapping with and without a linked rule.
+
+## Status
+DONE

--- a/artifacts/feat-3522/review/use-imapper-in-classification-history-handler.r1.md
+++ b/artifacts/feat-3522/review/use-imapper-in-classification-history-handler.r1.md
@@ -1,0 +1,17 @@
+# Code Review: Refactor GetClassificationHistoryHandler to Use IMapper
+
+## Summary
+The implementation exactly matches the task spec: the handler now injects `IMapper`, replaces the 17-line manual `Select` projection with a single `_mapper.Map<List<ClassificationHistoryDto>>(historyItems)` call, and the pre-existing `InvoiceClassificationMappingProfile` (with explicit overrides for `InvoiceId` and `RuleName`) reproduces the original mapping exactly, verified by `AssertConfigurationIsValid()` and two new unit tests covering the rule-present and rule-null cases. Build, format, and full InvoiceClassification test suite all pass.
+
+## Review Result: PASS
+
+### task: use-imapper-in-classification-history-handler
+**Status:** PASS
+
+## Overall Notes
+- Verified via `git diff origin/main...HEAD`: `using AutoMapper;` added, `_mapper` field added, constructor signature is exactly `(IClassificationHistoryRepository historyRepository, IMapper mapper, ILogger<GetClassificationHistoryHandler> logger)`, and `Handle` contains a single mapper call with zero manual property assignments remaining. Response envelope (`GetClassificationHistoryResponse` with `Items`, `TotalCount`, `Page`, `PageSize`) is unchanged.
+- `InvoiceClassificationMappingProfile.CreateMap<ClassificationHistory, ClassificationHistoryDto>()` explicitly maps `InvoiceId` from `AbraInvoiceId` and `RuleName` from `ClassificationRule?.Name`; all other DTO properties map by AutoMapper's default name convention, which is a byte-for-byte equivalent to the original manual `Select` projection.
+- `dotnet build` on the full solution: 0 errors.
+- `dotnet format --verify-no-changes` on the two changed files: clean (exit 0, no output).
+- `dotnet test --filter "FullyQualifiedName~InvoiceClassification"`: 88 passed, 0 failed (matches developer's reported run), including the 2 new `Map_ClassificationHistory_To_Dto_*` tests.
+- No DI registration changes were needed — `GetClassificationHistoryHandler` is only referenced via MediatR's assembly-scanning registration, and `IMapper` is already registered as part of AutoMapper's DI setup; no other callers of the constructor exist in the codebase.

--- a/artifacts/feat-3522/spec.r1.md
+++ b/artifacts/feat-3522/spec.r1.md
@@ -1,0 +1,99 @@
+# Specification: Refactor GetClassificationHistoryHandler to Use IMapper
+
+## Summary
+`GetClassificationHistoryHandler.Handle` hand-writes a 17-line `Select` projection from the `ClassificationHistory` domain entity to `ClassificationHistoryDto`, duplicating a mapping that `InvoiceClassificationMappingProfile` already defines in full. This spec covers replacing the manual projection with a single `IMapper.Map` call so the handler matches every sibling handler in the module and the mapping lives in exactly one place. It is a behavior-preserving internal refactor with no change to inputs, outputs, or the HTTP contract.
+
+## Background
+The InvoiceClassification module uses AutoMapper (via `InvoiceClassificationMappingProfile`) as its single source of truth for domain-to-DTO translation. Four of the module's handlers — `GetClassificationRulesHandler`, `GetInvoiceDetailsHandler`, `CreateClassificationRuleHandler`, `UpdateClassificationRuleHandler` — inject `IMapper` and delegate translation to it.
+
+`GetClassificationHistoryHandler` is the lone exception. It injects only `IClassificationHistoryRepository` and `ILogger`, and manually constructs each `ClassificationHistoryDto` inside a `Select` lambda, assigning all 14 properties by hand (lines 31–47). The mapping profile (line 14–16) already defines the identical `CreateMap<ClassificationHistory, ClassificationHistoryDto>()`, including the two non-trivial member rules:
+- `InvoiceId` ← `src.AbraInvoiceId`
+- `RuleName` ← `src.ClassificationRule != null ? src.ClassificationRule.Name : null`
+
+The remaining 12 properties are name-identical and map by AutoMapper convention.
+
+Because the mapping is expressed twice, adding, removing, or renaming a field on either `ClassificationHistory` or `ClassificationHistoryDto` requires a coordinated edit in two files, and nothing in the compiler or type system flags the second site if a developer forgets it. This is a latent maintenance defect: the profile's mapping is effectively dead code for this path today, and the manual projection can silently drift out of sync.
+
+## Functional Requirements
+
+### FR-1: Delegate history mapping to IMapper
+The handler must translate the paged `ClassificationHistory` items to `ClassificationHistoryDto` via the injected `IMapper` using the existing profile mapping, instead of the inline `Select` projection.
+
+**Acceptance criteria:**
+- `GetClassificationHistoryHandler` declares a `private readonly IMapper _mapper` field, assigned from a constructor parameter.
+- The constructor signature becomes `(IClassificationHistoryRepository historyRepository, IMapper mapper, ILogger<GetClassificationHistoryHandler> logger)` (parameter order at the implementer's discretion, but `IMapper` added alongside the existing dependencies; existing dependencies retained).
+- Lines 31–47 (the inline `Select(... new ClassificationHistoryDto { ... }).ToList()`) are replaced with `var historyDtos = _mapper.Map<List<ClassificationHistoryDto>>(historyItems);`.
+- No manual per-property assignment of `ClassificationHistoryDto` remains anywhere in the handler.
+- `using AutoMapper;` is added to the file's using directives.
+
+### FR-2: Preserve output equivalence
+The DTOs produced after the refactor must be field-for-field identical to those produced by the current manual projection for the same input.
+
+**Acceptance criteria:**
+- All 14 `ClassificationHistoryDto` properties are populated identically to the pre-refactor code: `Id`, `InvoiceId` (from `AbraInvoiceId`), `InvoiceNumber`, `InvoiceDate`, `CompanyName`, `Description`, `ClassificationRuleId`, `RuleName` (from `ClassificationRule?.Name`, null when the rule is null), `Department`, `Result`, `AccountingTemplateCode`, `ErrorMessage`, `Timestamp`, `ProcessedBy`.
+- When `ClassificationRule` is null, `RuleName` is null (the profile's conditional already guarantees this).
+- The `GetClassificationHistoryResponse` envelope is unchanged: `Items`, `TotalCount`, `Page`, and `PageSize` are populated exactly as before.
+- The repository call `GetPagedHistoryAsync(...)` and its arguments are unchanged.
+
+### FR-3: Registration and resolution remain valid
+The handler must continue to resolve from the DI container with all dependencies satisfied.
+
+**Acceptance criteria:**
+- `IMapper` is already registered in the application's service collection (it is, since sibling handlers consume it); no new registration is required. Confirm during implementation that no module-specific registration change is needed.
+- The application builds and the handler is constructible via the container with no runtime "unable to resolve" errors.
+
+### FR-4: Verify mapping profile completeness before deletion
+Before removing the manual projection, confirm the profile mapping covers every field the manual code sets, so no property is silently dropped.
+
+**Acceptance criteria:**
+- Each of the 14 manual assignments corresponds to either an explicit `ForMember` in the profile (`InvoiceId`, `RuleName`) or a convention-based name match (the other 12). This has been verified against the current source and holds; the implementer re-confirms if either type changed since.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change to latency or throughput is expected. AutoMapper compiles its mappings once at startup; per-item mapping cost is comparable to the manual projection. The single-page result set (bounded by `PageSize`) makes any per-item difference negligible. No new database round-trips are introduced.
+
+### NFR-2: Security
+No change to authentication, authorization, data exposure, or the set of fields returned to the client. The refactor is internal to the application layer and touches no endpoint surface, no data sensitivity classification, and no logging of sensitive values.
+
+### NFR-3: Maintainability
+After this change, the `ClassificationHistory → ClassificationHistoryDto` mapping exists in exactly one location (`InvoiceClassificationMappingProfile`), and all five module handlers follow one consistent pattern for DTO translation.
+
+### NFR-4: Backward compatibility
+The HTTP API response shape and values are unchanged. No client, contract, or generated OpenAPI client regeneration is required.
+
+## Data Model
+No schema or entity changes.
+
+- **`ClassificationHistory`** (domain entity, `Anela.Heblo.Domain.Features.InvoiceClassification`) — source. Relevant fields: `Id`, `AbraInvoiceId`, `InvoiceNumber`, `InvoiceDate`, `CompanyName`, `Description`, `ClassificationRuleId`, `ClassificationRule` (navigation, nullable), `Department`, `Result`, `AccountingTemplateCode`, `ErrorMessage`, `Timestamp`, `ProcessedBy`.
+- **`ClassificationHistoryDto`** (`...Application.Features.InvoiceClassification.Contracts`) — destination, 14 properties, class (not record) per project DTO rule.
+- **Mapping** (`InvoiceClassificationMappingProfile`, lines 14–16) — `CreateMap<ClassificationHistory, ClassificationHistoryDto>()` with `ForMember` for `InvoiceId` and `RuleName`; unchanged by this spec.
+
+## API / Interface Design
+No public interface changes.
+
+- **Handler:** `GetClassificationHistoryHandler : IRequestHandler<GetClassificationHistoryRequest, GetClassificationHistoryResponse>` — constructor gains an `IMapper` parameter; `Handle` body swaps the projection for a mapper call. Signature of `Handle` unchanged.
+- **Request/Response contracts:** `GetClassificationHistoryRequest`, `GetClassificationHistoryResponse` — unchanged.
+- **Endpoint:** the MVC controller action fronting this request — unchanged.
+
+## Dependencies
+- **AutoMapper** — already referenced by the Application project and configured via `InvoiceClassificationMappingProfile`; already registered in DI and consumed by sibling handlers.
+- **MediatR** — unchanged.
+- No new packages, services, or configuration.
+
+## Testing
+- Existing behavior is unit-testable: no test currently references `GetClassificationHistoryHandler` (confirmed — none found under `backend/test`). Adding a focused unit test is recommended but optional per this spec's scope; if added, it should assert that a `ClassificationHistory` (including one case with a null `ClassificationRule`) maps to the expected `ClassificationHistoryDto` field values and that the response envelope (`TotalCount`, `Page`, `PageSize`) is populated.
+- An AutoMapper `ConfigurationProvider.AssertConfigurationIsValid()` check, if one exists in the test suite, must still pass.
+- Validation gate per project rules: `dotnet build` succeeds and `dotnet format` reports no changes on the touched file.
+
+## Out of Scope
+- Refactoring any other handler or any other manual projection elsewhere in the codebase.
+- Changing the mapping profile, the DTO, the domain entity, or the repository.
+- Altering paging, filtering, or sorting behavior of `GetPagedHistoryAsync`.
+- Modifying the controller, request/response contracts, or the OpenAPI client.
+- Removing the `ILogger` dependency (retained even though it is currently unused in `Handle`; its removal is a separate concern).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-07-07T10:17:04.595609Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T10:17:13.094488Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T10:18:43.461810Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T10:18:48.799742Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T10:18:59.081792Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T10:15:13.978054Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T10:17:04.595609Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T10:17:13.094488Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T10:15:13.978054Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-07T10:49:07.430965Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-07T10:50:13.964028Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3522",
+  "issue_number": 3522,
+  "created_at": "2026-07-07T10:14:09.144217Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T10:20:18.252731Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T10:20:44.914487Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T10:49:07.430965Z"
     }
   },
   "tasks": [
     {
       "name": "use-imapper-in-classification-history-handler",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-07T10:20:45.138767Z"
+      "updated_at": "2026-07-07T10:49:06.921281Z"
     }
   ]
 }

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T10:20:18.252731Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T10:20:44.914487Z"
     }
   },
   "tasks": [
     {
       "name": "use-imapper-in-classification-history-handler",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-07T10:20:45.138767Z"
     }
   ]
 }

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-07T10:18:48.799742Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T10:18:59.081792Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T10:20:18.252731Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "use-imapper-in-classification-history-handler",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3522/state.json
+++ b/artifacts/feat-3522/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-07T10:49:07.430965Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T10:50:13.964028Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T10:51:18.102228Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3522/task-context/use-imapper-in-classification-history-handler.md
+++ b/artifacts/feat-3522/task-context/use-imapper-in-classification-history-handler.md
@@ -1,0 +1,57 @@
+### task: use-imapper-in-classification-history-handler
+
+**Goal**
+Replace the hand-written 17-line `Select` projection in `GetClassificationHistoryHandler.Handle` with a single `IMapper.Map<List<ClassificationHistoryDto>>(...)` call, injecting `IMapper` via the constructor. This makes the handler match its sibling `GetClassificationRulesHandler` and eliminates a duplicate of the mapping already fully defined in `InvoiceClassificationMappingProfile`. Output must remain byte-for-byte equivalent.
+
+**File to touch (only this one)**
+`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs`
+
+Do NOT touch: `InvoiceClassificationMappingProfile`, `ClassificationHistoryDto`, the domain entity, the repository, the request/response contracts, the controller, or DI registration. `IMapper` is already registered in DI, so no registration change is needed.
+
+**Exact changes**
+
+1. Add `using AutoMapper;` to the using block (top of file, alongside the existing usings — place it first to match the sibling handler's ordering).
+
+2. Add a mapper field next to the existing fields:
+   - Keep `private readonly IClassificationHistoryRepository _historyRepository;` and `private readonly ILogger<GetClassificationHistoryHandler> _logger;`
+   - Add `private readonly IMapper _mapper;`
+
+3. Change the constructor signature to inject `IMapper` and assign it. The constructor becomes:
+   ```csharp
+   public GetClassificationHistoryHandler(
+       IClassificationHistoryRepository historyRepository,
+       IMapper mapper,
+       ILogger<GetClassificationHistoryHandler> logger)
+   {
+       _historyRepository = historyRepository;
+       _mapper = mapper;
+       _logger = logger;
+   }
+   ```
+   (Parameter order exactly: `historyRepository`, `mapper`, `logger` — as specified in FR-1.)
+
+4. In `Handle`, replace the entire manual projection block (current lines 31-47, the `var historyDtos = historyItems.Select(history => new ClassificationHistoryDto { ... }).ToList();`) with a single line:
+   ```csharp
+   var historyDtos = _mapper.Map<List<ClassificationHistoryDto>>(historyItems);
+   ```
+   No per-property assignment may remain. Leave the `_historyRepository.GetPagedHistoryAsync(...)` call above it and the `return new GetClassificationHistoryResponse { Items = historyDtos, TotalCount = totalCount, Page = request.Page, PageSize = request.PageSize };` block below it unchanged.
+
+**Important correctness notes (why this is safe)**
+- `InvoiceClassificationMappingProfile` already maps all 14 `ClassificationHistoryDto` properties, including the two non-convention ones: `InvoiceId` ← `AbraInvoiceId`, and `RuleName` ← `ClassificationRule?.Name` (null-safe when the rule is null). The other 12 properties are same-name convention mappings. Do not re-add any of these manually and do not modify the profile.
+- The `_logger` field is retained even if currently unused elsewhere — do not remove it; scope is limited to the mapping refactor.
+
+**Optional (recommended) unit test**
+If adding a test, create it under the module's test project mirroring the existing test layout for InvoiceClassification handlers (locate the sibling handler/profile tests first; do not invent a new structure). The test should map a `ClassificationHistory` domain instance to `ClassificationHistoryDto` via the real `InvoiceClassificationMappingProfile` (construct a `MapperConfiguration` with that profile, `AssertConfigurationIsValid()`, then `CreateMapper()`), asserting:
+- `InvoiceId` equals the source `AbraInvoiceId`.
+- `RuleName` equals `ClassificationRule.Name` when the rule is present.
+- `RuleName` is null when `ClassificationRule` is null (second case).
+- The remaining 12 properties are copied identically.
+This guards against silent output drift on the convention-mapped properties. If the surrounding test infrastructure does not already exist and creating it would exceed the surgical scope, skip the test rather than scaffolding a new test project.
+
+**Acceptance criteria**
+- The handler declares `private readonly IMapper _mapper;`, the constructor signature is exactly `(IClassificationHistoryRepository historyRepository, IMapper mapper, ILogger<GetClassificationHistoryHandler> logger)`, and `Handle` contains the single `_mapper.Map<List<ClassificationHistoryDto>>(historyItems)` call with zero manual property assignments.
+- `using AutoMapper;` is present; no unused usings introduced.
+- The response envelope (`Items`, `TotalCount`, `Page`, `PageSize`) is unchanged and populated as before.
+- `dotnet build` succeeds.
+- `dotnet format` reports no changes (i.e., run it and confirm a clean diff on the touched file).
+- If a unit test was added, it passes.

--- a/artifacts/feat-3522/task-plan.r1.md
+++ b/artifacts/feat-3522/task-plan.r1.md
@@ -1,0 +1,57 @@
+### task: use-imapper-in-classification-history-handler
+
+**Goal**
+Replace the hand-written 17-line `Select` projection in `GetClassificationHistoryHandler.Handle` with a single `IMapper.Map<List<ClassificationHistoryDto>>(...)` call, injecting `IMapper` via the constructor. This makes the handler match its sibling `GetClassificationRulesHandler` and eliminates a duplicate of the mapping already fully defined in `InvoiceClassificationMappingProfile`. Output must remain byte-for-byte equivalent.
+
+**File to touch (only this one)**
+`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs`
+
+Do NOT touch: `InvoiceClassificationMappingProfile`, `ClassificationHistoryDto`, the domain entity, the repository, the request/response contracts, the controller, or DI registration. `IMapper` is already registered in DI, so no registration change is needed.
+
+**Exact changes**
+
+1. Add `using AutoMapper;` to the using block (top of file, alongside the existing usings — place it first to match the sibling handler's ordering).
+
+2. Add a mapper field next to the existing fields:
+   - Keep `private readonly IClassificationHistoryRepository _historyRepository;` and `private readonly ILogger<GetClassificationHistoryHandler> _logger;`
+   - Add `private readonly IMapper _mapper;`
+
+3. Change the constructor signature to inject `IMapper` and assign it. The constructor becomes:
+   ```csharp
+   public GetClassificationHistoryHandler(
+       IClassificationHistoryRepository historyRepository,
+       IMapper mapper,
+       ILogger<GetClassificationHistoryHandler> logger)
+   {
+       _historyRepository = historyRepository;
+       _mapper = mapper;
+       _logger = logger;
+   }
+   ```
+   (Parameter order exactly: `historyRepository`, `mapper`, `logger` — as specified in FR-1.)
+
+4. In `Handle`, replace the entire manual projection block (current lines 31-47, the `var historyDtos = historyItems.Select(history => new ClassificationHistoryDto { ... }).ToList();`) with a single line:
+   ```csharp
+   var historyDtos = _mapper.Map<List<ClassificationHistoryDto>>(historyItems);
+   ```
+   No per-property assignment may remain. Leave the `_historyRepository.GetPagedHistoryAsync(...)` call above it and the `return new GetClassificationHistoryResponse { Items = historyDtos, TotalCount = totalCount, Page = request.Page, PageSize = request.PageSize };` block below it unchanged.
+
+**Important correctness notes (why this is safe)**
+- `InvoiceClassificationMappingProfile` already maps all 14 `ClassificationHistoryDto` properties, including the two non-convention ones: `InvoiceId` ← `AbraInvoiceId`, and `RuleName` ← `ClassificationRule?.Name` (null-safe when the rule is null). The other 12 properties are same-name convention mappings. Do not re-add any of these manually and do not modify the profile.
+- The `_logger` field is retained even if currently unused elsewhere — do not remove it; scope is limited to the mapping refactor.
+
+**Optional (recommended) unit test**
+If adding a test, create it under the module's test project mirroring the existing test layout for InvoiceClassification handlers (locate the sibling handler/profile tests first; do not invent a new structure). The test should map a `ClassificationHistory` domain instance to `ClassificationHistoryDto` via the real `InvoiceClassificationMappingProfile` (construct a `MapperConfiguration` with that profile, `AssertConfigurationIsValid()`, then `CreateMapper()`), asserting:
+- `InvoiceId` equals the source `AbraInvoiceId`.
+- `RuleName` equals `ClassificationRule.Name` when the rule is present.
+- `RuleName` is null when `ClassificationRule` is null (second case).
+- The remaining 12 properties are copied identically.
+This guards against silent output drift on the convention-mapped properties. If the surrounding test infrastructure does not already exist and creating it would exceed the surgical scope, skip the test rather than scaffolding a new test project.
+
+**Acceptance criteria**
+- The handler declares `private readonly IMapper _mapper;`, the constructor signature is exactly `(IClassificationHistoryRepository historyRepository, IMapper mapper, ILogger<GetClassificationHistoryHandler> logger)`, and `Handle` contains the single `_mapper.Map<List<ClassificationHistoryDto>>(historyItems)` call with zero manual property assignments.
+- `using AutoMapper;` is present; no unused usings introduced.
+- The response envelope (`Items`, `TotalCount`, `Page`, `PageSize`) is unchanged and populated as before.
+- `dotnet build` succeeds.
+- `dotnet format` reports no changes (i.e., run it and confirm a clean diff on the touched file).
+- If a unit test was added, it passes.

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs
@@ -1,3 +1,4 @@
+using AutoMapper;
 using MediatR;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
 using Anela.Heblo.Application.Features.InvoiceClassification.Contracts;
@@ -8,13 +9,16 @@ namespace Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetCla
 public class GetClassificationHistoryHandler : IRequestHandler<GetClassificationHistoryRequest, GetClassificationHistoryResponse>
 {
     private readonly IClassificationHistoryRepository _historyRepository;
+    private readonly IMapper _mapper;
     private readonly ILogger<GetClassificationHistoryHandler> _logger;
 
     public GetClassificationHistoryHandler(
         IClassificationHistoryRepository historyRepository,
+        IMapper mapper,
         ILogger<GetClassificationHistoryHandler> logger)
     {
         _historyRepository = historyRepository;
+        _mapper = mapper;
         _logger = logger;
     }
 
@@ -28,23 +32,7 @@ public class GetClassificationHistoryHandler : IRequestHandler<GetClassification
             request.InvoiceNumber,
             request.CompanyName);
 
-        var historyDtos = historyItems.Select(history => new ClassificationHistoryDto
-        {
-            Id = history.Id,
-            InvoiceId = history.AbraInvoiceId,
-            InvoiceNumber = history.InvoiceNumber,
-            InvoiceDate = history.InvoiceDate,
-            CompanyName = history.CompanyName,
-            Description = history.Description,
-            ClassificationRuleId = history.ClassificationRuleId,
-            RuleName = history.ClassificationRule?.Name,
-            Department = history.Department,
-            Result = history.Result,
-            AccountingTemplateCode = history.AccountingTemplateCode,
-            ErrorMessage = history.ErrorMessage,
-            Timestamp = history.Timestamp,
-            ProcessedBy = history.ProcessedBy
-        }).ToList();
+        var historyDtos = _mapper.Map<List<ClassificationHistoryDto>>(historyItems);
 
         return new GetClassificationHistoryResponse
         {

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationMappingProfileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationMappingProfileTests.cs
@@ -99,4 +99,55 @@ public class InvoiceClassificationMappingProfileTests
         dto.Name.Should().Be("Widget");
         dto.Amount.Should().Be(42.5m);
     }
+
+    [Fact]
+    public void Map_ClassificationHistory_To_Dto_WithClassificationRule_MapsInvoiceIdAndRuleName()
+    {
+        var rule = new DomainTypes.ClassificationRule(
+            name: "Office supplies rule",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Acme",
+            accountingTemplateCode: "ACC-001",
+            department: "OPS",
+            createdBy: "system");
+
+        var source = new DomainTypes.ClassificationHistory(
+            abraInvoiceId: "INV-123",
+            invoiceNumber: "FV-2026-001",
+            invoiceDate: new DateTime(2026, 5, 26),
+            companyName: "Acme s.r.o.",
+            description: "Materials for May",
+            result: DomainTypes.ClassificationResult.Success,
+            processedBy: "system",
+            classificationRuleId: rule.Id,
+            accountingTemplateCode: "ACC-001",
+            department: "OPS");
+
+        typeof(DomainTypes.ClassificationHistory)
+            .GetProperty(nameof(DomainTypes.ClassificationHistory.ClassificationRule))!
+            .SetValue(source, rule);
+
+        var dto = _mapper.Map<ContractTypes.ClassificationHistoryDto>(source);
+
+        dto.InvoiceId.Should().Be("INV-123");
+        dto.RuleName.Should().Be("Office supplies rule");
+    }
+
+    [Fact]
+    public void Map_ClassificationHistory_To_Dto_WithoutClassificationRule_RuleNameIsNull()
+    {
+        var source = new DomainTypes.ClassificationHistory(
+            abraInvoiceId: "INV-456",
+            invoiceNumber: "FV-2026-002",
+            invoiceDate: new DateTime(2026, 5, 27),
+            companyName: "Beta s.r.o.",
+            description: "Materials for review",
+            result: DomainTypes.ClassificationResult.ManualReviewRequired,
+            processedBy: "system");
+
+        var dto = _mapper.Map<ContractTypes.ClassificationHistoryDto>(source);
+
+        dto.InvoiceId.Should().Be("INV-456");
+        dto.RuleName.Should().BeNull();
+    }
 }


### PR DESCRIPTION
Closes #3522

## What the issue was
`GetClassificationHistoryHandler.Handle` manually projected `ClassificationHistory` → `ClassificationHistoryDto` with a 17-line `Select` lambda, explicitly assigning all 14 properties. `InvoiceClassificationMappingProfile` already defines this exact mapping (including the two non-conventional members `InvoiceId ← AbraInvoiceId` and `RuleName ← ClassificationRule?.Name`), and every sibling handler in the module (`GetClassificationRulesHandler`, `GetInvoiceDetailsHandler`, `CreateClassificationRuleHandler`, `UpdateClassificationRuleHandler`) already injects `IMapper` and uses it — this handler was the lone exception, creating a duplicated mapping that could silently drift out of sync.

## How it was fixed / handled
- Injected `IMapper` into `GetClassificationHistoryHandler`'s constructor (`IClassificationHistoryRepository historyRepository, IMapper mapper, ILogger<GetClassificationHistoryHandler> logger`).
- Replaced the manual 17-line `Select` projection with a single `_mapper.Map<List<ClassificationHistoryDto>>(historyItems)` call.
- Added `using AutoMapper;`; no changes to the mapping profile, DTO, domain entity, repository, controller, or contracts — output is byte-for-byte equivalent to the prior manual projection.
- Added two unit tests in `InvoiceClassificationMappingProfileTests` covering the rule-present case (`InvoiceId` from `AbraInvoiceId`, `RuleName` populated) and the rule-null case (`RuleName` is null), to lock in the equivalence.
- Verified: `dotnet build` (0 errors), `dotnet format --verify-no-changes` (clean), and the full InvoiceClassification test suite (88/88 passed, including the 2 new tests).

## Artifacts
Brief, spec, arch-review, task plan, impl, and review markdown are committed under `artifacts/feat-3522/` in this branch.

## Code review

Final whole-branch review (see `artifacts/feat-3522/code-review.r1.md`):

```
## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None
```

AutoMapper scans the whole `Anela.Heblo.Application` assembly, so `InvoiceClassificationMappingProfile` (pre-existing) is auto-registered — no DI change needed. The profile's explicit mappings for `InvoiceId` and `RuleName` exactly match the removed manual projection; all other DTO properties map by AutoMapper's name convention. New tests cover both branches. The change mirrors the sibling `GetClassificationRulesHandler` pattern precisely.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6eJt9tCRcDccouCJRLQBZ)_