### PR TITLE
feat: add screen-view tracking to admin detail and lot-identification screens

### DIFF
--- a/frontend/src/components/terminal/lot-identification/ContainerScanLoop.tsx
+++ b/frontend/src/components/terminal/lot-identification/ContainerScanLoop.tsx
@@ -5,6 +5,7 @@ import ScanInput from '../ScanInput';
 import { useCreateMaterialContainers } from '../../../api/hooks/useMaterialContainers';
 import { CreateMaterialContainerItem } from '../../../api/generated/api-client';
 import { ErrorCodes } from '../../../types/errors';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 const CODE_FORMAT = /^M\d{8}$/;
 const INVALID_FORMAT_MESSAGE = 'Neplatný formát kódu (očekáváno M + 8 číslic).';
@@ -17,6 +18,7 @@ interface ContainerScanLoopProps {
 }
 
 const ContainerScanLoop = ({ mode }: ContainerScanLoopProps) => {
+  useScreenView('Terminal', 'LotIdentificationContainerScan', mode);
   const params = useParams<{ material: string; lot: string; id?: string; lineId?: string }>();
   const materialCode = params.material ?? '';
   const lotCode = params.lot ?? '';

--- a/frontend/src/components/terminal/lot-identification/FinishPoStep.tsx
+++ b/frontend/src/components/terminal/lot-identification/FinishPoStep.tsx
@@ -1,8 +1,10 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useUpdatePurchaseOrderStatusMutation } from '../../../api/hooks/usePurchaseOrders';
 import { UpdatePurchaseOrderStatusRequest } from '../../../api/generated/api-client';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 const FinishPoStep = () => {
+  useScreenView('Terminal', 'LotIdentificationFinishPo');
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const poId = id ? parseInt(id, 10) : 0;

--- a/frontend/src/components/terminal/lot-identification/FreeformMaterialStep.tsx
+++ b/frontend/src/components/terminal/lot-identification/FreeformMaterialStep.tsx
@@ -1,8 +1,10 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ScanInput from '../ScanInput';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 const FreeformMaterialStep = () => {
+  useScreenView('Terminal', 'LotIdentificationFreeformMaterial');
   const navigate = useNavigate();
 
   const handleScan = useCallback(

--- a/frontend/src/components/terminal/lot-identification/LotEntryStep.tsx
+++ b/frontend/src/components/terminal/lot-identification/LotEntryStep.tsx
@@ -2,12 +2,14 @@ import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ScanInput from '../ScanInput';
 import { useLastUsedLotForMaterial } from '../../../api/hooks/useMaterialContainers';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 interface LotEntryStepProps {
   mode: 'freeform' | 'po';
 }
 
 const LotEntryStep = ({ mode }: LotEntryStepProps) => {
+  useScreenView('Terminal', 'LotIdentificationLotEntry', mode);
   const navigate = useNavigate();
   const params = useParams<{ material?: string; id?: string; lineId?: string }>();
   const materialCode = params.material ?? '';

--- a/frontend/src/components/terminal/lot-identification/PoLinePickStep.tsx
+++ b/frontend/src/components/terminal/lot-identification/PoLinePickStep.tsx
@@ -1,8 +1,10 @@
 import { Link, useParams } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { usePurchaseOrderDetailQuery } from '../../../api/hooks/usePurchaseOrders';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 const PoLinePickStep = () => {
+  useScreenView('Terminal', 'LotIdentificationPoLinePick');
   const { id } = useParams<{ id: string }>();
   const poId = id ? parseInt(id, 10) : 0;
   const { data, isLoading } = usePurchaseOrderDetailQuery(poId);

--- a/frontend/src/components/terminal/lot-identification/PoPickStep.tsx
+++ b/frontend/src/components/terminal/lot-identification/PoPickStep.tsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router-dom';
 import { ChevronRight, ClipboardList } from 'lucide-react';
 import { usePurchaseOrdersQuery } from '../../../api/hooks/usePurchaseOrders';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 const PoPickStep = () => {
+  useScreenView('Terminal', 'LotIdentificationPoPick');
   const { data, isLoading } = usePurchaseOrdersQuery({ status: 'InTransit' });
 
   if (isLoading) {

--- a/frontend/src/pages/GroupDetailPage.tsx
+++ b/frontend/src/pages/GroupDetailPage.tsx
@@ -25,6 +25,7 @@ import {
   useUnsavedChangesDialog,
 } from "../hooks/useUnsavedChangesDialog";
 import { resolveInheritedPermissions } from "../components/access-management/groupClosure";
+import { useScreenView } from "../telemetry/useScreenView";
 
 interface GroupDraft {
   name: string;
@@ -86,6 +87,7 @@ function buildMemberMutationArgs(
 }
 
 export default function GroupDetailPage() {
+  useScreenView("Admin", "GroupDetail");
   const { id = "" } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const toast = useToast();

--- a/frontend/src/pages/UserDetailPage.tsx
+++ b/frontend/src/pages/UserDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   useUnsavedChangesDialog,
 } from "../hooks/useUnsavedChangesDialog";
 import ErrorState from "../components/common/ErrorState";
+import { useScreenView } from "../telemetry/useScreenView";
 
 interface UserDraft {
   displayName: string;
@@ -25,6 +26,7 @@ interface UserDraft {
 }
 
 export default function UserDetailPage() {
+  useScreenView("Admin", "UserDetail");
   const { id = "" } = useParams<{ id: string }>();
   const toast = useToast();
 

--- a/scripts/monitoring/usage-analytics-workbook.content.json
+++ b/scripts/monitoring/usage-analytics-workbook.content.json
@@ -51,6 +51,25 @@
             "resourceType": "microsoft.insights/components"
           },
           {
+            "id": "a4444444-4444-4444-4444-444444444444",
+            "version": "KqlParameterItem/1.0",
+            "name": "SubScreen",
+            "label": "Sub-screen",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), subScreen = tostring(customDimensions.subScreen) | where '*' in ({Module}) or module in ({Module}) | where isnotempty(subScreen) | summarize by subScreen | order by subScreen asc",
+            "value": ["value::all"],
+            "typeSettings": {
+              "additionalResourceOptions": ["value::all"],
+              "selectAllValue": "*"
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
             "id": "a3333333-3333-3333-3333-333333333333",
             "version": "KqlParameterItem/1.0",
             "name": "User",
@@ -80,7 +99,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), screen = tostring(customDimensions.screen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({User}) or userDisplay in ({User}) | summarize ['Screen views'] = count(), ['Active users'] = dcount(userDisplay), ['Distinct screens'] = dcount(strcat(module, '/', screen))",
+        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), screen = tostring(customDimensions.screen), subScreen = tostring(customDimensions.subScreen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({SubScreen}) or subScreen in ({SubScreen}) | where '*' in ({User}) or userDisplay in ({User}) | summarize ['Screen views'] = count(), ['Active users'] = dcount(userDisplay), ['Distinct screens'] = dcount(strcat(module, '/', screen))",
         "size": 4,
         "title": "Overview",
         "timeContextFromParameter": "TimeRange",
@@ -94,7 +113,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({User}) or userDisplay in ({User}) | summarize Hits = count(), Users = dcount(userDisplay) by module | order by Hits desc",
+        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), subScreen = tostring(customDimensions.subScreen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({SubScreen}) or subScreen in ({SubScreen}) | where '*' in ({User}) or userDisplay in ({User}) | summarize Hits = count(), Users = dcount(userDisplay) by module | order by Hits desc",
         "size": 0,
         "title": "Usage by module",
         "timeContextFromParameter": "TimeRange",
@@ -108,7 +127,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), screen = tostring(customDimensions.screen), subScreen = tostring(customDimensions.subScreen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({User}) or userDisplay in ({User}) | summarize Hits = count(), Users = dcount(userDisplay) by module, screen, subScreen | order by Hits desc",
+        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), screen = tostring(customDimensions.screen), subScreen = tostring(customDimensions.subScreen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({SubScreen}) or subScreen in ({SubScreen}) | where '*' in ({User}) or userDisplay in ({User}) | summarize Hits = count(), Users = dcount(userDisplay) by module, screen, subScreen | order by Hits desc",
         "size": 0,
         "title": "Screen and sub-screen usage",
         "timeContextFromParameter": "TimeRange",
@@ -125,7 +144,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), screen = tostring(customDimensions.screen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId), userEmail = tostring(customDimensions.userEmail) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({User}) or userDisplay in ({User}) | summarize ['Screen views'] = count(), ['Distinct screens'] = dcount(strcat(module, '/', screen)), ['Last seen'] = max(timestamp) by User = userDisplay, Email = userEmail | order by ['Screen views'] desc",
+        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), screen = tostring(customDimensions.screen), subScreen = tostring(customDimensions.subScreen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId), userEmail = tostring(customDimensions.userEmail) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({SubScreen}) or subScreen in ({SubScreen}) | where '*' in ({User}) or userDisplay in ({User}) | summarize ['Screen views'] = count(), ['Distinct screens'] = dcount(strcat(module, '/', screen)), ['Last seen'] = max(timestamp) by User = userDisplay, Email = userEmail | order by ['Screen views'] desc",
         "size": 0,
         "title": "Usage by user",
         "timeContextFromParameter": "TimeRange",
@@ -159,7 +178,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({User}) or userDisplay in ({User}) | summarize ['Screen views'] = count(), ['Active users'] = dcount(userDisplay) by bin(timestamp, 1d) | order by timestamp asc",
+        "query": "customEvents | where name == 'ScreenViewed' | extend module = tostring(customDimensions.module), subScreen = tostring(customDimensions.subScreen), userDisplay = coalesce(tostring(customDimensions.userName), user_AuthenticatedId) | where '*' in ({Module}) or module in ({Module}) | where '*' in ({SubScreen}) or subScreen in ({SubScreen}) | where '*' in ({User}) or userDisplay in ({User}) | summarize ['Screen views'] = count(), ['Active users'] = dcount(userDisplay) by bin(timestamp, 1d) | order by timestamp asc",
         "size": 0,
         "title": "Daily trend",
         "timeContextFromParameter": "TimeRange",


### PR DESCRIPTION
Adds `useScreenView` to the 8 route-target screens that were still missing it, so the existing `ScreenViewed` Application Insights telemetry now covers every navigable screen: the admin group/user detail pages (`Admin/GroupDetail`, `Admin/UserDetail`) and the six terminal lot-identification wizard steps (`Terminal/LotIdentification*`, with `LotEntryStep`/`ContainerScanLoop` passing the `po`/`freeform` mode as the sub-screen). Each change is a single import plus one hook call placed before any early return; no other code is touched. This closes the coverage gap that surfaced while building the companion "UI Screen Usage" Azure Monitor Workbook (deployed live to Application Insights `aiHeblo`, not part of this diff). Validated with `npm run build`, lint on the changed files, and the touched telemetry/lot-identification test suites (25 tests passing).