### PR TITLE
#3540: fix Stock Operations list not rendering in E2E (missing E2E role claims)

### DIFF
--- a/artifacts/feat-3540/MANUAL-FOLLOWUP.md
+++ b/artifacts/feat-3540/MANUAL-FOLLOWUP.md
@@ -1,0 +1,36 @@
+# Manual follow-up required after merge (feat-3540)
+
+This PR fixes the backend API authorization gap (FR-1: E2E synthetic user now holds
+`warehouse.stock_up.read`/`write` role claims) and hardens a broken E2E test (FR-3). It does
+**not** and cannot make one additional required change:
+
+## Action required: grant `warehouse.stock_up.read` to the E2E test account in the staging DB
+
+The frontend route guard (`RequireMenuPath` on `/stock-up-operations`) does not consume the
+ASP.NET Core role claims this PR adds. It gates on `GET /api/auth/me`'s resolved permission
+list, which comes from a separate, DB-backed permission resolver
+(`IPermissionResolver.ResolveAsync`, `backend/src/Anela.Heblo.Persistence/Features/Authorization/PermissionResolver.cs`).
+That resolver looks up the E2E test `AppUser`'s **DB group memberships** — a mechanism this PR's
+code change does not touch and a sandboxed development environment cannot reach or modify
+(per this repo's CLAUDE.md: database migrations/data changes are manual, and secrets/config
+live in Azure Key Vault, never in Web App environment variables edited directly).
+
+**Steps for the repo owner to perform manually on staging, after this PR is merged and deployed:**
+
+1. Sign in to `https://heblo.stg.anela.cz/admin/access` as an administrator.
+2. Find the E2E test account (`oid` / `entraObjectId` = `e2e-test-object-id`, email
+   `e2e-test@anela-heblo.com`).
+3. Confirm whether its resolved permissions already include `warehouse.stock_up.read` — either
+   via the `/admin/access` UI's effective-permissions view, or by calling `GET /api/auth/me`
+   while authenticated as that account and inspecting the `permissions` array in the response.
+4. If `warehouse.stock_up.read` is **not** present, add the E2E test account to an existing
+   access group that grants it, or grant it directly through the `/admin/access` UI — scoped
+   **only** to the E2E/staging test account, not to any production group or user (per spec
+   NFR-2).
+5. Re-run the nightly E2E suite (or manually run `./scripts/run-playwright-tests.sh
+   stock-operations` against staging) and confirm all 56 previously-failing tests in
+   `frontend/test/e2e/stock-operations/*.spec.ts` now pass.
+
+This step is independent of and not blocked by the code changes in this PR — it can be done in
+parallel with code review, but the nightly suite will not go fully green until both this PR's
+code changes are deployed **and** this DB grant is made.

--- a/artifacts/feat-3540/arch-review.r1.md
+++ b/artifacts/feat-3540/arch-review.r1.md
@@ -1,0 +1,139 @@
+# Architecture Review: Fix Stock Operations list page never rendering rows/empty-state (56 nightly E2E failures)
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a permission-configuration bug, not a UI or architecture defect. `StockOperationsPage.tsx` and `useStockUpOperationsQuery` follow the same loading/error/empty/data pattern used across the app; no new component, screen, or design decision is needed. The fix belongs entirely in the E2E identity's authorization setup (one file) plus a test-suite correction, both of which slot into existing, already-established patterns in this codebase — this exact class of bug (E2E synthetic identity missing a `Feature`-gated role) has been hit and fixed twice before in this repo.
+
+Two independent, both-necessary integration points:
+1. **Backend/E2E auth config**: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs` — the synthetic claims list handed to every E2E request.
+2. **E2E test file**: `frontend/test/e2e/stock-operations/navigation.spec.ts` — a pre-existing, independently broken test (confirmed by the analyst, confirmed again here).
+
+## Definitive root cause (resolves the spec's Open Questions)
+
+**The E2E synthetic test identity does not hold `Feature.Warehouse_StockUp` Read (`warehouse.stock_up.read`), and this is gated in *two* places, not one — both of which produce the exact "neither rows nor empty-state" symptom.**
+
+Evidence chain:
+
+1. **Backend gate** — `backend/src/Anela.Heblo.API/Controllers/StockUpOperationsController.cs:12`:
+   ```csharp
+   [FeatureAuthorize(Feature.Warehouse_StockUp)]   // AccessLevel.Read by default
+   public class StockUpOperationsController : ControllerBase
+   ```
+   `GetOperations` (the list endpoint) has no method-level override, so the class-level Read gate applies. `FeatureAuthorizeAttribute` resolves this to `Roles = AccessRoles.WarehouseStockUpRead = "warehouse.stock_up.read"` (`AccessRoles.generated.cs:43`, `AccessMatrix.generated.cs:39`).
+
+2. **Frontend route gate (a second, earlier point of failure)** — `frontend/src/App.tsx:452` wraps the route in `guard("/stock-up-operations", <StockOperationsPage />)`, which renders `RequireMenuPath`. `RequireMenuPath.tsx:17-18` redirects to `/` (`<Navigate to={redirectTo} replace />`) if the current user's resolved permissions don't include every permission in `ACCESS_ROUTES["/stock-up-operations"]`. That entry, `frontend/src/auth/accessMatrix.generated.ts:32`, requires exactly `["warehouse.stock_up.read"]`. **If the E2E identity lacks this permission, `StockOperationsPage` never mounts at all** — the SPA silently redirects to the dashboard. This produces the same "no `tbody tr`, no `h3` empty-state, no `h3` error banner" symptom as the analyst's error-branch hypothesis, but via a different mechanism (route redirect vs. in-page error render). It also better explains why `navigation.spec.ts`'s *first* test ("should navigate to page via direct URL", which asserts `page.url()).toContain('/stock-up-operations')` and the page `<h1>` text) is among the 4 failing tests in that file — that assertion has nothing to do with `waitForTableUpdate` and would only fail on a redirect, not on an in-page error state.
+
+3. **The E2E identity's actual claims** — `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs:71-86`, `CreateSyntheticUserClaims()`:
+   ```csharp
+   new Claim(ClaimTypes.Role, AccessRoles.Base),
+   new Claim("scp", "access_as_user"),
+   // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
+   new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead)
+   ```
+   Only two roles are hardcoded: `Base` and `FinanceFinancialOverviewRead`. **There is no `AccessRoles.WarehouseStockUpRead` claim.** The comment on the existing `FinanceFinancialOverviewRead` line is direct proof this file is where E2E-specific permission grants are made *by hand, one feature at a time*, precisely because the synthetic principal has no real Entra group membership to inherit permissions from.
+   (`PermissionClaimsTransformation.cs` additionally resolves DB-backed group permissions for the synthetic `oid="e2e-test-object-id"` AppUser and unions them in, so it is theoretically possible staging's DB grants this role out-of-band — but that is not verifiable from code, is not how the prior, identical gap was fixed, and would be a fragile, undocumented dependency to rely on instead of the established in-code pattern.)
+
+4. **Direct precedent for this exact failure class** — `docs/routines/telemetry-anomaly/2026-06-13-stockupoperations-summary-403.md` documents a near-identical incident: `GET /api/StockUpOperations/summary`, gated by the same `[FeatureAuthorize(Feature.Warehouse_StockUp)]` class-level attribute, was returning 403 to callers without `warehouse.stock_up.read`. That incident's fix (R-A) only gated the two *optional widget* callsites (`TransportBoxList`, `GiftPackageManufacturing`) on the frontend so they degrade gracefully without the permission — it did **not** grant the permission to the E2E identity, and it did **not** touch the Stock Operations list page itself, whose entire purpose requires the data (there is no graceful degrade option for the primary page). That gap is exactly what is now surfacing as 56 E2E failures.
+
+5. **Server-side code review turns up no throw hazard.** `GetStockUpOperationsHandler` and `StockUpOperationRepository.QueryAsync` (`backend/src/Anela.Heblo.Persistence/Catalog/Stock/StockUpOperationRepository.cs`) are straightforward EF LINQ with no null-deref or unhandled-cast risk on the default `state=Active` path — this weakens hypothesis (b) (unhandled server exception) relative to the permission hypothesis. A hang (hypothesis c) is also inconsistent with `retry: 1` settling the query client within seconds, as the spec itself already argued.
+
+**Conclusion:** hypothesis (a) from the spec (permission gap) is confirmed as the primary root cause, with the added, more precise detail that the failure most likely happens at the frontend route guard (silent redirect to `/`) before the backend 403 branch is even reached for most of the 56 tests — though both mechanisms exist and both point to the same one-line fix.
+
+## Proposed Architecture
+
+No new components. This is a one-claim addition plus a test-file correction.
+
+### Component Overview
+
+```
+Playwright test (stock-operations/*.spec.ts)
+        │  navigateToStockOperations(page) / navigateToApp(page)
+        ▼
+E2ETestAuthenticationMiddleware  ──uses──▶  E2ESessionService.CreateSyntheticUserClaims()
+        │  sets ClaimsPrincipal (Base, FinanceFinancialOverviewRead, [MISSING: WarehouseStockUpRead])
+        ▼
+PermissionClaimsTransformation  ──unions in resolved DB permissions, adds Role claims
+        │
+        ├──▶ Frontend: GET /api/Auth/me → usePermissions → PermissionsContext.hasPermission()
+        │         └──▶ RequireMenuPath("/stock-up-operations") → redirect to "/" if permission missing  [FAILS HERE, likely]
+        │
+        └──▶ Backend: [FeatureAuthorize(Feature.Warehouse_StockUp)] on StockUpOperationsController
+                  └──▶ 403 on GET /api/StockUpOperations if permission missing            [OR FAILS HERE]
+```
+
+### Key Design Decisions
+
+#### Decision 1: Where to grant the permission
+**Options considered:**
+- (A) Add `AccessRoles.WarehouseStockUpRead` as a hardcoded claim in `E2ESessionService.CreateSyntheticUserClaims()`.
+- (B) Grant the permission via the staging database (assign the "e2e-test-user" AppUser to an access group holding `warehouse.stock_up.read`), mirroring how a real user gets it.
+- (C) Weaken/relax the `[FeatureAuthorize]` gate or `ACCESS_ROUTES` entry for this route.
+
+**Chosen approach:** (A), matching the existing, working precedent for `FinanceFinancialOverviewRead` in the same file/method.
+
+**Rationale:** The synthetic E2E principal has no real Entra Object ID or group membership — DB-based group assignment (B) would be an out-of-band, undocumented, hard-to-audit dependency invisible to code review and not reproducible by `dotnet build`/tests. Option (A) is exactly the pattern this codebase already uses for this identity (see the existing comment on the `FinanceFinancialOverviewRead` claim), keeps the grant in source control, and is self-documenting. Option (C) is explicitly forbidden by the spec's NFR-2 and would broaden production access to work around a test-identity gap — not applicable here since (A) doesn't touch production authorization at all, it only affects the E2E-only synthetic principal that already only exists in Staging/Development environments (`E2ETestAuthenticationMiddleware.ShouldBeRegistered`).
+
+#### Decision 2: Scope of the granted role
+**Options considered:**
+- Grant `Warehouse_StockUp` Read only (matches what `GetOperations`/`GetSummary` need).
+- Also grant `Warehouse_StockUp` Write (would let E2E tests exercise `RetryOperation`/`AcceptOperation`, which `retry.spec.ts` and `accept.spec.ts` need).
+
+**Chosen approach:** Grant **both Read and Write** (`AccessRoles.WarehouseStockUpRead` and `AccessRoles.WarehouseStockUpWrite`).
+
+**Rationale:** The affected-specs table in the brief includes `retry.spec.ts` (6 failures) and `accept.spec.ts` (3 failures), which exercise `POST /{id}/retry` and `POST /{id}/accept` — both gated at `[FeatureAuthorize(Feature.Warehouse_StockUp, AccessLevel.Write)]` (`StockUpOperationsController.cs:76,95`). Granting Read only would fix the list-rendering symptom but leave those two spec files failing on the write actions for an unrelated (but adjacent) reason. Since this is the E2E-only synthetic identity in non-production environments, granting both levels for one feature carries no production security risk.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+- **Modify:** `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs`
+  Add two claims to `CreateSyntheticUserClaims()`, following the existing comment style:
+  ```csharp
+  new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpRead),
+  new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpWrite),
+  ```
+  with a comment analogous to the existing `FinanceFinancialOverviewRead` one, referencing the Stock Operations E2E module and this ticket.
+
+- **Add (recommended, not strictly required by the spec but cheap insurance):** a unit test asserting the synthetic claim set contains `warehouse.stock_up.read`/`warehouse.stock_up.write`, e.g. `backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs`, calling `CreateSyntheticUserClaims("Staging")` and asserting on the resulting `Claim[]`. This directly prevents the exact regression class this ticket is fixing (a claim silently missing from this list) — mirrors the existing precedent of `StockUpOperationsControllerAuthorizationTests.cs`, which reflection-tests the *controller* side of this same authorization contract but had no counterpart testing the *E2E identity* side.
+
+- **Modify:** `frontend/test/e2e/stock-operations/navigation.spec.ts` (lines 83-115) per spec FR-3:
+  - Fix the intercept pattern from `**/api/stock-up-operations**` to match the actual generated-client request path (`**/api/StockUpOperations**`, case-correct — confirmed at `frontend/src/api/generated/api-client.ts:12051`: `this.baseUrl + "/api/StockUpOperations?"`).
+  - Replace the `if (isErrorVisible) {...} else { console.log(...) }` soft branch with an unconditional `await expect(errorMessage).toBeVisible({ timeout: <appropriate> })`.
+
+- **Modify:** `frontend/test/e2e/helpers/stock-operations-test-helpers.ts` (`waitForTableUpdate`, lines 22-27) per spec FR-4:
+  - Extend the locator union to also match the error heading (`h3` containing "Chyba při načítání operací"), and if it resolves, throw immediately with the error banner's text rather than falling through to the generic 15s timeout. Do not change what the dedicated error-state test in FR-3 asserts on — that test should keep using its own explicit assertion, not this shared helper's short-circuit.
+
+### Interfaces and Contracts
+
+No public interface/contract changes. `AccessRoles.WarehouseStockUpRead` / `AccessRoles.WarehouseStockUpWrite` are pre-existing generated constants (`AccessRoles.generated.cs:43-44`) — the fix only changes which claims are attached to one synthetic `ClaimsIdentity`, it does not touch `FeatureAuthorizeAttribute`, `AccessMatrix`, or any generated file. No OpenAPI/client regeneration needed.
+
+### Data Flow
+
+1. Playwright test calls `navigateToStockOperations(page)` (or `navigateToApp` + manual nav), which authenticates via the `X-E2E-Test-Token` header or `E2ETestCookies` session.
+2. `E2ETestAuthenticationMiddleware` builds the `ClaimsPrincipal` from `E2ESessionService.CreateSyntheticUserClaims()` — after the fix, this includes `warehouse.stock_up.read` and `warehouse.stock_up.write` role claims.
+3. `PermissionClaimsTransformation` unions in any DB-resolved permissions (unaffected by this fix either way) and stamps `authz_applied`.
+4. Frontend `GET /api/Auth/me` returns `permissions` including `warehouse.stock_up.read` → `PermissionsContext.hasPermission('warehouse.stock_up.read')` → `RequireMenuPath` allows `StockOperationsPage` to mount instead of redirecting to `/`.
+5. `useStockUpOperationsQuery` calls `GET /api/StockUpOperations`, now authorized (200), and the page settles into either the data-table branch or, if staging genuinely has zero `Active` operations at test time, the correctly-matched "Žádné výsledky" branch — either way, `waitForTableUpdate` now resolves within its 15s window.
+6. `retry.spec.ts` / `accept.spec.ts` calls to `POST /{id}/retry` and `/{id}/accept` are now authorized (200) via the added Write role.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| The "e2e-test-object-id" AppUser already has DB-granted permissions overlapping/conflicting with the new hardcoded claims | Low | `PermissionClaimsTransformation` only *adds* claims not already present (`if (!identity.HasClaim(...))`), so this is additive and idempotent — no conflict possible. |
+| Granting Write access to the E2E identity could let a buggy test mutate/corrupt staging data it shouldn't | Low | Scope is limited to `Warehouse_StockUp` Write only (retry/accept of stock-up operations), consistent with what `retry.spec.ts`/`accept.spec.ts` are explicitly designed to exercise; identical risk profile already accepted for every other feature area E2E currently covers (transport boxes, catalog, etc.), and confined to Staging/Development per `E2ETestAuthenticationMiddleware.ShouldBeRegistered`. |
+| Root cause is not (solely) the permission gap — e.g., staging dataset happens to be empty for `Active` state at test time, or there's a genuine intermittent server error | Medium | Spec's FR-1 (staging repro capturing network status/body) should still be executed before closing the ticket, even though static evidence strongly points to the permission gap — a quick `curl`/DevTools check against staging with a token lacking `warehouse.stock_up.read` vs. one with it would conclusively confirm 403 vs 200, and is cheap to do before merging. |
+| `navigation.spec.ts` FR-3 fix and the permission fix are both required — fixing only one leaves failures | Medium | Both must land together: the permission fix alone does not fix the case-mismatched intercept test (it's a Playwright-route bug independent of auth), and the intercept fix alone does not fix the other 8 spec files' 56-test root cause. |
+| FR-4's stronger `waitForTableUpdate` could introduce new flakiness if the error heading briefly flashes during a legitimate retry/refetch | Low | Only fail-fast on the error heading; do not fail-fast on the loading spinner. Since React Query's `retry: 1` means the error state is only reached after retries are exhausted, a transient flash before recovery is not expected in normal operation. |
+
+## Specification Amendments
+
+- **FR-1 is now largely answered by static analysis**, not just "leave for staging repro": the concrete, most-likely finding is (a) — a permissions gap — manifesting via the **frontend route redirect** (`RequireMenuPath`) as the primary mechanism for most of the 56 failures, not solely the backend error-branch mechanism the spec's Background section focused on. Both mechanisms trace to the same missing role claim, so FR-1's staging repro becomes a confirmation step, not a discovery step — it can run in parallel with implementing the FR-2 fix rather than strictly gating it.
+- **FR-2's acceptance criteria should explicitly include the Write role**, not just Read: `retry.spec.ts` (6 tests) and `accept.spec.ts` (3 tests) require `warehouse.stock_up.write` on `POST /{id}/retry` and `POST /{id}/accept`, which is a separate gate from the Read gate on `GetOperations`/`GetSummary`. Granting Read alone would leave 9 of the 56 tests still failing.
+- **Add an explicit FR (or fold into FR-2)**: add regression coverage on the E2E synthetic claims list itself (`E2ESessionServiceTests`), not just on the controller's authorization contract (which already exists via `StockUpOperationsControllerAuthorizationTests.cs`). The controller-side test proves the gate is correctly *configured*; nothing currently proves the E2E identity actually *holds* the roles the gate requires — which is precisely the gap that caused this incident and the prior `FinancialOverview` one.
+
+## Prerequisites
+
+None. This is a same-PR code change (one file's claims list + one E2E test file + one E2E helper file) with no migrations, no infrastructure changes, and no new configuration. No Key Vault secrets, no Azure Portal changes. Recommended but not blocking: a quick staging repro (FR-1) to double-confirm 403 vs. 200 before/after, using either browser DevTools against `https://heblo.stg.anela.cz/stock-up-operations` or a direct `curl` with/without the E2E service-principal token.

--- a/artifacts/feat-3540/brief.md
+++ b/artifacts/feat-3540/brief.md
@@ -1,0 +1,47 @@
+## Summary
+
+In the nightly E2E regression run [#191](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966) (branch `main`, commit `738a99c`), 56 tests across the `stock-operations` module failed with the same root cause: the operations table never renders any rows and the empty-state header never appears either.
+
+## Root cause signature
+
+The shared setup waits for either a data row or the "no results" header, and times out — neither appears:
+
+```
+Error: expect(locator).toBeVisible() failed
+Error: element(s) not found
+
+  - Expect "toBeVisible" with timeout 15000ms
+  - waiting for locator('tbody tr').first().or(locator('h3').filter({ hasText: 'Žádné výsledky' }))
+
+  24 |   await expect(
+> 26 |   ).toBeVisible({ timeout: 15000 });
+```
+
+Because neither `tbody tr` nor the `Žádné výsledky` empty-state renders, the Stock Operations list page is effectively not loading its data. This blocks every downstream test (badges, filters, sorting, retry/accept actions, panel). One test — "should display error state on API failure" — passes, which suggests the page shell loads but the normal data path fails.
+
+## Affected specs (failing test count)
+
+| Spec | Failures |
+|------|---------:|
+| stock-operations/filters.spec.ts | 18 |
+| stock-operations/badges.spec.ts | 7 |
+| stock-operations/panel.spec.ts | 6 |
+| stock-operations/retry.spec.ts | 6 |
+| stock-operations/state-filter.spec.ts | 6 |
+| stock-operations/navigation.spec.ts | 4 |
+| stock-operations/accept.spec.ts | 3 |
+| stock-operations/sorting.spec.ts | 3 |
+| stock-operations/source-filter.spec.ts | 3 |
+| **Total** | **56** |
+
+## Environment
+
+- Workflow: E2E Nightly Regression Tests, run #191
+- Target: `https://heblo.stg.anela.cz` (staging)
+- Screenshots/video artifacts: `e2e-failure-screenshots-all-191`, `e2e-test-results-all-191` on the run page.
+
+## Suggested first steps
+
+1. Load the Stock Operations page on staging and inspect the list API call (does it return data / error / hang?).
+2. Confirm whether the default filters (State: Active, Source: All) return results in the current staging dataset.
+3. Verify the empty-state (`Žádné výsledky`) renders when there are genuinely no rows.

--- a/artifacts/feat-3540/code-review.r1.md
+++ b/artifacts/feat-3540/code-review.r1.md
@@ -1,0 +1,56 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+### Verification performed
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs:91-95` — confirmed
+  `AccessRoles.WarehouseStockUpRead`/`WarehouseStockUpWrite` exist in
+  `AccessRoles.generated.cs:43-44` with the exact expected values (`warehouse.stock_up.read` /
+  `warehouse.stock_up.write`), and are the same constants referenced by
+  `[FeatureAuthorize(Feature.Warehouse_StockUp)]` on `StockUpOperationsController`. The fix matches
+  spec FR-1 exactly and mirrors the existing `FinanceFinancialOverviewRead` precedent in the same
+  method.
+- `backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs` — new
+  regression test. Verified it compiles and passes:
+  `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` → 0 errors;
+  `dotnet test --filter FullyQualifiedName~E2ESessionServiceTests` → 1/1 passed.
+- `frontend/test/e2e/stock-operations/navigation.spec.ts:93` — confirmed the corrected glob
+  `'**/api/StockUpOperations**'` matches the generated client's actual request URL
+  (`frontend/src/api/generated/api-client.ts:12051`: `this.baseUrl + "/api/StockUpOperations?"`),
+  fixing the case-mismatch (`stock-up-operations` vs `StockUpOperations`) that previously made the
+  route interception a no-op. The soft `if (isErrorVisible) {...} else { console.log }` branch was
+  replaced with hard `await expect(errorMessage).toBeVisible(...)` / `await expect(retryButton).toBeVisible()`
+  assertions, so the test now genuinely fails if the error UI doesn't appear — matching FR-3.
+- `frontend/test/e2e/helpers/stock-operations-test-helpers.ts:22-39` — `waitForTableUpdate` now
+  also races on the error-card heading and throws a diagnostic error if it wins, instead of only
+  timing out generically after 15s. Checked all ~90 call sites across
+  `frontend/test/e2e/stock-operations/*.spec.ts` and `catalog/*.spec.ts` (catalog uses a different,
+  unrelated `waitForTableUpdate` from `catalog-test-helpers.ts`); none of the stock-operations
+  call sites intentionally invoke this helper in a scenario where the error card is the expected
+  outcome (the one legitimate error-state test, `navigation.spec.ts`'s "should display error state
+  on API failure", asserts on the error locator directly and does not call `waitForTableUpdate`),
+  so the new throw does not create a false failure for any existing test.
+
+### Note on review scope
+The supplied `/tmp/feat-3540-review.diff` includes six files under
+`backend/src/Anela.Heblo.API/Controllers/PackagingController.cs`,
+`backend/src/Anela.Heblo.API/Middleware/RequestLoggingMiddleware.cs`,
+`backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/GetPackageLabelPdf/*`,
+`backend/test/Anela.Heblo.Tests/Application/Packaging/GetPackageLabelPdfHandlerTests.cs`, and
+`frontend/src/components/baleni/printLabelPdf.ts` (+ its test) that are **not** part of this
+branch's contribution. `git merge-base HEAD origin/main` is `0e0ba73` ("fix: quiet
+GetPackageLabelPdf polling 404 log flood (#3538)"), which is already the tip of `origin/main` and
+already contains all of that `X-Label-Poll` code verbatim (`git diff origin/main HEAD -- <those
+files>` is empty). The supplied diff file appears to have been generated against a stale base
+predating #3538's merge, not against current `origin/main`. This review evaluated the actual
+branch contents (`git diff origin/main...HEAD -- . ':!artifacts'`), which match the 3-commit scope
+described in the task: `E2ESessionService.cs` + new `E2ESessionServiceTests.cs`,
+`stock-operations-test-helpers.ts`, and `navigation.spec.ts`. `artifacts/feat-3540/MANUAL-FOLLOWUP.md`
+(docs-only, excluded from diff per instructions) was also read and correctly documents the FR-2
+manual DB-grant step the pipeline cannot perform itself, with no code claims that could be wrong.
+No action needed from this finding — it's a note for whoever generated `/tmp/feat-3540-review.diff`,
+not a defect in the branch.

--- a/artifacts/feat-3540/design.r1.md
+++ b/artifacts/feat-3540/design.r1.md
@@ -1,0 +1,14 @@
+# Design: Fix Stock Operations E2E — page never renders rows or empty state
+
+## Skip Design: true
+
+The architecture review (`arch-review.r1.md`) determined `Skip Design: true` for this
+feature: the root cause is a missing role-claim grant for the E2E synthetic test
+identity plus a broken E2E test assertion — a permission-configuration and
+test-hardening fix with **no new or changed UI components, screens, layouts, or
+visual design decisions**. `StockOperationsPage.tsx` and its existing loading/error/
+empty/data render states were reviewed by both the analyst and the architect and
+require no changes.
+
+No design document is produced for this feature. Proceed directly to planning using
+`spec.r1.md` and `arch-review.r1.md`.

--- a/artifacts/feat-3540/impl/add-manual-followup-note-for-db-permission-grant.r1.md
+++ b/artifacts/feat-3540/impl/add-manual-followup-note-for-db-permission-grant.r1.md
@@ -1,0 +1,27 @@
+# Implementation: add-manual-followup-note-for-db-permission-grant
+
+## What was implemented
+
+Documented the one required change this pipeline cannot make itself (spec FR-2): granting
+`warehouse.stock_up.read` to the E2E test account's permission group in the staging database. This
+ensures the manual step isn't silently dropped once the PR merges.
+
+## Files created/modified
+- `artifacts/feat-3540/MANUAL-FOLLOWUP.md` (new) — explains why this can't be automated (separate
+  DB-backed permission resolver, not touched by the code fix in tasks 1-2), and gives the repo
+  owner exact steps to perform the grant on staging and verify it.
+
+## Tests
+Not applicable — documentation only, no code changes.
+
+## How to verify
+`cat artifacts/feat-3540/MANUAL-FOLLOWUP.md` — confirm the file is valid markdown with no unclosed
+code fences and the steps are accurate against `PermissionResolver.cs` and the `/admin/access` UI.
+
+## Notes
+Per the task-context, this content should be surfaced prominently in the PR description (not just
+left in `artifacts/`) so it isn't missed — the oneshot pipeline's finishing step will include it in
+the PR body under a "Manual follow-up required" heading.
+
+## Status
+DONE

--- a/artifacts/feat-3540/impl/grant-e2e-warehouse-stockup-claims.r1.md
+++ b/artifacts/feat-3540/impl/grant-e2e-warehouse-stockup-claims.r1.md
@@ -1,0 +1,46 @@
+# Implementation: grant-e2e-warehouse-stockup-claims
+
+## What was implemented
+
+Granted the E2E synthetic test principal the `warehouse.stock_up.read`/`warehouse.stock_up.write`
+role claims, so `[FeatureAuthorize(Feature.Warehouse_StockUp)]` on `StockUpOperationsController`
+stops rejecting the E2E principal's calls with 403. This is the root-cause fix for GitHub issue
+#3540 (56 failing nightly E2E tests in the `stock-operations` module) — without these claims, every
+`/api/StockUpOperations*` call the E2E identity made was rejected before the controller action ran,
+and the frontend route guard (`RequireMenuPath`) silently redirected away from
+`/stock-up-operations` as a result, so the page never mounted and neither the data table nor the
+empty-state header ever appeared.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs` — added
+  `new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpRead)` and
+  `new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpWrite)` to
+  `CreateSyntheticUserClaims()`, alongside the existing `FinanceFinancialOverviewRead` grant.
+- `backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs` (new) —
+  regression test asserting the E2E synthetic claims include both roles.
+
+## Tests
+- `E2ESessionServiceTests.CreateSyntheticUserClaims_IncludesWarehouseStockUpReadAndWriteRoles` —
+  confirmed red (failing) against the unfixed source, then confirmed green after the fix.
+- Full backend suite (`dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`) — all tests
+  pass, no regressions.
+- `dotnet build` — succeeds.
+- `dotnet format --verify-no-changes` — clean, no formatting changes needed.
+
+## How to verify
+```
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~E2ESessionServiceTests
+```
+Expect the new test to pass. Once deployed to staging, an authenticated E2E call to
+`GET /api/StockUpOperations` should return 200 instead of 403.
+
+## Notes
+No deviations from the task-context plan. Note this only fixes the backend API 403 (FR-1 from the
+spec) — the frontend `RequireMenuPath` guard also depends on a separate, DB-backed permission
+resolution (FR-2 in the spec), which requires a manual staging database grant that cannot be made
+from this sandboxed worktree; that is handled by a separate task
+(`add-manual-followup-note-for-db-permission-grant`) later in this plan.
+
+## Status
+DONE

--- a/artifacts/feat-3540/impl/harden-stock-operations-error-state-e2e-test.r1.md
+++ b/artifacts/feat-3540/impl/harden-stock-operations-error-state-e2e-test.r1.md
@@ -1,0 +1,44 @@
+# Implementation: harden-stock-operations-error-state-e2e-test
+
+## What was implemented
+
+Fixed the `'should display error state on API failure'` E2E test, which previously passed
+vacuously regardless of actual behavior — a masking bug identified alongside the root cause of
+issue #3540. Also hardened the shared `waitForTableUpdate` helper to fail fast with a clear
+diagnostic message when the page renders the error card instead of the generic 15s timeout.
+
+## Files created/modified
+- `frontend/test/e2e/stock-operations/navigation.spec.ts` — fixed the route-intercept glob from
+  `'**/api/stock-up-operations**'` (kebab-case, never matched the real endpoint) to
+  `'**/api/StockUpOperations**'` (matches the generated client's actual PascalCase URL); replaced
+  the soft `if (isErrorVisible) {...} else { console.log(...) }` with a hard
+  `await expect(errorMessage).toBeVisible({ timeout: 15000 })` assertion so the test genuinely
+  fails if the error UI doesn't appear; removed the now-redundant fixed `waitForTimeout(3000)`.
+- `frontend/test/e2e/helpers/stock-operations-test-helpers.ts` — `waitForTableUpdate` now also
+  matches the error-card heading and throws a descriptive error (pointing at the likely missing
+  permission) if it appears, instead of only timing out generically after 15s.
+
+## Tests
+This task modifies E2E test files themselves; no new unit tests. Verified:
+- `grep -n "stock-up-operations\|isErrorVisible"` on the edited spec confirms no leftover
+  kebab-case glob or the removed `isErrorVisible` variable (only the legitimate `/stock-up-operations`
+  URL path string remains).
+- `npx tsc --noEmit` against the edited `navigation.spec.ts` reports zero errors for that file.
+- Confirmed via `grep -rl "waitForTableUpdate"` that all other `stock-operations` spec files using
+  the helper are happy-path tests (badges, accept, filters, sorting, retry, panel, state/source
+  filter) that never intentionally expect an error state at the point they call it — none are
+  affected by the added error-throwing branch.
+
+## How to verify
+Cannot run the Playwright E2E suite from this sandbox (it targets staging and is excluded from
+this pipeline's validation per project convention — nightly-only). Once task 1's fix and a manual
+permission grant (task 3) are live on staging, `navigation.spec.ts`'s error-state test and the
+other `stock-operations` specs relying on `waitForTableUpdate` should be re-run in the nightly
+suite to confirm end-to-end.
+
+## Notes
+No deviations from the task-context plan. `npm run lint` intentionally skipped per the task's
+Step 6 — it only covers `frontend/src`, not `frontend/test/e2e`.
+
+## Status
+DONE

--- a/artifacts/feat-3540/review/add-manual-followup-note-for-db-permission-grant.r1.md
+++ b/artifacts/feat-3540/review/add-manual-followup-note-for-db-permission-grant.r1.md
@@ -1,0 +1,17 @@
+# Code Review: add-manual-followup-note-for-db-permission-grant
+
+## Summary
+Documentation-only task: `MANUAL-FOLLOWUP.md` was created with the exact content specified in the
+task context, correctly explaining the deferred DB permission grant (FR-2) and giving the repo
+owner actionable steps. No code paths are touched, so correctness risk is minimal.
+
+## Review Result: PASS
+
+### task: add-manual-followup-note-for-db-permission-grant
+**Status:** PASS
+
+## Overall Notes
+Content matches the task-context verbatim. The note correctly references the actual file path
+(`PermissionResolver.cs`) and scopes the manual grant to the E2E/staging account only, consistent
+with spec NFR-2. This file must be surfaced in the PR body per the task's own instruction — the
+oneshot pipeline's finishing step is responsible for that, not this task.

--- a/artifacts/feat-3540/review/grant-e2e-warehouse-stockup-claims.r1.md
+++ b/artifacts/feat-3540/review/grant-e2e-warehouse-stockup-claims.r1.md
@@ -1,0 +1,48 @@
+# Code Review: grant-e2e-warehouse-stockup-claims
+
+## Summary
+The implementation adds exactly the two role claims (`AccessRoles.WarehouseStockUpRead`,
+`AccessRoles.WarehouseStockUpWrite`) specified in the task context to
+`E2ESessionService.CreateSyntheticUserClaims()`, and adds the exact regression test file
+specified, verbatim. The actual commit diff matches the impl summary's description precisely, the
+constants referenced exist and map to the correct `Feature.Warehouse_StockUp` access levels, and
+the fix is correctly scoped to FR-1 only (the DB-backed FR-2 grant is explicitly and correctly
+deferred to a separate task in the plan).
+
+## Review Result: PASS
+
+### task: grant-e2e-warehouse-stockup-claims
+**Status:** PASS
+
+## Docs to Update
+(none)
+
+## Overall Notes
+Verification performed:
+- `git show 1150603` confirms the diff is a byte-for-byte match to the task-context's Step 3 (claim
+  additions) and Step 1 (new test file), touching only the two files the task specifies.
+- `AccessRoles.generated.cs:43-44` confirms `WarehouseStockUpRead = "warehouse.stock_up.read"` and
+  `WarehouseStockUpWrite = "warehouse.stock_up.write"` exist, and lines 102-103 confirm they map to
+  `(Feature.Warehouse_StockUp, AccessLevel.Read)` / `(..., AccessLevel.Write)` — matching
+  `StockUpOperationsController.cs:12`'s class-level `[FeatureAuthorize(Feature.Warehouse_StockUp)]`
+  (Read, for `GetOperations`) and the `AccessLevel.Write` gates on `RetryOperation`/`AcceptOperation`
+  cited in the spec.
+- `frontend/src/auth/accessMatrix.generated.ts:32` independently confirms
+  `"/stock-up-operations": { permissions: ["warehouse.stock_up.read"] }`, matching the permission
+  string granted.
+- The new test's constructor usage (`new E2ESessionService(_logger)`) matches the actual
+  `E2ESessionService` constructor signature (`ILogger<E2ESessionService> logger`), and the
+  `CreateSyntheticUserClaims(string environmentName)` signature and `ClaimTypes.Role` claim shape
+  match the production code, so the test is well-formed and asserts the right thing (role claims
+  present, not permission-claims or some other shape).
+- Scope check: `spec.r1.md` FR-1's acceptance criteria are fully satisfied by this diff. FR-2 (DB
+  permission grant for the frontend's `RequireMenuPath` guard) is explicitly out of scope for this
+  task per `task-plan.r1.md`, and the impl summary correctly notes this rather than silently
+  omitting it or overclaiming completion.
+- I started `dotnet test --filter FullyQualifiedName~E2ESessionServiceTests` in this review
+  environment to independently confirm green, but the build did not finish within the review
+  session (large solution, slow sandboxed build). This is a code-inspection-based PASS: the change
+  is a minimal, low-risk addition of two claims using existing, already-verified constants,
+  following an established working pattern in the same method (the `FinanceFinancialOverviewRead`
+  precedent), and the test file is syntactically consistent with the real API surface. No red flags
+  were found that would suggest a build or test failure.

--- a/artifacts/feat-3540/review/harden-stock-operations-error-state-e2e-test.r1.md
+++ b/artifacts/feat-3540/review/harden-stock-operations-error-state-e2e-test.r1.md
@@ -1,0 +1,39 @@
+# Code Review: harden-stock-operations-error-state-e2e-test
+
+## Summary
+The commit exactly matches the task spec's prescribed diff: the route-intercept glob was
+corrected from kebab-case (`**/api/stock-up-operations**`, never matched) to the generated
+client's real PascalCase URL (`**/api/StockUpOperations**`, verified against
+`frontend/src/api/generated/api-client.ts:12051`), the soft `isErrorVisible`/`if/else` assertion
+was replaced with a hard `expect(errorMessage).toBeVisible(...)`, and `waitForTableUpdate` now
+fails fast with a diagnostic error when the error card appears instead of timing out generically.
+All claims in the implementation summary are verifiably accurate.
+
+## Review Result: PASS
+
+### task: harden-stock-operations-error-state-e2e-test
+**Status:** PASS
+
+## Docs to Update
+None.
+
+## Overall Notes
+- Verified `grep -n "stock-up-operations\|isErrorVisible" navigation.spec.ts` returns only the
+  legitimate `/stock-up-operations` URL path occurrences (lines 13 and 99) — no leftover glob or
+  removed variable.
+- Verified the error heading text `Chyba při načítání operací` and retry button text
+  `Zkusit znovu` in the assertions match the actual rendered markup in
+  `frontend/src/pages/StockOperationsPage.tsx:383` and `:391`.
+- Verified `waitForTableUpdate`'s new error-heading selector (`h3` filtered by
+  `Chyba při načítání operací`) matches the same DOM element, and confirmed via
+  `grep -rln "waitForTableUpdate" frontend/test/e2e/stock-operations/` that all eight other spec
+  files calling the helper are happy-path tests that don't intentionally expect the error state at
+  that call site, so the new throw is safe.
+- Ran `npx tsc --noEmit -p tsconfig.json --skipLibCheck test/e2e/stock-operations/navigation.spec.ts`
+  — zero errors reported for the edited file, confirming the impl summary's type-check claim.
+- Removal of the fixed `waitForTimeout(3000)` is correct/beneficial: the following hard
+  `expect(...).toBeVisible({ timeout: 15000 })` already waits, so the extra sleep was redundant.
+- Per the task's Step 6, `npm run lint` does not cover `frontend/test/e2e`, so its omission is
+  expected and not a gap.
+- Could not run the Playwright suite against staging (out of scope per task instructions); review
+  is based on static diff/code inspection only, as directed.

--- a/artifacts/feat-3540/spec.r1.md
+++ b/artifacts/feat-3540/spec.r1.md
@@ -1,105 +1,254 @@
-# Specification: Fix Stock Operations list page never rendering rows/empty-state (56 nightly E2E failures)
+# Specification: Fix Stock Operations E2E — page never renders rows or empty state (56 nightly failures)
 
 ## Summary
-56 nightly E2E tests in the `stock-operations` module fail because the Stock Operations list page (`StockOperationsPage.tsx`, route `/stock-up-operations`) never settles into a state the shared test helper recognizes: neither a data row (`tbody tr`) nor the empty-state header ("Žádné výsledky") appears within 15 seconds. Code review shows the page has exactly three terminal render states — loading, empty, error — and the error state renders a *different* heading ("Chyba při načítání operací"), which the shared wait helper does not match. This means the most likely root cause is that the real `/api/StockUpOperations` call is failing (permission/authorization or server error) on staging, not that the page is stuck loading or that the dataset is genuinely empty. A second, independently confirmed bug in the test suite itself (a case-mismatched route-interception pattern with a soft assertion) has been masking this failure mode from being caught by its own dedicated "error state" test.
+
+The `stock-operations` E2E suite fails 56 times on staging because the E2E service-principal
+test account is never granted the `warehouse.stock_up.read` permission that the Stock Operations
+feature requires, so the frontend's route guard (`RequireMenuPath`) silently redirects every
+navigation to `/stock-up-operations` back to `/` (Dashboard) before the page — and its data
+table / empty state — ever mounts. The root cause is a code gap in the E2E synthetic-user claims
+setup (`E2ESessionService.CreateSyntheticUserClaims`), which was never updated when the
+`Warehouse_StockUp` feature-authorization gate was added — the exact same class of bug was already
+hit and fixed for the Financial Overview feature, as evidenced by a comment left in the same method.
 
 ## Background
-The Stock Operations list page (`frontend/src/pages/StockOperationsPage.tsx`) fetches data via `useStockUpOperationsQuery` (`frontend/src/api/hooks/useStockUpOperations.ts`), which calls the generated client method `stockUpOperations_GetOperations`, hitting `GET /api/StockUpOperations` on the backend (`StockUpOperationsController.GetOperations`, routed through `GetStockUpOperationsHandler` → `StockUpOperationRepository.QueryAsync`).
 
-The page has three mutually exclusive render branches:
-1. `isLoading` → spinner ("Načítání dat...")
-2. `error` (truthy) → red box with heading **"Chyba při načítání operací"** and a "Zkusit znovu" retry button
-3. `operations.length === 0` → heading **"Žádné výsledky"**
-4. otherwise → `<table>` with `<tbody><tr>` rows
+**Investigation trail (static code analysis only; staging is not reachable from this sandbox).**
 
-The shared E2E helper `waitForTableUpdate()` (`frontend/test/e2e/helpers/stock-operations-test-helpers.ts:22-27`) waits only for `tbody tr` OR an `h3` containing "Žádné výsledky":
-```ts
-await expect(
-  page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
-).toBeVisible({ timeout: 15000 });
-```
-Critically, this locator does **not** match branch 2 (the error state), which has its own `h3` with different text ("Chyba při načítání operací"). A page that is deterministically erroring on every real load — rather than being stuck in `isLoading` — produces exactly the observed symptom: the wait times out after 15s because it is looking for the wrong two of the three non-loading terminal states.
+1. `frontend/src/pages/StockOperationsPage.tsx` (lines 377-397, 583-598) has correct,
+   unremarkable render logic: `isLoading` → spinner, `error` → error box, `operations.length === 0`
+   → "Žádné výsledky" empty state, else → table. `frontend/src/api/hooks/useStockUpOperations.ts`
+   and the generated client call (`stockUpOperations_GetOperations`, `api-client.ts:12050`) build
+   the request correctly and match the backend controller's parameter names and order 1:1. The
+   backend handler (`GetStockUpOperationsHandler.cs`) and repository query
+   (`StockUpOperationRepository.QueryAsync`,
+   `backend/src/Anela.Heblo.Persistence/Catalog/Stock/StockUpOperationRepository.cs`) correctly
+   implement the "Active" state filter, pagination, and sorting, and always return
+   `Success = true`. None of this explains rows AND the empty state both failing to appear —
+   the bug is not in the page's own data/render logic.
 
-Since the global React Query client (`frontend/src/App.tsx:104-112`) is configured with `retry: 1`, a failing request settles into the error state within a few seconds, not 15s — ruling out "still loading" as the likely steady state at the 15s timeout mark, and pointing instead at the error branch (or, less likely, a genuine network/request hang independent of React Query, e.g. a hung backend request or CORS preflight failure that never resolves the fetch promise).
+2. The actual cause is one layer higher: the route is wrapped in an access guard.
+   `frontend/src/App.tsx:452` defines
+   `<Route path="/stock-up-operations" element={guard("/stock-up-operations", <StockOperationsPage />)} />`,
+   where `guard()` (`App.tsx:287-289`) wraps the element in
+   `frontend/src/components/auth/RequireMenuPath.tsx`. That component (lines 12-20) does:
+   ```tsx
+   const { hasPermission, isLoading } = usePermissionsContext();
+   if (isLoading) return null;
+   const req = ACCESS_ROUTES[path];
+   if (!req) return <Navigate to={redirectTo} replace />;
+   if (!req.permissions.every(p => hasPermission(p)))
+     return <Navigate to={redirectTo} replace />;
+   return <>{children}</>;
+   ```
+   `frontend/src/auth/accessMatrix.generated.ts:32` requires
+   `"/stock-up-operations": { permissions: ["warehouse.stock_up.read"] }`. If the current user
+   lacks that permission, this component **silently redirects to `/` — no error, no toast, no
+   distinguishing URL**. `StockOperationsPage` never mounts, so neither `tbody tr` nor the
+   `h3:has-text("Žádné výsledky")` element the shared E2E helper waits for
+   (`frontend/test/e2e/helpers/stock-operations-test-helpers.ts:22-27`, `waitForTableUpdate`) ever
+   appears — which is exactly the reported timeout signature (`toBeVisible({ timeout: 15000 })` on
+   `tbody tr .or(h3:"Žádné výsledky")`). It also explains why the *first* navigation test in the
+   suite ("should navigate to page via direct URL", which checks `page.url()` and the `h1` text)
+   would fail too: the browser never actually stays on `/stock-up-operations`.
 
-An empty active dataset (0 rows for the default `state=Active` filter) is **not** a plausible root cause: that outcome correctly renders "Žádné výsledky", which the wait helper matches successfully. The bug must be something that produces the *error* branch (or an indefinite hang) on effectively every navigation to the page, across all 9 spec files and 56 test cases.
+3. Permission resolution for this frontend gate comes from `GET /api/auth/me`
+   (`backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetMe/GetMeHandler.cs`,
+   lines 18-44), which returns the full permission set only when the caller is `super_user`;
+   otherwise it resolves DB-backed group/permission membership via
+   `IPermissionResolver.ResolveAsync(entraObjectId, ...)`
+   (`backend/src/Anela.Heblo.Domain/Features/Authorization/IPermissionResolver.cs`) — this is a
+   separate mechanism from the ASP.NET Core role-claim checks described next.
 
-**Confirmed compounding bug in the test suite** (found by code review, not the primary cause but must be fixed regardless): `frontend/test/e2e/stock-operations/navigation.spec.ts:83-115` ("should display error state on API failure") intercepts `page.route('**/api/stock-up-operations**', ...)` — a kebab-case, lowercase pattern. The actual backend route is `api/StockUpOperations` (from `[Route("api/[controller]")]` on `StockUpOperationsController`, confirmed by the generated client at `frontend/src/api/generated/api-client.ts:12051`: `this.baseUrl + "/api/StockUpOperations?"`). Playwright glob route patterns are case-sensitive, so this interception never fires — `route.abort('failed')` is dead code in this test. Worse, the test's own assertion is soft:
-```ts
-const isErrorVisible = await errorMessage.isVisible();
-if (isErrorVisible) { /* assert retry button */ } else { console.log('...possible caching'); }
-```
-It passes unconditionally whether or not the error banner appears. This is why this is the one test in the suite that "passes" — it is a false positive, not evidence that the error-rendering path works correctly. It provides no real coverage of the error state and does not confirm or rule out the primary hypothesis on its own.
+4. Independently, the backend API is gated the same way at the controller level.
+   `StockUpOperationsController.cs:12` carries `[FeatureAuthorize(Feature.Warehouse_StockUp)]` at
+   the class level (covers the read endpoint) and `AccessLevel.Write` on `RetryOperation` (line 76)
+   and `AcceptOperation` (line 95). `FeatureAuthorizeAttribute`
+   (`backend/src/Anela.Heblo.Domain/Features/Authorization/FeatureAuthorizeAttribute.cs:11-16`)
+   sets `Roles = AccessRoles.For(feature, level)`, which becomes a standard ASP.NET Core
+   `[Authorize(Roles = "warehouse.stock_up.read")]`-style check against the caller's
+   `ClaimsPrincipal` role claims — enforced independently of the DB-backed resolution in point 3.
+
+5. **The concrete, provable bug.** The E2E test user's role claims are hardcoded in
+   `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs`, method
+   `CreateSyntheticUserClaims()` (lines 70-92):
+   ```csharp
+   return new[]
+   {
+       new Claim(ClaimTypes.NameIdentifier, "e2e-test-user-id"),
+       ...
+       new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
+       new Claim("scp", "access_as_user"),
+       // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
+       // FeatureAuthorize checks the role claim (permission strings were renamed away from the
+       // old "FinancialOverview.View" form), so a stale "permission" claim no longer matches.
+       new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead)
+   };
+   ```
+   This grants **only** `AccessRoles.Base` and `AccessRoles.FinanceFinancialOverviewRead` — nothing
+   for `warehouse.stock_up.read` / `warehouse.stock_up.write`
+   (`AccessRoles.WarehouseStockUpRead` / `WarehouseStockUpWrite`,
+   `backend/src/Anela.Heblo.Domain/Features/Authorization/AccessRoles.generated.cs:43-44`). The
+   comment on the existing grant is direct evidence that this exact class of bug (E2E synthetic
+   user missing a newly-introduced feature's role claim, causing that feature's controller to
+   reject the E2E principal) has already been hit and fixed once, for `Warehouse_StockUp`'s sibling
+   feature `Finance_FinancialOverview` — and the same follow-up was never done when
+   `Warehouse_StockUp`'s `[FeatureAuthorize]` gate was added to `StockUpOperationsController`.
+   Every `/api/StockUpOperations*` call the E2E principal makes is rejected as Forbidden at the
+   ASP.NET Core authorization layer as a result.
+
+6. This also explains the failure's scope: `warehouse.stock_up.read`/`write` are the newest
+   permissions in the access matrix, introduced with this feature, and are the one gap not yet
+   covered by the E2E claims list — unlike `finance.financial_overview.read`, which was already
+   patched in after being hit by the same bug.
+
+7. **Secondary, independently-confirmed test bug** (masks this failure mode, does not cause it):
+   the one "passing" test, `frontend/test/e2e/stock-operations/navigation.spec.ts:83-115`
+   (`'should display error state on API failure'`), doesn't actually validate anything:
+   - It intercepts `page.route('**/api/stock-up-operations**', ...)` (kebab-case), but the real
+     generated client calls `/api/StockUpOperations` (PascalCase — `api-client.ts:12051`:
+     `this.baseUrl + "/api/StockUpOperations?"`). Playwright's glob route matching is
+     case-sensitive against the URL, so this interception **never fires**; the real
+     (currently-Forbidden) network call goes through untouched.
+   - Even if it fired, the assertion is soft: `if (isErrorVisible) { assert } else { console.log(...) }`
+     with no failure path in the `else` branch, so the test passes unconditionally regardless of
+     what the page renders. This is why it "passes" even though every other test in the module
+     times out — it is a false positive, not a working error-state check.
 
 ## Functional Requirements
 
-### FR-1: Diagnose the actual failure mode against staging before implementing a code fix
-This spec's code-review evidence narrows the cause to "the real API call errors (403/401/500) or hangs on every load" but cannot pinpoint which, since staging access, server logs, and captured network traces were not available during spec authoring.
-**Acceptance criteria:**
-- Reproduce the failure against `https://heblo.stg.anela.cz/stock-up-operations` (or the relevant nightly-run target) while capturing: browser console output, the network response (status code and body) for `GET /api/StockUpOperations`, and backend application logs for the corresponding request.
-- Confirm which of the following is occurring: (a) HTTP 401/403 from `[FeatureAuthorize(Feature.Warehouse_StockUp)]` denying the E2E service principal/test user, (b) HTTP 5xx from an unhandled exception in `GetStockUpOperationsHandler` / `StockUpOperationRepository.QueryAsync` / AutoMapper mapping of `StockUpOperationDto`, (c) a network-level failure (CORS, timeout, DNS) that never resolves the fetch promise, or (d) something else not anticipated by this spec's static analysis.
-- Attach the findings (status code, response body, stack trace if any) to the implementation ticket before FR-2 is coded.
+### FR-1: Grant the E2E test principal the Warehouse_StockUp role claims
+Add the missing role claims to the hardcoded E2E synthetic-user claim list so the ASP.NET Core
+`[Authorize(Roles=...)]` checks generated by `[FeatureAuthorize(Feature.Warehouse_StockUp, ...)]`
+on `StockUpOperationsController` stop rejecting the E2E principal's requests.
 
-### FR-2: Fix the confirmed root cause so the Stock Operations page reliably reaches a correct terminal state
-Once FR-1 identifies the concrete cause, fix it so that a normal authenticated user with `Warehouse_StockUp` read access loading `/stock-up-operations` with the default filters (`state=Active`, all source types) reliably reaches either the data table or the "Žádné výsledky" empty state within the existing test timeout — never gets stuck in the error branch.
-**Acceptance criteria:**
-- If FR-1 finds a permissions gap (e.g., the E2E test user/role is missing `Feature.Warehouse_StockUp` Read access): grant the appropriate role/permission to the E2E test identity, OR correct the `[FeatureAuthorize]` configuration if it is wrong relative to the intended access matrix (do not weaken production authorization to work around a test-identity gap).
-- If FR-1 finds a server-side exception: fix the throwing code path in the handler/repository/mapper and add a regression test in `backend/test/Anela.Heblo.Tests` covering the failing input shape.
-- If FR-1 finds a hang: identify and fix the blocking call (e.g., missing `CancellationToken` propagation, DB connection pool exhaustion, synchronous-over-async deadlock) and add a timeout at the appropriate layer so the frontend at least reaches the error state deterministically instead of hanging indefinitely.
-- After the fix, manually verify (or via a smoke E2E run) that `GET /api/StockUpOperations?state=Active` against staging returns HTTP 200 with a valid `GetStockUpOperationsResponse` body for the E2E test identity.
-- All 56 previously-failing tests across `filters.spec.ts`, `badges.spec.ts`, `panel.spec.ts`, `retry.spec.ts`, `state-filter.spec.ts`, `navigation.spec.ts`, `accept.spec.ts`, `sorting.spec.ts`, and `source-filter.spec.ts` pass in the next nightly run.
+**File:** `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs`,
+method `CreateSyntheticUserClaims()` (currently lines 70-92).
 
-### FR-3: Fix the broken route interception and soft assertion in the "error state" E2E test
-Independent of FR-1/FR-2, `navigation.spec.ts`'s "should display error state on API failure" test is broken and must be fixed so it provides real coverage and cannot silently pass regardless of behavior.
-**Acceptance criteria:**
-- The `page.route(...)` pattern is corrected to match the actual endpoint, e.g. `**/api/StockUpOperations**` (case-correct, matching the generated client's request URL), or better, matched via a case-insensitive/regex pattern anchored to the controller's actual route so future controller renames are caught rather than silently passing.
-- The test asserts unconditionally (no `if (isErrorVisible) { assert } else { log }` branching that allows a pass without exercising the assertion) — use `await expect(errorMessage).toBeVisible()` (with an appropriate timeout) so a regression here fails the test.
-- Verify the retry button ("Zkusit znovu") assertion still runs and passes when the error state is genuinely triggered via the now-correctly-intercepted route.
-- Confirm this test still passes after the fix, exercising the real interception (not a no-op).
+Add, alongside the existing `AccessRoles.FinanceFinancialOverviewRead` grant:
+```csharp
+new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpRead),
+new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpWrite),
+```
+(`Write` is required because `retry.spec.ts` and `accept.spec.ts` exercise
+`POST /api/StockUpOperations/{id}/retry` and `/accept`, both gated at `AccessLevel.Write` —
+`StockUpOperationsController.cs:76,95`.)
 
-### FR-4: Strengthen `waitForTableUpdate` so a persistent error state fails fast with a clear signal, instead of a generic 15s timeout
-The current failure mode (15s generic timeout, "element(s) not found") does not tell engineers *why* the table never loaded — it looks identical whether the cause is a slow network, a genuine hang, or a rendered error banner. This ambiguity cost investigation time for this very incident.
 **Acceptance criteria:**
-- `waitForTableUpdate` (or a wrapper around it used by the module's tests) also observes the error branch's heading ("Chyba při načítání operací") and, if it appears instead of rows/empty-state, fails immediately with a descriptive error message (e.g., including the error banner's text) rather than waiting out the full 15s generic timeout.
-- This does not change the assertion for the tests that are specifically testing the error state (FR-3) — those tests should continue to use their own explicit error-state assertions, not the strengthened `waitForTableUpdate`.
-- Existing passing tests in the module are unaffected (no new flakiness introduced).
+- `E2ESessionService.CreateSyntheticUserClaims()` returns a claim set that includes
+  `AccessRoles.WarehouseStockUpRead` and `AccessRoles.WarehouseStockUpWrite`.
+- A backend test asserts the E2E synthetic claims include these two roles (extend or add alongside
+  the existing tests in `backend/test/Anela.Heblo.Tests/Authorization/`).
+- After deploying, an authenticated call via the E2E service-principal flow to
+  `GET /api/StockUpOperations` returns 200, not 403/401.
+
+### FR-2: Confirm/grant the same permission in the DB-backed permission resolver used by the frontend menu guard
+`RequireMenuPath` (`frontend/src/components/auth/RequireMenuPath.tsx`) does not use the ASP.NET
+Core role claims touched in FR-1 at all — it gates on `GET /api/auth/me`'s resolved permission
+list, which for non-super-user accounts comes from `IPermissionResolver.ResolveAsync(...)`
+(DB-backed group/permission resolution — see `GetMeHandler.cs` and `IPermissionResolver.cs`).
+FR-1 alone fixes the backend API 403s but will **not** stop the silent `<Navigate to="/" />`
+redirect unless the E2E test account's DB-resolved permission set also includes
+`warehouse.stock_up.read`.
+
+**Acceptance criteria:**
+- After FR-1 is deployed, call `GET /api/auth/me` as the E2E test principal (or inspect via the
+  `/admin/access` UI) and confirm the returned `permissions` array includes
+  `warehouse.stock_up.read`.
+- If it is missing, grant it to the E2E account's permission group through the existing access
+  management mechanism (`/admin/access` UI, backed by the database) — this is a data/configuration
+  change, not a code change, consistent with how other manual DB updates are handled in this
+  project (see CLAUDE.md: "Database migrations are manual").
+- After the grant, navigating to `/stock-up-operations` as the E2E principal renders
+  `StockOperationsPage` (URL stays `/stock-up-operations`, `h1` reads "Operace naskladnění")
+  instead of redirecting to `/`.
+
+### FR-3: Harden the misleading "error state on API failure" E2E test
+Fix the test that currently passes regardless of outcome, so a similar regression fails loudly in
+the future instead of being masked.
+
+**File:** `frontend/test/e2e/stock-operations/navigation.spec.ts`, test
+`'should display error state on API failure'` (lines 83-115).
+
+- Fix the route-interception glob from `'**/api/stock-up-operations**'` to match the actual
+  endpoint casing used by the generated client (`/api/StockUpOperations`, see
+  `api-client.ts:12051`), e.g. `'**/api/StockUpOperations**'`, or a case-insensitive regex anchored
+  to the real path.
+- Replace the soft `if (isErrorVisible) { ... } else { console.log(...) }` with a hard
+  `await expect(errorMessage).toBeVisible()` assertion, so the test fails if the error state does
+  not appear once the call is genuinely intercepted and aborted.
+
+**Acceptance criteria:**
+- With the route fix, `page.route` reliably intercepts the real `GetOperations` call and aborts it.
+- The test fails (not silently passes) if the error UI (`"Chyba při načítání operací"` heading +
+  "Zkusit znovu" retry button) does not appear after the aborted call.
+- The test continues to pass once genuinely exercising the intercepted/aborted request path.
+
+### FR-4 (recommended, not required to close this issue): Make `RequireMenuPath` denials diagnosable
+`RequireMenuPath`'s silent `<Navigate to={redirectTo} replace />` on missing permission produces no
+console/network signal distinguishing "redirected due to missing permission" from "genuinely
+navigated to `/`". This is exactly what turned a straightforward permission gap into an opaque
+15-second E2E timeout with no actionable error, and cost significant investigation time for this
+incident. Consider logging a `console.warn` (or emitting a telemetry event) with the denied `path`
+and the missing permission(s) when this redirect fires, so future permission-gap regressions are
+diagnosable directly from browser/test logs.
+
+**Acceptance criteria:**
+- When `RequireMenuPath` denies access, a console warning (or equivalent telemetry) identifies the
+  requested path and the missing permission(s).
+- No behavior change to the redirect itself (still redirects to `redirectTo`).
 
 ## Non-Functional Requirements
 
 ### NFR-1: Performance
-- `GET /api/StockUpOperations` with default filters and `pageSize=50` must respond within the existing implicit expectation embedded in the E2E suite (well under the 15s wait timeout; target p95 < 2s against the staging dataset size).
-- No new N+1 queries or unbounded scans introduced by any FR-2 fix; the existing `StockUpOperationRepository.QueryAsync` pagination (`Skip`/`Take`) and count-then-fetch pattern must be preserved.
+No performance impact expected. FR-1 only adds two additional `Claim` objects to an
+already-in-memory claims list constructed once per E2E session login; FR-2 is a one-time
+permission grant.
 
 ### NFR-2: Security
-- Any permission-grant fix under FR-2 must follow the existing `Feature`/`AccessLevel`/role model (`AccessRoles.generated.cs`, `AccessMatrix.generated.cs`) — do not bypass or weaken `[FeatureAuthorize(Feature.Warehouse_StockUp)]` on the controller. If the E2E test identity needs the permission, grant it through the same mechanism a real user would receive it (role assignment), not through an authorization code change.
-- Do not log sensitive data (tokens, PII) when adding diagnostic instrumentation for FR-1.
+FR-1 only affects the `E2ETestCookies` authentication scheme, which `E2ETestController` already
+restricts to `Staging`/`Development` environments (`E2ETestController.cs:68-73,134-137,172-175`).
+Granting `warehouse.stock_up.read`/`write` to the synthetic E2E principal does not affect
+production authorization or any real user's permissions. FR-2's DB grant must be scoped to the
+E2E test account only, not broadened to any production group.
 
 ## Data Model
-No schema changes are anticipated by this spec. Relevant existing entities (unchanged unless FR-1 uncovers an entity/mapping bug):
-- `StockUpOperation` (backend entity, table `StockUpOperations`) — `Id`, `DocumentNumber`, `ProductCode`, `Amount`, `State` (enum: `Pending`, `Submitted`, `Completed`, `Failed` — post `RemoveVerifiedStateFromStockUpOperations` migration), `SourceType` (`TransportBox` | `GiftPackageManufacture`), `SourceId`, `CreatedAt`, `SubmittedAt`, `CompletedAt`, `FailedAt`, `ErrorMessage`.
-- `StockUpOperationDto` (`GetStockUpOperationsResponse.cs`) — DTO mirror of the above, returned to the frontend.
-- Partial index `IX_StockUpOperations_State_Active` (migration `20260506145627_AddPartialIndexForActiveStockUpOperations`) covers `State IN (Pending, Submitted, Failed)` — used by `GetActiveCountsAsync`, not directly by `QueryAsync`'s "Active" filter path, but worth checking under FR-1 if the query planner behaves unexpectedly on the `state=Active` OR-filter.
+No schema changes. This is a permission-configuration and test-hardening fix; no entities,
+migrations, or DTO changes are involved.
 
 ## API / Interface Design
-- `GET /api/StockUpOperations` — existing endpoint (`StockUpOperationsController.GetOperations`), no signature changes proposed. Query params: `state`, `pageSize`, `page`, `sourceType`, `sourceId`, `productCode`, `documentNumber`, `createdFrom`, `createdTo`, `sortBy`, `sortDescending`. Gated by `[FeatureAuthorize(Feature.Warehouse_StockUp)]` (Read).
-- No new endpoints. Any fix is expected to be either a permission/config change, a bug fix inside the existing handler/repository/mapper, or a test-file correction — not a new interface.
+No API contract changes. `GET /api/StockUpOperations`, `POST /api/StockUpOperations/{id}/retry`,
+and `POST /api/StockUpOperations/{id}/accept` remain as currently defined
+(`StockUpOperationsController.cs`); this fix only changes which claims the E2E principal presents
+when calling them (FR-1), and which permissions `GET /api/auth/me` resolves for that principal
+(FR-2).
 
 ## Dependencies
-- ASP.NET Core authorization pipeline and the generated `AccessRoles`/`AccessMatrix`/`Feature` files (`backend/src/Anela.Heblo.Domain/Features/Authorization/`).
-- React Query (`@tanstack/react-query`) client configuration in `frontend/src/App.tsx`.
-- Playwright E2E harness and staging environment `https://heblo.stg.anela.cz`, and the E2E service identity's role/permission assignment (owner/location unknown from code alone — needs FR-1 investigation).
-- Nightly E2E workflow (`E2E Nightly Regression Tests`) that surfaced this issue (run #191).
+- `backend/src/Anela.Heblo.Domain/Features/Authorization/AccessRoles.generated.cs` (auto-generated;
+  the `WarehouseStockUpRead`/`WarehouseStockUpWrite` constants already exist there — FR-1 only
+  references them, no regeneration needed).
+- The DB-backed permission/group administration feature (`/admin/access`) for FR-2.
+- `frontend/test/e2e/helpers/stock-operations-test-helpers.ts` (`waitForTableUpdate`) and
+  `frontend/test/e2e/helpers/e2e-auth-helper.ts` (`navigateToStockOperations`) — unchanged; their
+  current behavior (no assertion that navigation actually landed on the target page) is why this
+  failure surfaced as a 15s generic timeout rather than a clear "redirected unexpectedly" error.
 
 ## Out of Scope
-- Redesigning the Stock Operations page's loading/error/empty UI beyond what's needed to fix the root cause and add the FR-4 diagnostic improvement.
-- Changes to `StockUpOperationRepository.QueryAsync`'s filtering/sorting/pagination logic unless FR-1 specifically implicates it as the cause.
-- Broader refactor of the `waitForLoadingComplete`/`wait-helpers.ts` utilities beyond the targeted FR-4 change; the pre-existing race-condition notes in that file's docstring (US-001/US-002) describe a separate, already-addressed issue in the `catalog` module and are not part of this fix.
-- Fixing or hardening other soft/vacuous assertions elsewhere in the E2E suite outside the `stock-operations` module, even if the same anti-pattern (case-mismatched route + `if (isVisible)` branching) is suspected to exist elsewhere.
-- Any change to the `RemoveVerifiedStateFromStockUpOperations` or `AddPartialIndexForActiveStockUpOperations` migrations themselves; they are considered already-applied and correct unless FR-1 proves otherwise.
+- Any change to `StockOperationsPage.tsx`, `useStockUpOperations.ts`,
+  `GetStockUpOperationsHandler.cs`, or `StockUpOperationRepository.cs` — all were reviewed and are
+  functioning correctly; the bug is entirely in E2E authorization setup and menu-guard permission
+  resolution, not in the feature's own business logic.
+- Regenerating `accessMatrix.generated.ts` / `AccessRoles.generated.cs` — the required permission
+  constants already exist; only the E2E claims list (FR-1) and the DB group grant (FR-2) need
+  updating.
+- Granting `warehouse.stock_up.*` to any real production user/group — out of scope; FR-2 is scoped
+  to the E2E/staging test account only.
+- A broader audit of every other E2E-suite module for the same "missing E2E role claim when a new
+  `[FeatureAuthorize]` feature ships" pattern, even though the `FinanceFinancialOverviewRead`
+  precedent shows it has happened before and could recur for other newly-gated features.
 
 ## Open Questions
-1. What is the actual HTTP status/response body (or hang behavior) returned by staging for `GET /api/StockUpOperations` when called as the E2E test identity? This cannot be determined from static code review alone and blocks confirming which of the FR-2 sub-cases applies — needs a staging repro session (browser DevTools network tab, or backend logs for the nightly run's timeframe around run #191).
-2. Does the E2E test identity used by the nightly Playwright run currently hold `Feature.Warehouse_StockUp` Read access in the staging role/permission configuration? If not, was this permission ever granted, or did the `stock-operations` E2E suite pass previously without it (suggesting a recent regression in role assignment rather than a pre-existing gap)?
-3. Is there a way to correlate "since when" these 56 tests started failing (e.g., a previous nightly run where they passed), to determine whether this is a fresh regression (pointing at a recent deploy/config change) versus a suite that has never actually validated this path correctly? Run #191 alone doesn't establish this; earlier nightly run history should be checked in GitHub Actions.
 
-## Status: HAS_QUESTIONS
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3540/spec.r1.md
+++ b/artifacts/feat-3540/spec.r1.md
@@ -1,0 +1,105 @@
+# Specification: Fix Stock Operations list page never rendering rows/empty-state (56 nightly E2E failures)
+
+## Summary
+56 nightly E2E tests in the `stock-operations` module fail because the Stock Operations list page (`StockOperationsPage.tsx`, route `/stock-up-operations`) never settles into a state the shared test helper recognizes: neither a data row (`tbody tr`) nor the empty-state header ("Žádné výsledky") appears within 15 seconds. Code review shows the page has exactly three terminal render states — loading, empty, error — and the error state renders a *different* heading ("Chyba při načítání operací"), which the shared wait helper does not match. This means the most likely root cause is that the real `/api/StockUpOperations` call is failing (permission/authorization or server error) on staging, not that the page is stuck loading or that the dataset is genuinely empty. A second, independently confirmed bug in the test suite itself (a case-mismatched route-interception pattern with a soft assertion) has been masking this failure mode from being caught by its own dedicated "error state" test.
+
+## Background
+The Stock Operations list page (`frontend/src/pages/StockOperationsPage.tsx`) fetches data via `useStockUpOperationsQuery` (`frontend/src/api/hooks/useStockUpOperations.ts`), which calls the generated client method `stockUpOperations_GetOperations`, hitting `GET /api/StockUpOperations` on the backend (`StockUpOperationsController.GetOperations`, routed through `GetStockUpOperationsHandler` → `StockUpOperationRepository.QueryAsync`).
+
+The page has three mutually exclusive render branches:
+1. `isLoading` → spinner ("Načítání dat...")
+2. `error` (truthy) → red box with heading **"Chyba při načítání operací"** and a "Zkusit znovu" retry button
+3. `operations.length === 0` → heading **"Žádné výsledky"**
+4. otherwise → `<table>` with `<tbody><tr>` rows
+
+The shared E2E helper `waitForTableUpdate()` (`frontend/test/e2e/helpers/stock-operations-test-helpers.ts:22-27`) waits only for `tbody tr` OR an `h3` containing "Žádné výsledky":
+```ts
+await expect(
+  page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
+).toBeVisible({ timeout: 15000 });
+```
+Critically, this locator does **not** match branch 2 (the error state), which has its own `h3` with different text ("Chyba při načítání operací"). A page that is deterministically erroring on every real load — rather than being stuck in `isLoading` — produces exactly the observed symptom: the wait times out after 15s because it is looking for the wrong two of the three non-loading terminal states.
+
+Since the global React Query client (`frontend/src/App.tsx:104-112`) is configured with `retry: 1`, a failing request settles into the error state within a few seconds, not 15s — ruling out "still loading" as the likely steady state at the 15s timeout mark, and pointing instead at the error branch (or, less likely, a genuine network/request hang independent of React Query, e.g. a hung backend request or CORS preflight failure that never resolves the fetch promise).
+
+An empty active dataset (0 rows for the default `state=Active` filter) is **not** a plausible root cause: that outcome correctly renders "Žádné výsledky", which the wait helper matches successfully. The bug must be something that produces the *error* branch (or an indefinite hang) on effectively every navigation to the page, across all 9 spec files and 56 test cases.
+
+**Confirmed compounding bug in the test suite** (found by code review, not the primary cause but must be fixed regardless): `frontend/test/e2e/stock-operations/navigation.spec.ts:83-115` ("should display error state on API failure") intercepts `page.route('**/api/stock-up-operations**', ...)` — a kebab-case, lowercase pattern. The actual backend route is `api/StockUpOperations` (from `[Route("api/[controller]")]` on `StockUpOperationsController`, confirmed by the generated client at `frontend/src/api/generated/api-client.ts:12051`: `this.baseUrl + "/api/StockUpOperations?"`). Playwright glob route patterns are case-sensitive, so this interception never fires — `route.abort('failed')` is dead code in this test. Worse, the test's own assertion is soft:
+```ts
+const isErrorVisible = await errorMessage.isVisible();
+if (isErrorVisible) { /* assert retry button */ } else { console.log('...possible caching'); }
+```
+It passes unconditionally whether or not the error banner appears. This is why this is the one test in the suite that "passes" — it is a false positive, not evidence that the error-rendering path works correctly. It provides no real coverage of the error state and does not confirm or rule out the primary hypothesis on its own.
+
+## Functional Requirements
+
+### FR-1: Diagnose the actual failure mode against staging before implementing a code fix
+This spec's code-review evidence narrows the cause to "the real API call errors (403/401/500) or hangs on every load" but cannot pinpoint which, since staging access, server logs, and captured network traces were not available during spec authoring.
+**Acceptance criteria:**
+- Reproduce the failure against `https://heblo.stg.anela.cz/stock-up-operations` (or the relevant nightly-run target) while capturing: browser console output, the network response (status code and body) for `GET /api/StockUpOperations`, and backend application logs for the corresponding request.
+- Confirm which of the following is occurring: (a) HTTP 401/403 from `[FeatureAuthorize(Feature.Warehouse_StockUp)]` denying the E2E service principal/test user, (b) HTTP 5xx from an unhandled exception in `GetStockUpOperationsHandler` / `StockUpOperationRepository.QueryAsync` / AutoMapper mapping of `StockUpOperationDto`, (c) a network-level failure (CORS, timeout, DNS) that never resolves the fetch promise, or (d) something else not anticipated by this spec's static analysis.
+- Attach the findings (status code, response body, stack trace if any) to the implementation ticket before FR-2 is coded.
+
+### FR-2: Fix the confirmed root cause so the Stock Operations page reliably reaches a correct terminal state
+Once FR-1 identifies the concrete cause, fix it so that a normal authenticated user with `Warehouse_StockUp` read access loading `/stock-up-operations` with the default filters (`state=Active`, all source types) reliably reaches either the data table or the "Žádné výsledky" empty state within the existing test timeout — never gets stuck in the error branch.
+**Acceptance criteria:**
+- If FR-1 finds a permissions gap (e.g., the E2E test user/role is missing `Feature.Warehouse_StockUp` Read access): grant the appropriate role/permission to the E2E test identity, OR correct the `[FeatureAuthorize]` configuration if it is wrong relative to the intended access matrix (do not weaken production authorization to work around a test-identity gap).
+- If FR-1 finds a server-side exception: fix the throwing code path in the handler/repository/mapper and add a regression test in `backend/test/Anela.Heblo.Tests` covering the failing input shape.
+- If FR-1 finds a hang: identify and fix the blocking call (e.g., missing `CancellationToken` propagation, DB connection pool exhaustion, synchronous-over-async deadlock) and add a timeout at the appropriate layer so the frontend at least reaches the error state deterministically instead of hanging indefinitely.
+- After the fix, manually verify (or via a smoke E2E run) that `GET /api/StockUpOperations?state=Active` against staging returns HTTP 200 with a valid `GetStockUpOperationsResponse` body for the E2E test identity.
+- All 56 previously-failing tests across `filters.spec.ts`, `badges.spec.ts`, `panel.spec.ts`, `retry.spec.ts`, `state-filter.spec.ts`, `navigation.spec.ts`, `accept.spec.ts`, `sorting.spec.ts`, and `source-filter.spec.ts` pass in the next nightly run.
+
+### FR-3: Fix the broken route interception and soft assertion in the "error state" E2E test
+Independent of FR-1/FR-2, `navigation.spec.ts`'s "should display error state on API failure" test is broken and must be fixed so it provides real coverage and cannot silently pass regardless of behavior.
+**Acceptance criteria:**
+- The `page.route(...)` pattern is corrected to match the actual endpoint, e.g. `**/api/StockUpOperations**` (case-correct, matching the generated client's request URL), or better, matched via a case-insensitive/regex pattern anchored to the controller's actual route so future controller renames are caught rather than silently passing.
+- The test asserts unconditionally (no `if (isErrorVisible) { assert } else { log }` branching that allows a pass without exercising the assertion) — use `await expect(errorMessage).toBeVisible()` (with an appropriate timeout) so a regression here fails the test.
+- Verify the retry button ("Zkusit znovu") assertion still runs and passes when the error state is genuinely triggered via the now-correctly-intercepted route.
+- Confirm this test still passes after the fix, exercising the real interception (not a no-op).
+
+### FR-4: Strengthen `waitForTableUpdate` so a persistent error state fails fast with a clear signal, instead of a generic 15s timeout
+The current failure mode (15s generic timeout, "element(s) not found") does not tell engineers *why* the table never loaded — it looks identical whether the cause is a slow network, a genuine hang, or a rendered error banner. This ambiguity cost investigation time for this very incident.
+**Acceptance criteria:**
+- `waitForTableUpdate` (or a wrapper around it used by the module's tests) also observes the error branch's heading ("Chyba při načítání operací") and, if it appears instead of rows/empty-state, fails immediately with a descriptive error message (e.g., including the error banner's text) rather than waiting out the full 15s generic timeout.
+- This does not change the assertion for the tests that are specifically testing the error state (FR-3) — those tests should continue to use their own explicit error-state assertions, not the strengthened `waitForTableUpdate`.
+- Existing passing tests in the module are unaffected (no new flakiness introduced).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- `GET /api/StockUpOperations` with default filters and `pageSize=50` must respond within the existing implicit expectation embedded in the E2E suite (well under the 15s wait timeout; target p95 < 2s against the staging dataset size).
+- No new N+1 queries or unbounded scans introduced by any FR-2 fix; the existing `StockUpOperationRepository.QueryAsync` pagination (`Skip`/`Take`) and count-then-fetch pattern must be preserved.
+
+### NFR-2: Security
+- Any permission-grant fix under FR-2 must follow the existing `Feature`/`AccessLevel`/role model (`AccessRoles.generated.cs`, `AccessMatrix.generated.cs`) — do not bypass or weaken `[FeatureAuthorize(Feature.Warehouse_StockUp)]` on the controller. If the E2E test identity needs the permission, grant it through the same mechanism a real user would receive it (role assignment), not through an authorization code change.
+- Do not log sensitive data (tokens, PII) when adding diagnostic instrumentation for FR-1.
+
+## Data Model
+No schema changes are anticipated by this spec. Relevant existing entities (unchanged unless FR-1 uncovers an entity/mapping bug):
+- `StockUpOperation` (backend entity, table `StockUpOperations`) — `Id`, `DocumentNumber`, `ProductCode`, `Amount`, `State` (enum: `Pending`, `Submitted`, `Completed`, `Failed` — post `RemoveVerifiedStateFromStockUpOperations` migration), `SourceType` (`TransportBox` | `GiftPackageManufacture`), `SourceId`, `CreatedAt`, `SubmittedAt`, `CompletedAt`, `FailedAt`, `ErrorMessage`.
+- `StockUpOperationDto` (`GetStockUpOperationsResponse.cs`) — DTO mirror of the above, returned to the frontend.
+- Partial index `IX_StockUpOperations_State_Active` (migration `20260506145627_AddPartialIndexForActiveStockUpOperations`) covers `State IN (Pending, Submitted, Failed)` — used by `GetActiveCountsAsync`, not directly by `QueryAsync`'s "Active" filter path, but worth checking under FR-1 if the query planner behaves unexpectedly on the `state=Active` OR-filter.
+
+## API / Interface Design
+- `GET /api/StockUpOperations` — existing endpoint (`StockUpOperationsController.GetOperations`), no signature changes proposed. Query params: `state`, `pageSize`, `page`, `sourceType`, `sourceId`, `productCode`, `documentNumber`, `createdFrom`, `createdTo`, `sortBy`, `sortDescending`. Gated by `[FeatureAuthorize(Feature.Warehouse_StockUp)]` (Read).
+- No new endpoints. Any fix is expected to be either a permission/config change, a bug fix inside the existing handler/repository/mapper, or a test-file correction — not a new interface.
+
+## Dependencies
+- ASP.NET Core authorization pipeline and the generated `AccessRoles`/`AccessMatrix`/`Feature` files (`backend/src/Anela.Heblo.Domain/Features/Authorization/`).
+- React Query (`@tanstack/react-query`) client configuration in `frontend/src/App.tsx`.
+- Playwright E2E harness and staging environment `https://heblo.stg.anela.cz`, and the E2E service identity's role/permission assignment (owner/location unknown from code alone — needs FR-1 investigation).
+- Nightly E2E workflow (`E2E Nightly Regression Tests`) that surfaced this issue (run #191).
+
+## Out of Scope
+- Redesigning the Stock Operations page's loading/error/empty UI beyond what's needed to fix the root cause and add the FR-4 diagnostic improvement.
+- Changes to `StockUpOperationRepository.QueryAsync`'s filtering/sorting/pagination logic unless FR-1 specifically implicates it as the cause.
+- Broader refactor of the `waitForLoadingComplete`/`wait-helpers.ts` utilities beyond the targeted FR-4 change; the pre-existing race-condition notes in that file's docstring (US-001/US-002) describe a separate, already-addressed issue in the `catalog` module and are not part of this fix.
+- Fixing or hardening other soft/vacuous assertions elsewhere in the E2E suite outside the `stock-operations` module, even if the same anti-pattern (case-mismatched route + `if (isVisible)` branching) is suspected to exist elsewhere.
+- Any change to the `RemoveVerifiedStateFromStockUpOperations` or `AddPartialIndexForActiveStockUpOperations` migrations themselves; they are considered already-applied and correct unless FR-1 proves otherwise.
+
+## Open Questions
+1. What is the actual HTTP status/response body (or hang behavior) returned by staging for `GET /api/StockUpOperations` when called as the E2E test identity? This cannot be determined from static code review alone and blocks confirming which of the FR-2 sub-cases applies — needs a staging repro session (browser DevTools network tab, or backend logs for the nightly run's timeframe around run #191).
+2. Does the E2E test identity used by the nightly Playwright run currently hold `Feature.Warehouse_StockUp` Read access in the staging role/permission configuration? If not, was this permission ever granted, or did the `stock-operations` E2E suite pass previously without it (suggesting a recent regression in role assignment rather than a pre-existing gap)?
+3. Is there a way to correlate "since when" these 56 tests started failing (e.g., a previous nightly run where they passed), to determine whether this is a fresh regression (pointing at a recent deploy/config change) versus a suite that has never actually validated this path correctly? Run #191 alone doesn't establish this; earlier nightly run history should be checked in GitHub Actions.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "grant-e2e-warehouse-stockup-claims",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T01:40:12.952395Z"
+      "updated_at": "2026-07-08T02:26:50.787566Z"
     },
     {
       "name": "harden-stock-operations-error-state-e2e-test",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T02:27:03.328970Z"
     },
     {
       "name": "add-manual-followup-note-for-db-permission-grant",

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T02:29:47.549899Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-08T02:29:51.702241Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -28,9 +28,9 @@
   "tasks": [
     {
       "name": "grant-e2e-warehouse-stockup-claims",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T01:40:12.952395Z"
     },
     {
       "name": "harden-stock-operations-error-state-e2e-test",

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-08T01:39:40.033747Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T01:39:51.276964Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T02:29:47.549899Z"
     }
   },
   "tasks": [
@@ -40,9 +40,9 @@
     },
     {
       "name": "add-manual-followup-note-for-db-permission-grant",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T02:29:08.992892Z"
+      "updated_at": "2026-07-08T02:29:42.883714Z"
     }
   ]
 }

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -13,16 +13,16 @@
       "updated_at": "2026-07-08T01:34:39.474726Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T01:40:04.318544Z"
     },
     "planning": {
       "status": "completed",
       "updated_at": "2026-07-08T01:39:40.033747Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T01:39:51.276964Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-08T01:29:07.440539Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T01:34:39.474726Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "harden-stock-operations-error-state-e2e-test",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T02:27:03.328970Z"
+      "updated_at": "2026-07-08T02:29:02.619367Z"
     },
     {
       "name": "add-manual-followup-note-for-db-permission-grant",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T02:29:08.992892Z"
     }
   ]
 }

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -17,13 +17,32 @@
       "updated_at": null
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T01:39:40.033747Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "grant-e2e-warehouse-stockup-claims",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "harden-stock-operations-error-state-e2e-test",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "add-manual-followup-note-for-db-permission-grant",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T01:17:54.199036Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T01:29:07.440539Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-08T02:29:47.549899Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T02:29:51.702241Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T02:33:53.537059Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3540",
+  "issue_number": 3540,
+  "created_at": "2026-07-08T01:15:13.980209Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3540/state.json
+++ b/artifacts/feat-3540/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T01:17:54.199036Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3540/task-context/add-manual-followup-note-for-db-permission-grant.md
+++ b/artifacts/feat-3540/task-context/add-manual-followup-note-for-db-permission-grant.md
@@ -1,0 +1,109 @@
+### task: add-manual-followup-note-for-db-permission-grant
+
+**Files:**
+- Modify: `artifacts/feat-3540/task-plan.r1.md` (this file — no changes needed, informational only)
+- Add: `artifacts/feat-3540/MANUAL-FOLLOWUP.md` (new file)
+
+**Goal:** Surface the one change this pipeline cannot make itself — granting
+`warehouse.stock_up.read` to the E2E test account's permission group in the staging database (spec
+FR-2) — as an explicit, actionable manual follow-up so it isn't silently dropped once the PR merges.
+
+- [ ] Step 1: Create `artifacts/feat-3540/MANUAL-FOLLOWUP.md` with this exact content:
+
+  ```markdown
+  # Manual follow-up required after merge (feat-3540)
+
+  This PR fixes the backend API authorization gap (FR-1: E2E synthetic user now holds
+  `warehouse.stock_up.read`/`write` role claims) and hardens a broken E2E test (FR-3). It does
+  **not** and cannot make one additional required change:
+
+  ## Action required: grant `warehouse.stock_up.read` to the E2E test account in the staging DB
+
+  The frontend route guard (`RequireMenuPath` on `/stock-up-operations`) does not consume the
+  ASP.NET Core role claims this PR adds. It gates on `GET /api/auth/me`'s resolved permission
+  list, which comes from a separate, DB-backed permission resolver
+  (`IPermissionResolver.ResolveAsync`, `backend/src/Anela.Heblo.Persistence/Features/Authorization/PermissionResolver.cs`).
+  That resolver looks up the E2E test `AppUser`'s **DB group memberships** — a mechanism this PR's
+  code change does not touch and a sandboxed development environment cannot reach or modify
+  (per this repo's CLAUDE.md: database migrations/data changes are manual, and secrets/config
+  live in Azure Key Vault, never in Web App environment variables edited directly).
+
+  **Steps for the repo owner to perform manually on staging, after this PR is merged and deployed:**
+
+  1. Sign in to `https://heblo.stg.anela.cz/admin/access` as an administrator.
+  2. Find the E2E test account (`oid` / `entraObjectId` = `e2e-test-object-id`, email
+     `e2e-test@anela-heblo.com`).
+  3. Confirm whether its resolved permissions already include `warehouse.stock_up.read` — either
+     via the `/admin/access` UI's effective-permissions view, or by calling `GET /api/auth/me`
+     while authenticated as that account and inspecting the `permissions` array in the response.
+  4. If `warehouse.stock_up.read` is **not** present, add the E2E test account to an existing
+     access group that grants it, or grant it directly through the `/admin/access` UI — scoped
+     **only** to the E2E/staging test account, not to any production group or user (per spec
+     NFR-2).
+  5. Re-run the nightly E2E suite (or manually run `./scripts/run-playwright-tests.sh
+     stock-operations` against staging) and confirm all 56 previously-failing tests in
+     `frontend/test/e2e/stock-operations/*.spec.ts` now pass.
+
+  This step is independent of and not blocked by the code changes in this PR — it can be done in
+  parallel with code review, but the nightly suite will not go fully green until both this PR's
+  code changes are deployed **and** this DB grant is made.
+  ```
+
+- [ ] Step 2: Verify the file was created and is valid markdown (no unclosed code fences):
+  ```
+  cat artifacts/feat-3540/MANUAL-FOLLOWUP.md
+  ```
+
+- [ ] Step 3: Commit with message `docs(feat-3540): add manual staging DB follow-up note for warehouse.stock_up.read grant`.
+
+  Note for whoever finalizes the PR: surface the contents of
+  `artifacts/feat-3540/MANUAL-FOLLOWUP.md` prominently in the PR description (e.g. under a "Manual
+  follow-up required" heading) so it is not missed — this file living only in `artifacts/` is not
+  itself visible on the PR unless quoted into the PR body.
+
+---
+
+## Scope notes / deliberately omitted work
+
+- **Spec FR-4** (a reflection-based test scanning every `[FeatureAuthorize]`-gated controller
+  action and cross-checking it against `CreateSyntheticUserClaims()`, e.g.
+  `E2ESyntheticClaimsCoverageTests.cs`) is explicitly called out by `arch-review.r1.md` as
+  "recommended, not strictly required by the spec but cheap insurance," and describes a simpler,
+  equivalent alternative: a direct unit test asserting the synthetic claim set contains the two
+  `Warehouse_StockUp` roles. That simpler version is implemented in Task 1
+  (`E2ESessionServiceTests.cs`) as part of the TDD flow for the claims fix itself — it directly
+  prevents a recurrence of this exact bug (a claim silently missing from the hardcoded list) with
+  no additional task needed. The broader reflection-based sweep across *all* controllers is a
+  larger, separate effort (auditing every other feature's read endpoints and building an allowlist
+  for intentionally-unreachable ones) and is left out of this bite-sized plan; if desired, file it
+  as a separate follow-up issue rather than folding it into this fix.
+- **No task modifies `RequireMenuPath.tsx`** (e.g. adding a `console.warn` on permission-denied
+  redirects). Neither `spec.r1.md` nor `arch-review.r1.md` currently define this as a requirement
+  for this ticket — `RequireMenuPath.tsx` was read directly as part of planning this task and
+  confirmed to already exist as a small, side-effect-free component; adding logging there would be
+  a reasonable, low-risk future diagnostic improvement, but it is not needed to satisfy FR-1 or
+  FR-3's acceptance criteria and is left out to keep this change surgical, per this project's
+  "touch only what the task requires" rule.
+- **No task touches the staging database or Azure Key Vault.** Spec FR-2 (confirm/grant
+  `warehouse.stock_up.read` in the DB-backed permission resolver) is a data/configuration change in
+  a live environment that a sandboxed worktree cannot perform; Task 3 above produces the follow-up
+  documentation instead, per this plan's explicit constraint.
+
+## Self-review against spec acceptance criteria
+
+- FR-1 "`CreateSyntheticUserClaims()` returns a claim set including `WarehouseStockUpRead` and
+  `WarehouseStockUpWrite`" → Task 1, Step 3, verified by Task 1 Step 4's passing test.
+- FR-1 "an authenticated call ... to `GET /api/StockUpOperations` returns 200, not 403" → follows
+  directly from the claim grant (ASP.NET Core `[Authorize(Roles=...)]` behavior is not something
+  this repo's unit tests re-verify per-endpoint; `StockUpOperationsControllerAuthorizationTests.cs`
+  already covers the controller side of this contract and is unaffected by this change) —
+  confirmed at the "all 56 tests pass" level once this PR is deployed and Task 3's DB follow-up is
+  done, per FR-2's acceptance criteria.
+- FR-3 "route-interception pattern ... matches the real endpoint casing" → Task 2, Step 1.
+- FR-3 "hard `await expect(errorMessage).toBeVisible()` assertion, ... retry-button assertion
+  unconditional" → Task 2, Step 1 (both are now unconditional `expect(...).toBeVisible()` calls).
+- FR-3 "test fails (not silently passes) if the error UI ... does not appear" → satisfied by the
+  hard assertions in Task 2, Step 1; no `if`/`console.log`-only branch remains.
+- FR-3 "test continues to pass once genuinely exercising the intercepted/aborted request path" →
+  the fixed glob (`**/api/StockUpOperations**`) now matches the real request path regardless of
+  FR-1/FR-2's outcome, so the abort — and therefore the error UI — is deterministic.

--- a/artifacts/feat-3540/task-context/grant-e2e-warehouse-stockup-claims.md
+++ b/artifacts/feat-3540/task-context/grant-e2e-warehouse-stockup-claims.md
@@ -1,0 +1,102 @@
+### task: grant-e2e-warehouse-stockup-claims
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs:85-91`
+- Test: `backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs` (new file)
+
+**Goal:** Grant the E2E synthetic test principal `warehouse.stock_up.read`/`write` role claims so
+`[FeatureAuthorize(Feature.Warehouse_StockUp)]` stops rejecting its calls to
+`/api/StockUpOperations*` with 403.
+
+- [ ] Step 1: Create the test file `backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs` with this exact content:
+
+  ```csharp
+  using System.Linq;
+  using System.Security.Claims;
+  using Anela.Heblo.API.Infrastructure.Authentication;
+  using Anela.Heblo.Domain.Features.Authorization;
+  using FluentAssertions;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Logging.Abstractions;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Infrastructure.Authentication;
+
+  /// <summary>
+  /// Regression coverage for the E2E synthetic user's role claims. A new
+  /// [FeatureAuthorize]-gated feature shipping without a matching role claim added to
+  /// CreateSyntheticUserClaims() has already caused two incidents: FinancialOverview
+  /// (fixed previously) and Warehouse_StockUp (feat-3540, 56 nightly E2E failures).
+  /// </summary>
+  public class E2ESessionServiceTests
+  {
+      private readonly ILogger<E2ESessionService> _logger = NullLogger<E2ESessionService>.Instance;
+
+      [Fact]
+      public void CreateSyntheticUserClaims_IncludesWarehouseStockUpReadAndWriteRoles()
+      {
+          // Arrange
+          var sut = new E2ESessionService(_logger);
+
+          // Act
+          var claims = sut.CreateSyntheticUserClaims("Staging");
+
+          // Assert
+          var roleClaims = claims.Where(c => c.Type == ClaimTypes.Role).Select(c => c.Value);
+          roleClaims.Should().Contain(AccessRoles.WarehouseStockUpRead,
+              "the E2E principal must be able to call GET /api/StockUpOperations, which is " +
+              "gated by [FeatureAuthorize(Feature.Warehouse_StockUp)] (Read)");
+          roleClaims.Should().Contain(AccessRoles.WarehouseStockUpWrite,
+              "the E2E principal must be able to call POST /api/StockUpOperations/{id}/retry " +
+              "and /accept, which are gated at AccessLevel.Write");
+      }
+  }
+  ```
+
+- [ ] Step 2: Run the new test and confirm it fails (red) against the current, unfixed
+  `E2ESessionService`:
+  ```
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~E2ESessionServiceTests
+  ```
+  Expect `CreateSyntheticUserClaims_IncludesWarehouseStockUpReadAndWriteRoles` to fail because
+  neither role claim is present yet.
+
+- [ ] Step 3: In `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs`,
+  replace:
+  ```csharp
+              new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
+              new Claim("scp", "access_as_user"),
+              // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
+              // FeatureAuthorize checks the role claim (permission strings were renamed away from the
+              // old "FinancialOverview.View" form), so a stale "permission" claim no longer matches.
+              new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead)
+          };
+  ```
+  with:
+  ```csharp
+              new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
+              new Claim("scp", "access_as_user"),
+              // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
+              // FeatureAuthorize checks the role claim (permission strings were renamed away from the
+              // old "FinancialOverview.View" form), so a stale "permission" claim no longer matches.
+              new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead),
+              // Grant the Warehouse_StockUp read/write roles so E2E tests can reach
+              // /api/StockUpOperations* (list, retry, accept). Without these, FeatureAuthorize
+              // rejects every request with 403 before the controller action runs (feat-3540).
+              new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpRead),
+              new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpWrite)
+          };
+  ```
+
+- [ ] Step 4: Re-run the same filtered test command from Step 2 and confirm it now passes (green).
+
+- [ ] Step 5: Run the full backend test suite to check for regressions, then build:
+  ```
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj && dotnet build && dotnet format --verify-no-changes
+  ```
+  If `dotnet format` reports changes, run `dotnet format` (no `--verify-no-changes`) and re-check
+  the diff only touches the two files above.
+
+- [ ] Step 6: Commit with message `fix(e2e): grant Warehouse_StockUp read/write claims to E2E synthetic user (feat-3540)`.
+
+---

--- a/artifacts/feat-3540/task-context/harden-stock-operations-error-state-e2e-test.md
+++ b/artifacts/feat-3540/task-context/harden-stock-operations-error-state-e2e-test.md
@@ -1,0 +1,139 @@
+### task: harden-stock-operations-error-state-e2e-test
+
+**Files:**
+- Modify: `frontend/test/e2e/stock-operations/navigation.spec.ts:83-115`
+- Modify: `frontend/test/e2e/helpers/stock-operations-test-helpers.ts:22-27`
+
+**Goal:** Fix the case-mismatched route-intercept glob and replace the soft, no-op-on-failure
+assertion in the `'should display error state on API failure'` test so it actually exercises and
+verifies the error path, independent of Task 1's fix.
+
+- [ ] Step 1: Open `frontend/test/e2e/stock-operations/navigation.spec.ts` and replace the
+  `'should display error state on API failure'` test body (currently lines 83-115) — replace this
+  exact block:
+  ```typescript
+    // Intercept API calls and force failure
+    await page.route('**/api/stock-up-operations**', route => {
+      route.abort('failed');
+    });
+
+    // Navigate to stock operations page (will trigger failed API call)
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/stock-up-operations`);
+    await page.waitForTimeout(3000);
+
+    // Check for error message
+    const errorMessage = page.locator('text="Chyba při načítání operací"');
+    const isErrorVisible = await errorMessage.isVisible();
+
+    if (isErrorVisible) {
+      console.log('   ✅ Error state displayed');
+
+      // Verify retry button exists
+      const retryButton = page.getByRole('button', { name: /Zkusit znovu/i });
+      await expect(retryButton).toBeVisible();
+      console.log('   ✅ Retry button present');
+    } else {
+      console.log('   ℹ️ Error state not triggered (possible caching)');
+    }
+  ```
+  with:
+  ```typescript
+    // Intercept API calls and force failure.
+    // The generated client builds this.baseUrl + "/api/StockUpOperations?" (PascalCase, no
+    // dashes — see frontend/src/api/generated/api-client.ts:12051), so the glob must match
+    // that literal casing or the route never intercepts and the real request goes through.
+    await page.route('**/api/StockUpOperations**', route => {
+      route.abort('failed');
+    });
+
+    // Navigate to stock operations page (will trigger failed API call)
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/stock-up-operations`);
+
+    // Check for error message — hard assertion, so the test fails (not silently passes)
+    // if the intercepted/aborted request doesn't produce the error UI.
+    const errorMessage = page.locator('text="Chyba při načítání operací"');
+    await expect(errorMessage).toBeVisible({ timeout: 15000 });
+    console.log('   ✅ Error state displayed');
+
+    // Verify retry button exists
+    const retryButton = page.getByRole('button', { name: /Zkusit znovu/i });
+    await expect(retryButton).toBeVisible();
+    console.log('   ✅ Retry button present');
+  ```
+  Note this removes the `await page.waitForTimeout(3000);` line — the hard `expect(...).toBeVisible({ timeout: 15000 })` on the next line already waits, making the fixed timeout redundant and flake-prone.
+
+- [ ] Step 2: Confirm the edited test file has no leftover references to the old
+  `isErrorVisible` variable or the old glob pattern:
+  ```
+  grep -n "stock-up-operations\|isErrorVisible" frontend/test/e2e/stock-operations/navigation.spec.ts
+  ```
+  Expect no matches (the only `stock-up-operations` occurrences left should be the URL path
+  `/stock-up-operations`, not the API glob — re-check the grep output line by line, since that URL
+  string will legitimately still match `stock-up-operations` as a substring; confirm no
+  `**/api/stock-up-operations**` glob remains).
+
+- [ ] Step 3: Type-check the edited spec file so the change is syntactically valid (this repo has
+  no dedicated `tsconfig.json` under `frontend/test/e2e/`, so type-check directly against the root
+  config):
+  ```
+  cd frontend && npx tsc --noEmit -p tsconfig.json --skipLibCheck test/e2e/stock-operations/navigation.spec.ts
+  ```
+  If this reports unrelated pre-existing errors elsewhere in the E2E suite (common, since E2E specs
+  aren't part of the production build/tsconfig include list), confirm there are zero errors
+  reported specifically for `navigation.spec.ts` and move on — E2E specs are not covered by
+  `npm run build`, so this step is a best-effort syntax check, not a hard gate.
+
+- [ ] Step 4: In `frontend/test/e2e/helpers/stock-operations-test-helpers.ts`, harden the shared
+  `waitForTableUpdate` wait so it fails fast with a clear message instead of the generic 15s timeout
+  whenever the page lands on the error card instead of rows/empty-state — this directly prevents a
+  repeat of the exact failure mode this ticket investigated (56 tests all timing out with the same
+  unhelpful "element not found" error). Replace this exact block:
+  ```typescript
+  export async function waitForTableUpdate(page: Page): Promise<void> {
+    // Wait for either at least one data row or the empty-state message to appear
+    await expect(
+      page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
+    ).toBeVisible({ timeout: 15000 });
+  }
+  ```
+  with:
+  ```typescript
+  export async function waitForTableUpdate(page: Page): Promise<void> {
+    // Wait for a data row, the empty-state message, or the error card to appear. Failing fast
+    // on the error card (instead of only on the generic 15s timeout) gives a clear diagnostic
+    // — "Chyba při načítání operací" almost always means the E2E principal lacks a required
+    // permission (see feat-3540) rather than a genuine UI bug.
+    const success = page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }));
+    const errorHeading = page.locator('h3').filter({ hasText: 'Chyba při načítání operací' });
+    const result = success.or(errorHeading);
+    await expect(result).toBeVisible({ timeout: 15000 });
+
+    if (await errorHeading.isVisible().catch(() => false)) {
+      throw new Error(
+        'Stock Operations page rendered the error card ("Chyba při načítání operací") instead ' +
+        'of data rows or the empty state. This usually means the caller lacks a required ' +
+        'permission (e.g. warehouse.stock_up.read) rather than a genuine data/UI bug.'
+      );
+    }
+  }
+  ```
+
+- [ ] Step 5: Confirm no other spec file relies on `waitForTableUpdate` resolving successfully when
+  the page is in the error state (it shouldn't — the dedicated error-state test in Step 1 asserts
+  on `errorMessage` directly, not via this helper):
+  ```
+  grep -rln "waitForTableUpdate" frontend/test/e2e/stock-operations/
+  ```
+  Read each matching file's usage and confirm none of them intentionally expect an error state at
+  the point they call `waitForTableUpdate` (the error-state test itself, from Step 1, does not call
+  `waitForTableUpdate` at all, so it is unaffected by this change).
+
+- [ ] Step 6: This repo's `npm run lint` script (`eslint src --ext .ts,.tsx`) only covers
+  `frontend/src`, not `frontend/test/e2e`, so it will not pick up these two files — skip it for
+  this task and rely on Step 3's type-check plus manual review of the diff instead.
+
+- [ ] Step 7: Commit with message `fix(e2e): correct StockUpOperations route-intercept casing and use hard assertions in error-state test (feat-3540)`.
+
+---

--- a/artifacts/feat-3540/task-plan.r1.md
+++ b/artifacts/feat-3540/task-plan.r1.md
@@ -1,0 +1,377 @@
+# Task Plan: Fix Stock Operations E2E suite — 56 nightly failures (feat-3540)
+
+## Context for the implementer
+
+Root cause (confirmed by both `spec.r1.md` and `arch-review.r1.md`): the E2E synthetic test
+identity's hardcoded role claims (`E2ESessionService.CreateSyntheticUserClaims()`) never grant
+`AccessRoles.WarehouseStockUpRead` / `AccessRoles.WarehouseStockUpWrite`, so every
+`/api/StockUpOperations*` call the E2E principal makes is rejected (403) and/or the frontend's
+`RequireMenuPath` route guard silently redirects away from `/stock-up-operations` before the page
+ever mounts. Separately, one E2E test in `navigation.spec.ts` has a case-mismatched route-intercept
+glob and a soft (no-op-on-failure) assertion, so it "passes" without testing anything.
+
+This plan covers the two fully-automatable fixes (backend claims grant, broken test hardening) plus
+one small regression-test addition. It deliberately does **not** include a task that modifies the
+staging database or Azure Key Vault — per this project's CLAUDE.md, database changes are manual and
+secrets never go through Web App environment variables, and a sandboxed worktree has no access to
+either. Task 4 produces a documentation artifact that surfaces the required manual DB grant as an
+explicit follow-up in the PR body.
+
+Tasks are ordered so the branch is shippable after each one. Each task is self-contained — you do
+not need to have read this context section or any other task's reasoning, only the file paths and
+code below.
+
+---
+
+### task: grant-e2e-warehouse-stockup-claims
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs:85-91`
+- Test: `backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs` (new file)
+
+**Goal:** Grant the E2E synthetic test principal `warehouse.stock_up.read`/`write` role claims so
+`[FeatureAuthorize(Feature.Warehouse_StockUp)]` stops rejecting its calls to
+`/api/StockUpOperations*` with 403.
+
+- [ ] Step 1: Create the test file `backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs` with this exact content:
+
+  ```csharp
+  using System.Linq;
+  using System.Security.Claims;
+  using Anela.Heblo.API.Infrastructure.Authentication;
+  using Anela.Heblo.Domain.Features.Authorization;
+  using FluentAssertions;
+  using Microsoft.Extensions.Logging;
+  using Microsoft.Extensions.Logging.Abstractions;
+  using Xunit;
+
+  namespace Anela.Heblo.Tests.Infrastructure.Authentication;
+
+  /// <summary>
+  /// Regression coverage for the E2E synthetic user's role claims. A new
+  /// [FeatureAuthorize]-gated feature shipping without a matching role claim added to
+  /// CreateSyntheticUserClaims() has already caused two incidents: FinancialOverview
+  /// (fixed previously) and Warehouse_StockUp (feat-3540, 56 nightly E2E failures).
+  /// </summary>
+  public class E2ESessionServiceTests
+  {
+      private readonly ILogger<E2ESessionService> _logger = NullLogger<E2ESessionService>.Instance;
+
+      [Fact]
+      public void CreateSyntheticUserClaims_IncludesWarehouseStockUpReadAndWriteRoles()
+      {
+          // Arrange
+          var sut = new E2ESessionService(_logger);
+
+          // Act
+          var claims = sut.CreateSyntheticUserClaims("Staging");
+
+          // Assert
+          var roleClaims = claims.Where(c => c.Type == ClaimTypes.Role).Select(c => c.Value);
+          roleClaims.Should().Contain(AccessRoles.WarehouseStockUpRead,
+              "the E2E principal must be able to call GET /api/StockUpOperations, which is " +
+              "gated by [FeatureAuthorize(Feature.Warehouse_StockUp)] (Read)");
+          roleClaims.Should().Contain(AccessRoles.WarehouseStockUpWrite,
+              "the E2E principal must be able to call POST /api/StockUpOperations/{id}/retry " +
+              "and /accept, which are gated at AccessLevel.Write");
+      }
+  }
+  ```
+
+- [ ] Step 2: Run the new test and confirm it fails (red) against the current, unfixed
+  `E2ESessionService`:
+  ```
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~E2ESessionServiceTests
+  ```
+  Expect `CreateSyntheticUserClaims_IncludesWarehouseStockUpReadAndWriteRoles` to fail because
+  neither role claim is present yet.
+
+- [ ] Step 3: In `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs`,
+  replace:
+  ```csharp
+              new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
+              new Claim("scp", "access_as_user"),
+              // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
+              // FeatureAuthorize checks the role claim (permission strings were renamed away from the
+              // old "FinancialOverview.View" form), so a stale "permission" claim no longer matches.
+              new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead)
+          };
+  ```
+  with:
+  ```csharp
+              new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
+              new Claim("scp", "access_as_user"),
+              // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
+              // FeatureAuthorize checks the role claim (permission strings were renamed away from the
+              // old "FinancialOverview.View" form), so a stale "permission" claim no longer matches.
+              new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead),
+              // Grant the Warehouse_StockUp read/write roles so E2E tests can reach
+              // /api/StockUpOperations* (list, retry, accept). Without these, FeatureAuthorize
+              // rejects every request with 403 before the controller action runs (feat-3540).
+              new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpRead),
+              new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpWrite)
+          };
+  ```
+
+- [ ] Step 4: Re-run the same filtered test command from Step 2 and confirm it now passes (green).
+
+- [ ] Step 5: Run the full backend test suite to check for regressions, then build:
+  ```
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj && dotnet build && dotnet format --verify-no-changes
+  ```
+  If `dotnet format` reports changes, run `dotnet format` (no `--verify-no-changes`) and re-check
+  the diff only touches the two files above.
+
+- [ ] Step 6: Commit with message `fix(e2e): grant Warehouse_StockUp read/write claims to E2E synthetic user (feat-3540)`.
+
+---
+
+### task: harden-stock-operations-error-state-e2e-test
+
+**Files:**
+- Modify: `frontend/test/e2e/stock-operations/navigation.spec.ts:83-115`
+- Modify: `frontend/test/e2e/helpers/stock-operations-test-helpers.ts:22-27`
+
+**Goal:** Fix the case-mismatched route-intercept glob and replace the soft, no-op-on-failure
+assertion in the `'should display error state on API failure'` test so it actually exercises and
+verifies the error path, independent of Task 1's fix.
+
+- [ ] Step 1: Open `frontend/test/e2e/stock-operations/navigation.spec.ts` and replace the
+  `'should display error state on API failure'` test body (currently lines 83-115) — replace this
+  exact block:
+  ```typescript
+    // Intercept API calls and force failure
+    await page.route('**/api/stock-up-operations**', route => {
+      route.abort('failed');
+    });
+
+    // Navigate to stock operations page (will trigger failed API call)
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/stock-up-operations`);
+    await page.waitForTimeout(3000);
+
+    // Check for error message
+    const errorMessage = page.locator('text="Chyba při načítání operací"');
+    const isErrorVisible = await errorMessage.isVisible();
+
+    if (isErrorVisible) {
+      console.log('   ✅ Error state displayed');
+
+      // Verify retry button exists
+      const retryButton = page.getByRole('button', { name: /Zkusit znovu/i });
+      await expect(retryButton).toBeVisible();
+      console.log('   ✅ Retry button present');
+    } else {
+      console.log('   ℹ️ Error state not triggered (possible caching)');
+    }
+  ```
+  with:
+  ```typescript
+    // Intercept API calls and force failure.
+    // The generated client builds this.baseUrl + "/api/StockUpOperations?" (PascalCase, no
+    // dashes — see frontend/src/api/generated/api-client.ts:12051), so the glob must match
+    // that literal casing or the route never intercepts and the real request goes through.
+    await page.route('**/api/StockUpOperations**', route => {
+      route.abort('failed');
+    });
+
+    // Navigate to stock operations page (will trigger failed API call)
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    await page.goto(`${baseUrl}/stock-up-operations`);
+
+    // Check for error message — hard assertion, so the test fails (not silently passes)
+    // if the intercepted/aborted request doesn't produce the error UI.
+    const errorMessage = page.locator('text="Chyba při načítání operací"');
+    await expect(errorMessage).toBeVisible({ timeout: 15000 });
+    console.log('   ✅ Error state displayed');
+
+    // Verify retry button exists
+    const retryButton = page.getByRole('button', { name: /Zkusit znovu/i });
+    await expect(retryButton).toBeVisible();
+    console.log('   ✅ Retry button present');
+  ```
+  Note this removes the `await page.waitForTimeout(3000);` line — the hard `expect(...).toBeVisible({ timeout: 15000 })` on the next line already waits, making the fixed timeout redundant and flake-prone.
+
+- [ ] Step 2: Confirm the edited test file has no leftover references to the old
+  `isErrorVisible` variable or the old glob pattern:
+  ```
+  grep -n "stock-up-operations\|isErrorVisible" frontend/test/e2e/stock-operations/navigation.spec.ts
+  ```
+  Expect no matches (the only `stock-up-operations` occurrences left should be the URL path
+  `/stock-up-operations`, not the API glob — re-check the grep output line by line, since that URL
+  string will legitimately still match `stock-up-operations` as a substring; confirm no
+  `**/api/stock-up-operations**` glob remains).
+
+- [ ] Step 3: Type-check the edited spec file so the change is syntactically valid (this repo has
+  no dedicated `tsconfig.json` under `frontend/test/e2e/`, so type-check directly against the root
+  config):
+  ```
+  cd frontend && npx tsc --noEmit -p tsconfig.json --skipLibCheck test/e2e/stock-operations/navigation.spec.ts
+  ```
+  If this reports unrelated pre-existing errors elsewhere in the E2E suite (common, since E2E specs
+  aren't part of the production build/tsconfig include list), confirm there are zero errors
+  reported specifically for `navigation.spec.ts` and move on — E2E specs are not covered by
+  `npm run build`, so this step is a best-effort syntax check, not a hard gate.
+
+- [ ] Step 4: In `frontend/test/e2e/helpers/stock-operations-test-helpers.ts`, harden the shared
+  `waitForTableUpdate` wait so it fails fast with a clear message instead of the generic 15s timeout
+  whenever the page lands on the error card instead of rows/empty-state — this directly prevents a
+  repeat of the exact failure mode this ticket investigated (56 tests all timing out with the same
+  unhelpful "element not found" error). Replace this exact block:
+  ```typescript
+  export async function waitForTableUpdate(page: Page): Promise<void> {
+    // Wait for either at least one data row or the empty-state message to appear
+    await expect(
+      page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
+    ).toBeVisible({ timeout: 15000 });
+  }
+  ```
+  with:
+  ```typescript
+  export async function waitForTableUpdate(page: Page): Promise<void> {
+    // Wait for a data row, the empty-state message, or the error card to appear. Failing fast
+    // on the error card (instead of only on the generic 15s timeout) gives a clear diagnostic
+    // — "Chyba při načítání operací" almost always means the E2E principal lacks a required
+    // permission (see feat-3540) rather than a genuine UI bug.
+    const success = page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }));
+    const errorHeading = page.locator('h3').filter({ hasText: 'Chyba při načítání operací' });
+    const result = success.or(errorHeading);
+    await expect(result).toBeVisible({ timeout: 15000 });
+
+    if (await errorHeading.isVisible().catch(() => false)) {
+      throw new Error(
+        'Stock Operations page rendered the error card ("Chyba při načítání operací") instead ' +
+        'of data rows or the empty state. This usually means the caller lacks a required ' +
+        'permission (e.g. warehouse.stock_up.read) rather than a genuine data/UI bug.'
+      );
+    }
+  }
+  ```
+
+- [ ] Step 5: Confirm no other spec file relies on `waitForTableUpdate` resolving successfully when
+  the page is in the error state (it shouldn't — the dedicated error-state test in Step 1 asserts
+  on `errorMessage` directly, not via this helper):
+  ```
+  grep -rln "waitForTableUpdate" frontend/test/e2e/stock-operations/
+  ```
+  Read each matching file's usage and confirm none of them intentionally expect an error state at
+  the point they call `waitForTableUpdate` (the error-state test itself, from Step 1, does not call
+  `waitForTableUpdate` at all, so it is unaffected by this change).
+
+- [ ] Step 6: This repo's `npm run lint` script (`eslint src --ext .ts,.tsx`) only covers
+  `frontend/src`, not `frontend/test/e2e`, so it will not pick up these two files — skip it for
+  this task and rely on Step 3's type-check plus manual review of the diff instead.
+
+- [ ] Step 7: Commit with message `fix(e2e): correct StockUpOperations route-intercept casing and use hard assertions in error-state test (feat-3540)`.
+
+---
+
+### task: add-manual-followup-note-for-db-permission-grant
+
+**Files:**
+- Modify: `artifacts/feat-3540/task-plan.r1.md` (this file — no changes needed, informational only)
+- Add: `artifacts/feat-3540/MANUAL-FOLLOWUP.md` (new file)
+
+**Goal:** Surface the one change this pipeline cannot make itself — granting
+`warehouse.stock_up.read` to the E2E test account's permission group in the staging database (spec
+FR-2) — as an explicit, actionable manual follow-up so it isn't silently dropped once the PR merges.
+
+- [ ] Step 1: Create `artifacts/feat-3540/MANUAL-FOLLOWUP.md` with this exact content:
+
+  ```markdown
+  # Manual follow-up required after merge (feat-3540)
+
+  This PR fixes the backend API authorization gap (FR-1: E2E synthetic user now holds
+  `warehouse.stock_up.read`/`write` role claims) and hardens a broken E2E test (FR-3). It does
+  **not** and cannot make one additional required change:
+
+  ## Action required: grant `warehouse.stock_up.read` to the E2E test account in the staging DB
+
+  The frontend route guard (`RequireMenuPath` on `/stock-up-operations`) does not consume the
+  ASP.NET Core role claims this PR adds. It gates on `GET /api/auth/me`'s resolved permission
+  list, which comes from a separate, DB-backed permission resolver
+  (`IPermissionResolver.ResolveAsync`, `backend/src/Anela.Heblo.Persistence/Features/Authorization/PermissionResolver.cs`).
+  That resolver looks up the E2E test `AppUser`'s **DB group memberships** — a mechanism this PR's
+  code change does not touch and a sandboxed development environment cannot reach or modify
+  (per this repo's CLAUDE.md: database migrations/data changes are manual, and secrets/config
+  live in Azure Key Vault, never in Web App environment variables edited directly).
+
+  **Steps for the repo owner to perform manually on staging, after this PR is merged and deployed:**
+
+  1. Sign in to `https://heblo.stg.anela.cz/admin/access` as an administrator.
+  2. Find the E2E test account (`oid` / `entraObjectId` = `e2e-test-object-id`, email
+     `e2e-test@anela-heblo.com`).
+  3. Confirm whether its resolved permissions already include `warehouse.stock_up.read` — either
+     via the `/admin/access` UI's effective-permissions view, or by calling `GET /api/auth/me`
+     while authenticated as that account and inspecting the `permissions` array in the response.
+  4. If `warehouse.stock_up.read` is **not** present, add the E2E test account to an existing
+     access group that grants it, or grant it directly through the `/admin/access` UI — scoped
+     **only** to the E2E/staging test account, not to any production group or user (per spec
+     NFR-2).
+  5. Re-run the nightly E2E suite (or manually run `./scripts/run-playwright-tests.sh
+     stock-operations` against staging) and confirm all 56 previously-failing tests in
+     `frontend/test/e2e/stock-operations/*.spec.ts` now pass.
+
+  This step is independent of and not blocked by the code changes in this PR — it can be done in
+  parallel with code review, but the nightly suite will not go fully green until both this PR's
+  code changes are deployed **and** this DB grant is made.
+  ```
+
+- [ ] Step 2: Verify the file was created and is valid markdown (no unclosed code fences):
+  ```
+  cat artifacts/feat-3540/MANUAL-FOLLOWUP.md
+  ```
+
+- [ ] Step 3: Commit with message `docs(feat-3540): add manual staging DB follow-up note for warehouse.stock_up.read grant`.
+
+  Note for whoever finalizes the PR: surface the contents of
+  `artifacts/feat-3540/MANUAL-FOLLOWUP.md` prominently in the PR description (e.g. under a "Manual
+  follow-up required" heading) so it is not missed — this file living only in `artifacts/` is not
+  itself visible on the PR unless quoted into the PR body.
+
+---
+
+## Scope notes / deliberately omitted work
+
+- **Spec FR-4** (a reflection-based test scanning every `[FeatureAuthorize]`-gated controller
+  action and cross-checking it against `CreateSyntheticUserClaims()`, e.g.
+  `E2ESyntheticClaimsCoverageTests.cs`) is explicitly called out by `arch-review.r1.md` as
+  "recommended, not strictly required by the spec but cheap insurance," and describes a simpler,
+  equivalent alternative: a direct unit test asserting the synthetic claim set contains the two
+  `Warehouse_StockUp` roles. That simpler version is implemented in Task 1
+  (`E2ESessionServiceTests.cs`) as part of the TDD flow for the claims fix itself — it directly
+  prevents a recurrence of this exact bug (a claim silently missing from the hardcoded list) with
+  no additional task needed. The broader reflection-based sweep across *all* controllers is a
+  larger, separate effort (auditing every other feature's read endpoints and building an allowlist
+  for intentionally-unreachable ones) and is left out of this bite-sized plan; if desired, file it
+  as a separate follow-up issue rather than folding it into this fix.
+- **No task modifies `RequireMenuPath.tsx`** (e.g. adding a `console.warn` on permission-denied
+  redirects). Neither `spec.r1.md` nor `arch-review.r1.md` currently define this as a requirement
+  for this ticket — `RequireMenuPath.tsx` was read directly as part of planning this task and
+  confirmed to already exist as a small, side-effect-free component; adding logging there would be
+  a reasonable, low-risk future diagnostic improvement, but it is not needed to satisfy FR-1 or
+  FR-3's acceptance criteria and is left out to keep this change surgical, per this project's
+  "touch only what the task requires" rule.
+- **No task touches the staging database or Azure Key Vault.** Spec FR-2 (confirm/grant
+  `warehouse.stock_up.read` in the DB-backed permission resolver) is a data/configuration change in
+  a live environment that a sandboxed worktree cannot perform; Task 3 above produces the follow-up
+  documentation instead, per this plan's explicit constraint.
+
+## Self-review against spec acceptance criteria
+
+- FR-1 "`CreateSyntheticUserClaims()` returns a claim set including `WarehouseStockUpRead` and
+  `WarehouseStockUpWrite`" → Task 1, Step 3, verified by Task 1 Step 4's passing test.
+- FR-1 "an authenticated call ... to `GET /api/StockUpOperations` returns 200, not 403" → follows
+  directly from the claim grant (ASP.NET Core `[Authorize(Roles=...)]` behavior is not something
+  this repo's unit tests re-verify per-endpoint; `StockUpOperationsControllerAuthorizationTests.cs`
+  already covers the controller side of this contract and is unaffected by this change) —
+  confirmed at the "all 56 tests pass" level once this PR is deployed and Task 3's DB follow-up is
+  done, per FR-2's acceptance criteria.
+- FR-3 "route-interception pattern ... matches the real endpoint casing" → Task 2, Step 1.
+- FR-3 "hard `await expect(errorMessage).toBeVisible()` assertion, ... retry-button assertion
+  unconditional" → Task 2, Step 1 (both are now unconditional `expect(...).toBeVisible()` calls).
+- FR-3 "test fails (not silently passes) if the error UI ... does not appear" → satisfied by the
+  hard assertions in Task 2, Step 1; no `if`/`console.log`-only branch remains.
+- FR-3 "test continues to pass once genuinely exercising the intercepted/aborted request path" →
+  the fixed glob (`**/api/StockUpOperations**`) now matches the real request path regardless of
+  FR-1/FR-2's outcome, so the abort — and therefore the error UI — is deterministic.

--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs
@@ -87,7 +87,12 @@ public class E2ESessionService : IE2ESessionService
             // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
             // FeatureAuthorize checks the role claim (permission strings were renamed away from the
             // old "FinancialOverview.View" form), so a stale "permission" claim no longer matches.
-            new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead)
+            new Claim(ClaimTypes.Role, AccessRoles.FinanceFinancialOverviewRead),
+            // Grant the Warehouse_StockUp read/write roles so E2E tests can reach
+            // /api/StockUpOperations* (list, retry, accept). Without these, FeatureAuthorize
+            // rejects every request with 403 before the controller action runs (feat-3540).
+            new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpRead),
+            new Claim(ClaimTypes.Role, AccessRoles.WarehouseStockUpWrite)
         };
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/E2ESessionServiceTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using System.Security.Claims;
+using Anela.Heblo.API.Infrastructure.Authentication;
+using Anela.Heblo.Domain.Features.Authorization;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Regression coverage for the E2E synthetic user's role claims. A new
+/// [FeatureAuthorize]-gated feature shipping without a matching role claim added to
+/// CreateSyntheticUserClaims() has already caused two incidents: FinancialOverview
+/// (fixed previously) and Warehouse_StockUp (feat-3540, 56 nightly E2E failures).
+/// </summary>
+public class E2ESessionServiceTests
+{
+    private readonly ILogger<E2ESessionService> _logger = NullLogger<E2ESessionService>.Instance;
+
+    [Fact]
+    public void CreateSyntheticUserClaims_IncludesWarehouseStockUpReadAndWriteRoles()
+    {
+        // Arrange
+        var sut = new E2ESessionService(_logger);
+
+        // Act
+        var claims = sut.CreateSyntheticUserClaims("Staging");
+
+        // Assert
+        var roleClaims = claims.Where(c => c.Type == ClaimTypes.Role).Select(c => c.Value);
+        roleClaims.Should().Contain(AccessRoles.WarehouseStockUpRead,
+            "the E2E principal must be able to call GET /api/StockUpOperations, which is " +
+            "gated by [FeatureAuthorize(Feature.Warehouse_StockUp)] (Read)");
+        roleClaims.Should().Contain(AccessRoles.WarehouseStockUpWrite,
+            "the E2E principal must be able to call POST /api/StockUpOperations/{id}/retry " +
+            "and /accept, which are gated at AccessLevel.Write");
+    }
+}

--- a/frontend/test/e2e/helpers/stock-operations-test-helpers.ts
+++ b/frontend/test/e2e/helpers/stock-operations-test-helpers.ts
@@ -20,10 +20,22 @@ const UI_LABELS = {
  * matching layout/filter tables that may be present before the data table loads.
  */
 export async function waitForTableUpdate(page: Page): Promise<void> {
-  // Wait for either at least one data row or the empty-state message to appear
-  await expect(
-    page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
-  ).toBeVisible({ timeout: 15000 });
+  // Wait for a data row, the empty-state message, or the error card to appear. Failing fast
+  // on the error card (instead of only on the generic 15s timeout) gives a clear diagnostic
+  // — "Chyba při načítání operací" almost always means the E2E principal lacks a required
+  // permission (see feat-3540) rather than a genuine UI bug.
+  const success = page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }));
+  const errorHeading = page.locator('h3').filter({ hasText: 'Chyba při načítání operací' });
+  const result = success.or(errorHeading);
+  await expect(result).toBeVisible({ timeout: 15000 });
+
+  if (await errorHeading.isVisible().catch(() => false)) {
+    throw new Error(
+      'Stock Operations page rendered the error card ("Chyba při načítání operací") instead ' +
+      'of data rows or the empty state. This usually means the caller lacks a required ' +
+      'permission (e.g. warehouse.stock_up.read) rather than a genuine data/UI bug.'
+    );
+  }
 }
 
 /**

--- a/frontend/test/e2e/stock-operations/navigation.spec.ts
+++ b/frontend/test/e2e/stock-operations/navigation.spec.ts
@@ -86,30 +86,28 @@ test.describe('Stock Operations - Navigation & Initial Load', () => {
     // Set up auth first
     await navigateToApp(page);
 
-    // Intercept API calls and force failure
-    await page.route('**/api/stock-up-operations**', route => {
+    // Intercept API calls and force failure.
+    // The generated client builds this.baseUrl + "/api/StockUpOperations?" (PascalCase, no
+    // dashes — see frontend/src/api/generated/api-client.ts:12051), so the glob must match
+    // that literal casing or the route never intercepts and the real request goes through.
+    await page.route('**/api/StockUpOperations**', route => {
       route.abort('failed');
     });
 
     // Navigate to stock operations page (will trigger failed API call)
     const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
     await page.goto(`${baseUrl}/stock-up-operations`);
-    await page.waitForTimeout(3000);
 
-    // Check for error message
+    // Check for error message — hard assertion, so the test fails (not silently passes)
+    // if the intercepted/aborted request doesn't produce the error UI.
     const errorMessage = page.locator('text="Chyba při načítání operací"');
-    const isErrorVisible = await errorMessage.isVisible();
+    await expect(errorMessage).toBeVisible({ timeout: 15000 });
+    console.log('   ✅ Error state displayed');
 
-    if (isErrorVisible) {
-      console.log('   ✅ Error state displayed');
-
-      // Verify retry button exists
-      const retryButton = page.getByRole('button', { name: /Zkusit znovu/i });
-      await expect(retryButton).toBeVisible();
-      console.log('   ✅ Retry button present');
-    } else {
-      console.log('   ℹ️ Error state not triggered (possible caching)');
-    }
+    // Verify retry button exists
+    const retryButton = page.getByRole('button', { name: /Zkusit znovu/i });
+    await expect(retryButton).toBeVisible();
+    console.log('   ✅ Retry button present');
 
     console.log('✅ Error state test completed');
   });


### PR DESCRIPTION
Closes #3540

## What the issue was

56 nightly E2E tests in the `stock-operations` module failed because the Stock Operations list page never rendered rows or the empty-state header — every test in the module timed out waiting for `tbody tr` or the "Žádné výsledky" heading. One test ("should display error state on API failure") appeared to pass, which turned out to be a false positive.

## How it was fixed / handled

Root cause (confirmed independently by both the analyst and architect phases via direct code inspection): the E2E synthetic test identity was missing the `warehouse.stock_up.read`/`warehouse.stock_up.write` role claims that `[FeatureAuthorize(Feature.Warehouse_StockUp)]` requires on `StockUpOperationsController`. Every `/api/StockUpOperations*` call from the E2E principal was rejected with 403 before the controller action ran, which in turn made the frontend's `RequireMenuPath` route guard silently redirect away from `/stock-up-operations` before the page ever mounted — so neither the data table nor the empty state ever appeared. A code comment on an existing (different) role grant shows this exact bug class — a new `[FeatureAuthorize]`-gated feature shipping without a matching E2E claim — had already happened once before, for a sibling feature.

Changes:
1. **`E2ESessionService.cs`** — added the two missing role claims to `CreateSyntheticUserClaims()`, plus a new regression test (`E2ESessionServiceTests.cs`) asserting they're present.
2. **`navigation.spec.ts` + `stock-operations-test-helpers.ts`** — fixed the masking bug: the "error state" test's route-intercept glob was case-mismatched (`stock-up-operations` vs the real `/api/StockUpOperations`) and never actually fired, and its assertion was a soft `if/else` that passed unconditionally. Replaced with a correctly-cased glob and hard assertions. Also hardened the shared `waitForTableUpdate` helper to fail fast with a diagnostic message (pointing at the likely missing permission) instead of a generic 15s timeout whenever the page lands on the error card.
3. **`MANUAL-FOLLOWUP.md`** (docs) — see "Manual follow-up required" below; one required change (a staging DB permission grant) can't be made from this pipeline.

All backend tests, `dotnet build`, `dotnet format --verify-no-changes`, `npm run build`, and `npm run lint` pass. The Playwright E2E suite itself was not run (targets staging, nightly-only per project convention).

## Manual follow-up required (please read before/after merging)

The frontend route guard (`RequireMenuPath`) gates on a **separate**, DB-backed permission resolver (`GetMeHandler` / `IPermissionResolver`), not the ASP.NET Core role claims this PR fixes. This PR's code change alone will **not** be sufficient to turn the E2E suite green — the E2E test account's DB-resolved permissions also need `warehouse.stock_up.read`, which must be granted manually on staging:

1. Sign in to `https://heblo.stg.anela.cz/admin/access` as an administrator.
2. Find the E2E test account (`oid`/`entraObjectId` = `e2e-test-object-id`, email `e2e-test@anela-heblo.com`).
3. Confirm via the `/admin/access` UI or `GET /api/auth/me` whether `warehouse.stock_up.read` is already in its resolved `permissions`.
4. If missing, grant it — scoped only to the E2E/staging test account, not any production group.
5. Re-run the nightly suite (or `./scripts/run-playwright-tests.sh stock-operations` against staging) to confirm all 56 previously-failing tests now pass.

Full details in `artifacts/feat-3540/MANUAL-FOLLOWUP.md` on this branch.

## Artifacts

Brief, spec, architecture review, design note, task plan, per-task implementation summaries, and reviews are all committed under `artifacts/feat-3540/` on this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9A8rXiLeUqH8XNG7oP3sN)_