### PR TITLE
fix: correct FlexiBee stock-movement endpoint by bumping SDK to 0.1.139

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.1.3" />
-    <!-- SDK 0.1.138: adds IBoMClient.SetItemsOrderAsync and BoMItemFlexiDto.Order; 0.1.136 added lastUpdateFrom filter to ILedgerClient -->
-    <PackageReference Include="Rem.FlexiBeeSDK.Client" Version="0.1.138" />
+    <!-- SDK 0.1.139: fixes StockItemsMovementClient.SaveAsync to POST stock movements to the "skladovy-pohyb" (document) evidence instead of "skladovy-pohyb-polozka" (line items), which FlexiBee rejected with importNotAllowed; 0.1.138: adds IBoMClient.SetItemsOrderAsync and BoMItemFlexiDto.Order; 0.1.136 added lastUpdateFrom filter to ILedgerClient -->
+    <PackageReference Include="Rem.FlexiBeeSDK.Client" Version="0.1.139" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.4.1" />
     <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/ImportNotAllowedFilter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/ImportNotAllowedFilter.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Application.Features.Manufacture.ErrorFilters.Filters;
+
+public class ImportNotAllowedFilter : IManufactureErrorFilter
+{
+    public bool CanHandle(Exception exception) =>
+        exception.Message.Contains("importNotAllowed") ||
+        exception.Message.Contains("Import není povolen");
+
+    public string Transform(Exception exception) =>
+        "FlexiBee odmítl vytvoření skladového dokladu (import není povolen). Doklad nebyl vytvořen. "
+        + "Zkuste akci zopakovat; pokud problém přetrvává, kontaktujte správce systému.";
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/ImportNotAllowedFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/ImportNotAllowedFilterTests.cs
@@ -1,0 +1,58 @@
+using Anela.Heblo.Adapters.Flexi.Manufacture;
+using Anela.Heblo.Application.Features.Manufacture.ErrorFilters.Filters;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.ErrorFilters.Filters;
+
+public class ImportNotAllowedFilterTests
+{
+    private const string FriendlyMessage =
+        "FlexiBee odmítl vytvoření skladového dokladu (import není povolen). Doklad nebyl vytvořen. "
+        + "Zkuste akci zopakovat; pokud problém přetrvává, kontaktujte správce systému.";
+
+    private readonly ImportNotAllowedFilter _filter = new();
+
+    [Fact]
+    public void CanHandle_WhenMessageContainsWinstromImportNotAllowedCode_ReturnsTrue()
+    {
+        var ex = new FlexiManufactureException(
+            FlexiManufactureOperationKind.ConsumptionMovement,
+            "Failed to create consumption stock movement for warehouse 5",
+            warehouseId: 5,
+            rawFlexiError: "{\"winstrom\":{\"success\":\"false\",\"message@messageCode\":\"importNotAllowed\"}}");
+
+        _filter.CanHandle(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_WhenMessageContainsCzechImportNotAllowedText_ReturnsTrue()
+    {
+        var ex = new InvalidOperationException(
+            "Failed to create consumption stock movement for warehouse 5: Import není povolen.");
+
+        _filter.CanHandle(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_WhenMessageIsUnrelated_ReturnsFalse()
+    {
+        var ex = new InvalidOperationException("Some other error");
+
+        _filter.CanHandle(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Transform_ReturnsFriendlyMessage()
+    {
+        var ex = new FlexiManufactureException(
+            FlexiManufactureOperationKind.ConsumptionMovement,
+            "Failed to create consumption stock movement for warehouse 5",
+            warehouseId: 5,
+            rawFlexiError: "{\"winstrom\":{\"success\":\"false\",\"message@messageCode\":\"importNotAllowed\",\"message\":\"Import není povolen.\"}}");
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Be(FriendlyMessage);
+    }
+}

--- a/memory/gotchas/flexibee-importnotallowed-wrong-stock-endpoint.md
+++ b/memory/gotchas/flexibee-importnotallowed-wrong-stock-endpoint.md
@@ -1,0 +1,42 @@
+# FlexiBee `importNotAllowed` on manufacture consumption = SDK posted to wrong evidence
+
+## Symptom
+Moving a manufacture order to SemiProduct fails with the generic fallback:
+*"Při zpracování výroby došlo k neočekávané chybě. Technické detaily: Failed to create consumption
+stock movement for warehouse 5"*. "Warehouse 5" is incidental — it's the MATERIAL warehouse
+(FlexiBee `sklad` id 5 = "Sklad Materialu"), the first document written in the flow.
+Raw ERP response (App Insights `aiHeblo`, `traces | where message contains "winstrom"`):
+```json
+{"winstrom":{"success":"false","message@messageCode":"importNotAllowed","message":"Import není povolen."}}
+```
+
+## Root cause (verified)
+NOT an ERP license/permission problem (that was an early wrong theory). It was a **bug in
+Rem.FlexiBeeSDK.Client ≤ 0.1.138**: `StockItemsMovementClient.SaveAsync` POSTed the full stock
+document (header + `polozkyDokladu`) to the **line-items** evidence `skladovy-pohyb-polozka`
+instead of the **document** evidence `skladovy-pohyb`. FlexiBee refuses a document import into the
+line-items evidence with `importNotAllowed`.
+
+SDK diff 0.1.138 → 0.1.139 (only change, decompiled):
+```
+0.1.138: PostAsync(envelope, null, null,             null, ct)  // URL .../skladovy-pohyb-polozka
+0.1.139: PostAsync(envelope, null, "skladovy-pohyb", null, ct)  // URL .../skladovy-pohyb
+```
+`ResourceClient.GetUri` uses `customResourceIdentifier ?? ResourceIdentifier`; 0.1.139 passes the
+correct evidence. Fix = bump `Rem.FlexiBeeSDK.Client` to **0.1.139** in
+`backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj`.
+
+## How it was proven
+Dry-run against the live ERP (`petra-tesarikova.flexibee.eu`, creds in `kv-heblo-prod`
+`FlexiBeeSettings--*`, login `heblo`), same body `{"winstrom":{"skladovy-pohyb":[{…,"polozkyDokladu":[…]}]}}`:
+- `POST /c/{company}/skladovy-pohyb-polozka?dry-run=true` → `importNotAllowed` (reproduces prod error)
+- `POST /c/{company}/skladovy-pohyb?dry-run=true` → `success:true` (document validates, e.g. M-00393/2026)
+
+`?dry-run=true` validates without committing — use it to test FlexiBee imports safely.
+
+## Note on the error filter
+An `ImportNotAllowedFilter` (`.../Manufacture/ErrorFilters/Filters/`) was added as a defensive net
+so any future `importNotAllowed` shows a clean Czech message instead of the raw winstrom fallback.
+Its message is deliberately cause-neutral (retry / contact admin) — do NOT reintroduce a
+"check license/permissions" message; that was the wrong diagnosis. Filters auto-register via the
+assembly scan in `ManufactureModule.cs`.


### PR DESCRIPTION
Moving a manufacture order to the SemiProduct state failed with FlexiBee `importNotAllowed` ("Import není povolen") because `Rem.FlexiBeeSDK.Client` 0.1.138 POSTed the stock document to the line-items evidence (`skladovy-pohyb-polozka`) instead of the document evidence (`skladovy-pohyb`); bumping to 0.1.139 targets the correct endpoint. Verified against the live ERP with a dry-run: the old endpoint returns `importNotAllowed`, the new one succeeds. Also adds a defensive `ImportNotAllowedFilter` (with tests) so any future `importNotAllowed` surfaces a clean Czech message instead of the raw winstrom fallback, plus a memory note documenting the root cause. (The unrelated Plaud commit shown on the branch is already merged into main via backmerge and is not part of this PR's diff.)