### PR TITLE
feat: add dashboard tile for materials nearing lot expiration

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -150,6 +150,7 @@ public static class CatalogModule
         services.RegisterTile<ProductInventorySummaryTile>();
         services.RegisterTile<MaterialWithExpirationInventorySummaryTile>();
         services.RegisterTile<MaterialWithoutExpirationInventorySummaryTile>();
+        services.RegisterTile<MaterialExpirationSummaryTile>();
         services.RegisterTile<LowStockAlertTile>();
 
         return services;

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTile.cs
@@ -1,0 +1,88 @@
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Xcc.Services.Dashboard;
+
+namespace Anela.Heblo.Application.Features.Catalog.DashboardTiles;
+
+/// <summary>
+/// Dashboard tile showing material lots by proximity to their expiration date.
+/// Counts lots (with stock on hand) that are: already expired, expiring within 30 days,
+/// or expiring within 90 days. Lots expiring beyond the 90-day horizon are ignored.
+/// Scope: materials only (ProductType.Material with HasExpiration).
+/// </summary>
+[TileId("materialexpirationsummary")]
+public class MaterialExpirationSummaryTile : ITile
+{
+    private const int SoonDays = 30;
+    private const int HorizonDays = 90;
+
+    private readonly ICatalogRepository _catalogRepository;
+
+    public MaterialExpirationSummaryTile(ICatalogRepository catalogRepository)
+    {
+        _catalogRepository = catalogRepository;
+    }
+
+    public string Title => "Expirace surovin";
+    public string Description => "Přehled surovin podle blížící se expirace šarží";
+    public TileSize Size => TileSize.Small;
+    public TileCategory Category => TileCategory.Warehouse;
+    public bool DefaultEnabled => true;
+    public bool AutoShow => true;
+    public string[] RequiredPermissions => Array.Empty<string>();
+
+    public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var now = DateTime.UtcNow;
+            var today = DateOnly.FromDateTime(now);
+            var soonThreshold = today.AddDays(SoonDays);
+            var horizonThreshold = today.AddDays(HorizonDays);
+
+            var catalogItems = await _catalogRepository.GetAllAsync(cancellationToken);
+
+            var expirations = catalogItems
+                .Where(item => item.Type == ProductType.Material && item.HasExpiration)
+                .SelectMany(item => item.Stock.Lots)
+                .Where(lot => lot.Amount > 0 && lot.Expiration.HasValue)
+                .Select(lot => lot.Expiration!.Value)
+                .ToList();
+
+            var expired = expirations.Count(exp => exp < today);
+            var within30 = expirations.Count(exp => exp >= today && exp <= soonThreshold);
+            var within90 = expirations.Count(exp => exp > soonThreshold && exp <= horizonThreshold);
+
+            return new
+            {
+                status = "success",
+                data = new
+                {
+                    expired,     // already past expiration
+                    within30,    // expiring within 30 days
+                    within90,    // expiring within 31-90 days
+                    total = expired + within30 + within90,
+                    date = now
+                },
+                metadata = new
+                {
+                    lastUpdated = now,
+                    source = "CatalogRepository"
+                },
+                drillDown = new
+                {
+                    filters = new { type = "Material" },
+                    enabled = true,
+                    tooltip = "Zobrazit suroviny"
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            return new
+            {
+                status = "error",
+                error = ex.Message
+            };
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTileTests.cs
@@ -1,0 +1,275 @@
+using Anela.Heblo.Application.Features.Catalog.DashboardTiles;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Lots;
+using FluentAssertions;
+using Moq;
+using System.Text.Json;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.DashboardTiles;
+
+public class MaterialExpirationSummaryTileTests
+{
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly MaterialExpirationSummaryTile _tile;
+
+    public MaterialExpirationSummaryTileTests()
+    {
+        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _tile = new MaterialExpirationSummaryTile(_catalogRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_ExpiredLot_CountsAsExpired()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(today.AddDays(-1), amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("expired").GetInt32().Should().Be(1);
+        data.GetProperty("within30").GetInt32().Should().Be(0);
+        data.GetProperty("within90").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LotExpiringToday_CountsAsWithin30()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(today, amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("within30").GetInt32().Should().Be(1);
+        data.GetProperty("expired").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LotExpiringAtDay30_CountsAsWithin30()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(today.AddDays(30), amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("within30").GetInt32().Should().Be(1);
+        data.GetProperty("within90").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LotExpiringAtDay31_CountsAsWithin90()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(today.AddDays(31), amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("within90").GetInt32().Should().Be(1);
+        data.GetProperty("within30").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LotExpiringAtDay90_CountsAsWithin90()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(today.AddDays(90), amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("within90").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LotBeyondHorizon_IsExcluded()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(today.AddDays(91), amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("total").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LotWithZeroAmount_IsExcluded()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(today.AddDays(-1), amount: 0)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("total").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LotWithNullExpiration_IsExcluded()
+    {
+        // Arrange
+        SetupCatalog(CreateMaterial("MAT001", CreateLot(expiration: null, amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("total").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_NonMaterialType_IsExcluded()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var product = CreateMaterial("PROD001", CreateLot(today.AddDays(-1), amount: 5));
+        product.Type = ProductType.Product;
+        SetupCatalog(product);
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("total").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_MaterialWithoutHasExpiration_IsExcluded()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var material = CreateMaterial("MAT001", CreateLot(today.AddDays(-1), amount: 5));
+        material.HasExpiration = false;
+        SetupCatalog(material);
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("total").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_MaterialWithLotsSpanningBuckets_CountsEachLotInItsBucket()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001",
+            CreateLot(today.AddDays(-5), amount: 5),   // expired
+            CreateLot(today.AddDays(10), amount: 5),   // within30
+            CreateLot(today.AddDays(60), amount: 5),   // within90
+            CreateLot(today.AddDays(200), amount: 5))); // beyond horizon
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("expired").GetInt32().Should().Be(1);
+        data.GetProperty("within30").GetInt32().Should().Be(1);
+        data.GetProperty("within90").GetInt32().Should().Be(1);
+        data.GetProperty("total").GetInt32().Should().Be(3);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_EmptyRepository_ReturnsAllZeros()
+    {
+        // Arrange
+        SetupCatalog();
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert
+        data.GetProperty("expired").GetInt32().Should().Be(0);
+        data.GetProperty("within30").GetInt32().Should().Be(0);
+        data.GetProperty("within90").GetInt32().Should().Be(0);
+        data.GetProperty("total").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_HappyPath_ReturnsSuccessStatus()
+    {
+        // Arrange
+        SetupCatalog();
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var doc = Serialize(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_RepositoryThrows_ReturnsErrorStatus()
+    {
+        // Arrange
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var doc = Serialize(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("error");
+        doc.RootElement.GetProperty("error").GetString().Should().Be("boom");
+    }
+
+    private async Task<JsonElement> LoadDataSection()
+    {
+        var result = await _tile.LoadDataAsync();
+        var doc = Serialize(result);
+        return doc.RootElement.GetProperty("data").Clone();
+    }
+
+    private static JsonDocument Serialize(object result)
+    {
+        var json = JsonSerializer.Serialize(result);
+        return JsonDocument.Parse(json);
+    }
+
+    private void SetupCatalog(params CatalogAggregate[] items)
+    {
+        _catalogRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items.ToList());
+    }
+
+    private static CatalogAggregate CreateMaterial(string code, params CatalogLot[] lots)
+    {
+        var item = new CatalogAggregate
+        {
+            ProductCode = code,
+            Type = ProductType.Material,
+            HasExpiration = true
+        };
+        item.Stock.Lots.AddRange(lots);
+        return item;
+    }
+
+    private static CatalogLot CreateLot(DateOnly? expiration, decimal amount) => new()
+    {
+        Expiration = expiration,
+        Amount = amount
+    };
+}

--- a/frontend/src/components/dashboard/tiles/MaterialExpirationSummaryTile.tsx
+++ b/frontend/src/components/dashboard/tiles/MaterialExpirationSummaryTile.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  createFilteredUrl,
+  isTileClickable,
+  getTileTooltip,
+  TileDataWithDrillDown
+} from '../../../utils/urlUtils';
+
+interface MaterialExpirationSummaryTileProps {
+  data: TileDataWithDrillDown & {
+    status?: string;
+    data?: {
+      expired?: number;    // already past expiration
+      within30?: number;   // expiring within 30 days
+      within90?: number;   // expiring within 31-90 days
+      total?: number;
+      date?: string;
+    };
+    error?: string;
+  };
+  targetUrl?: string; // Base URL for navigation
+}
+
+export const MaterialExpirationSummaryTile: React.FC<MaterialExpirationSummaryTileProps> = ({ data, targetUrl }) => {
+  const navigate = useNavigate();
+
+  const isClickable = isTileClickable(data);
+  const tooltip = getTileTooltip(data);
+
+  const handleClick = () => {
+    if (isClickable && targetUrl && data.drillDown?.filters) {
+      const url = createFilteredUrl(targetUrl, data.drillDown.filters);
+      navigate(url);
+    }
+  };
+
+  // Error state
+  if (data.status === 'error') {
+    return (
+      <div className="h-full flex items-center justify-center text-center">
+        <div>
+          <div className="text-red-500 dark:text-red-400 text-2xl mb-2">⚠️</div>
+          <p className="text-red-600 dark:text-red-400 text-sm">{data.error || 'Chyba při načítání dat'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Extract data with defaults (urgency order: expired first)
+  const expired = data.data?.expired ?? 0;
+  const within30 = data.data?.within30 ?? 0;
+  const within90 = data.data?.within90 ?? 0;
+
+  const total = expired + within30 + within90;
+
+  // Calculate percentages for pie chart
+  const getPercentage = (value: number) => total > 0 ? (value / total) * 100 : 0;
+  const expiredPercent = getPercentage(expired);
+  const within30Percent = getPercentage(within30);
+  const within90Percent = getPercentage(within90);
+
+  // Create pie chart segments
+  const createPieSegment = (startPercent: number, endPercent: number) => {
+    const startAngle = (startPercent / 100) * 2 * Math.PI - Math.PI / 2;
+    const endAngle = (endPercent / 100) * 2 * Math.PI - Math.PI / 2;
+    const largeArc = endPercent - startPercent > 50 ? 1 : 0;
+
+    const x1 = 50 + 40 * Math.cos(startAngle);
+    const y1 = 50 + 40 * Math.sin(startAngle);
+    const x2 = 50 + 40 * Math.cos(endAngle);
+    const y2 = 50 + 40 * Math.sin(endAngle);
+
+    return `M 50 50 L ${x1} ${y1} A 40 40 0 ${largeArc} 1 ${x2} ${y2} Z`;
+  };
+
+  let currentPercent = 0;
+  const segments = [];
+
+  if (expiredPercent > 0) {
+    segments.push({ path: createPieSegment(currentPercent, currentPercent + expiredPercent), color: '#ef4444' });
+    currentPercent += expiredPercent;
+  }
+  if (within30Percent > 0) {
+    segments.push({ path: createPieSegment(currentPercent, currentPercent + within30Percent), color: '#f97316' });
+    currentPercent += within30Percent;
+  }
+  if (within90Percent > 0) {
+    segments.push({ path: createPieSegment(currentPercent, currentPercent + within90Percent), color: '#f59e0b' });
+  }
+
+  return (
+    <div
+      className={`
+        flex items-start gap-2 h-full pt-2 min-h-44
+        ${isClickable ? 'cursor-pointer hover:bg-gray-50 dark:hover:bg-white/5 active:bg-gray-100 dark:active:bg-white/10 transition-colors duration-200 rounded-lg' : ''}
+      `}
+      onClick={handleClick}
+      title={tooltip}
+      style={isClickable ? { touchAction: 'manipulation' } : undefined}
+    >
+      {/* Pie Chart */}
+      <div className="flex-shrink-0">
+        <svg className="w-48 md:w-32 h-48 md:h-32" viewBox="0 0 100 100">
+          {segments.length === 1 ? (
+            <circle cx="50" cy="50" r="40" fill={segments[0].color} />
+          ) : (
+            segments.map((segment, index) => (
+              <path key={index} d={segment.path} fill={segment.color} />
+            ))
+          )}
+        </svg>
+      </div>
+
+      {/* Legend with values */}
+      <div className="flex flex-col space-y-2 flex-1 pt-1 leading-relaxed">
+        {/* Red: expired */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <div className="w-4 h-4 rounded-sm bg-red-500"></div>
+            <span className="text-base md:text-sm text-gray-700 dark:text-graphite-muted">Po expiraci</span>
+          </div>
+          <span className="text-2xl md:text-xl font-bold text-gray-900 dark:text-graphite-text">{expired}</span>
+        </div>
+
+        {/* Orange: within 30 days */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <div className="w-4 h-4 rounded-sm bg-orange-500"></div>
+            <span className="text-base md:text-sm text-gray-700 dark:text-graphite-muted">&le; 30 dní</span>
+          </div>
+          <span className="text-2xl md:text-xl font-bold text-gray-900 dark:text-graphite-text">{within30}</span>
+        </div>
+
+        {/* Amber: within 90 days */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <div className="w-4 h-4 rounded-sm bg-amber-500"></div>
+            <span className="text-base md:text-sm text-gray-700 dark:text-graphite-muted">31–90 dní</span>
+          </div>
+          <span className="text-2xl md:text-xl font-bold text-gray-900 dark:text-graphite-text">{within90}</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/tiles/__tests__/MaterialExpirationSummaryTile.test.tsx
+++ b/frontend/src/components/dashboard/tiles/__tests__/MaterialExpirationSummaryTile.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { MaterialExpirationSummaryTile } from '../MaterialExpirationSummaryTile';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(<BrowserRouter>{component}</BrowserRouter>);
+};
+
+describe('MaterialExpirationSummaryTile', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders the three bucket labels', () => {
+    const data = { status: 'success', data: { expired: 0, within30: 0, within90: 0 } };
+
+    renderWithRouter(<MaterialExpirationSummaryTile data={data} />);
+
+    expect(screen.getByText('Po expiraci')).toBeInTheDocument();
+    expect(screen.getByText('≤ 30 dní')).toBeInTheDocument();
+    expect(screen.getByText('31–90 dní')).toBeInTheDocument();
+  });
+
+  it('renders the counts for each bucket', () => {
+    const data = { status: 'success', data: { expired: 4, within30: 2, within90: 7 } };
+
+    renderWithRouter(<MaterialExpirationSummaryTile data={data} />);
+
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('defaults missing bucket values to zero', () => {
+    const data = { status: 'success', data: {} };
+
+    renderWithRouter(<MaterialExpirationSummaryTile data={data} />);
+
+    expect(screen.getAllByText('0')).toHaveLength(3);
+  });
+
+  it('renders error state when status is error', () => {
+    const data = { status: 'error', error: 'Failed to load data' };
+
+    renderWithRouter(<MaterialExpirationSummaryTile data={data} />);
+
+    expect(screen.getByText('Failed to load data')).toBeInTheDocument();
+    expect(screen.getByText('⚠️')).toBeInTheDocument();
+  });
+
+  it('navigates to the filtered URL on click when drillDown is present', () => {
+    const data = {
+      status: 'success',
+      data: { expired: 1, within30: 0, within90: 0 },
+      drillDown: { enabled: true, filters: { type: 'Material' } },
+    };
+
+    renderWithRouter(<MaterialExpirationSummaryTile data={data} targetUrl="/manufacturing/inventory" />);
+
+    fireEvent.click(screen.getByText('Po expiraci'));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/manufacturing/inventory'));
+  });
+
+  it('does not navigate when drillDown is absent', () => {
+    const data = { status: 'success', data: { expired: 1, within30: 0, within90: 0 } };
+
+    renderWithRouter(<MaterialExpirationSummaryTile data={data} targetUrl="/manufacturing/inventory" />);
+
+    fireEvent.click(screen.getByText('Po expiraci'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/dashboard/tiles/tileRegistry.tsx
+++ b/frontend/src/components/dashboard/tiles/tileRegistry.tsx
@@ -7,6 +7,7 @@ import { ManualActionRequiredTile } from './ManualActionRequiredTile';
 import { PurchaseOrdersInTransitTile } from './PurchaseOrdersInTransitTile';
 import { CountTile } from './CountTile';
 import { InventorySummaryTile } from './InventorySummaryTile';
+import { MaterialExpirationSummaryTile } from './MaterialExpirationSummaryTile';
 import { LowStockAlertTile } from './LowStockAlertTile';
 import { DataQualityTile } from './DataQualityTile';
 import { DqtYesterdayStatusTile } from './DqtYesterdayStatusTile';
@@ -111,6 +112,9 @@ export const TILE_RENDERERS: Record<string, TileRenderer> = {
   ),
   materialwithoutexpirationinventorysummary: ({ data }) => (
     <InventorySummaryTile data={data} targetUrl="/manufacturing/inventory" />
+  ),
+  materialexpirationsummary: ({ data }) => (
+    <MaterialExpirationSummaryTile data={data} targetUrl="/manufacturing/inventory" />
   ),
   // Purchase efficiency tiles
   lowstockefficiency: ({ data, tile }) => (


### PR DESCRIPTION
Adds a new **"Expirace surovin"** dashboard tile that surfaces material lots by proximity to their ABRA Flexi lot (šarže) expiration date, bucketed as **Po expiraci / ≤30 dní / 31–90 dní** and counting only lots with stock on hand (`Amount > 0`); scope is materials (`ProductType.Material` with `HasExpiration`). Backend adds `MaterialExpirationSummaryTile` (`ITile`) that reads each catalog item's `Stock.Lots` and is registered in `CatalogModule`; frontend adds a pie/legend tile wired into `tileRegistry`, drilling through to `/manufacturing/inventory`. The counted unit is the individual lot, so a material with lots in different buckets contributes to each.

## Test plan
- [x] Backend unit tests (14) — bucket boundaries, `Amount>0` / null-expiration / non-material / `HasExpiration=false` filters, multi-bucket materials, empty repo, error path
- [x] Frontend unit tests (6) — labels, counts, defaults, error state, drill-down navigation
- [x] Backend build ✓, frontend build ✓, frontend lint ✓ (no new findings)