### PR TITLE
#3488: implementation

### DIFF
--- a/artifacts/feat-3488/arch-review.r1.md
+++ b/artifacts/feat-3488/arch-review.r1.md
@@ -1,0 +1,102 @@
+# Architecture Review: Inject TimeProvider into GetInvoiceImportStatisticsHandler
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a one-line-of-substance fix inside an existing MediatR handler; it introduces no new component, no new module, and no new contract. `TimeProvider` is already registered as a process-wide singleton (`services.AddSingleton(TimeProvider.System)` in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131`) and is already consumed via constructor injection by three other components in the same Analytics module:
+
+- `TimeWindowParser` (`Services/TimeWindowParser.cs`)
+- `InvoiceImportStatisticsTile` (`DashboardTiles/InvoiceImportStatisticsTile.cs`)
+- `GetBankStatementImportStatisticsHandler` (`UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`)
+
+`GetInvoiceImportStatisticsHandler` is the only time-aware class in the module still calling `DateTime.UtcNow` directly. `GetBankStatementImportStatisticsHandler` is structurally the closest sibling — same module, same layer (`IRequestHandler<TRequest,TResponse>`), same repository dependency (`IAnalyticsRepository`), same "compute a UTC date range, call repository" shape. It is the correct template to copy, and its test file (`GetBankStatementImportStatisticsHandlerTests.cs`) is the correct testing template. No new integration points, no DI registration changes, no cross-module impact.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. One existing node in the dependency graph gains one existing, already-available dependency:
+
+```
+DI container
+  └─ TimeProvider.System (singleton, registered once in ServiceCollectionExtensions.cs)
+       ├─ TimeWindowParser                          (already injected)
+       ├─ InvoiceImportStatisticsTile                (already injected)
+       ├─ GetBankStatementImportStatisticsHandler     (already injected)
+       └─ GetInvoiceImportStatisticsHandler           (← add injection here)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Reuse the already-registered singleton TimeProvider vs. introduce a new abstraction
+**Options considered:**
+1. Add a constructor parameter of type `TimeProvider` and use `_timeProvider.GetUtcNow()`.
+2. Introduce a module-specific clock abstraction (e.g. `IClock`) to decouple from BCL `TimeProvider`.
+
+**Chosen approach:** Option 1 — inject the BCL `TimeProvider` directly, exactly as `GetBankStatementImportStatisticsHandler` does.
+
+**Rationale:** The module has already standardized on `TimeProvider` (three existing consumers, one existing DI registration). Introducing a second abstraction would fragment the pattern for zero benefit — `TimeProvider` already supports deterministic testing via `Mock<TimeProvider>` / `FakeTimeProvider`, which is all this fix needs. This is also consistent with the spec's explicit instruction to match the sibling handler and not introduce a new testing convention.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files or directories. Edit in place:
+
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs`
+
+### Interfaces and Contracts
+Constructor changes from:
+```csharp
+public GetInvoiceImportStatisticsHandler(
+    IAnalyticsRepository analyticsRepository,
+    IOptions<InvoiceImportOptions> invoiceImportOptions)
+```
+to:
+```csharp
+public GetInvoiceImportStatisticsHandler(
+    IAnalyticsRepository analyticsRepository,
+    IOptions<InvoiceImportOptions> invoiceImportOptions,
+    TimeProvider timeProvider)
+```
+with a new `private readonly TimeProvider _timeProvider;` field assigned in the constructor body, matching the field-ordering and assignment style already used in `GetBankStatementImportStatisticsHandler`.
+
+Body change — replace:
+```csharp
+var endDate = DateTime.UtcNow.Date;
+endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+```
+with:
+```csharp
+var endDate = _timeProvider.GetUtcNow().Date;
+endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+```
+Everything downstream (`startDate`, repository call, response projection) is untouched, per spec.
+
+No public API contract (`GetInvoiceImportStatisticsRequest` / `GetInvoiceImportStatisticsResponse`) changes. MediatR auto-registers the handler by scanning, so no DI wiring change in `AnalyticsModule.cs` is needed — confirmed no explicit `services.AddScoped<GetInvoiceImportStatisticsHandler>` (or similar) registration exists anywhere in that file to touch.
+
+### Data Flow
+Unchanged except for the source of "now": `Handle()` still computes `[startDate, endDate]` from `daysBack`, calls `IAnalyticsRepository.GetInvoiceImportStatisticsAsync`, and projects results to `DailyInvoiceCountDto` with the threshold flag. The only difference is that "now" comes from the injected, mockable `TimeProvider.GetUtcNow()` instead of the static, unmockable `DateTime.UtcNow`.
+
+### Test Update
+`GetInvoiceImportStatisticsHandlerTests.cs` currently constructs the handler with two arguments in four places and asserts against live `DateTime.UtcNow.Date` in two tests (`Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`), which is itself a latent flakiness risk (midnight rollover between `Handle()`'s internal clock read and the test's own `DateTime.UtcNow.Date` read). Follow `GetBankStatementImportStatisticsHandlerTests.cs` exactly:
+```csharp
+private readonly Mock<TimeProvider> _timeProviderMock;
+private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);
+...
+_timeProviderMock = new Mock<TimeProvider>();
+_timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
+_handler = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, options, _timeProviderMock.Object);
+```
+Pass `_timeProviderMock.Object` at all four construction sites (the shared `_handler` in the constructor, plus the three ad-hoc handlers built inside `Handle_ShouldUseDefaultThresholdWhenNotConfigured`, `Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`), and replace their `DateTime.UtcNow.Date`-based expected values with `_fixedDateTime.Date`-based ones.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missing a `new GetInvoiceImportStatisticsHandler(...)` call site during the constructor signature change, breaking the build | Low | Only two call sites exist in production code (none — MediatR auto-resolves) and four in the single test file; a build-wide grep for `new GetInvoiceImportStatisticsHandler(` (as the spec's FR-2 acceptance criteria requires) is sufficient to catch all of them before considering the change complete |
+| Test-only regression: forgetting to update one of the two date-flakiness tests, leaving a hidden dependency on wall-clock time | Low | Both flagged tests (`Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`) must be updated per FR-2; run the full test file after the change and confirm no `DateTime.UtcNow` reference remains in it |
+
+## Specification Amendments
+None. The spec is complete, correctly scoped, and its acceptance criteria already reference the exact sibling files and testing convention this review independently confirmed by reading the code. No additions needed.
+
+## Prerequisites
+None. `TimeProvider` is already registered in the DI container (`backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:131`); no migration, config, or infrastructure work is required before implementation starts.

--- a/artifacts/feat-3488/brief.md
+++ b/artifacts/feat-3488/brief.md
@@ -1,0 +1,43 @@
+## Module
+Analytics
+
+## Finding
+`GetInvoiceImportStatisticsHandler` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs:36`) calls `DateTime.UtcNow` directly to determine the query end date:
+
+```csharp
+var endDate = DateTime.UtcNow.Date;
+endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+var startDate = endDate.AddDays(-daysBack);
+```
+
+Every other time-aware component in the same module uses the injected `TimeProvider`:
+- `TimeWindowParser` (line 8–9): `TimeProvider _timeProvider` → `_timeProvider.GetLocalNow()`
+- `InvoiceImportStatisticsTile` (line 10–11): `TimeProvider _timeProvider` → `_timeProvider.GetUtcNow()`
+
+`TimeProvider` is already registered in the DI container (both components prove this).
+
+## Why it matters
+Hard-coding `DateTime.UtcNow` makes the date range in this handler non-deterministic in tests. Unit tests for this handler cannot control "today" without static shims or other workarounds, breaking testability. It is also inconsistent with the established pattern in the module — `InvoiceImportStatisticsTile` (which calls the same repository method on the same data) uses `TimeProvider` correctly.
+
+## Suggested fix
+Inject `TimeProvider` and replace the direct call:
+
+```csharp
+public GetInvoiceImportStatisticsHandler(
+    IAnalyticsRepository analyticsRepository,
+    IOptions invoiceImportOptions,
+    TimeProvider timeProvider)               // ← add this
+{
+    _analyticsRepository = analyticsRepository;
+    _options = invoiceImportOptions.Value;
+    _timeProvider = timeProvider;
+}
+
+// In Handle():
+var endDate = _timeProvider.GetUtcNow().Date;
+```
+
+No DI registration change is needed — `TimeProvider` is already in the container.
+
+---
+_Filed by daily arch-review routine on 2026-07-05._

--- a/artifacts/feat-3488/code-review.r1.md
+++ b/artifacts/feat-3488/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3488/design.r1.md
+++ b/artifacts/feat-3488/design.r1.md
@@ -1,0 +1,48 @@
+# Design: Inject TimeProvider into GetInvoiceImportStatisticsHandler
+
+## Component Design
+
+No new components. Existing MediatR handler `GetInvoiceImportStatisticsHandler`
+(`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`)
+gains one additional constructor dependency: the already-registered singleton `TimeProvider`
+(`services.AddSingleton(TimeProvider.System)`), consistent with `TimeWindowParser`,
+`InvoiceImportStatisticsTile`, and `GetBankStatementImportStatisticsHandler`.
+
+**Constructor contract change:**
+
+```csharp
+public GetInvoiceImportStatisticsHandler(
+    IAnalyticsRepository analyticsRepository,
+    IOptions<InvoiceImportOptions> invoiceImportOptions,
+    TimeProvider timeProvider)
+```
+
+- New field: `private readonly TimeProvider _timeProvider;`, assigned in the constructor,
+  matching field-ordering/assignment style in `GetBankStatementImportStatisticsHandler`.
+- No interface (`IRequestHandler<TRequest, TResponse>`) or module registration changes —
+  MediatR resolves the handler by assembly scan; DI resolves `TimeProvider` from the
+  existing singleton registration.
+
+**`Handle()` body change:**
+
+- Replace `var endDate = DateTime.UtcNow.Date;` with `var endDate = _timeProvider.GetUtcNow().Date;`.
+- `endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);`, `startDate = endDate.AddDays(-daysBack)`,
+  the repository call (`GetInvoiceImportStatisticsAsync(startDate, endDate, request.DateType, cancellationToken)`),
+  threshold logic, and response projection are all unchanged.
+
+**Test contract change:**
+
+`backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs`
+follows the `GetBankStatementImportStatisticsHandlerTests.cs` pattern: a `Mock<TimeProvider>`
+field stubbed with a fixed `DateTimeOffset` via `GetUtcNow()`, passed as the third constructor
+argument at all four `new GetInvoiceImportStatisticsHandler(...)` call sites (shared `_handler`
+plus the three ad-hoc handlers in `Handle_ShouldUseDefaultThresholdWhenNotConfigured`,
+`Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`).
+Assertions that previously read `DateTime.UtcNow.Date` are rebased on the mock's fixed date.
+
+## Data Schemas
+
+No schema changes. `GetInvoiceImportStatisticsRequest`, `GetInvoiceImportStatisticsResponse`,
+and the `DailyInvoiceCountDto` projection are byte-for-byte unchanged. No new API endpoints,
+database schema, or event payloads are introduced — this is an internal time-source
+substitution only.

--- a/artifacts/feat-3488/impl/inject-timeprovider-into-handler-and-update-tests.r1.md
+++ b/artifacts/feat-3488/impl/inject-timeprovider-into-handler-and-update-tests.r1.md
@@ -1,0 +1,33 @@
+# Implementation: inject-timeprovider-into-handler-and-update-tests
+
+## What was implemented
+`GetInvoiceImportStatisticsHandler` now computes `endDate` from an injected `TimeProvider` instead of calling `DateTime.UtcNow` directly, matching the pattern already established by the sibling `GetBankStatementImportStatisticsHandler`, `TimeWindowParser`, and `InvoiceImportStatisticsTile` in the same Analytics module. The handler's unit tests were updated to construct the handler with a mocked `TimeProvider` returning a fixed date instead of relying on wall-clock time.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs` — added a `TimeProvider _timeProvider` field and constructor parameter; `Handle()` now reads `_timeProvider.GetUtcNow().Date` instead of `DateTime.UtcNow.Date`.
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` — added a `Mock<TimeProvider>` stubbed to return a fixed `DateTimeOffset` (2025-10-14T10:00:00Z), threaded `_timeProviderMock.Object` through all 4 handler construction sites, and rebased the two date-dependent assertions onto the fixed date instead of `DateTime.UtcNow.Date`.
+
+## Tests
+`backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` — covers threshold logic, default configuration, configurable days-back range (asserted against the fixed date), date-type pass-through, and default option values. All 6 tests are now deterministic (no wall-clock dependency).
+
+## How to verify
+```bash
+dotnet build Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetInvoiceImportStatisticsHandlerTests"
+```
+Expected: build succeeds, 6/6 tests pass.
+
+## Notes
+- No DI registration changes were needed — `TimeProvider.System` is already registered as a singleton in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`, and MediatR resolves the handler via assembly scan.
+- A full `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` run shows 64 pre-existing failures across the suite, all due to `Docker is either not running or misconfigured` (Testcontainers-based PostgreSQL integration tests) — a sandbox environment limitation unrelated to this change. 5588 tests pass, including all Analytics-related tests.
+- `dotnet format` was run against both changed files; it made no additional changes.
+
+## PR Summary
+Fixes an arch-review finding: `GetInvoiceImportStatisticsHandler` called `DateTime.UtcNow` directly instead of using the injected `TimeProvider` already used elsewhere in the Analytics module, making the handler's date range non-deterministic in tests. The fix injects `TimeProvider` via the constructor (already registered in DI) and replaces the direct call with `_timeProvider.GetUtcNow().Date`. The existing unit tests were updated to mock `TimeProvider` with a fixed date so they no longer depend on wall-clock time.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs` — inject and use `TimeProvider`
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` — mock `TimeProvider` with a fixed date across all handler construction sites
+
+## Status
+DONE

--- a/artifacts/feat-3488/review/inject-timeprovider-into-handler-and-update-tests.r1.md
+++ b/artifacts/feat-3488/review/inject-timeprovider-into-handler-and-update-tests.r1.md
@@ -1,0 +1,22 @@
+# Code Review: Inject TimeProvider into GetInvoiceImportStatisticsHandler
+
+## Summary
+The implementation matches the task spec exactly: `GetInvoiceImportStatisticsHandler` now takes an injected `TimeProvider` and uses `_timeProvider.GetUtcNow().Date` instead of `DateTime.UtcNow.Date`, and all 4 handler construction sites in the test file were updated to pass a mocked `TimeProvider` returning a fixed date. Verified the actual file contents against the spec's prescribed diff (byte-for-byte match) and independently ran a full solution build and the targeted test filter.
+
+## Review Result: PASS
+
+### task: inject-timeprovider-into-handler-and-update-tests
+**Status:** PASS
+
+## Verification performed
+- Read `GetInvoiceImportStatisticsHandler.cs`: contains the `_timeProvider` field, the new constructor parameter, and `var endDate = _timeProvider.GetUtcNow().Date;` — matches the spec's prescribed replacement exactly, with no unrelated changes.
+- Read `GetInvoiceImportStatisticsHandlerTests.cs`: `Mock<TimeProvider>` is stubbed to return a fixed `DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc)`; all 4 constructor call sites (main `_handler` field init plus 3 ad-hoc handlers in individual tests) pass `_timeProviderMock.Object`; date-dependent assertions (`Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`) now derive expected dates from `_fixedDateTime` rather than wall-clock time.
+- `grep` confirms no remaining `DateTime.UtcNow`/`DateTime.Now` in either file.
+- Ran `dotnet build Anela.Heblo.sln`: succeeded, 0 errors (250 pre-existing warnings unrelated to this change).
+- Ran `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetInvoiceImportStatisticsHandlerTests"`: 6/6 passed.
+- Confirmed `TimeProvider.System` is registered as singleton in `ServiceCollectionExtensions.cs:131`, so no DI changes were needed, consistent with the impl's claim.
+- Confirmed the change was committed (`faf363f Inject TimeProvider into GetInvoiceImportStatisticsHandler`) with only the two target files touched (plus the pipeline's own `state.json`, unrelated to this task).
+- The impl summary's note about 64 pre-existing Testcontainers/Docker-related failures in the full suite is a known sandbox limitation unrelated to this change and is not a basis for REVISION_NEEDED, per review instructions.
+
+## Overall Notes
+Implementation is a clean, minimal, surgical change that exactly follows the prescribed diff and the established pattern from `GetBankStatementImportStatisticsHandler`. No documentation updates are needed — this is an internal determinism fix with no change to public API behavior, contracts, or operational concerns.

--- a/artifacts/feat-3488/spec.r1.md
+++ b/artifacts/feat-3488/spec.r1.md
@@ -1,0 +1,56 @@
+# Specification: Inject TimeProvider into GetInvoiceImportStatisticsHandler
+
+## Summary
+`GetInvoiceImportStatisticsHandler` computes its query date range using `DateTime.UtcNow` directly instead of the injected `TimeProvider` abstraction used elsewhere in the Analytics module. This spec covers replacing the direct call with `TimeProvider`, matching the pattern already established by `TimeWindowParser`, `InvoiceImportStatisticsTile`, and the sibling `GetBankStatementImportStatisticsHandler`.
+
+## Background
+This is a small architecture-review fix, not a new feature. The Analytics module standardized on constructor-injected `TimeProvider` (registered in DI as the system default) to make "now" controllable in tests and consistent across components. `GetInvoiceImportStatisticsHandler` was missed during that standardization: it calls `DateTime.UtcNow.Date` directly (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs:37`), which makes the handler's date range non-deterministic in unit tests and inconsistent with `InvoiceImportStatisticsTile`, which reads from the same repository method but already uses `TimeProvider`.
+
+## Functional Requirements
+
+### FR-1: Inject `TimeProvider` into `GetInvoiceImportStatisticsHandler`
+Add a `TimeProvider timeProvider` constructor parameter to `GetInvoiceImportStatisticsHandler`, store it in a `private readonly TimeProvider _timeProvider` field, and use `_timeProvider.GetUtcNow().Date` in place of `DateTime.UtcNow.Date` when computing `endDate` in `Handle()`. No DI registration change is required — `TimeProvider` is already registered in the container (proven by its existing use in `TimeWindowParser` and `InvoiceImportStatisticsTile`).
+
+**Acceptance criteria:**
+- The handler's constructor signature becomes `GetInvoiceImportStatisticsHandler(IAnalyticsRepository analyticsRepository, IOptions<InvoiceImportOptions> invoiceImportOptions, TimeProvider timeProvider)`.
+- No remaining reference to `DateTime.UtcNow` (or `DateTime.Now`) exists in `GetInvoiceImportStatisticsHandler.cs`.
+- `endDate` is computed as `_timeProvider.GetUtcNow().Date`, then normalized with `DateTime.SpecifyKind(endDate, DateTimeKind.Utc)`, preserving the existing `startDate = endDate.AddDays(-daysBack)` logic unchanged.
+- Existing response shape, threshold logic, and repository call signature (`GetInvoiceImportStatisticsAsync(startDate, endDate, request.DateType, cancellationToken)`) are unchanged.
+- The application builds and starts successfully (DI resolves `GetInvoiceImportStatisticsHandler` without error), confirming `TimeProvider` is already available in the container.
+
+### FR-2: Update existing unit tests to supply a controllable `TimeProvider`
+`backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs` constructs `GetInvoiceImportStatisticsHandler` directly with two arguments (`_mockRepository.Object, options`) in three places. Once FR-1 lands, these call sites will fail to compile without a `TimeProvider` argument. Update the test file to follow the same pattern as `GetBankStatementImportStatisticsHandlerTests.cs`, which uses `Mock<TimeProvider>`.
+
+**Acceptance criteria:**
+- All `new GetInvoiceImportStatisticsHandler(...)` call sites in the test file pass a `TimeProvider` (e.g., a `Mock<TimeProvider>` configured with `GetUtcNow()` returning a fixed `DateTimeOffset`, consistent with the mocking style in `GetBankStatementImportStatisticsHandlerTests.cs`).
+- Tests that currently assert against `DateTime.UtcNow.Date` (e.g., `Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`) are updated to assert against the fixed date supplied by the mocked `TimeProvider`, removing their dependency on wall-clock time.
+- The full existing test suite in `GetInvoiceImportStatisticsHandlerTests.cs` passes with no flakiness introduced by clock/timing.
+- No other test files, callers, or DI registrations require changes (confirm via a build-wide search for `new GetInvoiceImportStatisticsHandler(`).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — this is a like-for-like substitution of one time-source call for another with no behavioral or performance impact.
+
+### NFR-2: Security
+Not applicable — no change to auth, data sensitivity, or external-facing surface.
+
+## Data Model
+No data model changes. No new entities, fields, or persistence changes.
+
+## API / Interface Design
+No public API, request, or response contract changes. `GetInvoiceImportStatisticsRequest` and `GetInvoiceImportStatisticsResponse` are untouched; only the handler's internal date computation and its constructor's dependency list change.
+
+## Dependencies
+- `TimeProvider` (`System`, .NET 8) — already registered in the DI container; no new registration needed.
+- No external services or new libraries introduced.
+
+## Out of Scope
+- Changing the date-range computation logic itself (e.g., `daysBack` semantics, threshold logic, or repository query behavior).
+- Refactoring other Analytics handlers beyond `GetInvoiceImportStatisticsHandler` and its test file.
+- Introducing `FakeTimeProvider` (from `Microsoft.Extensions.TimeProvider.Testing`) if the codebase's established convention for this module is `Mock<TimeProvider>` — follow the existing sibling test's approach rather than introducing a new testing convention.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-08T05:18:08.029291Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T05:18:32.085615Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T05:20:59.466301Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "inject-timeprovider-into-handler-and-update-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T05:20:59.466301Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T05:21:17.472802Z"
     }
   },
   "tasks": [
     {
       "name": "inject-timeprovider-into-handler-and-update-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T05:21:17.721065Z"
     }
   ]
 }

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T05:20:59.466301Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T05:21:17.472802Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T06:05:13.985481Z"
     }
   },
   "tasks": [
     {
       "name": "inject-timeprovider-into-handler-and-update-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T05:21:17.721065Z"
+      "updated_at": "2026-07-08T06:05:09.303099Z"
     }
   ]
 }

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T06:05:13.985481Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-08T06:05:17.955430Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -6,11 +6,11 @@
   "phases": {
     "analyzing": {
       "status": "completed",
-      "updated_at": "2026-07-08T05:15:56.023714Z"
+      "updated_at": "2026-07-08T05:16:00.474767Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T05:16:07.226839Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3488",
+  "issue_number": 3488,
+  "created_at": "2026-07-08T05:14:34.749545Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-08T05:15:56.023714Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-08T05:16:00.474767Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T05:16:07.226839Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T05:17:28.522756Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T05:17:35.921537Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3488/state.json
+++ b/artifacts/feat-3488/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-08T05:17:28.522756Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T05:17:35.921537Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T05:18:08.029291Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T05:18:32.085615Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3488/task-context/inject-timeprovider-into-handler-and-update-tests.md
+++ b/artifacts/feat-3488/task-context/inject-timeprovider-into-handler-and-update-tests.md
@@ -1,0 +1,396 @@
+### task: inject-timeprovider-into-handler-and-update-tests
+
+**Goal:** `GetInvoiceImportStatisticsHandler` computes `endDate` from an injected `TimeProvider` instead of `DateTime.UtcNow`, and its unit tests are updated to construct the handler with a mocked `TimeProvider` and assert against a fixed, deterministic date.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs`
+
+**Context for the engineer:**
+- The repo root is `/home/user/worktrees/feature-3488-Arch-Review-Analytics-Getinvoiceimportstatisticsha` (this is the working directory for all commands below).
+- The solution file is `Anela.Heblo.sln` at the repo root.
+- `TimeProvider` (BCL, .NET 8) is already registered in DI as a singleton (`services.AddSingleton(TimeProvider.System)` in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`), and is already consumed the same way by the sibling handler `GetBankStatementImportStatisticsHandler` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`) and its test `GetBankStatementImportStatisticsHandlerTests.cs`. No DI registration changes are needed in this task.
+- A build-wide grep confirms there are exactly 4 call sites constructing `GetInvoiceImportStatisticsHandler` directly (`new GetInvoiceImportStatisticsHandler(`), and all 4 are in the test file `GetInvoiceImportStatisticsHandlerTests.cs` (lines 23, 69, 94, 153 as of this writing). MediatR resolves the handler itself via assembly scanning, so there is no other production call site to update.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`. Its current full contents are:
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+
+/// <summary>
+/// Handler for getting invoice import statistics for monitoring purposes
+/// </summary>
+public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImportStatisticsRequest, GetInvoiceImportStatisticsResponse>
+{
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly InvoiceImportOptions _options;
+
+    public GetInvoiceImportStatisticsHandler(
+        IAnalyticsRepository analyticsRepository,
+        IOptions<InvoiceImportOptions> invoiceImportOptions)
+    {
+        _analyticsRepository = analyticsRepository;
+        _options = invoiceImportOptions.Value;
+    }
+
+    public async Task<GetInvoiceImportStatisticsResponse> Handle(
+        GetInvoiceImportStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        // Get configuration values
+        var minimumThreshold = _options.MinimumDailyThreshold;
+        var defaultDaysBack = _options.DefaultDaysBack;
+
+        // Use provided days back or default from configuration
+        var daysBack = request.DaysBack ?? defaultDaysBack;
+
+        // Calculate date range - work with UTC dates for consistency
+        // Repository will handle conversion to Unspecified for PostgreSQL timestamp without time zone
+        var endDate = DateTime.UtcNow.Date;
+        endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+        var startDate = endDate.AddDays(-daysBack);
+        startDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+
+        // Get daily invoice counts from repository
+        var dailyCounts = await _analyticsRepository.GetInvoiceImportStatisticsAsync(
+            startDate,
+            endDate,
+            request.DateType,
+            cancellationToken);
+
+        // Project to DTOs, marking days below threshold as problematic
+        var data = dailyCounts.Select(c => new DailyInvoiceCountDto
+        {
+            Date = c.Date,
+            Count = c.Count,
+            IsBelowThreshold = c.Count < minimumThreshold
+        }).ToList();
+
+        return new GetInvoiceImportStatisticsResponse
+        {
+            Data = data,
+            MinimumThreshold = minimumThreshold
+        };
+    }
+}
+```
+Replace the whole file with:
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+
+/// <summary>
+/// Handler for getting invoice import statistics for monitoring purposes
+/// </summary>
+public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImportStatisticsRequest, GetInvoiceImportStatisticsResponse>
+{
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly InvoiceImportOptions _options;
+    private readonly TimeProvider _timeProvider;
+
+    public GetInvoiceImportStatisticsHandler(
+        IAnalyticsRepository analyticsRepository,
+        IOptions<InvoiceImportOptions> invoiceImportOptions,
+        TimeProvider timeProvider)
+    {
+        _analyticsRepository = analyticsRepository;
+        _options = invoiceImportOptions.Value;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<GetInvoiceImportStatisticsResponse> Handle(
+        GetInvoiceImportStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        // Get configuration values
+        var minimumThreshold = _options.MinimumDailyThreshold;
+        var defaultDaysBack = _options.DefaultDaysBack;
+
+        // Use provided days back or default from configuration
+        var daysBack = request.DaysBack ?? defaultDaysBack;
+
+        // Calculate date range - work with UTC dates for consistency
+        // Repository will handle conversion to Unspecified for PostgreSQL timestamp without time zone
+        var endDate = _timeProvider.GetUtcNow().Date;
+        endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+        var startDate = endDate.AddDays(-daysBack);
+        startDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+
+        // Get daily invoice counts from repository
+        var dailyCounts = await _analyticsRepository.GetInvoiceImportStatisticsAsync(
+            startDate,
+            endDate,
+            request.DateType,
+            cancellationToken);
+
+        // Project to DTOs, marking days below threshold as problematic
+        var data = dailyCounts.Select(c => new DailyInvoiceCountDto
+        {
+            Date = c.Date,
+            Count = c.Count,
+            IsBelowThreshold = c.Count < minimumThreshold
+        }).ToList();
+
+        return new GetInvoiceImportStatisticsResponse
+        {
+            Data = data,
+            MinimumThreshold = minimumThreshold
+        };
+    }
+}
+```
+The only functional changes are: the new `private readonly TimeProvider _timeProvider;` field, the new third constructor parameter `TimeProvider timeProvider` with its assignment `_timeProvider = timeProvider;`, and replacing `var endDate = DateTime.UtcNow.Date;` with `var endDate = _timeProvider.GetUtcNow().Date;`. Everything else is byte-for-byte identical.
+
+- [ ] Step 2: Confirm the build now fails only in the test project (expected, since the constructor signature changed but the test file hasn't been updated yet). From the repo root, run:
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: build fails with CS7036 ("There is no argument given that corresponds to the required formal parameter 'timeProvider'") at the 4 call sites in `GetInvoiceImportStatisticsHandlerTests.cs` (lines 23, 69, 94, 153). This confirms the constructor change took effect and that these are the only call sites needing updates.
+
+- [ ] Step 3: Open `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs`. Replace its entire contents with:
+```csharp
+using Anela.Heblo.Application.Features.Analytics;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+using Anela.Heblo.Domain.Features.Analytics;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+public class GetInvoiceImportStatisticsHandlerTests
+{
+    private readonly Mock<IAnalyticsRepository> _mockRepository;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly GetInvoiceImportStatisticsHandler _handler;
+    private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);
+
+    public GetInvoiceImportStatisticsHandlerTests()
+    {
+        _mockRepository = new Mock<IAnalyticsRepository>();
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
+        var options = Options.Create(new InvoiceImportOptions
+        {
+            MinimumDailyThreshold = 10,
+            DefaultDaysBack = 14
+        });
+        _handler = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, options, _timeProviderMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnStatisticsWithMinimumThreshold()
+    {
+        // Arrange
+        var request = new GetInvoiceImportStatisticsRequest
+        {
+            DateType = ImportDateType.InvoiceDate,
+            DaysBack = 14
+        };
+
+        var expectedThreshold = 10;
+        var baseDate = _fixedDateTime.Date;
+        var expectedData = new List<DailyInvoiceCount>
+        {
+            new() { Date = DateTime.SpecifyKind(baseDate.AddDays(-1), DateTimeKind.Utc), Count = 15 },
+            new() { Date = DateTime.SpecifyKind(baseDate, DateTimeKind.Utc), Count = 5 } // IsBelowThreshold will be set by handler
+        };
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                ImportDateType.InvoiceDate,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedData);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        Assert.Equal(expectedThreshold, result.MinimumThreshold);
+        Assert.Equal(2, result.Data.Count);
+
+        // Verify threshold logic is applied
+        Assert.False(result.Data[0].IsBelowThreshold); // 15 >= 10
+        Assert.True(result.Data[1].IsBelowThreshold);  // 5 < 10
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseDefaultThresholdWhenNotConfigured()
+    {
+        // Arrange - Create handler with empty configuration
+        var handlerWithEmptyConfig = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions()),
+            _timeProviderMock.Object);
+
+        var request = new GetInvoiceImportStatisticsRequest();
+        var expectedData = new List<DailyInvoiceCount>();
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ImportDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedData);
+
+        // Act
+        var result = await handlerWithEmptyConfig.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(10, result.MinimumThreshold);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseConfigurableDefaultDaysBack()
+    {
+        // Arrange - Create handler with custom default days back
+        var handlerWithCustomConfig = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions { DefaultDaysBack = 30 }),
+            _timeProviderMock.Object);
+
+        var request = new GetInvoiceImportStatisticsRequest(); // DaysBack = null to use default
+        var expectedData = new List<DailyInvoiceCount>();
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ImportDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedData);
+
+        // Act
+        var result = await handlerWithCustomConfig.Handle(request, CancellationToken.None);
+
+        // Assert - Verify that 30 days range was used by checking repository call
+        // Implementation uses: startDate = endDate.AddDays(-daysBack), endDate = _timeProvider.GetUtcNow().Date
+        var expectedEndDate = _fixedDateTime.Date;
+        var expectedStartDate = expectedEndDate.AddDays(-30);
+
+        _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
+            It.Is<DateTime>(d => d.Date == expectedStartDate), // Should be 30 days before the fixed date
+            It.Is<DateTime>(d => d.Date == expectedEndDate), // Should be the fixed date
+            It.IsAny<ImportDateType>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(ImportDateType.InvoiceDate)]
+    [InlineData(ImportDateType.LastSyncTime)]
+    public async Task Handle_ShouldPassCorrectDateTypeToRepository(ImportDateType dateType)
+    {
+        // Arrange
+        var request = new GetInvoiceImportStatisticsRequest { DateType = dateType };
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                dateType,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DailyInvoiceCount>());
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
+            It.IsAny<DateTime>(),
+            It.IsAny<DateTime>(),
+            dateType,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless()
+    {
+        // Arrange
+        var handlerWithDefaults = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions()),
+            _timeProviderMock.Object);
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ImportDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DailyInvoiceCount>());
+
+        var request = new GetInvoiceImportStatisticsRequest();
+
+        // Act
+        var result = await handlerWithDefaults.Handle(request, CancellationToken.None);
+
+        // Assert - defaults are 10 and 14
+        Assert.Equal(10, result.MinimumThreshold);
+        _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
+            It.Is<DateTime>(d => d.Date == _fixedDateTime.Date.AddDays(-14)),
+            It.IsAny<DateTime>(),
+            It.IsAny<ImportDateType>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+Summary of changes made in this step (for review purposes):
+- Added `private readonly Mock<TimeProvider> _timeProviderMock;` and `private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);` fields.
+- In the constructor, initialize `_timeProviderMock` and stub `GetUtcNow()` to return `_fixedDateTime`, then pass `_timeProviderMock.Object` as the third argument to `_handler`'s construction.
+- Pass `_timeProviderMock.Object` as the third argument at the other 3 ad-hoc construction sites (`Handle_ShouldUseDefaultThresholdWhenNotConfigured`, `Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`).
+- In `Handle_ShouldReturnStatisticsWithMinimumThreshold`, `baseDate` now comes from `_fixedDateTime.Date` instead of `DateTime.UtcNow.Date` (this test doesn't assert on the exact dates passed to the repository, but removing the wall-clock read keeps the test fully deterministic).
+- In `Handle_ShouldUseConfigurableDefaultDaysBack`, `expectedEndDate` now comes from `_fixedDateTime.Date` instead of `DateTime.UtcNow.Date`.
+- In `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`, the `Verify` assertion now checks `d.Date == _fixedDateTime.Date.AddDays(-14)` instead of `d.Date == DateTime.UtcNow.Date.AddDays(-14)`.
+
+- [ ] Step 4: Confirm there is no remaining reference to `DateTime.UtcNow` or `DateTime.Now` in either file. From the repo root, run:
+```bash
+grep -n "DateTime.UtcNow\|DateTime.Now" backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
+```
+Expected: no output (no matches) from either file.
+
+- [ ] Step 5: Build the backend solution. From the repo root, run:
+```bash
+dotnet build Anela.Heblo.sln
+```
+Expected: `Build succeeded.` with 0 errors.
+
+- [ ] Step 6: Run the updated test file. From the repo root, run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetInvoiceImportStatisticsHandlerTests"
+```
+Expected: all 6 tests pass (`Handle_ShouldReturnStatisticsWithMinimumThreshold`, `Handle_ShouldUseDefaultThresholdWhenNotConfigured`, `Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldPassCorrectDateTypeToRepository` x2 theory cases, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`), 0 failed.
+
+- [ ] Step 7: Run the full test project to confirm no other test was broken by the constructor change. From the repo root, run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: all tests pass, 0 failed.
+
+- [ ] Step 8: Format the code to match repository conventions. From the repo root, run:
+```bash
+dotnet format Anela.Heblo.sln
+```
+Expected: exits successfully; if it modifies either of the two files, re-run Step 5 and Step 6 to confirm the build and tests still pass after formatting.
+
+- [ ] Step 9: Stage and commit the change. From the repo root, run:
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
+git commit -m "Inject TimeProvider into GetInvoiceImportStatisticsHandler
+
+Replaces the direct DateTime.UtcNow call with the module's standard
+injected TimeProvider, matching GetBankStatementImportStatisticsHandler,
+TimeWindowParser, and InvoiceImportStatisticsTile. Updates the handler's
+unit tests to use a mocked, fixed TimeProvider instead of asserting
+against wall-clock time."
+```
+Expected: commit succeeds; `git status` shows a clean working tree (no unstaged changes) for these two files.

--- a/artifacts/feat-3488/task-plan.r1.md
+++ b/artifacts/feat-3488/task-plan.r1.md
@@ -1,0 +1,401 @@
+# Task Plan: Inject TimeProvider into GetInvoiceImportStatisticsHandler
+
+## Overview
+Replace the direct `DateTime.UtcNow` call in `GetInvoiceImportStatisticsHandler` with an injected `TimeProvider`, matching the pattern already used by `GetBankStatementImportStatisticsHandler`, and update the handler's unit tests to supply a mocked, fixed `TimeProvider` instead of relying on wall-clock time.
+
+### task: inject-timeprovider-into-handler-and-update-tests
+
+**Goal:** `GetInvoiceImportStatisticsHandler` computes `endDate` from an injected `TimeProvider` instead of `DateTime.UtcNow`, and its unit tests are updated to construct the handler with a mocked `TimeProvider` and assert against a fixed, deterministic date.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs`
+
+**Context for the engineer:**
+- The repo root is `/home/user/worktrees/feature-3488-Arch-Review-Analytics-Getinvoiceimportstatisticsha` (this is the working directory for all commands below).
+- The solution file is `Anela.Heblo.sln` at the repo root.
+- `TimeProvider` (BCL, .NET 8) is already registered in DI as a singleton (`services.AddSingleton(TimeProvider.System)` in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`), and is already consumed the same way by the sibling handler `GetBankStatementImportStatisticsHandler` (`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetBankStatementImportStatistics/GetBankStatementImportStatisticsHandler.cs`) and its test `GetBankStatementImportStatisticsHandlerTests.cs`. No DI registration changes are needed in this task.
+- A build-wide grep confirms there are exactly 4 call sites constructing `GetInvoiceImportStatisticsHandler` directly (`new GetInvoiceImportStatisticsHandler(`), and all 4 are in the test file `GetInvoiceImportStatisticsHandlerTests.cs` (lines 23, 69, 94, 153 as of this writing). MediatR resolves the handler itself via assembly scanning, so there is no other production call site to update.
+
+- [ ] Step 1: Open `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs`. Its current full contents are:
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+
+/// <summary>
+/// Handler for getting invoice import statistics for monitoring purposes
+/// </summary>
+public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImportStatisticsRequest, GetInvoiceImportStatisticsResponse>
+{
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly InvoiceImportOptions _options;
+
+    public GetInvoiceImportStatisticsHandler(
+        IAnalyticsRepository analyticsRepository,
+        IOptions<InvoiceImportOptions> invoiceImportOptions)
+    {
+        _analyticsRepository = analyticsRepository;
+        _options = invoiceImportOptions.Value;
+    }
+
+    public async Task<GetInvoiceImportStatisticsResponse> Handle(
+        GetInvoiceImportStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        // Get configuration values
+        var minimumThreshold = _options.MinimumDailyThreshold;
+        var defaultDaysBack = _options.DefaultDaysBack;
+
+        // Use provided days back or default from configuration
+        var daysBack = request.DaysBack ?? defaultDaysBack;
+
+        // Calculate date range - work with UTC dates for consistency
+        // Repository will handle conversion to Unspecified for PostgreSQL timestamp without time zone
+        var endDate = DateTime.UtcNow.Date;
+        endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+        var startDate = endDate.AddDays(-daysBack);
+        startDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+
+        // Get daily invoice counts from repository
+        var dailyCounts = await _analyticsRepository.GetInvoiceImportStatisticsAsync(
+            startDate,
+            endDate,
+            request.DateType,
+            cancellationToken);
+
+        // Project to DTOs, marking days below threshold as problematic
+        var data = dailyCounts.Select(c => new DailyInvoiceCountDto
+        {
+            Date = c.Date,
+            Count = c.Count,
+            IsBelowThreshold = c.Count < minimumThreshold
+        }).ToList();
+
+        return new GetInvoiceImportStatisticsResponse
+        {
+            Data = data,
+            MinimumThreshold = minimumThreshold
+        };
+    }
+}
+```
+Replace the whole file with:
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+
+/// <summary>
+/// Handler for getting invoice import statistics for monitoring purposes
+/// </summary>
+public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImportStatisticsRequest, GetInvoiceImportStatisticsResponse>
+{
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly InvoiceImportOptions _options;
+    private readonly TimeProvider _timeProvider;
+
+    public GetInvoiceImportStatisticsHandler(
+        IAnalyticsRepository analyticsRepository,
+        IOptions<InvoiceImportOptions> invoiceImportOptions,
+        TimeProvider timeProvider)
+    {
+        _analyticsRepository = analyticsRepository;
+        _options = invoiceImportOptions.Value;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<GetInvoiceImportStatisticsResponse> Handle(
+        GetInvoiceImportStatisticsRequest request,
+        CancellationToken cancellationToken)
+    {
+        // Get configuration values
+        var minimumThreshold = _options.MinimumDailyThreshold;
+        var defaultDaysBack = _options.DefaultDaysBack;
+
+        // Use provided days back or default from configuration
+        var daysBack = request.DaysBack ?? defaultDaysBack;
+
+        // Calculate date range - work with UTC dates for consistency
+        // Repository will handle conversion to Unspecified for PostgreSQL timestamp without time zone
+        var endDate = _timeProvider.GetUtcNow().Date;
+        endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+        var startDate = endDate.AddDays(-daysBack);
+        startDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+
+        // Get daily invoice counts from repository
+        var dailyCounts = await _analyticsRepository.GetInvoiceImportStatisticsAsync(
+            startDate,
+            endDate,
+            request.DateType,
+            cancellationToken);
+
+        // Project to DTOs, marking days below threshold as problematic
+        var data = dailyCounts.Select(c => new DailyInvoiceCountDto
+        {
+            Date = c.Date,
+            Count = c.Count,
+            IsBelowThreshold = c.Count < minimumThreshold
+        }).ToList();
+
+        return new GetInvoiceImportStatisticsResponse
+        {
+            Data = data,
+            MinimumThreshold = minimumThreshold
+        };
+    }
+}
+```
+The only functional changes are: the new `private readonly TimeProvider _timeProvider;` field, the new third constructor parameter `TimeProvider timeProvider` with its assignment `_timeProvider = timeProvider;`, and replacing `var endDate = DateTime.UtcNow.Date;` with `var endDate = _timeProvider.GetUtcNow().Date;`. Everything else is byte-for-byte identical.
+
+- [ ] Step 2: Confirm the build now fails only in the test project (expected, since the constructor signature changed but the test file hasn't been updated yet). From the repo root, run:
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: build fails with CS7036 ("There is no argument given that corresponds to the required formal parameter 'timeProvider'") at the 4 call sites in `GetInvoiceImportStatisticsHandlerTests.cs` (lines 23, 69, 94, 153). This confirms the constructor change took effect and that these are the only call sites needing updates.
+
+- [ ] Step 3: Open `backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs`. Replace its entire contents with:
+```csharp
+using Anela.Heblo.Application.Features.Analytics;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+using Anela.Heblo.Domain.Features.Analytics;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+public class GetInvoiceImportStatisticsHandlerTests
+{
+    private readonly Mock<IAnalyticsRepository> _mockRepository;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly GetInvoiceImportStatisticsHandler _handler;
+    private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);
+
+    public GetInvoiceImportStatisticsHandlerTests()
+    {
+        _mockRepository = new Mock<IAnalyticsRepository>();
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
+        var options = Options.Create(new InvoiceImportOptions
+        {
+            MinimumDailyThreshold = 10,
+            DefaultDaysBack = 14
+        });
+        _handler = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, options, _timeProviderMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnStatisticsWithMinimumThreshold()
+    {
+        // Arrange
+        var request = new GetInvoiceImportStatisticsRequest
+        {
+            DateType = ImportDateType.InvoiceDate,
+            DaysBack = 14
+        };
+
+        var expectedThreshold = 10;
+        var baseDate = _fixedDateTime.Date;
+        var expectedData = new List<DailyInvoiceCount>
+        {
+            new() { Date = DateTime.SpecifyKind(baseDate.AddDays(-1), DateTimeKind.Utc), Count = 15 },
+            new() { Date = DateTime.SpecifyKind(baseDate, DateTimeKind.Utc), Count = 5 } // IsBelowThreshold will be set by handler
+        };
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                ImportDateType.InvoiceDate,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedData);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        Assert.Equal(expectedThreshold, result.MinimumThreshold);
+        Assert.Equal(2, result.Data.Count);
+
+        // Verify threshold logic is applied
+        Assert.False(result.Data[0].IsBelowThreshold); // 15 >= 10
+        Assert.True(result.Data[1].IsBelowThreshold);  // 5 < 10
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseDefaultThresholdWhenNotConfigured()
+    {
+        // Arrange - Create handler with empty configuration
+        var handlerWithEmptyConfig = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions()),
+            _timeProviderMock.Object);
+
+        var request = new GetInvoiceImportStatisticsRequest();
+        var expectedData = new List<DailyInvoiceCount>();
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ImportDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedData);
+
+        // Act
+        var result = await handlerWithEmptyConfig.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(10, result.MinimumThreshold);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseConfigurableDefaultDaysBack()
+    {
+        // Arrange - Create handler with custom default days back
+        var handlerWithCustomConfig = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions { DefaultDaysBack = 30 }),
+            _timeProviderMock.Object);
+
+        var request = new GetInvoiceImportStatisticsRequest(); // DaysBack = null to use default
+        var expectedData = new List<DailyInvoiceCount>();
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ImportDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedData);
+
+        // Act
+        var result = await handlerWithCustomConfig.Handle(request, CancellationToken.None);
+
+        // Assert - Verify that 30 days range was used by checking repository call
+        // Implementation uses: startDate = endDate.AddDays(-daysBack), endDate = _timeProvider.GetUtcNow().Date
+        var expectedEndDate = _fixedDateTime.Date;
+        var expectedStartDate = expectedEndDate.AddDays(-30);
+
+        _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
+            It.Is<DateTime>(d => d.Date == expectedStartDate), // Should be 30 days before the fixed date
+            It.Is<DateTime>(d => d.Date == expectedEndDate), // Should be the fixed date
+            It.IsAny<ImportDateType>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(ImportDateType.InvoiceDate)]
+    [InlineData(ImportDateType.LastSyncTime)]
+    public async Task Handle_ShouldPassCorrectDateTypeToRepository(ImportDateType dateType)
+    {
+        // Arrange
+        var request = new GetInvoiceImportStatisticsRequest { DateType = dateType };
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                dateType,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DailyInvoiceCount>());
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
+            It.IsAny<DateTime>(),
+            It.IsAny<DateTime>(),
+            dateType,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless()
+    {
+        // Arrange
+        var handlerWithDefaults = new GetInvoiceImportStatisticsHandler(
+            _mockRepository.Object,
+            Options.Create(new InvoiceImportOptions()),
+            _timeProviderMock.Object);
+
+        _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ImportDateType>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DailyInvoiceCount>());
+
+        var request = new GetInvoiceImportStatisticsRequest();
+
+        // Act
+        var result = await handlerWithDefaults.Handle(request, CancellationToken.None);
+
+        // Assert - defaults are 10 and 14
+        Assert.Equal(10, result.MinimumThreshold);
+        _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
+            It.Is<DateTime>(d => d.Date == _fixedDateTime.Date.AddDays(-14)),
+            It.IsAny<DateTime>(),
+            It.IsAny<ImportDateType>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+Summary of changes made in this step (for review purposes):
+- Added `private readonly Mock<TimeProvider> _timeProviderMock;` and `private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);` fields.
+- In the constructor, initialize `_timeProviderMock` and stub `GetUtcNow()` to return `_fixedDateTime`, then pass `_timeProviderMock.Object` as the third argument to `_handler`'s construction.
+- Pass `_timeProviderMock.Object` as the third argument at the other 3 ad-hoc construction sites (`Handle_ShouldUseDefaultThresholdWhenNotConfigured`, `Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`).
+- In `Handle_ShouldReturnStatisticsWithMinimumThreshold`, `baseDate` now comes from `_fixedDateTime.Date` instead of `DateTime.UtcNow.Date` (this test doesn't assert on the exact dates passed to the repository, but removing the wall-clock read keeps the test fully deterministic).
+- In `Handle_ShouldUseConfigurableDefaultDaysBack`, `expectedEndDate` now comes from `_fixedDateTime.Date` instead of `DateTime.UtcNow.Date`.
+- In `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`, the `Verify` assertion now checks `d.Date == _fixedDateTime.Date.AddDays(-14)` instead of `d.Date == DateTime.UtcNow.Date.AddDays(-14)`.
+
+- [ ] Step 4: Confirm there is no remaining reference to `DateTime.UtcNow` or `DateTime.Now` in either file. From the repo root, run:
+```bash
+grep -n "DateTime.UtcNow\|DateTime.Now" backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
+```
+Expected: no output (no matches) from either file.
+
+- [ ] Step 5: Build the backend solution. From the repo root, run:
+```bash
+dotnet build Anela.Heblo.sln
+```
+Expected: `Build succeeded.` with 0 errors.
+
+- [ ] Step 6: Run the updated test file. From the repo root, run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetInvoiceImportStatisticsHandlerTests"
+```
+Expected: all 6 tests pass (`Handle_ShouldReturnStatisticsWithMinimumThreshold`, `Handle_ShouldUseDefaultThresholdWhenNotConfigured`, `Handle_ShouldUseConfigurableDefaultDaysBack`, `Handle_ShouldPassCorrectDateTypeToRepository` x2 theory cases, `Handle_ShouldUseDefaultValuesWhenOptionsAreParameterless`), 0 failed.
+
+- [ ] Step 7: Run the full test project to confirm no other test was broken by the constructor change. From the repo root, run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: all tests pass, 0 failed.
+
+- [ ] Step 8: Format the code to match repository conventions. From the repo root, run:
+```bash
+dotnet format Anela.Heblo.sln
+```
+Expected: exits successfully; if it modifies either of the two files, re-run Step 5 and Step 6 to confirm the build and tests still pass after formatting.
+
+- [ ] Step 9: Stage and commit the change. From the repo root, run:
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
+git commit -m "Inject TimeProvider into GetInvoiceImportStatisticsHandler
+
+Replaces the direct DateTime.UtcNow call with the module's standard
+injected TimeProvider, matching GetBankStatementImportStatisticsHandler,
+TimeWindowParser, and InvoiceImportStatisticsTile. Updates the handler's
+unit tests to use a mocked, fixed TimeProvider instead of asserting
+against wall-clock time."
+```
+Expected: commit succeeds; `git status` shows a clean working tree (no unstaged changes) for these two files.

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetInvoiceImportStatistics/GetInvoiceImportStatisticsHandler.cs
@@ -12,13 +12,16 @@ public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImpor
 {
     private readonly IAnalyticsRepository _analyticsRepository;
     private readonly InvoiceImportOptions _options;
+    private readonly TimeProvider _timeProvider;
 
     public GetInvoiceImportStatisticsHandler(
         IAnalyticsRepository analyticsRepository,
-        IOptions<InvoiceImportOptions> invoiceImportOptions)
+        IOptions<InvoiceImportOptions> invoiceImportOptions,
+        TimeProvider timeProvider)
     {
         _analyticsRepository = analyticsRepository;
         _options = invoiceImportOptions.Value;
+        _timeProvider = timeProvider;
     }
 
     public async Task<GetInvoiceImportStatisticsResponse> Handle(
@@ -34,7 +37,7 @@ public class GetInvoiceImportStatisticsHandler : IRequestHandler<GetInvoiceImpor
 
         // Calculate date range - work with UTC dates for consistency
         // Repository will handle conversion to Unspecified for PostgreSQL timestamp without time zone
-        var endDate = DateTime.UtcNow.Date;
+        var endDate = _timeProvider.GetUtcNow().Date;
         endDate = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
 
         var startDate = endDate.AddDays(-daysBack);

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetInvoiceImportStatisticsHandlerTests.cs
@@ -10,17 +10,21 @@ namespace Anela.Heblo.Tests.Features.Analytics;
 public class GetInvoiceImportStatisticsHandlerTests
 {
     private readonly Mock<IAnalyticsRepository> _mockRepository;
+    private readonly Mock<TimeProvider> _timeProviderMock;
     private readonly GetInvoiceImportStatisticsHandler _handler;
+    private readonly DateTime _fixedDateTime = new DateTime(2025, 10, 14, 10, 0, 0, DateTimeKind.Utc);
 
     public GetInvoiceImportStatisticsHandlerTests()
     {
         _mockRepository = new Mock<IAnalyticsRepository>();
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(x => x.GetUtcNow()).Returns(_fixedDateTime);
         var options = Options.Create(new InvoiceImportOptions
         {
             MinimumDailyThreshold = 10,
             DefaultDaysBack = 14
         });
-        _handler = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, options);
+        _handler = new GetInvoiceImportStatisticsHandler(_mockRepository.Object, options, _timeProviderMock.Object);
     }
 
     [Fact]
@@ -34,7 +38,7 @@ public class GetInvoiceImportStatisticsHandlerTests
         };
 
         var expectedThreshold = 10;
-        var baseDate = DateTime.UtcNow.Date;
+        var baseDate = _fixedDateTime.Date;
         var expectedData = new List<DailyInvoiceCount>
         {
             new() { Date = DateTime.SpecifyKind(baseDate.AddDays(-1), DateTimeKind.Utc), Count = 15 },
@@ -68,7 +72,8 @@ public class GetInvoiceImportStatisticsHandlerTests
         // Arrange - Create handler with empty configuration
         var handlerWithEmptyConfig = new GetInvoiceImportStatisticsHandler(
             _mockRepository.Object,
-            Options.Create(new InvoiceImportOptions()));
+            Options.Create(new InvoiceImportOptions()),
+            _timeProviderMock.Object);
 
         var request = new GetInvoiceImportStatisticsRequest();
         var expectedData = new List<DailyInvoiceCount>();
@@ -93,7 +98,8 @@ public class GetInvoiceImportStatisticsHandlerTests
         // Arrange - Create handler with custom default days back
         var handlerWithCustomConfig = new GetInvoiceImportStatisticsHandler(
             _mockRepository.Object,
-            Options.Create(new InvoiceImportOptions { DefaultDaysBack = 30 }));
+            Options.Create(new InvoiceImportOptions { DefaultDaysBack = 30 }),
+            _timeProviderMock.Object);
 
         var request = new GetInvoiceImportStatisticsRequest(); // DaysBack = null to use default
         var expectedData = new List<DailyInvoiceCount>();
@@ -109,13 +115,13 @@ public class GetInvoiceImportStatisticsHandlerTests
         var result = await handlerWithCustomConfig.Handle(request, CancellationToken.None);
 
         // Assert - Verify that 30 days range was used by checking repository call
-        // Implementation uses: startDate = endDate.AddDays(-daysBack), endDate = DateTime.UtcNow.Date
-        var expectedEndDate = DateTime.UtcNow.Date;
+        // Implementation uses: startDate = endDate.AddDays(-daysBack), endDate = _timeProvider.GetUtcNow().Date
+        var expectedEndDate = _fixedDateTime.Date;
         var expectedStartDate = expectedEndDate.AddDays(-30);
 
         _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
-            It.Is<DateTime>(d => d.Date == expectedStartDate), // Should be 30 days ago
-            It.Is<DateTime>(d => d.Date == expectedEndDate), // Should be today
+            It.Is<DateTime>(d => d.Date == expectedStartDate), // Should be 30 days before the fixed date
+            It.Is<DateTime>(d => d.Date == expectedEndDate), // Should be the fixed date
             It.IsAny<ImportDateType>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -152,7 +158,8 @@ public class GetInvoiceImportStatisticsHandlerTests
         // Arrange
         var handlerWithDefaults = new GetInvoiceImportStatisticsHandler(
             _mockRepository.Object,
-            Options.Create(new InvoiceImportOptions()));
+            Options.Create(new InvoiceImportOptions()),
+            _timeProviderMock.Object);
 
         _mockRepository.Setup(r => r.GetInvoiceImportStatisticsAsync(
                 It.IsAny<DateTime>(),
@@ -169,7 +176,7 @@ public class GetInvoiceImportStatisticsHandlerTests
         // Assert - defaults are 10 and 14
         Assert.Equal(10, result.MinimumThreshold);
         _mockRepository.Verify(r => r.GetInvoiceImportStatisticsAsync(
-            It.Is<DateTime>(d => d.Date == DateTime.UtcNow.Date.AddDays(-14)),
+            It.Is<DateTime>(d => d.Date == _fixedDateTime.Date.AddDays(-14)),
             It.IsAny<DateTime>(),
             It.IsAny<ImportDateType>(),
             It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
Closes #3488

## What the issue was
`GetInvoiceImportStatisticsHandler` computed its query date range using `DateTime.UtcNow` directly instead of the injected `TimeProvider` abstraction already used elsewhere in the Analytics module (`TimeWindowParser`, `InvoiceImportStatisticsTile`, and the sibling `GetBankStatementImportStatisticsHandler`). This made the handler's date range non-deterministic in unit tests and inconsistent with the module's established pattern.

## How it was fixed / handled
Injected `TimeProvider` into `GetInvoiceImportStatisticsHandler`'s constructor (already registered in DI, no registration change needed) and replaced `DateTime.UtcNow.Date` with `_timeProvider.GetUtcNow().Date` when computing `endDate`. Updated the handler's existing unit tests (`GetInvoiceImportStatisticsHandlerTests.cs`) to construct the handler with a mocked `TimeProvider` returning a fixed date, following the same `Mock<TimeProvider>` pattern already used in `GetBankStatementImportStatisticsHandlerTests.cs`, and rebased the two date-dependent assertions onto the fixed date instead of wall-clock time.

Verified: `dotnet build` succeeds with 0 errors; the 6 handler unit tests pass; a full-suite run shows only pre-existing Testcontainers/Docker-related integration test failures unrelated to this change (no Docker daemon in the sandbox).

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, review, and code-review markdown are committed in this branch under `artifacts/feat-3488/`.

## Code review

```
## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFPE8rV4r2AyhEL6DsSaTc)_