### PR TITLE
#3548: implementation

### DIFF
--- a/artifacts/feat-3548/arch-review.r1.md
+++ b/artifacts/feat-3548/arch-review.r1.md
@@ -1,0 +1,93 @@
+# Architecture Review: Fix ArticleDetail `HtmlContent` theme reactivity
+
+## Skip Design: true
+
+This is a one-line-of-behavior bug fix inside an existing component: swapping a non-reactive DOM read for an existing reactive hook. No new UI, no new visual states, no layout change, no new component. Visual output when the fix works correctly (iframe colors match the active theme) is identical to what the component already intends to render — it just now does so reliably. Nothing here needs `docs/design/ui_design_document.md` or `docs/design/layout_definition.md` review beyond what's already encoded in the existing `srcDoc` string.
+
+## Architectural Fit Assessment
+
+This change fits cleanly into an established, already-adopted pattern — it does not introduce one. `ThemeContext.tsx` (`frontend/src/contexts/ThemeContext.tsx`) is the single source of theme truth for the app: it holds `theme: 'light' | 'dark'` in React state, syncs `document.documentElement`'s `dark` class and `localStorage` via `useEffect`, and exposes `useTheme()`. Every other consumer in the codebase already reads theme through this hook, not through the DOM:
+
+- `frontend/src/components/common/ThemeToggle.tsx:10-11` — `const { theme, toggle } = useTheme(); const isDark = theme === "dark";`
+- `frontend/src/pages/OrgChartPage.tsx:26` — `const { theme } = useTheme();`
+
+A repo-wide search (`grep -rn "document.documentElement.classList"` under `frontend/src`) confirms `ArticleDetail.tsx` is the **only** application component still reading the DOM class list directly (the only other hits are `ThemeContext.tsx` itself, which is the legitimate place to own that side effect, and its test file). This is a straightforward isolated anti-pattern instance, not a systemic issue — the spec correctly scopes the fix to this one file and defers any broader sweep as a separate follow-up (see Specification Amendments below for one clarification on that).
+
+The integration point is trivial: `ArticleDetail.tsx` already sits under the app's root `ThemeProvider` (same as every other routed page/component), so `useTheme()` is safe to call with no new provider wiring.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components, no new boundaries. The existing tree is unchanged:
+
+```
+ThemeProvider (app root, already wraps the whole tree)
+  └─ ArticleDetail (frontend/src/features/articles/ArticleDetail.tsx)
+       └─ ArticleView
+            └─ HtmlContent  ← only this function changes
+                 - was: isDark = document.documentElement.classList.contains('dark')  (non-reactive)
+                 - now: isDark = useTheme().theme === 'dark'                          (reactive)
+```
+
+`HtmlContent` moves from an ad-hoc, imperative theme read to the same declarative subscription every other themed component uses. The `key={isDark ? 'dark' : 'light'}` remount trick on the `<iframe>` is preserved as-is — it becomes *effective* now that `isDark` is backed by state that actually changes on toggle, whereas before it was a no-op safety net around a value that was frozen at mount/last-unrelated-render.
+
+### Key Design Decisions
+
+#### Decision 1: Source of truth for `isDark`
+**Options considered:**
+1. Keep the DOM query but wrap it in a `useEffect`/`MutationObserver` to make it reactive.
+2. Read `useTheme()` directly, as every other component in the codebase does.
+3. Lift theme derivation to a prop passed down from `ArticleDetail` or `ArticleView`.
+
+**Chosen approach:** Option 2 — call `useTheme()` inside `HtmlContent` directly, exactly as specified.
+
+**Rationale:** Option 1 reinvents state management that `ThemeContext` already provides, adds an observer to watch a class list `ThemeContext` itself controls, and is strictly worse than just reading the context. Option 3 (prop drilling through `ArticleView`) adds an unnecessary parameter to two components for no benefit, since `HtmlContent` can call the hook itself — React context is designed precisely to avoid this kind of drilling, and no other data threads through `ArticleView`/`ArticleDetail` for this purpose today. Option 2 matches the codebase's existing, singular convention (`ThemeToggle.tsx`, `OrgChartPage.tsx`) and requires touching only the two lines the spec identifies plus one import.
+
+#### Decision 2: Keep the `key`-based iframe remount mechanism
+**Options considered:**
+1. Replace `key={isDark ? 'dark' : 'light'}` remount with `postMessage`/direct DOM manipulation of the iframe's existing document to update styles in place.
+2. Keep the existing remount-via-`key` approach; only fix its input.
+
+**Chosen approach:** Option 2.
+
+**Rationale:** The iframe uses `sandbox="allow-same-origin"` with `srcDoc` (no `allow-scripts`), and its content is regenerated wholesale from `html` + inline colors on every render anyway. Remount-on-key-change is the idiomatic React way to force a full re-render of an uncontrolled subtree (here, an iframe's document) and was already the intended design — it just never fired correctly because its input never changed. This is explicitly Out of Scope per the spec, and there's no architectural reason to revisit it: changing the remount strategy would be a scope expansion with no corresponding bug to justify it.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files, no new directories. Single-file change:
+
+- `frontend/src/features/articles/ArticleDetail.tsx` — add one import, replace one line inside `HtmlContent`.
+
+Relative import path from `frontend/src/features/articles/ArticleDetail.tsx` to `frontend/src/contexts/ThemeContext.tsx` is `../../contexts/ThemeContext` (verified against actual directory depth: `features/articles/` → up two levels to `src/`, then into `contexts/`). This matches the spec's stated path exactly.
+
+### Interfaces and Contracts
+No public interface changes.
+- `HtmlContent`'s prop shape (`{ html: string }`) — unchanged.
+- `ArticleDetail`'s exported default and its props (`{ articleId: string }`) — unchanged.
+- New internal dependency: `HtmlContent` now calls `useTheme(): { theme: 'light' | 'dark'; toggle: () => void }` from `ThemeContext.tsx`. Only `theme` is consumed; `toggle` is not needed here (matches `OrgChartPage.tsx`'s usage, which also destructures only `theme`).
+
+### Data Flow
+Before: `document.documentElement` (DOM, mutated by `ThemeProvider`'s effect) → read once per render by `HtmlContent` → `isDark` (stale after re-renders unrelated to theme).
+
+After: `ThemeProvider` state (`theme`) → React Context → `useTheme()` in `HtmlContent` → `isDark` recomputed on every render, and `HtmlContent` re-renders whenever `ThemeContext`'s value changes (context consumers re-render on Provider value change) → `key` prop changes → iframe unmounts/remounts → new `srcDoc` built with correct colors.
+
+This closes the reactivity gap described in the brief: theme changes now flow through React's normal render cycle instead of requiring an incidental unrelated re-render to "catch up" to the DOM.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `HtmlContent` renders outside a `ThemeProvider` ancestor, causing `useTheme()`'s guard to throw | Low | Already mitigated by app structure — `ArticleDetail` is only ever rendered inside the routed app tree, which is wrapped by the root `ThemeProvider` (same guarantee every other `useTheme()` consumer already relies on, e.g. `ThemeToggle`, `OrgChartPage`). No new risk introduced. |
+| Regression: iframe stops remounting on theme change if the `key` logic is inadvertently altered during the edit | Low | Spec explicitly calls out that `key={isDark ? 'dark' : 'light'}` must remain untouched; a manual/E2E check (toggle theme with an article panel open, confirm colors update) is a cheap, high-confidence verification step. |
+| Scope creep into "fix this everywhere" | Low | Confirmed via search that `ArticleDetail.tsx` is the only application component with this anti-pattern today, so there is no hidden second instance to accidentally miss or unnecessarily touch in this change. |
+
+## Specification Amendments
+
+None required to the functional requirements — the spec's prescribed code change is correct, minimal, and matches the codebase's existing convention exactly (verified against `ThemeToggle.tsx` and `OrgChartPage.tsx`).
+
+One informational note, not a spec change: the spec's Out of Scope section mentions a possible "codebase-wide sweep" as a hypothetical follow-up. Architecturally confirmed: there is currently no other instance of this anti-pattern to sweep — `ArticleDetail.tsx` was the only offender. No follow-up ticket is architecturally necessary on that basis alone; leave it to product/PM discretion.
+
+## Prerequisites
+
+None. `ThemeContext.tsx` and its `ThemeProvider`/`useTheme()` already exist, are already mounted at the app root, and require no changes. No migrations, no config, no new dependencies. Implementation can start immediately.

--- a/artifacts/feat-3548/brief.md
+++ b/artifacts/feat-3548/brief.md
@@ -1,0 +1,53 @@
+## Module
+Article
+
+## Finding
+`HtmlContent` in `frontend/src/features/articles/ArticleDetail.tsx` (lines 13–15) reads the current theme at render time by querying the DOM directly:
+
+```tsx
+const isDark = document.documentElement.classList.contains('dark');
+```
+
+This value is **not reactive state** — it is a plain boolean captured once at render time. The project's `ThemeContext` (`frontend/src/contexts/ThemeContext.tsx`) exposes a `useTheme()` hook that returns a reactive `theme` value backed by React state. Reading the DOM class list instead of calling `useTheme()` means the component never subscribes to theme changes.
+
+The `key={isDark ? 'dark' : 'light'}` on the `<iframe>` (line 23) is meant to force a remount (and thus a re-render of the inline `srcDoc` styles) when the theme changes, but since `isDark` is captured once at initial render and never recomputed on re-render, the key never changes and the iframe keeps its stale theme colors after the user toggles the theme while an article panel is open.
+
+## Reference (read directly from source during triage)
+```tsx
+function HtmlContent({ html }: { html: string }) {
+  const isDark = document.documentElement.classList.contains('dark');
+  const srcdoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+    body{font-family:system-ui,sans-serif;line-height:1.6;color:${isDark ? '#E6E8EC' : '#1f2937'};background:${isDark ? '#202327' : 'transparent'};padding:1rem;margin:0}
+    h1,h2,h3{color:${isDark ? '#E6E8EC' : '#111827'}}p{margin:0 0 1em}ul,ol{padding-left:1.5em}
+    a{color:${isDark ? '#38BDF8' : '#2563eb'}}
+  </style></head><body>${html}</body></html>`;
+
+  return (
+    <iframe
+      key={isDark ? 'dark' : 'light'}
+      srcDoc={srcdoc}
+      sandbox="allow-same-origin"
+      className="w-full border-0 rounded"
+      style={{ minHeight: '500px' }}
+      onLoad={(e) => {
+        const iframe = e.currentTarget;
+        const body = iframe.contentDocument?.body;
+        if (body) {
+          iframe.style.height = `${body.scrollHeight + 32}px`;
+        }
+      }}
+      title="Obsah článku"
+    />
+  );
+}
+```
+
+## Recommended solution (from the finding)
+Replace the DOM query with the `useTheme()` hook so `isDark` becomes reactive state:
+
+```tsx
+const { theme } = useTheme();
+const isDark = theme === 'dark';
+```
+
+This makes `isDark` reactive, so the component re-renders and the `key` changes (remounting the iframe with corrected inline styles) whenever the theme changes — including while an article detail panel is already open.

--- a/artifacts/feat-3548/code-review.r1.md
+++ b/artifacts/feat-3548/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3548/impl/fix-articledetail-theme-reactivity.r1.md
+++ b/artifacts/feat-3548/impl/fix-articledetail-theme-reactivity.r1.md
@@ -1,0 +1,47 @@
+# Implementation: fix-articledetail-theme-reactivity
+
+## What was implemented
+`ArticleDetail.tsx`'s `HtmlContent` subcomponent computed `isDark` by reading
+`document.documentElement.classList.contains('dark')` directly at render time.
+Since this is a plain DOM read (not a React state/context subscription), the
+component never re-rendered when the user toggled the app theme, so the
+article's iframe (`srcDoc`) kept the stale light/dark colors until something
+else forced a re-render. Fixed by subscribing to the app's `ThemeContext` via
+`useTheme()` and deriving `isDark` from `theme === 'dark'`, so toggling the
+theme now properly re-renders `HtmlContent` and remounts the iframe (the
+existing `key={isDark ? 'dark' : 'light'}` was already correct, it just never
+got a fresh `isDark` value before).
+
+## Files created/modified
+- `frontend/src/features/articles/ArticleDetail.tsx` — added `import { useTheme } from '../../contexts/ThemeContext';`; in `HtmlContent`, replaced `const isDark = document.documentElement.classList.contains('dark');` with `const { theme } = useTheme(); const isDark = theme === 'dark';`. No other lines changed.
+- `frontend/src/features/articles/__tests__/ArticleDetail.test.tsx` — new regression test file. Renders `ArticleDetail` inside a real `ThemeProvider` (with `ThemeContext`'s global jest mock un-mocked for this file) alongside a `ToggleButton` that calls the real `toggle()`, then asserts the rendered iframe's `srcdoc` reflects the light/dark colors correctly both after a single toggle and after toggling twice (back to light).
+
+## Tests
+- `frontend/src/features/articles/__tests__/ArticleDetail.test.tsx`:
+  - `remounts the article iframe with dark colors after the theme is toggled to dark` — proves the iframe's `srcdoc` switches from light (`#1f2937`) to dark (`#E6E8EC`) colors after clicking the real theme toggle. This test reproduced the bug (RED) against the pre-fix code and now passes (GREEN) against the fix.
+  - `remounts the article iframe back to light colors after toggling twice` — proves toggling dark then light again correctly reverts the iframe content.
+
+## How to verify
+```
+cd frontend
+CI=true npx react-scripts test src/features/articles/__tests__/ArticleDetail.test.tsx --watchAll=false   # 2 passed
+CI=true npx react-scripts test --watchAll=false                                                          # 292 suites passed, no regressions
+grep -n "document.documentElement.classList" src/features/articles/ArticleDetail.tsx                     # no matches
+npm run build                                                                                              # Compiled successfully
+npm run lint                                                                                                # 162 problems (148 errors/14 warnings) - identical to pre-existing baseline, 0 new
+```
+
+## Notes
+- **Environment setup required first-time work**: this worktree had no `node_modules` installed. `npm ci` failed on a pre-existing peer-dependency conflict (`react-i18next@15` wants `typescript@^5`, project pins `typescript@^4.9.5`); installed with `npm install --legacy-peer-deps`, matching the flag already used in `.github/workflows/ci-feature-branch.yml` / `ci-main-branch.yml`. This is unrelated to the fix itself and no lockfile/package.json changes were made or committed.
+- **One deviation from the task's literal test code**: the plan's Step 1 test body used `document.querySelector('iframe')` to grab the iframe. Running it as-written passed functionally but introduced 6 new `testing-library/no-node-access` ESLint errors (confirmed by diffing lint output with/without the new test file: baseline 148 errors → 154 errors with the literal `document.querySelector` version). Per the task's own Step 3 acceptance bar ("no new lint errors introduced by this change") and the instruction to use judgment while staying faithful to intent, I replaced both `document.querySelector('iframe')` calls with `screen.getByTitle('Obsah článku')` (the iframe already has `title="Obsah článku"` in `ArticleDetail.tsx`), which queries the same element via Testing Library's recommended API. Test assertions and behavior are otherwise identical to the plan; verified lint is back to the exact pre-existing baseline (162 problems / 148 errors / 14 warnings, 0 attributable to the new/changed files).
+- All other verification steps (RED confirmation, GREEN fix, full suite, grep, build, lint) matched the plan's expected outcomes exactly.
+
+## PR Summary
+Fixes a bug where the article detail view's rendered HTML content (shown in an iframe) did not update its color theme when the user toggled light/dark mode. The root cause was `HtmlContent` reading `document.documentElement.classList.contains('dark')` directly instead of subscribing to React state, so it never re-rendered on theme change. The fix swaps that DOM read for the app's existing `useTheme()` hook from `ThemeContext`, so the iframe (keyed on `isDark`) now correctly remounts with the right colors whenever the theme toggles. Added a regression test suite that renders `ArticleDetail` under a real `ThemeProvider` with a live toggle button and asserts the iframe's `srcdoc` content switches between light/dark styling correctly, including toggling back and forth.
+
+### Changes
+- `frontend/src/features/articles/ArticleDetail.tsx` — `HtmlContent` now derives `isDark` from `useTheme()` instead of a direct DOM read.
+- `frontend/src/features/articles/__tests__/ArticleDetail.test.tsx` — new regression tests for theme reactivity.
+
+## Status
+DONE

--- a/artifacts/feat-3548/review/fix-articledetail-theme-reactivity.r1.md
+++ b/artifacts/feat-3548/review/fix-articledetail-theme-reactivity.r1.md
@@ -1,0 +1,27 @@
+# Code Review: Fix ArticleDetail `HtmlContent` theme reactivity
+
+## Summary
+The implementation exactly matches the spec's prescribed fix: `HtmlContent` now derives `isDark` from `useTheme()` instead of reading `document.documentElement.classList` directly, with no other lines touched. A regression test suite proves the iframe remounts with correct colors on theme toggle (both directions), and all verification commands pass.
+
+## Review Result: PASS
+
+### task: fix-articledetail-theme-reactivity
+**Status:** PASS
+
+Verification performed independently (not just trusting the impl summary):
+- `git show b631bf2` confirms the diff is exactly the 4-line change specified in `spec.r1.md` FR-1: added `import { useTheme } from '../../contexts/ThemeContext';`, and inside `HtmlContent` replaced `const isDark = document.documentElement.classList.contains('dark');` with `const { theme } = useTheme(); const isDark = theme === 'dark';`. No other line in `ArticleDetail.tsx` changed — `srcdoc` construction, `key={isDark ? 'dark' : 'light'}`, `sandbox`, `className`, `style`, `onLoad`, and `title` are all untouched, matching FR-1's explicit constraint and the arch-review's Decision 2 (keep the remount-via-`key` mechanism as-is).
+- Ran `cd frontend && CI=true npx react-scripts test src/features/articles/__tests__/ArticleDetail.test.tsx --watchAll=false` — both tests pass: iframe `srcdoc` switches from light (`#1f2937`) to dark (`#E6E8EC`) after a real `ThemeProvider`/`useTheme().toggle()` interaction, and reverts correctly after a second toggle.
+- Ran `grep -n "document.documentElement.classList" src/features/articles/ArticleDetail.tsx` — no matches (exit code 1), satisfying the explicit acceptance criterion.
+- Ran `npx eslint src/features/articles/__tests__/ArticleDetail.test.tsx` — clean, no errors.
+- Confirmed the iframe's `title="Obsah článku"` attribute exists in the source, so the test's use of `screen.getByTitle('Obsah článku')` (a documented, justified deviation from the task's literal `document.querySelector('iframe')` snippet, made to avoid introducing `testing-library/no-node-access` lint errors) queries the exact same element with equivalent behavior.
+- Architecture guidance (arch-review.r1.md, Skip Design: true) required no design review, no new components/boundaries, and preservation of the existing `key`-based remount trick — all satisfied.
+
+No functional requirement, architecture guideline, or acceptance criterion is violated. The one deviation from the task's literal test snippet is well-reasoned, narrowly scoped, and improves conformance with the codebase's lint rules without changing test semantics.
+
+## Docs to Update
+None. This is an internal bug fix with no public behavior change, no new concept, and no operational change — consistent with the spec's own assessment ("no architectural changes") and the arch-review's "Skip Design: true".
+
+## Overall Notes
+- The developer's implementation summary (`impl/fix-articledetail-theme-reactivity.r1.md`) accurately reflects the actual commit; spot-checking against the real diff found no discrepancies between claimed and actual changes.
+- The environment-setup note (`npm install --legacy-peer-deps` due to a pre-existing `react-i18next`/`typescript` peer conflict) is unrelated to this fix and correctly left out of the commit (no lockfile/package.json changes).
+- Full-suite and build/lint verification were not re-run in this review (only the targeted test file, the acceptance-criterion grep, and eslint on the new test file were re-executed), but the developer's reported results (292 suites passed, build succeeded, lint at pre-existing baseline) are consistent with the small, isolated nature of the diff and the passing targeted-test run observed here.

--- a/artifacts/feat-3548/spec.r1.md
+++ b/artifacts/feat-3548/spec.r1.md
@@ -1,0 +1,81 @@
+# Specification: Fix ArticleDetail `HtmlContent` theme reactivity
+
+## Summary
+`HtmlContent`, the component in `ArticleDetail.tsx` that renders an article's HTML body inside an `<iframe>`, currently determines dark/light styling by querying `document.documentElement.classList` directly at render time instead of subscribing to the app's reactive `useTheme()` hook. Because this read is not reactive state, toggling the theme while an article detail panel is mounted does not update the iframe's inline colors, leaving it visually stuck on the theme that was active when it first rendered. The fix is to source `isDark` from `useTheme()` so the component re-renders (and the iframe remounts via its existing `key` prop) whenever the theme changes.
+
+## Background
+The app uses a `ThemeContext` (`frontend/src/contexts/ThemeContext.tsx`) that exposes a `useTheme()` hook backed by React state (`theme: 'light' | 'dark'`, plus `toggle()`). The provider keeps `document.documentElement`'s `dark` class in sync with this state via a `useEffect`, and persists the choice to `localStorage`.
+
+`HtmlContent` (`frontend/src/features/articles/ArticleDetail.tsx`, lines 13–38) needs to know the current theme to build an inline `srcDoc` HTML string with theme-appropriate colors for the sandboxed iframe (since the iframe's contents are isolated from the app's Tailwind/CSS cascade and dark-mode class, colors must be hardcoded into the generated markup). It currently does this by reading `document.documentElement.classList.contains('dark')` directly on every render call, rather than consuming `useTheme()`.
+
+This DOM read is not React state, so it does not trigger a re-render when the theme changes — it only reflects the DOM's state at whatever moment the component happens to render (e.g., initial mount, or a re-render triggered by unrelated state/props changes such as article data refetching). The component also sets `key={isDark ? 'dark' : 'light'}` on the `<iframe>`, apparently intended to force React to unmount/remount the iframe (and thus regenerate `srcDoc`) when the theme changes — but since `isDark` is only recomputed when `HtmlContent` re-renders for some other reason, the key does not reliably change in response to a theme toggle, so the iframe keeps stale colors after the user switches themes while viewing an article.
+
+This is a small, targeted bug fix within a single component — no new UI, no new data flow, no architectural change.
+
+## Functional Requirements
+
+### FR-1: `HtmlContent` derives `isDark` from `useTheme()`
+Replace the direct DOM query with the reactive theme hook.
+
+**Current code (lines 13–14):**
+```tsx
+function HtmlContent({ html }: { html: string }) {
+  const isDark = document.documentElement.classList.contains('dark');
+```
+
+**Required change:**
+```tsx
+function HtmlContent({ html }: { html: string }) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+```
+
+Add the corresponding import:
+```tsx
+import { useTheme } from '../../contexts/ThemeContext';
+```
+(Adjust the relative path to match the actual location of `ThemeContext.tsx` relative to `ArticleDetail.tsx`; based on current repo layout this resolves to `../../contexts/ThemeContext`.)
+
+No other logic in `HtmlContent` changes: the `srcdoc` string construction, the `key={isDark ? 'dark' : 'light'}` prop, the `sandbox`, `className`, `style`, `onLoad` height-adjustment handler, and `title` all remain exactly as they are today.
+
+**Acceptance criteria:**
+- `HtmlContent` no longer references `document.documentElement.classList` anywhere in its body.
+- `isDark` is derived from the `theme` value returned by `useTheme()` (i.e., `theme === 'dark'`), not from a DOM query.
+- With an article detail panel open (an article whose `status === ArticleStatus.Generated` and which has non-empty `htmlContent`), toggling the app theme (light → dark or dark → light) via the existing theme toggle control causes the iframe to remount with updated colors: background, body text color, heading color, and link color all switch to match the new theme, without requiring the user to navigate away and back or refresh the page.
+- The iframe's `srcDoc` content (the actual article HTML markup passed in via the `html` prop) is unchanged after a theme toggle — only the inline `<style>` colors differ.
+- No other behavior of `ArticleDetail.tsx` (loading state, error state, in-progress state, status badge, source list, feedback section, debug panel) changes.
+- `HtmlContent` continues to work correctly when rendered while `ThemeProvider` is an ancestor in the component tree (as it always is in the app's actual render tree) — i.e., no new "must be used within a ThemeProvider" runtime error is introduced under normal app usage.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance regression. `useTheme()` is a cheap context read already used elsewhere in the app; swapping a synchronous DOM `classList.contains` call for a context read has negligible cost. The existing remount-via-`key` behavior (which was already present, just not correctly triggered) is unchanged in cost — it still fully remounts the iframe on a genuine theme change, which is the existing, accepted mechanism for refreshing `srcDoc`.
+
+### NFR-2: Security
+No change. The iframe continues to use `sandbox="allow-same-origin"` and renders content via `srcDoc` exactly as before; this fix does not touch sanitization, sandboxing, or how `html` is interpolated into the generated markup.
+
+## Data Model
+No data model changes. No new entities, no API/DTO changes. This is a pure frontend rendering fix scoped to a single component's internal state source.
+
+## API / Interface Design
+No new endpoints or events. Internal component interface change only:
+- `HtmlContent`'s prop signature (`{ html: string }`) is unchanged.
+- Internally, `HtmlContent` now calls `useTheme()` (from `frontend/src/contexts/ThemeContext.tsx`) instead of querying the DOM.
+
+No changes to `ArticleDetail`'s exported default component or its props (`{ articleId: string }`).
+
+## Dependencies
+- `frontend/src/contexts/ThemeContext.tsx` — provides `useTheme()`, already implemented and used elsewhere in the app; `ArticleDetail` (and thus `HtmlContent`) must render under a `ThemeProvider` ancestor, which is already guaranteed by the app's root component tree.
+- No new third-party libraries or backend changes required.
+
+## Out of Scope
+- Any change to how the iframe's `srcDoc` HTML/CSS is generated beyond swapping the theme source (e.g., no restyling, no switching to CSS custom properties, no removing the `key`-based remount trick).
+- Any change to `ThemeContext.tsx` itself.
+- Any change to other components in `frontend/src/features/articles/` (`ArticleSourceList`, `ArticleFeedbackSection`, `ArticleDebugPanel`, `articleStatusConfig`).
+- Broader audit of other components in the codebase for the same DOM-query-instead-of-`useTheme()` anti-pattern; this spec covers only the reported `HtmlContent` instance. (If a codebase-wide sweep is desired, it should be tracked as a separate follow-up item.)
+- Adding automated tests beyond what's naturally covered by existing test setup, unless the team's standard practice requires a unit/component test for this specific fix (see Open Questions).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-articledetail-theme-reactivity",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3548",
+  "issue_number": 3548,
+  "created_at": "2026-07-08T09:14:37.381570Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T09:17:18.029749Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -17,8 +17,8 @@
       "updated_at": null
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T09:21:54.175655Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -13,24 +13,24 @@
       "updated_at": "2026-07-08T09:18:35.084970Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T09:34:23.183016Z"
     },
     "planning": {
       "status": "completed",
       "updated_at": "2026-07-08T09:21:54.175655Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T09:22:08.531519Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T09:34:23.399966Z"
     }
   },
   "tasks": [
     {
       "name": "fix-articledetail-theme-reactivity",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-08T09:22:08.840505Z"
+      "updated_at": "2026-07-08T09:34:13.168279Z"
     }
   ]
 }

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-08T09:17:18.029749Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-08T09:18:35.084970Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-08T09:21:54.175655Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-08T09:22:08.531519Z"
     }
   },
   "tasks": [
     {
       "name": "fix-articledetail-theme-reactivity",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-08T09:22:08.840505Z"
     }
   ]
 }

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-08T09:34:23.399966Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-08T09:34:32.804137Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3548/state.json
+++ b/artifacts/feat-3548/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-08T09:34:23.399966Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-08T09:34:32.804137Z"
+      "status": "completed",
+      "updated_at": "2026-07-08T09:35:55.501189Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3548/task-context/fix-articledetail-theme-reactivity.md
+++ b/artifacts/feat-3548/task-context/fix-articledetail-theme-reactivity.md
@@ -1,0 +1,182 @@
+### task: fix-articledetail-theme-reactivity
+
+**Files:**
+- Modify: `frontend/src/features/articles/ArticleDetail.tsx`
+- Create: `frontend/src/features/articles/__tests__/ArticleDetail.test.tsx`
+
+- [ ] **Step 1: Write a failing regression test proving the iframe doesn't update on theme toggle (RED)**
+
+  Create `frontend/src/features/articles/__tests__/ArticleDetail.test.tsx` with the following content:
+
+  ```tsx
+  import { render, screen, act } from '@testing-library/react';
+  import ArticleDetail from '../ArticleDetail';
+  import { useGetArticleQuery } from '../../../api/hooks/useArticles';
+  import { ArticleStatus } from '../../../api/generated/api-client';
+  import { ThemeProvider, useTheme } from '../../../contexts/ThemeContext';
+
+  // setupTests.ts globally mocks ThemeContext with a fixed theme; restore the
+  // real implementation so this test can exercise actual theme toggling.
+  jest.unmock('../../../contexts/ThemeContext');
+
+  jest.mock('../../../api/hooks/useArticles', () => ({
+    ...jest.requireActual('../../../api/hooks/useArticles'),
+    useGetArticleQuery: jest.fn(),
+  }));
+
+  // Isolate the test from unrelated subcomponents that make their own API calls.
+  jest.mock('../ArticleSourceList', () => () => null);
+  jest.mock('../ArticleFeedbackSection', () => () => null);
+  jest.mock('../ArticleDebugPanel', () => () => null);
+
+  const mockedUseGetArticleQuery = useGetArticleQuery as jest.Mock;
+
+  const ARTICLE = {
+    id: 'article-1',
+    topic: 'Test topic',
+    scope: 'scope',
+    audience: null,
+    angle: null,
+    length: 'short',
+    title: 'Test title',
+    htmlContent: '<p>Hello world</p>',
+    status: ArticleStatus.Generated,
+    errorMessage: null,
+    createdAt: new Date().toISOString(),
+    generatedAt: new Date().toISOString(),
+    useKnowledgeBase: false,
+    useWebSearch: false,
+    sources: [],
+    precisionScore: null,
+    styleScore: null,
+    feedbackComment: null,
+  };
+
+  // Mirrors how ThemeToggle drives useTheme() elsewhere in the app: a real
+  // consumer that calls toggle() on the real ThemeProvider.
+  function ToggleButton() {
+    const { toggle } = useTheme();
+    return <button onClick={toggle}>toggle-theme</button>;
+  }
+
+  const renderWithTheme = () =>
+    render(
+      <ThemeProvider>
+        <ToggleButton />
+        <ArticleDetail articleId="article-1" />
+      </ThemeProvider>,
+    );
+
+  describe('ArticleDetail HtmlContent theme reactivity', () => {
+    beforeEach(() => {
+      localStorage.clear();
+      document.documentElement.classList.remove('dark');
+      mockedUseGetArticleQuery.mockReturnValue({
+        data: ARTICLE,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('remounts the article iframe with dark colors after the theme is toggled to dark', () => {
+      renderWithTheme();
+
+      const iframeBefore = document.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframeBefore).toBeInTheDocument();
+      expect(iframeBefore.srcdoc).toContain('#1f2937'); // light body text color
+      expect(iframeBefore.srcdoc).not.toContain('#E6E8EC');
+
+      act(() => {
+        screen.getByText('toggle-theme').click();
+      });
+
+      const iframeAfter = document.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframeAfter).toBeInTheDocument();
+      expect(iframeAfter.srcdoc).toContain('#E6E8EC'); // dark body text color
+      expect(iframeAfter.srcdoc).not.toContain('#1f2937');
+    });
+
+    it('remounts the article iframe back to light colors after toggling twice', () => {
+      renderWithTheme();
+
+      act(() => {
+        screen.getByText('toggle-theme').click(); // -> dark
+      });
+      act(() => {
+        screen.getByText('toggle-theme').click(); // -> light
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframe.srcdoc).toContain('#1f2937');
+      expect(iframe.srcdoc).not.toContain('#E6E8EC');
+    });
+  });
+  ```
+
+  Run:
+  ```
+  cd frontend && CI=true npx react-scripts test src/features/articles/__tests__/ArticleDetail.test.tsx --watchAll=false
+  ```
+
+  **Expected output:** Both tests in this file FAIL. With the current (buggy) code, `ArticleDetail`/`HtmlContent` never subscribes to `ThemeContext`, so clicking `toggle-theme` does not cause `HtmlContent` to re-render at all — `iframeAfter.srcdoc` still contains `#1f2937` and not `#E6E8EC`, failing the first test's post-toggle assertions. This confirms the test correctly reproduces the bug before touching the fix.
+
+- [ ] **Step 2: Apply the fix (GREEN)**
+
+  In `frontend/src/features/articles/ArticleDetail.tsx`, add the import (after the existing `ARTICLE_STATUS_LABELS` import on line 7):
+
+  ```tsx
+  import { ARTICLE_STATUS_LABELS, ARTICLE_STATUS_COLORS } from './articleStatusConfig';
+  import { useTheme } from '../../contexts/ThemeContext';
+  ```
+
+  Then replace line 14 (`const isDark = document.documentElement.classList.contains('dark');`) inside `HtmlContent`:
+
+  **Before:**
+  ```tsx
+  function HtmlContent({ html }: { html: string }) {
+    const isDark = document.documentElement.classList.contains('dark');
+  ```
+
+  **After:**
+  ```tsx
+  function HtmlContent({ html }: { html: string }) {
+    const { theme } = useTheme();
+    const isDark = theme === 'dark';
+  ```
+
+  No other line in `ArticleDetail.tsx` changes.
+
+- [ ] **Step 3: Verify the fix (tests, build, lint)**
+
+  Run, in order, and confirm each succeeds:
+  ```
+  cd frontend && CI=true npx react-scripts test src/features/articles/__tests__/ArticleDetail.test.tsx --watchAll=false
+  ```
+  **Expected output:** Both tests in `ArticleDetail.test.tsx` now PASS.
+
+  ```
+  cd frontend && CI=true npx react-scripts test --watchAll=false
+  ```
+  **Expected output:** Full frontend test suite passes (no regressions in other suites, including `src/contexts/__tests__/ThemeContext.test.tsx`).
+
+  ```
+  cd frontend && grep -n "document.documentElement.classList" src/features/articles/ArticleDetail.tsx
+  ```
+  **Expected output:** No matches (empty output / exit code 1) — confirms acceptance criterion "`HtmlContent` no longer references `document.documentElement.classList` anywhere in its body."
+
+  ```
+  cd frontend && npm run build
+  ```
+  **Expected output:** Build succeeds with no new TypeScript errors.
+
+  ```
+  cd frontend && npm run lint
+  ```
+  **Expected output:** No new lint errors introduced by this change.
+
+- [ ] **Step 4: Commit**
+
+  ```
+  git add frontend/src/features/articles/ArticleDetail.tsx frontend/src/features/articles/__tests__/ArticleDetail.test.tsx
+  git commit -m "fix(articles): derive HtmlContent theme from useTheme() instead of DOM read"
+  ```

--- a/artifacts/feat-3548/task-plan.r1.md
+++ b/artifacts/feat-3548/task-plan.r1.md
@@ -1,0 +1,192 @@
+# feat-3548 Implementation Plan
+
+**Goal:** Make `HtmlContent` in `ArticleDetail.tsx` derive `isDark` from the reactive `useTheme()` hook instead of a non-reactive `document.documentElement.classList` read, so the article iframe's colors update immediately when the user toggles the app theme.
+
+**Architecture:** No architectural change. `HtmlContent` is a private helper function inside `frontend/src/features/articles/ArticleDetail.tsx`; it swaps its theme source for the existing `useTheme()` hook from `frontend/src/contexts/ThemeContext.tsx` (already the single source of theme truth used elsewhere, e.g. `ThemeToggle.tsx`, `OrgChartPage.tsx`). The existing `key={isDark ? 'dark' : 'light'}` remount mechanism on the `<iframe>` is preserved untouched — it starts working correctly because its input (`isDark`) becomes real React state instead of a DOM snapshot.
+
+**Tech Stack:** React 18 + TypeScript (frontend), Jest + React Testing Library (`react-scripts test`), existing `ThemeContext` (React Context + `useState`).
+
+---
+
+### task: fix-articledetail-theme-reactivity
+
+**Files:**
+- Modify: `frontend/src/features/articles/ArticleDetail.tsx`
+- Create: `frontend/src/features/articles/__tests__/ArticleDetail.test.tsx`
+
+- [ ] **Step 1: Write a failing regression test proving the iframe doesn't update on theme toggle (RED)**
+
+  Create `frontend/src/features/articles/__tests__/ArticleDetail.test.tsx` with the following content:
+
+  ```tsx
+  import { render, screen, act } from '@testing-library/react';
+  import ArticleDetail from '../ArticleDetail';
+  import { useGetArticleQuery } from '../../../api/hooks/useArticles';
+  import { ArticleStatus } from '../../../api/generated/api-client';
+  import { ThemeProvider, useTheme } from '../../../contexts/ThemeContext';
+
+  // setupTests.ts globally mocks ThemeContext with a fixed theme; restore the
+  // real implementation so this test can exercise actual theme toggling.
+  jest.unmock('../../../contexts/ThemeContext');
+
+  jest.mock('../../../api/hooks/useArticles', () => ({
+    ...jest.requireActual('../../../api/hooks/useArticles'),
+    useGetArticleQuery: jest.fn(),
+  }));
+
+  // Isolate the test from unrelated subcomponents that make their own API calls.
+  jest.mock('../ArticleSourceList', () => () => null);
+  jest.mock('../ArticleFeedbackSection', () => () => null);
+  jest.mock('../ArticleDebugPanel', () => () => null);
+
+  const mockedUseGetArticleQuery = useGetArticleQuery as jest.Mock;
+
+  const ARTICLE = {
+    id: 'article-1',
+    topic: 'Test topic',
+    scope: 'scope',
+    audience: null,
+    angle: null,
+    length: 'short',
+    title: 'Test title',
+    htmlContent: '<p>Hello world</p>',
+    status: ArticleStatus.Generated,
+    errorMessage: null,
+    createdAt: new Date().toISOString(),
+    generatedAt: new Date().toISOString(),
+    useKnowledgeBase: false,
+    useWebSearch: false,
+    sources: [],
+    precisionScore: null,
+    styleScore: null,
+    feedbackComment: null,
+  };
+
+  // Mirrors how ThemeToggle drives useTheme() elsewhere in the app: a real
+  // consumer that calls toggle() on the real ThemeProvider.
+  function ToggleButton() {
+    const { toggle } = useTheme();
+    return <button onClick={toggle}>toggle-theme</button>;
+  }
+
+  const renderWithTheme = () =>
+    render(
+      <ThemeProvider>
+        <ToggleButton />
+        <ArticleDetail articleId="article-1" />
+      </ThemeProvider>,
+    );
+
+  describe('ArticleDetail HtmlContent theme reactivity', () => {
+    beforeEach(() => {
+      localStorage.clear();
+      document.documentElement.classList.remove('dark');
+      mockedUseGetArticleQuery.mockReturnValue({
+        data: ARTICLE,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('remounts the article iframe with dark colors after the theme is toggled to dark', () => {
+      renderWithTheme();
+
+      const iframeBefore = document.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframeBefore).toBeInTheDocument();
+      expect(iframeBefore.srcdoc).toContain('#1f2937'); // light body text color
+      expect(iframeBefore.srcdoc).not.toContain('#E6E8EC');
+
+      act(() => {
+        screen.getByText('toggle-theme').click();
+      });
+
+      const iframeAfter = document.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframeAfter).toBeInTheDocument();
+      expect(iframeAfter.srcdoc).toContain('#E6E8EC'); // dark body text color
+      expect(iframeAfter.srcdoc).not.toContain('#1f2937');
+    });
+
+    it('remounts the article iframe back to light colors after toggling twice', () => {
+      renderWithTheme();
+
+      act(() => {
+        screen.getByText('toggle-theme').click(); // -> dark
+      });
+      act(() => {
+        screen.getByText('toggle-theme').click(); // -> light
+      });
+
+      const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframe.srcdoc).toContain('#1f2937');
+      expect(iframe.srcdoc).not.toContain('#E6E8EC');
+    });
+  });
+  ```
+
+  Run:
+  ```
+  cd frontend && CI=true npx react-scripts test src/features/articles/__tests__/ArticleDetail.test.tsx --watchAll=false
+  ```
+
+  **Expected output:** Both tests in this file FAIL. With the current (buggy) code, `ArticleDetail`/`HtmlContent` never subscribes to `ThemeContext`, so clicking `toggle-theme` does not cause `HtmlContent` to re-render at all — `iframeAfter.srcdoc` still contains `#1f2937` and not `#E6E8EC`, failing the first test's post-toggle assertions. This confirms the test correctly reproduces the bug before touching the fix.
+
+- [ ] **Step 2: Apply the fix (GREEN)**
+
+  In `frontend/src/features/articles/ArticleDetail.tsx`, add the import (after the existing `ARTICLE_STATUS_LABELS` import on line 7):
+
+  ```tsx
+  import { ARTICLE_STATUS_LABELS, ARTICLE_STATUS_COLORS } from './articleStatusConfig';
+  import { useTheme } from '../../contexts/ThemeContext';
+  ```
+
+  Then replace line 14 (`const isDark = document.documentElement.classList.contains('dark');`) inside `HtmlContent`:
+
+  **Before:**
+  ```tsx
+  function HtmlContent({ html }: { html: string }) {
+    const isDark = document.documentElement.classList.contains('dark');
+  ```
+
+  **After:**
+  ```tsx
+  function HtmlContent({ html }: { html: string }) {
+    const { theme } = useTheme();
+    const isDark = theme === 'dark';
+  ```
+
+  No other line in `ArticleDetail.tsx` changes.
+
+- [ ] **Step 3: Verify the fix (tests, build, lint)**
+
+  Run, in order, and confirm each succeeds:
+  ```
+  cd frontend && CI=true npx react-scripts test src/features/articles/__tests__/ArticleDetail.test.tsx --watchAll=false
+  ```
+  **Expected output:** Both tests in `ArticleDetail.test.tsx` now PASS.
+
+  ```
+  cd frontend && CI=true npx react-scripts test --watchAll=false
+  ```
+  **Expected output:** Full frontend test suite passes (no regressions in other suites, including `src/contexts/__tests__/ThemeContext.test.tsx`).
+
+  ```
+  cd frontend && grep -n "document.documentElement.classList" src/features/articles/ArticleDetail.tsx
+  ```
+  **Expected output:** No matches (empty output / exit code 1) — confirms acceptance criterion "`HtmlContent` no longer references `document.documentElement.classList` anywhere in its body."
+
+  ```
+  cd frontend && npm run build
+  ```
+  **Expected output:** Build succeeds with no new TypeScript errors.
+
+  ```
+  cd frontend && npm run lint
+  ```
+  **Expected output:** No new lint errors introduced by this change.
+
+- [ ] **Step 4: Commit**
+
+  ```
+  git add frontend/src/features/articles/ArticleDetail.tsx frontend/src/features/articles/__tests__/ArticleDetail.test.tsx
+  git commit -m "fix(articles): derive HtmlContent theme from useTheme() instead of DOM read"
+  ```

--- a/frontend/src/features/articles/ArticleDetail.tsx
+++ b/frontend/src/features/articles/ArticleDetail.tsx
@@ -5,13 +5,15 @@ import ArticleSourceList from './ArticleSourceList';
 import ArticleFeedbackSection from './ArticleFeedbackSection';
 import ArticleDebugPanel from './ArticleDebugPanel';
 import { ARTICLE_STATUS_LABELS, ARTICLE_STATUS_COLORS } from './articleStatusConfig';
+import { useTheme } from '../../contexts/ThemeContext';
 
 interface ArticleDetailProps {
   articleId: string;
 }
 
 function HtmlContent({ html }: { html: string }) {
-  const isDark = document.documentElement.classList.contains('dark');
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
   const srcdoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
     body{font-family:system-ui,sans-serif;line-height:1.6;color:${isDark ? '#E6E8EC' : '#1f2937'};background:${isDark ? '#202327' : 'transparent'};padding:1rem;margin:0}
     h1,h2,h3{color:${isDark ? '#E6E8EC' : '#111827'}}p{margin:0 0 1em}ul,ol{padding-left:1.5em}

--- a/frontend/src/features/articles/__tests__/ArticleDetail.test.tsx
+++ b/frontend/src/features/articles/__tests__/ArticleDetail.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, act } from '@testing-library/react';
+import ArticleDetail from '../ArticleDetail';
+import { useGetArticleQuery } from '../../../api/hooks/useArticles';
+import { ArticleStatus } from '../../../api/generated/api-client';
+import { ThemeProvider, useTheme } from '../../../contexts/ThemeContext';
+
+// setupTests.ts globally mocks ThemeContext with a fixed theme; restore the
+// real implementation so this test can exercise actual theme toggling.
+jest.unmock('../../../contexts/ThemeContext');
+
+jest.mock('../../../api/hooks/useArticles', () => ({
+  ...jest.requireActual('../../../api/hooks/useArticles'),
+  useGetArticleQuery: jest.fn(),
+}));
+
+// Isolate the test from unrelated subcomponents that make their own API calls.
+jest.mock('../ArticleSourceList', () => () => null);
+jest.mock('../ArticleFeedbackSection', () => () => null);
+jest.mock('../ArticleDebugPanel', () => () => null);
+
+const mockedUseGetArticleQuery = useGetArticleQuery as jest.Mock;
+
+const ARTICLE = {
+  id: 'article-1',
+  topic: 'Test topic',
+  scope: 'scope',
+  audience: null,
+  angle: null,
+  length: 'short',
+  title: 'Test title',
+  htmlContent: '<p>Hello world</p>',
+  status: ArticleStatus.Generated,
+  errorMessage: null,
+  createdAt: new Date().toISOString(),
+  generatedAt: new Date().toISOString(),
+  useKnowledgeBase: false,
+  useWebSearch: false,
+  sources: [],
+  precisionScore: null,
+  styleScore: null,
+  feedbackComment: null,
+};
+
+// Mirrors how ThemeToggle drives useTheme() elsewhere in the app: a real
+// consumer that calls toggle() on the real ThemeProvider.
+function ToggleButton() {
+  const { toggle } = useTheme();
+  return <button onClick={toggle}>toggle-theme</button>;
+}
+
+const renderWithTheme = () =>
+  render(
+    <ThemeProvider>
+      <ToggleButton />
+      <ArticleDetail articleId="article-1" />
+    </ThemeProvider>,
+  );
+
+describe('ArticleDetail HtmlContent theme reactivity', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    mockedUseGetArticleQuery.mockReturnValue({
+      data: ARTICLE,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('remounts the article iframe with dark colors after the theme is toggled to dark', () => {
+    renderWithTheme();
+
+    const iframeBefore = screen.getByTitle('Obsah článku') as HTMLIFrameElement;
+    expect(iframeBefore).toBeInTheDocument();
+    expect(iframeBefore.srcdoc).toContain('#1f2937'); // light body text color
+    expect(iframeBefore.srcdoc).not.toContain('#E6E8EC');
+
+    act(() => {
+      screen.getByText('toggle-theme').click();
+    });
+
+    const iframeAfter = screen.getByTitle('Obsah článku') as HTMLIFrameElement;
+    expect(iframeAfter).toBeInTheDocument();
+    expect(iframeAfter.srcdoc).toContain('#E6E8EC'); // dark body text color
+    expect(iframeAfter.srcdoc).not.toContain('#1f2937');
+  });
+
+  it('remounts the article iframe back to light colors after toggling twice', () => {
+    renderWithTheme();
+
+    act(() => {
+      screen.getByText('toggle-theme').click(); // -> dark
+    });
+    act(() => {
+      screen.getByText('toggle-theme').click(); // -> light
+    });
+
+    const iframe = screen.getByTitle('Obsah článku') as HTMLIFrameElement;
+    expect(iframe.srcdoc).toContain('#1f2937');
+    expect(iframe.srcdoc).not.toContain('#E6E8EC');
+  });
+});


### PR DESCRIPTION
Closes #3548

## What the issue was
`HtmlContent` in `frontend/src/features/articles/ArticleDetail.tsx` computed `isDark` by reading `document.documentElement.classList.contains('dark')` directly at render time instead of subscribing to the app's reactive `useTheme()` hook (`frontend/src/contexts/ThemeContext.tsx`). Because this was a plain DOM read, not React state, `HtmlContent` never re-rendered when the user toggled the app theme. The `key={isDark ? 'dark' : 'light'}` on the article's `<iframe>` was meant to force a remount with corrected colors on theme change, but since `isDark` was frozen at whatever render happened to compute it, the key never actually changed on a theme toggle — so the iframe kept stale colors while an article panel was open.

## How it was fixed / handled
- Replaced the DOM query with `const { theme } = useTheme(); const isDark = theme === 'dark';` plus the corresponding import, matching the same pattern already used by `ThemeToggle.tsx` and `OrgChartPage.tsx` elsewhere in the codebase.
- No other logic in `HtmlContent` changed — `srcDoc` construction, the `key`-based remount mechanism, `sandbox`, `className`, `style`, `onLoad`, and `title` are all untouched.
- Added a regression test (`frontend/src/features/articles/__tests__/ArticleDetail.test.tsx`) that renders `ArticleDetail` under a real `ThemeProvider` with a live toggle control and asserts the iframe's `srcDoc` colors switch correctly on toggle, and revert on a second toggle.
- Verified: targeted test (2 passed), full frontend suite (292 suites, no regressions), `npm run build`, and `npm run lint` (baseline unchanged, 0 new lint errors).

## Artifacts
Brief, spec, arch-review, task plan, impl, and review markdown are committed under `artifacts/feat-3548/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01NcDMb6BX8pd5tXoZSWYUW4)_