### PR TITLE
fix: decouple lot-stock reconciliation DQ check from Catalog module

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -61,6 +61,7 @@ public static class CatalogModule
         // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
         services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
         services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+        services.AddScoped<IMaterialLotStockQuery, DataQualityMaterialLotStockQueryAdapter>();
         // DataQuality owns the resilience contract; Catalog (this module) provides the adapter implementation.
         services.AddScoped<IDqtResilienceService, DataQualityResilienceAdapter>();
 

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityMaterialLotStockQueryAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/DataQualityMaterialLotStockQueryAdapter.cs
@@ -1,0 +1,36 @@
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class DataQualityMaterialLotStockQueryAdapter : IMaterialLotStockQuery
+{
+    private readonly ICatalogRepository _catalogRepository;
+
+    public DataQualityMaterialLotStockQueryAdapter(ICatalogRepository catalogRepository)
+    {
+        _catalogRepository = catalogRepository;
+    }
+
+    public async Task<IReadOnlyList<MaterialLotStockSnapshot>> GetMaterialsWithExpirationAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var items = await _catalogRepository.GetAllAsync(cancellationToken);
+
+        var snapshots = new List<MaterialLotStockSnapshot>();
+        foreach (var item in items)
+        {
+            if (item.Type != ProductType.Material || !item.HasExpiration)
+                continue;
+
+            snapshots.Add(new MaterialLotStockSnapshot
+            {
+                ProductCode = item.ProductCode,
+                ErpStock = item.Stock.Erp,
+                LotAmounts = item.Stock.Lots.Select(l => l.Amount).ToList(),
+            });
+        }
+
+        return snapshots;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IMaterialLotStockQuery.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/IMaterialLotStockQuery.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public interface IMaterialLotStockQuery
+{
+    Task<IReadOnlyList<MaterialLotStockSnapshot>> GetMaterialsWithExpirationAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/MaterialLotStockSnapshot.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Contracts/MaterialLotStockSnapshot.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.DataQuality.Contracts;
+
+public sealed class MaterialLotStockSnapshot
+{
+    public required string ProductCode { get; init; }
+    public required decimal ErpStock { get; init; }
+    public required IReadOnlyList<decimal> LotAmounts { get; init; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/LotStockReconciliationComparer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/LotStockReconciliationComparer.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
 using Anela.Heblo.Domain.Features.DataQuality;
 
 namespace Anela.Heblo.Application.Features.DataQuality.Services;
@@ -12,30 +12,26 @@ public class LotStockReconciliationComparer : IDriftDqtComparer
 {
     private const decimal Tolerance = 0.01m;
 
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IMaterialLotStockQuery _materialLotStock;
 
     public DqtTestType TestType => DqtTestType.LotSumVsErpStock;
 
-    public LotStockReconciliationComparer(ICatalogRepository catalogRepository)
+    public LotStockReconciliationComparer(IMaterialLotStockQuery materialLotStock)
     {
-        _catalogRepository = catalogRepository;
+        _materialLotStock = materialLotStock;
     }
 
     public async Task<DriftComparisonResult> CompareAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
     {
         // Date range is intentionally unused — this is a current-state snapshot reconciliation.
-        var items = await _catalogRepository.GetAllAsync(ct);
-
-        var checkedItems = items
-            .Where(item => item.Type == ProductType.Material && item.HasExpiration)
-            .ToList();
+        var items = await _materialLotStock.GetMaterialsWithExpirationAsync(ct);
 
         var mismatches = new List<DriftMismatch>();
 
-        foreach (var item in checkedItems)
+        foreach (var item in items)
         {
-            var erp = item.Stock.Erp;
-            var lotSum = item.Stock.Lots.Sum(l => l.Amount);
+            var erp = item.ErpStock;
+            var lotSum = item.LotAmounts.Sum();
 
             if (Math.Abs(lotSum - erp) <= Tolerance)
                 continue;
@@ -55,7 +51,7 @@ public class LotStockReconciliationComparer : IDriftDqtComparer
         return new DriftComparisonResult
         {
             Mismatches = mismatches,
-            TotalChecked = checkedItems.Count
+            TotalChecked = items.Count
         };
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityMaterialLotStockQueryAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/DataQualityMaterialLotStockQueryAdapterTests.cs
@@ -1,0 +1,126 @@
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Lots;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class DataQualityMaterialLotStockQueryAdapterTests
+{
+    private readonly Mock<ICatalogRepository> _catalogMock = new();
+
+    private DataQualityMaterialLotStockQueryAdapter CreateAdapter() => new(_catalogMock.Object);
+
+    private void SetupCatalog(params CatalogAggregate[] items) =>
+        _catalogMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<CatalogAggregate>)items.ToList());
+
+    private static CatalogAggregate Item(
+        string code,
+        ProductType type,
+        bool hasExpiration,
+        decimal erp,
+        params decimal[] lotAmounts)
+    {
+        var item = new CatalogAggregate
+        {
+            ProductCode = code,
+            Type = type,
+            HasExpiration = hasExpiration,
+            Stock = new StockData { Erp = erp }
+        };
+        foreach (var amount in lotAmounts)
+            item.Stock.Lots.Add(new CatalogLot { ProductCode = code, Amount = amount });
+        return item;
+    }
+
+    [Fact]
+    public async Task GetMaterialsWithExpirationAsync_ProjectsErpAndLotAmounts()
+    {
+        // Arrange
+        SetupCatalog(Item("MAT001", ProductType.Material, hasExpiration: true, erp: 10m, lotAmounts: new[] { 4m, 6m }));
+
+        // Act
+        var result = await CreateAdapter().GetMaterialsWithExpirationAsync(CancellationToken.None);
+
+        // Assert
+        var snapshot = result.Single();
+        snapshot.ProductCode.Should().Be("MAT001");
+        snapshot.ErpStock.Should().Be(10m);
+        snapshot.LotAmounts.Should().Equal(4m, 6m);
+    }
+
+    [Fact]
+    public async Task GetMaterialsWithExpirationAsync_ExcludesNonMaterial()
+    {
+        // Arrange
+        SetupCatalog(Item("PROD001", ProductType.Product, hasExpiration: true, erp: 10m, lotAmounts: new[] { 1m }));
+
+        // Act
+        var result = await CreateAdapter().GetMaterialsWithExpirationAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMaterialsWithExpirationAsync_ExcludesMaterialWithoutExpiration()
+    {
+        // Arrange
+        SetupCatalog(Item("MAT001", ProductType.Material, hasExpiration: false, erp: 10m, lotAmounts: new[] { 1m }));
+
+        // Act
+        var result = await CreateAdapter().GetMaterialsWithExpirationAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMaterialsWithExpirationAsync_ReturnsOnlyInScopeItems()
+    {
+        // Arrange
+        SetupCatalog(
+            Item("MAT001", ProductType.Material, hasExpiration: true, erp: 10m, lotAmounts: new[] { 10m }),
+            Item("PROD001", ProductType.Product, hasExpiration: true, erp: 5m, lotAmounts: new[] { 5m }),
+            Item("MAT002", ProductType.Material, hasExpiration: false, erp: 3m, lotAmounts: new[] { 3m })
+        );
+
+        // Act
+        var result = await CreateAdapter().GetMaterialsWithExpirationAsync(CancellationToken.None);
+
+        // Assert
+        result.Select(s => s.ProductCode).Should().Equal("MAT001");
+    }
+
+    [Fact]
+    public async Task GetMaterialsWithExpirationAsync_WhenRepositoryEmpty_ReturnsEmpty()
+    {
+        // Arrange
+        SetupCatalog();
+
+        // Act
+        var result = await CreateAdapter().GetMaterialsWithExpirationAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMaterialsWithExpirationAsync_PropagatesCancellationToken()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        _catalogMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<CatalogAggregate>)new List<CatalogAggregate>());
+
+        // Act
+        await CreateAdapter().GetMaterialsWithExpirationAsync(cts.Token);
+
+        // Assert
+        _catalogMock.Verify(r => r.GetAllAsync(cts.Token), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationComparerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/LotStockReconciliationComparerTests.cs
@@ -1,7 +1,5 @@
+using Anela.Heblo.Application.Features.DataQuality.Contracts;
 using Anela.Heblo.Application.Features.DataQuality.Services;
-using Anela.Heblo.Domain.Features.Catalog;
-using Anela.Heblo.Domain.Features.Catalog.Lots;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.DataQuality;
 using FluentAssertions;
 using Moq;
@@ -10,32 +8,25 @@ namespace Anela.Heblo.Tests.Features.DataQuality;
 
 public class LotStockReconciliationComparerTests
 {
-    private readonly Mock<ICatalogRepository> _catalogMock = new();
+    private readonly Mock<IMaterialLotStockQuery> _materialLotStockMock = new();
     private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.Today);
 
-    private LotStockReconciliationComparer CreateSut() => new(_catalogMock.Object);
+    private LotStockReconciliationComparer CreateSut() => new(_materialLotStockMock.Object);
 
-    private void SetupCatalog(params CatalogAggregate[] items) =>
-        _catalogMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IEnumerable<CatalogAggregate>)items.ToList());
+    private void SetupMaterials(params MaterialLotStockSnapshot[] items) =>
+        _materialLotStockMock.Setup(q => q.GetMaterialsWithExpirationAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items.ToList());
 
-    private static CatalogAggregate Material(
+    private static MaterialLotStockSnapshot Material(
         string code,
         decimal erp,
-        bool hasExpiration = true,
-        params decimal[] lotAmounts)
-    {
-        var item = new CatalogAggregate
+        params decimal[] lotAmounts) =>
+        new()
         {
             ProductCode = code,
-            Type = ProductType.Material,
-            HasExpiration = hasExpiration,
-            Stock = new StockData { Erp = erp }
+            ErpStock = erp,
+            LotAmounts = lotAmounts.ToList()
         };
-        foreach (var amount in lotAmounts)
-            item.Stock.Lots.Add(new CatalogLot { ProductCode = code, Amount = amount });
-        return item;
-    }
 
     [Fact]
     public void TestType_IsLotSumVsErpStock()
@@ -47,7 +38,7 @@ public class LotStockReconciliationComparerTests
     public async Task CompareAsync_ReturnsNoMismatch_WhenLotSumEqualsErp_AndCountsItem()
     {
         // Arrange
-        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 4m, 6m }));
+        SetupMaterials(Material("MAT001", erp: 10m, lotAmounts: new[] { 4m, 6m }));
 
         // Act
         var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
@@ -61,7 +52,7 @@ public class LotStockReconciliationComparerTests
     public async Task CompareAsync_ReturnsNoMismatch_WhenDifferenceWithinTolerance()
     {
         // Arrange — |10.005 - 10| = 0.005 <= 0.01
-        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 10.005m }));
+        SetupMaterials(Material("MAT001", erp: 10m, lotAmounts: new[] { 10.005m }));
 
         // Act
         var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
@@ -75,7 +66,7 @@ public class LotStockReconciliationComparerTests
     public async Task CompareAsync_ReturnsSumMismatch_WhenLotSumDiffersBeyondTolerance()
     {
         // Arrange
-        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 5m, 3m }));
+        SetupMaterials(Material("MAT001", erp: 10m, lotAmounts: new[] { 5m, 3m }));
 
         // Act
         var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
@@ -97,7 +88,7 @@ public class LotStockReconciliationComparerTests
     public async Task CompareAsync_ReturnsMissingLots_WhenErpPositiveButNoLots()
     {
         // Arrange
-        SetupCatalog(Material("MAT001", erp: 10m));
+        SetupMaterials(Material("MAT001", erp: 10m));
 
         // Act
         var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
@@ -111,7 +102,7 @@ public class LotStockReconciliationComparerTests
     public async Task CompareAsync_ReturnsOrphanLots_WhenLotsPresentButErpZero()
     {
         // Arrange
-        SetupCatalog(Material("MAT001", erp: 0m, lotAmounts: new[] { 5m }));
+        SetupMaterials(Material("MAT001", erp: 0m, lotAmounts: new[] { 5m }));
 
         // Act
         var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
@@ -122,46 +113,10 @@ public class LotStockReconciliationComparerTests
     }
 
     [Fact]
-    public async Task CompareAsync_ExcludesNonMaterial_EvenWhenLotSumMismatches()
+    public async Task CompareAsync_ReturnsEmpty_WhenNoMaterialsInScope()
     {
         // Arrange
-        var goods = new CatalogAggregate
-        {
-            ProductCode = "PROD001",
-            Type = ProductType.Product,
-            HasExpiration = true,
-            Stock = new StockData { Erp = 10m }
-        };
-        goods.Stock.Lots.Add(new CatalogLot { ProductCode = "PROD001", Amount = 1m });
-        SetupCatalog(goods);
-
-        // Act
-        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
-
-        // Assert
-        result.Mismatches.Should().BeEmpty();
-        result.TotalChecked.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task CompareAsync_ExcludesMaterialWithoutExpiration()
-    {
-        // Arrange
-        SetupCatalog(Material("MAT001", erp: 10m, hasExpiration: false, lotAmounts: new[] { 1m }));
-
-        // Act
-        var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
-
-        // Assert
-        result.Mismatches.Should().BeEmpty();
-        result.TotalChecked.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task CompareAsync_ReturnsEmpty_WhenRepositoryEmpty()
-    {
-        // Arrange
-        SetupCatalog();
+        SetupMaterials();
 
         // Act
         var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
@@ -175,19 +130,18 @@ public class LotStockReconciliationComparerTests
     public async Task CompareAsync_CountsAllInScopeItems_AndReportsOnlyMismatches()
     {
         // Arrange
-        SetupCatalog(
+        SetupMaterials(
             Material("OK001", erp: 10m, lotAmounts: new[] { 10m }),          // matches
             Material("BAD001", erp: 10m, lotAmounts: new[] { 3m }),          // SumMismatch
             Material("MISS001", erp: 5m),                                    // MissingLots
-            Material("ORPH001", erp: 0m, lotAmounts: new[] { 2m }),          // OrphanLots
-            Material("NOEXP001", erp: 5m, hasExpiration: false, lotAmounts: new[] { 1m }) // excluded
+            Material("ORPH001", erp: 0m, lotAmounts: new[] { 2m })           // OrphanLots
         );
 
         // Act
         var result = await CreateSut().CompareAsync(Today, Today, CancellationToken.None);
 
         // Assert
-        result.TotalChecked.Should().Be(4); // NOEXP001 excluded
+        result.TotalChecked.Should().Be(4);
         result.Mismatches.Select(m => m.EntityKey)
             .Should().BeEquivalentTo(new[] { "BAD001", "MISS001", "ORPH001" });
     }
@@ -196,7 +150,7 @@ public class LotStockReconciliationComparerTests
     public async Task CompareAsync_IgnoresDateRange()
     {
         // Arrange
-        SetupCatalog(Material("MAT001", erp: 10m, lotAmounts: new[] { 10m }));
+        SetupMaterials(Material("MAT001", erp: 10m, lotAmounts: new[] { 10m }));
 
         // Act — arbitrary range must not affect the snapshot result
         var result = await CreateSut().CompareAsync(


### PR DESCRIPTION
The `DataQuality -> Catalog` architecture test (`ModuleBoundariesTests`) was failing on main because the new `LotStockReconciliationComparer` (#3553) injected `ICatalogRepository` and used Catalog domain types directly. This PR applies the module's established consumer-owned-contract pattern: DataQuality now owns `IMaterialLotStockQuery` + `MaterialLotStockSnapshot`, and Catalog supplies `DataQualityMaterialLotStockQueryAdapter` (registered in `CatalogModule`). The comparer keeps its reconciliation logic while item-scope filtering (material + expiration) moves into the adapter. Tests were re-pointed accordingly, with new adapter coverage; build, targeted tests (43/43), and `dotnet format` all pass.