### PR TITLE
feat: add lot-sum vs ERP stock reconciliation data quality check

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/DataQualityModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/DataQualityModule.cs
@@ -19,6 +19,7 @@ public static class DataQualityModule
         services.AddScoped<IDqtJobRunner, DriftDqtJobRunner>();
         services.AddScoped<IDriftDqtComparer, ProductPairingDqtComparer>();
         services.AddScoped<IDriftDqtComparer, StockWriteBackDqtComparer>();
+        services.AddScoped<IDriftDqtComparer, LotStockReconciliationComparer>();
 
         // Register dashboard tiles
         services.RegisterTile<DataQualityStatusTile>();

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Infrastructure/Jobs/LotStockReconciliationDqtJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Infrastructure/Jobs/LotStockReconciliationDqtJob.cs
@@ -1,0 +1,55 @@
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.DataQuality.Infrastructure.Jobs;
+
+public class LotStockReconciliationDqtJob : IRecurringJob
+{
+    private readonly IDqtRunRepository _repository;
+    private readonly IDriftDqtJobRunner _jobRunner;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILogger<LotStockReconciliationDqtJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "daily-lot-stock-dqt",
+        DisplayName = "Daily Lot/Stock Reconciliation Data Quality Test",
+        Description = "Reconciles the sum of loaded stock lots against ERP on-hand stock for materials with expiration",
+        CronExpression = "0 8 * * *", // Daily at 8:00 AM, after the earlier DQT checks
+        DefaultIsEnabled = true
+    };
+
+    public LotStockReconciliationDqtJob(
+        IDqtRunRepository repository,
+        IDriftDqtJobRunner jobRunner,
+        IRecurringJobStatusChecker statusChecker,
+        ILogger<LotStockReconciliationDqtJob> logger)
+    {
+        _repository = repository;
+        _jobRunner = jobRunner;
+        _statusChecker = statusChecker;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping execution.", Metadata.JobName);
+            return;
+        }
+
+        // Snapshot reconciliation — from/to are the current day for both bounds.
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        _logger.LogInformation("Starting {JobName} for {Date}", Metadata.JobName, today);
+
+        var run = DqtRun.Start(DqtTestType.LotSumVsErpStock, today, today, DqtTriggerType.Scheduled);
+        await _repository.AddAsync(run, cancellationToken);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        await _jobRunner.RunAsync(run.Id, cancellationToken);
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/LotStockReconciliationComparer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/LotStockReconciliationComparer.cs
@@ -1,0 +1,72 @@
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.DataQuality;
+
+namespace Anela.Heblo.Application.Features.DataQuality.Services;
+
+/// <summary>
+/// Reconciles, per material with expiration, the sum of loaded stock lots against the
+/// item's ERP on-hand stock. Surfaces drift (stale, missing, or orphan lots) that would
+/// otherwise be invisible between explicit stock-takings.
+/// </summary>
+public class LotStockReconciliationComparer : IDriftDqtComparer
+{
+    private const decimal Tolerance = 0.01m;
+
+    private readonly ICatalogRepository _catalogRepository;
+
+    public DqtTestType TestType => DqtTestType.LotSumVsErpStock;
+
+    public LotStockReconciliationComparer(ICatalogRepository catalogRepository)
+    {
+        _catalogRepository = catalogRepository;
+    }
+
+    public async Task<DriftComparisonResult> CompareAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
+    {
+        // Date range is intentionally unused — this is a current-state snapshot reconciliation.
+        var items = await _catalogRepository.GetAllAsync(ct);
+
+        var checkedItems = items
+            .Where(item => item.Type == ProductType.Material && item.HasExpiration)
+            .ToList();
+
+        var mismatches = new List<DriftMismatch>();
+
+        foreach (var item in checkedItems)
+        {
+            var erp = item.Stock.Erp;
+            var lotSum = item.Stock.Lots.Sum(l => l.Amount);
+
+            if (Math.Abs(lotSum - erp) <= Tolerance)
+                continue;
+
+            var flag = Classify(erp, lotSum);
+
+            mismatches.Add(new DriftMismatch
+            {
+                EntityKey = item.ProductCode,
+                MismatchCode = (int)flag,
+                HebloValue = erp.ToString("F2"),
+                ShoptetValue = lotSum.ToString("F2"),
+                Details = $"ERP: {erp:F2} | Šarže: {lotSum:F2} | Rozdíl: {lotSum - erp:F2}"
+            });
+        }
+
+        return new DriftComparisonResult
+        {
+            Mismatches = mismatches,
+            TotalChecked = checkedItems.Count
+        };
+    }
+
+    private static LotStockReconciliationMismatch Classify(decimal erp, decimal lotSum)
+    {
+        if (lotSum <= Tolerance)
+            return LotStockReconciliationMismatch.MissingLots;
+
+        if (erp <= Tolerance)
+            return LotStockReconciliationMismatch.OrphanLots;
+
+        return LotStockReconciliationMismatch.SumMismatch;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/UseCases/GetDqtRunDetail/GetDqtRunDetailHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/UseCases/GetDqtRunDetail/GetDqtRunDetailHandler.cs
@@ -45,7 +45,7 @@ public class GetDqtRunDetailHandler : IRequestHandler<GetDqtRunDetailRequest, Ge
                 };
             }
 
-            if (run.TestType is DqtTestType.ProductPairing or DqtTestType.StockWriteBackReconciliation)
+            if (run.TestType is DqtTestType.ProductPairing or DqtTestType.StockWriteBackReconciliation or DqtTestType.LotSumVsErpStock)
             {
                 var (driftItems, driftTotal) = await _repository.GetDriftResultsAsync(
                     run.Id, request.ResultPage, request.ResultPageSize, cancellationToken);

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
@@ -4,5 +4,6 @@ public enum DqtTestType
 {
     IssuedInvoiceComparison = 1,
     ProductPairing = 2,
-    StockWriteBackReconciliation = 3
+    StockWriteBackReconciliation = 3,
+    LotSumVsErpStock = 4
 }

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/LotStockReconciliationMismatch.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/LotStockReconciliationMismatch.cs
@@ -1,0 +1,16 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+[Flags]
+public enum LotStockReconciliationMismatch
+{
+    None = 0,
+
+    /// <summary>Lot sum and ERP stock are both non-zero but differ beyond tolerance.</summary>
+    SumMismatch = 1,
+
+    /// <summary>ERP stock is present but no lots are loaded.</summary>
+    MissingLots = 2,
+
+    /// <summary>Lots are present but ERP stock is effectively zero.</summary>
+    OrphanLots = 4
+}

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/GetDqtRunDetailHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/GetDqtRunDetailHandlerTests.cs
@@ -65,6 +65,44 @@ public class GetDqtRunDetailHandlerTests
         Assert.Null(response.ErrorCode);
     }
 
+    [Theory]
+    [InlineData(DqtTestType.ProductPairing)]
+    [InlineData(DqtTestType.StockWriteBackReconciliation)]
+    [InlineData(DqtTestType.LotSumVsErpStock)]
+    public async Task Handle_DriftTestType_ReturnsMappedDriftResults(DqtTestType testType)
+    {
+        var run = DqtRun.Start(testType, new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), DqtTriggerType.Manual);
+        var dto = new DqtRunDto { Id = run.Id };
+        var driftItems = new List<DqtDriftResult>();
+        var driftDtos = new List<DqtDriftResultDto>();
+
+        _repositoryMock
+            .Setup(r => r.GetWithResultsAsync(run.Id, 1, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(run);
+
+        _repositoryMock
+            .Setup(r => r.GetDriftResultsAsync(run.Id, 1, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((driftItems, 7));
+
+        _mapperMock
+            .Setup(m => m.Map<DqtRunDto>(run))
+            .Returns(dto);
+
+        _mapperMock
+            .Setup(m => m.Map<List<DqtDriftResultDto>>(driftItems))
+            .Returns(driftDtos);
+
+        var request = new GetDqtRunDetailRequest { Id = run.Id };
+
+        var response = await _sut.Handle(request, CancellationToken.None);
+
+        Assert.True(response.Success);
+        Assert.NotNull(response.Run);
+        Assert.Same(driftDtos, response.DriftResults);
+        Assert.Equal(7, response.TotalDriftResults);
+        Assert.Null(response.ErrorCode);
+    }
+
     [Fact]
     public async Task Handle_UnrecognizedTestType_ReturnsUnsupportedTestTypeError()
     {

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationComparerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationComparerTests.cs
@@ -1,0 +1,209 @@
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Lots;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.DataQuality;
+using FluentAssertions;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.DataQuality;
+
+public class LotStockReconciliationComparerTests
+{
+    private readonly Mock<ICatalogRepository> _catalogMock = new();
+    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.Today);
+
+    private LotStockReconciliationComparer CreateSut() => new(_catalogMock.Object);
+
+    private void SetupCatalog(params CatalogAggregate[] items) =>
+        _catalogMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<CatalogAggregate>)items.ToList());
+
+    private static CatalogAggregate Material(
+        string code,
+        decimal erp,
+        bool hasExpiration = true,
+        params decimal[] lotAmounts)
+    {
+        var item = new CatalogAggregate
+        {
+            ProductCode = code,
+            Type = ProductType.Material,
+            HasExpiration = hasExpiration,
+            Stock = new StockData { Erp = erp }
+        };
+        foreach (var amount in lotAmounts)
+            item.Stock.Lots.Add(new CatalogLot { ProductCode = code, Amount = amount });
+        return item;
+    }
+
+    [Fact]
+    public async Task TestType_IsLotSumVsErpStock()
+    {
+        CreateSut().TestType.Should().Be(DqtTestType.LotSumVsErpStock);
+    }
+
+    [Fact]
+    public async Task CompareAsync_ReturnsNoMismatch_WhenLotSumEqualsErp_AndCountsItem()
+    {
+        // Arrange
+        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 4m, 6m }));
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        result.Mismatches.Should().BeEmpty();
+        result.TotalChecked.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CompareAsync_ReturnsNoMismatch_WhenDifferenceWithinTolerance()
+    {
+        // Arrange — |10.005 - 10| = 0.005 <= 0.01
+        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 10.005m }));
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        result.Mismatches.Should().BeEmpty();
+        result.TotalChecked.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CompareAsync_ReturnsSumMismatch_WhenLotSumDiffersBeyondTolerance()
+    {
+        // Arrange
+        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 5m, 3m }));
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        var mismatch = result.Mismatches.Single();
+        mismatch.EntityKey.Should().Be("MAT001");
+        ((LotStockReconciliationMismatch)mismatch.MismatchCode)
+            .Should().Be(LotStockReconciliationMismatch.SumMismatch);
+        mismatch.HebloValue.Should().Be(10m.ToString("F2"));
+        mismatch.ShoptetValue.Should().Be(8m.ToString("F2"));
+        mismatch.Details.Should()
+            .Contain($"ERP: {10m:F2}")
+            .And.Contain($"Šarže: {8m:F2}")
+            .And.Contain($"Rozdíl: {-2m:F2}");
+    }
+
+    [Fact]
+    public async Task CompareAsync_ReturnsMissingLots_WhenErpPositiveButNoLots()
+    {
+        // Arrange
+        SetupCatalog(Material("MAT001", erp: 10m));
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        ((LotStockReconciliationMismatch)result.Mismatches.Single().MismatchCode)
+            .Should().Be(LotStockReconciliationMismatch.MissingLots);
+    }
+
+    [Fact]
+    public async Task CompareAsync_ReturnsOrphanLots_WhenLotsPresentButErpZero()
+    {
+        // Arrange
+        SetupCatalog(Material("MAT001", erp: 0m, lotAmounts: new[] { 5m }));
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        ((LotStockReconciliationMismatch)result.Mismatches.Single().MismatchCode)
+            .Should().Be(LotStockReconciliationMismatch.OrphanLots);
+    }
+
+    [Fact]
+    public async Task CompareAsync_ExcludesNonMaterial_EvenWhenLotSumMismatches()
+    {
+        // Arrange
+        var goods = new CatalogAggregate
+        {
+            ProductCode = "PROD001",
+            Type = ProductType.Product,
+            HasExpiration = true,
+            Stock = new StockData { Erp = 10m }
+        };
+        goods.Stock.Lots.Add(new CatalogLot { ProductCode = "PROD001", Amount = 1m });
+        SetupCatalog(goods);
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        result.Mismatches.Should().BeEmpty();
+        result.TotalChecked.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CompareAsync_ExcludesMaterialWithoutExpiration()
+    {
+        // Arrange
+        SetupCatalog(Material("MAT001", erp: 10m, hasExpiration: false, lotAmounts: new[] { 1m }));
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        result.Mismatches.Should().BeEmpty();
+        result.TotalChecked.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CompareAsync_ReturnsEmpty_WhenRepositoryEmpty()
+    {
+        // Arrange
+        SetupCatalog();
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        result.Mismatches.Should().BeEmpty();
+        result.TotalChecked.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CompareAsync_CountsAllInScopeItems_AndReportsOnlyMismatches()
+    {
+        // Arrange
+        SetupCatalog(
+            Material("OK001", erp: 10m, lotAmounts: new[] { 10m }),          // matches
+            Material("BAD001", erp: 10m, lotAmounts: new[] { 3m }),          // SumMismatch
+            Material("MISS001", erp: 5m),                                    // MissingLots
+            Material("ORPH001", erp: 0m, lotAmounts: new[] { 2m }),          // OrphanLots
+            Material("NOEXP001", erp: 5m, hasExpiration: false, lotAmounts: new[] { 1m }) // excluded
+        );
+
+        // Act
+        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
+
+        // Assert
+        result.TotalChecked.Should().Be(4); // NOEXP001 excluded
+        result.Mismatches.Select(m => m.EntityKey)
+            .Should().BeEquivalentTo(new[] { "BAD001", "MISS001", "ORPH001" });
+    }
+
+    [Fact]
+    public async Task CompareAsync_IgnoresDateRange()
+    {
+        // Arrange
+        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 10m }));
+
+        // Act — arbitrary range must not affect the snapshot result
+        var result = await CreateSut().CompareAsync(
+            new DateOnly(2020, 1, 1), new DateOnly(2020, 1, 2), CancellationToken.None);
+
+        // Assert
+        result.TotalChecked.Should().Be(1);
+        result.Mismatches.Should().BeEmpty();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationComparerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationComparerTests.cs
@@ -38,7 +38,7 @@ public class LotStockReconciliationComparerTests
     }
 
     [Fact]
-    public async Task TestType_IsLotSumVsErpStock()
+    public void TestType_IsLotSumVsErpStock()
     {
         CreateSut().TestType.Should().Be(DqtTestType.LotSumVsErpStock);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationDqtJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationDqtJobTests.cs
@@ -1,0 +1,92 @@
+using Anela.Heblo.Application.Features.DataQuality.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.DataQuality;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.DataQuality;
+
+public class LotStockReconciliationDqtJobTests
+{
+    private readonly Mock<IDqtRunRepository> _repositoryMock = new();
+    private readonly Mock<IDriftDqtJobRunner> _jobRunnerMock = new();
+    private readonly Mock<IRecurringJobStatusChecker> _statusCheckerMock = new();
+    private readonly LotStockReconciliationDqtJob _sut;
+
+    public LotStockReconciliationDqtJobTests()
+    {
+        _sut = new LotStockReconciliationDqtJob(
+            _repositoryMock.Object,
+            _jobRunnerMock.Object,
+            _statusCheckerMock.Object,
+            NullLogger<LotStockReconciliationDqtJob>.Instance);
+    }
+
+    [Fact]
+    public void Metadata_UsesExpectedJobNameAndSchedule()
+    {
+        _sut.Metadata.JobName.Should().Be("daily-lot-stock-dqt");
+        _sut.Metadata.CronExpression.Should().Be("0 8 * * *");
+        _sut.Metadata.DefaultIsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JobEnabled_PersistsRunBeforeInvokingRunner()
+    {
+        // Arrange
+        _statusCheckerMock
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
+            .ReturnsAsync(true);
+
+        var calls = new List<string>();
+
+        _repositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<DqtRun>(), It.IsAny<CancellationToken>()))
+            .Callback(() => calls.Add("AddAsync"))
+            .ReturnsAsync((DqtRun run, CancellationToken _) => run);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => calls.Add("SaveChangesAsync"))
+            .ReturnsAsync(1);
+
+        _jobRunnerMock
+            .Setup(j => j.RunAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback(() => calls.Add("RunAsync"))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(new[] { "AddAsync", "SaveChangesAsync", "RunAsync" }, calls);
+
+        _repositoryMock.Verify(
+            r => r.AddAsync(
+                It.Is<DqtRun>(run =>
+                    run.TestType == DqtTestType.LotSumVsErpStock &&
+                    run.TriggerType == DqtTriggerType.Scheduled &&
+                    run.Status == DqtRunStatus.Running),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JobDisabled_DoesNotPersistOrInvokeRunner()
+    {
+        // Arrange
+        _statusCheckerMock
+            .Setup(s => s.IsJobEnabledAsync(_sut.Metadata.JobName, It.IsAny<CancellationToken>(), true))
+            .ReturnsAsync(false);
+
+        // Act
+        await _sut.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(r => r.AddAsync(It.IsAny<DqtRun>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _jobRunnerMock.Verify(j => j.RunAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -19432,6 +19432,7 @@ export enum DqtTestType {
     IssuedInvoiceComparison = "IssuedInvoiceComparison",
     ProductPairing = "ProductPairing",
     StockWriteBackReconciliation = "StockWriteBackReconciliation",
+    LotSumVsErpStock = "LotSumVsErpStock",
 }
 
 export enum DqtRunStatus {

--- a/frontend/src/components/data-quality/DqtRunDetail.tsx
+++ b/frontend/src/components/data-quality/DqtRunDetail.tsx
@@ -34,6 +34,12 @@ const STOCK_WRITE_BACK_FLAGS: Record<number, string> = {
   4: 'Chyba inventury',
 };
 
+const LOT_STOCK_FLAGS: Record<number, string> = {
+  1: 'Nesouhlasí součet',
+  2: 'Chybí šarže',
+  4: 'Šarže bez skladu',
+};
+
 function decodeMismatchFlags(code: number, labels: Record<number, string>): string[] {
   return Object.entries(labels)
     .filter(([flag]) => (code & Number(flag)) !== 0)
@@ -149,7 +155,9 @@ const DqtRunDetail: React.FC<DqtRunDetailProps> = ({ runId }) => {
   const driftResults = data?.driftResults ?? [];
 
   const isDriftTestType =
-    run?.testType === 'ProductPairing' || run?.testType === 'StockWriteBackReconciliation';
+    run?.testType === 'ProductPairing' ||
+    run?.testType === 'StockWriteBackReconciliation' ||
+    run?.testType === 'LotSumVsErpStock';
 
   const hasNoResults = isDriftTestType ? driftResults.length === 0 : results.length === 0;
 
@@ -162,8 +170,16 @@ const DqtRunDetail: React.FC<DqtRunDetailProps> = ({ runId }) => {
   }
 
   if (isDriftTestType) {
-    const flagMap =
-      run?.testType === 'ProductPairing' ? PRODUCT_PAIRING_FLAGS : STOCK_WRITE_BACK_FLAGS;
+    let flagMap = STOCK_WRITE_BACK_FLAGS;
+    if (run?.testType === 'ProductPairing') {
+      flagMap = PRODUCT_PAIRING_FLAGS;
+    } else if (run?.testType === 'LotSumVsErpStock') {
+      flagMap = LOT_STOCK_FLAGS;
+    }
+
+    const isLotStock = run?.testType === 'LotSumVsErpStock';
+    const hebloHeader = isLotStock ? 'ERP' : 'Heblo';
+    const shoptetHeader = isLotStock ? 'Šarže' : 'Shoptet';
 
     return (
       <div className="overflow-auto">
@@ -172,8 +188,8 @@ const DqtRunDetail: React.FC<DqtRunDetailProps> = ({ runId }) => {
             <tr className="border-b text-left">
               <th className="py-2 pr-4 font-medium">Entita</th>
               <th className="py-2 pr-4 font-medium">Neshoda</th>
-              <th className="py-2 pr-4 font-medium">Heblo</th>
-              <th className="py-2 pr-4 font-medium">Shoptet</th>
+              <th className="py-2 pr-4 font-medium">{hebloHeader}</th>
+              <th className="py-2 pr-4 font-medium">{shoptetHeader}</th>
               <th className="py-2 font-medium">Detail</th>
             </tr>
           </thead>

--- a/frontend/src/components/data-quality/DqtRunsTable.tsx
+++ b/frontend/src/components/data-quality/DqtRunsTable.tsx
@@ -21,6 +21,7 @@ const TEST_TYPE_LABELS: Record<string, string> = {
   IssuedInvoiceComparison: 'Porovnání faktur',
   ProductPairing: 'Párování produktů',
   StockWriteBackReconciliation: 'Zpětný zápis skladu',
+  LotSumVsErpStock: 'Šarže vs. ERP sklad',
 };
 
 const formatDateTime = (iso: string): string => {

--- a/frontend/src/components/data-quality/RunDqtButton.tsx
+++ b/frontend/src/components/data-quality/RunDqtButton.tsx
@@ -28,6 +28,7 @@ const TEST_TYPE_OPTIONS: TestTypeOption[] = [
   { value: 'IssuedInvoiceComparison', label: 'Porovnání faktur' },
   { value: 'ProductPairing', label: 'Párování produktů' },
   { value: 'StockWriteBackReconciliation', label: 'Zpětný zápis skladu' },
+  { value: 'LotSumVsErpStock', label: 'Šarže vs. ERP sklad' },
 ];
 
 const RunDqtButton: React.FC = () => {

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -323,6 +323,7 @@ const resources = {
           IssuedInvoiceComparison: "Porovnání faktur",
           ProductPairing: "Párování produktů",
           StockWriteBackReconciliation: "Zpětný zápis skladu",
+          LotSumVsErpStock: "Šarže vs. ERP sklad",
         },
         productPairingMismatches: {
           MissingInErp: "Chybí v ERP",
@@ -450,6 +451,7 @@ const resources = {
           IssuedInvoiceComparison: "Invoice Comparison",
           ProductPairing: "Product Pairing",
           StockWriteBackReconciliation: "Stock Write-Back Reconciliation",
+          LotSumVsErpStock: "Lot Sum vs. ERP Stock",
         },
         productPairingMismatches: {
           MissingInErp: "Missing in ERP",

--- a/memory/gotchas/dqt-new-test-type-checklist.md
+++ b/memory/gotchas/dqt-new-test-type-checklist.md
@@ -1,0 +1,28 @@
+# Adding a DQT test type: the pipeline is NOT fully generic
+
+The drift DQT pipeline (`DriftDqtJobRunner`/`RunDqtHandler`/`IDriftDqtComparer`) resolves
+comparers by `DqtTestType` and *is* generic for **running** a check. But **reading the run
+detail is not**: `GetDqtRunDetailHandler.Handle` shapes results with an explicit per-type
+branch:
+
+- `IssuedInvoiceComparison` → invoice results
+- `ProductPairing`/`StockWriteBackReconciliation`/`LotSumVsErpStock` → drift results (`GetDriftResultsAsync`)
+- anything else → `throw new NotSupportedException("No result-shaping logic registered ...")`
+
+So a new **drift** test type that only adds enum + comparer + job + DI will run and persist
+results fine, then blow up the moment someone opens its run detail:
+`System.NotSupportedException: No result-shaping logic registered for DqtTestType X`.
+
+## Checklist when adding a DQT drift test type
+1. `DqtTestType` enum value
+2. `IDriftDqtComparer` implementation + DI registration in `DataQualityModule`
+3. auto-discovered `IRecurringJob`
+4. **`GetDqtRunDetailHandler` — add the new value to the drift branch** ← the easy-to-miss one
+5. Frontend: `RunDqtButton`, `DqtRunsTable`, `DqtRunDetail` (isDriftTestType + flag map + headers), `i18n.ts`, regenerate TS client
+
+Grep `grep -rn --include="*.cs" "StockWriteBackReconciliation" backend/src` to find every
+per-type branch before assuming "generic, no handler changes." (Quote the `--include` glob —
+unquoted it gets eaten by zsh and the grep silently finds nothing, which is how this was
+missed the first time.)
+
+Seen 2026-07-08 on the LotSumVsErpStock (Šarže vs. ERP sklad) check, PR #3553.


### PR DESCRIPTION
Adds a Data Quality (DQT) check that reconciles, per material with expiration, the sum of loaded stock lots against ERP on-hand stock (`Stock.Erp`) at a 0.01 tolerance, surfacing drift as one of three flags — sum mismatch, missing lots, or orphan lots — on the existing Data Quality page. The backend reuses the generic drift pipeline: a new `DqtTestType.LotSumVsErpStock`, an `IDriftDqtComparer` over `ICatalogRepository`, and an auto-discovered daily recurring job (`daily-lot-stock-dqt`, 08:00) — no runner/handler/repository/migration changes. The frontend adds the run-button option, runs-table and detail flag labels, and per-type column headers (`ERP`/`Šarže`), plus the regenerated TS client enum and cs/en i18n labels. Covered by 14 new backend tests (11 comparer, 3 job); `dotnet build`/`format` and `npm run build`/`lint` all pass. Remaining manual step: trigger the run on staging and eyeball the detail table.