### PR TITLE
fix: render KB product references as inflected name links, never raw codes

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseOptions.cs
@@ -117,8 +117,10 @@ public class KnowledgeBaseOptions : RagFeatureOptions
         - Zohledni typ pleti a potíže zákazníka
         - Odpovídej v češtině, přátelsky ale odborně
         - Pokud kontext obsahuje více podobných případů, syntetizuj je
-        - Pokud zmiňuješ produkt Anela, uveď jeho produktový kódem
-          v závorce (přesně takto: (AKL001)), nikdy ne jeho název. Použij pouze kódy z přiloženého seznamu produktů.
+        - Pokud zmiňuješ produkt Anela, zapiš ho jako odkaz ve formátu Markdown:
+          text odkazu je název produktu přirozeně skloňovaný do věty a cíl odkazu je
+          jeho produktový kód – přesně takto: [Klidné nožky](MAS009). Používej pouze
+          kódy z přiloženého seznamu produktů a v názvu neuváděj velikost balení (ml/g).
 
         Kontext z podobných konverzací:
         {context}

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ContextSanitizer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ContextSanitizer.cs
@@ -1,0 +1,25 @@
+using System.Text.RegularExpressions;
+
+namespace Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
+
+/// <summary>
+/// Normalizes retrieved context before it is injected into the answer prompt.
+/// Historical conversations often contain human-authored Markdown product links
+/// ([Name](url)). Left in the context, the model imitates that pattern and copies
+/// stale URLs instead of emitting the instructed [Name](CODE) format. Stripping the
+/// links down to their plain product name removes the competing example so product
+/// formatting is resolved consistently by <see cref="PostAnswerEnrichmentMiddleware"/>.
+/// </summary>
+public static class ContextSanitizer
+{
+    private static readonly Regex MarkdownLinkPattern =
+        new(@"\[([^\]]+)\]\([^)]*\)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Replaces every Markdown link with its link text, leaving all other content intact.
+    /// </summary>
+    public static string StripMarkdownLinks(string context) =>
+        string.IsNullOrEmpty(context)
+            ? context
+            : MarkdownLinkPattern.Replace(context, "$1");
+}

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/PostAnswerEnrichmentMiddleware.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/PostAnswerEnrichmentMiddleware.cs
@@ -4,13 +4,24 @@ using Microsoft.Extensions.AI;
 namespace Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
 
 /// <summary>
-/// M.E.AI pipeline middleware that enriches KB answers by replacing (CODE) product annotations
-/// with inline references: [Name](url) when a URL is present, or Name (CODE) otherwise.
+/// M.E.AI pipeline middleware that turns product references in KB answers into presentation.
+/// The model is instructed to emit products as [Name](CODE) Markdown links (name = naturally
+/// inflected display text, target = product code). This middleware resolves the code to a URL:
+/// [Name](url) when a URL is present, or the plain Name otherwise — the customer never sees a
+/// raw product code. A legacy fallback also resolves bare (CODE) tokens for resilience.
 /// Product data is resolved from <see cref="IProductEnrichmentCache"/>.
 /// </summary>
 public class PostAnswerEnrichmentMiddleware : DelegatingChatClient
 {
-    private static readonly Regex ProductCodePattern = new(@"\(([A-Z0-9]+)\)", RegexOptions.Compiled);
+    // [Name](CODE) — the instructed format. The code group only matches an all-caps/digit token,
+    // so real Markdown URLs (lowercase, ':', '/') are never mistaken for a product code.
+    private static readonly Regex LinkedProductPattern =
+        new(@"\[(?<name>[^\]]+)\]\((?<code>[A-Z0-9]+)\)", RegexOptions.Compiled);
+
+    // Bare (CODE) — legacy/fallback for answers where the model omitted the name.
+    private static readonly Regex BareCodePattern =
+        new(@"\((?<code>[A-Z0-9]+)\)", RegexOptions.Compiled);
+
     private readonly IProductEnrichmentCache _cache;
 
     public PostAnswerEnrichmentMiddleware(IChatClient inner, IProductEnrichmentCache cache)
@@ -31,14 +42,34 @@ public class PostAnswerEnrichmentMiddleware : DelegatingChatClient
             return response;
 
         var lookup = await _cache.GetProductLookupAsync(cancellationToken);
-        var enriched = ProductCodePattern.Replace(rawText, match =>
+
+        // Primary: [Name](CODE) — keep the model's inflected name, resolve the code to a URL.
+        var enriched = LinkedProductPattern.Replace(rawText, match =>
         {
-            var code = match.Groups[1].Value;
+            var name = match.Groups["name"].Value;
+            var code = match.Groups["code"].Value;
+
+            // Unknown/hallucinated code: keep the readable name, drop the code.
+            if (!lookup.TryGetValue(code, out var entry))
+                return name;
+
+            return string.IsNullOrEmpty(entry.Url)
+                ? name
+                : $"[{name}]({entry.Url})";
+        });
+
+        // Fallback: bare (CODE) with no name — resolve using the catalog name so the
+        // customer never sees a raw code, even when the model ignores the link format.
+        enriched = BareCodePattern.Replace(enriched, match =>
+        {
+            var code = match.Groups["code"].Value;
+
+            // Not a known product code: leave the token untouched (may be unrelated).
             if (!lookup.TryGetValue(code, out var entry))
                 return match.Value;
 
             return string.IsNullOrEmpty(entry.Url)
-                ? $"{entry.ProductName} ({code})"
+                ? entry.ProductName
                 : $"[{entry.ProductName}]({entry.Url})";
         });
 

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/AskQuestion/AskQuestionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/AskQuestion/AskQuestionHandler.cs
@@ -47,7 +47,9 @@ public class AskQuestionHandler : IRequestHandler<AskQuestionRequest, AskQuestio
             };
         }
 
-        var context = string.Join("\n\n---\n\n", searchResult.Chunks.Select(c => c.Content));
+        var context = string.Join(
+            "\n\n---\n\n",
+            searchResult.Chunks.Select(c => ContextSanitizer.StripMarkdownLinks(c.Content)));
 
         var productLookup = await _enrichmentCache.GetProductLookupAsync(cancellationToken);
         var productTable = string.Join("\n", productLookup.Values.OrderBy(p => p.ProductCode).Select(p => $"{p.ProductCode} | {p.ProductName}"));

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ContextSanitizerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ContextSanitizerTests.cs
@@ -1,0 +1,41 @@
+using Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
+using Xunit;
+
+namespace Anela.Heblo.Tests.KnowledgeBase.Pipeline;
+
+public class ContextSanitizerTests
+{
+    [Fact]
+    public void StripMarkdownLinks_ReplacesLinkWithItsText()
+    {
+        var result = ContextSanitizer.StripMarkdownLinks(
+            "Doporučili jsme [Klidné nožky](https://anela.cz/klidne-nozky) na večer.");
+
+        Assert.Equal("Doporučili jsme Klidné nožky na večer.", result);
+    }
+
+    [Fact]
+    public void StripMarkdownLinks_StripsMultipleLinks()
+    {
+        var result = ContextSanitizer.StripMarkdownLinks(
+            "[A](https://x.cz/a) a také [B](https://x.cz/b).");
+
+        Assert.Equal("A a také B.", result);
+    }
+
+    [Fact]
+    public void StripMarkdownLinks_TextWithoutLinks_ReturnedUnchanged()
+    {
+        const string text = "Problém: suchá pleť. Doporučení: hydratace.";
+
+        Assert.Equal(text, ContextSanitizer.StripMarkdownLinks(text));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void StripMarkdownLinks_NullOrEmpty_ReturnedAsIs(string? input)
+    {
+        Assert.Equal(input, ContextSanitizer.StripMarkdownLinks(input!));
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/PostAnswerEnrichmentMiddlewareTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/PostAnswerEnrichmentMiddlewareTests.cs
@@ -47,14 +47,67 @@ public class PostAnswerEnrichmentMiddlewareTests
     }
 
     [Fact]
-    public async Task GetResponseAsync_CodeWithoutUrl_ReplacesWithPlainText()
+    public async Task GetResponseAsync_BareCodeWithoutUrl_ReplacesWithPlainNameAndDropsCode()
     {
         SetupInner("Použijte (KRM002) ráno i večer.");
         SetupCache(("KRM002", "Hydratační krém", null));
 
         var result = await Create().GetResponseAsync([], null, default);
 
-        Assert.Equal("Použijte Hydratační krém (KRM002) ráno i večer.", result.Text);
+        // The raw code is never shown to the customer, even without a URL.
+        Assert.Equal("Použijte Hydratační krém ráno i večer.", result.Text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_LinkedFormatWithUrl_KeepsModelNameAndAddsUrl()
+    {
+        // Model wrote the name inflected into the sentence + the code as the link target.
+        SetupInner("Doporučuji vám [Klidné nožky](MAS009) na večer.");
+        SetupCache(("MAS009", "Klidné nožky balzám", "https://anela.cz/klidne-nozky"));
+
+        var result = await Create().GetResponseAsync([], null, default);
+
+        // The model's inflected display text is preserved; only the target becomes the URL.
+        Assert.Equal(
+            "Doporučuji vám [Klidné nožky](https://anela.cz/klidne-nozky) na večer.",
+            result.Text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_LinkedFormatWithoutUrl_KeepsModelNameAsPlainText()
+    {
+        SetupInner("Zkuste [Umyju něžně](OCH008030) každý den.");
+        SetupCache(("OCH008030", "Umyju něžně 30ml", null));
+
+        var result = await Create().GetResponseAsync([], null, default);
+
+        // No URL: fall back to the model's inflected name, never the raw code.
+        Assert.Equal("Zkuste Umyju něžně každý den.", result.Text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_LinkedFormatUnknownCode_KeepsNameDropsCode()
+    {
+        SetupInner("Zkuste [nějaký produkt](FAKE001) na pleť.");
+        SetupCache(("MAS009", "Klidné nožky", "https://anela.cz/klidne-nozky"));
+
+        var result = await Create().GetResponseAsync([], null, default);
+
+        // Hallucinated code: keep the readable name, drop the code.
+        Assert.Equal("Zkuste nějaký produkt na pleť.", result.Text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_RealMarkdownLink_LeftUnchanged()
+    {
+        // A genuine URL target must not be mistaken for a product code.
+        const string text = "Více na [našem webu](https://anela.cz/blog).";
+        SetupInner(text);
+        SetupCache(("MAS009", "Klidné nožky", "https://anela.cz/klidne-nozky"));
+
+        var result = await Create().GetResponseAsync([], null, default);
+
+        Assert.Equal(text, result.Text);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Reworks how KnowledgeBase answers render Anela product references so customers never see a raw product code (e.g. the recurring `(OCH008030)`) and product names read grammatically in Czech.

- **Prompt** (`KnowledgeBaseOptions.cs`): the AskQuestion system prompt now instructs `[Name](CODE)` markdown links with a naturally inflected product name and no pack size, instead of "emit the code, never the name".
- **Post-processing** (`PostAnswerEnrichmentMiddleware.cs`): resolves `[Name](CODE)` by keeping the model's inflected name and swapping the code for the real URL (`[Name](url)`), or plain `Name` when no URL / unknown code; a legacy bare-`(CODE)` fallback also drops the code so a raw code is never shown.
- **Context** (new `ContextSanitizer` + `AskQuestionHandler`): strips pre-existing markdown links out of retrieved context so the model stops copying stale human-authored URLs.

## Behavior change

The no-URL case now renders just `Name` (previously `Name (CODE)`); the existing test was updated to match.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] KnowledgeBase unit/pipeline tests: 228 passed (6 new/updated middleware cases + 4 sanitizer cases). Docker-based integration tests were skipped locally (Docker not running), unrelated to this change.
- [x] `dotnet format --verify-no-changes` — clean