### PR TITLE
#3546: implementation

### DIFF
--- a/artifacts/feat-3546/arch-review.r1.md
+++ b/artifacts/feat-3546/arch-review.r1.md
@@ -1,0 +1,138 @@
+# Architecture Review: Move RuleName enrichment into InvoiceClassificationService
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a textbook application of the module-boundary rules already codified in
+`docs/architecture/development_guidelines.md`: "Direct access to another module's entities" and
+"Shared repositories across modules" are listed as forbidden practices, and the guidance is explicit
+that cross-cutting communication should go through a slice's own service abstraction, not by reaching
+past it into the persistence layer. `ClassifyInvoicesHandler` currently violates the spirit of that
+rule *within* the same module — it depends on `IClassificationRuleRepository` (owned conceptually by
+`InvoiceClassificationService`) purely to re-fetch a `Name` that `InvoiceClassificationService` already
+held moments earlier during `ClassifyInvoiceAsync`. The fix is the standard resolution: widen the
+service's return contract (`InvoiceClassificationResult`) by one field so the data flows out through
+the existing seam instead of a second, parallel path into the repository.
+
+Verified against the real code (not assumed):
+- `ClassifyInvoicesHandler.cs:13,20,26,97-104` — constructor takes 5 params including
+  `IClassificationRuleRepository _ruleRepository`, used only at lines 97-104 to look up `rule.Name` for
+  the error message.
+- `InvoiceClassificationResult.cs` — currently `Result`, `RuleId`, `AccountingTemplateCode`,
+  `Department`, `ErrorMessage`. No `RuleName`.
+- `InvoiceClassificationService.ClassifyInvoiceAsync` (lines 28-94) — `matchedRule` (a full
+  `ClassificationRule`, which has `.Name`) is in scope in the `Success` branch (57-63) and the
+  ABRA-update-failed `Error` branch (71-77); it is *not* in scope in the no-rule `ManualReviewRequired`
+  branch (43-46) or the outer-exception `Error` branch (88-92).
+- `IClassificationRuleRepository` (Domain layer interface) is registered once in
+  `InvoiceClassificationModule.cs` and consumed by `InvoiceClassificationService` plus five other
+  `UseCases/*Handler.cs` classes that manage rules directly (Create/Update/Delete/Reorder/Get) — those
+  are legitimate consumers and are explicitly out of scope here.
+
+No new integration points, no new module, no new dependency direction — this only removes one.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before:
+  ClassifyInvoicesHandler ──> IInvoiceClassificationService ──> IClassificationRuleRepository
+           │
+           └──────────────────────────────────────────────────> IClassificationRuleRepository  (extra edge, DB round-trip per error)
+
+After:
+  ClassifyInvoicesHandler ──> IInvoiceClassificationService ──> IClassificationRuleRepository
+           (reads RuleName off the InvoiceClassificationResult the service already returns)
+```
+
+No new components. One edge removed from the handler; one field added to an existing DTO-like result
+object that already crosses the handler/service seam.
+
+### Key Design Decisions
+
+#### Decision 1: Carry `RuleName` on `InvoiceClassificationResult` vs. a handler-side cache/lookup helper
+**Options considered:**
+1. Add `RuleName` to `InvoiceClassificationResult` (spec's approach).
+2. Keep the repository dependency in the handler but cache rule lookups (e.g. a dictionary keyed by
+   `RuleId`) to cut down repeated round trips within one `Handle` invocation.
+3. Introduce a lightweight `IRuleNameLookupService` just for this.
+
+**Chosen approach:** Option 1.
+
+**Rationale:** The data the handler needs already exists, unpersisted, inside
+`InvoiceClassificationService.ClassifyInvoiceAsync` at the exact point the result is constructed.
+Threading it through the existing return type is strictly simpler than any caching layer and fully
+eliminates the DB round trip rather than just amortizing it. Option 2 keeps the boundary violation the
+finding is about. Option 3 adds a component for a one-field, one-call-site need — not warranted at this
+scope.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. All changes are in-place edits within
+`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/`:
+- `Services/InvoiceClassificationResult.cs`
+- `Services/InvoiceClassificationService.cs`
+- `UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+  (path not directly verified in this pass — confirm exact file name/location before editing; spec
+  references line numbers 148/228/69/288 that imply it already asserts on `RuleId` in the same
+  branches).
+
+### Interfaces and Contracts
+- `InvoiceClassificationResult` gains `public string? RuleName { get; set; }`, positioned next to
+  `RuleId` for readability. No constructor — this class uses object-initializer construction
+  throughout the codebase (confirmed at all four `return new InvoiceClassificationResult { ... }`
+  sites), so the new property must stay a settable auto-property, not a constructor parameter.
+- `IInvoiceClassificationService.ClassifyInvoiceAsync` signature is unchanged (`Task<InvoiceClassificationResult>`).
+- `ClassifyInvoicesHandler` constructor drops from 5 params to 4:
+  `(IReceivedInvoicesClient, IInvoiceClassificationService, ICurrentUserService, ILogger<ClassifyInvoicesHandler>)`.
+- `IClassificationRuleRepository` itself is untouched — it keeps its six methods and its five other
+  consumers exactly as today.
+
+### Data Flow
+1. `ClassifyInvoicesHandler.Handle` calls `_classificationService.ClassifyInvoiceAsync(invoice, processedBy)` (unchanged call site).
+2. Inside `InvoiceClassificationService.ClassifyInvoiceAsync`:
+   - `matchedRule` is resolved (line 34) as today.
+   - In the `Success` branch (57-63) and the ABRA-failure `Error` branch (71-77), set
+     `RuleName = matchedRule.Name` alongside the existing `RuleId = matchedRule.Id`.
+   - The `ManualReviewRequired` branch (43-46, no `matchedRule`) and the outer-exception `Error` branch
+     (88-92, `matchedRule` out of scope) leave `RuleName` unset (null), mirroring current `RuleId`
+     behavior exactly — no new null-handling logic needed anywhere.
+3. Back in the handler's `Error` case (91-107): replace the `result.RuleId.HasValue` branch that calls
+   `await _ruleRepository.GetByIdAsync(result.RuleId.Value)` with a direct
+   `!string.IsNullOrEmpty(result.RuleName)` check, building the same `"Invoice {N} (Rule: {Name}): {Msg}"`
+   string from `result.RuleName` — no `await`, no repository call, loop stays fully synchronous with
+   respect to rule data.
+
+This is a pure "widen the return value, shrink the constructor" change — no new async paths, no new
+error states, no behavior change to `ClassificationHistory` recording (`RecordClassificationHistory`
+already takes `ruleId`, not `ruleName`, and is untouched per spec's Out of Scope).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missing one of the two `matchedRule`-in-scope branches when setting `RuleName`, leaving it null in the ABRA-failure case | Low | Spec's FR-2 acceptance criteria + a targeted unit test on `InvoiceClassificationServiceTests` for the error/matched-rule branch (mirrors existing `RuleId` assertion at line 228) catches this at compile/test time, not runtime |
+| Test file compiles against old 5-arg constructor after the handler change lands out of order | Low | Handler and test changes should land in the same commit/PR; `dotnet build` will fail loudly (constructor arity mismatch) if missed, per CLAUDE.md's mandatory `dotnet build` validation step |
+| Someone re-adds `IClassificationRuleRepository` to the handler later out of habit (e.g. copy-pasting another use-case handler) | Very low | No enforcement needed at this scope; if recurrence becomes a pattern, an architecture test analogous to `PersistenceModuleTests.AddPersistenceServices_RegistersNoRepositoryBindings` could assert `ClassifyInvoicesHandler`'s constructor arity, but that's over-engineering for a single current fix |
+
+## Specification Amendments
+
+None required — the spec's FR-1 through FR-5 already precisely match the verified shape of
+`InvoiceClassificationResult`, `InvoiceClassificationService.ClassifyInvoiceAsync`, and
+`ClassifyInvoicesHandler`. One clarification worth calling out for the implementer rather than a
+change to the spec: `InvoiceClassificationResult` is populated exclusively via object initializers
+(`new InvoiceClassificationResult { ... }`) at all four construction sites in
+`InvoiceClassificationService.cs` — `RuleName` must be added as a plain auto-property (as FR-1
+specifies), not routed through a constructor, or three of the four call sites will fail to compile.
+
+## Prerequisites
+
+None. No migration, no config, no new DI registration — `IClassificationRuleRepository` remains
+registered exactly as-is in `InvoiceClassificationModule.cs` (still needed by
+`InvoiceClassificationService` and five other handlers); only the handler's constructor parameter list
+shrinks. Safe to implement immediately.

--- a/artifacts/feat-3546/brief.md
+++ b/artifacts/feat-3546/brief.md
@@ -1,0 +1,26 @@
+## Module
+InvoiceClassification
+
+## Finding
+`ClassifyInvoicesHandler` (`ClassifyInvoicesHandler.cs:13, 99–103`) injects `IClassificationRuleRepository` alongside `IInvoiceClassificationService`. The repository is used for exactly one purpose: looking up the rule name to enrich an error message when the service reports `ClassificationResult.Error` with a non-null `RuleId`:
+
+```csharp
+var rule = await _ruleRepository.GetByIdAsync(result.RuleId.Value);
+if (rule != null)
+{
+    errorMessage = $"Invoice {invoice.InvoiceNumber} (Rule: {rule.Name}): {result.ErrorMessage}";
+}
+```
+
+Meanwhile `IInvoiceClassificationService` already has access to the matched rule when it records the failure (it calls `_ruleRepository.GetActiveRulesOrderedAsync()` internally). The result type `InvoiceClassificationResult` (`InvoiceClassificationResult.cs`) carries `RuleId` but not `RuleName`, so the handler has to re-query the DB per errored invoice.
+
+## Why it matters
+- Breaks the handler's contract with the service abstraction: the handler reaches past `IInvoiceClassificationService` into the same data layer the service owns.
+- Introduces per-error DB round trips inside the classification loop (one `GetByIdAsync` for every invoice that fails with a known rule).
+- Makes the handler harder to test: mocking two repositories for a single use-case handler instead of one service.
+
+## Suggested fix
+Add `string? RuleName` to `InvoiceClassificationResult` and populate it inside `InvoiceClassificationService.ClassifyInvoiceAsync` at the point where the matched rule is already in scope (before the response is returned). Remove `IClassificationRuleRepository` from `ClassifyInvoicesHandler`'s constructor entirely.
+
+---
+_Filed by daily arch-review routine on 2026-07-07._

--- a/artifacts/feat-3546/code-review.r1.md
+++ b/artifacts/feat-3546/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3546/design.r1.md
+++ b/artifacts/feat-3546/design.r1.md
@@ -1,0 +1,56 @@
+# Design: Move RuleName enrichment into InvoiceClassificationService
+
+## Component Design
+
+No new components. This is a contract-widening change on one existing seam, plus removal of a
+now-unnecessary dependency edge.
+
+### `InvoiceClassificationResult` (`Services/InvoiceClassificationResult.cs`)
+- Application-layer result DTO returned by `IInvoiceClassificationService.ClassifyInvoiceAsync`.
+- Gains one settable auto-property, `RuleName`, alongside the existing `RuleId`. Populated via
+  object initializer at all construction sites (no constructor exists for this type today, and
+  none is introduced).
+
+### `InvoiceClassificationService` (`Services/InvoiceClassificationService.cs`)
+- `ClassifyInvoiceAsync` responsibility is unchanged: resolve `matchedRule`, evaluate it, return an
+  `InvoiceClassificationResult`.
+- Additionally sets `RuleName = matchedRule.Name` in the two branches where `matchedRule` is
+  already in scope (`Success`, and the ABRA-update-failed `Error` branch). The `ManualReviewRequired`
+  branch and the outer-exception `Error` branch continue to leave `RuleName` null, exactly mirroring
+  current `RuleId` behavior — no new branching logic.
+- `IInvoiceClassificationService.ClassifyInvoiceAsync` method signature is unchanged
+  (`Task<InvoiceClassificationResult>`).
+
+### `ClassifyInvoicesHandler` (`UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`)
+- Loses its `IClassificationRuleRepository` dependency entirely (field, constructor parameter,
+  assignment). Constructor becomes 4 params: `IReceivedInvoicesClient`,
+  `IInvoiceClassificationService`, `ICurrentUserService`, `ILogger<ClassifyInvoicesHandler>`.
+- Error-message construction switches from an async repository lookup
+  (`await _ruleRepository.GetByIdAsync(result.RuleId.Value)`) to a synchronous read of
+  `result.RuleName`. Message format is unchanged: `"Invoice {InvoiceNumber} (Rule: {RuleName}): {ErrorMessage}"`
+  when `RuleName` is non-empty, else `"Invoice {InvoiceNumber}: {ErrorMessage}"`.
+- No other responsibility changes; `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse` contracts
+  untouched.
+
+### `IClassificationRuleRepository`
+- Untouched. Remains registered in `InvoiceClassificationModule.cs` and consumed by
+  `InvoiceClassificationService` and the five rule-management handlers (Create/Update/Delete/Reorder/Get).
+  Only the edge from `ClassifyInvoicesHandler` is removed.
+
+## Data Schemas
+
+### `InvoiceClassificationResult` (in-memory application DTO, not persisted)
+
+| Property | Type | Notes |
+|---|---|---|
+| `Result` | `ClassificationResult` (enum) | unchanged |
+| `RuleId` | `Guid?` | unchanged |
+| `RuleName` | `string?` | **new** — name of the matched `ClassificationRule`; mirrors `RuleId`, null when no rule matched (manual-review or pre-match exception paths) |
+| `AccountingTemplateCode` | `string?` | unchanged |
+| `Department` | `string?` | unchanged |
+| `ErrorMessage` | `string?` | unchanged |
+
+No changes to persisted entities (`ClassificationRule`, `ClassificationHistory`), to
+`IClassificationRuleRepository`'s interface, or to any HTTP-facing request/response contract
+(`ClassifyInvoicesRequest`/`ClassifyInvoicesResponse`). No OpenAPI/TypeScript client regeneration
+is triggered.

--- a/artifacts/feat-3546/impl/move-rulename-into-classification-result.r1.md
+++ b/artifacts/feat-3546/impl/move-rulename-into-classification-result.r1.md
@@ -1,0 +1,39 @@
+# Implementation: move-rulename-into-classification-result
+
+## What was implemented
+Added a `RuleName` property to `InvoiceClassificationResult`, populated it in `InvoiceClassificationService.ClassifyInvoiceAsync` at the two branches where the matched rule is already in scope (Success and ABRA-update-failed Error), and removed `ClassifyInvoicesHandler`'s `IClassificationRuleRepository` dependency, switching its error-message enrichment to read `result.RuleName` synchronously instead of issuing a per-error `GetByIdAsync` DB lookup.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs` — added `public string? RuleName { get; set; }`
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs` — sets `RuleName = matchedRule.Name` in the Success and ABRA-failure branches
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs` — removed `IClassificationRuleRepository` field/constructor param; error message now built from `result.RuleName` directly, no repository call
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs` — removed `_ruleRepositoryMock`; added `Handle_WhenErrorResultHasRuleName_IncludesRuleNameInErrorMessage` and `Handle_WhenErrorResultHasNoRuleName_OmitsRuleSegmentFromErrorMessage`
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs` — added `RuleName` assertions to the four existing tests covering the Success, ABRA-failure, no-match, and exception branches
+
+## Tests
+- `ClassifyInvoicesHandlerTests.cs` — 7 tests (5 existing unchanged + 2 new), all covering the handler's error-message formatting and the removal of the repository dependency
+- `InvoiceClassificationServiceTests.cs` — 4 tests, each now asserting `RuleName` alongside the existing `RuleId` assertion
+
+## How to verify
+```bash
+cd backend
+dotnet build Anela.Heblo.sln
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ClassifyInvoicesHandlerTests|FullyQualifiedName~InvoiceClassificationServiceTests"
+```
+Build succeeds with 0 errors; all 11 targeted tests pass (verified locally: Total 11, Passed 11).
+
+## Notes
+No DI registration changes needed — `IClassificationRuleRepository` stays registered for its other consumers (the service itself, and the classification-rule CRUD handlers). No HTTP contract or OpenAPI client changes, since nothing HTTP-facing changed.
+
+## PR Summary
+`ClassifyInvoicesHandler` was reaching past `IInvoiceClassificationService` into `IClassificationRuleRepository` just to re-look-up a rule name for an error message, causing one extra DB round trip per errored invoice. `InvoiceClassificationService` already has the matched rule in scope when it builds the result, so this moves the rule-name lookup there: `InvoiceClassificationResult` gained a `RuleName` field, the service populates it wherever `matchedRule` is known, and the handler now reads `result.RuleName` directly instead of querying the repository — removing the per-error DB call and the repository dependency from the handler entirely.
+
+### Changes
+- `InvoiceClassificationResult.cs` — new `RuleName` property
+- `InvoiceClassificationService.cs` — populates `RuleName` at the two branches where the rule is in scope
+- `ClassifyInvoicesHandler.cs` — drops `IClassificationRuleRepository`, uses `result.RuleName` synchronously
+- `ClassifyInvoicesHandlerTests.cs` — repository mock removed, 2 new tests
+- `InvoiceClassificationServiceTests.cs` — `RuleName` assertions added to 4 existing tests
+
+## Status
+DONE

--- a/artifacts/feat-3546/review/move-rulename-into-classification-result.r1.md
+++ b/artifacts/feat-3546/review/move-rulename-into-classification-result.r1.md
@@ -1,0 +1,25 @@
+# Code Review: move-rulename-into-classification-result
+
+## Summary
+The implementation follows the task spec precisely: `RuleName` was added to `InvoiceClassificationResult`, populated in the two `InvoiceClassificationService.ClassifyInvoiceAsync` branches where `matchedRule` is in scope, and `ClassifyInvoicesHandler` was slimmed to 4 constructor parameters with the per-error DB lookup replaced by a synchronous read of `result.RuleName`. Both target test files were updated exactly as prescribed, including the two new handler tests covering the with/without-`RuleName` error-message paths.
+
+## Review Result: PASS
+
+### task: move-rulename-into-classification-result
+**Status:** PASS
+
+Verification performed:
+- `git show 49c5575` confirms all 5 files listed in the spec were touched, with no unrelated files changed.
+- `InvoiceClassificationResult.cs`: `RuleName` added as a plain `string?` auto-property immediately after `RuleId`, as specified.
+- `InvoiceClassificationService.cs`: `RuleName = matchedRule.Name` added to exactly the Success and ABRA-update-failed `Error` branches; the `ManualReviewRequired` and outer-exception branches are untouched (verified by test assertions of `RuleName.Should().BeNull()` in those paths).
+- `ClassifyInvoicesHandler.cs`: `IClassificationRuleRepository` field, constructor param, and the `await _ruleRepository.GetByIdAsync(...)` call are fully removed; `grep -n "IClassificationRuleRepository|_ruleRepository"` on the handler file returns no matches. Error-message construction now branches synchronously on `string.IsNullOrEmpty(result.RuleName)`, preserving the exact original message formats (`"Invoice {n} (Rule: {name}): {msg}"` / `"Invoice {n}: {msg}"`).
+- `ClassifyInvoicesHandlerTests.cs`: `_ruleRepositoryMock` field/instantiation/constructor-arg removed; `grep` for `_ruleRepositoryMock` in the test file returns no matches. Two new tests added exactly as specified (`Handle_WhenErrorResultHasRuleName_IncludesRuleNameInErrorMessage`, `Handle_WhenErrorResultHasNoRuleName_OmitsRuleSegmentFromErrorMessage`), each asserting the correct message shape.
+- `InvoiceClassificationServiceTests.cs`: `RuleName` assertions added alongside `RuleId` assertions in all 4 specified tests (Success, ABRA-failure, no-match, exception branches).
+- `dotnet build` on the full solution: 0 errors (250 pre-existing warnings, unrelated to this change).
+- `dotnet test --filter "FullyQualifiedName~ClassifyInvoicesHandlerTests|FullyQualifiedName~InvoiceClassificationServiceTests"`: 11/11 passed (7 handler + 4 service), matching the spec's expected count.
+- No DI registration changes were made, consistent with the spec (`IClassificationRuleRepository` remains registered for its other consumers).
+
+No issues found.
+
+## Overall Notes
+Clean, minimal, surgical diff — exactly the 5 files specified, no scope creep. The refactor correctly eliminates the per-error `IClassificationRuleRepository.GetByIdAsync` DB round trip while preserving identical error-message output shape.

--- a/artifacts/feat-3546/spec.r1.md
+++ b/artifacts/feat-3546/spec.r1.md
@@ -1,0 +1,95 @@
+# Specification: Move RuleName enrichment into InvoiceClassificationService
+
+## Summary
+`ClassifyInvoicesHandler` currently injects `IClassificationRuleRepository` solely to re-look up a rule's name when `InvoiceClassificationService` reports a classification error tied to a known rule. This is an architecture cleanup: add a `RuleName` field to `InvoiceClassificationResult`, populate it inside `InvoiceClassificationService.ClassifyInvoiceAsync` where the matched rule is already in memory, and remove the now-unnecessary `IClassificationRuleRepository` dependency (and its per-error DB round trip) from the handler.
+
+## Background
+`ClassifyInvoicesHandler` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`) depends on `IInvoiceClassificationService` for the actual classification logic. It additionally depends on `IClassificationRuleRepository`, used in exactly one place (lines 97–104): when `ClassifyInvoiceAsync` returns `ClassificationResult.Error` with a non-null `RuleId`, the handler calls `_ruleRepository.GetByIdAsync(result.RuleId.Value)` to fetch the rule's `Name` and build a richer error message (`"Invoice {InvoiceNumber} (Rule: {rule.Name}): {ErrorMessage}"`).
+
+`InvoiceClassificationService.ClassifyInvoiceAsync` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`) already loads the full `ClassificationRule` object (`matchedRule`, including `Name`) via `_ruleRepository.GetActiveRulesOrderedAsync()` and rule matching, before returning its result — including in the `Error` branch (lines 65–78) where `matchedRule` is in scope but only `matchedRule.Id` is copied onto the result via `RuleId`.
+
+This means the handler reaches into the same data layer the service already owns, purely to re-fetch data the service had a moment ago, adding an avoidable DB round trip per errored invoice and an extra mocked dependency in handler tests. The fix threads `RuleName` through the existing result object instead of re-querying.
+
+## Functional Requirements
+
+### FR-1: Add `RuleName` to `InvoiceClassificationResult`
+Add a `public string? RuleName { get; set; }` property to `InvoiceClassificationResult` (`backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs`), alongside the existing `RuleId`.
+
+**Acceptance criteria:**
+- `InvoiceClassificationResult` exposes a nullable `RuleName` string property.
+- No other properties on `InvoiceClassificationResult` are changed.
+
+### FR-2: Populate `RuleName` in `InvoiceClassificationService`
+In `InvoiceClassificationService.ClassifyInvoiceAsync`, set `RuleName = matchedRule.Name` on every `InvoiceClassificationResult` constructed after a rule has matched (`matchedRule != null`) — i.e. both the `Success` branch (lines 57–63) and the `Error` branch for a failed ABRA update (lines 71–77). The `ManualReviewRequired` branch (no matched rule, lines 43–46) and the outer-exception `Error` branch (lines 88–92, no matched rule in scope) continue to leave `RuleName` (and `RuleId`) unset/null, matching current `RuleId` behavior.
+
+**Acceptance criteria:**
+- When classification succeeds, the returned result's `RuleName` equals `matchedRule.Name`.
+- When classification fails because the ABRA update did not succeed (matched rule known), the returned result's `RuleName` equals `matchedRule.Name`.
+- When no rule matches (manual review required), `RuleName` is null.
+- When an unhandled exception occurs before/during rule matching, `RuleName` is null.
+- No change to `IRuleEvaluationEngine`, `IClassificationRuleRepository`, or `ClassificationHistory` recording behavior.
+
+### FR-3: Handler builds the enriched error message from the result directly
+In `ClassifyInvoicesHandler.Handle`, replace the `_ruleRepository.GetByIdAsync(result.RuleId.Value)` lookup (lines 97–104) with a direct read of `result.RuleName`. If `result.RuleName` is non-null/non-empty, build the message as `"Invoice {invoice.InvoiceNumber} (Rule: {result.RuleName}): {result.ErrorMessage}"`; otherwise keep the existing unqualified message `"Invoice {invoice.InvoiceNumber}: {result.ErrorMessage}"`. No DB call is made from the handler.
+
+**Acceptance criteria:**
+- Given a service result with `Result = Error`, `RuleId` set, and `RuleName` set, the handler's error message includes `(Rule: {RuleName})`.
+- Given a service result with `Result = Error` and `RuleName` null (e.g. exception path, no matched rule), the handler's error message has no `(Rule: ...)` segment — same as today's behavior when the repository lookup returns null.
+- Behavior/format of the produced error message string is otherwise unchanged from the current implementation (only the data source changes, not the message shape).
+
+### FR-4: Remove `IClassificationRuleRepository` from `ClassifyInvoicesHandler`
+Remove the `IClassificationRuleRepository _ruleRepository` field, constructor parameter, and assignment from `ClassifyInvoicesHandler`. Remove the now-unused `using Anela.Heblo.Domain.Features.InvoiceClassification;` import only if nothing else in the file still needs it (`ReceivedInvoice`, `ClassificationResult` also live in that namespace, so the `using` itself likely stays — only the repository dependency is removed).
+
+**Acceptance criteria:**
+- `ClassifyInvoicesHandler`'s constructor takes 4 parameters: `IReceivedInvoicesClient`, `IInvoiceClassificationService`, `ICurrentUserService`, `ILogger<ClassifyInvoicesHandler>`.
+- No reference to `IClassificationRuleRepository` remains in `ClassifyInvoicesHandler.cs`.
+- DI registration for `ClassifyInvoicesHandler` (MediatR auto-registration; no explicit constructor wiring expected in `InvoiceClassificationModule.cs`) continues to resolve without changes, since `IClassificationRuleRepository` is still registered for other consumers (`UpdateClassificationRuleHandler`, `ReorderClassificationRulesHandler`, `GetClassificationRulesHandler`, `DeleteClassificationRuleHandler`, `CreateClassificationRuleHandler`, and `InvoiceClassificationService` itself).
+
+### FR-5: Update existing tests for the new constructor signature and behavior
+`backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs` constructs `ClassifyInvoicesHandler` with a `Mock<IClassificationRuleRepository>` as the third constructor argument (lines 16, 25, 33–38). This must be removed to match the new constructor. Existing tests set up `InvoiceClassificationResult` without `RuleName`/`RuleId` (e.g. lines 63, 97, 126, 155, 184), which remains valid since the new field is optional and defaults to null — no behavioral change to those assertions is expected.
+
+**Acceptance criteria:**
+- `ClassifyInvoicesHandlerTests` compiles and all existing tests pass against the new 4-parameter constructor, with no `Mock<IClassificationRuleRepository>` remaining in the file.
+- A new/updated test covers FR-3: given an `Error` result with `RuleId` and `RuleName` populated, `response.ErrorMessages` contains a message with the `(Rule: {RuleName})` segment, without any repository mock being invoked.
+- A new/updated test (or existing one, if already covering this) confirms the unqualified message format is preserved when `RuleName` is null.
+- `InvoiceClassificationServiceTests.cs` gains or updates assertions confirming `result.RuleName` is populated in the `Success` and rule-matched-`Error` cases (mirroring existing `result.RuleId.Should().Be(...)` assertions at lines 148 and 228) and remains null in the no-rule-matched and exception cases (mirroring lines 69 and 288).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Eliminates one `IClassificationRuleRepository.GetByIdAsync` database round trip per invoice that fails classification with a known rule, inside the `ClassifyInvoicesHandler.Handle` loop. No new I/O is introduced — `RuleName` is sourced from data already fetched by `InvoiceClassificationService` during rule evaluation.
+
+### NFR-2: Security
+No change. No new data exposure: `RuleName` is already readable by any caller with access to `IClassificationRuleRepository` (used elsewhere in the module, e.g. `GetClassificationRulesHandler`), and is already surfaced indirectly today via the handler's repository lookup. This change does not alter authorization or data sensitivity.
+
+## Data Model
+`InvoiceClassificationResult` (application-layer DTO, not persisted) gains one field:
+
+| Property | Type | Notes |
+|---|---|---|
+| `RuleName` | `string?` | Name of the matched `ClassificationRule`, mirrors `RuleId`; null when no rule matched. |
+
+No changes to persisted entities (`ClassificationRule`, `ClassificationHistory`) or to the `IClassificationRuleRepository` interface.
+
+## API / Interface Design
+No public API (HTTP endpoint / DTO contract) changes. This is an internal application-layer refactor:
+- `IInvoiceClassificationService.ClassifyInvoiceAsync` signature is unchanged; only the returned `InvoiceClassificationResult`'s shape gains a field.
+- `ClassifyInvoicesHandler` constructor signature changes (drops `IClassificationRuleRepository` parameter) — this is an internal DI-resolved type, not exposed externally, so no OpenAPI/TypeScript client regeneration is triggered.
+- `ClassifyInvoicesRequest` / `ClassifyInvoicesResponse` (the MediatR request/response and the controller contract) are unchanged.
+
+## Dependencies
+- No new external dependencies.
+- Depends on existing `ClassificationRule.Name` (already present, immutable after construction/`Update`).
+- `IClassificationRuleRepository` remains injected in `InvoiceClassificationService` and in the other `InvoiceClassification` use-case handlers (`UpdateClassificationRuleHandler`, `ReorderClassificationRulesHandler`, `GetClassificationRulesHandler`, `DeleteClassificationRuleHandler`, `CreateClassificationRuleHandler`) — only `ClassifyInvoicesHandler`'s dependency is removed.
+
+## Out of Scope
+- Any change to `ClassificationResult` enum values or overall classification logic/flow.
+- Any change to `IClassificationRuleRepository` or its other consumers.
+- Any change to `ClassificationHistory` persistence or the `RecordClassificationHistory` method.
+- Any change to the HTTP-facing `ClassifyInvoicesRequest`/`ClassifyInvoicesResponse` contracts or frontend.
+- Broader refactors of error-message formatting beyond substituting the data source for the rule name.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-08T08:19:53.413750Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T08:20:38.530216Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T08:22:36.504136Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T08:23:00.690408Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T08:37:09.434164Z"
     }
   },
   "tasks": [
     {
       "name": "move-rulename-into-classification-result",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T08:23:00.898647Z"
+      "updated_at": "2026-07-08T08:37:00.856427Z"
     }
   ]
 }

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3546",
+  "issue_number": 3546,
+  "created_at": "2026-07-08T08:15:25.167150Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T08:22:36.504136Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T08:23:00.690408Z"
     }
   },
   "tasks": [
     {
       "name": "move-rulename-into-classification-result",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T08:23:00.898647Z"
     }
   ]
 }

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-08T08:37:09.434164Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T08:37:14.060038Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T08:39:54.900894Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T08:37:09.434164Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-08T08:37:14.060038Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-08T08:20:38.530216Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T08:22:36.504136Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T08:18:27.859636Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-08T08:18:27.859636Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T08:19:53.413750Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3546/state.json
+++ b/artifacts/feat-3546/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "move-rulename-into-classification-result",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3546/task-context/move-rulename-into-classification-result.md
+++ b/artifacts/feat-3546/task-context/move-rulename-into-classification-result.md
@@ -1,0 +1,307 @@
+### task: move-rulename-into-classification-result
+
+## Goal
+Add `RuleName` to `InvoiceClassificationResult`, populate it inside `InvoiceClassificationService.ClassifyInvoiceAsync`
+wherever `matchedRule` is already in scope, and remove `ClassifyInvoicesHandler`'s now-unnecessary
+`IClassificationRuleRepository` dependency (and the per-error DB round trip it caused) by reading
+`result.RuleName` directly instead. Update the two affected unit test files to match.
+
+This eliminates one `IClassificationRuleRepository.GetByIdAsync` call per errored invoice inside
+`ClassifyInvoicesHandler.Handle`'s loop, and removes a repository dependency that the handler only used
+for that lookup.
+
+## Files to touch
+
+1. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs`
+2. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`
+3. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`
+4. `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+5. `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+
+No other files change. No DI registration changes are needed: `IClassificationRuleRepository` stays
+registered in `InvoiceClassificationModule.cs` for its other consumers (`InvoiceClassificationService`
+itself, plus `UpdateClassificationRuleHandler`, `ReorderClassificationRulesHandler`,
+`GetClassificationRulesHandler`, `DeleteClassificationRuleHandler`, `CreateClassificationRuleHandler`).
+No OpenAPI/TypeScript client regeneration is triggered — nothing HTTP-facing changes.
+
+## Step 1 — Add `RuleName` to `InvoiceClassificationResult`
+
+File: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs`
+
+Current content (6 properties on lines 5–16):
+```csharp
+public class InvoiceClassificationResult
+{
+    public ClassificationResult Result { get; set; }
+
+    public Guid? RuleId { get; set; }
+
+    public string? AccountingTemplateCode { get; set; }
+
+    public string? Department { get; set; }
+
+    public string? ErrorMessage { get; set; }
+}
+```
+
+Add a settable auto-property `RuleName` immediately after `RuleId`:
+```csharp
+public class InvoiceClassificationResult
+{
+    public ClassificationResult Result { get; set; }
+
+    public Guid? RuleId { get; set; }
+
+    public string? RuleName { get; set; }
+
+    public string? AccountingTemplateCode { get; set; }
+
+    public string? Department { get; set; }
+
+    public string? ErrorMessage { get; set; }
+}
+```
+
+This class is populated exclusively via object initializers at all four construction sites in
+`InvoiceClassificationService.cs` — it has no constructor, so `RuleName` must stay a plain auto-property,
+not a constructor parameter (otherwise the other three sites fail to compile).
+
+## Step 2 — Populate `RuleName` in `InvoiceClassificationService.ClassifyInvoiceAsync`
+
+File: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`
+
+`ClassifyInvoiceAsync` (lines 28–94) constructs `InvoiceClassificationResult` at 4 sites. `matchedRule`
+(type `ClassificationRule`, has `.Name`) is in scope at 2 of them:
+
+- **Success branch** (currently lines 57–63): add `RuleName = matchedRule.Name` alongside the existing
+  `RuleId = matchedRule.Id`:
+  ```csharp
+  return new InvoiceClassificationResult
+  {
+      Result = ClassificationResult.Success,
+      RuleId = matchedRule.Id,
+      RuleName = matchedRule.Name,
+      AccountingTemplateCode = matchedRule.AccountingTemplateCode,
+      Department = matchedRule.Department
+  };
+  ```
+
+- **ABRA-update-failed `Error` branch** (currently lines 71–77): same addition:
+  ```csharp
+  return new InvoiceClassificationResult
+  {
+      Result = ClassificationResult.Error,
+      RuleId = matchedRule.Id,
+      RuleName = matchedRule.Name,
+      Department = matchedRule.Department,
+      ErrorMessage = errorMessage
+  };
+  ```
+
+Leave the other two construction sites unchanged — `matchedRule` is not in scope there, so `RuleName`
+(like `RuleId` today) stays unset/null:
+- `ManualReviewRequired` branch (currently lines 43–46, `matchedRule == null`) — no change.
+- Outer-exception `Error` branch (currently lines 88–92, inside the `catch (Exception ex)` block) — no change.
+
+Do not touch `RecordClassificationHistory` — it takes `ruleId`, not `ruleName`, and stays exactly as is
+per the spec's explicit out-of-scope note (`ClassificationHistory` persistence is unaffected).
+
+## Step 3 — Remove `IClassificationRuleRepository` from `ClassifyInvoicesHandler` and use `result.RuleName`
+
+File: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`
+
+Current constructor and field (lines 9–29):
+```csharp
+public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, ClassifyInvoicesResponse>
+{
+    private readonly IReceivedInvoicesClient _invoicesClient;
+    private readonly IInvoiceClassificationService _classificationService;
+    private readonly IClassificationRuleRepository _ruleRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<ClassifyInvoicesHandler> _logger;
+
+    public ClassifyInvoicesHandler(
+        IReceivedInvoicesClient invoicesClient,
+        IInvoiceClassificationService classificationService,
+        IClassificationRuleRepository ruleRepository,
+        ICurrentUserService currentUserService,
+        ILogger<ClassifyInvoicesHandler> logger)
+    {
+        _invoicesClient = invoicesClient;
+        _classificationService = classificationService;
+        _ruleRepository = ruleRepository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+```
+
+Change to (4 params, no repository):
+```csharp
+public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, ClassifyInvoicesResponse>
+{
+    private readonly IReceivedInvoicesClient _invoicesClient;
+    private readonly IInvoiceClassificationService _classificationService;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<ClassifyInvoicesHandler> _logger;
+
+    public ClassifyInvoicesHandler(
+        IReceivedInvoicesClient invoicesClient,
+        IInvoiceClassificationService classificationService,
+        ICurrentUserService currentUserService,
+        ILogger<ClassifyInvoicesHandler> logger)
+    {
+        _invoicesClient = invoicesClient;
+        _classificationService = classificationService;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+```
+
+Then in `Handle`, the `ClassificationResult.Error` case currently (lines 91–107):
+```csharp
+                        case ClassificationResult.Error:
+                            response.Errors++;
+                            if (!string.IsNullOrEmpty(result.ErrorMessage))
+                            {
+                                // Add rule name to error message if available
+                                var errorMessage = $"Invoice {invoice.InvoiceNumber}: {result.ErrorMessage}";
+                                if (result.RuleId.HasValue)
+                                {
+                                    var rule = await _ruleRepository.GetByIdAsync(result.RuleId.Value);
+                                    if (rule != null)
+                                    {
+                                        errorMessage = $"Invoice {invoice.InvoiceNumber} (Rule: {rule.Name}): {result.ErrorMessage}";
+                                    }
+                                }
+                                errorMessages.Add(errorMessage);
+                            }
+                            break;
+```
+
+Replace with a synchronous check on `result.RuleName` — no repository call, no `await`:
+```csharp
+                        case ClassificationResult.Error:
+                            response.Errors++;
+                            if (!string.IsNullOrEmpty(result.ErrorMessage))
+                            {
+                                // Add rule name to error message if available
+                                var errorMessage = !string.IsNullOrEmpty(result.RuleName)
+                                    ? $"Invoice {invoice.InvoiceNumber} (Rule: {result.RuleName}): {result.ErrorMessage}"
+                                    : $"Invoice {invoice.InvoiceNumber}: {result.ErrorMessage}";
+                                errorMessages.Add(errorMessage);
+                            }
+                            break;
+```
+
+Message format/shape is unchanged — only the data source changes (`result.RuleName` instead of a repo
+lookup keyed by `result.RuleId`).
+
+Leave the `using Anela.Heblo.Domain.Features.InvoiceClassification;` import in place — `ReceivedInvoice`
+and `ClassificationResult` (the enum) still live in that namespace and are still used elsewhere in this
+file; only the `IClassificationRuleRepository` symbol becomes unused, not the whole namespace.
+
+After this change the constructor is exactly:
+`(IReceivedInvoicesClient, IInvoiceClassificationService, ICurrentUserService, ILogger<ClassifyInvoicesHandler>)`
+— 4 parameters, no `IClassificationRuleRepository` reference anywhere in the file.
+
+No change needed to `InvoiceClassificationModule.cs` — MediatR auto-registers `ClassifyInvoicesHandler`
+via its handler interface; there is no explicit constructor wiring for it to update, and
+`IClassificationRuleRepository`'s registration is untouched (still needed by other consumers).
+
+## Step 4 — Update `ClassifyInvoicesHandlerTests.cs`
+
+File: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+
+- Remove the `Mock<IClassificationRuleRepository> _ruleRepositoryMock` field (line 16) and its
+  instantiation `_ruleRepositoryMock = new Mock<IClassificationRuleRepository>();` (line 25).
+- Remove `_ruleRepositoryMock.Object,` from the `ClassifyInvoicesHandler` constructor call in the test
+  constructor (currently lines 33–38), so it becomes:
+  ```csharp
+  _handler = new ClassifyInvoicesHandler(
+      _invoicesClientMock.Object,
+      _classificationServiceMock.Object,
+      _currentUserServiceMock.Object,
+      _loggerMock.Object);
+  ```
+- The `using Anela.Heblo.Domain.Features.InvoiceClassification;` import (line 3) stays — `ReceivedInvoice`,
+  `ClassificationResult`, and `IClassificationRuleRepository` (still referenced in type position for the
+  removed mock, so re-check after edits: once the mock field is gone, confirm no other symbol from that
+  namespace requires the import to be dropped — `ReceivedInvoice` at minimum still needs it, e.g. line 53).
+  In practice: leave the `using` alone; only remove the two `Mock<IClassificationRuleRepository>` lines and
+  the constructor argument.
+- The existing 5 tests construct `InvoiceClassificationResult` without `RuleName`/`RuleId` (e.g. lines 63,
+  97, 126, 155, 184) — these remain valid unchanged, since `RuleName` is optional and defaults to null.
+- Add two new tests covering FR-3 from the spec, exercising the `ClassificationResult.Error` branch
+  (which none of the current 5 tests do):
+  1. **`Handle_WhenErrorResultHasRuleName_IncludesRuleNameInErrorMessage`**: set up
+     `_classificationServiceMock` to return
+     `new InvoiceClassificationResult { Result = ClassificationResult.Error, RuleId = someGuid, RuleName = "My Rule", ErrorMessage = "boom" }`
+     for one invoice (use the `InvoiceIds`-driven single-invoice path, mirroring the existing
+     `GetInvoiceByIdAsync` setup pattern, or the unclassified-invoices path — either is fine as long as
+     exactly one invoice with a known `InvoiceNumber` flows through). Assert
+     `response.ErrorMessages` contains a message equal to
+     `$"Invoice {invoiceNumber} (Rule: My Rule): boom"`. Also assert `_ruleRepositoryMock` no longer
+     exists (i.e. this compiles without any repository mock in scope) — the absence of the mock is itself
+     the proof no DB call is made.
+  2. **`Handle_WhenErrorResultHasNoRuleName_OmitsRuleSegmentFromErrorMessage`**: same shape but
+     `RuleName = null` (and optionally `RuleId = null`, matching the exception/no-match path). Assert
+     `response.ErrorMessages` contains `$"Invoice {invoiceNumber}: boom"` with no `(Rule: ...)` segment.
+- Run `grep -n "_ruleRepositoryMock" backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+  after editing — it must return no matches.
+
+## Step 5 — Update `InvoiceClassificationServiceTests.cs`
+
+File: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+
+Add `RuleName` assertions alongside the existing `RuleId` assertions in the tests that already exercise
+`matchedRule`-in-scope branches:
+
+- `ClassifyInvoiceAsync_RuleMatchedAndAbraSucceeds_RecordsSuccessAndReturnsRuleResult` (Success branch):
+  after the existing `result.RuleId.Should().Be(ruleWithId.Id);` (line 148), add:
+  ```csharp
+  result.RuleName.Should().Be(ruleWithId.Name);
+  ```
+- `ClassifyInvoiceAsync_RuleMatchedAndAbraFails_RecordsErrorAndReturnsRuleIdForDisplay` (ABRA-failure
+  `Error` branch): after the existing `result.RuleId.Should().Be(matchedRule.Id);` (line 228), add:
+  ```csharp
+  result.RuleName.Should().Be(matchedRule.Name);
+  ```
+- `ClassifyInvoiceAsync_NoMatchingRule_MarksForManualReviewAndRecordsHistory` (no-match branch): after
+  the existing `result.RuleId.Should().BeNull();` (line 69), add:
+  ```csharp
+  result.RuleName.Should().BeNull();
+  ```
+- `ClassifyInvoiceAsync_ExceptionThrown_RecordsErrorWithMessageAndReturnsErrorResult` (outer-exception
+  branch): after the existing `result.RuleId.Should().BeNull();` (line 288), add:
+  ```csharp
+  result.RuleName.Should().BeNull();
+  ```
+
+No other changes to this file — `InvoiceClassificationService`'s constructor signature and the
+`_ruleRepositoryMock` it legitimately depends on (`GetActiveRulesOrderedAsync`) are unaffected by this
+refactor (the service keeps its `IClassificationRuleRepository` dependency; only the handler loses its
+separate one).
+
+## Verification
+
+Run from the repo root of this worktree:
+
+```bash
+cd backend
+dotnet build
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"
+```
+
+Both commands must succeed:
+- `dotnet build` must show zero errors (confirms `ClassifyInvoicesHandler`'s new 4-arg constructor,
+  `InvoiceClassificationResult.RuleName`, and both test files all compile together).
+- The filtered `dotnet test` run must show all tests passing in
+  `Anela.Heblo.Tests.Features.InvoiceClassification.ClassifyInvoicesHandlerTests` (7 tests: the original 5
+  plus the 2 new ones) and `Anela.Heblo.Tests.Features.InvoiceClassification.InvoiceClassificationServiceTests`
+  (4 tests, all with new `RuleName` assertions), with 0 failures.
+
+If time allows, also run the full test project (`dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`)
+to confirm no unrelated regression, though the filtered run above is the minimum bar for this task.
+
+Do not run `dotnet format` changes beyond what the edits above require; match existing file style
+(4-space indent, existing brace/blank-line conventions already visible in both handler and service files).

--- a/artifacts/feat-3546/task-plan.r1.md
+++ b/artifacts/feat-3546/task-plan.r1.md
@@ -1,0 +1,315 @@
+# Implementation Plan: Move RuleName enrichment into InvoiceClassificationService
+
+Source docs: `artifacts/feat-3546/spec.r1.md`, `artifacts/feat-3546/arch-review.r1.md`, `artifacts/feat-3546/design.r1.md`.
+
+This is a small, self-contained refactor (add a field, populate it at its natural source, delete a
+now-redundant dependency and its DB round trip). It is implemented as a single task — splitting it
+further would just fragment one atomic change across artificial boundaries.
+
+### task: move-rulename-into-classification-result
+
+## Goal
+Add `RuleName` to `InvoiceClassificationResult`, populate it inside `InvoiceClassificationService.ClassifyInvoiceAsync`
+wherever `matchedRule` is already in scope, and remove `ClassifyInvoicesHandler`'s now-unnecessary
+`IClassificationRuleRepository` dependency (and the per-error DB round trip it caused) by reading
+`result.RuleName` directly instead. Update the two affected unit test files to match.
+
+This eliminates one `IClassificationRuleRepository.GetByIdAsync` call per errored invoice inside
+`ClassifyInvoicesHandler.Handle`'s loop, and removes a repository dependency that the handler only used
+for that lookup.
+
+## Files to touch
+
+1. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs`
+2. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`
+3. `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`
+4. `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+5. `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+
+No other files change. No DI registration changes are needed: `IClassificationRuleRepository` stays
+registered in `InvoiceClassificationModule.cs` for its other consumers (`InvoiceClassificationService`
+itself, plus `UpdateClassificationRuleHandler`, `ReorderClassificationRulesHandler`,
+`GetClassificationRulesHandler`, `DeleteClassificationRuleHandler`, `CreateClassificationRuleHandler`).
+No OpenAPI/TypeScript client regeneration is triggered — nothing HTTP-facing changes.
+
+## Step 1 — Add `RuleName` to `InvoiceClassificationResult`
+
+File: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs`
+
+Current content (6 properties on lines 5–16):
+```csharp
+public class InvoiceClassificationResult
+{
+    public ClassificationResult Result { get; set; }
+
+    public Guid? RuleId { get; set; }
+
+    public string? AccountingTemplateCode { get; set; }
+
+    public string? Department { get; set; }
+
+    public string? ErrorMessage { get; set; }
+}
+```
+
+Add a settable auto-property `RuleName` immediately after `RuleId`:
+```csharp
+public class InvoiceClassificationResult
+{
+    public ClassificationResult Result { get; set; }
+
+    public Guid? RuleId { get; set; }
+
+    public string? RuleName { get; set; }
+
+    public string? AccountingTemplateCode { get; set; }
+
+    public string? Department { get; set; }
+
+    public string? ErrorMessage { get; set; }
+}
+```
+
+This class is populated exclusively via object initializers at all four construction sites in
+`InvoiceClassificationService.cs` — it has no constructor, so `RuleName` must stay a plain auto-property,
+not a constructor parameter (otherwise the other three sites fail to compile).
+
+## Step 2 — Populate `RuleName` in `InvoiceClassificationService.ClassifyInvoiceAsync`
+
+File: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs`
+
+`ClassifyInvoiceAsync` (lines 28–94) constructs `InvoiceClassificationResult` at 4 sites. `matchedRule`
+(type `ClassificationRule`, has `.Name`) is in scope at 2 of them:
+
+- **Success branch** (currently lines 57–63): add `RuleName = matchedRule.Name` alongside the existing
+  `RuleId = matchedRule.Id`:
+  ```csharp
+  return new InvoiceClassificationResult
+  {
+      Result = ClassificationResult.Success,
+      RuleId = matchedRule.Id,
+      RuleName = matchedRule.Name,
+      AccountingTemplateCode = matchedRule.AccountingTemplateCode,
+      Department = matchedRule.Department
+  };
+  ```
+
+- **ABRA-update-failed `Error` branch** (currently lines 71–77): same addition:
+  ```csharp
+  return new InvoiceClassificationResult
+  {
+      Result = ClassificationResult.Error,
+      RuleId = matchedRule.Id,
+      RuleName = matchedRule.Name,
+      Department = matchedRule.Department,
+      ErrorMessage = errorMessage
+  };
+  ```
+
+Leave the other two construction sites unchanged — `matchedRule` is not in scope there, so `RuleName`
+(like `RuleId` today) stays unset/null:
+- `ManualReviewRequired` branch (currently lines 43–46, `matchedRule == null`) — no change.
+- Outer-exception `Error` branch (currently lines 88–92, inside the `catch (Exception ex)` block) — no change.
+
+Do not touch `RecordClassificationHistory` — it takes `ruleId`, not `ruleName`, and stays exactly as is
+per the spec's explicit out-of-scope note (`ClassificationHistory` persistence is unaffected).
+
+## Step 3 — Remove `IClassificationRuleRepository` from `ClassifyInvoicesHandler` and use `result.RuleName`
+
+File: `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs`
+
+Current constructor and field (lines 9–29):
+```csharp
+public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, ClassifyInvoicesResponse>
+{
+    private readonly IReceivedInvoicesClient _invoicesClient;
+    private readonly IInvoiceClassificationService _classificationService;
+    private readonly IClassificationRuleRepository _ruleRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<ClassifyInvoicesHandler> _logger;
+
+    public ClassifyInvoicesHandler(
+        IReceivedInvoicesClient invoicesClient,
+        IInvoiceClassificationService classificationService,
+        IClassificationRuleRepository ruleRepository,
+        ICurrentUserService currentUserService,
+        ILogger<ClassifyInvoicesHandler> logger)
+    {
+        _invoicesClient = invoicesClient;
+        _classificationService = classificationService;
+        _ruleRepository = ruleRepository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+```
+
+Change to (4 params, no repository):
+```csharp
+public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, ClassifyInvoicesResponse>
+{
+    private readonly IReceivedInvoicesClient _invoicesClient;
+    private readonly IInvoiceClassificationService _classificationService;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<ClassifyInvoicesHandler> _logger;
+
+    public ClassifyInvoicesHandler(
+        IReceivedInvoicesClient invoicesClient,
+        IInvoiceClassificationService classificationService,
+        ICurrentUserService currentUserService,
+        ILogger<ClassifyInvoicesHandler> logger)
+    {
+        _invoicesClient = invoicesClient;
+        _classificationService = classificationService;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+```
+
+Then in `Handle`, the `ClassificationResult.Error` case currently (lines 91–107):
+```csharp
+                        case ClassificationResult.Error:
+                            response.Errors++;
+                            if (!string.IsNullOrEmpty(result.ErrorMessage))
+                            {
+                                // Add rule name to error message if available
+                                var errorMessage = $"Invoice {invoice.InvoiceNumber}: {result.ErrorMessage}";
+                                if (result.RuleId.HasValue)
+                                {
+                                    var rule = await _ruleRepository.GetByIdAsync(result.RuleId.Value);
+                                    if (rule != null)
+                                    {
+                                        errorMessage = $"Invoice {invoice.InvoiceNumber} (Rule: {rule.Name}): {result.ErrorMessage}";
+                                    }
+                                }
+                                errorMessages.Add(errorMessage);
+                            }
+                            break;
+```
+
+Replace with a synchronous check on `result.RuleName` — no repository call, no `await`:
+```csharp
+                        case ClassificationResult.Error:
+                            response.Errors++;
+                            if (!string.IsNullOrEmpty(result.ErrorMessage))
+                            {
+                                // Add rule name to error message if available
+                                var errorMessage = !string.IsNullOrEmpty(result.RuleName)
+                                    ? $"Invoice {invoice.InvoiceNumber} (Rule: {result.RuleName}): {result.ErrorMessage}"
+                                    : $"Invoice {invoice.InvoiceNumber}: {result.ErrorMessage}";
+                                errorMessages.Add(errorMessage);
+                            }
+                            break;
+```
+
+Message format/shape is unchanged — only the data source changes (`result.RuleName` instead of a repo
+lookup keyed by `result.RuleId`).
+
+Leave the `using Anela.Heblo.Domain.Features.InvoiceClassification;` import in place — `ReceivedInvoice`
+and `ClassificationResult` (the enum) still live in that namespace and are still used elsewhere in this
+file; only the `IClassificationRuleRepository` symbol becomes unused, not the whole namespace.
+
+After this change the constructor is exactly:
+`(IReceivedInvoicesClient, IInvoiceClassificationService, ICurrentUserService, ILogger<ClassifyInvoicesHandler>)`
+— 4 parameters, no `IClassificationRuleRepository` reference anywhere in the file.
+
+No change needed to `InvoiceClassificationModule.cs` — MediatR auto-registers `ClassifyInvoicesHandler`
+via its handler interface; there is no explicit constructor wiring for it to update, and
+`IClassificationRuleRepository`'s registration is untouched (still needed by other consumers).
+
+## Step 4 — Update `ClassifyInvoicesHandlerTests.cs`
+
+File: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+
+- Remove the `Mock<IClassificationRuleRepository> _ruleRepositoryMock` field (line 16) and its
+  instantiation `_ruleRepositoryMock = new Mock<IClassificationRuleRepository>();` (line 25).
+- Remove `_ruleRepositoryMock.Object,` from the `ClassifyInvoicesHandler` constructor call in the test
+  constructor (currently lines 33–38), so it becomes:
+  ```csharp
+  _handler = new ClassifyInvoicesHandler(
+      _invoicesClientMock.Object,
+      _classificationServiceMock.Object,
+      _currentUserServiceMock.Object,
+      _loggerMock.Object);
+  ```
+- The `using Anela.Heblo.Domain.Features.InvoiceClassification;` import (line 3) stays — `ReceivedInvoice`,
+  `ClassificationResult`, and `IClassificationRuleRepository` (still referenced in type position for the
+  removed mock, so re-check after edits: once the mock field is gone, confirm no other symbol from that
+  namespace requires the import to be dropped — `ReceivedInvoice` at minimum still needs it, e.g. line 53).
+  In practice: leave the `using` alone; only remove the two `Mock<IClassificationRuleRepository>` lines and
+  the constructor argument.
+- The existing 5 tests construct `InvoiceClassificationResult` without `RuleName`/`RuleId` (e.g. lines 63,
+  97, 126, 155, 184) — these remain valid unchanged, since `RuleName` is optional and defaults to null.
+- Add two new tests covering FR-3 from the spec, exercising the `ClassificationResult.Error` branch
+  (which none of the current 5 tests do):
+  1. **`Handle_WhenErrorResultHasRuleName_IncludesRuleNameInErrorMessage`**: set up
+     `_classificationServiceMock` to return
+     `new InvoiceClassificationResult { Result = ClassificationResult.Error, RuleId = someGuid, RuleName = "My Rule", ErrorMessage = "boom" }`
+     for one invoice (use the `InvoiceIds`-driven single-invoice path, mirroring the existing
+     `GetInvoiceByIdAsync` setup pattern, or the unclassified-invoices path — either is fine as long as
+     exactly one invoice with a known `InvoiceNumber` flows through). Assert
+     `response.ErrorMessages` contains a message equal to
+     `$"Invoice {invoiceNumber} (Rule: My Rule): boom"`. Also assert `_ruleRepositoryMock` no longer
+     exists (i.e. this compiles without any repository mock in scope) — the absence of the mock is itself
+     the proof no DB call is made.
+  2. **`Handle_WhenErrorResultHasNoRuleName_OmitsRuleSegmentFromErrorMessage`**: same shape but
+     `RuleName = null` (and optionally `RuleId = null`, matching the exception/no-match path). Assert
+     `response.ErrorMessages` contains `$"Invoice {invoiceNumber}: boom"` with no `(Rule: ...)` segment.
+- Run `grep -n "_ruleRepositoryMock" backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs`
+  after editing — it must return no matches.
+
+## Step 5 — Update `InvoiceClassificationServiceTests.cs`
+
+File: `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs`
+
+Add `RuleName` assertions alongside the existing `RuleId` assertions in the tests that already exercise
+`matchedRule`-in-scope branches:
+
+- `ClassifyInvoiceAsync_RuleMatchedAndAbraSucceeds_RecordsSuccessAndReturnsRuleResult` (Success branch):
+  after the existing `result.RuleId.Should().Be(ruleWithId.Id);` (line 148), add:
+  ```csharp
+  result.RuleName.Should().Be(ruleWithId.Name);
+  ```
+- `ClassifyInvoiceAsync_RuleMatchedAndAbraFails_RecordsErrorAndReturnsRuleIdForDisplay` (ABRA-failure
+  `Error` branch): after the existing `result.RuleId.Should().Be(matchedRule.Id);` (line 228), add:
+  ```csharp
+  result.RuleName.Should().Be(matchedRule.Name);
+  ```
+- `ClassifyInvoiceAsync_NoMatchingRule_MarksForManualReviewAndRecordsHistory` (no-match branch): after
+  the existing `result.RuleId.Should().BeNull();` (line 69), add:
+  ```csharp
+  result.RuleName.Should().BeNull();
+  ```
+- `ClassifyInvoiceAsync_ExceptionThrown_RecordsErrorWithMessageAndReturnsErrorResult` (outer-exception
+  branch): after the existing `result.RuleId.Should().BeNull();` (line 288), add:
+  ```csharp
+  result.RuleName.Should().BeNull();
+  ```
+
+No other changes to this file — `InvoiceClassificationService`'s constructor signature and the
+`_ruleRepositoryMock` it legitimately depends on (`GetActiveRulesOrderedAsync`) are unaffected by this
+refactor (the service keeps its `IClassificationRuleRepository` dependency; only the handler loses its
+separate one).
+
+## Verification
+
+Run from the repo root of this worktree:
+
+```bash
+cd backend
+dotnet build
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~InvoiceClassification"
+```
+
+Both commands must succeed:
+- `dotnet build` must show zero errors (confirms `ClassifyInvoicesHandler`'s new 4-arg constructor,
+  `InvoiceClassificationResult.RuleName`, and both test files all compile together).
+- The filtered `dotnet test` run must show all tests passing in
+  `Anela.Heblo.Tests.Features.InvoiceClassification.ClassifyInvoicesHandlerTests` (7 tests: the original 5
+  plus the 2 new ones) and `Anela.Heblo.Tests.Features.InvoiceClassification.InvoiceClassificationServiceTests`
+  (4 tests, all with new `RuleName` assertions), with 0 failures.
+
+If time allows, also run the full test project (`dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`)
+to confirm no unrelated regression, though the filtered run above is the minimum bar for this task.
+
+Do not run `dotnet format` changes beyond what the edits above require; match existing file style
+(4-space indent, existing brace/blank-line conventions already visible in both handler and service files).

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationResult.cs
@@ -8,6 +8,8 @@ public class InvoiceClassificationResult
 
     public Guid? RuleId { get; set; }
 
+    public string? RuleName { get; set; }
+
     public string? AccountingTemplateCode { get; set; }
 
     public string? Department { get; set; }

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/Services/InvoiceClassificationService.cs
@@ -58,6 +58,7 @@ public class InvoiceClassificationService : IInvoiceClassificationService
                 {
                     Result = ClassificationResult.Success,
                     RuleId = matchedRule.Id,
+                    RuleName = matchedRule.Name,
                     AccountingTemplateCode = matchedRule.AccountingTemplateCode,
                     Department = matchedRule.Department
                 };
@@ -72,6 +73,7 @@ public class InvoiceClassificationService : IInvoiceClassificationService
                 {
                     Result = ClassificationResult.Error,
                     RuleId = matchedRule.Id,
+                    RuleName = matchedRule.Name,
                     Department = matchedRule.Department,
                     ErrorMessage = errorMessage
                 };

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs
@@ -10,20 +10,17 @@ public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, 
 {
     private readonly IReceivedInvoicesClient _invoicesClient;
     private readonly IInvoiceClassificationService _classificationService;
-    private readonly IClassificationRuleRepository _ruleRepository;
     private readonly ICurrentUserService _currentUserService;
     private readonly ILogger<ClassifyInvoicesHandler> _logger;
 
     public ClassifyInvoicesHandler(
         IReceivedInvoicesClient invoicesClient,
         IInvoiceClassificationService classificationService,
-        IClassificationRuleRepository ruleRepository,
         ICurrentUserService currentUserService,
         ILogger<ClassifyInvoicesHandler> logger)
     {
         _invoicesClient = invoicesClient;
         _classificationService = classificationService;
-        _ruleRepository = ruleRepository;
         _currentUserService = currentUserService;
         _logger = logger;
     }
@@ -93,15 +90,9 @@ public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, 
                             if (!string.IsNullOrEmpty(result.ErrorMessage))
                             {
                                 // Add rule name to error message if available
-                                var errorMessage = $"Invoice {invoice.InvoiceNumber}: {result.ErrorMessage}";
-                                if (result.RuleId.HasValue)
-                                {
-                                    var rule = await _ruleRepository.GetByIdAsync(result.RuleId.Value);
-                                    if (rule != null)
-                                    {
-                                        errorMessage = $"Invoice {invoice.InvoiceNumber} (Rule: {rule.Name}): {result.ErrorMessage}";
-                                    }
-                                }
+                                var errorMessage = !string.IsNullOrEmpty(result.RuleName)
+                                    ? $"Invoice {invoice.InvoiceNumber} (Rule: {result.RuleName}): {result.ErrorMessage}"
+                                    : $"Invoice {invoice.InvoiceNumber}: {result.ErrorMessage}";
                                 errorMessages.Add(errorMessage);
                             }
                             break;

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs
@@ -13,7 +13,6 @@ public class ClassifyInvoicesHandlerTests
 {
     private readonly Mock<IReceivedInvoicesClient> _invoicesClientMock;
     private readonly Mock<IInvoiceClassificationService> _classificationServiceMock;
-    private readonly Mock<IClassificationRuleRepository> _ruleRepositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<ILogger<ClassifyInvoicesHandler>> _loggerMock;
     private readonly ClassifyInvoicesHandler _handler;
@@ -22,7 +21,6 @@ public class ClassifyInvoicesHandlerTests
     {
         _invoicesClientMock = new Mock<IReceivedInvoicesClient>();
         _classificationServiceMock = new Mock<IInvoiceClassificationService>();
-        _ruleRepositoryMock = new Mock<IClassificationRuleRepository>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _loggerMock = new Mock<ILogger<ClassifyInvoicesHandler>>();
 
@@ -33,7 +31,6 @@ public class ClassifyInvoicesHandlerTests
         _handler = new ClassifyInvoicesHandler(
             _invoicesClientMock.Object,
             _classificationServiceMock.Object,
-            _ruleRepositoryMock.Object,
             _currentUserServiceMock.Object,
             _loggerMock.Object);
     }
@@ -190,5 +187,65 @@ public class ClassifyInvoicesHandlerTests
         _classificationServiceMock.Verify(
             x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), "jane.doe"),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenErrorResultHasRuleName_IncludesRuleNameInErrorMessage()
+    {
+        var invoiceId = "INV-005";
+
+        _invoicesClientMock
+            .Setup(x => x.GetInvoiceByIdAsync(invoiceId))
+            .ReturnsAsync(new ReceivedInvoice { InvoiceNumber = invoiceId, Labels = Array.Empty<string>() });
+
+        _classificationServiceMock
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()))
+            .ReturnsAsync(new InvoiceClassificationResult
+            {
+                Result = ClassificationResult.Error,
+                RuleId = Guid.NewGuid(),
+                RuleName = "My Rule",
+                ErrorMessage = "boom"
+            });
+
+        var request = new ClassifyInvoicesRequest
+        {
+            InvoiceIds = new List<string> { invoiceId }
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.Errors.Should().Be(1);
+        response.ErrorMessages.Should().Contain($"Invoice {invoiceId} (Rule: My Rule): boom");
+    }
+
+    [Fact]
+    public async Task Handle_WhenErrorResultHasNoRuleName_OmitsRuleSegmentFromErrorMessage()
+    {
+        var invoiceId = "INV-006";
+
+        _invoicesClientMock
+            .Setup(x => x.GetInvoiceByIdAsync(invoiceId))
+            .ReturnsAsync(new ReceivedInvoice { InvoiceNumber = invoiceId, Labels = Array.Empty<string>() });
+
+        _classificationServiceMock
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoice>(), It.IsAny<string>()))
+            .ReturnsAsync(new InvoiceClassificationResult
+            {
+                Result = ClassificationResult.Error,
+                RuleId = null,
+                RuleName = null,
+                ErrorMessage = "boom"
+            });
+
+        var request = new ClassifyInvoicesRequest
+        {
+            InvoiceIds = new List<string> { invoiceId }
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.Errors.Should().Be(1);
+        response.ErrorMessages.Should().Contain($"Invoice {invoiceId}: boom");
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/InvoiceClassificationServiceTests.cs
@@ -67,6 +67,7 @@ public class InvoiceClassificationServiceTests
         // Assert
         result.Result.Should().Be(ClassificationResult.ManualReviewRequired);
         result.RuleId.Should().BeNull();
+        result.RuleName.Should().BeNull();
         result.AccountingTemplateCode.Should().BeNull();
         result.Department.Should().BeNull();
         result.ErrorMessage.Should().BeNull();
@@ -146,6 +147,7 @@ public class InvoiceClassificationServiceTests
         // Assert
         result.Result.Should().Be(ClassificationResult.Success);
         result.RuleId.Should().Be(ruleWithId.Id);
+        result.RuleName.Should().Be(ruleWithId.Name);
         result.AccountingTemplateCode.Should().Be("TEMPLATE_001");
         result.Department.Should().Be("Sales");
         result.ErrorMessage.Should().BeNull();
@@ -226,6 +228,7 @@ public class InvoiceClassificationServiceTests
         // Assert
         result.Result.Should().Be(ClassificationResult.Error);
         result.RuleId.Should().Be(matchedRule.Id);
+        result.RuleName.Should().Be(matchedRule.Name);
         result.Department.Should().Be("Purchases");
         result.AccountingTemplateCode.Should().BeNull();
         result.ErrorMessage.Should().Be("Failed to update invoice classification in ABRA");
@@ -286,6 +289,7 @@ public class InvoiceClassificationServiceTests
         // Assert
         result.Result.Should().Be(ClassificationResult.Error);
         result.RuleId.Should().BeNull();
+        result.RuleName.Should().BeNull();
         result.AccountingTemplateCode.Should().BeNull();
         result.Department.Should().BeNull();
         result.ErrorMessage.Should().Contain("Exception during classification")


### PR DESCRIPTION
Closes #3546

## What the issue was
`ClassifyInvoicesHandler` injected `IClassificationRuleRepository` alongside `IInvoiceClassificationService` for exactly one purpose: re-looking up a matched rule's name (`GetByIdAsync`) to enrich an error message. This reached past the service abstraction into the same data layer the service already owns, and caused one extra DB round trip per errored invoice inside the classification loop.

## How it was fixed / handled
- Added a nullable `RuleName` property to `InvoiceClassificationResult`.
- `InvoiceClassificationService.ClassifyInvoiceAsync` now populates `RuleName` at the two branches where the matched rule is already in scope (the Success branch and the ABRA-update-failed Error branch), mirroring the existing `RuleId` population.
- `ClassifyInvoicesHandler` no longer depends on `IClassificationRuleRepository` at all — its constructor dropped the dependency, and the error-message enrichment now reads `result.RuleName` synchronously instead of issuing a DB lookup. Message format/shape is unchanged.
- Updated `ClassifyInvoicesHandlerTests.cs` (removed the repository mock; added two tests covering the with/without-`RuleName` error-message paths) and `InvoiceClassificationServiceTests.cs` (added `RuleName` assertions to the four branches that already asserted `RuleId`).
- No DI registration changes — `IClassificationRuleRepository` remains registered for its other consumers (the service itself and the classification-rule CRUD handlers).

Verified: `dotnet build` succeeds with 0 errors; the 92 InvoiceClassification tests (including the 11 directly touched) all pass.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3546/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

No correctness bugs found and no cleanup suggestions worth flagging; a tight, spec-faithful refactor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqsip2aWcfPjeYkU2BrTi2)_