### PR TITLE
#3543: fix batch-planning error-handling E2E navigation selectors

### DIFF
--- a/artifacts/feat-3543/arch-review.r1.md
+++ b/artifacts/feat-3543/arch-review.r1.md
@@ -1,0 +1,158 @@
+# Architecture Review: Fix Batch-Planning Error-Handling E2E Tests
+
+## Skip Design: true
+This is a test-only defect with zero application/product code impact. No new or changed UI
+components, screens, layouts, or visual decisions are involved. The fix realigns navigation,
+heading assertion, and load-wait strategy inside one Playwright spec file so it reliably
+reaches the existing `/manufacturing/batch-planning` page. No design work is required.
+
+## Architectural Fit Assessment
+
+The proposed fix aligns cleanly with the existing E2E conventions and I verified every load-bearing
+claim in the spec against the actual codebase:
+
+- **Sidebar labels/routes** (`frontend/src/components/Layout/Sidebar.tsx`): the "Výroba" section contains
+  `id: "kalkulator-davek"` / name **"Kalkulačka dávek"** → `/manufacturing/batch-calculator` (lines 233-236),
+  listed **before** `id: "planovani-davek"` / name **"Plánování dávek"** → `/manufacturing/batch-planning`
+  (lines 239-242). Confirmed.
+- **Routing** (`frontend/src/App.tsx` lines 420-421): both routes exist and are guarded (`guard(...)`);
+  `BatchPlanningCalculator` is the planning page component, `ManufactureBatchCalculator` the calculator.
+- **Headings**: planning page `<h1>` = **"Plánovač výrobních dávek"** (`ManufactureBatchPlanning.tsx:505-506`);
+  calculator page `<h1>` = **"Kalkulačka dávek pro výrobu"** (`ManufactureBatchCalculator.tsx:247`).
+- **The defect is real**: the failing selector `text=/Plánovač|Kalkulačka dávek/i` cannot match the real
+  link text "Plánování dávek" (the alternatives are `Plánovač` — suffix *-ovač* not *-ování* — and the
+  literal `Kalkulačka dávek`). The only sidebar item it matches is "Kalkulačka dávek", which routes to the
+  wrong page. The loose heading regex `/Plánovač|Planning|Dávek|Kalkulačka/i` then fails to catch the
+  wrong-page landing (it would even accept "Kalkulačka…").
+- **The reference is proven**: the passing `batch-planning-workflow.spec.ts` navigates via
+  `getByRole('link', { name: /plánovač výrobních dávek|plánování dávek/i })`, asserts the exact `<h1>`, and
+  waits on `domcontentloaded`. It uses the same `TestCatalogItems.hedvabnyPan` (MAS001001M) fixture, proving
+  the data exists on staging.
+- **Fixture** (`frontend/test/e2e/fixtures/test-data.ts:70-73`): `hedvabnyPan = { code: 'MAS001001M',
+  name: 'Hedvábný pan Jasmín', type: 'Polotovar' }`. Confirmed.
+- **Module placement** (`docs/testing/e2e-module-guide.md`): `batch-planning-error-handling.spec.ts` already
+  lives in the `manufacturing/` module and is registered there (line 118). No relocation needed.
+
+The fix is a "copy the proven sibling" change — the safest possible class of E2E fix. There is no
+architectural tension; it *reduces* drift between the two manufacturing specs.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+navigateToApp(page)  ──►  Entra auth + frontend session  (helpers/e2e-auth-helper.ts)
+        │
+        ▼
+Sidebar "Výroba" button ──click──► "Plánování dávek" link ──► /manufacturing/batch-planning
+        │                                                              │
+        │  (BROKEN today: text=/Plánovač|Kalkulačka dávek/i            ▼
+        │   matches "Kalkulačka dávek" → /manufacturing/batch-      BatchPlanningCalculator
+        │   calculator, the WRONG page)                             <h1>Plánovač výrobních dávek</h1>
+        ▼                                                           [role=combobox] (CatalogAutocomplete)
+   heading assertion  ──►  h1 filter /plánovač výrobních dávek/i    <table> product rows
+        │                  (must be exact, fail loudly)             "Přepočítat" button
+        ▼
+   combobox → select MAS001001M → product table → check fixed → set qty → Přepočítat → assert
+```
+
+The only components that change are the two `test(...)` blocks and the `beforeEach` inside
+`frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts`.
+
+### Key Design Decisions
+
+#### Decision 1: Mirror the passing workflow spec's navigation, not invent a new one
+**Options considered:**
+(a) Fix only the regex in the existing `text=` selector; (b) Replace navigation with the role-based
+approach used by the passing `batch-planning-workflow.spec.ts`; (c) Navigate exclusively via
+`page.goto('/manufacturing/batch-planning')`.
+**Chosen approach:** (b) — `getByRole('button', { name: 'Výroba' }).click()` then
+`getByRole('link', { name: /plánování dávek/i }).click()` (optionally also `/plánovač výrobních dávek/i`
+for parity). Keep a `goto('/manufacturing/batch-planning')` only as a genuine fallback when the link is
+absent.
+**Rationale:** Option (b) is already proven on staging by the sibling spec and exercises the real user
+navigation path (which the error-handling test's *intent* is to cover). Role + accessible-name is resilient
+to unrelated text changes (NFR-3). Option (a) leaves a fragile broad `text=` regex that can cross-match the
+sibling page again; option (c) would silently stop testing the sidebar, weakening coverage.
+
+#### Decision 2: Tighten the heading assertion to the exact page title
+**Options considered:** Keep the permissive `h1, h2` + `/Plánovač|Planning|Dávek|Kalkulačka/i`;
+or use `page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })`.
+**Chosen approach:** The exact `h1` filter, identical to the workflow spec.
+**Rationale:** The loose regex is precisely what masked this bug — it would pass on the calculator page.
+An exact assertion turns a wrong-page regression into an immediate, legible failure at the navigation step
+rather than a confusing downstream combobox/timeout failure.
+
+#### Decision 3: Replace `networkidle` with `domcontentloaded`
+**Options considered:** Keep `waitForLoadState('networkidle')`; switch to `'domcontentloaded'`.
+**Chosen approach:** `'domcontentloaded'` in `beforeEach` and post-navigation, matching the workflow spec.
+**Rationale:** Staging emits background telemetry/polling that keeps the network busy, making `networkidle`
+flaky and slow. The proven spec uses `domcontentloaded` + explicit element visibility waits, which is the
+correct gating mechanism. Visibility assertions (`toBeVisible({ timeout })`) already provide the real
+synchronization.
+
+#### Decision 4: Treat FR-6 (shared nav helper) as optional and deferred
+**Chosen approach:** Do not block the fix on extracting a `navigateToBatchPlanning(page)` helper.
+**Rationale:** The spec marks it optional. The existing `helpers/` directory (e.g. `e2e-auth-helper.ts`,
+`wait-helpers.ts`) is the correct home *if* it is done, but introducing shared state across two specs is a
+larger change than this bug warrants. Recommend deferring; if implemented, it must be adopted by both
+error-handling tests and leave the workflow spec's behavior unchanged.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+- **Only file to change:** `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts`.
+- No new files required. Do **not** create a helper unless FR-6 is explicitly adopted; if so, it belongs at
+  `frontend/test/e2e/helpers/` and must be imported with the `../` prefix (per module guide §"Use Correct
+  Import Paths").
+- Do **not** touch: `ManufactureBatchPlanning.tsx`, `ManufactureBatchCalculator.tsx`, `Sidebar.tsx`,
+  `App.tsx`, `CatalogAutocomplete.tsx`, `test-data.ts`, `playwright.config.ts`, or the passing
+  `batch-planning-workflow.spec.ts`.
+
+### Interfaces and Contracts
+The spec must conform to these existing, verified landmarks (all confirmed present):
+- Navigation: section button accessible name `'Výroba'`; link accessible name matching `/plánování dávek/i`.
+- Page identity: `page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })`.
+- Product selection: `[role="combobox"]` (rendered by `CatalogAutocomplete` via react-select), then
+  `[role="option"]` results, then `tbody tr` rows > 0.
+- Recalculation trigger: `button` with text `/Přepočítat|Calculate|Vypočítat/i`.
+- Auth: continue via `navigateToApp(page)` (CLAUDE.md rule — never `createE2EAuthSession()` alone).
+- Fixture: `TestCatalogItems.hedvabnyPan` (MAS001001M). Keep the existing `throw` (not `test.skip`) when no
+  options appear, per the project's "throw on missing fixture data" rule.
+
+### Data Flow
+For both tests the corrected flow is: `navigateToApp` (auth + session) → click "Výroba" → click
+"Plánování dávek" link → `waitForLoadState('domcontentloaded')` → assert exact `<h1>` → open combobox →
+type "Hedvábný pan Jasmín" → select first `[role="option"]` → product `<table>` + `tbody tr` populate →
+check fixed checkbox(es) → set quantity (`9999` over-volume for test 1; `10` reasonable for test 2) →
+click "Přepočítat" → assert (test 1: table/rows remain visible, toaster checks stay logged-only; test 2:
+zero error toasters via `.toast, .Toastify__toast, [role="alert"]` filtered by error text). Behavioral
+assertions are preserved exactly (FR-5); only navigation, page-load gating, and wait strategy change.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| The two staging manufacturing menu items are permission-gated (`RequireMenuPath`); if the E2E principal lacks the planning menu path, the link won't render and the test still fails. | Medium | The passing workflow spec navigates to the same route with the same auth, proving the link renders for the E2E user. If it regresses, the exact-heading assertion fails loudly at the navigation step, making diagnosis immediate. |
+| Retaining a `goto('/manufacturing/batch-planning')` fallback could again mask a broken link click. | Low | Only invoke the fallback when the link is genuinely absent (link `isVisible` false), never as a catch for having clicked the wrong link (FR-1 acceptance criteria). |
+| Test 2 (line 248) currently lacks a heading guard before touching the combobox. | Low | Add the same exact-`h1` visibility assertion after navigation in test 2 so a wrong page fails before the combobox step (FR-2). |
+| Removing `networkidle` could race the combobox on slow staging. | Low | Rely on `toBeVisible({ timeout: 10000 })` element waits already present; keep the modest `waitForTimeout` React-init pauses the workflow spec uses. |
+| Both manufacturing pages expose `[role="combobox"]`; a future wrong-page navigation would still find *a* combobox. | Low | The exact-heading assertion (Decision 2) gates the page before any combobox interaction, so a wrong page cannot reach the combobox step. |
+
+## Specification Amendments
+None required — the spec is accurate and complete. Two clarifications for the implementer:
+1. **FR-2 for test 2:** make explicit that the exact-`h1` guard is *added* to the correction test (line 248),
+   which today has no page-loaded assertion before the combobox. The spec mentions this ("should add/keep an
+   equivalent page-loaded guard") — treat it as required, not optional.
+2. **FR-1 navigation regex:** prefer `/plánování dávek/i` as the primary link matcher (it matches the real
+   label). Including `/plánovač výrobních dávek/i` as an alternative is harmless parity with the workflow
+   spec but is not strictly needed, since that string is the page `<h1>`, not the sidebar link text.
+
+## Prerequisites
+None beyond the existing E2E environment. Specifically:
+- Staging (`https://heblo.stg.anela.cz`) reachable with valid E2E auth (`E2E_CLIENT_ID` / `E2E_CLIENT_SECRET`
+  / `AZURE_TENANT_ID`) and the `MAS001001M` semiproduct present with configured products — all already
+  satisfied (proven by the passing workflow spec).
+- No migrations, config, feature flags, or infrastructure changes.
+- Validation per CLAUDE.md: `npm run lint` (frontend) plus the E2E run
+  `./scripts/run-playwright-tests.sh manufacturing` against staging; both error-handling tests must pass and
+  the sibling workflow spec must remain green.

--- a/artifacts/feat-3543/brief.md
+++ b/artifacts/feat-3543/brief.md
@@ -1,0 +1,31 @@
+## Summary
+
+In the nightly E2E regression run **[#191](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966)** (branch `main`, commit `738a99c`), **2 tests in `manufacturing/batch-planning-error-handling.spec.ts` failed** because the batch planning calculator / modal never renders.
+
+## Root cause signature
+
+```
+Error: expect(locator).toBeVisible() failed / element(s) not found
+  - waiting for locator('h1, h2').filter({ hasText: /Plánovač|Planning|Dávek|Kalkulačka/i }).first()
+  - waiting for locator('[role="combobox"]').first()
+```
+
+The planning heading and the product/combobox control never appear, so the "fixed products exceed volume" error-handling flow can't be exercised.
+
+## Failing tests
+
+- `batch-planning-error-handling.spec.ts:25` — should handle fixed products exceed volume with toaster and visual indicators
+- `batch-planning-error-handling.spec.ts:248` — should allow user to correct fixed quantities and recalculate successfully
+
+Note: the broader `manufacturing/batch-planning-workflow.spec.ts` and other manufacturing specs passed, so this is scoped to the error-handling entry point rather than the whole batch-planning feature.
+
+## Environment
+
+- Workflow: 🎭 E2E Nightly Regression Tests, run #191
+- Target: `https://heblo.stg.anela.cz` (staging)
+- Screenshots/video artifacts: `e2e-failure-screenshots-all-191`, `e2e-test-results-all-191` on the [run page](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966).
+
+## Suggested first steps
+
+1. Reproduce the batch-planning error-handling scenario on staging and confirm the planner modal (heading + combobox) opens.
+2. Compare the setup against the passing `batch-planning-workflow.spec.ts` to see why this entry point doesn't reach the calculator.

--- a/artifacts/feat-3543/code-review.r1.md
+++ b/artifacts/feat-3543/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts:37` and `:260` — the navigation link locator and page-load verification logic (click "Výroba" → resolve link by role/name → fall back to `page.goto`, then wait + assert `h1`) is now duplicated verbatim between the two tests (and largely duplicated again in `batch-planning-workflow.spec.ts:32-47`). Per spec FR-6 this was flagged as optional hardening; extracting a shared `navigateToBatchPlanning(page)` helper under `frontend/test/e2e/helpers/` would remove the triplication, though the spec explicitly allows deferring this.

--- a/artifacts/feat-3543/design.r1.md
+++ b/artifacts/feat-3543/design.r1.md
@@ -1,0 +1,44 @@
+# Design: Fix Batch-Planning Error-Handling E2E Tests
+
+## Component Design
+
+No application or UI components change. The only artifact modified is the test file
+`frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts` (both `test(...)` blocks
+and the shared `beforeEach`). No new files are required unless FR-6 (optional, deferred) is
+adopted, in which case a helper `navigateToBatchPlanning(page)` would live under
+`frontend/test/e2e/helpers/`.
+
+Changes to make in the spec file, mirroring the proven, passing sibling
+`frontend/test/e2e/manufacturing/batch-planning-workflow.spec.ts`:
+
+- **Navigation selector**: replace the broad/incorrect
+  `page.locator('text=/Plánovač|Kalkulačka dávek/i').first()` with role-based, accessible-name
+  matching: `page.getByRole('button', { name: 'Výroba' }).click()` then
+  `page.getByRole('link', { name: /plánování dávek/i }).click()`. Keep a
+  `page.goto('/manufacturing/batch-planning')` fallback only for the case where the link is
+  genuinely absent — never as a silent recovery from having clicked the wrong link.
+- **Heading assertion**: replace the permissive `page.locator('h1, h2').filter({ hasText:
+  /Plánovač|Planning|Dávek|Kalkulačka/i })` with the exact
+  `page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })`, applied after navigation
+  in **both** tests (test 2, currently missing this guard entirely, gets it added per FR-2/arch
+  review clarification 1).
+- **Load-wait strategy**: replace `page.waitForLoadState('networkidle')` with
+  `page.waitForLoadState('domcontentloaded')` in `beforeEach` and after navigation, matching the
+  workflow spec; rely on existing `toBeVisible({ timeout })` element waits for synchronization.
+- **Combobox / table / recalculation interactions, fixture usage
+  (`TestCatalogItems.hedvabnyPan` / `MAS001001M`), and the "missing test data" `throw` guard are
+  unchanged** — these already work once the correct page loads.
+- **Assertions preserved (FR-5)**: test 1 (fixed products exceed volume) still checks fixed
+  checkboxes, sets `9999`, clicks "Přepočítat", and asserts table/rows remain visible; test 2
+  (correct fixed quantities) still sets `10`, recalculates, and asserts no error toaster appears.
+  No assertions are weakened — only navigation, page-load gating, and wait strategy change.
+
+Explicitly out of scope / untouched: `ManufactureBatchPlanning.tsx`,
+`ManufactureBatchCalculator.tsx`, `Sidebar.tsx`, `App.tsx`, `CatalogAutocomplete.tsx`,
+`test-data.ts`, `playwright.config.ts`, and `batch-planning-workflow.spec.ts`.
+
+## Data Schemas
+
+Not applicable — no database, API, or event-payload changes. No new or modified data schemas;
+the existing `TestCatalogItems.hedvabnyPan` fixture (`code: 'MAS001001M'`,
+`name: 'Hedvábný pan Jasmín'`, `type: 'Polotovar'`) is reused unchanged.

--- a/artifacts/feat-3543/impl/fix-batch-planning-error-handling-e2e-navigation.r1.md
+++ b/artifacts/feat-3543/impl/fix-batch-planning-error-handling-e2e-navigation.r1.md
@@ -1,0 +1,78 @@
+# Implementation: fix-batch-planning-error-handling-e2e-navigation
+
+## What was implemented
+Fixed `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts` so both tests reliably
+navigate to and load `/manufacturing/batch-planning` (component `BatchPlanningCalculator`) instead of
+silently landing on `/manufacturing/batch-calculator`. Applied the three edits described in the task
+context, copied from the proven-working sibling `batch-planning-workflow.spec.ts`:
+
+1. **Navigation selector (FR-1)** — replaced `page.locator('text=/Plánovač|Kalkulačka dávek/i').first()`
+   with the role-based `page.getByRole('link', { name: /plánování dávek/i })` in both tests' navigation
+   blocks. This matcher does not match "Kalkulačka dávek" (which routes to the wrong page), so it can no
+   longer silently mis-navigate. The existing `isVisible` → click / `page.goto` fallback structure was
+   kept as-is (fallback only fires when the link is genuinely absent).
+2. **Heading assertion (FR-2)** — replaced the permissive
+   `page.locator('h1, h2').filter({ hasText: /Plánovač|Planning|Dávek|Kalkulačka/i })` with the exact
+   `page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })` in test 1, and **added** the
+   same exact-heading assertion to test 2 (which previously had no page-loaded guard at all before
+   touching the combobox).
+3. **Load-wait strategy (FR-4)** — replaced every `page.waitForLoadState('networkidle')` in the file
+   (in `beforeEach` and after each navigation/action) with `page.waitForLoadState('domcontentloaded')`,
+   matching the workflow spec. All 7 occurrences in the file were changed.
+
+Everything else was left untouched: the combobox interaction, the `TestCatalogItems.hedvabnyPan` /
+`MAS001001M` fixture usage, the "missing test data" `throw` guards, the checkbox/quantity/`Přepočítat`
+button flow in test 1, the `10`/no-error-toaster flow in test 2, and `navigateToApp(page)` for auth.
+No other files were modified.
+
+## Files created/modified
+- `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts` — navigation selector,
+  heading assertion (added to both tests), and wait-strategy changes as described above.
+
+## Tests
+- **Lint**: `npm run lint` (from `frontend/`) was run — it only lints the `src` directory
+  (`eslint src --ext .ts,.tsx` per `package.json`), so this E2E spec file is outside its scope and the
+  command's outcome is unaffected by this change (its 148 pre-existing errors/warnings are all in
+  unrelated `src/**/__tests__` files, not touched here).
+- Ran `node_modules/.bin/eslint` directly against the modified file (installed local ESLint 8.57.1,
+  since `npx eslint` was resolving an incompatible v10 with no flat config). It reports 4
+  `testing-library/prefer-screen-queries` errors, all false positives from the `react-app/jest` ESLint
+  preset misfiring on Playwright's `page.getByRole(...)` calls. Confirmed this is a pre-existing,
+  file-wide false-positive pattern by running the same direct lint against the untouched reference
+  sibling `batch-planning-workflow.spec.ts`, which reports 28 similar/related pre-existing errors
+  (including on its own `page.getByRole` navigation lines that this task explicitly told us to copy
+  verbatim). No new class of lint issue was introduced.
+- Ran a standalone `tsc --noEmit` type-check against the file: one pre-existing error at line 231
+  (`hasClass` is not a valid Playwright locator filter option) — present before this change, on a line
+  this task did not touch (visual-indicator check, explicitly marked non-critical/logged-only in the
+  task context). No new type errors were introduced by the edits.
+- Manually diffed the file against the task context's required changes line-by-line; confirmed no
+  remaining `networkidle` occurrences (`grep -n networkidle` → no matches) and that both tests now have
+  the exact `<h1>` heading guard.
+- **Not performed**: a live Playwright run against staging (`./scripts/run-playwright-tests.sh
+  manufacturing`) — no network access to `https://heblo.stg.anela.cz` in this sandboxed environment.
+  This is deferred to the pipeline's verification step, per the task instructions.
+
+## How to verify
+1. `cd frontend && npm run lint` — confirm no new failures attributable to this file (it's out of that
+   script's `src`-only scope).
+2. `cd frontend && ./scripts/run-playwright-tests.sh manufacturing` (or the repo's standard E2E runner)
+   against staging — confirm both tests in `batch-planning-error-handling.spec.ts` pass, and that
+   `batch-planning-workflow.spec.ts` remains green (no regression).
+3. Spot-check: after navigation in either test, `page.url()` ends with `/manufacturing/batch-planning`,
+   the `<h1>` "Plánovač výrobních dávek" is visible, and selecting `MAS001001M` populates `tbody tr` rows.
+
+## Notes
+- Deviation from a literal reading of task step 5: `npm run lint` as configured in this repo does not
+  include `frontend/test/**` at all, so it cannot "fail" or "pass" specifically for this file — it was
+  still run per instruction, and the file was additionally lint-checked directly with the project's
+  local ESLint binary for a more meaningful signal, per the instruction's fix-lint-issues intent.
+- Kept the optional `page.goto('/manufacturing/batch-planning')` fallback structure exactly as it was
+  (only fires when the link is not visible), matching task guidance that this is acceptable and that
+  extracting a shared nav helper (FR-6) is explicitly deferred/out of scope.
+- No dependency, config, or non-spec source files were changed. `npm install --legacy-peer-deps` was
+  run locally in this worktree only to obtain a working ESLint/TypeScript toolchain for verification;
+  no lockfile or `package.json` changes were made or committed.
+
+## Status
+DONE

--- a/artifacts/feat-3543/review/fix-batch-planning-error-handling-e2e-navigation.r1.md
+++ b/artifacts/feat-3543/review/fix-batch-planning-error-handling-e2e-navigation.r1.md
@@ -1,0 +1,56 @@
+# Code Review: Batch Planning Error Handling E2E Navigation Fix
+
+## Summary
+The implementation correctly addresses all five functional requirements from the specification. Navigation selectors have been replaced with role-based locators that target the correct sidebar link ("Plánování dávek"), heading assertions have been made exact and applied to both tests, and all load-wait strategies have been updated from `networkidle` to `domcontentloaded`. All behavioral assertions and fixture usage are preserved. The fix copies proven patterns from the reference `batch-planning-workflow.spec.ts` as instructed.
+
+## Review Result: PASS
+
+### task: fix-batch-planning-error-handling-e2e-navigation
+**Status:** PASS
+
+## Detailed Findings
+
+**FR-1 (Navigation selector)** — Correct in both tests:
+- Test 1 (line 33 diff): Changed from `text=/Plánovač|Kalkulačka dávek/i` to `getByRole('link', { name: /plánování dávek/i })`
+- Test 2 (line 77 diff): Same selector change applied
+- Critical improvement: The old regex never matched "Plánování dávek" (note spelling difference from "Plánovač"), but did match "Kalkulačka dávek" (wrong page). New selector matches only the correct link and explicitly does not match the calculator link.
+
+**FR-2 (Heading assertion)** — Correctly applied to both tests:
+- Test 1 (line 50 diff): Replaced permissive `h1, h2` filter with exact-match `h1` filter on `/plánovač výrobních dávek/i`
+- Test 2 (lines 89–93 diff): Added the missing page-load guard that was entirely absent before this change. Added exactly where required: after `waitForLoadState` and timeout, before combobox interaction.
+- Verification: New assertion correctly rejects "Kalkulačka dávek" pages, so wrong-page navigation fails loudly at this assertion rather than silently continuing to a wrong-combobox timeout.
+
+**FR-4 (Load-wait strategy)** — All occurrences replaced:
+- Diff shows 7 replacements of `networkidle` → `domcontentloaded`:
+  - `beforeEach` (line 23)
+  - Test 1: After navigation (line 41), after combobox selection (line 58), after recalculate button (line 67)
+  - Test 2: Before navigation (line 85), after combobox selection (line 102), after recalculate (line 111)
+- Matches the staging telemetry pattern described in the spec.
+
+**FR-3/FR-5 (Preserve all behavior)** — Verified:
+- Combobox interaction code for product selection unchanged
+- `TestCatalogItems.hedvabnyPan` / `MAS001001M` fixture usage preserved
+- Missing-data `throw` guards unchanged
+- Test 1 checkbox/quantity/`Přepočítat` button flow preserved
+- Test 2 no-error-toaster assertion preserved
+- `navigateToApp(page)` authentication preserved (correct per CLAUDE.md rule)
+
+**FR-6 (No helper extraction)** — Compliant:
+- No new utility functions or shared navigation helpers extracted
+- Explicit fallback to `page.goto('/manufacturing/batch-planning')` kept, which is acceptable per spec guidance
+
+**Testing & Verification:**
+- Implementation correctly notes that E2E test files fall outside `npm run lint`'s `src/**` scope; the standard lint command is unaffected.
+- Direct ESLint check reports 4 `testing-library/prefer-screen-queries` false positives; implementation confirmed these also appear in the reference file `batch-planning-workflow.spec.ts` (which the task explicitly instructs us to copy patterns from). Not a regression.
+- Pre-existing TypeScript error at line 231 (`hasClass` not valid) confirmed unrelated to this change and on a visual-indicator check marked non-critical in the spec.
+- Live E2E run against staging correctly deferred to the pipeline verification step as acknowledged in the task instructions.
+
+## Overall Notes
+The implementation demonstrates careful adherence to the specification:
+- Patterns copied from the proven reference file are applied correctly
+- The critical selector fix (from text-based to role-based) eliminates the silent mis-navigation root cause
+- The heading assertion addition to test 2 closes the safety gap where wrong-page navigation could go undetected
+- All 7 wait-strategy changes are accounted for and correct
+- No over-reaching changes; scope is surgical and matches the spec exactly
+
+All acceptance criteria are satisfied. Ready for pipeline E2E verification against staging.

--- a/artifacts/feat-3543/spec.r1.md
+++ b/artifacts/feat-3543/spec.r1.md
@@ -1,0 +1,135 @@
+# Specification: Fix Batch-Planning Error-Handling E2E Tests (Calculator/Modal Never Renders)
+
+## Summary
+Two E2E tests in `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts` fail on staging because the batch-planning page (heading + product combobox) never renders for them, while the sibling `batch-planning-workflow.spec.ts` passes. Root cause is a **test-side navigation/selector defect**: the error-handling tests locate the sidebar entry with `text=/Plánovač|Kalkulačka dávek/i`, which does not match the real batch-planning link "Plánování dávek" and instead only matches "Kalkulačka dávek" — a *different* feature that routes to `/manufacturing/batch-calculator`. The fix is to align the error-handling tests' navigation, heading, and load-wait strategy with the proven, passing workflow test so they reliably reach `/manufacturing/batch-planning`.
+
+## Background
+
+The manufacturing module exposes two visually similar but distinct pages, wired in `frontend/src/App.tsx`:
+
+- `/manufacturing/batch-calculator` → `ManufactureBatchCalculator` (component `frontend/src/components/pages/ManufactureBatchCalculator.tsx`, `<h1>` = "Kalkulačka dávek pro výrobu"). Sidebar label: **"Kalkulačka dávek"** (`Sidebar.tsx`, id `kalkulator-davek`).
+- `/manufacturing/batch-planning` → `BatchPlanningCalculator` (component `frontend/src/components/pages/ManufactureBatchPlanning.tsx`, `<h1>` = "Plánovač výrobních dávek"). Sidebar label: **"Plánování dávek"** (`Sidebar.tsx`, id `planovani-davek`). This is the page under test — it renders the semiproduct/product `react-select` combobox, the product table, fixed-quantity checkboxes, and the "Přepočítat" recalculation used by the error-handling scenario.
+
+In the sidebar's "Výroba" section, "Kalkulačka dávek" appears **before** "Plánování dávek" in DOM order.
+
+The **passing** `batch-planning-workflow.spec.ts` navigates correctly:
+```ts
+await page.getByRole('button', { name: 'Výroba' }).click();
+await page.getByRole('link', { name: /plánovač výrobních dávek|plánování dávek/i }).click();
+// heading assertion:
+page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i });
+```
+It also waits with `waitForLoadState('domcontentloaded')`.
+
+The **failing** `batch-planning-error-handling.spec.ts` navigates incorrectly:
+```ts
+await page.getByRole('button', { name: 'Výroba' }).click();
+const batchPlanningLink = page.locator('text=/Plánovač|Kalkulačka dávek/i').first();
+if (await batchPlanningLink.isVisible({ timeout: 5000 })) {
+  await batchPlanningLink.click();
+} else {
+  await page.goto('/manufacturing/batch-planning');
+}
+// heading assertion (too permissive):
+page.locator('h1, h2').filter({ hasText: /Plánovač|Planning|Dávek|Kalkulačka/i });
+```
+It waits with `waitForLoadState('networkidle')`.
+
+### Why it fails
+1. The regex alternatives are `Plánovač` and `Kalkulačka dávek`. The real link text is **"Plánování dávek"** — it contains neither `Plánovač` (note the different suffix: *-ování* vs *-ovač*) nor `Kalkulačka dávek`. So the intended link is **never matched**.
+2. The only sidebar item that *does* match is **"Kalkulačka dávek"**, which navigates to the wrong route `/manufacturing/batch-calculator`. That page has no product table / fixed-quantity flow the error-handling test needs, so the test cannot reach the calculator/modal state it asserts on. Depending on staging menu visibility, the click may also land the app somewhere with no matching heading at all (the `.first()` fallback `page.goto('/manufacturing/batch-planning')` only runs when the wrong link is *not* visible — an inconsistent, fragile branch).
+3. The heading assertion `/Plánovač|Planning|Dávek|Kalkulačka/i` is too loose: it would also pass on the calculator page ("Kalkulačka…"), masking the wrong-page navigation and making the failure harder to diagnose.
+4. `waitForLoadState('networkidle')` is flaky on staging (telemetry / polling requests keep the network active); the passing test uses `domcontentloaded`.
+
+Both `react-select` comboboxes (calculator and planning pages) expose `role="combobox"` via `CatalogAutocomplete` (`frontend/src/components/common/CatalogAutocomplete.tsx`), so `[role="combobox"]` is a valid selector *once the correct page is loaded*. The Playwright `baseURL` is `https://heblo.stg.anela.cz` (`frontend/playwright.config.ts`), so `page.goto('/manufacturing/batch-planning')` resolves correctly. Test data (`MAS001001M` / "Hedvábný pan Jasmín", `TestCatalogItems.hedvabnyPan`) is confirmed to exist on staging because the workflow test uses it successfully.
+
+This is a **test-only bug**: the product feature works (proven by the passing workflow test). No application/product code change is required.
+
+## Functional Requirements
+
+### FR-1: Correct sidebar navigation to the batch-planning page
+Both failing tests must navigate to `/manufacturing/batch-planning` (the `BatchPlanningCalculator` page), not `/manufacturing/batch-calculator`. Navigation must use the same robust, role-based approach as the passing workflow test.
+
+**Acceptance criteria:**
+- Navigation clicks the "Výroba" section button, then a link resolved by accessible name matching the real label, e.g. `page.getByRole('link', { name: /plánování dávek/i })` (optionally also allowing `/plánovač výrobních dávek/i` for parity with the workflow test).
+- The navigation selector no longer matches "Kalkulačka dávek" and never routes to `/manufacturing/batch-calculator`.
+- After navigation, `page.url()` ends with `/manufacturing/batch-planning`.
+- If a direct-URL fallback is retained, it targets `/manufacturing/batch-planning` and is only used when the link is genuinely absent (not as a masked recovery from clicking the wrong link).
+
+### FR-2: Precise page-load (heading) assertion
+The heading assertion must uniquely identify the batch-planning page and fail loudly if the wrong page loads.
+
+**Acceptance criteria:**
+- Heading is asserted via `page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })` (matching the actual `<h1>` "Plánovač výrobních dávek"), consistent with the workflow test.
+- The assertion no longer accepts "Kalkulačka…" (i.e., it would fail on the calculator page), so a wrong-page regression is caught immediately.
+- Assertion passes on staging within the existing 10s timeout for both tests (test at line 25 explicitly; the correction test at line 248 should add/keep an equivalent page-loaded guard before interacting with the combobox).
+
+### FR-3: Reliable combobox interaction
+Once on the correct page, both tests must locate and drive the semiproduct/product `react-select` combobox to select `MAS001001M` / "Hedvábný pan Jasmín".
+
+**Acceptance criteria:**
+- The combobox is located via `role="combobox"` (react-select renders this role) and is visible within timeout on the batch-planning page.
+- Selecting the fixture semiproduct yields `[role="option"]` results and populates the product table (`tbody tr` rows > 0), consistent with the existing test steps.
+- The existing "test data missing" guard `throw`s (does not silently skip) when no options appear.
+
+### FR-4: Stable load-state waiting
+Replace flaky `networkidle` waits in this spec's `beforeEach` and navigation steps with the load strategy proven on staging.
+
+**Acceptance criteria:**
+- `beforeEach` uses `waitForLoadState('domcontentloaded')` (matching the workflow spec) rather than `networkidle`.
+- Post-navigation waits do not rely on `networkidle` to gate the heading/combobox assertions.
+
+### FR-5: Preserve error-handling scenario coverage
+The behavioral intent of both tests must be preserved after the navigation fix.
+
+**Acceptance criteria:**
+- Test 1 ("fixed products exceed volume") still: checks fixed checkboxes, sets an over-volume quantity (e.g. `9999`), clicks "Přepočítat", and asserts the table/rows remain visible; toaster/visual-indicator checks remain (non-critical warnings may stay as logged-only as they are today, unless FR-6 tightens them).
+- Test 2 ("correct fixed quantities and recalculate") still: sets a reasonable quantity (e.g. `10`), recalculates, and asserts no error toaster (`.toast, .Toastify__toast, [role="alert"]` filtered by error text) appears.
+- No assertions are weakened merely to make the tests pass; changes are limited to navigation, page-load gating, and wait strategy.
+
+### FR-6: (Optional hardening) Shared navigation helper
+To prevent recurrence and drift between the two manufacturing specs, extract the batch-planning navigation into a reusable helper.
+
+**Acceptance criteria:**
+- If implemented, a helper (e.g. `navigateToBatchPlanning(page)` under `frontend/test/e2e/helpers/`) encapsulates the "Výroba" → "Plánování dávek" click + heading wait, and both error-handling tests (and optionally the workflow test) use it.
+- If not implemented, this is explicitly deferred; it must not block the fix.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- No change to application runtime performance (test-only change).
+- Both tests should complete well within Playwright's per-test timeout on staging; removing `networkidle` should reduce flaky long waits.
+
+### NFR-2: Security
+- No security impact. No new secrets, no auth changes. Tests continue to authenticate via `navigateToApp(page)` (per `helpers/e2e-auth-helper` and the CLAUDE.md rule that E2E auth must go through `navigateToApp()`).
+
+### NFR-3: Reliability / Maintainability
+- Selectors must be resilient to unrelated UI text changes: prefer role + accessible-name matching over broad `text=` regexes.
+- Regexes used for navigation must be verified against the actual sidebar labels in `frontend/src/components/Layout/Sidebar.tsx` ("Plánování dávek", "Kalkulačka dávek") to avoid accidental cross-matching between the two manufacturing pages.
+
+## Data Model
+No data-model changes. Relevant existing entities/fixtures only:
+- `TestCatalogItems.hedvabnyPan` = `{ code: 'MAS001001M', name: 'Hedvábný pan Jasmín', type: 'Polotovar' }` (`frontend/test/e2e/fixtures/test-data.ts`) — the semiproduct selected in both tests; confirmed present on staging via the passing workflow test.
+
+## API / Interface Design
+No API changes. Relevant UI/routing surface (for grounding, unchanged):
+- Route map (`frontend/src/App.tsx`): `/manufacturing/batch-planning` → `BatchPlanningCalculator`; `/manufacturing/batch-calculator` → `ManufactureBatchCalculator` (both guarded by `RequireMenuPath`).
+- Sidebar labels (`frontend/src/components/Layout/Sidebar.tsx`): section "Výroba"; items "Kalkulačka dávek" (calculator) and "Plánování dávek" (planning).
+- Page landmarks on the planning page: `<h1>` "Plánovač výrobních dávek"; `react-select` combobox (`role="combobox"`) from `CatalogAutocomplete`; product `<table>`; "Přepočítat" button.
+
+## Dependencies
+- Playwright E2E harness and `frontend/playwright.config.ts` (`baseURL` = `https://heblo.stg.anela.cz`).
+- `frontend/test/e2e/helpers/e2e-auth-helper` (`navigateToApp`).
+- Staging environment reachable with valid E2E auth and containing the `MAS001001M` semiproduct with configured products.
+- E2E run script `./scripts/run-playwright-tests.sh` (per CLAUDE.md) for verification.
+
+## Out of Scope
+- Any change to application/product code (`ManufactureBatchPlanning.tsx`, `ManufactureBatchCalculator.tsx`, `Sidebar.tsx`, routing, or `CatalogAutocomplete`) — the feature is confirmed working.
+- Fixing or refactoring the passing `batch-planning-workflow.spec.ts` or other manufacturing specs beyond the optional shared-helper adoption in FR-6.
+- Adding `data-testid` attributes to the sidebar or page (could be a future hardening; not required and would touch product code).
+- Broadening error-handling coverage (new toaster/validation assertions) beyond restoring the existing intent.
+
+## Open Questions
+None. (Assumptions taken, all low-risk: (1) the correct fix mirrors the passing workflow test — verified against both spec files; (2) `MAS001001M` test data exists on staging — verified via the passing workflow test using the same fixture; (3) `role="combobox"` is valid — verified in `CatalogAutocomplete` via react-select. Final confirmation is the staging E2E run per the validation step.)
+
+## Status: COMPLETE

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-08T04:23:32.517644Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T04:24:55.268286Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-batch-planning-error-handling-e2e-navigation",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-08T04:31:40.633348Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T04:31:45.777092Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T04:33:06.921504Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-08T04:22:51.683254Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T04:23:32.517644Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T04:20:27.668810Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-08T04:20:27.668810Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T04:22:51.683254Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3543",
+  "issue_number": 3543,
+  "created_at": "2026-07-08T04:15:19.905928Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T04:31:40.633348Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-08T04:31:45.777092Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T04:24:55.268286Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T04:25:29.211272Z"
     }
   },
   "tasks": [
     {
       "name": "fix-batch-planning-error-handling-e2e-navigation",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T04:25:29.466274Z"
     }
   ]
 }

--- a/artifacts/feat-3543/state.json
+++ b/artifacts/feat-3543/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T04:24:55.268286Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T04:25:29.211272Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T04:31:40.633348Z"
     }
   },
   "tasks": [
     {
       "name": "fix-batch-planning-error-handling-e2e-navigation",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T04:25:29.466274Z"
+      "updated_at": "2026-07-08T04:31:34.799848Z"
     }
   ]
 }

--- a/artifacts/feat-3543/task-context/fix-batch-planning-error-handling-e2e-navigation.md
+++ b/artifacts/feat-3543/task-context/fix-batch-planning-error-handling-e2e-navigation.md
@@ -1,0 +1,54 @@
+### task: fix-batch-planning-error-handling-e2e-navigation
+## Goal
+Make both tests in `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts` reliably navigate to and load the batch-planning page (`/manufacturing/batch-planning`, component `BatchPlanningCalculator`, `<h1>` = "Plánovač výrobních dávek"), so the error-handling scenarios run against the correct page. Preserve all existing behavioral assertions — only navigation, page-load gating, and wait strategy change. The root cause is a test-only defect: the current selector `text=/Plánovač|Kalkulačka dávek/i` never matches the real sidebar link "Plánování dávek" and instead matches "Kalkulačka dávek", which routes to the wrong page `/manufacturing/batch-calculator`.
+
+## Files to change
+- **Only** `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts`.
+
+Do NOT touch any of these (confirmed working / out of scope): `ManufactureBatchPlanning.tsx`, `ManufactureBatchCalculator.tsx`, `Sidebar.tsx`, `App.tsx`, `CatalogAutocomplete.tsx`, `test-data.ts`, `playwright.config.ts`, and the passing `batch-planning-workflow.spec.ts`.
+
+Reference the passing sibling `frontend/test/e2e/manufacturing/batch-planning-workflow.spec.ts` for the exact patterns to copy — its navigation, heading assertion, and wait strategy are proven on staging with the same auth and the same `MAS001001M` fixture.
+
+## Changes
+Apply these edits to `batch-planning-error-handling.spec.ts`. Read the current file first to locate the exact lines (the navigation block is around line 27, test 1's page-load assertion around line 25, and test 2 around line 248), then make each change surgically.
+
+1. **Navigation selector (FR-1).** Replace the broad/incorrect navigation:
+   ```ts
+   const batchPlanningLink = page.locator('text=/Plánovač|Kalkulačka dávek/i').first();
+   if (await batchPlanningLink.isVisible({ timeout: 5000 })) { ... } else { await page.goto('/manufacturing/batch-planning'); }
+   ```
+   with the role-based, accessible-name approach used by the workflow spec:
+   ```ts
+   await page.getByRole('button', { name: 'Výroba' }).click();
+   await page.getByRole('link', { name: /plánování dávek/i }).click();
+   ```
+   `/plánování dávek/i` is the primary matcher — it matches the real sidebar label and, critically, does NOT match "Kalkulačka dávek" (which routes to the wrong page). You may include `/plánovač výrobních dávek|plánování dávek/i` for exact parity with the workflow spec, but that is optional. If a `page.goto('/manufacturing/batch-planning')` fallback is retained, invoke it ONLY when the link is genuinely absent (link `isVisible` is false) — never as a silent recovery after clicking a link. After navigation `page.url()` must end with `/manufacturing/batch-planning`.
+
+2. **Heading assertion (FR-2).** Replace the permissive assertion:
+   ```ts
+   page.locator('h1, h2').filter({ hasText: /Plánovač|Planning|Dávek|Kalkulačka/i })
+   ```
+   with the exact one from the workflow spec:
+   ```ts
+   await expect(page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })).toBeVisible({ timeout: 10000 });
+   ```
+   This must NOT accept "Kalkulačka…" so a wrong-page landing fails loudly at the navigation step. Apply this heading guard in **both** tests. Test 2 (around line 248) currently has NO page-loaded guard before it touches the combobox — you MUST add this exact-`h1` assertion there after navigation (per arch-review clarification 1, this is required, not optional).
+
+3. **Load-wait strategy (FR-4).** Replace every `page.waitForLoadState('networkidle')` in this file (in `beforeEach` and after navigation) with `page.waitForLoadState('domcontentloaded')`, matching the workflow spec. Staging emits background telemetry/polling that keeps `networkidle` from settling. Rely on the existing `toBeVisible({ timeout })` element waits for real synchronization; keep any modest `waitForTimeout` React-init pauses the workflow spec uses.
+
+4. **Preserve everything else (FR-3, FR-5).** Do NOT change: the combobox interaction (`[role="combobox"]` → type "Hedvábný pan Jasmín" → select first `[role="option"]` → assert `tbody tr` rows > 0), the `TestCatalogItems.hedvabnyPan` / `MAS001001M` fixture usage, or the "missing test data" `throw` guard (it must `throw`, never `test.skip`). Keep test 1's behavior (check fixed checkboxes, set `9999` over-volume quantity, click "Přepočítat" — button matched by `/Přepočítat|Calculate|Vypočítat/i` — assert table/rows remain visible; toaster/visual-indicator checks stay as they are today, logged-only if currently non-critical). Keep test 2's behavior (set reasonable `10`, recalculate, assert no error toaster via `.toast, .Toastify__toast, [role="alert"]` filtered by error text). Do NOT weaken any assertion to make tests pass.
+
+5. **FR-6 (shared nav helper) is explicitly deferred** — do NOT extract a `navigateToBatchPlanning` helper. It must not block or expand this fix.
+
+6. Continue authenticating via `navigateToApp(page)` (already in the spec) — never `createE2EAuthSession()` alone (CLAUDE.md rule).
+
+## Verification
+1. **Lint (must pass):** from `frontend/`, run `npm run lint`.
+2. **E2E run against staging (per CLAUDE.md testing docs):** run `./scripts/run-playwright-tests.sh manufacturing`.
+   - Both error-handling tests in `batch-planning-error-handling.spec.ts` must pass:
+     - Test 1: "fixed products exceed volume" (checks fixed checkboxes, sets `9999`, recalculates, table/rows remain visible).
+     - Test 2: "correct fixed quantities and recalculate" (sets `10`, recalculates, asserts no error toaster).
+   - The sibling `batch-planning-workflow.spec.ts` must remain green (no regression).
+3. **Spot checks:** after navigation each test lands on a URL ending in `/manufacturing/batch-planning`; the exact `<h1>` "Plánovač výrobních dávek" is visible; the `[role="combobox"]` selection of `MAS001001M` populates the product table (`tbody tr` > 0). If the exact-heading assertion ever fails, it now surfaces the wrong-page problem immediately at the navigation step rather than as a downstream combobox timeout.
+
+Prerequisites (already satisfied, no action needed): staging `https://heblo.stg.anela.cz` reachable with valid E2E auth (`E2E_CLIENT_ID` / `E2E_CLIENT_SECRET` / `AZURE_TENANT_ID`) and the `MAS001001M` semiproduct present with configured products — all proven by the passing workflow spec. No migrations, config, feature flags, or infrastructure changes.

--- a/artifacts/feat-3543/task-plan.r1.md
+++ b/artifacts/feat-3543/task-plan.r1.md
@@ -1,0 +1,59 @@
+# Task Plan: Fix Batch-Planning Error-Handling E2E Tests
+
+## Overview
+A single Playwright E2E spec (`batch-planning-error-handling.spec.ts`) fails on staging because its sidebar navigation selector, heading assertion, and load-wait strategy are wrong — it never reaches `/manufacturing/batch-planning`. The fix realigns those three concerns with the proven, passing sibling spec `batch-planning-workflow.spec.ts`. No application/product code changes. This is exactly one developer task.
+
+### task: fix-batch-planning-error-handling-e2e-navigation
+## Goal
+Make both tests in `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts` reliably navigate to and load the batch-planning page (`/manufacturing/batch-planning`, component `BatchPlanningCalculator`, `<h1>` = "Plánovač výrobních dávek"), so the error-handling scenarios run against the correct page. Preserve all existing behavioral assertions — only navigation, page-load gating, and wait strategy change. The root cause is a test-only defect: the current selector `text=/Plánovač|Kalkulačka dávek/i` never matches the real sidebar link "Plánování dávek" and instead matches "Kalkulačka dávek", which routes to the wrong page `/manufacturing/batch-calculator`.
+
+## Files to change
+- **Only** `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts`.
+
+Do NOT touch any of these (confirmed working / out of scope): `ManufactureBatchPlanning.tsx`, `ManufactureBatchCalculator.tsx`, `Sidebar.tsx`, `App.tsx`, `CatalogAutocomplete.tsx`, `test-data.ts`, `playwright.config.ts`, and the passing `batch-planning-workflow.spec.ts`.
+
+Reference the passing sibling `frontend/test/e2e/manufacturing/batch-planning-workflow.spec.ts` for the exact patterns to copy — its navigation, heading assertion, and wait strategy are proven on staging with the same auth and the same `MAS001001M` fixture.
+
+## Changes
+Apply these edits to `batch-planning-error-handling.spec.ts`. Read the current file first to locate the exact lines (the navigation block is around line 27, test 1's page-load assertion around line 25, and test 2 around line 248), then make each change surgically.
+
+1. **Navigation selector (FR-1).** Replace the broad/incorrect navigation:
+   ```ts
+   const batchPlanningLink = page.locator('text=/Plánovač|Kalkulačka dávek/i').first();
+   if (await batchPlanningLink.isVisible({ timeout: 5000 })) { ... } else { await page.goto('/manufacturing/batch-planning'); }
+   ```
+   with the role-based, accessible-name approach used by the workflow spec:
+   ```ts
+   await page.getByRole('button', { name: 'Výroba' }).click();
+   await page.getByRole('link', { name: /plánování dávek/i }).click();
+   ```
+   `/plánování dávek/i` is the primary matcher — it matches the real sidebar label and, critically, does NOT match "Kalkulačka dávek" (which routes to the wrong page). You may include `/plánovač výrobních dávek|plánování dávek/i` for exact parity with the workflow spec, but that is optional. If a `page.goto('/manufacturing/batch-planning')` fallback is retained, invoke it ONLY when the link is genuinely absent (link `isVisible` is false) — never as a silent recovery after clicking a link. After navigation `page.url()` must end with `/manufacturing/batch-planning`.
+
+2. **Heading assertion (FR-2).** Replace the permissive assertion:
+   ```ts
+   page.locator('h1, h2').filter({ hasText: /Plánovač|Planning|Dávek|Kalkulačka/i })
+   ```
+   with the exact one from the workflow spec:
+   ```ts
+   await expect(page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })).toBeVisible({ timeout: 10000 });
+   ```
+   This must NOT accept "Kalkulačka…" so a wrong-page landing fails loudly at the navigation step. Apply this heading guard in **both** tests. Test 2 (around line 248) currently has NO page-loaded guard before it touches the combobox — you MUST add this exact-`h1` assertion there after navigation (per arch-review clarification 1, this is required, not optional).
+
+3. **Load-wait strategy (FR-4).** Replace every `page.waitForLoadState('networkidle')` in this file (in `beforeEach` and after navigation) with `page.waitForLoadState('domcontentloaded')`, matching the workflow spec. Staging emits background telemetry/polling that keeps `networkidle` from settling. Rely on the existing `toBeVisible({ timeout })` element waits for real synchronization; keep any modest `waitForTimeout` React-init pauses the workflow spec uses.
+
+4. **Preserve everything else (FR-3, FR-5).** Do NOT change: the combobox interaction (`[role="combobox"]` → type "Hedvábný pan Jasmín" → select first `[role="option"]` → assert `tbody tr` rows > 0), the `TestCatalogItems.hedvabnyPan` / `MAS001001M` fixture usage, or the "missing test data" `throw` guard (it must `throw`, never `test.skip`). Keep test 1's behavior (check fixed checkboxes, set `9999` over-volume quantity, click "Přepočítat" — button matched by `/Přepočítat|Calculate|Vypočítat/i` — assert table/rows remain visible; toaster/visual-indicator checks stay as they are today, logged-only if currently non-critical). Keep test 2's behavior (set reasonable `10`, recalculate, assert no error toaster via `.toast, .Toastify__toast, [role="alert"]` filtered by error text). Do NOT weaken any assertion to make tests pass.
+
+5. **FR-6 (shared nav helper) is explicitly deferred** — do NOT extract a `navigateToBatchPlanning` helper. It must not block or expand this fix.
+
+6. Continue authenticating via `navigateToApp(page)` (already in the spec) — never `createE2EAuthSession()` alone (CLAUDE.md rule).
+
+## Verification
+1. **Lint (must pass):** from `frontend/`, run `npm run lint`.
+2. **E2E run against staging (per CLAUDE.md testing docs):** run `./scripts/run-playwright-tests.sh manufacturing`.
+   - Both error-handling tests in `batch-planning-error-handling.spec.ts` must pass:
+     - Test 1: "fixed products exceed volume" (checks fixed checkboxes, sets `9999`, recalculates, table/rows remain visible).
+     - Test 2: "correct fixed quantities and recalculate" (sets `10`, recalculates, asserts no error toaster).
+   - The sibling `batch-planning-workflow.spec.ts` must remain green (no regression).
+3. **Spot checks:** after navigation each test lands on a URL ending in `/manufacturing/batch-planning`; the exact `<h1>` "Plánovač výrobních dávek" is visible; the `[role="combobox"]` selection of `MAS001001M` populates the product table (`tbody tr` > 0). If the exact-heading assertion ever fails, it now surfaces the wrong-page problem immediately at the navigation step rather than as a downstream combobox timeout.
+
+Prerequisites (already satisfied, no action needed): staging `https://heblo.stg.anela.cz` reachable with valid E2E auth (`E2E_CLIENT_ID` / `E2E_CLIENT_SECRET` / `AZURE_TENANT_ID`) and the `MAS001001M` semiproduct present with configured products — all proven by the passing workflow spec. No migrations, config, feature flags, or infrastructure changes.

--- a/frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts
+++ b/frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts
@@ -12,7 +12,7 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
       await navigateToApp(page);
 
       // Wait for app to load
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForTimeout(3000); // Give extra time for React components to initialize
 
       console.log('✅ Batch planning test setup completed successfully');
@@ -34,7 +34,7 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
       await page.waitForTimeout(500); // Wait for submenu to open
 
       // Try to find navigation link
-      const batchPlanningLink = page.locator('text=/Plánovač|Kalkulačka dávek/i').first();
+      const batchPlanningLink = page.getByRole('link', { name: /plánování dávek/i });
 
       if (await batchPlanningLink.isVisible({ timeout: 5000 })) {
         await batchPlanningLink.click();
@@ -50,14 +50,14 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
     }
 
     // Wait for batch planning page to load
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(2000); // Give time for React components to initialize
 
     // Step 2: Verify we're on the batch planning page
     console.log('🔍 Verifying batch planning page loaded...');
 
     // Look for page title or header
-    const pageTitle = page.locator('h1, h2').filter({ hasText: /Plánovač|Planning|Dávek|Kalkulačka/i });
+    const pageTitle = page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i });
     await expect(pageTitle.first()).toBeVisible({ timeout: 10000 });
     console.log('✅ Batch planning page loaded successfully');
 
@@ -98,7 +98,7 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
     console.log(`✅ Selected semiproduct: ${testSemiproduct.name}`);
 
     // Wait for data to load after selection
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(3000);
 
     // Step 4: Verify product table loaded
@@ -175,7 +175,7 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
     console.log('✅ Clicked calculate button');
 
     // Wait for API call to complete
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(3000);
 
     // Step 7: Verify toaster notification appears
@@ -257,7 +257,7 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
       await page.getByRole('button', { name: 'Výroba' }).click();
       await page.waitForTimeout(500);
 
-      const batchPlanningLink = page.locator('text=/Plánovač|Kalkulačka dávek/i').first();
+      const batchPlanningLink = page.getByRole('link', { name: /plánování dávek/i });
 
       if (await batchPlanningLink.isVisible({ timeout: 5000 })) {
         await batchPlanningLink.click();
@@ -268,8 +268,14 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
       await page.goto('/manufacturing/batch-planning');
     }
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(2000);
+
+    // Verify we're on the batch planning page
+    console.log('🔍 Verifying batch planning page loaded...');
+    const pageTitle = page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i });
+    await expect(pageTitle.first()).toBeVisible({ timeout: 10000 });
+    console.log('✅ Batch planning page loaded successfully');
 
     console.log(`🔍 Selecting semiproduct: ${testSemiproduct.name}`);
 
@@ -295,7 +301,7 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
     await options.first().click();
     console.log(`✅ Selected semiproduct: ${testSemiproduct.name}`);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(2000);
 
     // Verify table loaded
@@ -341,7 +347,7 @@ test.describe('Batch Planning Error Handling - Fixed Products Exceed Volume', ()
     console.log('✅ Recalculated with corrected quantities');
 
     // Wait for successful response
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(2000);
 
     // Verify no error toasters appear


### PR DESCRIPTION
Closes #3543

## What the issue was

In the nightly E2E regression run [#191](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966), 2 tests in `manufacturing/batch-planning-error-handling.spec.ts` failed because the batch-planning calculator/modal (heading + combobox) never rendered, blocking the "fixed products exceed volume" error-handling flow from being exercised.

## How it was fixed / handled

Root cause (confirmed by direct code inspection in both the analyst and architect phases): this was a **test-only defect**, not an application bug. The failing spec navigated using `page.locator('text=/Plánovač|Kalkulačka dávek/i').first()`, which never matches the real sidebar link text "Plánování dávek" (note *-ování* vs *-ovač*) and instead cross-matches "Kalkulačka dávek" — a *different* feature that routes to `/manufacturing/batch-calculator`. A too-permissive heading regex (`/Plánovač|Planning|Dávek|Kalkulačka/i`) then failed to catch the wrong-page landing, and `waitForLoadState('networkidle')` added flakiness on staging.

The sibling spec `batch-planning-workflow.spec.ts` already does this correctly and passes reliably, so the fix mirrors its proven pattern in `batch-planning-error-handling.spec.ts`:
- Navigation: role-based `getByRole('link', { name: /plánování dávek/i })` instead of the broken text selector.
- Heading assertion: exact `page.locator('h1').filter({ hasText: /plánovač výrobních dávek/i })` in both tests (test 2 previously had no page-loaded guard at all — this was added).
- Load-wait: `domcontentloaded` instead of `networkidle` (7 occurrences).

No application/product code was changed — only the test file `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts`.

## Artifacts
- Brief, spec, arch-review, design, task-plan, task-context, impl, and review markdown are committed under `artifacts/feat-3543/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `frontend/test/e2e/manufacturing/batch-planning-error-handling.spec.ts:37` and `:260` — the navigation link locator and page-load verification logic is now duplicated verbatim between the two tests (and largely duplicated again in `batch-planning-workflow.spec.ts:32-47`). Per spec FR-6 this was flagged as optional hardening; extracting a shared `navigateToBatchPlanning(page)` helper under `frontend/test/e2e/helpers/` would remove the triplication, though the spec explicitly allows deferring this.

## Verification note

This is a test-only fix targeting Playwright E2E specs that run against the live staging environment (`https://heblo.stg.anela.cz`). Per this repo's testing setup, the E2E suite runs nightly rather than in PR CI, and this sandbox has no E2E auth credentials (`E2E_CLIENT_ID`/`E2E_CLIENT_SECRET`) configured, so the fixed tests were not re-run live here. The fix was verified by static diff review against the confirmed-passing sibling spec and by reading the actual application source (`Sidebar.tsx`, `ManufactureBatchPlanning.tsx`) to confirm the new selectors resolve uniquely and correctly. The next nightly E2E run will provide live confirmation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01881eD8KEM9vccJThM1wFtf)_