### PR TITLE
fix: gate readiness on configurable hydration tier per environment

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.Development.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Development.json
@@ -72,6 +72,7 @@
     "BlobContainerName": "expedition-lists-stg"
   },
   "BackgroundServices": {
-    "EnableHydration": false
+    "EnableHydration": false,
+    "ReadinessTier": 0
   }
 }

--- a/backend/src/Anela.Heblo.API/appsettings.Production.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Production.json
@@ -1,4 +1,7 @@
 {
+  "BackgroundServices": {
+    "ReadinessTier": 2
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning",

--- a/backend/src/Anela.Heblo.API/appsettings.Staging.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Staging.json
@@ -1,4 +1,7 @@
 {
+  "BackgroundServices": {
+    "ReadinessTier": 1
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Error",

--- a/backend/src/Anela.Heblo.Application/Common/BackgroundServicesReadyHealthCheck.cs
+++ b/backend/src/Anela.Heblo.Application/Common/BackgroundServicesReadyHealthCheck.cs
@@ -1,21 +1,33 @@
 using Anela.Heblo.Xcc.Services.BackgroundRefresh;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Common;
 
 public class BackgroundServicesReadyHealthCheck : IHealthCheck
 {
     private readonly IBackgroundServiceReadinessTracker _readinessTracker;
+    private readonly BackgroundServicesOptions _options;
 
-    public BackgroundServicesReadyHealthCheck(IBackgroundServiceReadinessTracker readinessTracker)
+    public BackgroundServicesReadyHealthCheck(
+        IBackgroundServiceReadinessTracker readinessTracker,
+        IOptions<BackgroundServicesOptions> options)
     {
         _readinessTracker = readinessTracker;
+        _options = options.Value;
     }
 
     public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
+        // Hydration disabled (e.g. Development/Test): nothing to wait for, so the app is ready.
+        if (!_options.EnableHydration)
+        {
+            return Task.FromResult(
+                HealthCheckResult.Healthy("Hydration disabled - no background services to wait for"));
+        }
+
         var hydrationDetails = _readinessTracker.GetHydrationDetails() ?? new Dictionary<string, object>();
         var data = new Dictionary<string, object>(hydrationDetails);
 

--- a/backend/src/Anela.Heblo.Xcc/Services/BackgroundRefresh/BackgroundServicesOptions.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/BackgroundRefresh/BackgroundServicesOptions.cs
@@ -12,4 +12,12 @@ public class BackgroundServicesOptions
     /// When false, hydration will not run (useful for testing environments).
     /// </summary>
     public bool EnableHydration { get; set; } = true;
+
+    /// <summary>
+    /// Hydration tier at/below which the app is considered ready (/health/ready → 200).
+    /// Readiness is reached once all tiers with tier &lt;= ReadinessTier complete.
+    /// Higher tiers keep hydrating in the background and do not block readiness.
+    /// 0 = ready immediately (no tier is required). Default 1.
+    /// </summary>
+    public int ReadinessTier { get; set; } = 1;
 }

--- a/backend/src/Anela.Heblo.Xcc/Services/BackgroundRefresh/HydrationOrchestratorWrapper.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/BackgroundRefresh/HydrationOrchestratorWrapper.cs
@@ -28,11 +28,11 @@ public class HydrationOrchestratorWrapper : BackgroundService
             _readinessTracker.ReportHydrationStarted();
             _logger.LogDebug("HydrationOrchestratorWrapper: Hydration started");
 
-            // Wait for orchestrator to complete
-            await _orchestrator.WaitForHydrationCompletionAsync();
+            // Report ready once the readiness tier(s) complete; higher tiers keep hydrating in the background.
+            await _orchestrator.WaitForReadinessAsync();
 
             _readinessTracker.ReportHydrationCompleted();
-            _logger.LogDebug("HydrationOrchestratorWrapper: Hydration completed successfully");
+            _logger.LogDebug("HydrationOrchestratorWrapper: Readiness reached");
         }
         catch (Exception ex)
         {

--- a/backend/src/Anela.Heblo.Xcc/Services/BackgroundRefresh/TierBasedHydrationOrchestrator.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/BackgroundRefresh/TierBasedHydrationOrchestrator.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Xcc.Services.BackgroundRefresh;
 
@@ -7,32 +8,47 @@ public class TierBasedHydrationOrchestrator : BackgroundService
 {
     private readonly ILogger<TierBasedHydrationOrchestrator> _logger;
     private readonly BackgroundRefreshTaskRegistry _taskRegistry;
+    private readonly int _readinessTier;
     private readonly TaskCompletionSource _hydrationCompleted = new();
+    private readonly TaskCompletionSource _readinessReached = new();
 
     public TierBasedHydrationOrchestrator(
         ILogger<TierBasedHydrationOrchestrator> logger,
-        BackgroundRefreshTaskRegistry taskRegistry)
+        BackgroundRefreshTaskRegistry taskRegistry,
+        IOptions<BackgroundServicesOptions> options)
     {
         _logger = logger;
         _taskRegistry = taskRegistry;
+        _readinessTier = options.Value.ReadinessTier;
     }
 
+    /// <summary>
+    /// Completes when all tiers have finished hydrating (used to gate periodic scheduling).
+    /// </summary>
     public Task WaitForHydrationCompletionAsync() => _hydrationCompleted.Task;
+
+    /// <summary>
+    /// Completes once all tiers at/below <see cref="BackgroundServicesOptions.ReadinessTier"/> have
+    /// finished. Higher tiers keep hydrating in the background — used to gate /health/ready.
+    /// </summary>
+    public Task WaitForReadinessAsync() => _readinessReached.Task;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
         {
-            _logger.LogInformation("🚀 Starting tier-based hydration process");
+            _logger.LogInformation("🚀 Starting tier-based hydration process (readiness tier {ReadinessTier})", _readinessTier);
 
             await ExecuteHydrationTiersAsync(stoppingToken);
 
             _logger.LogInformation("✅ Tier-based hydration completed successfully");
+            _readinessReached.TrySetResult();
             _hydrationCompleted.SetResult();
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "❌ Tier-based hydration failed");
+            _readinessReached.TrySetException(ex);
             _hydrationCompleted.SetException(ex);
             throw;
         }
@@ -59,12 +75,52 @@ public class TierBasedHydrationOrchestrator : BackgroundService
         _logger.LogInformation("Found {TierCount} hydration tiers with {TaskCount} total tasks",
             tasksByTier.Count, allTasks.Count);
 
+        // Highest tier that must complete before the app is considered ready. int.MinValue when no
+        // tier is required (e.g. ReadinessTier = 0) — readiness is then signaled immediately.
+        var maxRequiredTier = tasksByTier
+            .Select(group => group.Key)
+            .Where(tier => tier <= _readinessTier)
+            .DefaultIfEmpty(int.MinValue)
+            .Max();
+
+        if (maxRequiredTier == int.MinValue)
+        {
+            _logger.LogInformation("No hydration tiers at/below readiness tier {ReadinessTier} - app is ready immediately", _readinessTier);
+            _readinessReached.TrySetResult();
+        }
+
         foreach (var tierGroup in tasksByTier)
         {
             var tier = tierGroup.Key;
             var tierTasks = tierGroup.ToList();
 
+            if (tier > _readinessTier)
+            {
+                // Optional tier: keep hydrating in the background but never fail readiness or crash the host.
+                try
+                {
+                    await ExecuteTierAsync(tier, tierTasks, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "⚠️ Optional hydration tier {Tier} (> readiness tier {ReadinessTier}) failed - continuing", tier, _readinessTier);
+                }
+
+                continue;
+            }
+
+            // Required tier: failures propagate and block readiness.
             await ExecuteTierAsync(tier, tierTasks, cancellationToken);
+
+            if (tier == maxRequiredTier)
+            {
+                _logger.LogInformation("✅ Readiness reached - all tiers at/below readiness tier {ReadinessTier} completed", _readinessTier);
+                _readinessReached.TrySetResult();
+            }
         }
     }
 

--- a/backend/test/Anela.Heblo.Tests/Common/BackgroundServicesReadyHealthCheckTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Common/BackgroundServicesReadyHealthCheckTests.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Common;
 using Anela.Heblo.Xcc.Services.BackgroundRefresh;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -14,7 +15,13 @@ public class BackgroundServicesReadyHealthCheckTests
     public BackgroundServicesReadyHealthCheckTests()
     {
         _readinessTrackerMock = new Mock<IBackgroundServiceReadinessTracker>();
-        _healthCheck = new BackgroundServicesReadyHealthCheck(_readinessTrackerMock.Object);
+        _healthCheck = CreateHealthCheck(enableHydration: true);
+    }
+
+    private BackgroundServicesReadyHealthCheck CreateHealthCheck(bool enableHydration)
+    {
+        var options = Options.Create(new BackgroundServicesOptions { EnableHydration = enableHydration });
+        return new BackgroundServicesReadyHealthCheck(_readinessTrackerMock.Object, options);
     }
 
     [Fact]
@@ -83,5 +90,21 @@ public class BackgroundServicesReadyHealthCheckTests
         Assert.Equal(HealthStatus.Healthy, result.Status);
         Assert.Equal("Tier-based hydration completed - all background refresh tasks ready", result.Description);
         Assert.Empty(result.Data); // Refresh task system doesn't track individual services
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ShouldReturnHealthy_WhenHydrationDisabled()
+    {
+        // Arrange - hydration disabled (e.g. Development/Test): nothing flips the tracker, so ready by default
+        var healthCheck = CreateHealthCheck(enableHydration: false);
+        _readinessTrackerMock.Setup(x => x.AreAllServicesReady()).Returns(false);
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Equal("Hydration disabled - no background services to wait for", result.Description);
+        _readinessTrackerMock.Verify(x => x.AreAllServicesReady(), Times.Never);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Xcc/BackgroundRefresh/BackgroundRefreshSchedulerServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Xcc/BackgroundRefresh/BackgroundRefreshSchedulerServiceTests.cs
@@ -45,7 +45,8 @@ public class BackgroundRefreshSchedulerServiceTests
             registryServiceProviderMock.Object,
             setupMock);
 
-        _orchestrator = new TierBasedHydrationOrchestrator(_orchestratorLoggerMock.Object, _taskRegistry);
+        var backgroundServicesOptions = Microsoft.Extensions.Options.Options.Create(new BackgroundServicesOptions());
+        _orchestrator = new TierBasedHydrationOrchestrator(_orchestratorLoggerMock.Object, _taskRegistry, backgroundServicesOptions);
 
         // Setup service provider mocks for scheduler service
         _serviceScopeMock = new Mock<IServiceScope>();

--- a/backend/test/Anela.Heblo.Tests/Xcc/BackgroundRefresh/TierBasedHydrationOrchestratorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Xcc/BackgroundRefresh/TierBasedHydrationOrchestratorTests.cs
@@ -39,6 +39,26 @@ public class TierBasedHydrationOrchestratorTests
             setupMock);
     }
 
+    private TierBasedHydrationOrchestrator CreateOrchestrator(int readinessTier = 1)
+    {
+        var options = Microsoft.Extensions.Options.Options.Create(
+            new BackgroundServicesOptions { ReadinessTier = readinessTier });
+        return new TierBasedHydrationOrchestrator(_loggerMock.Object, _taskRegistry, options);
+    }
+
+    private void RegisterTask(string taskId, int tier, Func<Task> body, bool enabled = true)
+    {
+        var config = new RefreshTaskConfiguration
+        {
+            TaskId = taskId,
+            InitialDelay = TimeSpan.Zero,
+            RefreshInterval = TimeSpan.FromMinutes(1),
+            Enabled = enabled,
+            HydrationTier = tier
+        };
+        _taskRegistry.RegisterTask(taskId, (_, _) => body(), config);
+    }
+
     [Fact]
     public async Task ShouldNotExecuteDisabledTasks()
     {
@@ -76,7 +96,7 @@ public class TierBasedHydrationOrchestratorTests
             return Task.CompletedTask;
         }, disabledConfig);
 
-        var orchestrator = new TierBasedHydrationOrchestrator(_loggerMock.Object, _taskRegistry);
+        var orchestrator = CreateOrchestrator();
         var cts = new CancellationTokenSource();
 
         // Act
@@ -151,7 +171,7 @@ public class TierBasedHydrationOrchestratorTests
             return Task.CompletedTask;
         }, task3Config);
 
-        var orchestrator = new TierBasedHydrationOrchestrator(_loggerMock.Object, _taskRegistry);
+        var orchestrator = CreateOrchestrator();
         var cts = new CancellationTokenSource();
 
         // Act
@@ -203,7 +223,7 @@ public class TierBasedHydrationOrchestratorTests
             return Task.CompletedTask;
         }, disabledConfig2);
 
-        var orchestrator = new TierBasedHydrationOrchestrator(_loggerMock.Object, _taskRegistry);
+        var orchestrator = CreateOrchestrator();
         var cts = new CancellationTokenSource();
 
         // Act
@@ -295,7 +315,7 @@ public class TierBasedHydrationOrchestratorTests
             }
         }, tier3Task);
 
-        var orchestrator = new TierBasedHydrationOrchestrator(_loggerMock.Object, _taskRegistry);
+        var orchestrator = CreateOrchestrator();
         var cts = new CancellationTokenSource();
 
         // Act
@@ -315,5 +335,111 @@ public class TierBasedHydrationOrchestratorTests
 
         Assert.True(tier1Index < tier2Index, "Tier 1 should execute before Tier 2");
         Assert.True(tier2Index < tier3Index, "Tier 2 should execute before Tier 3");
+    }
+
+    [Fact]
+    public async Task ReadinessTier1_ReportsReadyAfterTier1_WhileTier2StillRunning()
+    {
+        // Arrange
+        var tier2Gate = new TaskCompletionSource();
+        RegisterTask("TestTask.Tier1", tier: 1, body: () => Task.CompletedTask);
+        RegisterTask("TestTask.Tier2", tier: 2, body: () => tier2Gate.Task);
+
+        var orchestrator = CreateOrchestrator(readinessTier: 1);
+        var cts = new CancellationTokenSource();
+
+        // Act
+        var hydrationTask = orchestrator.StartAsync(cts.Token);
+        await orchestrator.WaitForReadinessAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert - ready after Tier 1, but full hydration still waiting on the gated Tier 2
+        Assert.False(orchestrator.WaitForHydrationCompletionAsync().IsCompleted,
+            "Full hydration should not be complete while Tier 2 is still running");
+
+        // Release Tier 2 and let hydration finish
+        tier2Gate.SetResult();
+        await orchestrator.WaitForHydrationCompletionAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+        await hydrationTask;
+    }
+
+    [Fact]
+    public async Task ReadinessTier2_ReportsReadyOnlyAfterTiers1And2()
+    {
+        // Arrange
+        var tier2Gate = new TaskCompletionSource();
+        var tier3Gate = new TaskCompletionSource();
+        RegisterTask("TestTask.Tier1", tier: 1, body: () => Task.CompletedTask);
+        RegisterTask("TestTask.Tier2", tier: 2, body: () => tier2Gate.Task);
+        RegisterTask("TestTask.Tier3", tier: 3, body: () => tier3Gate.Task);
+
+        var orchestrator = CreateOrchestrator(readinessTier: 2);
+        var cts = new CancellationTokenSource();
+
+        // Act
+        var hydrationTask = orchestrator.StartAsync(cts.Token);
+
+        // Give Tier 1 a moment; readiness must NOT be reached while Tier 2 is gated
+        await Task.Delay(100);
+        Assert.False(orchestrator.WaitForReadinessAsync().IsCompleted,
+            "Readiness should wait for Tier 2 when ReadinessTier = 2");
+
+        // Release Tier 2 -> readiness reached, even though Tier 3 is still gated
+        tier2Gate.SetResult();
+        await orchestrator.WaitForReadinessAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(orchestrator.WaitForHydrationCompletionAsync().IsCompleted,
+            "Full hydration should still wait on the gated Tier 3");
+
+        // Release Tier 3 and let hydration finish
+        tier3Gate.SetResult();
+        await orchestrator.WaitForHydrationCompletionAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+        await hydrationTask;
+    }
+
+    [Fact]
+    public async Task ReadinessTier0_ReportsReadyImmediately_BeforeAnyTierCompletes()
+    {
+        // Arrange - Tier 1 is gated so it cannot complete during the test
+        var tier1Gate = new TaskCompletionSource();
+        RegisterTask("TestTask.Tier1", tier: 1, body: () => tier1Gate.Task);
+
+        var orchestrator = CreateOrchestrator(readinessTier: 0);
+        var cts = new CancellationTokenSource();
+
+        // Act
+        var hydrationTask = orchestrator.StartAsync(cts.Token);
+
+        // Assert - ready immediately, even though the only tier is still running
+        await orchestrator.WaitForReadinessAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(orchestrator.WaitForHydrationCompletionAsync().IsCompleted,
+            "Full hydration should not be complete while Tier 1 is still gated");
+
+        // Cleanup
+        tier1Gate.SetResult();
+        await orchestrator.WaitForHydrationCompletionAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+        await hydrationTask;
+    }
+
+    [Fact]
+    public async Task OptionalTierFailure_DoesNotFaultReadinessOrHydration()
+    {
+        // Arrange - Tier 1 succeeds (required), Tier 2 throws (optional under ReadinessTier = 1)
+        RegisterTask("TestTask.Tier1", tier: 1, body: () => Task.CompletedTask);
+        RegisterTask("TestTask.Tier2", tier: 2, body: () => throw new InvalidOperationException("boom"));
+
+        var orchestrator = CreateOrchestrator(readinessTier: 1);
+        var cts = new CancellationTokenSource();
+
+        // Act
+        var hydrationTask = orchestrator.StartAsync(cts.Token);
+
+        // Assert - readiness reached and full hydration completes without surfacing the optional failure
+        await orchestrator.WaitForReadinessAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await orchestrator.WaitForHydrationCompletionAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        await hydrationTask; // ExecuteAsync must not have faulted
     }
 }


### PR DESCRIPTION
The nightly E2E regression has failed every night since PR #3401 added a `/health/ready` deploy gate: that endpoint stayed HTTP 503 until *all* tier-based hydration finished (~8 min, dominated by Tier 3's 5-minute financial-refresh delay), so the ~6-minute gate timed out and the E2E tests never ran. Readiness now means "all tiers ≤ `ReadinessTier` complete", configured per environment (dev=0, staging=1, prod=2), so staging flips ready after Tier 1 (~1–3 min) well inside the existing gate — no workflow change needed. Tiers above the threshold keep hydrating in the background and are optional (their failures no longer block readiness or stop the host), while the scheduler still waits for full hydration and the health check reports ready when hydration is disabled (dev/test). Covered by new unit tests for each readiness tier, optional-tier-failure tolerance, and hydration-disabled health.

## Test plan
- [x] `dotnet build` + `dotnet format --verify-no-changes` (clean)
- [x] Backend unit tests pass (background-refresh + health-check suites)
- [ ] Post-merge: confirm staging `/health/ready` returns 200 within ~3 min after deploy, then the nightly E2E matrix runs