### PR TITLE
#3524: remove redundant re-filter/re-sort in RuleEvaluationEngine

### DIFF
--- a/artifacts/feat-3524/arch-review.r1.md
+++ b/artifacts/feat-3524/arch-review.r1.md
@@ -1,0 +1,85 @@
+# Architecture Review: Remove redundant filter/sort in RuleEvaluationEngine.FindMatchingRule
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a one-line internal refactor inside `RuleEvaluationEngine.FindMatchingRule` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs`, line 16). It touches no public contract, no DTO, no controller, no persistence, and no UI. Verified against the actual source:
+
+- `IRuleEvaluationEngine.FindMatchingRule(ReceivedInvoice invoice, List<ClassificationRule> rules)` — signature is unchanged by this fix; only its implicit contract tightens.
+- `InvoiceClassificationService.ClassifyInvoiceAsync` (lines 38-40) is the **only** production call site, and it always supplies `await _ruleRepository.GetActiveRulesOrderedAsync()`.
+- `ClassificationRuleRepository.GetActiveRulesOrderedAsync()` (lines 22-27) already does `.Where(r => r.IsActive).OrderBy(r => r.Order)` at the EF Core query level (translated to SQL, not in-memory LINQ).
+- A repo-wide search confirms no other caller of `IRuleEvaluationEngine.FindMatchingRule` exists in production code (only test doubles construct `RuleEvaluationEngine` directly).
+
+This aligns cleanly with the codebase's existing convention of pushing filtering/sorting to the repository/query layer (see `GetAllAsync()` in the same repository, which also pre-sorts by `Order` for its own consumers). The engine re-doing `Where`/`OrderBy` was pure duplication with no offsetting benefit — it's a textbook KISS/YAGNI cleanup, not a design change. No architectural decision is required beyond confirming the "callers pre-filter and pre-sort" contract, which the codebase already honors everywhere except this one spot.
+
+## Proposed Architecture
+
+### Component Overview
+No new or restructured components. Existing collaboration is unchanged:
+
+```
+InvoiceClassificationJob (hourly batch)
+        |
+        v
+InvoiceClassificationService.ClassifyInvoiceAsync(invoice)
+        |
+        |-- ClassificationRuleRepository.GetActiveRulesOrderedAsync()   [DB: WHERE IsActive ORDER BY Order]
+        |
+        v
+RuleEvaluationEngine.FindMatchingRule(invoice, rules)   <-- only this method's body changes
+        |
+        v
+EvaluateRule(invoice, rule)  -> IClassificationRule.Evaluate(...)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Where filtering/ordering responsibility lives
+**Options considered:**
+1. Remove the redundant `Where`/`OrderBy` from the engine, formalizing "caller pre-filters and pre-sorts" as the contract (the brief's and spec's chosen direction).
+2. Keep the engine defensive and instead change the caller to pass `GetAllAsync()`, making the engine own filtering/ordering.
+
+**Chosen approach:** Option 1 — remove the redundant LINQ pass from `RuleEvaluationEngine.FindMatchingRule`; iterate `rules` directly.
+
+**Rationale:** Option 1 is strictly less code and matches how the only real caller already behaves (repository does the filtering in SQL, which is more efficient than in-memory re-filtering). Option 2 would require changing `InvoiceClassificationService` and its tests, expand scope, and push work that SQL already does efficiently back into the application layer for no benefit. The spec explicitly places Option 2 out of scope — this review confirms that's the right call; there is no functional or performance reason to prefer it.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files or directories. Two files change:
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs` — production fix.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs` — test reconciliation.
+
+### Interfaces and Contracts
+`IRuleEvaluationEngine.FindMatchingRule(ReceivedInvoice invoice, List<ClassificationRule> rules)` signature is unchanged. The **implicit** contract becomes explicit and should ideally be documented with a short XML doc comment on the interface method (nice-to-have per spec, not required, but cheap enough that I'd recommend doing it in this same PR since it costs one line and directly prevents the "future second caller forgets to pre-filter" risk called out in the brief):
+
+```csharp
+/// <summary>
+/// Returns the first rule (in list order) that matches the invoice.
+/// Callers must supply an already-filtered (active-only) and already-ordered (by Order) list.
+/// </summary>
+ClassificationRule? FindMatchingRule(ReceivedInvoice invoice, List<ClassificationRule> rules);
+```
+This is a documentation-only addition inside the interface file already being touched conceptually — it is optional and should not block the fix if the developer prefers to keep the change to the single line specified in FR-1.
+
+### Data Flow
+Unchanged. `ClassifyInvoiceAsync` → `GetActiveRulesOrderedAsync()` (SQL-level filter+sort) → `FindMatchingRule` (now a plain linear scan, first match wins) → same downstream classification/history/logging behavior. Byte-for-byte identical production outcomes, per NFR-1.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A future second call site passes unfiltered/unordered rules and silently gets wrong classification (the exact concern raised in the brief) | Low (no such call site exists today) | Add the one-line XML doc comment on `IRuleEvaluationEngine.FindMatchingRule` documenting the pre-filtered/pre-sorted contract (see above); relies on code review to catch violations since there's no compile-time enforcement |
+| Test suite under-verifies the new contract, silently reintroducing filter/sort behavior later without a failing test | Low | Ensure at least one test explicitly asserts plain in-order iteration (e.g., a rule out of `Order` sequence but first in list order is picked) — see Specification Amendment below |
+| Regression in production classification behavior | Very low | `ClassifyInvoiceAsync` and its tests (`InvoiceClassificationServiceTests.cs`) are untouched and continue to pass pre-filtered/pre-sorted input from the repository; no behavior change is possible through that path |
+
+## Specification Amendments
+Verified against the actual test file (`RuleEvaluationEngineTests.cs`) — the spec's FR-2 undercounts the affected tests by one:
+
+- **`FindMatchingRule_MultipleMatchingRules_ReturnsLowestOrderMatch`** (lines 21-40) is **not** actually safe "as-is." Its `rules` list is `{ ruleHigherOrder (order:2), ruleLowerOrder (order:1) }` — inserted in *reverse* order, relying on the engine's `OrderBy` to put `ruleLowerOrder` first. Once the sort is removed, iteration will hit `ruleHigherOrder` first, which also matches (`RULE_B` evaluates true), and the test will fail (`match` will be `ruleHigherOrder`, not `ruleLowerOrder`).
+  - **Amendment:** Either reorder the input list to `{ ruleLowerOrder, ruleHigherOrder }` (list order = intended pre-sorted order) so the existing assertion holds, or rename/rewrite it alongside the other two affected tests. Recommend folding this into FR-2's list of tests requiring changes — three tests need attention, not two.
+- Recommend the rewritten/consolidated test(s) include one case where a rule with a numerically higher `Order` value appears earlier in the list and is picked, explicitly proving the engine no longer sorts (this directly documents the "caller must pre-sort" contract called out in FR-2's acceptance criteria, and closes the "silently reintroduces sort" risk above).
+
+No other amendments — FR-1, NFR-1, NFR-2, Data Model, and API sections all check out against the current source.
+
+## Prerequisites
+None. No migrations, config, or infrastructure changes needed. Implementation can start immediately: edit `RuleEvaluationEngine.cs` line 16, then update the three affected tests in `RuleEvaluationEngineTests.cs`, then run `dotnet test` scoped to `Anela.Heblo.Tests.Features.InvoiceClassification`.

--- a/artifacts/feat-3524/brief.md
+++ b/artifacts/feat-3524/brief.md
@@ -1,0 +1,29 @@
+## Module
+InvoiceClassification
+
+## Finding
+`RuleEvaluationEngine.FindMatchingRule` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs`, lines 15–16) applies:
+```csharp
+foreach (var rule in rules.Where(r => r.IsActive).OrderBy(r => r.Order))
+```
+
+The only caller is `InvoiceClassificationService.ClassifyInvoiceAsync` (line 40), which always passes the result of `_ruleRepository.GetActiveRulesOrderedAsync()` — a repository method that already filters to active rules and orders by `Order` (confirmed in `ClassificationRuleRepository`, lines 22–27).
+
+The re-filtering is therefore always a no-op. The re-sort imposes unnecessary LINQ overhead on every classification call.
+
+More importantly, the method signature (`List rules`) implies to any future caller that the engine handles unfiltered, unordered rule sets — a false contract. A developer who adds a second call path (e.g., classifying against a subset of rules for preview/testing) could easily forget to pre-filter and get silently correct behavior only because the engine double-checks; or they might pass an already-ordered slice and be surprised by the re-sort's cost.
+
+## Why it matters
+- KISS violation: two redundant LINQ passes on each of potentially many invoices in the hourly batch job.
+- Misleading contract: the engine's interface suggests it handles mixed active/inactive input, but the system never exercises that path.
+
+## Suggested fix
+Remove the redundant `.Where(r => r.IsActive).OrderBy(r => r.Order)` from `RuleEvaluationEngine.FindMatchingRule`. Iterate `rules` directly:
+```csharp
+foreach (var rule in rules)
+```
+
+If the engine should own filtering responsibility (valid design), update the caller to pass all rules via `GetAllAsync()` and document clearly that filtering is the engine's job — but do not do both.
+
+---
+_Filed by daily arch-review routine on 2026-07-07._

--- a/artifacts/feat-3524/code-review.r1.md
+++ b/artifacts/feat-3524/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3524/impl/remove-redundant-filter-sort-from-rule-evaluation-engine.r1.md
+++ b/artifacts/feat-3524/impl/remove-redundant-filter-sort-from-rule-evaluation-engine.r1.md
@@ -1,0 +1,50 @@
+# Implementation: remove-redundant-filter-sort-from-rule-evaluation-engine
+
+## What was implemented
+Removed the redundant `.Where(r => r.IsActive).OrderBy(r => r.Order)` from
+`RuleEvaluationEngine.FindMatchingRule`. The engine's only production caller
+(`InvoiceClassificationService.ClassifyInvoiceAsync`) already fetches rules
+pre-filtered and pre-sorted via `IClassificationRuleRepository.GetActiveRulesOrderedAsync()`
+(filtering/sorting at the EF Core/SQL level), so the re-filter/re-sort was a
+permanent no-op plus unnecessary per-invoice LINQ overhead in an hourly batch job.
+The engine's contract tightens to "iterates `rules` in the order given and
+returns the first one that evaluates true"; callers must supply an
+already-filtered, already-ordered list. No interface signature changes.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs` — `FindMatchingRule` now does `foreach (var rule in rules)` instead of `foreach (var rule in rules.Where(r => r.IsActive).OrderBy(r => r.Order))`. `EvaluateRule` unchanged.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs` — rewrote the three tests that depended on the engine's own filter/sort behavior:
+  - `FindMatchingRule_MultipleMatchingRules_ReturnsLowestOrderMatch` → renamed `FindMatchingRule_MultipleMatchingRules_ReturnsFirstMatchInGivenOrder`; list is now constructed in the intended evaluation order (`ruleLowerOrder` first).
+  - `FindMatchingRule_SkipsInactiveRules` → renamed `FindMatchingRule_DoesNotFilterByIsActive_EvaluatesInGivenOrder`; now asserts an inactive rule listed first is still matched (engine no longer filters by `IsActive`).
+  - `FindMatchingRule_SortsByOrder_NotByListInsertionOrder` → renamed `FindMatchingRule_IgnoresOrderField_IteratesInGivenListOrder`; assertion flipped to prove the rule inserted first wins regardless of its numerically higher `Order` value.
+  - The other four tests (`FindMatchingRule_NoActiveRuleMatches_ReturnsNull`, `FindMatchingRule_EmptyRulesList_ReturnsNull`, `FindMatchingRule_UnknownRuleTypeIdentifier_DoesNotThrowAndReturnsNull`, `FindMatchingRule_FirstMatch_ShortCircuitsSubsequentEvaluations`) left unchanged as specified.
+
+## Tests
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs` — 7 tests covering: first-match-in-given-order semantics, no filtering by `IsActive`, no re-sorting by `Order`, no-match/empty-list/unknown-identifier edge cases, and short-circuit evaluation.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs` — untouched; verified still passing (mocks `IRuleEvaluationEngine` and `GetActiveRulesOrderedAsync()` directly, unaffected by this change).
+
+## How to verify
+```bash
+cd backend
+dotnet build ../Anela.Heblo.sln
+dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~RuleEvaluationEngineTests"   # 7/7 pass
+dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~InvoiceClassification"        # 86/86 pass
+dotnet format ../Anela.Heblo.sln --include src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs
+```
+Manual check: `grep -n "Where\|OrderBy" backend/src/.../RuleEvaluationEngine.cs` returns nothing.
+
+## Notes
+- `dotnet build` succeeded with 0 errors (254 pre-existing nullable-reference warnings across the test project, unrelated to this change).
+- `dotnet format` made no further changes to the two touched files (they were already compliant).
+- No changes made to `InvoiceClassificationService.cs`, `InvoiceClassificationServiceTests.cs`, `ClassificationRuleRepository.cs`, or the `IRuleEvaluationEngine` interface, per scope.
+- `artifacts/feat-3524/state.json` shows as modified in the worktree (pipeline bookkeeping updated externally); it was not touched by this task's code commit.
+
+## PR Summary
+This is a pure refactor removing dead defensive code from `RuleEvaluationEngine.FindMatchingRule`: the `.Where(IsActive).OrderBy(Order)` it applied to its `rules` parameter was a permanent no-op because its only caller already supplies a pre-filtered, pre-sorted list from the repository (filtering/sorting happens at the SQL level via `GetActiveRulesOrderedAsync()`). Removing it eliminates unnecessary per-invoice LINQ overhead in an hourly batch job with zero change to production classification outcomes. The engine's contract now explicitly requires callers to pass an already-filtered, already-ordered list — no interface signature changes. Three unit tests that previously exercised the engine's own filter/sort logic were rewritten to instead prove the new contract (in-order iteration, no `IsActive` filtering, no `Order` re-sorting); four unrelated tests were left untouched.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs` — removed `.Where(r => r.IsActive).OrderBy(r => r.Order)` from the `foreach` in `FindMatchingRule`.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs` — renamed and rewrote three tests to assert plain in-order iteration instead of engine-side filtering/sorting.
+
+## Status
+DONE

--- a/artifacts/feat-3524/review/remove-redundant-filter-sort-from-rule-evaluation-engine.r1.md
+++ b/artifacts/feat-3524/review/remove-redundant-filter-sort-from-rule-evaluation-engine.r1.md
@@ -1,0 +1,49 @@
+# Code Review: remove-redundant-filter-sort-from-rule-evaluation-engine
+
+## Summary
+The diff (commit `976c30d`) matches the task spec exactly: `RuleEvaluationEngine.FindMatchingRule`
+now iterates `rules` directly instead of re-applying `.Where(r => r.IsActive).OrderBy(r => r.Order)`,
+and the three affected unit tests were renamed and rewritten to assert the new contract (in-order
+iteration, no `IsActive` filtering, no `Order` re-sorting). Verified by reading the actual diff,
+confirming the only production caller (`InvoiceClassificationService.ClassifyInvoiceAsync`) already
+sources rules via `IClassificationRuleRepository.GetActiveRulesOrderedAsync()`, which filters/sorts
+at the EF Core/SQL level, and by rebuilding and re-running the tests locally.
+
+## Review Result: PASS
+
+### task: remove-redundant-filter-sort-from-rule-evaluation-engine
+**Status:** PASS
+
+## Verification performed
+- `git show 976c30d` reviewed line-by-line against the task spec — matches exactly (production
+  change is the single-line `foreach (var rule in rules)`; `EvaluateRule` untouched; the three
+  named tests renamed/rewritten; the four other tests untouched).
+- `IClassificationRuleRepository.GetActiveRulesOrderedAsync()` (in
+  `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs`)
+  confirmed to apply `.Where(r => r.IsActive).OrderBy(r => r.Order)` at the EF Core query level —
+  supports the spec's premise that the engine's own filter/sort was a no-op for its only
+  production caller.
+- Confirmed `InvoiceClassificationService.cs` is the only production caller of
+  `IRuleEvaluationEngine.FindMatchingRule` (grepped `backend/src`), and it was left untouched.
+  `GetClassificationRulesHandler` also calls `GetActiveRulesOrderedAsync()` but never calls
+  `FindMatchingRule`, so it is unaffected by this change.
+- `dotnet build Anela.Heblo.sln` — 0 errors, 254 pre-existing nullable-reference warnings
+  (unrelated to this change, as claimed in the impl summary).
+- `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~RuleEvaluationEngineTests"`
+  — 7/7 pass.
+- `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~InvoiceClassification"`
+  — 86/86 pass.
+- Manually confirmed `RuleEvaluationEngine.cs` no longer contains `.Where(` or `.OrderBy(` in
+  `FindMatchingRule`, and `EvaluateRule` is byte-for-byte unchanged from the original.
+
+## Docs to Update
+None. This is an internal refactor with no public API, DTO, or interface signature change; no
+doc references the removed filter/sort behavior.
+
+## Overall Notes
+No issues found. The implementation is a clean, minimal, surgical change that exactly follows the
+task spec's prescribed diff and test rewrites, and all acceptance criteria are met:
+`FindMatchingRule` no longer calls `.Where(...)`/`.OrderBy(...)`; `InvoiceClassificationService`
+and its tests are untouched; the rewritten tests explicitly prove in-order iteration ignoring both
+`IsActive` and `Order`; the full `InvoiceClassification` suite passes; no public API/DTO/persistence
+changes were made.

--- a/artifacts/feat-3524/spec.r1.md
+++ b/artifacts/feat-3524/spec.r1.md
@@ -1,0 +1,72 @@
+# Specification: Remove redundant filter/sort in RuleEvaluationEngine.FindMatchingRule
+
+## Summary
+`RuleEvaluationEngine.FindMatchingRule` re-applies `.Where(r => r.IsActive).OrderBy(r => r.Order)` to a `rules` list that its only caller already fetches pre-filtered and pre-sorted via `IClassificationRuleRepository.GetActiveRulesOrderedAsync()`. This is a small code-quality fix: remove the redundant LINQ pass so the method iterates `rules` directly, and update the unit tests whose assertions depend on the engine performing its own filtering/sorting.
+
+## Background
+`InvoiceClassificationService.ClassifyInvoiceAsync` (line 38-40) always calls:
+```csharp
+var rules = await _ruleRepository.GetActiveRulesOrderedAsync();
+var matchedRule = _ruleEngine.FindMatchingRule(invoice, rules);
+```
+`ClassificationRuleRepository.GetActiveRulesOrderedAsync()` (lines 22-27) already does `.Where(r => r.IsActive).OrderBy(r => r.Order)` at the EF Core query level. `RuleEvaluationEngine.FindMatchingRule` (lines 14-25) redundantly re-filters and re-sorts the already-clean list in memory. `IRuleEvaluationEngine.FindMatchingRule` has exactly one call site in production code, so the re-filter is a permanent no-op and the re-sort is unnecessary LINQ overhead on every invoice classification (this method runs per-invoice in an hourly batch job).
+
+Beyond the minor performance cost, the current signature (`List<ClassificationRule> rules`) misleadingly implies the engine is responsible for filtering/ordering an arbitrary rule set, which is not exercised anywhere in the system today.
+
+## Functional Requirements
+
+### FR-1: Remove redundant filter/sort from FindMatchingRule
+In `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs`, change:
+```csharp
+foreach (var rule in rules.Where(r => r.IsActive).OrderBy(r => r.Order))
+```
+to:
+```csharp
+foreach (var rule in rules)
+```
+No other logic in `FindMatchingRule` or `EvaluateRule` changes. The engine's contract becomes: "iterate `rules` in the order given and return the first one that evaluates true" — callers are responsible for supplying an already-filtered, already-ordered list.
+
+**Acceptance criteria:**
+- `FindMatchingRule` no longer calls `.Where(...)` or `.OrderBy(...)` on the input `rules` parameter.
+- `InvoiceClassificationService.ClassifyInvoiceAsync` is unchanged and continues to pass the result of `GetActiveRulesOrderedAsync()` — end-to-end classification behavior (which rule matches a given invoice) is identical to before the change.
+- `RuleEvaluationEngine` continues to short-circuit on the first matching rule (existing behavior preserved).
+
+### FR-2: Reconcile existing unit tests with the new contract
+`backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs` contains two tests that assert the engine itself performs filtering/sorting, which will no longer hold once FR-1 lands:
+- `FindMatchingRule_SkipsInactiveRules` (lines 43-60) — passes an inactive rule with lower `Order` than an active one and asserts the inactive rule is skipped. Once filtering is removed, the engine will evaluate rules in list order regardless of `IsActive`, so this test's premise is no longer valid for the engine in isolation.
+- `FindMatchingRule_SortsByOrder_NotByListInsertionOrder` (lines 117-135) — passes rules in reverse `Order` and asserts the engine picks the lowest-`Order` match. Once sorting is removed, the engine will evaluate in list (insertion) order, not `Order` value, so this test's premise is no longer valid.
+
+These two tests must be updated or removed to reflect that filtering/ordering is now the caller's responsibility, not the engine's. The other four tests in the file (`MultipleMatchingRules_ReturnsLowestOrderMatch` — only valid if input is pre-sorted, `NoActiveRuleMatches_ReturnsNull`, `EmptyRulesList_ReturnsNull`, `UnknownRuleTypeIdentifier_DoesNotThrowAndReturnsNull`, `FirstMatch_ShortCircuitsSubsequentEvaluations`) remain valid as-is or with input already in final order, since they either pass single-rule lists, empty lists, or lists already in intended iteration order.
+
+**Acceptance criteria:**
+- No test in `RuleEvaluationEngineTests.cs` asserts that the engine filters out inactive rules or re-sorts input by `Order`.
+- Test names/bodies that previously exercised filter/sort behavior are either removed, or rewritten to assert plain in-order iteration (e.g., renaming to something like `FindMatchingRule_IteratesInGivenOrder_ReturnsFirstMatch` with pre-ordered/pre-filtered input), so the suite documents the new "caller pre-filters and pre-sorts" contract.
+- `InvoiceClassificationServiceTests.cs` (which mocks `IRuleEvaluationEngine` and `GetActiveRulesOrderedAsync()` directly, not `RuleEvaluationEngine`'s internals) requires no changes, since it never exercises the removed filter/sort logic.
+- All tests in the `InvoiceClassification` test suite pass after the change (`dotnet test` scoped to the affected test class, or full backend suite).
+
+## Non-Functional Requirements
+
+### NFR-1: Behavior preservation
+This is a pure refactor: production classification outcomes (which rule matches which invoice) must be byte-for-byte identical before and after the change, since the sole caller already supplies filtered/sorted input.
+
+### NFR-2: Performance
+Eliminates one redundant `Where` + `OrderBy` LINQ pass per `FindMatchingRule` call. No new allocations or algorithmic complexity introduced. No measurable performance target beyond "strictly less work than before."
+
+## Data Model
+No data model changes. `ClassificationRule` entity and `IClassificationRuleRepository` are untouched.
+
+## API / Interface Design
+No public API, controller, or DTO changes. `IRuleEvaluationEngine.FindMatchingRule(ReceivedInvoice invoice, List<ClassificationRule> rules)` signature is unchanged — only its documented/implicit contract (caller must pre-filter and pre-sort) is now enforced by the implementation rather than defensively re-checked.
+
+## Dependencies
+None beyond the existing `IClassificationRuleRepository` and `IRuleEvaluationEngine` abstractions already in place.
+
+## Out of Scope
+- Moving filtering/ordering responsibility into the engine (the alternative fix suggested in the arch-review finding, i.e. have the engine accept `GetAllAsync()` and own filtering). The brief selects the "remove redundant work from the engine" direction, not this alternative.
+- Any change to `ClassificationRuleRepository`, `GetActiveRulesOrderedAsync()`, or `GetAllAsync()`.
+- Any change to `InvoiceClassificationService.ClassifyInvoiceAsync` or its tests (`InvoiceClassificationServiceTests.cs`), which do not exercise the engine's internal filter/sort logic.
+- Adding XML doc comments or README notes documenting the "pre-filtered, pre-sorted" contract (nice-to-have, not required for this surgical fix).
+
+## Open Questions
+
+None.

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-07-07T12:16:52.532793Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T12:16:57.696749Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T12:18:32.734751Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-07T12:18:33.157640Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T12:18:33.396492Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-07T12:29:54.107931Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-07T12:30:06.560862Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T12:15:15.603836Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T12:16:52.532793Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T12:16:57.696749Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T12:20:02.419140Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T12:20:14.399317Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T12:29:54.107931Z"
     }
   },
   "tasks": [
     {
       "name": "remove-redundant-filter-sort-from-rule-evaluation-engine",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-07T12:20:14.647575Z"
+      "updated_at": "2026-07-07T12:29:46.798968Z"
     }
   ]
 }

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-07T12:18:33.157640Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-07T12:18:33.396492Z"
+      "status": "completed",
+      "updated_at": "2026-07-07T12:20:02.419140Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "remove-redundant-filter-sort-from-rule-evaluation-engine",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-07T12:20:02.419140Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T12:20:14.399317Z"
     }
   },
   "tasks": [
     {
       "name": "remove-redundant-filter-sort-from-rule-evaluation-engine",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-07T12:20:14.647575Z"
     }
   ]
 }

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3524",
+  "issue_number": 3524,
+  "created_at": "2026-07-07T12:14:53.538417Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3524/state.json
+++ b/artifacts/feat-3524/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-07T12:15:15.603836Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3524/task-context/remove-redundant-filter-sort-from-rule-evaluation-engine.md
+++ b/artifacts/feat-3524/task-context/remove-redundant-filter-sort-from-rule-evaluation-engine.md
@@ -1,0 +1,164 @@
+### task: remove-redundant-filter-sort-from-rule-evaluation-engine
+
+**Context**
+
+`RuleEvaluationEngine.FindMatchingRule` re-applies `.Where(r => r.IsActive).OrderBy(r => r.Order)`
+to a `rules` list that its only production caller (`InvoiceClassificationService.ClassifyInvoiceAsync`)
+already fetches pre-filtered and pre-sorted via `IClassificationRuleRepository.GetActiveRulesOrderedAsync()`
+(filter/sort happens at the EF Core/SQL level). The re-filter is a permanent no-op and the
+re-sort is unnecessary per-invoice LINQ overhead in an hourly batch job. This is a pure
+refactor: production classification outcomes must be byte-for-byte identical before and
+after the change (NFR-1 in spec.r1.md).
+
+The engine's contract tightens from "defensively filters/sorts whatever it's given" to
+"iterates `rules` in the order given and returns the first one that evaluates true; callers
+must supply an already-filtered, already-ordered list." No interface signature changes.
+
+**Files to touch**
+
+1. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs`
+2. `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs`
+
+Do **not** touch:
+- `InvoiceClassificationService.cs` / `InvoiceClassificationServiceTests.cs` — out of scope, unaffected (mocks `IRuleEvaluationEngine` and `GetActiveRulesOrderedAsync()` directly, never exercises the engine's internal filter/sort logic).
+- `ClassificationRuleRepository.cs`, `IClassificationRuleRepository` — out of scope.
+- `IRuleEvaluationEngine` interface signature — unchanged (an XML doc comment documenting the new contract is optional/nice-to-have per arch-review, not required; skip it to keep the change minimal unless it's trivial to add).
+
+**Step 1 — Production fix**
+
+In `RuleEvaluationEngine.cs`, change line 16 from:
+
+```csharp
+foreach (var rule in rules.Where(r => r.IsActive).OrderBy(r => r.Order))
+```
+
+to:
+
+```csharp
+foreach (var rule in rules)
+```
+
+No other lines in `FindMatchingRule` or `EvaluateRule` change. The method still returns the
+first rule for which `EvaluateRule` returns true, still short-circuits, still returns `null`
+if nothing matches or `rules` is empty.
+
+**Step 2 — Update the three affected tests**
+
+The arch-review (arch-review.r1.md) identified that **three** tests in
+`RuleEvaluationEngineTests.cs` depend on the engine's own filter/sort behavior (the spec
+initially undercounted this at two — trust the arch-review's list, it was verified against
+the actual test file):
+
+1. **`FindMatchingRule_MultipleMatchingRules_ReturnsLowestOrderMatch`** (currently lines 20-40)
+   Currently builds `rules = { ruleHigherOrder (order:2, RULE_B), ruleLowerOrder (order:1, RULE_A) }`
+   — inserted in *reverse* of `Order`, relying on the engine's removed `OrderBy` to put
+   `ruleLowerOrder` first. Once sorting is removed, iteration hits `ruleHigherOrder` first,
+   which also evaluates true (`RULE_B`), so the existing assertion (`match.Should().BeSameAs(ruleLowerOrder)`)
+   will fail.
+   **Fix:** Reorder the list construction so list order matches the intended evaluation
+   order — the list itself represents "already pre-sorted by caller" input:
+   ```csharp
+   var rules = new List<ClassificationRule> { ruleLowerOrder, ruleHigherOrder };
+   ```
+   Rename the test to `FindMatchingRule_MultipleMatchingRules_ReturnsFirstMatchInGivenOrder`
+   to reflect that the engine no longer sorts — it just returns the first match in the list
+   order it was given (which happens to be `ruleLowerOrder` because the caller pre-sorted it
+   that way). Keep the rest of the test body (mocks, invoice, assertion) unchanged aside from
+   the list construction order and the rename.
+
+2. **`FindMatchingRule_SkipsInactiveRules`** (currently lines 42-60)
+   Currently asserts the engine itself filters out an inactive rule. This premise is no
+   longer valid — the engine no longer checks `IsActive` at all; that's now the caller's
+   job (enforced via `GetActiveRulesOrderedAsync()`, untouched by this change).
+   **Fix:** Replace the test with one that documents the new contract explicitly — that the
+   engine evaluates whatever it's given, active or not, in list order. Rename to
+   `FindMatchingRule_DoesNotFilterByIsActive_EvaluatesInGivenOrder` and rewrite so an
+   *inactive* rule that matches is returned first, proving no filtering happens:
+   ```csharp
+   [Fact]
+   public void FindMatchingRule_DoesNotFilterByIsActive_EvaluatesInGivenOrder()
+   {
+       // Arrange
+       var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
+       var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+       var invoice = InvoiceClassificationFixtures.CreateInvoice();
+       var inactiveRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1, isActive: false);
+       var activeRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 2, isActive: true);
+
+       // Inactive rule listed first: engine no longer filters by IsActive, so it must
+       // still be evaluated and matched — filtering is the caller's responsibility now.
+       var rules = new List<ClassificationRule> { inactiveRule, activeRule };
+
+       // Act
+       var match = sut.FindMatchingRule(invoice, rules);
+
+       // Assert
+       match.Should().BeSameAs(inactiveRule);
+   }
+   ```
+
+3. **`FindMatchingRule_SortsByOrder_NotByListInsertionOrder`** (currently lines 116-135)
+   Currently asserts the engine sorts by `Order` regardless of list insertion order. This
+   premise is now false — the engine iterates in list order and ignores `Order` entirely.
+   **Fix:** Replace/rename to `FindMatchingRule_IgnoresOrderField_IteratesInGivenListOrder`,
+   flip the assertion to prove the *opposite*: the rule inserted first is returned even
+   though its `Order` value is numerically higher:
+   ```csharp
+   [Fact]
+   public void FindMatchingRule_IgnoresOrderField_IteratesInGivenListOrder()
+   {
+       // Arrange
+       var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
+       var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+       var invoice = InvoiceClassificationFixtures.CreateInvoice();
+       var insertedFirstHighOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 10);
+       var insertedSecondLowOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1);
+
+       // List insertion order deliberately does NOT match Order value ascending —
+       // proves the engine no longer sorts by Order; it evaluates in given list order.
+       var rules = new List<ClassificationRule> { insertedFirstHighOrder, insertedSecondLowOrder };
+
+       // Act
+       var match = sut.FindMatchingRule(invoice, rules);
+
+       // Assert
+       match.Should().BeSameAs(insertedFirstHighOrder);
+   }
+   ```
+
+The other four tests in the file are unaffected and must be left exactly as-is:
+`FindMatchingRule_NoActiveRuleMatches_ReturnsNull`, `FindMatchingRule_EmptyRulesList_ReturnsNull`,
+`FindMatchingRule_UnknownRuleTypeIdentifier_DoesNotThrowAndReturnsNull`,
+`FindMatchingRule_FirstMatch_ShortCircuitsSubsequentEvaluations` (this last one already uses
+rules inserted in ascending `Order` = list order, so it remains valid unchanged).
+
+**Verification**
+
+- Run the scoped test class:
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~RuleEvaluationEngineTests"
+  ```
+  All 7 tests (4 unchanged + 3 rewritten/renamed) must pass.
+- Confirm no test in the file references `.Where(` / `.OrderBy(` expectations that
+  contradict plain in-order iteration (i.e., grep the file for "Order" in assertions to
+  double check nothing else implicitly relies on sorting).
+- Run the full `InvoiceClassification` test suite to confirm `InvoiceClassificationServiceTests.cs`
+  is unaffected:
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~InvoiceClassification"
+  ```
+- `dotnet build` and `dotnet format` (per repo validation rules) on the touched projects.
+- Manually confirm `RuleEvaluationEngine.cs` no longer contains `.Where(` or `.OrderBy(` in
+  `FindMatchingRule`, and that `EvaluateRule` is byte-for-byte unchanged.
+
+**Acceptance criteria (from spec.r1.md / arch-review.r1.md)**
+
+- `FindMatchingRule` no longer calls `.Where(...)` or `.OrderBy(...)` on `rules`.
+- `InvoiceClassificationService.ClassifyInvoiceAsync` and its tests are untouched.
+- No test in `RuleEvaluationEngineTests.cs` asserts the engine filters inactive rules or
+  re-sorts by `Order`; at least one test explicitly proves in-order iteration ignoring
+  `IsActive`, and at least one explicitly proves in-order iteration ignoring `Order`.
+- All tests in the `InvoiceClassification` test suite pass.
+- No public API, DTO, controller, or persistence changes.

--- a/artifacts/feat-3524/task-plan.r1.md
+++ b/artifacts/feat-3524/task-plan.r1.md
@@ -1,0 +1,175 @@
+# Task Plan: Remove redundant filter/sort in RuleEvaluationEngine.FindMatchingRule
+
+## Scope
+Tiny, surgical backend-only fix. One production line changes; three unit tests are
+reconciled with the new (tightened) contract. No API, DTO, controller, persistence,
+or UI changes. Design was skipped (see brief/spec/arch-review — no `design.r1.md`).
+
+Given the size, this is implemented as a single task.
+
+---
+
+### task: remove-redundant-filter-sort-from-rule-evaluation-engine
+
+**Context**
+
+`RuleEvaluationEngine.FindMatchingRule` re-applies `.Where(r => r.IsActive).OrderBy(r => r.Order)`
+to a `rules` list that its only production caller (`InvoiceClassificationService.ClassifyInvoiceAsync`)
+already fetches pre-filtered and pre-sorted via `IClassificationRuleRepository.GetActiveRulesOrderedAsync()`
+(filter/sort happens at the EF Core/SQL level). The re-filter is a permanent no-op and the
+re-sort is unnecessary per-invoice LINQ overhead in an hourly batch job. This is a pure
+refactor: production classification outcomes must be byte-for-byte identical before and
+after the change (NFR-1 in spec.r1.md).
+
+The engine's contract tightens from "defensively filters/sorts whatever it's given" to
+"iterates `rules` in the order given and returns the first one that evaluates true; callers
+must supply an already-filtered, already-ordered list." No interface signature changes.
+
+**Files to touch**
+
+1. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs`
+2. `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs`
+
+Do **not** touch:
+- `InvoiceClassificationService.cs` / `InvoiceClassificationServiceTests.cs` — out of scope, unaffected (mocks `IRuleEvaluationEngine` and `GetActiveRulesOrderedAsync()` directly, never exercises the engine's internal filter/sort logic).
+- `ClassificationRuleRepository.cs`, `IClassificationRuleRepository` — out of scope.
+- `IRuleEvaluationEngine` interface signature — unchanged (an XML doc comment documenting the new contract is optional/nice-to-have per arch-review, not required; skip it to keep the change minimal unless it's trivial to add).
+
+**Step 1 — Production fix**
+
+In `RuleEvaluationEngine.cs`, change line 16 from:
+
+```csharp
+foreach (var rule in rules.Where(r => r.IsActive).OrderBy(r => r.Order))
+```
+
+to:
+
+```csharp
+foreach (var rule in rules)
+```
+
+No other lines in `FindMatchingRule` or `EvaluateRule` change. The method still returns the
+first rule for which `EvaluateRule` returns true, still short-circuits, still returns `null`
+if nothing matches or `rules` is empty.
+
+**Step 2 — Update the three affected tests**
+
+The arch-review (arch-review.r1.md) identified that **three** tests in
+`RuleEvaluationEngineTests.cs` depend on the engine's own filter/sort behavior (the spec
+initially undercounted this at two — trust the arch-review's list, it was verified against
+the actual test file):
+
+1. **`FindMatchingRule_MultipleMatchingRules_ReturnsLowestOrderMatch`** (currently lines 20-40)
+   Currently builds `rules = { ruleHigherOrder (order:2, RULE_B), ruleLowerOrder (order:1, RULE_A) }`
+   — inserted in *reverse* of `Order`, relying on the engine's removed `OrderBy` to put
+   `ruleLowerOrder` first. Once sorting is removed, iteration hits `ruleHigherOrder` first,
+   which also evaluates true (`RULE_B`), so the existing assertion (`match.Should().BeSameAs(ruleLowerOrder)`)
+   will fail.
+   **Fix:** Reorder the list construction so list order matches the intended evaluation
+   order — the list itself represents "already pre-sorted by caller" input:
+   ```csharp
+   var rules = new List<ClassificationRule> { ruleLowerOrder, ruleHigherOrder };
+   ```
+   Rename the test to `FindMatchingRule_MultipleMatchingRules_ReturnsFirstMatchInGivenOrder`
+   to reflect that the engine no longer sorts — it just returns the first match in the list
+   order it was given (which happens to be `ruleLowerOrder` because the caller pre-sorted it
+   that way). Keep the rest of the test body (mocks, invoice, assertion) unchanged aside from
+   the list construction order and the rename.
+
+2. **`FindMatchingRule_SkipsInactiveRules`** (currently lines 42-60)
+   Currently asserts the engine itself filters out an inactive rule. This premise is no
+   longer valid — the engine no longer checks `IsActive` at all; that's now the caller's
+   job (enforced via `GetActiveRulesOrderedAsync()`, untouched by this change).
+   **Fix:** Replace the test with one that documents the new contract explicitly — that the
+   engine evaluates whatever it's given, active or not, in list order. Rename to
+   `FindMatchingRule_DoesNotFilterByIsActive_EvaluatesInGivenOrder` and rewrite so an
+   *inactive* rule that matches is returned first, proving no filtering happens:
+   ```csharp
+   [Fact]
+   public void FindMatchingRule_DoesNotFilterByIsActive_EvaluatesInGivenOrder()
+   {
+       // Arrange
+       var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
+       var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+       var invoice = InvoiceClassificationFixtures.CreateInvoice();
+       var inactiveRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1, isActive: false);
+       var activeRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 2, isActive: true);
+
+       // Inactive rule listed first: engine no longer filters by IsActive, so it must
+       // still be evaluated and matched — filtering is the caller's responsibility now.
+       var rules = new List<ClassificationRule> { inactiveRule, activeRule };
+
+       // Act
+       var match = sut.FindMatchingRule(invoice, rules);
+
+       // Assert
+       match.Should().BeSameAs(inactiveRule);
+   }
+   ```
+
+3. **`FindMatchingRule_SortsByOrder_NotByListInsertionOrder`** (currently lines 116-135)
+   Currently asserts the engine sorts by `Order` regardless of list insertion order. This
+   premise is now false — the engine iterates in list order and ignores `Order` entirely.
+   **Fix:** Replace/rename to `FindMatchingRule_IgnoresOrderField_IteratesInGivenListOrder`,
+   flip the assertion to prove the *opposite*: the rule inserted first is returned even
+   though its `Order` value is numerically higher:
+   ```csharp
+   [Fact]
+   public void FindMatchingRule_IgnoresOrderField_IteratesInGivenListOrder()
+   {
+       // Arrange
+       var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
+       var sut = new RuleEvaluationEngine(new[] { strategy.Object });
+
+       var invoice = InvoiceClassificationFixtures.CreateInvoice();
+       var insertedFirstHighOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 10);
+       var insertedSecondLowOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1);
+
+       // List insertion order deliberately does NOT match Order value ascending —
+       // proves the engine no longer sorts by Order; it evaluates in given list order.
+       var rules = new List<ClassificationRule> { insertedFirstHighOrder, insertedSecondLowOrder };
+
+       // Act
+       var match = sut.FindMatchingRule(invoice, rules);
+
+       // Assert
+       match.Should().BeSameAs(insertedFirstHighOrder);
+   }
+   ```
+
+The other four tests in the file are unaffected and must be left exactly as-is:
+`FindMatchingRule_NoActiveRuleMatches_ReturnsNull`, `FindMatchingRule_EmptyRulesList_ReturnsNull`,
+`FindMatchingRule_UnknownRuleTypeIdentifier_DoesNotThrowAndReturnsNull`,
+`FindMatchingRule_FirstMatch_ShortCircuitsSubsequentEvaluations` (this last one already uses
+rules inserted in ascending `Order` = list order, so it remains valid unchanged).
+
+**Verification**
+
+- Run the scoped test class:
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~RuleEvaluationEngineTests"
+  ```
+  All 7 tests (4 unchanged + 3 rewritten/renamed) must pass.
+- Confirm no test in the file references `.Where(` / `.OrderBy(` expectations that
+  contradict plain in-order iteration (i.e., grep the file for "Order" in assertions to
+  double check nothing else implicitly relies on sorting).
+- Run the full `InvoiceClassification` test suite to confirm `InvoiceClassificationServiceTests.cs`
+  is unaffected:
+  ```bash
+  dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~InvoiceClassification"
+  ```
+- `dotnet build` and `dotnet format` (per repo validation rules) on the touched projects.
+- Manually confirm `RuleEvaluationEngine.cs` no longer contains `.Where(` or `.OrderBy(` in
+  `FindMatchingRule`, and that `EvaluateRule` is byte-for-byte unchanged.
+
+**Acceptance criteria (from spec.r1.md / arch-review.r1.md)**
+
+- `FindMatchingRule` no longer calls `.Where(...)` or `.OrderBy(...)` on `rules`.
+- `InvoiceClassificationService.ClassifyInvoiceAsync` and its tests are untouched.
+- No test in `RuleEvaluationEngineTests.cs` asserts the engine filters inactive rules or
+  re-sorts by `Order`; at least one test explicitly proves in-order iteration ignoring
+  `IsActive`, and at least one explicitly proves in-order iteration ignoring `Order`.
+- All tests in the `InvoiceClassification` test suite pass.
+- No public API, DTO, controller, or persistence changes.

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/RuleEvaluationEngine.cs
@@ -13,7 +13,7 @@ public class RuleEvaluationEngine : IRuleEvaluationEngine
 
     public ClassificationRule? FindMatchingRule(ReceivedInvoice invoice, List<ClassificationRule> rules)
     {
-        foreach (var rule in rules.Where(r => r.IsActive).OrderBy(r => r.Order))
+        foreach (var rule in rules)
         {
             if (EvaluateRule(invoice, rule))
             {

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/Services/RuleEvaluationEngineTests.cs
@@ -18,7 +18,7 @@ public class RuleEvaluationEngineTests
     }
 
     [Fact]
-    public void FindMatchingRule_MultipleMatchingRules_ReturnsLowestOrderMatch()
+    public void FindMatchingRule_MultipleMatchingRules_ReturnsFirstMatchInGivenOrder()
     {
         // Arrange
         var strategyA = CreateStrategyMock("RULE_A", evaluateResult: true);
@@ -30,7 +30,7 @@ public class RuleEvaluationEngineTests
         var ruleHigherOrder = InvoiceClassificationFixtures.CreateRule("RULE_B", pattern: "p", order: 2);
         var ruleLowerOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1);
 
-        var rules = new List<ClassificationRule> { ruleHigherOrder, ruleLowerOrder };
+        var rules = new List<ClassificationRule> { ruleLowerOrder, ruleHigherOrder };
 
         // Act
         var match = sut.FindMatchingRule(invoice, rules);
@@ -40,7 +40,7 @@ public class RuleEvaluationEngineTests
     }
 
     [Fact]
-    public void FindMatchingRule_SkipsInactiveRules()
+    public void FindMatchingRule_DoesNotFilterByIsActive_EvaluatesInGivenOrder()
     {
         // Arrange
         var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
@@ -50,13 +50,15 @@ public class RuleEvaluationEngineTests
         var inactiveRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1, isActive: false);
         var activeRule = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 2, isActive: true);
 
+        // Inactive rule listed first: engine no longer filters by IsActive, so it must
+        // still be evaluated and matched — filtering is the caller's responsibility now.
         var rules = new List<ClassificationRule> { inactiveRule, activeRule };
 
         // Act
         var match = sut.FindMatchingRule(invoice, rules);
 
         // Assert
-        match.Should().BeSameAs(activeRule);
+        match.Should().BeSameAs(inactiveRule);
     }
 
     [Fact]
@@ -114,7 +116,7 @@ public class RuleEvaluationEngineTests
     }
 
     [Fact]
-    public void FindMatchingRule_SortsByOrder_NotByListInsertionOrder()
+    public void FindMatchingRule_IgnoresOrderField_IteratesInGivenListOrder()
     {
         // Arrange
         var strategy = CreateStrategyMock("RULE_A", evaluateResult: true);
@@ -124,14 +126,15 @@ public class RuleEvaluationEngineTests
         var insertedFirstHighOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 10);
         var insertedSecondLowOrder = InvoiceClassificationFixtures.CreateRule("RULE_A", pattern: "p", order: 1);
 
-        // List insertion order intentionally reversed vs. desired evaluation order.
+        // List insertion order deliberately does NOT match Order value ascending —
+        // proves the engine no longer sorts by Order; it evaluates in given list order.
         var rules = new List<ClassificationRule> { insertedFirstHighOrder, insertedSecondLowOrder };
 
         // Act
         var match = sut.FindMatchingRule(invoice, rules);
 
         // Assert
-        match.Should().BeSameAs(insertedSecondLowOrder);
+        match.Should().BeSameAs(insertedFirstHighOrder);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #3524

## What the issue was
`RuleEvaluationEngine.FindMatchingRule` re-applied `.Where(r => r.IsActive).OrderBy(r => r.Order)` on every classification call, even though its sole caller (`InvoiceClassificationService.ClassifyInvoiceAsync`) always passes rules already filtered and ordered by `ClassificationRuleRepository.GetActiveRulesOrderedAsync()`. The re-filter/re-sort was a permanent no-op that added unnecessary LINQ overhead on every invoice classification (part of the hourly batch job) and gave a misleading impression that the engine handles unfiltered/unordered input.

## How it was fixed / handled
Removed the redundant `.Where(...).OrderBy(...)` from `FindMatchingRule`, so it now iterates `rules` directly in the order the caller provides them. Updated the three unit tests in `RuleEvaluationEngineTests.cs` that previously asserted the engine's own filtering/sorting behavior, rewriting them to assert the new contract: the engine evaluates rules in the exact order given, without filtering by `IsActive` or sorting by `Order` — that responsibility now belongs entirely to the caller/repository. Verified via grep that `FindMatchingRule` has no other production callers, and confirmed end-to-end classification behavior is unchanged since the repository already filters/sorts at the EF Core query level.

Verified: `dotnet build` (0 errors), `RuleEvaluationEngineTests` (7/7 passed), full `InvoiceClassification` suite (86/86 passed).

## Artifacts
Brief, spec, arch-review, task plan, impl, review, and whole-branch code-review markdown are committed under `artifacts/feat-3524/` on this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01EvMZpvshtBSpduxzpjohjk)_