### PR TITLE
#3544: Remove unused methods from IClassificationHistoryRepository

### DIFF
--- a/artifacts/feat-3544/arch-review.r1.md
+++ b/artifacts/feat-3544/arch-review.r1.md
@@ -1,0 +1,123 @@
+# Architecture Review: Remove unused methods from IClassificationHistoryRepository
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a pure dead-code removal within a single vertical slice (`InvoiceClassification`), touching only the `Anela.Heblo.Domain` and `Anela.Heblo.Persistence` projects. It does not cross module boundaries, does not touch DI registration, and does not change any MediatR request/response contract or controller surface. It fully aligns with the project's Vertical Slice Architecture and the "no speculative methods" principle already codified in `docs/architecture/development_guidelines.md` (§ Cross-Module Communication Example: "exposing only the operations it actually consumes (no speculative methods)"). There is no new architectural surface introduced — the task is a subtraction, not an addition — so no new pattern, ADR, or design decision is required.
+
+Verification performed directly against the working tree (not just the spec's claims):
+- `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs` — confirmed 4 members: `AddAsync`, `GetHistoryAsync` (line 7), `GetHistoryByInvoiceIdAsync` (line 9), `GetPagedHistoryAsync`.
+- `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs` — confirmed `GetHistoryAsync` implementation spans lines 22–30, `GetHistoryByInvoiceIdAsync` spans lines 32–39, both using `_context.ClassificationHistory` with `.Include(h => h.ClassificationRule)`.
+- Codebase-wide grep for `GetHistoryAsync(` and `GetHistoryByInvoiceIdAsync(` restricted to InvoiceClassification-related files returned zero call sites (the unqualified `GetHistoryAsync` name collides with an unrelated `FlexiManufactureHistoryClientTests.cs` method in the Manufacture module — a false positive on naming, not a real usage of this interface).
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs` — mocks `IClassificationHistoryRepository` via `Mock<IClassificationHistoryRepository>` but only ever sets up `.Setup(x => x.AddAsync(...))`. No `.Setup` or `.Verify` call references either target method. Since Moq mocks are interface-driven, no code change is needed here even after the methods are removed from the interface — the mock will simply no longer expose them.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationHistoryRepositoryTests.cs` — grepped for both method names, zero matches. This test only exercises `GetPagedHistoryAsync` (and implicitly `AddAsync` for fixture setup, per the spec).
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs` — confirmed it calls only `_historyRepository.GetPagedHistoryAsync(...)`.
+- Only 6 files in the whole repo reference `IClassificationHistoryRepository` by name: the interface, the implementation, the two consumers above, `InvoiceClassificationModule.cs` (DI registration), and `InvoiceClassificationServiceTests.cs`. None of the latter four need any edit.
+
+All spec claims are verified accurate. No additional dead-code or hidden coupling was found beyond what the spec already identified.
+
+## Proposed Architecture
+
+### Component Overview
+No component, layer, or dependency graph changes. The slice's shape before and after:
+
+```
+Anela.Heblo.Domain/Features/InvoiceClassification/
+  IClassificationHistoryRepository.cs   <- 2 methods removed (AddAsync, GetPagedHistoryAsync remain)
+
+Anela.Heblo.Persistence/InvoiceClassification/
+  ClassificationHistoryRepository.cs    <- 2 implementations removed
+
+Anela.Heblo.Application/Features/InvoiceClassification/
+  Services/InvoiceClassificationService.cs        <- unchanged, uses AddAsync
+  UseCases/GetClassificationHistory/GetClassificationHistoryHandler.cs <- unchanged, uses GetPagedHistoryAsync
+  InvoiceClassificationModule.cs                   <- unchanged, DI binding unaffected
+```
+
+No sequence diagram is warranted — no runtime behavior changes for any existing consumer.
+
+### Key Design Decisions
+
+#### Decision 1: Delete outright vs. deprecate first
+**Options considered:**
+- (a) Mark `[Obsolete]` and delete in a later PR.
+- (b) Delete immediately.
+
+**Chosen approach:** (b) Delete immediately.
+
+**Rationale:** These are `internal`-scope backend contract methods (not a published/public API, not consumed by any external module or the frontend). There is no external consumer to give a deprecation window to — grep confirms zero call sites. `[Obsolete]` would only add ceremony without protecting any real caller, and the spec's own YAGNI framing ("add them back when the consumer exists") supports a clean, immediate deletion over staged deprecation.
+
+#### Decision 2: Scope of the change
+**Options considered:**
+- (a) Also address the `AbraInvoiceId`/`InvoiceNumber` naming ambiguity mentioned in the brief.
+- (b) Leave that naming question untouched, as the spec's "Out of Scope" section directs.
+
+**Chosen approach:** (b).
+
+**Rationale:** The spec explicitly tracks the naming ambiguity as a separate companion issue. `GetHistoryByInvoiceIdAsync` (the only method that filtered on `AbraInvoiceId`) is being deleted entirely, which removes the ambiguous surface as a side effect — there is nothing left to rename. Mixing an unrelated rename into a dead-code-removal PR would violate the project's "surgical changes" rule (CLAUDE.md: "Touch only what the task requires").
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files, directories, or modules. Exactly two existing files are edited:
+
+1. `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs`
+   - Delete line 7: `Task<List<ClassificationHistory>> GetHistoryAsync(int skip = 0, int take = 50);`
+   - Delete the blank line after it and line 9: `Task<List<ClassificationHistory>> GetHistoryByInvoiceIdAsync(string abraInvoiceId);`
+   - Delete the blank line that separated it from `GetPagedHistoryAsync`, OR keep exactly one blank line — match the existing blank-line-between-members style already used before `AddAsync`/`GetPagedHistoryAsync`, i.e. leave one blank line between `AddAsync` and `GetPagedHistoryAsync` after the middle two are removed. Resulting file body:
+     ```csharp
+     namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+     public interface IClassificationHistoryRepository
+     {
+         Task<ClassificationHistory> AddAsync(ClassificationHistory history);
+
+         Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+             int page = 1,
+             int pageSize = 20,
+             DateTime? fromDate = null,
+             DateTime? toDate = null,
+             string? invoiceNumber = null,
+             string? companyName = null);
+     }
+     ```
+
+2. `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs`
+   - Delete the `GetHistoryAsync` method body (currently lines 22–30, including its blank surrounding lines as needed to avoid double blank lines).
+   - Delete the `GetHistoryByInvoiceIdAsync` method body (currently lines 32–39).
+   - Leave `AddAsync` and `GetPagedHistoryAsync` byte-for-byte unchanged; only remove the two method blocks and normalize surrounding whitespace to a single blank line between remaining members, matching existing style.
+
+No changes to `using` directives are needed in either file — `Skip`/`Take`/`Where` LINQ extensions used only inside the deleted methods come from `Microsoft.EntityFrameworkCore`, which remains needed for `GetPagedHistoryAsync`'s own `Skip`/`Take`/`Where` calls (verified: `GetPagedHistoryAsync` already uses `.Where`, `.Skip`, `.Take`, `.CountAsync`, `.OrderByDescending`, `.ToListAsync` from the same namespace).
+
+### Interfaces and Contracts
+Post-change interface (already validated against source, matches the spec's "After" block exactly):
+
+```csharp
+public interface IClassificationHistoryRepository
+{
+    Task<ClassificationHistory> AddAsync(ClassificationHistory history);
+    Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+        int page = 1, int pageSize = 20, DateTime? fromDate = null,
+        DateTime? toDate = null, string? invoiceNumber = null, string? companyName = null);
+}
+```
+
+No other module, contract, or DTO depends on this interface's shape — it is not referenced from `Contracts/` (MediatR request/response) types, so this is not a breaking API change from any HTTP-facing perspective.
+
+### Data Flow
+Unaffected. `InvoiceClassificationService.ClassifyInvoiceAsync` continues to call `AddAsync` after processing an invoice; `GetClassificationHistoryHandler.Handle` continues to call `GetPagedHistoryAsync` in response to `GetClassificationHistoryRequest`. Both paths are independently verified as untouched by this change.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A hidden caller outside the grepped surface (e.g. reflection-based invocation, a Razor/dynamic call) breaks at runtime instead of compile time | Very Low | Both methods are called only via the strongly-typed `IClassificationHistoryRepository` interface with no reflection usage found anywhere in the repo for this type; `dotnet build` will fail immediately if any remaining reference exists, since C# is statically typed and this is not a virtual/dynamic dispatch scenario. |
+| Whitespace/formatting drift after deletion (stray blank lines, inconsistent brace style) | Very Low | Run `dotnet format` after the edit, per CLAUDE.md's mandatory validation step; visually diff both files before committing to confirm exactly the two method blocks were removed and nothing else changed. |
+| Future developer re-adds one of these methods speculatively | Low | Spec's "Out of Scope" section already states the YAGNI stance: re-add only when a concrete consumer exists. No code-level guard is needed beyond this documented intent — do not add an analyzer/test to "forbid" unused methods, as that is disproportionate to a two-method cleanup. |
+
+## Specification Amendments
+None. The spec's file/line references, before/after interface listing, and consumer analysis were all independently verified against the working tree and are accurate as written. No functional requirement needs correction.
+
+One clarifying note for the implementer (not a spec change, just an implementation detail worth calling out explicitly since the spec doesn't spell it out): when deleting the two method blocks from `ClassificationHistoryRepository.cs`, delete one full blank line between remaining methods (not zero, not two) to match the file's existing one-blank-line-between-methods convention, consistent with FR-1's "no blank/orphaned lines or stray whitespace" acceptance criterion, which is written for the interface file but should be applied identically to the implementation file for consistency.
+
+## Prerequisites
+None. No migrations, config, feature flags, or infrastructure changes are needed — this is a same-commit, two-file, non-breaking source change. Standard validation (`dotnet build`, `dotnet format`, and the existing test suite: `InvoiceClassificationServiceTests`, `ClassificationHistoryRepositoryTests`) is sufficient to confirm correctness; no new tests are required since no new behavior is introduced.

--- a/artifacts/feat-3544/brief.md
+++ b/artifacts/feat-3544/brief.md
@@ -1,0 +1,19 @@
+## Module
+InvoiceClassification
+
+## Finding
+`IClassificationHistoryRepository` declares two methods that no handler ever calls:
+
+- `GetHistoryAsync(int skip, int take)` — `IClassificationHistoryRepository.cs:7`, implemented in `ClassificationHistoryRepository.cs:22`
+- `GetHistoryByInvoiceIdAsync(string abraInvoiceId)` — `IClassificationHistoryRepository.cs:9`, implemented in `ClassificationHistoryRepository.cs:32`
+
+The only handler that uses this repository is `GetClassificationHistoryHandler`, which calls only `GetPagedHistoryAsync`. A codebase-wide search confirms neither of the two methods is called from any handler, service, or test.
+
+## Why it matters
+Dead methods on a domain interface violate YAGNI and the Interface Segregation Principle: callers are forced to stub/mock additional surface they do not consume. The `GetHistoryByInvoiceIdAsync` method also conflates `AbraInvoiceId` with `InvoiceNumber` in a way that could mislead a future implementer (see companion issue). Keeping dead methods on the contract makes it harder to reason about what the module actually requires.
+
+## Suggested fix
+Remove `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync` from `IClassificationHistoryRepository` and delete their implementations in `ClassificationHistoryRepository`. If a future use-case needs them, add them back when the consumer exists.
+
+---
+_Filed by daily arch-review routine on 2026-07-07._

--- a/artifacts/feat-3544/code-review.r1.md
+++ b/artifacts/feat-3544/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3544/design.r1.md
+++ b/artifacts/feat-3544/design.r1.md
@@ -1,0 +1,45 @@
+# Design: Remove unused methods from IClassificationHistoryRepository
+
+## Component Design
+
+### `IClassificationHistoryRepository` (Anela.Heblo.Domain/Features/InvoiceClassification)
+**Responsibility:** Domain-facing contract for persisting and querying `ClassificationHistory` records, exposing only the operations actually consumed by the InvoiceClassification slice.
+
+**Interface after change:**
+```csharp
+namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+public interface IClassificationHistoryRepository
+{
+    Task<ClassificationHistory> AddAsync(ClassificationHistory history);
+
+    Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+        int page = 1,
+        int pageSize = 20,
+        DateTime? fromDate = null,
+        DateTime? toDate = null,
+        string? invoiceNumber = null,
+        string? companyName = null);
+}
+```
+`GetHistoryAsync(int skip = 0, int take = 50)` and `GetHistoryByInvoiceIdAsync(string abraInvoiceId)` are removed — no callers exist. `AddAsync` and `GetPagedHistoryAsync` are unchanged (signature, defaults, and behavior).
+
+### `ClassificationHistoryRepository` (Anela.Heblo.Persistence/InvoiceClassification)
+**Responsibility:** EF Core implementation of `IClassificationHistoryRepository` against `ApplicationDbContext.ClassificationHistory`.
+
+**Change:** Delete the `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync` method bodies. Retain `AddAsync` and `GetPagedHistoryAsync` byte-for-byte, including their existing use of `.Include(h => h.ClassificationRule)`, `.Where`, `.Skip`, `.Take`, `.CountAsync`, `.OrderByDescending`, `.ToListAsync`. No `using` directive changes — `Microsoft.EntityFrameworkCore` remains required by `GetPagedHistoryAsync`.
+
+### Consumers (unchanged — no edits, listed for boundary clarity)
+- `InvoiceClassificationService.cs` — calls `AddAsync` only; continues to compile and behave identically against the reduced interface.
+- `GetClassificationHistoryHandler.cs` — calls `GetPagedHistoryAsync` only; continues to compile and behave identically.
+- `InvoiceClassificationModule.cs` — DI registration `services.AddScoped<IClassificationHistoryRepository, ClassificationHistoryRepository>();` is unaffected by the reduced interface surface.
+- `InvoiceClassificationServiceTests.cs` — mocks `IClassificationHistoryRepository` via Moq but only stubs `AddAsync`; the mock simply exposes less surface after the change, no test edit required.
+- `ClassificationHistoryRepositoryTests.cs` — exercises only `GetPagedHistoryAsync` (and `AddAsync` for fixture setup); no test edit required.
+
+### Boundary summary
+This is a pure surface reduction on an internal (non-HTTP-facing) repository contract, scoped entirely to the `InvoiceClassification` vertical slice's Domain and Persistence layers. No component gains or loses a dependency; no new component is introduced.
+
+## Data Schemas
+No data schema changes. The `ClassificationHistory` EF Core entity, its mapping in `ApplicationDbContext`, and its relationship to `ClassificationRule` (`.Include(h => h.ClassificationRule)`) are unaffected — only two unused query methods against the existing model are removed. No database migration is required.
+
+No API/HTTP request or response shapes change: neither removed method was ever reachable through `GetClassificationHistoryHandler` or any controller, so there is no MediatR contract, DTO, or frontend-facing payload to update.

--- a/artifacts/feat-3544/impl/remove-unused-classification-history-methods.r1.md
+++ b/artifacts/feat-3544/impl/remove-unused-classification-history-methods.r1.md
@@ -1,0 +1,33 @@
+# Implementation: remove-unused-classification-history-methods
+
+## What was implemented
+Removed the two unused methods (`GetHistoryAsync(int skip, int take)` and `GetHistoryByInvoiceIdAsync(string abraInvoiceId)`) from `IClassificationHistoryRepository` and their implementations from `ClassificationHistoryRepository`, per the task plan. `AddAsync` and `GetPagedHistoryAsync` are unchanged. Independently verified via repo-wide grep that neither removed method had any caller before deleting them.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs` — dropped the two unused method declarations, now exposes only `AddAsync` and `GetPagedHistoryAsync`.
+- `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs` — dropped the two unused method implementations.
+
+## Tests
+- `dotnet build Anela.Heblo.sln` — succeeded, 0 errors (confirms no remaining caller references the removed methods; C# is statically typed so any lingering reference would be a compile error).
+- `dotnet format Anela.Heblo.sln --verify-no-changes --include <the two changed files>` — no formatting diffs.
+- `grep -rn "GetHistoryAsync\|GetHistoryByInvoiceIdAsync" backend/ --include=*.cs` — `GetHistoryByInvoiceIdAsync` has zero remaining matches anywhere. Remaining `GetHistoryAsync` matches are all unrelated methods on other interfaces/classes (`IPurchaseHistoryClient`, `IManufactureHistoryClient`, `IPurchaseOrderRepository`, `FlexiManufactureHistoryClient`, `FlexiPurchaseHistoryQueryClient`, `PurchaseOrderRepository`) — none reference `IClassificationHistoryRepository`.
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"` — 90/90 passed.
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` (full project) — 5588 passed, 4 skipped, 64 failed. All 64 failures are pre-existing Testcontainers/Docker-dependent integration tests (Bank, Catalog stock-up, Leaflet, MeetingTasks, Photobank, Purchase SQL-shape, KnowledgeBase, GridLayouts, Smartsupp) failing with `System.ArgumentException: Docker is either not running or misconfigured` — this sandbox has no Docker daemon. None of the 64 failures are in the InvoiceClassification module or reference the removed methods; this is an environment limitation unrelated to this change.
+
+## How to verify
+1. `dotnet build Anela.Heblo.sln` — should succeed with 0 errors.
+2. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"` — should show 90/90 passing.
+3. `grep -rn "GetHistoryByInvoiceIdAsync" backend/` — should return no results.
+
+## Notes
+No test, mock, or fake referenced the two removed methods (confirmed by the task plan's analysis and independently by grep), so no test files needed changes. The pre-existing Docker-dependent integration test failures in the full suite run are unrelated to this change and are an artifact of this sandbox environment lacking a Docker daemon, not a regression introduced here.
+
+## PR Summary
+`IClassificationHistoryRepository` declared two methods — `GetHistoryAsync(int skip, int take)` and `GetHistoryByInvoiceIdAsync(string abraInvoiceId)` — that no handler, service, or test in the codebase ever called. This PR deletes both from the interface and their implementations from `ClassificationHistoryRepository`, leaving only the two methods actually in use: `AddAsync` and `GetPagedHistoryAsync`. This is a pure subtraction with no behavioral change to any existing consumer.
+
+### Changes
+- `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs` — removed 2 unused method declarations
+- `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs` — removed 2 unused method implementations
+
+## Status
+DONE

--- a/artifacts/feat-3544/review/remove-unused-classification-history-methods.r1.md
+++ b/artifacts/feat-3544/review/remove-unused-classification-history-methods.r1.md
@@ -1,0 +1,16 @@
+# Code Review: Remove unused methods from IClassificationHistoryRepository
+
+## Summary
+The implementation removes exactly `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync` from `IClassificationHistoryRepository` and `ClassificationHistoryRepository`, matching the task spec's target content byte-for-byte. `AddAsync` and `GetPagedHistoryAsync` are untouched, whitespace is normalized to a single blank line between remaining members, and no other file in the repo references the removed methods.
+
+## Review Result: PASS
+
+### task: remove-unused-classification-history-methods
+**Status:** PASS
+
+## Overall Notes
+- Verified `git show --stat HEAD~1` and the full diff: exactly the two expected method blocks were deleted (interface: lines 7-9 removed; implementation: `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync` bodies removed), with no unrelated changes and no stray blank lines.
+- Read the current contents of both files directly — they match the spec's Step 1/Step 2 target content exactly, including the retained `using Microsoft.EntityFrameworkCore;` directive (still required by `GetPagedHistoryAsync`).
+- Ran `grep -rn "GetHistoryAsync\|GetHistoryByInvoiceIdAsync" backend/ --include=*.cs` independently: zero matches for `GetHistoryByInvoiceIdAsync` anywhere, and all remaining `GetHistoryAsync` matches belong to unrelated interfaces/classes in the Manufacture and Purchase/Catalog modules (`IManufactureHistoryClient`, `IPurchaseHistoryClient`, `IPurchaseOrderRepository`, `FlexiManufactureHistoryClient`, `FlexiPurchaseHistoryQueryClient`, `PurchaseOrderRepository`), none of which reference `IClassificationHistoryRepository`. This confirms both the spec's and the impl summary's claims.
+- No test files (`InvoiceClassificationServiceTests.cs`, `ClassificationHistoryRepositoryTests.cs`) required changes, consistent with the spec's prediction that no mock or fake referenced the removed methods.
+- This is a pure subtraction with no behavioral change to any existing consumer, aligned with the arch-review's guidance (delete immediately, no deprecation window needed, no scope creep into the unrelated naming-ambiguity issue).

--- a/artifacts/feat-3544/spec.r1.md
+++ b/artifacts/feat-3544/spec.r1.md
@@ -1,0 +1,107 @@
+# Specification: Remove unused methods from IClassificationHistoryRepository
+
+## Summary
+`IClassificationHistoryRepository` in the InvoiceClassification module declares two methods, `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync`, that have no callers anywhere in the codebase. This spec covers removing both methods from the interface and deleting their corresponding implementations in `ClassificationHistoryRepository`, leaving the interface's actual consumed surface (`AddAsync`, `GetPagedHistoryAsync`) unchanged.
+
+## Background
+This is a dead-code cleanup identified by the daily architecture-review routine on 2026-07-07. `IClassificationHistoryRepository` currently declares four members, but only two are used:
+
+- `AddAsync(ClassificationHistory history)` — called from `InvoiceClassificationService.cs:113`.
+- `GetPagedHistoryAsync(...)` — called from `GetClassificationHistoryHandler.cs:27`, the sole handler that reads classification history.
+
+The other two members are unused dead code:
+
+- `GetHistoryAsync(int skip = 0, int take = 50)` — declared at `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs:7`, implemented at `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs:22-30`.
+- `GetHistoryByInvoiceIdAsync(string abraInvoiceId)` — declared at `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs:9`, implemented at `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs:32-39`.
+
+A repository-wide search confirms neither method is referenced by any handler, service, controller, test, or mock setup outside their own declaration/implementation. The only consumer of `IClassificationHistoryRepository` besides the repository implementation itself is `InvoiceClassificationServiceTests.cs`, which mocks the interface via `Mock<IClassificationHistoryRepository>` but never stubs or asserts against these two methods.
+
+Dead methods on a domain-facing interface violate YAGNI and the Interface Segregation Principle: every consumer and every mock of `IClassificationHistoryRepository` is forced to account for surface area it never uses. Additionally, `GetHistoryByInvoiceIdAsync`'s parameter name `abraInvoiceId` is filtered against the `AbraInvoiceId` column, which is a separate but easily confused concept from `InvoiceNumber` (used as a filter in `GetPagedHistoryAsync`) — removing the method also removes this latent source of confusion for a future implementer. (The naming ambiguity itself is tracked as a companion issue and is not in scope here.)
+
+## Functional Requirements
+
+### FR-1: Remove dead methods from IClassificationHistoryRepository
+Delete the following two member declarations from `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs`:
+- `Task<List<ClassificationHistory>> GetHistoryAsync(int skip = 0, int take = 50);` (line 7)
+- `Task<List<ClassificationHistory>> GetHistoryByInvoiceIdAsync(string abraInvoiceId);` (line 9)
+
+The interface retains exactly two members after this change: `AddAsync` and `GetPagedHistoryAsync`.
+
+**Acceptance criteria:**
+- `IClassificationHistoryRepository` no longer declares `GetHistoryAsync` or `GetHistoryByInvoiceIdAsync`.
+- `AddAsync` and `GetPagedHistoryAsync` signatures are unchanged (no parameter, return type, or default-value modifications).
+- No blank/orphaned lines or stray whitespace left behind where the two method declarations were removed.
+
+### FR-2: Remove dead implementations from ClassificationHistoryRepository
+Delete the following two method implementations from `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs`:
+- `GetHistoryAsync(int skip = 0, int take = 50)` (lines 22-30)
+- `GetHistoryByInvoiceIdAsync(string abraInvoiceId)` (lines 32-39)
+
+**Acceptance criteria:**
+- `ClassificationHistoryRepository` no longer defines `GetHistoryAsync` or `GetHistoryByInvoiceIdAsync`.
+- `ClassificationHistoryRepository` still implements `IClassificationHistoryRepository` with no other changes to `AddAsync` or `GetPagedHistoryAsync`.
+- The class continues to compile without the removed methods (no other class member depends on them; none was found in the current codebase).
+
+### FR-3: No behavioral change to existing consumers
+`InvoiceClassificationService` (uses `AddAsync`) and `GetClassificationHistoryHandler` (uses `GetPagedHistoryAsync`) must continue to function identically — this change is a pure interface/implementation surface reduction with zero impact on any calling code, DI registration, or test setup.
+
+**Acceptance criteria:**
+- `InvoiceClassificationModule.cs:18` DI registration (`services.AddScoped<IClassificationHistoryRepository, ClassificationHistoryRepository>();`) requires no change.
+- `GetClassificationHistoryHandler.cs` requires no change.
+- `InvoiceClassificationService.cs` requires no change.
+- `InvoiceClassificationServiceTests.cs` (which mocks `IClassificationHistoryRepository`) requires no change, since it never stubs the two removed methods.
+- `ClassificationHistoryRepositoryTests.cs` (which exercises `GetPagedHistoryAsync` directly against the repository) requires no change, since it does not exercise the two removed methods.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable. This change removes unused code paths; it has no runtime performance impact on any executed code path.
+
+### NFR-2: Security
+Not applicable. No authentication, authorization, or data-sensitivity surface is touched. The removed methods performed read-only queries against `ClassificationHistory` and carried no distinct security posture from the retained `GetPagedHistoryAsync`.
+
+## Data Model
+No data model changes. `ClassificationHistory` (EF Core entity, mapped via `ApplicationDbContext.ClassificationHistory`) and its relationship to `ClassificationRule` (via `.Include(h => h.ClassificationRule)`) are unaffected — only two query methods against this existing model are removed.
+
+## API / Interface Design
+This is a backend-internal contract cleanup with no HTTP-facing surface:
+
+**Before:**
+```csharp
+public interface IClassificationHistoryRepository
+{
+    Task<ClassificationHistory> AddAsync(ClassificationHistory history);
+    Task<List<ClassificationHistory>> GetHistoryAsync(int skip = 0, int take = 50);
+    Task<List<ClassificationHistory>> GetHistoryByInvoiceIdAsync(string abraInvoiceId);
+    Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+        int page = 1, int pageSize = 20, DateTime? fromDate = null,
+        DateTime? toDate = null, string? invoiceNumber = null, string? companyName = null);
+}
+```
+
+**After:**
+```csharp
+public interface IClassificationHistoryRepository
+{
+    Task<ClassificationHistory> AddAsync(ClassificationHistory history);
+    Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+        int page = 1, int pageSize = 20, DateTime? fromDate = null,
+        DateTime? toDate = null, string? invoiceNumber = null, string? companyName = null);
+}
+```
+
+No REST endpoints, MediatR requests/responses, or frontend contracts are affected — these methods were never exposed through `GetClassificationHistoryHandler` or any controller.
+
+## Dependencies
+None. This is a self-contained, two-file change within the InvoiceClassification module (`Anela.Heblo.Domain` and `Anela.Heblo.Persistence` projects). No other module, feature, or external service depends on the removed methods.
+
+## Out of Scope
+- Renaming or clarifying the `AbraInvoiceId` vs. `InvoiceNumber` naming ambiguity noted in the brief — tracked separately as a companion issue.
+- Any change to `GetPagedHistoryAsync` or `AddAsync` behavior, signature, or tests.
+- Any change to `GetClassificationHistoryHandler`, `InvoiceClassificationService`, `InvoiceClassificationModule`, or any test file.
+- Re-introducing either removed method — if a future use case needs paged-free history retrieval or lookup-by-invoice-id, it should be added fresh when a concrete consumer exists, per YAGNI.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T06:50:30.697685Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-08T06:50:31.065744Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T06:21:15.756546Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T06:21:43.102477Z"
     }
   },
   "tasks": [
     {
       "name": "remove-unused-classification-history-methods",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T06:21:43.313464Z"
     }
   ]
 }

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T06:21:15.756546Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T06:21:43.102477Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T06:50:30.697685Z"
     }
   },
   "tasks": [
     {
       "name": "remove-unused-classification-history-methods",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T06:21:43.313464Z"
+      "updated_at": "2026-07-08T06:50:22.788772Z"
     }
   ]
 }

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-08T06:17:01.417453Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T06:17:10.804192Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T06:18:37.136689Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T06:18:49.848409Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-08T06:19:17.883433Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T06:19:47.725623Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T06:21:15.756546Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "remove-unused-classification-history-methods",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T06:15:36.014966Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-08T06:50:30.697685Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T06:50:31.065744Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T06:52:41.250568Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3544",
+  "issue_number": 3544,
+  "created_at": "2026-07-08T06:14:45.697241Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-08T06:18:37.136689Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T06:18:49.848409Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T06:19:17.883433Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T06:19:47.725623Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3544/state.json
+++ b/artifacts/feat-3544/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T06:15:36.014966Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T06:17:01.417453Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T06:17:10.804192Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3544/task-context/remove-unused-classification-history-methods.md
+++ b/artifacts/feat-3544/task-context/remove-unused-classification-history-methods.md
@@ -1,0 +1,116 @@
+### task: remove-unused-classification-history-methods
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs:1-18`
+- Modify: `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs:22-39`
+- Test (read-only verification, no edit needed): `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+- Test (read-only verification, no edit needed): `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationHistoryRepositoryTests.cs`
+
+**Goal:** Delete the unused `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync` members from `IClassificationHistoryRepository` and their implementations from `ClassificationHistoryRepository`, leaving `AddAsync` and `GetPagedHistoryAsync` byte-for-byte unchanged.
+
+- [ ] Step 1: In `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs`, replace the full file contents with:
+
+  ```csharp
+  namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+  public interface IClassificationHistoryRepository
+  {
+      Task<ClassificationHistory> AddAsync(ClassificationHistory history);
+
+      Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+          int page = 1,
+          int pageSize = 20,
+          DateTime? fromDate = null,
+          DateTime? toDate = null,
+          string? invoiceNumber = null,
+          string? companyName = null);
+  }
+  ```
+
+  This removes lines 7 (`Task<List<ClassificationHistory>> GetHistoryAsync(int skip = 0, int take = 50);`), 8 (blank), and 9 (`Task<List<ClassificationHistory>> GetHistoryByInvoiceIdAsync(string abraInvoiceId);`) from the original file, and collapses the surrounding blank lines so exactly one blank line separates `AddAsync` from `GetPagedHistoryAsync` (matching the original's one-blank-line-between-members style).
+
+- [ ] Step 2: In `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs`, replace the full file contents with:
+
+  ```csharp
+  using Microsoft.EntityFrameworkCore;
+  using Anela.Heblo.Domain.Features.InvoiceClassification;
+
+  namespace Anela.Heblo.Persistence.InvoiceClassification;
+
+  public class ClassificationHistoryRepository : IClassificationHistoryRepository
+  {
+      private readonly ApplicationDbContext _context;
+
+      public ClassificationHistoryRepository(ApplicationDbContext context)
+      {
+          _context = context;
+      }
+
+      public async Task<ClassificationHistory> AddAsync(ClassificationHistory history)
+      {
+          _context.ClassificationHistory.Add(history);
+          await _context.SaveChangesAsync();
+          return history;
+      }
+
+      public async Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+          int page = 1,
+          int pageSize = 20,
+          DateTime? fromDate = null,
+          DateTime? toDate = null,
+          string? invoiceNumber = null,
+          string? companyName = null)
+      {
+          var query = _context.ClassificationHistory
+              .Include(h => h.ClassificationRule)
+              .AsQueryable();
+
+          // Apply filters
+          if (fromDate.HasValue)
+              query = query.Where(h => h.Timestamp >= fromDate.Value);
+
+          if (toDate.HasValue)
+          {
+              // Include the full end day: toDate is sent as midnight (00:00:00), so we extend to the start of the next day
+              var endOfDay = toDate.Value.Date.AddDays(1);
+              query = query.Where(h => h.Timestamp < endOfDay);
+          }
+
+          if (!string.IsNullOrEmpty(invoiceNumber))
+              query = query.Where(h => h.AbraInvoiceId.Contains(invoiceNumber));
+
+          if (!string.IsNullOrEmpty(companyName))
+              query = query.Where(h => h.CompanyName.Contains(companyName));
+
+          var totalCount = await query.CountAsync();
+
+          var items = await query
+              .OrderByDescending(h => h.Timestamp)
+              .Skip((page - 1) * pageSize)
+              .Take(pageSize)
+              .ToListAsync();
+
+          return (items, totalCount);
+      }
+  }
+  ```
+
+  This removes the `GetHistoryAsync` method (original lines 22-30) and the `GetHistoryByInvoiceIdAsync` method (original lines 32-39) in full, along with their surrounding blank lines, leaving exactly one blank line between the remaining `AddAsync` and `GetPagedHistoryAsync` methods. The `using Microsoft.EntityFrameworkCore;` directive stays because `GetPagedHistoryAsync` still uses `.Where`, `.Skip`, `.Take`, `.CountAsync`, `.OrderByDescending`, `.ToListAsync`, `.Include`, and `.AsQueryable` from it.
+
+- [ ] Step 3: Verify no remaining references anywhere in `backend/` to the removed method names on this interface by running:
+  `grep -rn "GetHistoryAsync\|GetHistoryByInvoiceIdAsync" backend/ --include=*.cs`
+  Expected result: the only matches are the four unrelated occurrences in `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs` (a different `GetHistoryAsync` method on an unrelated Flexi client class — not `IClassificationHistoryRepository`). No matches should exist in `IClassificationHistoryRepository.cs` or `ClassificationHistoryRepository.cs` anymore, and no matches should appear in any InvoiceClassification test file.
+
+- [ ] Step 4: Build the backend solution: `dotnet build Anela.Heblo.sln` (run from the repo root `/home/user/worktrees/feature-3544-Arch-Review-Invoiceclassification-Two-Unused-Metho`). Expected result: build succeeds with 0 errors — this confirms no other file references the removed methods, since C# is statically typed and any lingering reference would be a compile error.
+
+- [ ] Step 5: Run `dotnet format` on the solution (per CLAUDE.md validation requirements): `dotnet format Anela.Heblo.sln`. Expected result: completes without reporting unexpected diffs beyond whitespace already normalized in Steps 1-2; re-check that `IClassificationHistoryRepository.cs` and `ClassificationHistoryRepository.cs` still match the exact content specified in Steps 1 and 2 (no unrelated reformatting was introduced elsewhere).
+
+- [ ] Step 6: Run the InvoiceClassification unit tests: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"`. Expected result: all tests in `InvoiceClassificationServiceTests.cs` and `ClassificationHistoryRepositoryTests.cs` pass, with no compile errors from the Moq mock of `IClassificationHistoryRepository` (it only ever stubs `AddAsync`, which still exists).
+
+- [ ] Step 7: Run the full `Anela.Heblo.Tests` project to confirm no other suite was affected: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`. Expected result: all tests pass (no new failures compared to the pre-change baseline).
+
+- [ ] Step 8: Commit the change:
+  ```
+  git add backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs
+  git commit -m "Remove unused GetHistoryAsync and GetHistoryByInvoiceIdAsync from IClassificationHistoryRepository"
+  ```

--- a/artifacts/feat-3544/task-plan.r1.md
+++ b/artifacts/feat-3544/task-plan.r1.md
@@ -1,0 +1,136 @@
+# Task Plan: Remove unused methods from IClassificationHistoryRepository (feat-3544)
+
+## Context for the implementer
+
+`IClassificationHistoryRepository` (in the InvoiceClassification vertical slice) declares four members, but only two are actually called anywhere in the codebase: `AddAsync` (called from `InvoiceClassificationService.cs`) and `GetPagedHistoryAsync` (called from `GetClassificationHistoryHandler.cs`). The other two — `GetHistoryAsync(int skip = 0, int take = 50)` and `GetHistoryByInvoiceIdAsync(string abraInvoiceId)` — are dead code with zero callers anywhere in the repo (verified by direct grep across `backend/`, both source and test trees). This was flagged by the daily architecture-review routine on 2026-07-07 as a YAGNI / Interface Segregation Principle violation: every mock and every implementer of the interface is forced to account for surface area nobody uses.
+
+This is a pure subtraction with no behavioral change to any existing consumer:
+- `InvoiceClassificationService.cs` only uses `AddAsync` — untouched.
+- `GetClassificationHistoryHandler.cs` only uses `GetPagedHistoryAsync` — untouched.
+- `InvoiceClassificationModule.cs` DI registration (`services.AddScoped<IClassificationHistoryRepository, ClassificationHistoryRepository>();`) is untouched — it registers the concrete class, not individual members.
+- `InvoiceClassificationServiceTests.cs` mocks `IClassificationHistoryRepository` via Moq but only ever sets up `.Setup(x => x.AddAsync(...))` — never the two methods being removed. Moq mocks are interface-driven, so the mock simply exposes less surface after the change; no test edit is needed.
+- `ClassificationHistoryRepositoryTests.cs` exercises only `GetPagedHistoryAsync` (and implicitly `AddAsync` for fixture setup) — no test edit is needed.
+- A repo-wide grep for the literal names `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync` under `backend/` turns up one unrelated false positive: `FlexiManufactureHistoryClientTests.cs` in the Manufacture module has its own, differently-typed `GetHistoryAsync` method on an unrelated client class — not a caller of `IClassificationHistoryRepository`. It requires no changes and must not be touched.
+
+Because no test, mock, or fake anywhere references the two methods being removed, this whole change is self-contained in exactly two files and fits in a single task: edit the interface, edit the implementation, build, run the two InvoiceClassification test files (plus the full test project, since nothing else should be affected), commit.
+
+No `using` directive changes are needed in either file: `Microsoft.EntityFrameworkCore` (for `.Include`, `.Where`, `.Skip`, `.Take`, `.CountAsync`, `.OrderByDescending`, `.ToListAsync`) remains required because `GetPagedHistoryAsync`, which is staying, uses all of these itself.
+
+---
+
+### task: remove-unused-classification-history-methods
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs:1-18`
+- Modify: `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs:22-39`
+- Test (read-only verification, no edit needed): `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+- Test (read-only verification, no edit needed): `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationHistoryRepositoryTests.cs`
+
+**Goal:** Delete the unused `GetHistoryAsync` and `GetHistoryByInvoiceIdAsync` members from `IClassificationHistoryRepository` and their implementations from `ClassificationHistoryRepository`, leaving `AddAsync` and `GetPagedHistoryAsync` byte-for-byte unchanged.
+
+- [ ] Step 1: In `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs`, replace the full file contents with:
+
+  ```csharp
+  namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+  public interface IClassificationHistoryRepository
+  {
+      Task<ClassificationHistory> AddAsync(ClassificationHistory history);
+
+      Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+          int page = 1,
+          int pageSize = 20,
+          DateTime? fromDate = null,
+          DateTime? toDate = null,
+          string? invoiceNumber = null,
+          string? companyName = null);
+  }
+  ```
+
+  This removes lines 7 (`Task<List<ClassificationHistory>> GetHistoryAsync(int skip = 0, int take = 50);`), 8 (blank), and 9 (`Task<List<ClassificationHistory>> GetHistoryByInvoiceIdAsync(string abraInvoiceId);`) from the original file, and collapses the surrounding blank lines so exactly one blank line separates `AddAsync` from `GetPagedHistoryAsync` (matching the original's one-blank-line-between-members style).
+
+- [ ] Step 2: In `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs`, replace the full file contents with:
+
+  ```csharp
+  using Microsoft.EntityFrameworkCore;
+  using Anela.Heblo.Domain.Features.InvoiceClassification;
+
+  namespace Anela.Heblo.Persistence.InvoiceClassification;
+
+  public class ClassificationHistoryRepository : IClassificationHistoryRepository
+  {
+      private readonly ApplicationDbContext _context;
+
+      public ClassificationHistoryRepository(ApplicationDbContext context)
+      {
+          _context = context;
+      }
+
+      public async Task<ClassificationHistory> AddAsync(ClassificationHistory history)
+      {
+          _context.ClassificationHistory.Add(history);
+          await _context.SaveChangesAsync();
+          return history;
+      }
+
+      public async Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
+          int page = 1,
+          int pageSize = 20,
+          DateTime? fromDate = null,
+          DateTime? toDate = null,
+          string? invoiceNumber = null,
+          string? companyName = null)
+      {
+          var query = _context.ClassificationHistory
+              .Include(h => h.ClassificationRule)
+              .AsQueryable();
+
+          // Apply filters
+          if (fromDate.HasValue)
+              query = query.Where(h => h.Timestamp >= fromDate.Value);
+
+          if (toDate.HasValue)
+          {
+              // Include the full end day: toDate is sent as midnight (00:00:00), so we extend to the start of the next day
+              var endOfDay = toDate.Value.Date.AddDays(1);
+              query = query.Where(h => h.Timestamp < endOfDay);
+          }
+
+          if (!string.IsNullOrEmpty(invoiceNumber))
+              query = query.Where(h => h.AbraInvoiceId.Contains(invoiceNumber));
+
+          if (!string.IsNullOrEmpty(companyName))
+              query = query.Where(h => h.CompanyName.Contains(companyName));
+
+          var totalCount = await query.CountAsync();
+
+          var items = await query
+              .OrderByDescending(h => h.Timestamp)
+              .Skip((page - 1) * pageSize)
+              .Take(pageSize)
+              .ToListAsync();
+
+          return (items, totalCount);
+      }
+  }
+  ```
+
+  This removes the `GetHistoryAsync` method (original lines 22-30) and the `GetHistoryByInvoiceIdAsync` method (original lines 32-39) in full, along with their surrounding blank lines, leaving exactly one blank line between the remaining `AddAsync` and `GetPagedHistoryAsync` methods. The `using Microsoft.EntityFrameworkCore;` directive stays because `GetPagedHistoryAsync` still uses `.Where`, `.Skip`, `.Take`, `.CountAsync`, `.OrderByDescending`, `.ToListAsync`, `.Include`, and `.AsQueryable` from it.
+
+- [ ] Step 3: Verify no remaining references anywhere in `backend/` to the removed method names on this interface by running:
+  `grep -rn "GetHistoryAsync\|GetHistoryByInvoiceIdAsync" backend/ --include=*.cs`
+  Expected result: the only matches are the four unrelated occurrences in `backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs` (a different `GetHistoryAsync` method on an unrelated Flexi client class — not `IClassificationHistoryRepository`). No matches should exist in `IClassificationHistoryRepository.cs` or `ClassificationHistoryRepository.cs` anymore, and no matches should appear in any InvoiceClassification test file.
+
+- [ ] Step 4: Build the backend solution: `dotnet build Anela.Heblo.sln` (run from the repo root `/home/user/worktrees/feature-3544-Arch-Review-Invoiceclassification-Two-Unused-Metho`). Expected result: build succeeds with 0 errors — this confirms no other file references the removed methods, since C# is statically typed and any lingering reference would be a compile error.
+
+- [ ] Step 5: Run `dotnet format` on the solution (per CLAUDE.md validation requirements): `dotnet format Anela.Heblo.sln`. Expected result: completes without reporting unexpected diffs beyond whitespace already normalized in Steps 1-2; re-check that `IClassificationHistoryRepository.cs` and `ClassificationHistoryRepository.cs` still match the exact content specified in Steps 1 and 2 (no unrelated reformatting was introduced elsewhere).
+
+- [ ] Step 6: Run the InvoiceClassification unit tests: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"`. Expected result: all tests in `InvoiceClassificationServiceTests.cs` and `ClassificationHistoryRepositoryTests.cs` pass, with no compile errors from the Moq mock of `IClassificationHistoryRepository` (it only ever stubs `AddAsync`, which still exists).
+
+- [ ] Step 7: Run the full `Anela.Heblo.Tests` project to confirm no other suite was affected: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`. Expected result: all tests pass (no new failures compared to the pre-change baseline).
+
+- [ ] Step 8: Commit the change:
+  ```
+  git add backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs
+  git commit -m "Remove unused GetHistoryAsync and GetHistoryByInvoiceIdAsync from IClassificationHistoryRepository"
+  ```

--- a/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationHistoryRepository.cs
@@ -4,10 +4,6 @@ public interface IClassificationHistoryRepository
 {
     Task<ClassificationHistory> AddAsync(ClassificationHistory history);
 
-    Task<List<ClassificationHistory>> GetHistoryAsync(int skip = 0, int take = 50);
-
-    Task<List<ClassificationHistory>> GetHistoryByInvoiceIdAsync(string abraInvoiceId);
-
     Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
         int page = 1,
         int pageSize = 20,

--- a/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryRepository.cs
@@ -19,25 +19,6 @@ public class ClassificationHistoryRepository : IClassificationHistoryRepository
         return history;
     }
 
-    public async Task<List<ClassificationHistory>> GetHistoryAsync(int skip = 0, int take = 50)
-    {
-        return await _context.ClassificationHistory
-            .Include(h => h.ClassificationRule)
-            .OrderByDescending(h => h.Timestamp)
-            .Skip(skip)
-            .Take(take)
-            .ToListAsync();
-    }
-
-    public async Task<List<ClassificationHistory>> GetHistoryByInvoiceIdAsync(string abraInvoiceId)
-    {
-        return await _context.ClassificationHistory
-            .Include(h => h.ClassificationRule)
-            .Where(h => h.AbraInvoiceId == abraInvoiceId)
-            .OrderByDescending(h => h.Timestamp)
-            .ToListAsync();
-    }
-
     public async Task<(List<ClassificationHistory> Items, int TotalCount)> GetPagedHistoryAsync(
         int page = 1,
         int pageSize = 20,


### PR DESCRIPTION
Closes #3544

## What the issue was
`IClassificationHistoryRepository` declared two methods — `GetHistoryAsync(int skip, int take)` and `GetHistoryByInvoiceIdAsync(string abraInvoiceId)` — that no handler, service, or test in the codebase ever called. The only consumer of this repository, `GetClassificationHistoryHandler`, calls only `GetPagedHistoryAsync`. Keeping dead methods on a domain interface violates YAGNI and the Interface Segregation Principle, and forces mocks/implementers to account for surface area nobody uses.

## How it was fixed / handled
Deleted both unused methods from `IClassificationHistoryRepository` and their implementations from `ClassificationHistoryRepository`, leaving only `AddAsync` and `GetPagedHistoryAsync`. This is a pure subtraction with no behavioral change to any existing consumer — verified by:
- `dotnet build` succeeding with 0 errors (a lingering reference would be a compile error)
- a repo-wide grep confirming zero remaining references to either removed method name on this interface
- the InvoiceClassification test suite (90 tests) passing unchanged

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, review, and code-review markdown are committed in this branch under `artifacts/feat-3544/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01FGfdjg5nQAj1KhbXBtBmiu)_