### PR TITLE
fix: persist Plaud CLI token rotations to Key Vault to stop auth-expiry recurrence

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/IPlaudTokenRefresher.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/IPlaudTokenRefresher.cs
@@ -8,4 +8,12 @@ namespace Anela.Heblo.Adapters.Plaud;
 public interface IPlaudTokenRefresher
 {
     Task RefreshAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Mirrors the current on-disk <c>~/.plaud/tokens.json</c> to Key Vault when it has changed.
+    /// The Plaud CLI rotates the refresh token on disk during normal use without going through
+    /// <see cref="RefreshAsync"/>; without this sync those rotations never reach Key Vault, so a
+    /// container restart re-seeds a stale token. Best-effort — never throws.
+    /// </summary>
+    Task SyncToKeyVaultAsync(CancellationToken ct = default);
 }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudAuthExpiredException.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudAuthExpiredException.cs
@@ -2,11 +2,19 @@ namespace Anela.Heblo.Adapters.Plaud;
 
 public sealed class PlaudAuthExpiredException : Exception
 {
+    // Recovery must target the Key Vault secret, NOT the App Service env var: Key Vault overrides
+    // the `Plaud__TokensJson` env var at startup, so editing the env var has no effect.
+    private const string RecoveryHint =
+        "Plaud authentication expired (stored refresh token is dead). Recover: run `plaud login`, "
+        + "then write the fresh ~/.plaud/tokens.json into Key Vault secret `Plaud--TokensJson` "
+        + "(kv-heblo-prod / kv-heblo-stg) and restart the app. "
+        + "See docs/integrations/plaud-token-auto-refresh.md.";
+
     public PlaudAuthExpiredException(string stderr)
-        : base($"Plaud authentication expired. Run `plaud login` and update App Service setting `Plaud__TokensJson`. CLI stderr: {stderr ?? "(empty)"}")
+        : base($"{RecoveryHint} CLI stderr: {stderr ?? "(empty)"}")
     { }
 
     public PlaudAuthExpiredException(string stderr, Exception innerException)
-        : base($"Plaud authentication expired. Run `plaud login` and update App Service setting `Plaud__TokensJson`. CLI stderr: {stderr ?? "(empty)"}", innerException)
+        : base($"{RecoveryHint} CLI stderr: {stderr ?? "(empty)"}", innerException)
     { }
 }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudCliClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudCliClient.cs
@@ -83,7 +83,11 @@ public sealed class PlaudCliClient : IPlaudClient
     {
         try
         {
-            return await RunCliCoreAsync(args, ct);
+            var output = await RunCliCoreAsync(args, ct);
+            // The CLI rotates the on-disk refresh token during a normal (non-AUTH_FAILED) call.
+            // Mirror it to Key Vault so a container restart never re-seeds a stale token. Best-effort.
+            await _tokenRefresher.SyncToKeyVaultAsync(ct);
+            return output;
         }
         catch (PlaudAuthExpiredException)
         {
@@ -100,6 +104,7 @@ public sealed class PlaudCliClient : IPlaudClient
 
             _logger.LogInformation("Plaud token refreshed; retrying CLI call.");
             // A second AUTH_FAILED here means the refreshed token is still rejected — surface it.
+            // RefreshAsync already persisted the fresh token to Key Vault, so no extra sync needed.
             return await RunCliCoreAsync(args, ct);
         }
     }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudTokenRefresher.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudTokenRefresher.cs
@@ -18,6 +18,10 @@ public sealed class PlaudTokenRefresher : IPlaudTokenRefresher
     private readonly string _tokensFilePath;
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
 
+    // Last token JSON successfully written to Key Vault. Lets SyncToKeyVaultAsync skip a KV write
+    // when the on-disk token is unchanged, so continuous 5-minute polling doesn't spam KV versions.
+    private string? _lastPersistedJson;
+
     public PlaudTokenRefresher(
         IPlaudTokenRefreshClient refreshClient,
         ILogger<PlaudTokenRefresher> logger,
@@ -85,6 +89,7 @@ public sealed class PlaudTokenRefresher : IPlaudTokenRefresher
                 try
                 {
                     await _secretClient.SetSecretAsync(KeyVaultSecretName, newJson, ct);
+                    _lastPersistedJson = newJson;
                 }
                 catch (Exception ex)
                 {
@@ -95,6 +100,38 @@ public sealed class PlaudTokenRefresher : IPlaudTokenRefresher
             }
 
             _logger.LogInformation("Plaud token refreshed. expires_at={ExpiresAt}", newTokens.ExpiresAt);
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    public async Task SyncToKeyVaultAsync(CancellationToken ct = default)
+    {
+        // Nothing to mirror to when KV isn't configured (local dev) or the file isn't there yet.
+        if (_secretClient is null || !File.Exists(_tokensFilePath))
+            return;
+
+        // Share the refresh lock so a sync can't race a concurrent RefreshAsync writing the file.
+        await _refreshLock.WaitAsync(ct);
+        try
+        {
+            var diskJson = await File.ReadAllTextAsync(_tokensFilePath, ct);
+
+            // Only push when the CLI actually rotated the token — avoids a KV write on every poll.
+            if (diskJson == _lastPersistedJson)
+                return;
+
+            await _secretClient.SetSecretAsync(KeyVaultSecretName, diskJson, ct);
+            _lastPersistedJson = diskJson;
+            _logger.LogInformation("Plaud on-disk token mirrored to Key Vault.");
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a failed sync only means a future restart could re-seed a slightly older
+            // token. It must never fail the CLI call that triggered the sync.
+            _logger.LogError(ex, "Failed to mirror Plaud on-disk token to Key Vault.");
         }
         finally
         {

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudTokenRefresher.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudTokenRefresher.cs
@@ -114,7 +114,9 @@ public sealed class PlaudTokenRefresher : IPlaudTokenRefresher
             return;
 
         // Share the refresh lock so a sync can't race a concurrent RefreshAsync writing the file.
-        await _refreshLock.WaitAsync(ct);
+        // CancellationToken.None: this is best-effort and must never throw, so we don't let the
+        // caller's ct cancel the lock wait and escape the catch block below.
+        await _refreshLock.WaitAsync(CancellationToken.None);
         try
         {
             var diskJson = await File.ReadAllTextAsync(_tokensFilePath, ct);

--- a/backend/test/Anela.Heblo.Adapters.Plaud.Tests/PlaudAuthExceptionTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Plaud.Tests/PlaudAuthExceptionTests.cs
@@ -12,7 +12,9 @@ public sealed class PlaudAuthExceptionTests
         var ex = new PlaudAuthExpiredException(stderr);
 
         ex.Message.Should().Contain(stderr);
-        ex.Message.Should().Contain("Plaud__TokensJson");
+        // Recovery must point at the Key Vault secret, not the (overridden) App Service env var.
+        ex.Message.Should().Contain("Plaud--TokensJson");
+        ex.Message.Should().Contain("plaud login");
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Adapters/Plaud/PlaudTokenRefresherTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/Plaud/PlaudTokenRefresherTests.cs
@@ -151,4 +151,67 @@ public sealed class PlaudTokenRefresherTests : IDisposable
         var diskContent = await File.ReadAllTextAsync(_tokensPath);
         diskContent.Should().Contain("new-refresh");
     }
+
+    [Fact]
+    public async Task SyncToKeyVaultAsync_WritesDiskTokenToKeyVault()
+    {
+        await File.WriteAllTextAsync(_tokensPath, CurrentTokensJson);
+
+        await CreateRefresher().SyncToKeyVaultAsync();
+
+        _secretClient.Verify(
+            s => s.SetSecretAsync(
+                "Plaud--TokensJson",
+                It.Is<string>(v => v.Contains("old-refresh")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncToKeyVaultAsync_SkipsWriteWhenDiskUnchanged()
+    {
+        await File.WriteAllTextAsync(_tokensPath, CurrentTokensJson);
+        var refresher = CreateRefresher();
+
+        await refresher.SyncToKeyVaultAsync();
+        await refresher.SyncToKeyVaultAsync(); // disk unchanged — must not write again
+
+        _secretClient.Verify(
+            s => s.SetSecretAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncToKeyVaultAsync_NoOpWhenKeyVaultNotConfigured()
+    {
+        await File.WriteAllTextAsync(_tokensPath, CurrentTokensJson);
+
+        Func<Task> act = () => CreateRefresher(withKeyVault: false).SyncToKeyVaultAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SyncToKeyVaultAsync_NoOpWhenTokensFileMissing()
+    {
+        // No tokens.json written.
+        await CreateRefresher().SyncToKeyVaultAsync();
+
+        _secretClient.Verify(
+            s => s.SetSecretAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SyncToKeyVaultAsync_KeyVaultFailureIsBestEffort_NoThrow()
+    {
+        await File.WriteAllTextAsync(_tokensPath, CurrentTokensJson);
+        _secretClient
+            .Setup(s => s.SetSecretAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RequestFailedException("KV unavailable"));
+
+        Func<Task> act = () => CreateRefresher().SyncToKeyVaultAsync();
+
+        await act.Should().NotThrowAsync();
+    }
 }

--- a/docs/integrations/plaud-token-auto-refresh.md
+++ b/docs/integrations/plaud-token-auto-refresh.md
@@ -23,6 +23,12 @@
    propagates as `PlaudAuthExpiredException` and fires the Azure Monitor alert.
 4. `PlaudTokenBootstrapper` re-seeds `~/.plaud/tokens.json` from Key Vault on the next container
    restart, so the KV-persisted token survives restarts.
+5. **Disk→KV sync on every successful call.** The Plaud CLI silently rotates the on-disk refresh
+   token during a *normal* (non-`AUTH_FAILED`) call, which the reactive path never sees. After each
+   successful CLI call `PlaudCliClient` calls `IPlaudTokenRefresher.SyncToKeyVaultAsync`, which
+   mirrors `~/.plaud/tokens.json` to KV `Plaud--TokensJson` **only when it changed** (best-effort).
+   This keeps Key Vault current so a restart never re-seeds a stale token — the fix for the
+   restart-stale-token problem below.
 
 The refresh HTTP client is registered unconditionally; Key Vault persistence is wired only when
 `KeyVault:Uri` is set (production/staging). In local dev the refresher writes disk only.
@@ -42,20 +48,51 @@ az keyvault secret set --vault-name kv-heblo-prod --name Plaud--TokensJson \
 az webapp restart -g rgHeblo -n heblo
 ```
 
-## Root Cause of the Bootstrapper-Overwrite Problem
+## Root Cause of the Restart-Stale-Token Problem (fixed)
 
 `PlaudTokenBootstrapper` (`backend/src/Adapters/Anela.Heblo.Adapters.Plaud/PlaudTokenBootstrapper.cs`)
-writes `~/.plaud/tokens.json` from the App Service setting `Plaud__TokensJson` on every container start.
+writes `~/.plaud/tokens.json` from `PlaudOptions.TokensJson` on every container start.
 
-The Plaud CLI auto-refreshes its tokens on every call, so continuous 5-minute polling normally keeps the
-refresh token alive indefinitely. However, a container restart re-seeds a potentially stale token from
-the App Service setting. If the stored `refresh_token` has aged past Plaud's hard TTL, every subsequent
-CLI call fails with `[AUTH_FAILED] Token invalid or expired`.
+**Config precedence:** `Program.cs` adds environment variables first (via `CreateBuilder`), then layers
+`AddAzureKeyVault` on top (only user-secrets and command-line are re-added after KV). So the **Key Vault
+secret `Plaud--TokensJson` overrides the App Service env var `Plaud__TokensJson`** — Key Vault is the
+effective source of truth on startup. Editing the env var has no effect; it should not exist (secrets
+live in Key Vault only) and has been removed.
 
-**Short-term mitigation (implemented):** `PlaudPollingJob` now has
-`[AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Fail)]`, which prevents the
-10× retry flood and throws `PlaudAuthExpiredException` with actionable message. An Azure Monitor alert
-fires within 5 minutes of the first failure (see monitoring alert `Heblo-Plaud-AuthExpired`).
+The Plaud CLI auto-refreshes (rotates) its refresh token on disk during normal polling. Previously those
+rotations were **never mirrored to Key Vault** (only the reactive `PlaudTokenRefresher` wrote KV, and only
+on `AUTH_FAILED`), so the KV secret froze at its seeded value. A container restart then re-seeded that
+now-invalidated refresh token, and every subsequent CLI call failed `[AUTH_FAILED]` → refresh returned
+`{"detail":"REFRESH_TOKEN_INVALID"}` (HTTP 401) before it could heal KV → permanent wedge.
+
+**Fix (implemented):** `SyncToKeyVaultAsync` (step 5 in *How It Works*) mirrors the CLI's on-disk token
+rotations to KV after every successful call, so the KV secret always reflects the live token and a
+restart re-seeds a valid one. `PlaudPollingJob` keeps
+`[AutomaticRetry(Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Fail)]` so a genuinely dead
+token surfaces `PlaudAuthExpiredException` immediately (no 10× retry flood) and fires the Azure Monitor
+alert `Heblo-Plaud-AuthExpired` within 5 minutes.
+
+## Recovery Runbook (refresh token dead → `REFRESH_TOKEN_INVALID`)
+
+If the stored refresh token dies (e.g. aged past Plaud's hard TTL while polling was paused), the token
+must be re-minted and written to **Key Vault** — not the App Service env var (which is overridden). For
+production (`kv-heblo-prod` / app `heblo`); use `kv-heblo-stg` / `heblo-test` for staging:
+
+```bash
+plaud login                                   # interactive — mints a fresh token pair
+cat ~/.plaud/tokens.json                       # verify access_token, refresh_token, expires_at (13-digit ms)
+
+az keyvault secret set --vault-name kv-heblo-prod --name "Plaud--TokensJson" \
+    --value "$(cat ~/.plaud/tokens.json)"      # write to the source of truth
+
+az webapp config appsettings delete -g rgHeblo -n heblo --setting-names Plaud__TokensJson  # remove stale env var (if present)
+az webapp restart -g rgHeblo -n heblo          # re-seed disk from fresh KV
+
+# Verify: no new auth failures, and KV 'updated' starts advancing as polling rotates + syncs the token
+az monitor app-insights query --app aiHeblo -g rgHeblo \
+  --analytics-query "exceptions | where type endswith 'PlaudAuthExpiredException' | where timestamp > ago(15m) | count"
+az keyvault secret show --vault-name kv-heblo-prod --name Plaud--TokensJson --query attributes.updated -o tsv
+```
 
 ## Observed Refresh Endpoint
 
@@ -90,7 +127,12 @@ re-serializes.
 > **Open question:** Confirm Plaud's refresh-token hard TTL by inspecting `expires_in` and observing
 > rotation over several days. The hard TTL appears to be ~30 days but is not officially documented.
 
-## Proposed Design
+## Proposed Design (historical — superseded by the reactive implementation above)
+
+> This section is the original design sketch. It has been **implemented differently**: refresh is
+> reactive (no standalone `plaud-token-refresh` job), KV is kept current via `SyncToKeyVaultAsync`
+> (see *How It Works* step 5), and the `Plaud__TokensJson` App Service env var has been removed —
+> Key Vault `Plaud--TokensJson` is the source of truth. Kept for context only.
 
 ### `PlaudTokenRefreshClient`
 


### PR DESCRIPTION
`PlaudPollingJob` kept failing on prod with `REFRESH_TOKEN_INVALID` because the Plaud CLI silently rotates the on-disk refresh token during normal polling, but those rotations were never mirrored to Key Vault — so a container restart re-seeded a stale token and wedged auth until a manual re-seed. This adds `IPlaudTokenRefresher.SyncToKeyVaultAsync`, called from `PlaudCliClient.RunCliAsync` after every successful CLI call, which best-effort mirrors `~/.plaud/tokens.json` to KV secret `Plaud--TokensJson` only when it changed, keeping KV current so restarts re-seed a valid token. It also fixes the misleading `PlaudAuthExpiredException` message to direct recovery at the Key Vault secret (which overrides the App Service env var at startup) rather than the `Plaud__TokensJson` env var. Includes new sync unit tests, an updated auth-exception assertion, and a corrected root-cause explanation plus recovery runbook in `docs/integrations/plaud-token-auto-refresh.md`.

Verified: `dotnet build` + `dotnet format --verify-no-changes` clean; Plaud adapter tests (21) and `PlaudTokenRefresher` tests (11, incl. 5 new) pass.