### PR TITLE
#3545: push MaxOrder computation into the database for ClassificationRule creation

### DIFF
--- a/artifacts/feat-3545/arch-review.r1.md
+++ b/artifacts/feat-3545/arch-review.r1.md
@@ -1,0 +1,102 @@
+# Architecture Review: Push MaxOrder computation into the database for InvoiceClassification rules
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a textbook fit for the existing pattern in this codebase and requires no new abstractions. `IClassificationRuleRepository` (`backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`) already exposes a small, purpose-built set of methods (`GetAllAsync`, `GetActiveRulesOrderedAsync`, `GetByIdAsync`, `AddAsync`, `UpdateAsync`, `DeleteAsync`, `ReorderRulesAsync`) that mix full-collection reads, single-row lookups, and targeted mutations on the same `ApplicationDbContext.ClassificationRules` set. Adding one more targeted read method (`GetMaxOrderAsync`) is consistent with that shape — it does not introduce a new interface, a new repository, or a new DI registration; it extends the one that exists.
+
+The change sits entirely inside the InvoiceClassification vertical slice:
+- Domain layer: interface addition (`Anela.Heblo.Domain`)
+- Persistence layer: implementation using the already-injected `ApplicationDbContext` (`Anela.Heblo.Persistence`)
+- Application layer: one handler swaps two lines for one (`Anela.Heblo.Application`)
+
+No module boundary is crossed, no contract (`Contracts/` DTOs) changes, no controller changes, and per `docs/architecture/development_guidelines.md` ADR-004, the repository's DI binding already lives in the feature's own module (not `PersistenceModule.cs`) — confirmed by inspection, this fix doesn't touch DI registration at all since the same `IClassificationRuleRepository` → `ClassificationRuleRepository` binding is reused unchanged.
+
+## Proposed Architecture
+
+### Component Overview
+```
+CreateClassificationRuleHandler (Application)
+        │
+        │  await _ruleRepository.GetMaxOrderAsync()   [NEW — replaces GetAllAsync()+Max()]
+        ▼
+IClassificationRuleRepository (Domain)               ← interface gains one member
+        │
+        ▼
+ClassificationRuleRepository (Persistence)            ← implements via EF Core MaxAsync
+        │
+        ▼
+ApplicationDbContext.ClassificationRules
+        │
+        ▼
+SELECT MAX([Order]) FROM ClassificationRules          (single scalar aggregate)
+```
+
+No new components. This is a same-shape extension of an existing interface/implementation/consumer triad.
+
+### Key Design Decisions
+
+#### Decision 1: Extend the existing repository interface vs. introduce a new abstraction (e.g., a query object, a CQRS "GetMaxOrderQuery")
+**Options considered:**
+1. Add `GetMaxOrderAsync()` directly to `IClassificationRuleRepository` / `ClassificationRuleRepository`.
+2. Introduce a separate read-model/query service for this one aggregate.
+
+**Chosen approach:** Option 1, exactly as specified in FR-1/FR-2.
+
+**Rationale:** The repository already owns all reads and writes against `ClassificationRules`; a second abstraction for a single scalar aggregate would violate the project's YAGNI stance (this whole fix exists *because* of a YAGNI/efficiency finding) and add an unnecessary layer for one method. Option 2 is over-engineering relative to the size of the change.
+
+#### Decision 2: Nullable-cast pattern for `MaxAsync` on an empty table
+**Options considered:**
+1. `await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0` (spec's approach).
+2. `_context.ClassificationRules.Any() ? await _context.ClassificationRules.MaxAsync(r => r.Order) : 0` (existence check first, two queries).
+
+**Chosen approach:** Option 1.
+
+**Rationale:** `Order` is a non-nullable `int` on `ClassificationRule`, and EF Core's `MaxAsync` throws `InvalidOperationException` on an empty non-nullable sequence. Casting to `int?` inside the projection lets the provider translate the whole thing into one `SELECT MAX([Order]) FROM ...` (returning `NULL` for an empty table) and `?? 0` maps that back to the handler's existing "no rules yet → start at 1" semantics. This is a single round trip; option 2 costs an extra query for no benefit and is the kind of thing this fix is explicitly trying to eliminate.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files or folders. Modify these three existing files only:
+- `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs` — add `Task<int> GetMaxOrderAsync();` to the interface (alongside the existing method declarations, order doesn't matter but keep it near `GetAllAsync`/`GetActiveRulesOrderedAsync` for readability).
+- `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs` — add the `GetMaxOrderAsync()` implementation as specified in FR-2, placed near `GetAllAsync`/`GetActiveRulesOrderedAsync`.
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs` — replace lines 29–30 with the single-line call per FR-3.
+
+Do not touch `GetAllAsync`, `GetActiveRulesOrderedAsync`, `ReorderRulesAsync`, or any other repository method — they are unrelated to this fix and `GetAllAsync` is still needed elsewhere (rule listing).
+
+### Interfaces and Contracts
+```csharp
+// IClassificationRuleRepository.cs — new member
+Task<int> GetMaxOrderAsync();
+```
+```csharp
+// ClassificationRuleRepository.cs — new implementation
+public async Task<int> GetMaxOrderAsync()
+{
+    return await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;
+}
+```
+No public/HTTP-facing contract changes — `IClassificationRuleRepository` is an internal (Domain-layer) interface, not a cross-module `Contracts/` type, so the "DTOs live in contracts/" rule from `docs/architecture/development_guidelines.md` does not apply here.
+
+### Data Flow
+1. `POST` request reaches `CreateClassificationRuleHandler.Handle` via the existing controller → MediatR pipeline (unchanged).
+2. Handler resolves current user (unchanged) and now calls `_ruleRepository.GetMaxOrderAsync()` instead of `GetAllAsync()` + in-memory `Max`.
+3. Repository issues `SELECT MAX([Order]) FROM ClassificationRules` (or the InMemory-provider equivalent in tests) and returns a single `int` (0 if the table is empty).
+4. Handler proceeds exactly as before: constructs the new `ClassificationRule`, calls `rule.SetOrder(maxOrder + 1)`, persists via `AddAsync`, maps to `ClassificationRuleDto`, returns response.
+
+Behavior is bit-for-bit identical from the caller's perspective; only the query shape changes.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| EF Core `MaxAsync` on an empty table with the `(int?)` cast doesn't translate as expected on some provider (e.g. InMemory provider used in tests vs. real SQL provider in production) | Low | Add the repository-level test described below to lock in empty-table → `0` behavior against the actual provider used in CI (InMemory), which is representative enough given the simplicity of the query. |
+| Concurrent `CreateClassificationRule` calls can still read the same `maxOrder` and both assign the same `Order` (pre-existing race, called out in brief and spec) | Low | Explicitly out of scope for this fix (per spec's "Out of Scope" section). Pre-existing behavior, not introduced or worsened by moving the aggregation into the DB — narrowing the read from a full table scan to a scalar query does not widen the race window. Accepted as residual risk; file separately if it needs addressing. |
+| Interface change (`IClassificationRuleRepository`) requires any test doubles/mocks of this interface to add the new member | Low | Search shows no existing `CreateClassificationRuleHandlerTests` or hand-rolled mock of `IClassificationRuleRepository` in `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/` today; if a mocking framework (Moq/NSubstitute) is used elsewhere for this interface, it auto-satisfies new members without extra setup unless `GetMaxOrderAsync()` is actually invoked in that test path. |
+
+## Specification Amendments
+None. FR-1 through FR-3, the acceptance criteria, and the NFRs are implementable exactly as written against the current source — verified against the live files: `IClassificationRuleRepository.cs`, `ClassificationRuleRepository.cs`, and `CreateClassificationRuleHandler.cs` (lines 29–30 match the spec's quoted snippet exactly).
+
+One clarification for the implementer (not a spec change): the codebase's `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/` folder has no dedicated `ClassificationRuleRepositoryTests.cs` today (only `ClassificationHistoryRepositoryTests.cs` exists as a sibling repository-test pattern, using `UseInMemoryDatabase` + direct repository instantiation — no mocking). Follow that same pattern if adding a test per the spec's Open Questions: instantiate `ClassificationRuleRepository` against an `ApplicationDbContext` backed by `UseInMemoryDatabase(Guid.NewGuid())`, and assert `GetMaxOrderAsync()` returns `0` on an empty set and the correct max on a populated one. This is proportional — one small test file (or a couple of methods added to a new minimal `ClassificationRuleRepositoryTests.cs`), not new test infrastructure.
+
+## Prerequisites
+None. No schema changes, no migrations, no configuration, no infrastructure work. The fix can be implemented directly against `main`/the current worktree state.

--- a/artifacts/feat-3545/brief.md
+++ b/artifacts/feat-3545/brief.md
@@ -1,0 +1,34 @@
+# [arch-review] InvoiceClassification: CreateClassificationRuleHandler loads all rules to compute max order
+
+## Module
+InvoiceClassification
+
+## Finding
+`CreateClassificationRuleHandler` (`CreateClassificationRuleHandler.cs:29–30`) fetches the entire rule set to derive the next order value:
+
+```csharp
+var allRules = await _ruleRepository.GetAllAsync();
+var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+```
+
+`GetAllAsync` issues `SELECT * FROM ClassificationRules ORDER BY Order`, transferring every column of every rule across the wire just to extract a single integer. The cost grows linearly with the number of rules, and the full dataset is discarded immediately afterward.
+
+## Why it matters
+This is a YAGNI/efficiency violation: the repository interface already has a database-backed implementation, so pushing the aggregation into the DB is straightforward. Under moderate load (batch imports, concurrent creation) this also creates a race window where two concurrent handlers read the same max and assign duplicate order values.
+
+## Suggested fix
+Add `Task GetMaxOrderAsync()` to `IClassificationRuleRepository` and implement it as a targeted query:
+
+```csharp
+public async Task GetMaxOrderAsync()
+    => await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;
+```
+
+Replace the two handler lines with:
+
+```csharp
+var maxOrder = await _ruleRepository.GetMaxOrderAsync();
+```
+
+---
+_Filed by daily arch-review routine on 2026-07-07._

--- a/artifacts/feat-3545/code-review.r1.md
+++ b/artifacts/feat-3545/code-review.r1.md
@@ -1,0 +1,30 @@
+## Review Result: CLEAN
+
+### Summary
+This is a small, well-executed tech-debt fix. It implements exactly what the spec asked for: a targeted `GetMaxOrderAsync()` query replaces the full-table `GetAllAsync()` + in-memory `Max()` pattern in `CreateClassificationRuleHandler`. No scope creep, no unrelated changes.
+
+### Plan Alignment
+- **FR-1** (interface method): `IClassificationRuleRepository.GetMaxOrderAsync()` added with the exact signature `Task<int> GetMaxOrderAsync();`, matching spec. `GetAllAsync()` left untouched on the interface. ✔
+- **FR-2** (repository implementation): `ClassificationRuleRepository.GetMaxOrderAsync()` implements the exact query specified — `await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;` — verbatim match to the spec, correctly nullable-casting to avoid `MaxAsync` throwing `InvalidOperationException` on an empty table. ✔
+- **FR-3** (handler update): `CreateClassificationRuleHandler` now does `var maxOrder = await _ruleRepository.GetMaxOrderAsync();`, replacing the two-liner. Rest of the handler (rule construction, `SetOrder(maxOrder + 1)`, `AddAsync`, response mapping) is byte-for-byte unchanged. ✔
+- **Out of scope items respected**: no changes to `GetAllAsync()`, `GetActiveRulesOrderedAsync()`, `ReorderRulesAsync()`, no locking/transaction/uniqueness changes, no attempt to fix the pre-existing concurrent-duplicate-Order race. ✔
+
+No deviations from the plan were found.
+
+### Code Quality
+- The new repository method is idiomatic EF Core and matches the existing style of neighboring methods in the same file (short pass-through methods over `_context`).
+- New test file `ClassificationRuleRepositoryTests.cs` uses EF Core InMemory provider consistent with other repository tests in the suite, and covers both required behaviors: empty-table → `0`, and multi-row → correct max (using non-sequential `Order` values 1, 5, 3 to actually exercise `Max`, not just "last inserted").
+- No production code was left implementing `IClassificationRuleRepository` other than the real EF repository, so there was no risk of a stale fake/mock breaking compilation — verified via `IClassificationRuleRepository` reference search.
+
+### Verification performed
+- `dotnet build Anela.Heblo.sln -c Release` — succeeds, 0 errors (only pre-existing, unrelated warnings in other files).
+- `dotnet format Anela.Heblo.sln --verify-no-changes --include <changed files>` — clean, no formatting diffs.
+- `dotnet test --filter "FullyQualifiedName~InvoiceClassification"` — 92/92 passed, including the 2 new `ClassificationRuleRepositoryTests` cases.
+
+### Issues
+None found — Critical, Important, or Suggestion.
+
+### What was done well
+- Faithful, minimal diff that traces 1:1 to the spec's three functional requirements.
+- Correct handling of the EF Core `MaxAsync` empty-sequence edge case via nullable cast, exactly as specified (an easy mistake to get wrong — using non-nullable `Max(r => r.Order)` would throw on an empty table).
+- New tests target the actual behavior change (empty table, non-trivial max) rather than being superficial.

--- a/artifacts/feat-3545/design.r1.md
+++ b/artifacts/feat-3545/design.r1.md
@@ -1,0 +1,69 @@
+# Design: Push MaxOrder computation into the database for InvoiceClassification rules
+
+## Component Design
+
+### `IClassificationRuleRepository` (Domain — `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`)
+Gains one new member, placed near `GetAllAsync`/`GetActiveRulesOrderedAsync`:
+
+```csharp
+Task<int> GetMaxOrderAsync();
+```
+
+**Responsibility:** Return the current maximum `Order` value across all `ClassificationRule` rows, or `0` if no rules exist. No other member of the interface changes.
+
+### `ClassificationRuleRepository` (Persistence — `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs`)
+Implements the new member as a single EF Core scalar aggregate query, placed near `GetAllAsync`/`GetActiveRulesOrderedAsync`:
+
+```csharp
+public async Task<int> GetMaxOrderAsync()
+{
+    return await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;
+}
+```
+
+**Responsibility:** Translate to `SELECT MAX([Order]) FROM ClassificationRules` (or the InMemory-provider equivalent in tests) instead of loading full rows. The `(int?)` cast avoids `MaxAsync` throwing `InvalidOperationException` on an empty table; `?? 0` preserves existing "no rules yet" semantics. No other repository method changes.
+
+### `CreateClassificationRuleHandler` (Application — `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs`)
+Replaces the current full-table load + in-memory `Max`:
+
+```csharp
+var allRules = await _ruleRepository.GetAllAsync();
+var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+```
+
+with a single call to the new repository method:
+
+```csharp
+var maxOrder = await _ruleRepository.GetMaxOrderAsync();
+```
+
+**Responsibility:** Unchanged apart from this swap — resolves current user, constructs the new `ClassificationRule`, calls `rule.SetOrder(maxOrder + 1)`, persists via `AddAsync`, maps to `ClassificationRuleDto`, returns the response. `GetAllAsync()` remains on the interface/implementation unchanged (still used elsewhere, e.g. rule listing).
+
+### Component interaction
+
+```
+CreateClassificationRuleHandler (Application)
+        │  await _ruleRepository.GetMaxOrderAsync()
+        ▼
+IClassificationRuleRepository (Domain)
+        ▼
+ClassificationRuleRepository (Persistence) — EF Core MaxAsync
+        ▼
+ApplicationDbContext.ClassificationRules
+        ▼
+SELECT MAX([Order]) FROM ClassificationRules
+```
+
+No new components, no new interfaces, no DI registration changes — the existing `IClassificationRuleRepository` → `ClassificationRuleRepository` binding is reused unchanged.
+
+## Data Schemas
+
+No schema or migration changes. No new/changed request or response DTOs, controller contracts, or event payloads — this is an internal repository-interface addition consumed entirely within the InvoiceClassification vertical slice.
+
+**New internal method contract:**
+
+| Method | Input | Output | Behavior |
+|---|---|---|---|
+| `GetMaxOrderAsync()` | none | `Task<int>` | Returns the maximum `ClassificationRule.Order` value in the `ClassificationRules` table, or `0` if the table is empty |
+
+Existing table/entity used as-is: `ClassificationRule.Order` (`int`, non-nullable) on the `ClassificationRules` table via `ApplicationDbContext`.

--- a/artifacts/feat-3545/impl/add-get-max-order-repository-method.r1.md
+++ b/artifacts/feat-3545/impl/add-get-max-order-repository-method.r1.md
@@ -1,0 +1,34 @@
+# Implementation: add-get-max-order-repository-method (revision 1)
+
+## Summary
+
+Replaced `CreateClassificationRuleHandler`'s full-table `GetAllAsync()` + in-memory `Max()` with a
+single targeted `GetMaxOrderAsync()` repository call that executes as a `SELECT MAX([Order])`
+database aggregate, exactly as specified in the task plan.
+
+## Changes
+
+- `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`
+  — added `Task<int> GetMaxOrderAsync();` to the interface, right after `GetActiveRulesOrderedAsync`.
+- `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs`
+  — implemented `GetMaxOrderAsync()` as `await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0`.
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs`
+  — replaced the two-line `GetAllAsync()` + in-memory `Max()` block with
+  `var maxOrder = await _ruleRepository.GetMaxOrderAsync();`. No other line in the handler changed.
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs` (new)
+  — repository-level tests against an EF Core InMemory `ApplicationDbContext`, following the sibling
+  `ClassificationHistoryRepositoryTests` pattern:
+  - `GetMaxOrderAsync_WithNoRules_ReturnsZero`
+  - `GetMaxOrderAsync_WithMultipleRules_ReturnsHighestOrder`
+
+`GetAllAsync()` itself is untouched and remains in use elsewhere (rule listing).
+
+## Verification
+
+- `dotnet build` on the full solution (`Anela.Heblo.sln`): **Build succeeded, 0 Error(s)**. (One
+  pre-existing, unrelated warning from the `AccessMatrixGen` post-build tool crashing on an
+  unrelated JSON file — present on `main` before this change, not touched by this task.)
+- `dotnet test --filter "FullyQualifiedName~ClassificationRuleRepositoryTests"`:
+  **Passed! - Failed: 0, Passed: 2, Skipped: 0**.
+
+## Status: DONE

--- a/artifacts/feat-3545/review/add-get-max-order-repository-method.r1.md
+++ b/artifacts/feat-3545/review/add-get-max-order-repository-method.r1.md
@@ -1,0 +1,19 @@
+# Code Review: add-get-max-order-repository-method
+
+## Summary
+
+The implementation exactly matches the task spec: `GetMaxOrderAsync()` was added to `IClassificationRuleRepository`, implemented in `ClassificationRuleRepository` via a single `MaxAsync` aggregate query, and `CreateClassificationRuleHandler` was updated to call it instead of loading the full table with `GetAllAsync()` and computing `Max()` in memory. A new repository-level test file covers both the empty-table and populated-table cases. The diff footprint is minimal and surgical — only the four intended files changed, with no unrelated edits.
+
+## Review Result: PASS
+
+### task: add-get-max-order-repository-method
+**Status:** PASS
+
+## Overall Notes
+
+- Verified all four files directly (interface, repository implementation, handler, test file) against the spec's prescribed content — byte-for-byte match, including the `?? 0` fallback for the null-max case (empty table) and preservation of `rule.SetOrder(maxOrder + 1)` and the rest of the handler untouched.
+- `GetAllAsync()` remains in the interface/implementation and is still used elsewhere (e.g. `GetClassificationRulesHandler`), consistent with the spec's instruction not to remove it.
+- Searched the whole `backend/` tree for other implementers/consumers of `IClassificationRuleRepository`; the only test-side usages are Moq-based (`ClassifyInvoicesHandlerTests.cs`, `InvoiceClassificationServiceTests.cs`), which do not require implementing new interface members, so no CS0535 risk elsewhere.
+- Confirmed via `git show 4ba8156 --stat` that the actual code commit touches exactly the four files named in the spec, with line counts consistent with the described changes (interface +2, repository +5, handler net -1, new test file +79).
+- New tests (`GetMaxOrderAsync_WithNoRules_ReturnsZero`, `GetMaxOrderAsync_WithMultipleRules_ReturnsHighestOrder`) correctly exercise both the empty and non-empty cases and mirror the existing `ClassificationHistoryRepositoryTests` pattern (EF Core InMemory provider, no mocking framework).
+- The implementation report's build/test claims (build succeeded, repository tests passed 2/2) are consistent with the code as written; no logic in the change would plausibly fail to build or pass these tests.

--- a/artifacts/feat-3545/spec.r1.md
+++ b/artifacts/feat-3545/spec.r1.md
@@ -1,0 +1,97 @@
+# Specification: Push MaxOrder computation into the database for InvoiceClassification rules
+
+## Summary
+`CreateClassificationRuleHandler` currently loads every `ClassificationRule` row from the database via `GetAllAsync()` just to compute the next `Order` value in memory. This change adds a targeted `GetMaxOrderAsync()` query to `IClassificationRuleRepository` / `ClassificationRuleRepository` and updates the handler to use it, eliminating the unnecessary full-table transfer. This is a small, self-contained tech-debt fix from an automated arch-review finding.
+
+## Background
+The arch-review finding (`artifacts/feat-3545/brief.md`) identified that `CreateClassificationRuleHandler.Handle` (lines 29-30) fetches the entire `ClassificationRules` table — every column of every row, ordered — solely to compute `Max(r => r.Order)` and discards the data immediately after. The fix is to move the aggregation into the database using EF Core's `MaxAsync`, which SQL Server/the underlying provider can execute as a single scalar aggregate query instead of a full table scan and network transfer.
+
+The brief also notes that this pattern creates a race window where two concurrent `CreateClassificationRule` calls could read the same max and assign duplicate `Order` values. That race condition is **pre-existing and out of scope for this fix** — see Out of Scope / Open Questions.
+
+## Functional Requirements
+
+### FR-1: Add `GetMaxOrderAsync()` to `IClassificationRuleRepository`
+Add a new method to the repository interface at `backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`:
+
+```csharp
+Task<int> GetMaxOrderAsync();
+```
+
+This returns the current maximum `Order` value across all `ClassificationRule` rows, or `0` if no rules exist.
+
+**Acceptance criteria:**
+- `IClassificationRuleRepository` declares `Task<int> GetMaxOrderAsync();`.
+- Method signature returns `Task<int>` (not `Task`), matching the brief's intent despite the brief's pseudocode omitting the generic type.
+
+### FR-2: Implement `GetMaxOrderAsync()` in `ClassificationRuleRepository`
+Implement the method in `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs` as a targeted EF Core aggregate query:
+
+```csharp
+public async Task<int> GetMaxOrderAsync()
+{
+    return await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;
+}
+```
+
+The nullable cast (`(int?)r.Order`) is required so `MaxAsync` does not throw `InvalidOperationException` when the table is empty; the `?? 0` fallback preserves the existing behavior of `CreateClassificationRuleHandler` (empty table → order starts at 1, i.e., `maxOrder + 1`).
+
+**Acceptance criteria:**
+- The implementation issues a single aggregate query (e.g., `SELECT MAX(Order) FROM ClassificationRules`) rather than loading full rows.
+- Returns `0` when the `ClassificationRules` table is empty.
+- Returns the correct maximum `Order` value when rows exist.
+- No change to any other repository method.
+
+### FR-3: Update `CreateClassificationRuleHandler` to use the new method
+Replace lines 29-30 in `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs`:
+
+```csharp
+var allRules = await _ruleRepository.GetAllAsync();
+var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+```
+
+with:
+
+```csharp
+var maxOrder = await _ruleRepository.GetMaxOrderAsync();
+```
+
+The rest of the handler (rule construction, `SetOrder(maxOrder + 1)`, `AddAsync`, response mapping) is unchanged.
+
+**Acceptance criteria:**
+- `CreateClassificationRuleHandler.Handle` no longer calls `GetAllAsync()`.
+- Behavior of the handler is otherwise identical: a newly created rule receives `Order = maxOrder + 1`, where `maxOrder` is the highest existing `Order` value (or 0 if none exist).
+- `GetAllAsync()` remains on the interface/implementation unchanged (still used elsewhere, e.g. rule listing) — it is not removed.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+`GetMaxOrderAsync()` must execute as a single scalar aggregate query against the database (e.g., `SELECT MAX([Order]) FROM ClassificationRules`), not as an in-memory aggregation over a materialized list. This removes the O(n) row/column transfer that scaled with the total number of classification rules on every rule-creation call.
+
+### NFR-2: Security
+No change. This fix does not alter authentication, authorization, or data sensitivity — it is a read-path optimization on an already-accessible repository method.
+
+## Data Model
+No schema changes. Uses the existing `ClassificationRule.Order` (int) property on the existing `ClassificationRules` table via `ApplicationDbContext`.
+
+## API / Interface Design
+Internal repository interface change only — no public API, controller, or contract changes:
+
+- New interface member: `Task<int> GetMaxOrderAsync()` on `IClassificationRuleRepository`.
+- No changes to `CreateClassificationRuleRequest`, `CreateClassificationRuleResponse`, or any HTTP-facing contract.
+
+## Dependencies
+- Entity Framework Core `MaxAsync` extension (`Microsoft.EntityFrameworkCore`), already referenced in `ClassificationRuleRepository.cs`.
+- No new packages or external services.
+
+## Out of Scope
+- Fixing the concurrent-duplicate-`Order` race condition mentioned in the brief's "Why it matters" section (two concurrent `CreateClassificationRule` calls could both read the same max and assign the same `Order`). This is pre-existing behavior, not introduced or worsened by this change, and is not part of this fix.
+- Any change to `GetAllAsync()`, `GetActiveRulesOrderedAsync()`, `ReorderRulesAsync()`, or other repository methods.
+- Any change to unrelated `CreateClassificationRuleHandler` logic (validation, user resolution, mapping).
+- Adding database-level uniqueness constraints or locking/transaction changes to `Order` assignment.
+- Unit/integration test additions beyond what's needed to cover the new method, if the team's existing test suite pattern requires one (see Open Questions).
+
+## Open Questions
+- Should a unit/integration test be added for `GetMaxOrderAsync()` (e.g., empty table → 0, populated table → correct max) as part of this change, or is this fix small enough to rely on existing `CreateClassificationRuleHandler` test coverage exercising the new code path indirectly? Recommend adding a minimal repository-level test if the project's existing test conventions cover other `ClassificationRuleRepository` methods (check `backend/test` for existing patterns) — otherwise proportional to the fix's size, no new test infra is warranted.
+- The concurrent-duplicate-`Order` race condition is explicitly out of scope per task framing, but should it be filed as a separate follow-up arch-review/tech-debt item so it isn't lost? (No action required for this spec; flagging for visibility only.)
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3545",
+  "issue_number": 3545,
+  "created_at": "2026-07-08T07:14:58.124320Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-08T07:19:41.303421Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T07:20:22.858613Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-08T07:18:01.153362Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T07:19:41.303421Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-08T07:20:22.858613Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T07:22:29.515781Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T07:18:01.153362Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T07:22:29.515781Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T07:22:55.533111Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T07:43:38.347842Z"
     }
   },
   "tasks": [
     {
       "name": "add-get-max-order-repository-method",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T07:22:55.698342Z"
+      "updated_at": "2026-07-08T07:43:33.518220Z"
     }
   ]
 }

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T07:43:38.347842Z"
+    },
+    "code-review": {
+      "status": "completed",
+      "updated_at": "2026-07-08T07:48:32.055054Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T07:22:29.515781Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T07:22:55.533111Z"
     }
   },
   "tasks": [
     {
       "name": "add-get-max-order-repository-method",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T07:22:55.698342Z"
     }
   ]
 }

--- a/artifacts/feat-3545/state.json
+++ b/artifacts/feat-3545/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-get-max-order-repository-method",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3545/task-context/add-get-max-order-repository-method.md
+++ b/artifacts/feat-3545/task-context/add-get-max-order-repository-method.md
@@ -1,0 +1,277 @@
+### task: add-get-max-order-repository-method
+
+**Context:** This is a small, self-contained tech-debt fix from an automated arch-review finding (feat-3545). `CreateClassificationRuleHandler.Handle` currently loads every row of the `ClassificationRules` table via `GetAllAsync()` just to compute the next `Order` value in memory (lines 29-30). This task adds a targeted `GetMaxOrderAsync()` method to the repository interface and implementation, and updates the handler to use it instead — eliminating the unnecessary full-table transfer while preserving identical behavior (new rule gets `Order = maxOrder + 1`, where `maxOrder` is `0` if no rules exist).
+
+This task covers all three edits (interface, implementation, call site) plus a repository-level test, because they are one cohesive change with no independently-testable/committable sub-steps.
+
+**Files:**
+- Modify: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`
+- Modify: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs`
+- Modify: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs`
+- Create: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs`
+
+#### Step 1 — Add `GetMaxOrderAsync()` to the repository interface
+
+Open `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`. Its current full contents are:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+public interface IClassificationRuleRepository
+{
+    Task<List<ClassificationRule>> GetAllAsync();
+
+    Task<List<ClassificationRule>> GetActiveRulesOrderedAsync();
+
+    Task<ClassificationRule?> GetByIdAsync(Guid id);
+
+    Task<ClassificationRule> AddAsync(ClassificationRule rule);
+
+    Task<ClassificationRule> UpdateAsync(ClassificationRule rule);
+
+    Task DeleteAsync(Guid id);
+
+    Task ReorderRulesAsync(List<Guid> ruleIds);
+}
+```
+
+Replace it with (adds `Task<int> GetMaxOrderAsync();` right after `GetActiveRulesOrderedAsync`):
+
+```csharp
+namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+public interface IClassificationRuleRepository
+{
+    Task<List<ClassificationRule>> GetAllAsync();
+
+    Task<List<ClassificationRule>> GetActiveRulesOrderedAsync();
+
+    Task<int> GetMaxOrderAsync();
+
+    Task<ClassificationRule?> GetByIdAsync(Guid id);
+
+    Task<ClassificationRule> AddAsync(ClassificationRule rule);
+
+    Task<ClassificationRule> UpdateAsync(ClassificationRule rule);
+
+    Task DeleteAsync(Guid id);
+
+    Task ReorderRulesAsync(List<Guid> ruleIds);
+}
+```
+
+Use the Edit tool with `old_string` matching the block from `Task<List<ClassificationRule>> GetActiveRulesOrderedAsync();` through the blank line before `Task<ClassificationRule?> GetByIdAsync(Guid id);`, inserting the new line in between.
+
+#### Step 2 — Implement `GetMaxOrderAsync()` in the repository
+
+Open `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs`. Find the `GetActiveRulesOrderedAsync` method (lines 22-28):
+
+```csharp
+    public async Task<List<ClassificationRule>> GetActiveRulesOrderedAsync()
+    {
+        return await _context.ClassificationRules
+            .Where(r => r.IsActive)
+            .OrderBy(r => r.Order)
+            .ToListAsync();
+    }
+```
+
+Immediately after it (before `GetByIdAsync`), insert the new method:
+
+```csharp
+    public async Task<List<ClassificationRule>> GetActiveRulesOrderedAsync()
+    {
+        return await _context.ClassificationRules
+            .Where(r => r.IsActive)
+            .OrderBy(r => r.Order)
+            .ToListAsync();
+    }
+
+    public async Task<int> GetMaxOrderAsync()
+    {
+        return await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;
+    }
+```
+
+Use the Edit tool with `old_string` set to the `GetActiveRulesOrderedAsync` method body shown above (unique in the file) and `new_string` set to that same body plus the new `GetMaxOrderAsync` method appended after it, as shown.
+
+No new `using` is required — `Microsoft.EntityFrameworkCore` (which provides `MaxAsync`) is already imported at the top of this file (line 1).
+
+#### Step 3 — Update `CreateClassificationRuleHandler` to use the new method
+
+Open `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs`. Find lines 29-30:
+
+```csharp
+        var allRules = await _ruleRepository.GetAllAsync();
+        var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+```
+
+Replace with:
+
+```csharp
+        var maxOrder = await _ruleRepository.GetMaxOrderAsync();
+```
+
+Use the Edit tool with `old_string`:
+```
+        var allRules = await _ruleRepository.GetAllAsync();
+        var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+```
+and `new_string`:
+```
+        var maxOrder = await _ruleRepository.GetMaxOrderAsync();
+```
+
+Do not change anything else in this file — `rule.SetOrder(maxOrder + 1)`, the `AddAsync` call, and the response mapping (lines 32-49) remain exactly as they are. `GetAllAsync()` is not removed from the interface or implementation; it remains unchanged and is still used elsewhere (rule listing).
+
+#### Step 4 — Build to confirm the interface/implementation/call-site are consistent
+
+Run from the backend directory:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend && dotnet build
+```
+
+Expected output: `Build succeeded.` with `0 Error(s)` (warnings unrelated to this change, if any, are pre-existing and not introduced by this fix). If it fails with a CS0535 "does not implement interface member" error, it means `ClassificationRuleRepository` is missing `GetMaxOrderAsync()` — re-check Step 2. If it fails with CS1061 on `_ruleRepository.GetMaxOrderAsync()`, re-check Step 1.
+
+#### Step 5 — Add a repository-level test for `GetMaxOrderAsync()`
+
+The project's existing sibling pattern for this kind of test is `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationHistoryRepositoryTests.cs`, which instantiates the repository directly against an `ApplicationDbContext` backed by `UseInMemoryDatabase(Guid.NewGuid())` — no mocking framework, no `CreateClassificationRuleHandlerTests` exists to indirectly cover this path, and no existing `ClassificationRuleRepositoryTests.cs` exists yet. Per the arch-review's explicit guidance, follow that same pattern: create a new minimal test file.
+
+Create `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs` with the following full contents:
+
+```csharp
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.InvoiceClassification;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification;
+
+public class ClassificationRuleRepositoryTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ClassificationRuleRepository _repository;
+
+    public ClassificationRuleRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"ClassificationRuleTests_{Guid.NewGuid()}")
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new ClassificationRuleRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task GetMaxOrderAsync_WithNoRules_ReturnsZero()
+    {
+        // Act
+        var maxOrder = await _repository.GetMaxOrderAsync();
+
+        // Assert
+        Assert.Equal(0, maxOrder);
+    }
+
+    [Fact]
+    public async Task GetMaxOrderAsync_WithMultipleRules_ReturnsHighestOrder()
+    {
+        // Arrange
+        var rule1 = new ClassificationRule(
+            name: "Rule A",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Acme",
+            accountingTemplateCode: "TPL1",
+            department: null,
+            createdBy: "tester");
+        rule1.SetOrder(1);
+
+        var rule2 = new ClassificationRule(
+            name: "Rule B",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Globex",
+            accountingTemplateCode: "TPL2",
+            department: null,
+            createdBy: "tester");
+        rule2.SetOrder(5);
+
+        var rule3 = new ClassificationRule(
+            name: "Rule C",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Initech",
+            accountingTemplateCode: "TPL3",
+            department: null,
+            createdBy: "tester");
+        rule3.SetOrder(3);
+
+        _context.ClassificationRules.AddRange(rule1, rule2, rule3);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var maxOrder = await _repository.GetMaxOrderAsync();
+
+        // Assert
+        Assert.Equal(5, maxOrder);
+    }
+}
+```
+
+This mirrors `ClassificationHistoryRepositoryTests.cs`'s constructor/dispose pattern exactly and uses the real `ClassificationRule` constructor signature (`name, ruleTypeIdentifier, pattern, accountingTemplateCode, department, createdBy`) plus the existing public `SetOrder(int)` method to set each rule's `Order` after construction (the constructor always initializes `Order = 0`).
+
+#### Step 6 — Run the new and existing InvoiceClassification tests
+
+Run from the backend directory:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend && dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.InvoiceClassification"
+```
+
+Expected output: all tests pass, including the two new `ClassificationRuleRepositoryTests` tests (`GetMaxOrderAsync_WithNoRules_ReturnsZero`, `GetMaxOrderAsync_WithMultipleRules_ReturnsHighestOrder`) and the pre-existing `ClassificationHistoryRepositoryTests`, `ClassifyInvoicesHandlerTests`, `GetClassificationRuleTypesHandlerTests`, `GetInvoiceDetailsHandlerTests`, `InvoiceClassificationMappingProfileTests`, `InvoiceClassificationServiceTests`, and the `Rules/` and `Services/` subfolder tests — none of which are touched by this change and should be unaffected. Look for a summary line like `Passed! - Failed: 0, Passed: N, Skipped: 0`.
+
+If any pre-existing test in this filter fails, stop and investigate before proceeding — it indicates this change had an unintended side effect (it should not, since `GetAllAsync()` is untouched and no other method was modified).
+
+#### Step 7 — Full solution build (final confirmation)
+
+Run from the backend directory:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend && dotnet build
+```
+
+Expected output: `Build succeeded.` with `0 Error(s)`. This is a final sanity check that no other project in the solution references `IClassificationRuleRepository` in a way broken by the new interface member (e.g., a hand-rolled mock elsewhere implementing the interface without a mocking framework). If this fails with a CS0535 in a file outside the three modified above, locate that file, add a `GetMaxOrderAsync()` implementation/mock consistent with its existing style, and re-run this build step.
+
+#### Step 8 — Commit
+
+Stage exactly the four files touched/created in this task and commit:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica && git add backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs
+```
+
+```bash
+git commit -m "$(cat <<'EOF'
+Push MaxOrder computation into the database for ClassificationRule creation
+
+CreateClassificationRuleHandler loaded the entire ClassificationRules
+table via GetAllAsync() just to compute Max(Order) in memory. Add a
+targeted GetMaxOrderAsync() repository method that issues a single
+SELECT MAX([Order]) aggregate query instead, and switch the handler
+to use it. Behavior is unchanged (new rule gets maxOrder + 1, or 1 if
+no rules exist).
+EOF
+)"
+```
+
+Verify the commit succeeded:
+
+```bash
+git status
+```
+
+Expected output: `nothing to commit, working tree clean` (aside from any unrelated pre-existing changes in the worktree, if present).

--- a/artifacts/feat-3545/task-plan.r1.md
+++ b/artifacts/feat-3545/task-plan.r1.md
@@ -1,0 +1,285 @@
+# Push MaxOrder Computation Into the Database Implementation Plan
+
+**Goal:** Replace `CreateClassificationRuleHandler`'s full-table `GetAllAsync()` + in-memory `Max()` with a single targeted `GetMaxOrderAsync()` repository call that executes as a `SELECT MAX([Order])` database aggregate.
+**Architecture:** Extends the existing `IClassificationRuleRepository` / `ClassificationRuleRepository` triad (Domain interface → Persistence implementation → Application consumer) already used for `GetAllAsync`, `GetActiveRulesOrderedAsync`, etc. No new abstractions, no DI changes, no contract/schema changes — a same-shape extension of one existing interface.
+**Tech Stack:** .NET 8, EF Core (`MaxAsync`), MediatR, xUnit with EF Core InMemory provider.
+
+---
+
+### task: add-get-max-order-repository-method
+
+**Context:** This is a small, self-contained tech-debt fix from an automated arch-review finding (feat-3545). `CreateClassificationRuleHandler.Handle` currently loads every row of the `ClassificationRules` table via `GetAllAsync()` just to compute the next `Order` value in memory (lines 29-30). This task adds a targeted `GetMaxOrderAsync()` method to the repository interface and implementation, and updates the handler to use it instead — eliminating the unnecessary full-table transfer while preserving identical behavior (new rule gets `Order = maxOrder + 1`, where `maxOrder` is `0` if no rules exist).
+
+This task covers all three edits (interface, implementation, call site) plus a repository-level test, because they are one cohesive change with no independently-testable/committable sub-steps.
+
+**Files:**
+- Modify: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`
+- Modify: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs`
+- Modify: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs`
+- Create: `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs`
+
+#### Step 1 — Add `GetMaxOrderAsync()` to the repository interface
+
+Open `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs`. Its current full contents are:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+public interface IClassificationRuleRepository
+{
+    Task<List<ClassificationRule>> GetAllAsync();
+
+    Task<List<ClassificationRule>> GetActiveRulesOrderedAsync();
+
+    Task<ClassificationRule?> GetByIdAsync(Guid id);
+
+    Task<ClassificationRule> AddAsync(ClassificationRule rule);
+
+    Task<ClassificationRule> UpdateAsync(ClassificationRule rule);
+
+    Task DeleteAsync(Guid id);
+
+    Task ReorderRulesAsync(List<Guid> ruleIds);
+}
+```
+
+Replace it with (adds `Task<int> GetMaxOrderAsync();` right after `GetActiveRulesOrderedAsync`):
+
+```csharp
+namespace Anela.Heblo.Domain.Features.InvoiceClassification;
+
+public interface IClassificationRuleRepository
+{
+    Task<List<ClassificationRule>> GetAllAsync();
+
+    Task<List<ClassificationRule>> GetActiveRulesOrderedAsync();
+
+    Task<int> GetMaxOrderAsync();
+
+    Task<ClassificationRule?> GetByIdAsync(Guid id);
+
+    Task<ClassificationRule> AddAsync(ClassificationRule rule);
+
+    Task<ClassificationRule> UpdateAsync(ClassificationRule rule);
+
+    Task DeleteAsync(Guid id);
+
+    Task ReorderRulesAsync(List<Guid> ruleIds);
+}
+```
+
+Use the Edit tool with `old_string` matching the block from `Task<List<ClassificationRule>> GetActiveRulesOrderedAsync();` through the blank line before `Task<ClassificationRule?> GetByIdAsync(Guid id);`, inserting the new line in between.
+
+#### Step 2 — Implement `GetMaxOrderAsync()` in the repository
+
+Open `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs`. Find the `GetActiveRulesOrderedAsync` method (lines 22-28):
+
+```csharp
+    public async Task<List<ClassificationRule>> GetActiveRulesOrderedAsync()
+    {
+        return await _context.ClassificationRules
+            .Where(r => r.IsActive)
+            .OrderBy(r => r.Order)
+            .ToListAsync();
+    }
+```
+
+Immediately after it (before `GetByIdAsync`), insert the new method:
+
+```csharp
+    public async Task<List<ClassificationRule>> GetActiveRulesOrderedAsync()
+    {
+        return await _context.ClassificationRules
+            .Where(r => r.IsActive)
+            .OrderBy(r => r.Order)
+            .ToListAsync();
+    }
+
+    public async Task<int> GetMaxOrderAsync()
+    {
+        return await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;
+    }
+```
+
+Use the Edit tool with `old_string` set to the `GetActiveRulesOrderedAsync` method body shown above (unique in the file) and `new_string` set to that same body plus the new `GetMaxOrderAsync` method appended after it, as shown.
+
+No new `using` is required — `Microsoft.EntityFrameworkCore` (which provides `MaxAsync`) is already imported at the top of this file (line 1).
+
+#### Step 3 — Update `CreateClassificationRuleHandler` to use the new method
+
+Open `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs`. Find lines 29-30:
+
+```csharp
+        var allRules = await _ruleRepository.GetAllAsync();
+        var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+```
+
+Replace with:
+
+```csharp
+        var maxOrder = await _ruleRepository.GetMaxOrderAsync();
+```
+
+Use the Edit tool with `old_string`:
+```
+        var allRules = await _ruleRepository.GetAllAsync();
+        var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+```
+and `new_string`:
+```
+        var maxOrder = await _ruleRepository.GetMaxOrderAsync();
+```
+
+Do not change anything else in this file — `rule.SetOrder(maxOrder + 1)`, the `AddAsync` call, and the response mapping (lines 32-49) remain exactly as they are. `GetAllAsync()` is not removed from the interface or implementation; it remains unchanged and is still used elsewhere (rule listing).
+
+#### Step 4 — Build to confirm the interface/implementation/call-site are consistent
+
+Run from the backend directory:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend && dotnet build
+```
+
+Expected output: `Build succeeded.` with `0 Error(s)` (warnings unrelated to this change, if any, are pre-existing and not introduced by this fix). If it fails with a CS0535 "does not implement interface member" error, it means `ClassificationRuleRepository` is missing `GetMaxOrderAsync()` — re-check Step 2. If it fails with CS1061 on `_ruleRepository.GetMaxOrderAsync()`, re-check Step 1.
+
+#### Step 5 — Add a repository-level test for `GetMaxOrderAsync()`
+
+The project's existing sibling pattern for this kind of test is `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationHistoryRepositoryTests.cs`, which instantiates the repository directly against an `ApplicationDbContext` backed by `UseInMemoryDatabase(Guid.NewGuid())` — no mocking framework, no `CreateClassificationRuleHandlerTests` exists to indirectly cover this path, and no existing `ClassificationRuleRepositoryTests.cs` exists yet. Per the arch-review's explicit guidance, follow that same pattern: create a new minimal test file.
+
+Create `/home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs` with the following full contents:
+
+```csharp
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.InvoiceClassification;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification;
+
+public class ClassificationRuleRepositoryTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ClassificationRuleRepository _repository;
+
+    public ClassificationRuleRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"ClassificationRuleTests_{Guid.NewGuid()}")
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new ClassificationRuleRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task GetMaxOrderAsync_WithNoRules_ReturnsZero()
+    {
+        // Act
+        var maxOrder = await _repository.GetMaxOrderAsync();
+
+        // Assert
+        Assert.Equal(0, maxOrder);
+    }
+
+    [Fact]
+    public async Task GetMaxOrderAsync_WithMultipleRules_ReturnsHighestOrder()
+    {
+        // Arrange
+        var rule1 = new ClassificationRule(
+            name: "Rule A",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Acme",
+            accountingTemplateCode: "TPL1",
+            department: null,
+            createdBy: "tester");
+        rule1.SetOrder(1);
+
+        var rule2 = new ClassificationRule(
+            name: "Rule B",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Globex",
+            accountingTemplateCode: "TPL2",
+            department: null,
+            createdBy: "tester");
+        rule2.SetOrder(5);
+
+        var rule3 = new ClassificationRule(
+            name: "Rule C",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Initech",
+            accountingTemplateCode: "TPL3",
+            department: null,
+            createdBy: "tester");
+        rule3.SetOrder(3);
+
+        _context.ClassificationRules.AddRange(rule1, rule2, rule3);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var maxOrder = await _repository.GetMaxOrderAsync();
+
+        // Assert
+        Assert.Equal(5, maxOrder);
+    }
+}
+```
+
+This mirrors `ClassificationHistoryRepositoryTests.cs`'s constructor/dispose pattern exactly and uses the real `ClassificationRule` constructor signature (`name, ruleTypeIdentifier, pattern, accountingTemplateCode, department, createdBy`) plus the existing public `SetOrder(int)` method to set each rule's `Order` after construction (the constructor always initializes `Order = 0`).
+
+#### Step 6 — Run the new and existing InvoiceClassification tests
+
+Run from the backend directory:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend && dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.InvoiceClassification"
+```
+
+Expected output: all tests pass, including the two new `ClassificationRuleRepositoryTests` tests (`GetMaxOrderAsync_WithNoRules_ReturnsZero`, `GetMaxOrderAsync_WithMultipleRules_ReturnsHighestOrder`) and the pre-existing `ClassificationHistoryRepositoryTests`, `ClassifyInvoicesHandlerTests`, `GetClassificationRuleTypesHandlerTests`, `GetInvoiceDetailsHandlerTests`, `InvoiceClassificationMappingProfileTests`, `InvoiceClassificationServiceTests`, and the `Rules/` and `Services/` subfolder tests — none of which are touched by this change and should be unaffected. Look for a summary line like `Passed! - Failed: 0, Passed: N, Skipped: 0`.
+
+If any pre-existing test in this filter fails, stop and investigate before proceeding — it indicates this change had an unintended side effect (it should not, since `GetAllAsync()` is untouched and no other method was modified).
+
+#### Step 7 — Full solution build (final confirmation)
+
+Run from the backend directory:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica/backend && dotnet build
+```
+
+Expected output: `Build succeeded.` with `0 Error(s)`. This is a final sanity check that no other project in the solution references `IClassificationRuleRepository` in a way broken by the new interface member (e.g., a hand-rolled mock elsewhere implementing the interface without a mocking framework). If this fails with a CS0535 in a file outside the three modified above, locate that file, add a `GetMaxOrderAsync()` implementation/mock consistent with its existing style, and re-run this build step.
+
+#### Step 8 — Commit
+
+Stage exactly the four files touched/created in this task and commit:
+
+```bash
+cd /home/user/worktrees/feature-3545-Arch-Review-Invoiceclassification-Createclassifica && git add backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs
+```
+
+```bash
+git commit -m "$(cat <<'EOF'
+Push MaxOrder computation into the database for ClassificationRule creation
+
+CreateClassificationRuleHandler loaded the entire ClassificationRules
+table via GetAllAsync() just to compute Max(Order) in memory. Add a
+targeted GetMaxOrderAsync() repository method that issues a single
+SELECT MAX([Order]) aggregate query instead, and switch the handler
+to use it. Behavior is unchanged (new rule gets maxOrder + 1, or 1 if
+no rules exist).
+EOF
+)"
+```
+
+Verify the commit succeeded:
+
+```bash
+git status
+```
+
+Expected output: `nothing to commit, working tree clean` (aside from any unrelated pre-existing changes in the worktree, if present).

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/CreateClassificationRule/CreateClassificationRuleHandler.cs
@@ -26,8 +26,7 @@ public class CreateClassificationRuleHandler : IRequestHandler<CreateClassificat
         var currentUser = _currentUserService.GetCurrentUser();
         var now = DateTime.UtcNow;
 
-        var allRules = await _ruleRepository.GetAllAsync();
-        var maxOrder = allRules.Count > 0 ? allRules.Max(r => r.Order) : 0;
+        var maxOrder = await _ruleRepository.GetMaxOrderAsync();
 
         var rule = new ClassificationRule(
             request.Name,

--- a/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRuleRepository.cs
@@ -6,6 +6,8 @@ public interface IClassificationRuleRepository
 
     Task<List<ClassificationRule>> GetActiveRulesOrderedAsync();
 
+    Task<int> GetMaxOrderAsync();
+
     Task<ClassificationRule?> GetByIdAsync(Guid id);
 
     Task<ClassificationRule> AddAsync(ClassificationRule rule);

--- a/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleRepository.cs
@@ -27,6 +27,11 @@ public class ClassificationRuleRepository : IClassificationRuleRepository
             .ToListAsync();
     }
 
+    public async Task<int> GetMaxOrderAsync()
+    {
+        return await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;
+    }
+
     public async Task<ClassificationRule?> GetByIdAsync(Guid id)
     {
         return await _context.ClassificationRules

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassificationRuleRepositoryTests.cs
@@ -1,0 +1,79 @@
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.InvoiceClassification;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification;
+
+public class ClassificationRuleRepositoryTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ClassificationRuleRepository _repository;
+
+    public ClassificationRuleRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"ClassificationRuleTests_{Guid.NewGuid()}")
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new ClassificationRuleRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task GetMaxOrderAsync_WithNoRules_ReturnsZero()
+    {
+        // Act
+        var maxOrder = await _repository.GetMaxOrderAsync();
+
+        // Assert
+        Assert.Equal(0, maxOrder);
+    }
+
+    [Fact]
+    public async Task GetMaxOrderAsync_WithMultipleRules_ReturnsHighestOrder()
+    {
+        // Arrange
+        var rule1 = new ClassificationRule(
+            name: "Rule A",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Acme",
+            accountingTemplateCode: "TPL1",
+            department: null,
+            createdBy: "tester");
+        rule1.SetOrder(1);
+
+        var rule2 = new ClassificationRule(
+            name: "Rule B",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Globex",
+            accountingTemplateCode: "TPL2",
+            department: null,
+            createdBy: "tester");
+        rule2.SetOrder(5);
+
+        var rule3 = new ClassificationRule(
+            name: "Rule C",
+            ruleTypeIdentifier: "CompanyName",
+            pattern: "Initech",
+            accountingTemplateCode: "TPL3",
+            department: null,
+            createdBy: "tester");
+        rule3.SetOrder(3);
+
+        _context.ClassificationRules.AddRange(rule1, rule2, rule3);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var maxOrder = await _repository.GetMaxOrderAsync();
+
+        // Assert
+        Assert.Equal(5, maxOrder);
+    }
+}


### PR DESCRIPTION
Closes #3545

## What the issue was
`CreateClassificationRuleHandler` fetched the entire `ClassificationRules` table via `GetAllAsync()` just to compute the next `Order` value in memory (`allRules.Max(r => r.Order)`). This transferred every column of every rule across the wire just to extract a single integer, with cost growing linearly with the number of rules.

## How it was fixed / handled
Added a targeted `GetMaxOrderAsync()` method to `IClassificationRuleRepository`, implemented in `ClassificationRuleRepository` as a single EF Core aggregate query (`_context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0`), and updated `CreateClassificationRuleHandler` to call it instead of loading the full table. Behavior is unchanged — a new rule still gets `Order = maxOrder + 1` (or `1` if no rules exist). `GetAllAsync()` itself is untouched and remains in use elsewhere (rule listing). Added `ClassificationRuleRepositoryTests` covering the empty-table and populated-table cases.

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, review, and whole-branch code-review markdown are committed under `artifacts/feat-3545/` in this branch.

## Code review

## Review Result: CLEAN

### Summary
This is a small, well-executed tech-debt fix. It implements exactly what the spec asked for: a targeted `GetMaxOrderAsync()` query replaces the full-table `GetAllAsync()` + in-memory `Max()` pattern in `CreateClassificationRuleHandler`. No scope creep, no unrelated changes.

### Plan Alignment
- **FR-1** (interface method): `IClassificationRuleRepository.GetMaxOrderAsync()` added with the exact signature `Task<int> GetMaxOrderAsync();`, matching spec. `GetAllAsync()` left untouched on the interface. ✔
- **FR-2** (repository implementation): `ClassificationRuleRepository.GetMaxOrderAsync()` implements the exact query specified — `await _context.ClassificationRules.MaxAsync(r => (int?)r.Order) ?? 0;` — verbatim match to the spec, correctly nullable-casting to avoid `MaxAsync` throwing `InvalidOperationException` on an empty table. ✔
- **FR-3** (handler update): `CreateClassificationRuleHandler` now does `var maxOrder = await _ruleRepository.GetMaxOrderAsync();`, replacing the two-liner. Rest of the handler (rule construction, `SetOrder(maxOrder + 1)`, `AddAsync`, response mapping) is byte-for-byte unchanged. ✔
- **Out of scope items respected**: no changes to `GetAllAsync()`, `GetActiveRulesOrderedAsync()`, `ReorderRulesAsync()`, no locking/transaction/uniqueness changes, no attempt to fix the pre-existing concurrent-duplicate-Order race. ✔

No deviations from the plan were found.

### Verification performed
- `dotnet build Anela.Heblo.sln -c Release` — succeeds, 0 errors (only pre-existing, unrelated warnings in other files).
- `dotnet format Anela.Heblo.sln --verify-no-changes --include <changed files>` — clean, no formatting diffs.
- `dotnet test --filter "FullyQualifiedName~InvoiceClassification"` — 92/92 passed, including the 2 new `ClassificationRuleRepositoryTests` cases.

### Issues
None found — Critical, Important, or Suggestion.


---
_Generated by [Claude Code](https://claude.ai/code/session_012z2CbazdBFRDSBqLTaHpNt)_