### PR TITLE
fix: quiet GetPackageLabelPdf polling 404 log flood

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
@@ -26,6 +26,13 @@ public class ScanOrderBody
 [Route("api/packaging")]
 public class PackagingController : BaseApiController
 {
+    /// <summary>
+    /// Header sent by the frontend readiness-poll loop to mark a label PDF request as an automated
+    /// poll. Expected transient 404s carrying this header are logged at Debug instead of Warning so
+    /// the polling does not flood the logs. The final (post-timeout) confirmation request omits it.
+    /// </summary>
+    private const string LabelPollHeader = "X-Label-Poll";
+
     private readonly IMediator _mediator;
 
     public PackagingController(IMediator mediator)
@@ -83,7 +90,12 @@ public class PackagingController : BaseApiController
         CancellationToken cancellationToken)
     {
         var response = await _mediator.Send(
-            new GetPackageLabelPdfRequest { OrderCode = orderCode, PackageNumber = packageNumber },
+            new GetPackageLabelPdfRequest
+            {
+                OrderCode = orderCode,
+                PackageNumber = packageNumber,
+                IsPoll = Request.Headers.ContainsKey(LabelPollHeader),
+            },
             cancellationToken);
 
         if (!response.Success || response.Content is null)

--- a/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackagingController.cs
@@ -31,7 +31,7 @@ public class PackagingController : BaseApiController
     /// poll. Expected transient 404s carrying this header are logged at Debug instead of Warning so
     /// the polling does not flood the logs. The final (post-timeout) confirmation request omits it.
     /// </summary>
-    private const string LabelPollHeader = "X-Label-Poll";
+    internal const string LabelPollHeader = "X-Label-Poll";
 
     private readonly IMediator _mediator;
 

--- a/backend/src/Anela.Heblo.API/Middleware/RequestLoggingMiddleware.cs
+++ b/backend/src/Anela.Heblo.API/Middleware/RequestLoggingMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using Anela.Heblo.API.Controllers;
 
 namespace Anela.Heblo.API.Middleware;
 
@@ -186,7 +187,7 @@ public class RequestLoggingMiddleware
             // omits the header, so its 404 still logs as a warning.
             var isExpectedLabelPoll =
                 response.StatusCode == StatusCodes.Status404NotFound &&
-                request.Headers.ContainsKey("X-Label-Poll");
+                request.Headers.ContainsKey(PackagingController.LabelPollHeader);
 
             if (response.StatusCode >= 400 && !isExpectedLabelPoll)
             {

--- a/backend/src/Anela.Heblo.API/Middleware/RequestLoggingMiddleware.cs
+++ b/backend/src/Anela.Heblo.API/Middleware/RequestLoggingMiddleware.cs
@@ -180,7 +180,15 @@ public class RequestLoggingMiddleware
                 ? responseBody.Substring(0, 1000) + "... (truncated)"
                 : responseBody;
 
-            if (response.StatusCode >= 400)
+            // The label PDF endpoint is polled until the label is ready, so 404s are expected and
+            // frequent. Poll requests carry the X-Label-Poll header — suppress the ERROR warning
+            // for those so the logs are not flooded. The final (post-timeout) confirmation request
+            // omits the header, so its 404 still logs as a warning.
+            var isExpectedLabelPoll =
+                response.StatusCode == StatusCodes.Status404NotFound &&
+                request.Headers.ContainsKey("X-Label-Poll");
+
+            if (response.StatusCode >= 400 && !isExpectedLabelPoll)
             {
                 _logger.LogWarning(
                     "Response ERROR - {Method} {Path} - Status: {StatusCode}, Body: {Body}",

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackageLabelPdf/GetPackageLabelPdfHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackageLabelPdf/GetPackageLabelPdfHandler.cs
@@ -30,12 +30,18 @@ public class GetPackageLabelPdfHandler : IRequestHandler<GetPackageLabelPdfReque
         // in the order's labels — matching the PackageNumber persisted at scan time.
         var index = request.PackageNumber - 1;
 
+        // The frontend polls this endpoint until the label is ready, so 404s are expected and
+        // frequent during that window. Poll requests are logged at Debug to avoid flooding the
+        // logs; the final (post-timeout) confirmation request is not a poll, so its 404 is logged
+        // at Warning with full diagnostics.
+        var notReadyLevel = request.IsPoll ? LogLevel.Debug : LogLevel.Warning;
+
         var labels = await _shipmentClient.GetLabelsByOrderCodeAsync(request.OrderCode, ct);
         var label = labels.ElementAtOrDefault(index);
 
         if (label is null)
         {
-            _logger.LogWarning(
+            _logger.Log(notReadyLevel,
                 "Label not found for order {OrderCode} package {PackageNumber} (index {Index}): " +
                 "live shipment fetch returned {LabelCount} label(s) [{PackageNames}]",
                 request.OrderCode, request.PackageNumber, index, labels.Count,
@@ -45,7 +51,7 @@ public class GetPackageLabelPdfHandler : IRequestHandler<GetPackageLabelPdfReque
 
         if (string.IsNullOrWhiteSpace(label.LabelUrl))
         {
-            _logger.LogWarning(
+            _logger.Log(notReadyLevel,
                 "Label URL unavailable for order {OrderCode} package {PackageNumber} (single-shot check, LabelUrl empty)",
                 request.OrderCode, request.PackageNumber);
             return new GetPackageLabelPdfResponse(ErrorCodes.PackageLabelNotFound);

--- a/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackageLabelPdf/GetPackageLabelPdfRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackageLabelPdf/GetPackageLabelPdfRequest.cs
@@ -8,4 +8,8 @@ public class GetPackageLabelPdfRequest : IRequest<GetPackageLabelPdfResponse>
 
     /// <summary>1-based position of the package within the order's shipment labels.</summary>
     public int PackageNumber { get; set; }
+
+    /// <summary>True when the request is an automated readiness poll (header X-Label-Poll present).
+    /// Expected transient 404s are logged at Debug instead of Warning to avoid flooding logs.</summary>
+    public bool IsPoll { get; set; }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/Packaging/GetPackageLabelPdfHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Packaging/GetPackageLabelPdfHandlerTests.cs
@@ -20,6 +20,7 @@ public class GetPackageLabelPdfHandlerTests
     private readonly Mock<IShipmentClient> _shipmentClient = new();
     private readonly Mock<HttpMessageHandler> _httpMessageHandler = new(MockBehavior.Strict);
     private readonly Mock<IHttpClientFactory> _httpClientFactory = new();
+    private readonly Mock<ILogger<GetPackageLabelPdfHandler>> _logger = new();
 
     public GetPackageLabelPdfHandlerTests()
     {
@@ -29,13 +30,23 @@ public class GetPackageLabelPdfHandlerTests
     }
 
     private GetPackageLabelPdfHandler CreateHandler() =>
-        new(_shipmentClient.Object, _httpClientFactory.Object, new Mock<ILogger<GetPackageLabelPdfHandler>>().Object);
+        new(_shipmentClient.Object, _httpClientFactory.Object, _logger.Object);
 
     private static GetPackageLabelPdfRequest Request() => new()
     {
         OrderCode = OrderCode,
         PackageNumber = PackageNumber,
     };
+
+    private void VerifyLogged(LogLevel level, Times times) =>
+        _logger.Verify(
+            l => l.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+            times);
 
     private void SetupShipmentLabels(params ShipmentLabel[] labels)
     {
@@ -100,6 +111,33 @@ public class GetPackageLabelPdfHandlerTests
         var response = await CreateHandler().Handle(Request(), CancellationToken.None);
 
         response.ErrorCode.Should().Be(ErrorCodes.PackageLabelNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_NotReady_WhenPoll_LogsAtDebugNotWarning()
+    {
+        // Automated readiness polls must not flood the logs: expected 404s log at Debug.
+        SetupShipmentLabels();
+
+        await CreateHandler().Handle(
+            new GetPackageLabelPdfRequest { OrderCode = OrderCode, PackageNumber = PackageNumber, IsPoll = true },
+            CancellationToken.None);
+
+        VerifyLogged(LogLevel.Warning, Times.Never());
+        VerifyLogged(LogLevel.Debug, Times.Once());
+    }
+
+    [Fact]
+    public async Task Handle_NotReady_WhenNotPoll_LogsAtWarning()
+    {
+        // The final (post-timeout) confirmation request is not a poll: its 404 is a real warning.
+        SetupShipmentLabels();
+
+        await CreateHandler().Handle(
+            new GetPackageLabelPdfRequest { OrderCode = OrderCode, PackageNumber = PackageNumber, IsPoll = false },
+            CancellationToken.None);
+
+        VerifyLogged(LogLevel.Warning, Times.Once());
     }
 
     [Fact]

--- a/frontend/src/components/baleni/__tests__/printLabelPdf.test.ts
+++ b/frontend/src/components/baleni/__tests__/printLabelPdf.test.ts
@@ -55,7 +55,11 @@ describe('printLabelPdf', () => {
     printLabelPdf('250001', labelWithPackage);
     await flushAsync();
 
-    expect(fetchMock).toHaveBeenCalledWith(expectedProxyUrl);
+    // The readiness loop marks its polling attempts with the X-Label-Poll header so the backend
+    // logs the expected transient 404s quietly instead of flooding the error log.
+    expect(fetchMock).toHaveBeenCalledWith(expectedProxyUrl, {
+      headers: { 'X-Label-Poll': '1' },
+    });
     expect(window.open).not.toHaveBeenCalled();
 
     jest.restoreAllMocks();
@@ -410,6 +414,27 @@ describe('fetchAndPrintLabel', () => {
 
     jest.restoreAllMocks();
   });
+
+  it('sends the X-Label-Poll header when isPoll is true', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+    await fetchAndPrintLabel('250001', 1, undefined, true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://api.test/api/packaging/orders/250001/packages/1/label.pdf',
+      { headers: { 'X-Label-Poll': '1' } },
+    );
+  });
+
+  it('omits the X-Label-Poll header (single-arg fetch) when isPoll is false', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+    await fetchAndPrintLabel('250001', 1, undefined, false);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://api.test/api/packaging/orders/250001/packages/1/label.pdf',
+    );
+  });
 });
 
 describe('printLabelWithReadiness', () => {
@@ -541,6 +566,55 @@ describe('printLabelWithReadiness', () => {
     const result = await promise;
 
     expect(result).toEqual({ printed: false, timedOut: true });
+  });
+
+  it('makes one final non-poll confirmation fetch (without the header) after the polling window', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+    const promise = printLabelWithReadiness('250001', 1);
+
+    for (let i = 0; i < 10; i++) {
+      await pumpStep(READINESS_BACKOFF_MS[Math.min(i, READINESS_BACKOFF_MS.length - 1)] + 1);
+    }
+    await promise;
+
+    // Every in-loop poll carries the header; the last call is the confirmation fetch without it,
+    // so the backend logs exactly one warning for a label that never became ready.
+    const calls = fetchMock.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toEqual([
+      'http://api.test/api/packaging/orders/250001/packages/1/label.pdf',
+    ]);
+    expect(lastCall).toHaveLength(1);
+    // All the earlier attempts were polls.
+    calls.slice(0, -1).forEach((call) => {
+      expect(call[1]).toEqual({ headers: { 'X-Label-Poll': '1' } });
+    });
+  });
+
+  it('returns printed: true when the label appears on the final confirmation fetch', async () => {
+    // Polls (header present) always 404; only the final non-poll confirmation fetch succeeds.
+    // Keying on the header keeps this independent of exactly which backoff step hits the timeout.
+    fetchMock.mockImplementation((_url: string, init?: RequestInit) =>
+      init
+        ? Promise.resolve({ ok: false, status: 404 })
+        : Promise.resolve({
+            ok: true,
+            status: 200,
+            blob: async () => new Blob(['%PDF'], { type: 'application/pdf' }),
+          }),
+    );
+    jest.spyOn(document.body, 'appendChild').mockImplementation(() => null as any);
+
+    const promise = printLabelWithReadiness('250001', 1);
+
+    for (let i = 0; i < 10; i++) {
+      await pumpStep(READINESS_BACKOFF_MS[Math.min(i, READINESS_BACKOFF_MS.length - 1)] + 1);
+    }
+
+    const result = await promise;
+
+    expect(result).toEqual({ printed: true, status: 200 });
   });
 
   it('returns printed: false (no timedOut) when aborted via AbortSignal before first attempt', async () => {

--- a/frontend/src/components/baleni/printLabelPdf.ts
+++ b/frontend/src/components/baleni/printLabelPdf.ts
@@ -17,11 +17,24 @@ export interface PrintAttemptResult {
   status?: number;
 }
 
-const silentPrintViaBlob = async (url: string, onAfterPrint?: () => void): Promise<PrintAttemptResult> => {
+/**
+ * Header marking a label PDF request as an automated readiness poll. The backend logs the
+ * expected transient 404s from polling at Debug instead of Warning so they don't flood the logs.
+ * The final post-timeout confirmation request omits it so its 404 is logged as a real warning.
+ */
+const LABEL_POLL_HEADER = 'X-Label-Poll';
+
+const silentPrintViaBlob = async (
+  url: string,
+  onAfterPrint?: () => void,
+  isPoll = false,
+): Promise<PrintAttemptResult> => {
   const apiClient = getAuthenticatedApiClient(false) as unknown as ApiClientWithInternals;
   let response: Response;
   try {
-    response = await apiClient.http.fetch(url);
+    response = isPoll
+      ? await apiClient.http.fetch(url, { headers: { [LABEL_POLL_HEADER]: '1' } })
+      : await apiClient.http.fetch(url);
   } catch {
     return { printed: false };
   }
@@ -72,9 +85,10 @@ export const fetchAndPrintLabel = (
   orderCode: string,
   packageNumber: number,
   onAfterPrint?: () => void,
+  isPoll = false,
 ): Promise<PrintAttemptResult> => {
   const url = buildProxyUrl(orderCode, packageNumber);
-  return silentPrintViaBlob(url, onAfterPrint);
+  return silentPrintViaBlob(url, onAfterPrint, isPoll);
 };
 
 export interface ReadinessWaitOptions {
@@ -107,7 +121,9 @@ export const printLabelWithReadiness = async (
   while (true) {
     if (signal?.aborted) return { printed: false };
 
-    const result = await fetchAndPrintLabel(orderCode, packageNumber, onAfterPrint);
+    // In-loop attempts are automated polls: mark them so the backend logs their expected 404s
+    // quietly (Debug) instead of flooding the error log.
+    const result = await fetchAndPrintLabel(orderCode, packageNumber, onAfterPrint, true);
 
     if (result.printed) return { printed: true, status: result.status };
 
@@ -122,7 +138,14 @@ export const printLabelWithReadiness = async (
     if (signal?.aborted) return { printed: false };
 
     const elapsed = Date.now() - startedAt;
-    if (elapsed >= READINESS_TIMEOUT_MS) return { printed: false, timedOut: true };
+    if (elapsed >= READINESS_TIMEOUT_MS) {
+      // Polling window exhausted. Make one final, non-poll confirmation fetch so the backend logs
+      // exactly one warning for a label that genuinely never became ready. If the label appeared
+      // right at the deadline, this final attempt prints it.
+      const finalResult = await fetchAndPrintLabel(orderCode, packageNumber, onAfterPrint, false);
+      if (finalResult.printed) return { printed: true, status: finalResult.status };
+      return { printed: false, timedOut: true };
+    }
 
     attempt++;
   }


### PR DESCRIPTION
The frontend readiness loop polls `GET /api/packaging/.../label.pdf` until the carrier label is ready, so every expected "not ready" 404 was emitting two Warning log lines (in the handler and `RequestLoggingMiddleware`), flooding the logs across packages and operators. Polls now carry an `X-Label-Poll` header and the backend logs those transient 404s at Debug; when the 30s polling window is exhausted the frontend issues one final non-poll confirmation fetch, so a label that genuinely never became ready produces exactly one Warning with full diagnostics. Real error paths (carrier exception / non-2xx → 503) are unchanged.

**Verification:** backend build clean, 8/8 handler tests pass (2 new), `dotnet format` clean; frontend 31/31 `printLabelPdf` tests pass (6 new/updated), `npm run build` succeeds.