### PR TITLE
#3539: fix navigateToCatalog E2E helper fallback

### DIFF
--- a/artifacts/feat-3539/arch-review.r1.md
+++ b/artifacts/feat-3539/arch-review.r1.md
@@ -1,0 +1,127 @@
+# Architecture Review: Fix Catalog Page Navigation E2E Regression (navigateToCatalog)
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a test-infrastructure bug confined to a single helper function, `navigateToCatalog`, in `frontend/test/e2e/helpers/e2e-auth-helper.ts`. It does not touch product code, routing, or UI. The fix should adopt a pattern that already exists twice in the exact same file (`navigateToTransportBoxes`, lines 178-232; `navigateToTransportBoxReceive`, lines 277-319), so there is no new architecture to design — only a structural correction to bring one outlier helper in line with its siblings. I confirmed by reading the file directly that:
+
+- `navigateToCatalog` (lines 234-260) is the only UI-driving helper whose fallback lives inside `catch` rather than unconditionally after `try/catch`.
+- It is also the only one still using 2000ms `isVisible` timeouts; every other UI-driving helper (`navigateToTransportBoxes`, `navigateToTransportBoxReceive`, `navigateToInvoiceClassification`, `navigateToIssuedInvoices`, `navigateToMarketingCalendar`) uses 5000ms.
+- None of the working helpers self-verify the end URL by throwing — `navigateToMarketingCalendar` gets closest by waiting on an `h1` heading with a 15s timeout on both paths, which is a reasonable model for "confirm the destination was reached" but not literally a URL check. `navigateToCatalog`'s spec explicitly requires a URL-based self-check with a descriptive throw, which is new within this file (first helper to do so) but consistent with FR-1/NFR-2 in the spec and doesn't conflict with any existing pattern.
+
+No other module is affected. The 9 catalog spec files (`frontend/test/e2e/catalog/*.spec.ts`) call `navigateToCatalog(page)` and then independently assert `page.url()`; per the spec this redundant assertion may remain (harmless once the helper self-verifies) — removing it is optional cleanup, not required.
+
+## Proposed Architecture
+
+No new components. Single-function restructuring inside the existing helper module.
+
+### Component Overview
+
+```
+frontend/test/e2e/catalog/*.spec.ts (9 files)
+        │  calls
+        ▼
+navigateToCatalog(page)  [frontend/test/e2e/helpers/e2e-auth-helper.ts]
+        │
+        ├─ navigateToApp(page)               (unchanged — auth + app shell mount)
+        ├─ UI path: click "Produkty" → click "Katalog"   (isVisible timeout 2000→5000ms)
+        ├─ fallback: page.goto(`${baseUrl}/catalog`)      (moved outside catch, unconditional)
+        └─ self-check: throw if page.url() doesn't contain '/catalog'  (new)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Fallback placement — outside try/catch, gated by early return on UI success
+
+**Options considered:**
+- (a) Keep fallback in `catch`, additionally check the result of `isVisible()` and manually invoke the fallback logic in the `if`-false branches too (duplicating the goto/wait code at three call sites within the function).
+- (b) Restructure to match `navigateToTransportBoxes`/`navigateToTransportBoxReceive`: attempt UI navigation inside `try`, `return` immediately once the UI path is confirmed to have landed on `/catalog`, and — for every other path, whether via a timeout-driven `isVisible() === false`, an exception, or a UI click that didn't actually route to `/catalog` — fall through to a single direct-navigation block placed unconditionally after the `try/catch`.
+
+**Chosen approach:** (b), matching the two existing correct helpers verbatim in structure.
+
+**Rationale:** This is a one-function bug fix in a file with an established, working pattern used by two sibling helpers. Duplicating fallback logic per branch (option a) would diverge from that pattern for no benefit and add more places for the same class of bug to recur. Reusing the sibling pattern also means the "early return only on confirmed success" idiom is uniform across the file, which is directly what the spec's FR-1 item 1 asks for ("mirroring the pattern already used by `navigateToTransportBoxes`/`navigateToTransportBoxReceive`").
+
+#### Decision 2: Where "confirmed success" is checked before the early return
+
+**Options considered:**
+- (a) Return early as soon as the "Katalog" click resolves, without checking the URL (this is closer to what `navigateToTransportBoxReceive` does — it returns after the click succeeds, trusting the click).
+- (b) Explicitly check `page.url().includes('/catalog')` after the UI click before returning early, and treat a click that didn't actually navigate (e.g., `RequireMenuPath` redirect-to-`/` on insufficient permission) as a miss that should still fall through to the fallback/self-check.
+
+**Chosen approach:** (b).
+
+**Rationale:** The spec's root-cause analysis explicitly notes `RequireMenuPath` will redirect to `/` if permissions are confirmed insufficient — a scenario where the "Katalog" element is clicked but the resulting page is not `/catalog`. Checking the URL after the click (rather than trusting the click alone, as `navigateToTransportBoxReceive` does by checking for content markers instead) is what lets a single shared self-verification step at the end of the function catch every failure mode uniformly, satisfying FR-1 item 3 and NFR-2 without adding a second, UI-path-specific check. This also keeps the function simpler than `navigateToTransportBoxes`, which checks page *content* markers (`h1, h2, h3, [data-testid*="transport"]`) — a URL check is sufficient and simpler here since the acceptance criterion is explicitly `page.url()`-based.
+
+#### Decision 3: Timeout value
+
+**Options considered:** Leave at 2000ms; raise to 5000ms (matching siblings); raise higher (e.g. 10000ms).
+
+**Chosen approach:** 5000ms, matching every other UI-driving helper in the file.
+
+**Rationale:** Spec FR-1 item 2 and NFR-1 both specify 5000ms explicitly, for consistency with existing helpers and to avoid over-lengthening the suite. No reason to deviate.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files or directories. Single edit to the existing function in `frontend/test/e2e/helpers/e2e-auth-helper.ts` (lines 234-260). No changes to `frontend/test/e2e/catalog/*.spec.ts`, `frontend/src/**`, or any other helper in this file.
+
+### Interfaces and Contracts
+
+Signature unchanged:
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void>
+```
+
+Updated contract: on return, `page.url()` is guaranteed to contain `/catalog`. If neither the UI path nor the direct-goto fallback reaches `/catalog`, the function throws an `Error` describing what was attempted (UI click path vs. fallback goto) and the final URL — this is new behavior; today the function can return silently while still on the app root.
+
+### Data Flow (target implementation shape)
+
+```
+navigateToCatalog(page):
+  await navigateToApp(page)
+
+  try:
+    if produktySelector.isVisible({ timeout: 5000 }):
+      click produktySelector
+      await waitForLoadingComplete(page)
+      if katalogSelector.isVisible({ timeout: 5000 }):
+        click katalogSelector
+        await page.waitForLoadState('domcontentloaded')
+        await waitForLoadingComplete(page)
+        if page.url().includes('/catalog'):
+          return   // early return — mirrors sibling helpers' "return on confirmed success"
+  catch (e):
+    // log only, matching sibling helpers' catch-and-continue style; do not swallow into a silent return
+    console.log('UI navigation failed:', e.message)
+
+  // Unconditional fallback — reached on isVisible timeout-miss, on a UI click that
+  // didn't land on /catalog, and on a thrown exception alike.
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz'
+  await page.goto(`${baseUrl}/catalog`)
+  await page.waitForLoadState('domcontentloaded')
+  await waitForLoadingComplete(page)
+
+  // Self-verification (new) — turns a silent no-op into a fast, diagnosable failure.
+  if not page.url().includes('/catalog'):
+    throw new Error(`navigateToCatalog: failed to reach /catalog via UI navigation or direct goto fallback; final URL was ${page.url()}`)
+```
+
+This is guidance on shape, not literal code to paste — follow the exact style (console.log wording, try/catch structure) already used by `navigateToTransportBoxes` immediately above it in the file for consistency.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| E2E service principal actually lacks `products.catalog.read`, so both UI path and fallback land on `/` via `RequireMenuPath` redirect | Medium | Out of scope for the code fix itself, but the new self-check throw turns this into an immediate, descriptive failure at the helper call site (FR-2) instead of 84 opaque downstream failures — verify principal's permission grant separately per spec FR-2 |
+| Raising timeout 2000ms→5000ms adds latency across many test setups | Low | Only affects the "not visible" (worst) case; NFR-1 accepts a few seconds/test since suite runs nightly, not in PR CI |
+| Self-check throw changes failure mode for the 9 spec files' own redundant `expect(page.url()).toContain('/catalog')` assertions | Low | Both fail the test either way (throw vs. failed expect); no behavior regression. Removing the now-redundant per-spec assertions is optional cleanup, not required by this fix |
+
+## Specification Amendments
+
+None. The spec's FR-1/FR-2/NFR-1/NFR-2 are implementable as written and match the code read during this review. One clarification worth calling out to the implementer (not a spec change): use a URL check (`page.url().includes('/catalog')`) as the "confirmed success" gate for the early return after the UI click, rather than a content-marker check as in `navigateToTransportBoxes` — see Decision 2 above. This is the simplest way to satisfy the spec's single self-verification requirement without adding a second, path-specific check.
+
+## Prerequisites
+
+None. No migrations, config, or infrastructure changes needed. FR-2 (confirming the E2E principal holds `products.catalog.read` and that the permissions fetch isn't abnormally slow in E2E mode) is an out-of-band verification step, not a code prerequisite — it can be done via a staging smoke run after the code fix lands, per the spec's own framing ("do not silently paper over a slow-permissions-fetch product bug by only raising the E2E helper's timeout").

--- a/artifacts/feat-3539/brief.md
+++ b/artifacts/feat-3539/brief.md
@@ -1,0 +1,49 @@
+## Summary
+
+In the nightly E2E regression run **[#191](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966)** (branch `main`, commit `738a99c`), **all 84 tests across the `catalog` module failed** with the same root cause: navigation to the Catalog page never actually lands on `/catalog`.
+
+## Root cause signature
+
+The shared `beforeEach` calls `navigateToCatalog(page)` and then asserts the URL, which fails:
+
+```
+expect(received).toContain(expected)
+
+Expected substring: "/catalog"
+Received string:    "https://heblo.stg.anela.cz/?e2e=true"
+
+  16 |     console.log('🧭 Navigating to catalog page...');
+  17 |     await navigateToCatalog(page);
+> 18 |     expect(page.url()).toContain('/catalog');
+  19 |     console.log('✅ On catalog page:', page.url());
+     at frontend/test/e2e/catalog/*.spec.ts:18
+```
+
+The app stays on the root URL (`/?e2e=true`) — the catalog route is never reached. This blocks every downstream catalog test (filters, sorting, pagination, etc.). Likely candidates: broken sidebar navigation to Catalog, a routing regression, or the initial catalog load hanging so the redirect/route change never completes.
+
+## Affected specs (failing test count)
+
+| Spec | Failures |
+|------|---------:|
+| catalog/filter-edge-cases.spec.ts | 17 |
+| catalog/text-search-filters.spec.ts | 16 |
+| catalog/combined-filters.spec.ts | 13 |
+| catalog/pagination-with-filters.spec.ts | 13 |
+| catalog/clear-filters.spec.ts | 10 |
+| catalog/sorting-with-filters.spec.ts | 10 |
+| catalog/product-type-filter.spec.ts | 3 |
+| catalog/margins-chart.spec.ts | 1 |
+| catalog/ui.spec.ts | 1 |
+| **Total** | **84** |
+
+## Environment
+
+- Workflow: 🎭 E2E Nightly Regression Tests, run #191
+- Target: `https://heblo.stg.anela.cz` (staging)
+- Screenshots/video artifacts: `e2e-failure-screenshots-all-191`, `e2e-test-results-all-191` on the [run page](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966).
+
+## Suggested first steps
+
+1. Manually verify Catalog navigation on staging (does the sidebar link route to `/catalog`?).
+2. Check whether the initial catalog data load is failing/hanging and preventing the route from settling.
+3. Once navigation works, re-run the catalog E2E suite to confirm downstream assertions pass.

--- a/artifacts/feat-3539/code-review.r1.md
+++ b/artifacts/feat-3539/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts:258` and `frontend/test/e2e/helpers/e2e-auth-helper.ts:283` — the `/catalog` URL-containment check (`page.url().includes('/catalog')`) is duplicated between the UI-success check and the final self-verification. A tiny local helper (e.g. `const isOnCatalog = () => page.url().includes('/catalog');`) would remove the duplication and keep both checks trivially in sync if the target path ever changes.

--- a/artifacts/feat-3539/design.r1.md
+++ b/artifacts/feat-3539/design.r1.md
@@ -1,0 +1,31 @@
+# Design: Fix Catalog Page Navigation E2E Regression (navigateToCatalog)
+
+## Component Design
+
+**`navigateToCatalog(page)`** — `frontend/test/e2e/helpers/e2e-auth-helper.ts` (lines 234-260)
+
+Sole component in scope. No new files, no product-code changes. The fix restructures this one function to match the existing, working pattern used by its siblings `navigateToTransportBoxes` and `navigateToTransportBoxReceive` in the same file:
+
+- `navigateToApp(page)` — called first, unchanged; mounts the app shell but does not wait for the permissions fetch.
+- **UI path** (inside `try`): locate "Produkty" with `isVisible({ timeout: 5000 })` (was 2000ms), click it, wait for load, locate "Katalog" with the same 5000ms timeout, click it, wait for load. Only if `page.url()` is then confirmed to contain `/catalog` does the function `return` early. A click that lands elsewhere (e.g. a `RequireMenuPath` redirect to `/`) is treated as a miss, not a success.
+- **`catch` block**: logs the exception (matching sibling style) and falls through — it no longer performs navigation itself.
+- **Fallback** (unconditional, after `try/catch`): reached whenever the UI path didn't already return — i.e. on an `isVisible` timeout-miss, a UI click that didn't route to `/catalog`, or a thrown exception alike. Navigates directly via `page.goto(\`${baseUrl}/catalog\`)` using the same `baseUrl` resolution already in the current code (`PLAYWRIGHT_FRONTEND_URL` → `PLAYWRIGHT_BASE_URL` → staging default), then waits for load.
+- **Self-verification** (new): after the fallback, throws a descriptive `Error` (naming that both the UI path and the goto fallback were attempted, plus the final `page.url()`) if the URL still does not contain `/catalog`. This replaces the current silent-return behavior with a fast, diagnosable failure at the helper call site.
+
+No other helper in `e2e-auth-helper.ts` is touched. No changes to `Sidebar.tsx`, `App.tsx`, `RequireMenuPath.tsx`, or `PermissionsContext.tsx` — all were inspected and confirmed correctly wired; this is scoped entirely to the test helper.
+
+## Data Schemas
+
+Not applicable — no persistence, API, or event payloads involved. The relevant contract is the helper function's signature and behavior:
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void>
+```
+
+**Pre-conditions:** `page` is an authenticated Playwright page (post-`navigateToApp`/E2E session setup); the E2E principal is assumed to hold `products.catalog.read` (verified out-of-band per spec FR-2, not by this function).
+
+**Post-conditions:**
+- On successful return: `page.url()` contains `/catalog`, reached via either the UI click path or the direct `goto` fallback.
+- On failure to reach `/catalog` by either means: the function throws an `Error` describing what was attempted (UI navigation vs. fallback goto) and the final URL, instead of returning silently.
+
+**Unchanged for callers:** the 9 spec files in `frontend/test/e2e/catalog/*.spec.ts` continue to call `await navigateToCatalog(page);` followed by their own `expect(page.url()).toContain('/catalog')`, which becomes redundant but harmless once the helper self-verifies.

--- a/artifacts/feat-3539/impl/fix-navigate-to-catalog-fallback.r1.md
+++ b/artifacts/feat-3539/impl/fix-navigate-to-catalog-fallback.r1.md
@@ -1,0 +1,118 @@
+# Implementation: fix-navigate-to-catalog-fallback
+
+## What was implemented
+Restructured `navigateToCatalog` in the Playwright E2E auth helper so the direct-navigation
+fallback (`page.goto(.../catalog)`) is reached unconditionally whenever the UI-navigation
+`try` block did not already confirm landing on `/catalog` — not only when an exception was
+thrown. Previously, an `isVisible({ timeout: 2000 })` resolving to `false` (a timeout-miss,
+the actual staging failure mode from the incident) would fall through the `try` block silently
+without ever reaching the fallback `goto`, leaving the page on whatever it was on before. Also
+raised the `isVisible` timeouts for "Produkty" and "Katalog" from 2000ms to 5000ms to match
+sibling helpers (`navigateToTransportBoxes`, `navigateToTransportBoxReceive`), added an early
+`return` on confirmed UI-navigation success, and added a final self-check that throws a
+descriptive error (referencing both attempted paths and the final URL) if the URL still
+doesn't contain `/catalog` after both the UI path and the fallback have been attempted.
+
+## Files created/modified
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` — replaced the body of `navigateToCatalog`
+  (previously lines 234-260) with the restructured version: `try` block now only performs UI
+  navigation and returns early on confirmed success; `catch` only logs and falls through; an
+  unconditional fallback `goto` sits after the `try/catch`; a final `if (!page.url().includes('/catalog'))`
+  throws a descriptive `Error`. No other function in the file was touched.
+
+## Tests
+- **Manual read-through against all four failure/success paths** (per task-context validation
+  step 1) — traced by hand and confirmed:
+  - *UI success*: both `isVisible` checks resolve `true`, both clicks succeed, `page.url()`
+    contains `/catalog` after the "Katalog" click → early `return`; fallback never runs.
+  - *Timeout miss* (the actual staging failure mode): `produktySelector.isVisible({ timeout: 5000 })`
+    resolves to `false` (no throw) → both `if` bodies skipped, `else` branches log → `try`
+    completes normally, `catch` does not run → falls through to the unconditional fallback →
+    `page.goto` succeeds → self-check passes → function returns normally.
+  - *Click lands off-`/catalog`* (e.g. `RequireMenuPath` redirect): "Katalog" click resolves,
+    `page.url()` doesn't contain `/catalog` → no early return → falls to fallback `goto` → if
+    fallback also fails to land on `/catalog`, the final `if` throws the descriptive error.
+  - *Thrown exception* (e.g. strict-mode locator violation): caught, logged via
+    `console.log('❌ UI navigation failed:', e.message)`, falls through to the same
+    unconditional fallback as the timeout-miss case.
+  All four paths confirmed: none can return without `page.url().includes('/catalog')` being
+  true; the only way out without that guarantee is the explicit `throw`.
+- **Type-check**: The root `frontend/tsconfig.json` only includes `"src"`, so `test/e2e` is
+  never covered by `npx tsc --noEmit` as configured for this project — that command passes
+  (module-resolution deprecation warnings only, pre-existing and unrelated to `test/e2e`).
+  For a scoped check, I stood up a temporary tsconfig (same compiler options, `include` pointed
+  at `test/e2e/**/*.ts`) and ran `npx tsc --noEmit --project <temp-config>` after `npm install
+  --legacy-peer-deps` (node_modules was not present in this sandbox and had to be installed;
+  a plain `npm install` fails on a pre-existing `react-i18next`/`typescript` peer-dependency
+  conflict unrelated to this change). Result: no new error categories from this change — the
+  only line flagged in the diff (`e.message` inside `catch (e) {}` at the new line 270) has
+  `TS18046: 'e' is of type 'unknown'` under strict mode, but this is the pre-existing pattern
+  used verbatim in every sibling function in this same file (`navigateToTransportBoxes`,
+  `navigateToStockOperations`, `navigateToTransportBoxReceive`, `navigateToInvoiceClassification`
+  — all untouched, all already using `catch (e) { ... e.message }`), and is required by the
+  task context's exact-match spec. The scoped check also surfaces ~40 pre-existing errors in
+  unrelated spec files (`batch-planning-workflow.spec.ts`, `invoice-classification-history-actions.spec.ts`,
+  etc.) confirming this is baseline noise, not something introduced here.
+- **Lint**: `npm run lint` (the project script) only targets `src` (`eslint src --ext .ts,.tsx`)
+  and never scans `test/e2e`, so it is structurally unaffected by this change — confirmed it
+  runs and shows the same 162 pre-existing problems, all under `src`, none related to this file.
+  As a targeted due-diligence check, also ran
+  `npx eslint test/e2e/helpers/e2e-auth-helper.ts --no-eslintrc -c .eslintrc.json --ext .ts`
+  directly against the modified file: exit code 0, no output — no violations.
+- **Staging E2E** (`./scripts/run-playwright-tests.sh catalog` against `https://heblo.stg.anela.cz`):
+  not run — no access to the staging environment from this sandbox. Pending/out of scope for
+  this step; flagged below.
+
+## How to verify
+1. Read `frontend/test/e2e/helpers/e2e-auth-helper.ts` lines 234-290 and trace the four paths
+   described above.
+2. `cd frontend && npm install --legacy-peer-deps` (if `node_modules` isn't already present).
+3. `cd frontend && npx tsc --noEmit` — passes (test/e2e not in scope of this config; pre-existing
+   `node_modules/react-i18next` d.ts errors are unrelated/baseline).
+4. `cd frontend && npm run lint` — passes for `src`; run
+   `npx eslint test/e2e/helpers/e2e-auth-helper.ts --no-eslintrc -c .eslintrc.json --ext .ts`
+   for a targeted check of the modified file (expect exit code 0).
+5. Against staging: `./scripts/run-playwright-tests.sh catalog` and confirm all 9 catalog spec
+   files' setup assertions pass, then `./scripts/run-playwright-tests.sh transport` and
+   `./scripts/run-playwright-tests.sh stock-operations` to confirm no regression in sibling
+   helpers.
+
+## Notes
+- Staging E2E verification (task-context validation step 4 — `./scripts/run-playwright-tests.sh catalog`
+  against `https://heblo.stg.anela.cz`, all 9 catalog spec files / 84 tests, plus targeted
+  transport/stock-operations regression runs) could **not** be run from this sandbox (no network
+  access to staging) and is pending.
+- The FR-2 out-of-band note (task-context validation step 5 — confirming the E2E service
+  principal holds `products.catalog.read` per `frontend/src/auth/accessMatrix.generated.ts`,
+  and whether the permissions fetch was observed to be abnormally slow in `?e2e=true` mode
+  during the staging run) also could not be checked from this sandbox and needs a human/CI run
+  against staging before the underlying issue is closed.
+- `node_modules` was not present in this worktree; I ran `npm install --legacy-peer-deps` to get
+  a working local toolchain for validation. A plain `npm install` (no flag) fails on a
+  pre-existing `react-i18next@15.7.4` (wants `typescript@^5`) vs. `typescript@^4.9.5` (root
+  `package.json`) peer-dependency conflict — unrelated to this change, not modified as part of
+  this fix, and not committed (node_modules is gitignored).
+- No deviations from the task-context's exact before/after code were made; the replacement was
+  applied verbatim including console.log wording/emoji and the new throw message.
+
+## PR Summary
+Fixes the E2E `navigateToCatalog` helper so its direct-navigation fallback is unconditionally
+reached whenever UI navigation via the sidebar ("Produkty" > "Katalog") doesn't confirm landing
+on `/catalog` — previously the fallback only ran inside a `catch` block, so an `isVisible`
+timeout-miss (no exception, just a `false` resolution) silently skipped both the UI click *and*
+the fallback, leaving tests on the wrong page. This was the actual failure mode observed in the
+staging incident. The fix also raises the "Produkty"/"Katalog" `isVisible` timeouts from 2000ms
+to 5000ms to match sibling navigation helpers, adds an early return once UI navigation is
+confirmed via URL check (guarding against a silent `RequireMenuPath` redirect-on-insufficient-permission
+false positive), and adds a final self-check that throws a descriptive error — naming both
+attempted paths and the final URL — if `/catalog` still wasn't reached after both attempts, so
+failures are diagnosable at the helper call site rather than surfacing as generic downstream
+assertion failures across the 9 catalog spec files that call it.
+
+### Changes
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` — restructured `navigateToCatalog`: unconditional
+  fallback after `try/catch`, 2000ms→5000ms `isVisible` timeouts, early return on confirmed
+  UI-navigation success, and a new throw on failure to reach `/catalog` via either path.
+
+## Status
+DONE_WITH_CONCERNS

--- a/artifacts/feat-3539/review/fix-navigate-to-catalog-fallback.r1.md
+++ b/artifacts/feat-3539/review/fix-navigate-to-catalog-fallback.r1.md
@@ -1,0 +1,19 @@
+# Code Review: fix-navigate-to-catalog-fallback
+
+## Summary
+The implementation matches the task-context's exact-required code verbatim, verified directly against `git show 4780a6b` and the live file (`frontend/test/e2e/helpers/e2e-auth-helper.ts` lines 234-290). The fallback is now unconditional (reached on timeout-miss, off-`/catalog` landing, or thrown exception), timeouts were raised from 2000ms to 5000ms, an early return guards confirmed UI success, and a descriptive throw was added for the double-failure case. Scope was respected: only `navigateToCatalog` changed, no sibling helpers or app source files were touched.
+
+## Review Result: PASS
+
+### task: fix-navigate-to-catalog-fallback
+**Status:** PASS
+
+## Docs to Update
+(none)
+
+## Overall Notes
+- Diff verified line-by-line against the task-context's prescribed before/after code block — the committed version (`4780a6bf2f3c7bdbc95fce8af25b1a9c2267d0f6`) is an exact match, including console.log wording/emoji, comments, and the new `Error` message referencing both attempted paths and the final URL.
+- `git show --stat` confirms the commit touches only `frontend/test/e2e/helpers/e2e-auth-helper.ts` (plus the task's own impl artifact and `state.json` bookkeeping) — no incidental edits to `navigateToTransportBoxes`, `navigateToTransportBoxReceive`, `Sidebar.tsx`, `App.tsx`, `RequireMenuPath.tsx`, `PermissionsContext.tsx`, or any `catalog/*.spec.ts` file, as required.
+- The restructuring is logically sound: the `try` block can now only exit via early `return` after confirming `page.url().includes('/catalog')`; every other path (timeout-miss, off-`/catalog` click, or caught exception) falls through to the unconditional fallback `goto`, which itself is self-verified by the trailing throw. This directly fixes the reported bug (a timeout-miss previously produced a silent no-op, leaving the page in an indeterminate state).
+- Per the review-criteria carve-outs, staging E2E execution (`./scripts/run-playwright-tests.sh catalog`) and the FR-2 out-of-band permission/latency check are runtime verifications requiring live browser/network access to staging and cannot be produced or confirmed by this headless review — the implementation summary appropriately flags both as pending/out of scope for the sandbox and does not claim them as done. This does not block PASS per the review criteria.
+- The developer's summary is accurate and matches the real diff; no discrepancies found between the r1 implementation summary and the actual committed code.

--- a/artifacts/feat-3539/spec.r1.md
+++ b/artifacts/feat-3539/spec.r1.md
@@ -1,0 +1,131 @@
+# Specification: Fix Catalog Page Navigation E2E Regression (navigateToCatalog)
+
+## Summary
+
+The nightly E2E regression suite reports 84 failing tests across every spec in `frontend/test/e2e/catalog/`, all failing at the same `beforeEach`/setup assertion: after calling `navigateToCatalog(page)`, `page.url()` still shows the app root (`https://heblo.stg.anela.cz/?e2e=true`) instead of `/catalog`. Code inspection confirms the root cause is a structural bug in the `navigateToCatalog` test helper (`frontend/test/e2e/helpers/e2e-auth-helper.ts`), not in the Catalog page/route/sidebar itself: the helper's direct-navigation fallback is unreachable under the exact conditions staging produces, so when UI-based navigation doesn't complete in time, the test is silently left on the root URL. This spec defines the fix to `navigateToCatalog` (and verification of the surrounding sidebar/route code it depends on) so that the Catalog page reliably loads before the 84 downstream assertions run.
+
+## Background
+
+`frontend/test/e2e/catalog/*.spec.ts` (9 spec files, 84 tests) all import and call `navigateToCatalog` from `frontend/test/e2e/helpers/e2e-auth-helper.ts` in their `beforeEach`/setup, then immediately assert `expect(page.url()).toContain('/catalog')`. In nightly run #191 (branch `main`, commit `738a99c`) every one of these assertions failed with the browser still on `/?e2e=true`.
+
+Reading the current implementation of `navigateToCatalog` (lines 234-260 of `e2e-auth-helper.ts`):
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void> {
+  await navigateToApp(page);
+
+  const produktySelector = page.locator('text="Produkty"').first();
+  try {
+    if (await produktySelector.isVisible({ timeout: 2000 })) {
+      await produktySelector.click();
+      await waitForLoadingComplete(page);
+
+      const katalog = page.locator('text="Katalog"').first();
+      if (await katalog.isVisible({ timeout: 2000 })) {
+        await katalog.click();
+        await page.waitForLoadState('domcontentloaded');
+        await waitForLoadingComplete(page);
+      }
+    }
+  } catch (e) {
+    // If UI navigation fails, go directly to the path
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/catalog`);
+    await page.waitForLoadState('domcontentloaded');
+    await waitForLoadingComplete(page);
+  }
+}
+```
+
+Two defects combine to produce the observed symptom:
+
+1. **The fallback is dead code under the failure mode that actually occurs.** Playwright's `locator.isVisible({ timeout })` resolves to `false` when the element isn't found within the timeout — it does **not** throw. The only code path that reaches direct navigation to `/catalog` is the `catch` block, which only runs on a genuine thrown exception (e.g. a strict-mode locator violation). If `produktySelector` or `katalog` simply isn't visible in time, `isVisible()` returns `false`, the `if` bodies are skipped, the `try` block completes normally, `catch` never runs, and the function returns having done nothing. The test is left exactly where `navigateToApp()` left it: the app root. This matches the reported symptom exactly (`https://heblo.stg.anela.cz/?e2e=true`).
+
+   Contrast with the two working helpers in the same file, `navigateToTransportBoxes` and `navigateToTransportBoxReceive`: both place their direct-navigation fallback **unconditionally after** the `try/catch` block (only skipped via an explicit early `return` on confirmed UI-navigation success). That structure guarantees a fallback runs whenever UI navigation didn't succeed, regardless of whether a timeout or an exception caused the miss. `navigateToCatalog` is the odd one out — its fallback is nested inside `catch` only.
+
+2. **The 2000ms `isVisible` timeouts race against permission-gated, asynchronously-loaded sidebar content.** `frontend/src/components/Layout/Sidebar.tsx` builds `navigationSections` by filtering `allSections` through `canSeeItem`, which calls `hasPermission()` from `frontend/src/auth/PermissionsContext.tsx`. In `PermissionsContext.tsx`, `hasPermission` is defined as `(data?.isSuperUser ?? false) || (data?.permissions ?? []).includes(perm)` — while the `/me`-style permissions fetch (`usePermissions`) is still in flight, `data` is `undefined`, so `hasPermission` returns `false` for every permission and every gated section (including "Produkty", which gates the "Katalog" sub-item at `href: "/catalog"`, `key: "/catalog"`) is filtered out of `navigationSections` entirely (`if (visibleItems.length === 0) continue;` in `Sidebar.tsx`). `navigateToApp()` (called at the top of `navigateToCatalog`) only waits for the React shell to mount (`.App`, `#root > div`, or `nav`) — it does **not** wait for the permissions fetch to resolve. So on any run where the permissions call is slow (staging network/cold-start latency is called out repeatedly elsewhere in this same file, e.g. the 120s auth timeout and exponential backoff on `createE2EAuthSession`), "Produkty" — and therefore "Katalog" — can legitimately not exist in the DOM yet when `navigateToCatalog` checks for it with only a 2000ms budget. Every other UI-driving helper in this file (`navigateToTransportBoxes`, `navigateToTransportBoxReceive`) uses a 5000ms timeout for the equivalent check.
+
+Given defect 1 makes the fallback unreachable on a timeout miss, and defect 2 makes a timeout miss plausible/likely under staging conditions, the two together fully explain why all 84 catalog tests fail identically at the same assertion, and why the failure is intermittent-looking at the level of "the app worked, but only sometimes" (a timing race, not a permanent route break). The `/catalog` route itself (`frontend/src/App.tsx`, `<Route path="/catalog" element={guard("/catalog", <CatalogList />)} />` guarded by `RequireMenuPath`) and the sidebar's "Katalog" entry (`frontend/src/components/Layout/Sidebar.tsx`, `{ id: "catalog", name: "Katalog", href: "/catalog", key: "/catalog" }`) are present, correctly wired, and not implicated by this investigation — this is a test-infrastructure bug, not a product bug.
+
+`RequireMenuPath.tsx` was also inspected to rule out an alternative theory (redirect-on-permission-denied racing with page load): it returns `null` while `isLoading` is true (no premature redirect) and only issues `<Navigate to="/" replace />` once permissions have resolved and are confirmed insufficient — this does not explain the failure by itself, but is noted because it means the fix's direct-navigation fallback is safe to rely on: it will not be redirected away as long as the E2E principal genuinely holds `products.catalog.read` (see Open Questions/assumption below).
+
+## Functional Requirements
+
+### FR-1: Fix Catalog page navigation E2E regression
+
+`navigateToCatalog` in `frontend/test/e2e/helpers/e2e-auth-helper.ts` must reliably land the browser on a URL containing `/catalog` before returning, regardless of whether the sidebar UI path or a direct `page.goto` fallback was used, and regardless of transient permission-fetch latency on staging.
+
+Required changes to `navigateToCatalog`:
+
+1. **Make the fallback reachable on a timeout miss, not just on a thrown exception.** Restructure so that direct navigation to `${baseUrl}/catalog` runs whenever UI navigation did not already confirm success — mirroring the pattern already used by `navigateToTransportBoxes`/`navigateToTransportBoxReceive` in the same file (fallback placed after the try/catch, success path returns early). A caught exception must not be the only trigger for the fallback.
+2. **Give the permission-gated sidebar items enough time to appear.** Align the `isVisible` timeout(s) for "Produkty" and "Katalog" with the rest of the file's UI-driven helpers (5000ms), rather than the current 2000ms, since these are gated behind an async permissions fetch that `navigateToApp()` does not wait for.
+3. **Verify the end state before returning.** After UI navigation and/or the fallback, the function must confirm `page.url()` contains `/catalog` (or equivalent) before returning; if neither UI navigation nor the fallback lands on `/catalog`, the helper should throw a clear, descriptive error rather than returning silently. This turns a silent no-op into a fast, diagnosable failure at the helper call site instead of 84 generic downstream assertion failures.
+4. **No changes to product code required.** `frontend/src/components/Layout/Sidebar.tsx`, `frontend/src/App.tsx` (route + `guard`), and `frontend/src/components/auth/RequireMenuPath.tsx` were inspected and are correctly wired; this is scoped to the E2E helper only unless implementation turns up evidence to the contrary (see FR-2).
+
+**Acceptance criteria:**
+- Given the E2E service principal is authenticated and holds `products.catalog.read`, calling `navigateToCatalog(page)` against staging results in `page.url()` containing `/catalog` on completion, in both the UI-click path and the direct-`goto` fallback path (verify by temporarily forcing each path, e.g. via a short-circuited "Produkty" locator in a local test, or by asserting behavior via code review + a staging smoke run).
+- The specific failing assertion from the brief no longer fails:
+  ```
+  await navigateToCatalog(page);
+  expect(page.url()).toContain('/catalog');
+  ```
+  This assertion (or its equivalent) passes for all 9 affected spec files: `catalog/filter-edge-cases.spec.ts` (17 tests), `catalog/text-search-filters.spec.ts` (16), `catalog/combined-filters.spec.ts` (13), `catalog/pagination-with-filters.spec.ts` (13), `catalog/clear-filters.spec.ts` (10), `catalog/sorting-with-filters.spec.ts` (10), `catalog/product-type-filter.spec.ts` (3), `catalog/margins-chart.spec.ts` (1), `catalog/ui.spec.ts` (1) — 84 tests total.
+  - Note: passing this initial navigation assertion unblocks each test to proceed into its own filter/sort/pagination logic; this spec's acceptance criteria cover only the navigation step. Any *further* failures inside a given test, once navigation succeeds, belong to that test/feature and are out of scope here (see Out of Scope).
+- If UI navigation fails and the fallback also fails to reach `/catalog` (e.g., genuine permission denial), `navigateToCatalog` throws a descriptive error (naming what was attempted and the resulting URL) instead of returning silently — verifiable by unit-level/manual test of the helper with a deliberately-revoked permission or an unreachable route.
+- No regression to the other navigation helpers in `e2e-auth-helper.ts` (`navigateToTransportBoxes`, `navigateToStockOperations`, `navigateToTransportBoxReceive`, `navigateToApp`) — their behavior and timeouts are unchanged by this fix unless FR-2 determines a shared fix is warranted.
+- `frontend/src/components/Layout/Sidebar.tsx`, `frontend/src/App.tsx`, `frontend/src/components/auth/RequireMenuPath.tsx`, and `frontend/src/auth/PermissionsContext.tsx` remain unmodified by this fix (product code is not implicated) — unless investigation during implementation finds a genuine product-side defect, in which case FR-2 governs.
+
+### FR-2: Confirm no product-side contribution and no impact to E2E-mode permission loading
+
+Before closing this issue, confirm (via a staging run capturing timing, or via targeted logging/tracing during a debug run) that:
+- The permissions fetch (`usePermissions` → `/me`-equivalent endpoint) that gates sidebar visibility is not abnormally slow or failing in the E2E-authenticated (`?e2e=true`) mode specifically (as opposed to normal user auth), since E2E tests use a service-principal-issued session distinct from interactive login.
+- The E2E service principal used by the nightly suite genuinely holds `products.catalog.read` (per `frontend/src/auth/accessMatrix.generated.ts`: `"/catalog": { permissions: ["products.catalog.read"] }`), so that the FR-1 fallback is guaranteed to succeed rather than merely relocating the same failure one level down (UI nav timeout → fallback redirect-to-"/" via `RequireMenuPath`).
+
+**Acceptance criteria:**
+- A written note (PR description or code comment) confirms the E2E principal's permission grant was checked and is sufficient, OR a follow-up ticket is filed if it is found to be insufficient/misconfigured.
+- If the permissions fetch is found to be abnormally slow in E2E mode, that finding is captured (either fixed here if trivial and in-scope, or filed as a separate ticket if it requires backend/infra changes) — do not silently paper over a slow-permissions-fetch product bug by only raising the E2E helper's timeout.
+
+## Non-Functional Requirements
+
+### NFR-1: Test reliability / flakiness budget
+
+`navigateToCatalog` must not introduce new flakiness. The increased timeout (2000ms → 5000ms) must not materially slow the overall catalog suite (84 tests) beyond what's already budgeted for nightly runs (suite currently runs unattended overnight per `CLAUDE.md`: "E2E suite runs nightly, not in PR CI" — a few extra seconds per test setup is acceptable; multi-minute regressions are not).
+
+### NFR-2: Fail-fast diagnostics
+
+When `navigateToCatalog` cannot reach `/catalog` by any means, it must fail loudly and specifically (thrown error naming the attempted paths and final URL) at the helper call site, rather than allowing execution to continue into a test body that will fail later with a less informative, generically-worded assertion. This directly serves future debuggability of this exact class of regression.
+
+## Data Model
+
+Not applicable — this is a test-infrastructure fix with no change to domain entities, persistence, or API contracts.
+
+## API / Interface Design
+
+No public API changes. The only interface affected is the internal contract of the exported helper function:
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void>
+```
+
+Contract (updated): on successful return, `page.url()` is guaranteed to contain `/catalog`. On failure to reach `/catalog` by any means, the function throws (it must not return silently while still on a non-`/catalog` URL). Call sites (`frontend/test/e2e/catalog/*.spec.ts`, 9 files) are unchanged — they continue to call `await navigateToCatalog(page);` followed by their own `expect(page.url()).toContain('/catalog')` (which becomes redundant but harmless once the helper self-verifies; removing that duplicate assertion from the 9 spec files is optional cleanup, not required).
+
+## Dependencies
+
+- Playwright (`@playwright/test`) — existing E2E framework, no version change implied.
+- Staging environment `https://heblo.stg.anela.cz` — the fix must be validated there per `docs/testing/playwright-e2e-testing.md`, since there is no sandbox equivalent for this class of timing issue.
+- E2E service principal credentials/permissions (`E2E_CLIENT_ID`/`AZURE_CLIENT_ID`, `E2E_CLIENT_SECRET`/`AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`) and its grant of `products.catalog.read` — see FR-2.
+- `frontend/test/e2e/helpers/wait-helpers.ts` (`waitForLoadingComplete`, `waitForPageLoad`) — used as-is; note the existing documented caveat in that file (lines ~98-129) that `waitForLoadingComplete`'s loading-indicator selectors (`[data-loading="true"], .loading, .spinner, [aria-busy="true"]`) don't match anything rendered by `CatalogList.tsx`, so it currently returns immediately without actually waiting for catalog data to load. This is a separate, pre-existing gap (not part of the reported 84-test failure, since those fail before ever reaching the catalog page) but is worth flagging as a related risk: once navigation is fixed, tests may newly expose catalog-data-loading race conditions that this helper doesn't currently guard against. Out of scope for this fix unless it causes new failures during validation.
+
+## Out of Scope
+
+- Fixing any filter/sort/pagination/margins-chart logic *within* the Catalog page itself. This spec only restores the ability to reach `/catalog`; once there, each test's own assertions govern its own pass/fail, and any such failures are separate issues.
+- Rewriting `waitForLoadingComplete` to correctly detect `CatalogList.tsx`'s React-Query-driven loading state (documented as a known gap in `wait-helpers.ts`). Only revisit if FR-1 validation surfaces new flakiness traceable to this gap.
+- Auditing or fixing the equivalent try/catch-fallback pattern bug in *other* untouched navigation helpers beyond `navigateToCatalog`, unless FR-2 investigation shows they share the exact same defect and are also causing nightly failures. `navigateToTransportBoxes` and `navigateToTransportBoxReceive` already use the correct (fallback-outside-try/catch) pattern and are not known to be broken.
+- Backend/API changes to the permissions endpoint (`/me`-equivalent) or to `accessMatrix.generated.ts`/RBAC configuration, unless FR-2 investigation finds the E2E principal is missing `products.catalog.read` (in which case granting it is a config/ops change, not a code change, and should be tracked separately if discovered).
+- Any UI/UX changes to `Sidebar.tsx`, the `/catalog` route, or `RequireMenuPath.tsx` — all three were inspected and found correctly implemented.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T00:22:51.394615Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T00:23:47.514818Z"
     }
   },
   "tasks": [
     {
       "name": "fix-navigate-to-catalog-fallback",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T00:23:47.778127Z"
     }
   ]
 }

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-08T00:18:34.409625Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T00:19:55.634770Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-08T00:20:44.080781Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T00:22:51.394615Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-08T00:30:35.678267Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T00:30:39.988809Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T00:32:42.238111Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T00:30:35.678267Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-08T00:30:39.988809Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T00:22:51.394615Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T00:23:47.514818Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T00:30:35.678267Z"
     }
   },
   "tasks": [
     {
       "name": "fix-navigate-to-catalog-fallback",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T00:23:47.778127Z"
+      "updated_at": "2026-07-08T00:30:31.303911Z"
     }
   ]
 }

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3539",
+  "issue_number": 3539,
+  "created_at": "2026-07-08T00:14:03.295270Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T00:18:34.409625Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-08T00:19:55.634770Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T00:20:44.080781Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3539/state.json
+++ b/artifacts/feat-3539/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-navigate-to-catalog-fallback",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3539/task-context/fix-navigate-to-catalog-fallback.md
+++ b/artifacts/feat-3539/task-context/fix-navigate-to-catalog-fallback.md
@@ -1,0 +1,127 @@
+### task: fix-navigate-to-catalog-fallback
+
+**Goal:** Restructure `navigateToCatalog` so the direct-navigation fallback runs whenever UI navigation did not already confirm landing on `/catalog` (not only inside `catch`), raise the `isVisible` timeouts for "Produkty"/"Katalog" from 2000ms to 5000ms to match sibling helpers, and throw a descriptive error if the URL still doesn't contain `/catalog` after both the UI path and the fallback have been attempted.
+
+**Files:**
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` (modify lines 234-260, the `navigateToCatalog` function only)
+
+**Details:**
+
+Replace the current `navigateToCatalog` function (current lines 234-260):
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void> {
+  await navigateToApp(page);
+
+  // Navigate to catalog via UI
+  // First, try to find and click on "Produkty" section
+  const produktySelector = page.locator('text="Produkty"').first();
+  try {
+    if (await produktySelector.isVisible({ timeout: 2000 })) {
+      await produktySelector.click();
+      await waitForLoadingComplete(page);
+
+      // Then click on "Katalog" sub-item
+      const katalog = page.locator('text="Katalog"').first();
+      if (await katalog.isVisible({ timeout: 2000 })) {
+        await katalog.click();
+        await page.waitForLoadState('domcontentloaded');
+        await waitForLoadingComplete(page);
+      }
+    }
+  } catch (e) {
+    // If UI navigation fails, go directly to the path
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/catalog`);
+    await page.waitForLoadState('domcontentloaded');
+    await waitForLoadingComplete(page);
+  }
+}
+```
+
+with:
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void> {
+  await navigateToApp(page);
+
+  // Navigate to catalog via UI
+  // First, try to find and click on "Produkty" section
+  const produktySelector = page.locator('text="Produkty"').first();
+  try {
+    console.log('🧭 Attempting UI navigation to catalog via Produkty...');
+    if (await produktySelector.isVisible({ timeout: 5000 })) {
+      console.log('✅ Found Produkty menu item, clicking...');
+      await produktySelector.click();
+      await waitForLoadingComplete(page);
+
+      // Then click on "Katalog" sub-item
+      const katalog = page.locator('text="Katalog"').first();
+      if (await katalog.isVisible({ timeout: 5000 })) {
+        console.log('✅ Found Katalog submenu, clicking...');
+        await katalog.click();
+        await page.waitForLoadState('domcontentloaded');
+        await waitForLoadingComplete(page);
+
+        // Verify we actually landed on the catalog page (a RequireMenuPath
+        // redirect-to-"/" on insufficient permission would still resolve the
+        // click without an exception, so a URL check is required here).
+        if (page.url().includes('/catalog')) {
+          console.log('✅ UI navigation successful');
+          return;
+        }
+        console.log('❌ Katalog click did not land on /catalog, current URL:', page.url());
+      } else {
+        console.log('❌ Katalog submenu not found under Produkty');
+      }
+    } else {
+      console.log('❌ Produkty menu item not found');
+    }
+  } catch (e) {
+    console.log('❌ UI navigation failed:', e.message);
+  }
+
+  // Unconditional fallback — reached on an isVisible timeout-miss, a UI click
+  // that didn't land on /catalog, and a thrown exception alike.
+  console.log('🔄 Trying direct navigation to catalog...');
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/catalog`);
+  await page.waitForLoadState('domcontentloaded');
+  await waitForLoadingComplete(page);
+
+  // Self-verification: turn a silent no-op into a fast, diagnosable failure
+  // instead of leaving the caller on a non-/catalog URL.
+  if (!page.url().includes('/catalog')) {
+    throw new Error(
+      `navigateToCatalog: failed to reach /catalog via UI navigation (Produkty > Katalog) or direct goto fallback (${baseUrl}/catalog); final URL was ${page.url()}`
+    );
+  }
+
+  console.log('✅ Direct navigation to catalog completed');
+}
+```
+
+Key points the developer must preserve exactly:
+- The `try` block now only performs UI navigation and, on confirmed success (`page.url().includes('/catalog')` after the "Katalog" click), `return`s early — mirroring `navigateToTransportBoxes` (lines 178-232) and `navigateToTransportBoxReceive` (lines 277-319) in the same file.
+- The `catch` block only logs (`console.log('❌ UI navigation failed:', e.message);`) and falls through — it must **not** perform navigation itself anymore, since that logic now lives unconditionally below.
+- The fallback `page.goto` block sits **after** the `try/catch`, unconditionally, so it runs whenever the `try` block didn't already `return` — whether because `isVisible` timed out (returned `false`), the "Katalog" click landed somewhere other than `/catalog` (e.g. a `RequireMenuPath` redirect to `/`), or an exception was thrown and caught.
+- `baseUrl` resolution is unchanged: `process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz'`.
+- The final `if (!page.url().includes('/catalog'))` throw is new behavior (per spec FR-1 item 3 / NFR-2) — it must reference both attempted paths and the final URL in the message, as shown, so a failure is diagnosable at the helper call site instead of surfacing as a generic downstream assertion failure in each of the 9 spec files.
+- Do not touch any other function in this file (`navigateToApp`, `navigateToTransportBoxes`, `navigateToStockOperations`, `navigateToTransportBoxReceive`, `navigateToInvoiceClassification`, `navigateToIssuedInvoices`, `navigateToMarketingCalendar`) and do not touch `frontend/test/e2e/catalog/*.spec.ts` — their existing `expect(page.url()).toContain('/catalog')` assertions remain valid and are now redundant-but-harmless.
+- Do not modify `frontend/src/components/Layout/Sidebar.tsx`, `frontend/src/App.tsx`, `frontend/src/components/auth/RequireMenuPath.tsx`, or `frontend/src/auth/PermissionsContext.tsx` — all four were inspected during spec/arch-review and confirmed correctly wired; this fix is scoped entirely to the test helper.
+
+**Validation (no isolated unit test harness exists for this Playwright helper, so validate via read-through plus staging verification):**
+
+1. **Targeted read-through against all four failure/success paths** — before moving on, trace the new function by hand against each scenario and confirm the code does what's claimed:
+   - *UI success*: `produktySelector` visible within 5000ms → click → `katalog` visible within 5000ms → click → `page.url()` contains `/catalog` → early `return`, fallback block never runs.
+   - *Timeout miss* (the actual staging failure mode from the incident, per spec Background item 1): `produktySelector.isVisible({ timeout: 5000 })` resolves to `false` (no throw) → both `if` bodies skipped → `try` completes normally → `catch` does not run → falls through past the `try/catch` into the unconditional fallback → `page.goto(.../catalog)` → self-check passes since goto succeeded → function returns normally without throwing.
+   - *Click lands off-`/catalog`* (e.g. `RequireMenuPath` redirect if permissions were insufficient): "Katalog" click resolves, but `page.url()` does not contain `/catalog` → no early return → falls through to fallback goto → if the fallback also fails to land on `/catalog` (e.g. genuine permission denial), the final `if (!page.url().includes('/catalog'))` throws the descriptive error.
+   - *Thrown exception* (e.g. strict-mode locator violation): caught, logged, falls through to the same unconditional fallback as the timeout-miss case.
+   Confirm none of these four paths can return without first satisfying `page.url().includes('/catalog')`, and that the only way out without that guarantee is the explicit `throw`.
+2. **Type-check the change** — run `cd frontend && npx tsc --noEmit` (or the project's existing TS check, if `tsconfig.json` scopes differently for `test/e2e`) to confirm the restructured function compiles cleanly (no implicit-any / unreachable-code issues from moving the fallback block).
+3. **Lint** — run `cd frontend && npm run lint` and confirm no new violations are introduced in `e2e-auth-helper.ts`.
+4. **Staging verification** (required per `docs/testing/playwright-e2e-testing.md` — there is no sandbox for this class of timing issue): run `./scripts/run-playwright-tests.sh catalog` from the repo root against `https://heblo.stg.anela.cz` and confirm:
+   - All 9 catalog spec files' `beforeEach`/setup `expect(page.url()).toContain('/catalog')` assertions pass (84 tests total: `filter-edge-cases.spec.ts` 17, `text-search-filters.spec.ts` 16, `combined-filters.spec.ts` 13, `pagination-with-filters.spec.ts` 13, `clear-filters.spec.ts` 10, `sorting-with-filters.spec.ts` 10, `product-type-filter.spec.ts` 3, `margins-chart.spec.ts` 1, `ui.spec.ts` 1).
+   - The suite's total run time doesn't regress by more than a few seconds per test (per NFR-1 — the 2000ms→5000ms change only adds latency on the worst-case "not visible" branch, so no multi-minute regression is expected).
+   - No regression in `navigateToTransportBoxes`, `navigateToStockOperations`, or `navigateToTransportBoxReceive` — these are untouched, but a targeted run of their specs (e.g. `./scripts/run-playwright-tests.sh transport`, `./scripts/run-playwright-tests.sh stock-operations`) confirms no incidental breakage.
+5. **FR-2 out-of-band note** (not a code change, but required before closing the issue per spec FR-2/acceptance criteria): capture in the PR description whether the E2E service principal was confirmed to hold `products.catalog.read` (per `frontend/src/auth/accessMatrix.generated.ts`) and whether the permissions fetch was observed to be abnormally slow in `?e2e=true` mode during the staging run in step 4. If the principal is missing the permission or the fetch is abnormally slow, file that as a separate follow-up ticket rather than silently working around it by raising the timeout alone.

--- a/artifacts/feat-3539/task-plan.r1.md
+++ b/artifacts/feat-3539/task-plan.r1.md
@@ -1,0 +1,133 @@
+# Task Plan: Fix Catalog Page Navigation E2E Regression (navigateToCatalog)
+
+## Overview
+
+This is a single, tightly-scoped bug fix confined to one function — `navigateToCatalog` in `frontend/test/e2e/helpers/e2e-auth-helper.ts` (lines 234-260) — with no product-code changes and no changes to any other helper or spec file. The spec, arch-review, and design all agree on the same three-part fix and the same target pattern (mirror `navigateToTransportBoxes`/`navigateToTransportBoxReceive` in the same file), so there is nothing to decompose: splitting this into multiple tasks would just fragment one cohesive edit. This plan is therefore a single task that restructures the function per FR-1/NFR-1/NFR-2 of `spec.r1.md` and Decisions 1-3 of `arch-review.r1.md`.
+
+### task: fix-navigate-to-catalog-fallback
+
+**Goal:** Restructure `navigateToCatalog` so the direct-navigation fallback runs whenever UI navigation did not already confirm landing on `/catalog` (not only inside `catch`), raise the `isVisible` timeouts for "Produkty"/"Katalog" from 2000ms to 5000ms to match sibling helpers, and throw a descriptive error if the URL still doesn't contain `/catalog` after both the UI path and the fallback have been attempted.
+
+**Files:**
+- `frontend/test/e2e/helpers/e2e-auth-helper.ts` (modify lines 234-260, the `navigateToCatalog` function only)
+
+**Details:**
+
+Replace the current `navigateToCatalog` function (current lines 234-260):
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void> {
+  await navigateToApp(page);
+
+  // Navigate to catalog via UI
+  // First, try to find and click on "Produkty" section
+  const produktySelector = page.locator('text="Produkty"').first();
+  try {
+    if (await produktySelector.isVisible({ timeout: 2000 })) {
+      await produktySelector.click();
+      await waitForLoadingComplete(page);
+
+      // Then click on "Katalog" sub-item
+      const katalog = page.locator('text="Katalog"').first();
+      if (await katalog.isVisible({ timeout: 2000 })) {
+        await katalog.click();
+        await page.waitForLoadState('domcontentloaded');
+        await waitForLoadingComplete(page);
+      }
+    }
+  } catch (e) {
+    // If UI navigation fails, go directly to the path
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/catalog`);
+    await page.waitForLoadState('domcontentloaded');
+    await waitForLoadingComplete(page);
+  }
+}
+```
+
+with:
+
+```ts
+export async function navigateToCatalog(page: any): Promise<void> {
+  await navigateToApp(page);
+
+  // Navigate to catalog via UI
+  // First, try to find and click on "Produkty" section
+  const produktySelector = page.locator('text="Produkty"').first();
+  try {
+    console.log('🧭 Attempting UI navigation to catalog via Produkty...');
+    if (await produktySelector.isVisible({ timeout: 5000 })) {
+      console.log('✅ Found Produkty menu item, clicking...');
+      await produktySelector.click();
+      await waitForLoadingComplete(page);
+
+      // Then click on "Katalog" sub-item
+      const katalog = page.locator('text="Katalog"').first();
+      if (await katalog.isVisible({ timeout: 5000 })) {
+        console.log('✅ Found Katalog submenu, clicking...');
+        await katalog.click();
+        await page.waitForLoadState('domcontentloaded');
+        await waitForLoadingComplete(page);
+
+        // Verify we actually landed on the catalog page (a RequireMenuPath
+        // redirect-to-"/" on insufficient permission would still resolve the
+        // click without an exception, so a URL check is required here).
+        if (page.url().includes('/catalog')) {
+          console.log('✅ UI navigation successful');
+          return;
+        }
+        console.log('❌ Katalog click did not land on /catalog, current URL:', page.url());
+      } else {
+        console.log('❌ Katalog submenu not found under Produkty');
+      }
+    } else {
+      console.log('❌ Produkty menu item not found');
+    }
+  } catch (e) {
+    console.log('❌ UI navigation failed:', e.message);
+  }
+
+  // Unconditional fallback — reached on an isVisible timeout-miss, a UI click
+  // that didn't land on /catalog, and a thrown exception alike.
+  console.log('🔄 Trying direct navigation to catalog...');
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/catalog`);
+  await page.waitForLoadState('domcontentloaded');
+  await waitForLoadingComplete(page);
+
+  // Self-verification: turn a silent no-op into a fast, diagnosable failure
+  // instead of leaving the caller on a non-/catalog URL.
+  if (!page.url().includes('/catalog')) {
+    throw new Error(
+      `navigateToCatalog: failed to reach /catalog via UI navigation (Produkty > Katalog) or direct goto fallback (${baseUrl}/catalog); final URL was ${page.url()}`
+    );
+  }
+
+  console.log('✅ Direct navigation to catalog completed');
+}
+```
+
+Key points the developer must preserve exactly:
+- The `try` block now only performs UI navigation and, on confirmed success (`page.url().includes('/catalog')` after the "Katalog" click), `return`s early — mirroring `navigateToTransportBoxes` (lines 178-232) and `navigateToTransportBoxReceive` (lines 277-319) in the same file.
+- The `catch` block only logs (`console.log('❌ UI navigation failed:', e.message);`) and falls through — it must **not** perform navigation itself anymore, since that logic now lives unconditionally below.
+- The fallback `page.goto` block sits **after** the `try/catch`, unconditionally, so it runs whenever the `try` block didn't already `return` — whether because `isVisible` timed out (returned `false`), the "Katalog" click landed somewhere other than `/catalog` (e.g. a `RequireMenuPath` redirect to `/`), or an exception was thrown and caught.
+- `baseUrl` resolution is unchanged: `process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz'`.
+- The final `if (!page.url().includes('/catalog'))` throw is new behavior (per spec FR-1 item 3 / NFR-2) — it must reference both attempted paths and the final URL in the message, as shown, so a failure is diagnosable at the helper call site instead of surfacing as a generic downstream assertion failure in each of the 9 spec files.
+- Do not touch any other function in this file (`navigateToApp`, `navigateToTransportBoxes`, `navigateToStockOperations`, `navigateToTransportBoxReceive`, `navigateToInvoiceClassification`, `navigateToIssuedInvoices`, `navigateToMarketingCalendar`) and do not touch `frontend/test/e2e/catalog/*.spec.ts` — their existing `expect(page.url()).toContain('/catalog')` assertions remain valid and are now redundant-but-harmless.
+- Do not modify `frontend/src/components/Layout/Sidebar.tsx`, `frontend/src/App.tsx`, `frontend/src/components/auth/RequireMenuPath.tsx`, or `frontend/src/auth/PermissionsContext.tsx` — all four were inspected during spec/arch-review and confirmed correctly wired; this fix is scoped entirely to the test helper.
+
+**Validation (no isolated unit test harness exists for this Playwright helper, so validate via read-through plus staging verification):**
+
+1. **Targeted read-through against all four failure/success paths** — before moving on, trace the new function by hand against each scenario and confirm the code does what's claimed:
+   - *UI success*: `produktySelector` visible within 5000ms → click → `katalog` visible within 5000ms → click → `page.url()` contains `/catalog` → early `return`, fallback block never runs.
+   - *Timeout miss* (the actual staging failure mode from the incident, per spec Background item 1): `produktySelector.isVisible({ timeout: 5000 })` resolves to `false` (no throw) → both `if` bodies skipped → `try` completes normally → `catch` does not run → falls through past the `try/catch` into the unconditional fallback → `page.goto(.../catalog)` → self-check passes since goto succeeded → function returns normally without throwing.
+   - *Click lands off-`/catalog`* (e.g. `RequireMenuPath` redirect if permissions were insufficient): "Katalog" click resolves, but `page.url()` does not contain `/catalog` → no early return → falls through to fallback goto → if the fallback also fails to land on `/catalog` (e.g. genuine permission denial), the final `if (!page.url().includes('/catalog'))` throws the descriptive error.
+   - *Thrown exception* (e.g. strict-mode locator violation): caught, logged, falls through to the same unconditional fallback as the timeout-miss case.
+   Confirm none of these four paths can return without first satisfying `page.url().includes('/catalog')`, and that the only way out without that guarantee is the explicit `throw`.
+2. **Type-check the change** — run `cd frontend && npx tsc --noEmit` (or the project's existing TS check, if `tsconfig.json` scopes differently for `test/e2e`) to confirm the restructured function compiles cleanly (no implicit-any / unreachable-code issues from moving the fallback block).
+3. **Lint** — run `cd frontend && npm run lint` and confirm no new violations are introduced in `e2e-auth-helper.ts`.
+4. **Staging verification** (required per `docs/testing/playwright-e2e-testing.md` — there is no sandbox for this class of timing issue): run `./scripts/run-playwright-tests.sh catalog` from the repo root against `https://heblo.stg.anela.cz` and confirm:
+   - All 9 catalog spec files' `beforeEach`/setup `expect(page.url()).toContain('/catalog')` assertions pass (84 tests total: `filter-edge-cases.spec.ts` 17, `text-search-filters.spec.ts` 16, `combined-filters.spec.ts` 13, `pagination-with-filters.spec.ts` 13, `clear-filters.spec.ts` 10, `sorting-with-filters.spec.ts` 10, `product-type-filter.spec.ts` 3, `margins-chart.spec.ts` 1, `ui.spec.ts` 1).
+   - The suite's total run time doesn't regress by more than a few seconds per test (per NFR-1 — the 2000ms→5000ms change only adds latency on the worst-case "not visible" branch, so no multi-minute regression is expected).
+   - No regression in `navigateToTransportBoxes`, `navigateToStockOperations`, or `navigateToTransportBoxReceive` — these are untouched, but a targeted run of their specs (e.g. `./scripts/run-playwright-tests.sh transport`, `./scripts/run-playwright-tests.sh stock-operations`) confirms no incidental breakage.
+5. **FR-2 out-of-band note** (not a code change, but required before closing the issue per spec FR-2/acceptance criteria): capture in the PR description whether the E2E service principal was confirmed to hold `products.catalog.read` (per `frontend/src/auth/accessMatrix.generated.ts`) and whether the permissions fetch was observed to be abnormally slow in `?e2e=true` mode during the staging run in step 4. If the principal is missing the permission or the fetch is abnormally slow, file that as a separate follow-up ticket rather than silently working around it by raising the timeout alone.

--- a/frontend/test/e2e/helpers/e2e-auth-helper.ts
+++ b/frontend/test/e2e/helpers/e2e-auth-helper.ts
@@ -238,25 +238,55 @@ export async function navigateToCatalog(page: any): Promise<void> {
   // First, try to find and click on "Produkty" section
   const produktySelector = page.locator('text="Produkty"').first();
   try {
-    if (await produktySelector.isVisible({ timeout: 2000 })) {
+    console.log('🧭 Attempting UI navigation to catalog via Produkty...');
+    if (await produktySelector.isVisible({ timeout: 5000 })) {
+      console.log('✅ Found Produkty menu item, clicking...');
       await produktySelector.click();
       await waitForLoadingComplete(page);
 
       // Then click on "Katalog" sub-item
       const katalog = page.locator('text="Katalog"').first();
-      if (await katalog.isVisible({ timeout: 2000 })) {
+      if (await katalog.isVisible({ timeout: 5000 })) {
+        console.log('✅ Found Katalog submenu, clicking...');
         await katalog.click();
         await page.waitForLoadState('domcontentloaded');
         await waitForLoadingComplete(page);
+
+        // Verify we actually landed on the catalog page (a RequireMenuPath
+        // redirect-to-"/" on insufficient permission would still resolve the
+        // click without an exception, so a URL check is required here).
+        if (page.url().includes('/catalog')) {
+          console.log('✅ UI navigation successful');
+          return;
+        }
+        console.log('❌ Katalog click did not land on /catalog, current URL:', page.url());
+      } else {
+        console.log('❌ Katalog submenu not found under Produkty');
       }
+    } else {
+      console.log('❌ Produkty menu item not found');
     }
   } catch (e) {
-    // If UI navigation fails, go directly to the path
-    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
-    await page.goto(`${baseUrl}/catalog`);
-    await page.waitForLoadState('domcontentloaded');
-    await waitForLoadingComplete(page);
+    console.log('❌ UI navigation failed:', e.message);
   }
+
+  // Unconditional fallback — reached on an isVisible timeout-miss, a UI click
+  // that didn't land on /catalog, and a thrown exception alike.
+  console.log('🔄 Trying direct navigation to catalog...');
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  await page.goto(`${baseUrl}/catalog`);
+  await page.waitForLoadState('domcontentloaded');
+  await waitForLoadingComplete(page);
+
+  // Self-verification: turn a silent no-op into a fast, diagnosable failure
+  // instead of leaving the caller on a non-/catalog URL.
+  if (!page.url().includes('/catalog')) {
+    throw new Error(
+      `navigateToCatalog: failed to reach /catalog via UI navigation (Produkty > Katalog) or direct goto fallback (${baseUrl}/catalog); final URL was ${page.url()}`
+    );
+  }
+
+  console.log('✅ Direct navigation to catalog completed');
 }
 
 export async function navigateToStockOperations(page: any): Promise<void> {


### PR DESCRIPTION
Closes #3539

## What the issue was

The nightly E2E regression suite reported 84 failing tests across every spec in `frontend/test/e2e/catalog/`, all failing at the same setup assertion: after calling `navigateToCatalog(page)`, the browser was still on the app root (`/?e2e=true`) instead of `/catalog`.

Investigation found this is a test-infrastructure bug, not a product bug. `navigateToCatalog` in `frontend/test/e2e/helpers/e2e-auth-helper.ts` had two compounding defects:
1. Its direct-navigation (`page.goto`) fallback only ran inside the `catch` block. Playwright's `locator.isVisible({ timeout })` resolves to `false` (it does not throw) when an element isn't found in time, so on a timeout-miss the function silently returned having done nothing — leaving the test on the root URL. This matches the reported symptom exactly.
2. The sidebar's "Produkty"/"Katalog" items are gated behind an async permissions fetch that `navigateToApp()` doesn't wait for, and the helper only allowed 2000ms (vs. 5000ms used by the working sibling helpers `navigateToTransportBoxes`/`navigateToTransportBoxReceive`) for them to appear — making a timeout-miss plausible under staging latency.

The `/catalog` route, sidebar entry, and route guard (`RequireMenuPath`) were all inspected and confirmed correctly wired — no product code changes were needed.

## How it was fixed / handled

Restructured `navigateToCatalog` (the only function changed) to mirror the already-correct pattern used by its sibling helpers:
- The direct-navigation fallback now runs unconditionally whenever UI navigation didn't already confirm landing on `/catalog` — not only on a thrown exception.
- Raised the `isVisible` timeouts for "Produkty"/"Katalog" from 2000ms to 5000ms to match the working sibling helpers.
- Added an early `return` once UI navigation is confirmed via a `page.url()` check (guarding against a silent redirect-on-insufficient-permission false positive).
- Added a final self-verification that throws a descriptive error (naming both attempted paths and the final URL) if `/catalog` still isn't reached after the UI path and the fallback — turning a silent no-op into a fast, diagnosable failure instead of 84 generic downstream assertion failures.

No other helper, spec file, or product source file was touched.

**Note:** Staging E2E verification (`./scripts/run-playwright-tests.sh catalog`) and the FR-2 out-of-band check (confirming the E2E service principal holds `products.catalog.read` and that the permissions fetch isn't abnormally slow in `?e2e=true` mode) could not be run from this sandbox (no network access to staging) — these are flagged as pending and should be confirmed against staging (e.g. via the nightly run) before closing the underlying issue.

## Artifacts

Brief, spec, architecture review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3539/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `frontend/test/e2e/helpers/e2e-auth-helper.ts:258` and `frontend/test/e2e/helpers/e2e-auth-helper.ts:283` — the `/catalog` URL-containment check (`page.url().includes('/catalog')`) is duplicated between the UI-success check and the final self-verification. A tiny local helper (e.g. `const isOnCatalog = () => page.url().includes('/catalog');`) would remove the duplication and keep both checks trivially in sync if the target path ever changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_019V4nGz5hybR7LySrKwxzGr)_