### PR TITLE
#3541: fix Issued Invoices page shell blocked by grid-data loading

### DIFF
--- a/artifacts/feat-3541/arch-review.r1.md
+++ b/artifacts/feat-3541/arch-review.r1.md
@@ -1,0 +1,241 @@
+# Architecture Review: Fix Issued Invoices page shell blocked by grid-data loading
+
+## Skip Design: true
+
+Pure bug fix to existing rendering/data-fetching logic. No new screens, components, or visual
+design decisions — the heading and tab bar already exist and are visually correct; the defect is
+purely in *when* they render and which query gates them. `Skip Design: true`.
+
+## Architectural Fit Assessment
+
+This is a textbook regression against an already-established, already-correct convention in this
+codebase, not a new architectural problem. Three sibling pages follow the same shape and get it
+right:
+
+- `frontend/src/pages/customer/BankStatementsOverviewPage.tsx` (lines 12–63) — shell (`<h1>` +
+  tab `<nav>`) renders unconditionally with **zero** data hooks at the page level; each tab is a
+  separate component (`StatisticsTab`, `ImportTab`) that owns its own fetch/loading/error state.
+- `frontend/src/pages/KnowledgeBasePage.tsx` (lines 28–61) — same shape.
+- `frontend/src/pages/ArticlesPage.tsx` (lines 28–85) — `isLoading` is passed down as a prop into
+  the list component, never used to gate the page shell.
+
+`IssuedInvoicesPage.tsx` deviates: it calls `useIssuedInvoicesList` (grid) at the page level, and
+places a page-level `if (loading) return …` / `if (error) return …` guard (lines 314–334, verified
+in the current worktree) *before* the JSX that renders the `<h1>` (line 431) and tab `<nav>` (lines
+435–460). Because `activeTab` defaults to `'statistics'` (line 31) but the guard is keyed to the
+**grid** query, the entire shell — including the tab the user is actually on — is held hostage by
+a fetch the user hasn't asked for yet. The grid tab already has its own correctly-scoped
+loading/error block (lines 591–604) that is currently unreachable dead code because the page-level
+guard short-circuits before it.
+
+`StatisticsTab` (lines 337–358, an inline component within the same file) is the one piece of this
+file that already follows the correct pattern: `syncStatsLoading`/`syncStatsError` are fully
+self-contained within its own render, not hoisted to the page level. The fix is to make the grid
+tab behave the same way `StatisticsTab` already does — not to invent a new pattern.
+
+No backend, contract, or cross-module changes are required for the core fix. `GET /api/invoices`
+(`InvoicesController.GetInvoicesList` → `GetIssuedInvoicesListHandler` →
+`IssuedInvoiceRepository.GetPaginatedAsync`) is unchanged; this is a frontend rendering/query-gating
+fix only.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+IssuedInvoicesPage
+├── (page level, mount-time)
+│   ├── useIssuedInvoiceSyncStats(...)      # unconditional, unchanged
+│   └── useIssuedInvoicesList(..., { enabled: activeTab === 'grid' })  # now tab-gated
+├── Shell (renders unconditionally, no data-dependent early return)
+│   ├── <h1>Vydané faktury</h1>
+│   └── <nav> Statistiky | Seznam </nav>
+└── Tab Content (mutually exclusive, each owns its own loading/error region)
+    ├── activeTab === 'statistics' → StatisticsTab
+    │     (already correct: syncStatsLoading/syncStatsError scoped internally, lines 337–358)
+    └── activeTab === 'grid' → grid panel
+          (filters/import bar + data grid; loading/error scoped to the grid container,
+           lines 591–604 — currently dead code, becomes live once the page-level guard is removed)
+```
+
+No new components are introduced. The existing two-branch structure (`StatisticsTab` inline
+component + inline grid JSX under `activeTab === 'grid'`) is preserved as-is; only the gating logic
+changes.
+
+### Key Design Decisions
+
+#### Decision 1: Remove the page-level `if (loading) / if (error)` guard (lines 314–334)
+
+**Options considered:**
+1. Delete the guard outright and rely on the grid tab's existing scoped loading/error block
+   (lines 591–604).
+2. Keep a page-level guard but narrow its condition to something like
+   `loading && activeTab === 'grid' && !hasEverMountedShell`.
+3. Extract the grid tab into its own `GridTab` component (mirroring
+   `BankStatementsOverviewPage`'s `ImportTab` / `StatisticsTab` split) so the page component itself
+   never touches `useIssuedInvoicesList`'s loading state at all.
+
+**Chosen approach:** Option 1 — delete the guard. The scoped replacement already exists in the
+file (lines 591–604) and is functionally equivalent; no new JSX needs to be written.
+
+**Rationale:** Option 2 reintroduces exactly the coupling that caused the bug, just with an extra
+condition — fragile and harder to reason about. Option 3 (full extraction into `GridTab.tsx`/
+`StatisticsTab.tsx` files matching the `BankStatementsOverviewPage` convention) is architecturally
+the *nicest* long-term shape, but the spec explicitly places "broader refactor of
+`IssuedInvoicesPage.tsx`... beyond what FR-1–FR-3 require" out of scope, and CLAUDE.md's "surgical
+changes" rule applies directly here: touch only what the bug requires. Option 1 fixes the defect
+with the smallest possible diff and reuses code that's already written and already correct.
+
+#### Decision 2: Gate `useIssuedInvoicesList` with `enabled: activeTab === 'grid'` (spec FR-2)
+
+**Options considered:**
+1. Leave the grid query eager (fires on mount regardless of active tab), rely solely on Decision 1
+   to keep the shell unblocked.
+2. Add `enabled: activeTab === 'grid'` to `useIssuedInvoicesList`'s `useQuery` options.
+
+**Chosen approach:** Option 2.
+
+**Rationale:** Decision 1 alone is sufficient to fix the *reported* bug (shell no longer blocks on
+this query). But leaving the grid query eager means a slow/hanging `/api/invoices` response is
+still fetched on every page load even when the user never opens the Seznam tab — the exact request
+that caused this incident keeps firing unnecessarily. `enabled` is a one-line, well-established
+React Query option already used implicitly via the `useEffect` gate at lines 191–195
+(`refetchRunningJobs` only fires when `activeTab === 'grid'`), so this isn't a new pattern for this
+file. Risk is low and the diff is trivial; recommend including it in this PR.
+
+#### Decision 3: Add `data-loading="true"` to the grid loading container (spec FR-4)
+
+**Options considered:**
+1. Leave the loading container as-is (plain `<div>` with `Loader2` + Czech text, no machine
+   marker).
+2. Add `data-loading="true"` (or `aria-busy="true"`) to the container at (formerly dead, now live)
+   lines 591–597.
+
+**Chosen approach:** Option 2.
+
+**Rationale:** `waitForLoadingComplete()` (`frontend/test/e2e/helpers/wait-helpers.ts`) looks for
+`[data-loading="true"], .loading, .spinner, [aria-busy="true"]` and silently no-ops when none
+match — a known issue already documented in that file for the Catalog module. Once this page's
+shell fix makes the scoped spinner reachable, leaving it unmarked reproduces the same "test looks
+like it waited but didn't" failure class for a different reason. This is a one-attribute addition
+to markup already being touched in this PR (same lines as Decision 1's fix) — effectively free to
+include.
+
+#### Decision 4: FR-5 (backend latency diagnosis) and the `Success: false` swallowing bug — split out of this PR
+
+**Options considered:**
+1. Bundle FR-5's diagnosis and the `Success: false`-swallowed-as-empty-list fix into this PR.
+2. Fix only the rendering/gating defect (Decisions 1–3) in this PR; track FR-5 separately.
+
+**Chosen approach:** Option 2.
+
+**Rationale — diagnosis half of FR-5:** Confirming *why* `/api/invoices` was slow enough to blow a
+30s Playwright timeout requires staging Application Insights / logs access this pipeline does not
+have (the spec's own Open Question #1/#3 already flags this as unresolved and unresolvable via
+static review). This review does not attempt to answer it. Instead, the architecture is designed
+to be **correct regardless of the underlying latency cause**: once the shell no longer blocks on
+the grid query (Decision 1) and the grid query only fires when the user actually opens that tab
+(Decision 2), a slow or hanging `/api/invoices` response degrades to "the Seznam tab shows a
+spinner" — a contained, recoverable UI state — instead of "the entire page, including tabs the user
+didn't ask for, is frozen." That is the resilience this fix can deliver without knowing the root
+cause.
+
+**Rationale — `Success: false` swallowing:** This is a real, independent correctness bug
+(`GetIssuedInvoicesListHandler`'s catch block returns `Success = false` +
+`ErrorCode = ErrorCodes.Exception`, but `InvoicesController.GetInvoicesList` unconditionally
+returns `Ok(result)`, and `useIssuedInvoices.ts`'s hand-rolled fetch only treats non-2xx as an
+error — so a caught backend exception silently renders as "0 invoices found" instead of an error).
+It is **not** the cause of the reported 30s-timeout failure (the spec itself says so: "this does
+not explain the 30s timeout"). It was found incidentally during this investigation, on a code path
+adjacent to — but not the same as — the one this PR fixes. Per CLAUDE.md's "surgical changes" rule
+and the instruction to keep a single-developer-reviewed bugfix PR tight, this belongs in its own
+follow-up PR with its own test, not folded into the E2E-unblocking fix. It is *not* an "open
+design question" in the way spec Open Question #2 frames it, though: the codebase already answers
+it — `useIssuedInvoiceSyncStats.ts:53` (`if (!data.success) { throw new Error(...) }`) is the
+sibling hook for the *same feature*, calling `getAuthenticatedApiClient()` the same hand-rolled
+way, and it already checks `data.success`. The follow-up fix is: make `useIssuedInvoicesList` do
+exactly what `useIssuedInvoiceSyncStats` already does — no controller/HTTP-status change, no new
+open question to resolve with the team.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files or directories. All changes are within:
+- `frontend/src/pages/customer/IssuedInvoicesPage.tsx` — remove lines 314–334; add
+  `data-loading="true"` to the container currently at lines 591–597.
+- `frontend/src/api/hooks/useIssuedInvoices.ts` — add `enabled: activeTab === 'grid'` to the
+  `useQuery` options in `useIssuedInvoicesList` (requires passing `activeTab` or an `enabled`
+  boolean into the hook's filters/options; keep the hook's existing signature shape rather than
+  inventing a new parameter-passing convention — e.g. extend `IssuedInvoicesFilters` is the wrong
+  place since `enabled` isn't a filter; add a second, optional `options: { enabled?: boolean }`
+  argument to `useIssuedInvoicesList`, matching how `useIssuedInvoiceDetail` already uses `enabled`
+  internally at line 116 for its own `!!invoiceId` gate).
+
+Follow-up (separate PR, not this one): `useIssuedInvoices.ts` — add the `data.success` check
+mirroring `useIssuedInvoiceSyncStats.ts:53`.
+
+### Interfaces and Contracts
+
+No DTO, controller, or API contract changes. `GetIssuedInvoicesListResponse` is unchanged.
+`IssuedInvoicesFilters` (the frontend filter interface, `useIssuedInvoices.ts:8–20`) is unchanged;
+the tab-gating flag is a `useQuery`-level `enabled` option, not a filter value, and must not be
+folded into `IssuedInvoicesFilters` or the query key — doing so would change the query's cache key
+and defeat the `staleTime`-based caching FR-2's acceptance criteria depends on ("switching back to
+Statistics and then back to Grid does not re-fetch if data is still within `staleTime`").
+
+### Data Flow
+
+1. `IssuedInvoicesPage` mounts. `activeTab` = `'statistics'`. Shell (`<h1>` + tab `<nav>`) renders
+   immediately — no data dependency.
+2. `useIssuedInvoiceSyncStats` fires unconditionally (unchanged); `StatisticsTab` renders its own
+   scoped loading/error/content based on that query alone.
+3. `useIssuedInvoicesList` does **not** fire yet (`enabled: false` while `activeTab !== 'grid'`).
+4. User clicks "Seznam" → `activeTab` becomes `'grid'` → `useIssuedInvoicesList` becomes enabled →
+   fires `GET /api/invoices` for the first time → the grid panel (not the whole page) shows its own
+   scoped spinner (now carrying `data-loading="true"`) → resolves to data or a scoped error, while
+   the shell and tab bar remain interactive throughout.
+5. Subsequent tab switches back and forth reuse React Query's cache per the existing `staleTime: 5
+   * 60 * 1000` / `gcTime: 10 * 60 * 1000` — unaffected by this fix.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Removing the page-level guard also removes its (currently unreachable) error surface, and a mistake in the refactor leaves the grid tab with no error UI at all | Medium | The scoped block at lines 591–604 already contains both the loading *and* error branches; verify with a manual test (artificially force `useIssuedInvoicesList` to reject) that the grid panel — not the whole page — shows the error message, per FR-2/FR-3 acceptance criteria |
+| `enabled: activeTab === 'grid'` changes when the first `/api/invoices` request fires (on tab click instead of on mount), which could make the Seznam tab feel slower on first click than today (today's request is already in flight by the time the user gets there) | Low | Acceptable, explicitly called out in spec FR-2's acceptance criteria as the intended behavior; the scoped spinner (Decision 3) makes this an expected, bounded wait rather than a silent stall |
+| Existing E2E specs (`filters.spec.ts`, `pagination.spec.ts`, etc.) may have assumptions baked in about the grid query firing on page load (e.g. timing assumptions in `beforeEach`) | Medium | Spec's Out of Scope section explicitly preserves the existing `Promise.race` / `waitForTimeout` patterns in these specs as already correct; re-run the full `issued-invoices` E2E suite against staging before merging (per CLAUDE.md's "All tests touched by the change must pass" and the nightly E2E gate) — do not assume green from code review alone |
+| Bundling the `Success: false` swallowing fix (Decision 4) into this PR would touch a second, independently-reasoned code path in the same review cycle as the E2E-unblocking fix | Low (if avoided) | Keep it out per Decision 4; file as a small, separate follow-up PR referencing the sibling pattern in `useIssuedInvoiceSyncStats.ts:53` |
+
+## Specification Amendments
+
+1. **FR-5's diagnosis sub-goal cannot be executed by this pipeline.** No App Insights, staging log,
+   or GitHub Actions run-history access is available here (confirmed in the spec's own Open
+   Questions). Recommend re-scoping FR-5 in the spec to two independently-trackable items: (a) a
+   manual/human follow-up to pull staging APM data for `GET /api/invoices` around run #191's
+   timestamp — outside this PR's deliverable — and (b) the `Success: false` swallowing fix, which
+   *is* independently fixable and should move to its own small follow-up ticket rather than block
+   or bloat this PR.
+2. **FR-5's `Success: false` fix has a settled answer, not an open question.** Spec Open Question
+   #2 asks whether the controller should return non-2xx or the frontend should check `data.success`.
+   The codebase already answers this: `useIssuedInvoiceSyncStats.ts:53` checks `data.success` on an
+   HTTP-200 response for the exact same feature. The follow-up fix for `useIssuedInvoicesList`
+   should mirror that hook exactly — no controller/HTTP-status change, no team discussion required.
+3. **FR-2's `enabled` flag placement**: the spec doesn't specify how `activeTab` reaches
+   `useIssuedInvoicesList` (the hook currently only takes `IssuedInvoicesFilters`). Implementation
+   guidance above specifies: add an optional second argument (`options: { enabled?: boolean }`) to
+   `useIssuedInvoicesList`, do not add `activeTab` to `IssuedInvoicesFilters` or the query key.
+4. Recommend the spec's Acceptance Criteria for FR-1/FR-3 be tested first locally (React DevTools /
+   throttled network) before the full staging E2E re-run, since the staging E2E run is slow
+   (nightly-only per CLAUDE.md) and the fix itself does not require staging to validate — only the
+   *original* latency cause (out of scope here) does.
+
+## Prerequisites
+
+None. No migrations, config, feature flags, or infrastructure changes are required. The fix is
+deployable independently of any resolution to FR-5's diagnosis question — that is precisely the
+point of Decision 1/2 (make the UI resilient to the underlying cause rather than dependent on
+knowing it). Before implementation starts, confirm locally that `npm run build` and `npm run lint`
+pass (per CLAUDE.md validation rules) and that the existing `issued-invoices` Playwright specs can
+be pointed at a local/dev backend with an artificially delayed `/api/invoices` response to validate
+FR-1–FR-4's acceptance criteria without needing a staging deploy.

--- a/artifacts/feat-3541/brief.md
+++ b/artifacts/feat-3541/brief.md
@@ -1,0 +1,42 @@
+## Summary
+
+In the nightly E2E regression run **[#191](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966)** (branch `main`, commit `738a99c`), **29 tests across the `issued-invoices` module failed** with the same root cause: the "Seznam" (grid/list) tab button never becomes clickable.
+
+## Root cause signature
+
+The shared setup switches to the Grid tab after the page loads, but the button never appears (30s timeout):
+
+```
+TimeoutError: locator.click: Timeout 30000ms exceeded.
+Call log:
+  - waiting for locator('button:has-text("Seznam")')
+
+  33 |     // Now switch to Grid tab (should be visible after loading completes)
+> 34 |     await gridTab.click();
+     at frontend/test/e2e/issued-invoices/filters.spec.ts:34
+```
+
+A couple of variants also time out waiting for `h1:has-text("Vydané faktury")` and `button:has-text("Statistiky")`, confirming the Issued Invoices page shell / tab bar isn't rendering (or is stuck loading).
+
+## Affected specs (failing test count)
+
+| Spec | Failures |
+|------|---------:|
+| issued-invoices/filters.spec.ts | 9 |
+| issued-invoices/pagination.spec.ts | 7 |
+| issued-invoices/sorting.spec.ts | 7 |
+| issued-invoices/status-badges.spec.ts | 4 |
+| issued-invoices/navigation.spec.ts | 2 |
+| **Total** | **29** |
+
+## Environment
+
+- Workflow: 🎭 E2E Nightly Regression Tests, run #191
+- Target: `https://heblo.stg.anela.cz` (staging)
+- Screenshots/video artifacts: `e2e-failure-screenshots-all-191`, `e2e-test-results-all-191` on the [run page](https://github.com/onpaj/Anela.Heblo/actions/runs/28888238966).
+
+## Suggested first steps
+
+1. Open the Issued Invoices page on staging and confirm the `Vydané faktury` heading, `Seznam`, and `Statistiky` tabs render.
+2. Check whether the page is stuck on a loading spinner (the tab is expected "after loading completes").
+3. Inspect the invoices data/list API for errors or long latency exceeding the 30s wait.

--- a/artifacts/feat-3541/code-review.r1.md
+++ b/artifacts/feat-3541/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3541/design.r1.md
+++ b/artifacts/feat-3541/design.r1.md
@@ -1,0 +1,114 @@
+# Design: Fix Issued Invoices page shell blocked by grid-data loading (Seznam tab never appears)
+
+## Component Design
+
+No new components. Two existing modules change; both keep their current external call sites
+except for the one new argument described below.
+
+### `useIssuedInvoicesList` (`frontend/src/api/hooks/useIssuedInvoices.ts`)
+
+**Current signature:**
+```ts
+export const useIssuedInvoicesList = (filters: IssuedInvoicesFilters) => { ... }
+```
+
+**New signature:**
+```ts
+export interface UseIssuedInvoicesListOptions {
+  enabled?: boolean;
+}
+
+export const useIssuedInvoicesList = (
+  filters: IssuedInvoicesFilters,
+  options?: UseIssuedInvoicesListOptions,
+) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.issuedInvoices, filters],
+    queryFn: async (): Promise<IGetIssuedInvoicesListResponse> => { /* unchanged */ },
+    enabled: options?.enabled ?? true,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+};
+```
+
+Contract notes (per arch review Decision 2 and Interfaces/Contracts section):
+- `options` is a **second, optional** parameter, separate from `filters`. `enabled` is a query-gating
+  concern, not a filter value, and must never be merged into `IssuedInvoicesFilters` or appended to
+  `queryKey` — doing so would change the cache key and break the `staleTime`-based "no refetch on
+  tab-switch-back" acceptance criterion (FR-2).
+- Default (`options` omitted, or `options.enabled` omitted) is `true`, so any other caller of this
+  hook (if one is ever added outside `IssuedInvoicesPage`) keeps today's eager-fetch behavior with
+  zero changes required at that call site.
+- Mirrors the existing internal pattern in the same file: `useIssuedInvoiceDetail` already passes
+  `enabled: !!invoiceId` into `useQuery`; this hook now exposes the same React Query primitive to
+  its caller instead of hardcoding `true`.
+- No change to `queryFn`, `queryKey` shape (still `[...QUERY_KEYS.issuedInvoices, filters]`),
+  `staleTime`, or `gcTime`. No change to the shape of data returned or thrown.
+
+**Call site — `IssuedInvoicesPage.tsx`:**
+```ts
+const { data, isLoading: loading, error } = useIssuedInvoicesList(
+  { pageNumber, pageSize, sortBy, sortDescending, /* ...existing filters */ },
+  { enabled: activeTab === 'grid' },
+);
+```
+
+### `IssuedInvoicesPage` (`frontend/src/pages/customer/IssuedInvoicesPage.tsx`)
+
+Responsibility split changes from "page owns list-loading state and gates all rendering on it" to
+"page owns tab state only; each tab owns its own data lifecycle" — matching the already-correct
+sibling pattern in `BankStatementsOverviewPage.tsx` and the already-correct `StatisticsTab` in this
+same file.
+
+- **Remove**: the page-level `if (loading) return ...` block (lines 314–323) and `if (error)
+  return ...` block (lines 325–334). These currently execute before the `<h1>`/tab-`<nav>` JSX and
+  are the direct cause of the bug; the arch review's Decision 1 selects deleting them outright
+  (Option 1) over narrowing the condition (Option 2, rejected as reintroducing the same coupling) or
+  extracting a `GridTab` component (Option 3, out of scope per "surgical changes").
+- **Unchanged**: the `<h1>Vydané faktury</h1>` heading and the tab `<nav>` (Statistiky / Seznam
+  buttons) — these already render correctly once nothing short-circuits ahead of them; no JSX
+  changes needed there.
+- **Unchanged**: `StatisticsTab` inline component (lines 337–358) — already scopes
+  `syncStatsLoading`/`syncStatsError` to itself; not touched by this fix.
+- **Now reachable (previously dead code)**: the grid-scoped loading/error block at lines 591–604,
+  inside the `activeTab === 'grid'` branch. This becomes the sole loading/error UI for the list
+  query. Add `data-loading="true"` to its loading container (currently a plain `<div>` at line
+  592) so `waitForLoadingComplete()` (`frontend/test/e2e/helpers/wait-helpers.ts`, matches
+  `[data-loading="true"], .loading, .spinner, [aria-busy="true"]`) actually blocks instead of
+  no-op'ing, per FR-4 / Decision 3.
+- **Unchanged**: the existing `useEffect` at lines 191–195 that only fires `refetchRunningJobs` when
+  `activeTab === 'grid'` — this is the precedent the new `enabled` gate follows, not something this
+  fix modifies.
+- **Unchanged**: `useIssuedInvoiceSyncStats` call — remains unconditional/eager on mount, since
+  Statistics is the default tab (spec Open Question 4 explicitly keeps this out of scope).
+
+### Data flow after the fix
+
+1. Mount, `activeTab = 'statistics'`. Shell (`<h1>` + tab `<nav>`) renders immediately with no data
+   dependency.
+2. `useIssuedInvoiceSyncStats` fires unconditionally; `StatisticsTab` shows its own scoped
+   loading/error/content.
+3. `useIssuedInvoicesList` does not fire (`enabled: false` while `activeTab !== 'grid'`) — no
+   `/api/invoices` request issued.
+4. User clicks "Seznam" → `activeTab` becomes `'grid'` → `enabled` becomes `true` →
+   `useIssuedInvoicesList` fires `GET /api/invoices` for the first time → the grid panel (not the
+   page) shows its scoped spinner (now carrying `data-loading="true"`) → resolves to data or a
+   scoped error, while the header and tab bar stay interactive throughout.
+5. Switching tabs back and forth reuses React Query's cache (`staleTime: 5 min`, `gcTime: 10 min`)
+   unchanged; toggling `enabled` does not evict cached data or reset `queryKey`.
+
+## Data Schemas
+
+No changes.
+
+- No database schema changes.
+- No API request/response shape changes: `GET /api/invoices` and `GetIssuedInvoicesListResponse`
+  (`IssuedInvoiceDto`, `Items`, `TotalCount`, `PageNumber`, `PageSize`, `Success`, `ErrorCode`,
+  `Params`) are unmodified — this is a frontend rendering/query-gating fix only, and Decision 4
+  explicitly defers both the FR-5 latency diagnosis and the `Success: false`-swallowed-as-empty-list
+  correctness fix to a separate follow-up PR.
+- No event payload changes.
+- Frontend-internal type addition only: `UseIssuedInvoicesListOptions { enabled?: boolean }` in
+  `useIssuedInvoices.ts`, consumed solely by `useIssuedInvoicesList`'s own signature — not part of
+  any wire contract, not exported to `IssuedInvoicesFilters`, not part of the React Query cache key.

--- a/artifacts/feat-3541/impl/decouple-issued-invoices-shell-from-grid-loading.r1.md
+++ b/artifacts/feat-3541/impl/decouple-issued-invoices-shell-from-grid-loading.r1.md
@@ -1,0 +1,85 @@
+# Implementation: decouple-issued-invoices-shell-from-grid-loading
+
+## What was implemented
+
+Decoupled the Issued Invoices page shell (header + tab navigation) from the grid-only
+`useIssuedInvoicesList` query's loading/error state, and made that query lazy so it only fires
+once the user opens the "Seznam" (grid) tab.
+
+1. `useIssuedInvoicesList` now accepts an optional second `options?: { enabled?: boolean }`
+   parameter, wired to React Query's `enabled` (default `true` when omitted, preserving existing
+   eager-fetch behavior for any other/future caller). `queryKey`, `queryFn` body, `staleTime`, and
+   `gcTime` are byte-for-byte unchanged.
+2. `IssuedInvoicesPage.tsx` now calls `useIssuedInvoicesList({...filters}, { enabled: activeTab === 'grid' })`.
+3. Removed the page-level `if (loading) return ...` / `if (error) return ...` early-return blocks
+   that previously ran before the `<h1>` and tab `<nav>` were reached, blocking the whole page
+   shell on a query that the default Statistics tab never needed.
+4. Added `data-loading="true"` to the grid tab's own scoped loading container (the ternary at the
+   `activeTab === 'grid'` branch), which was previously dead code and is now reachable — this
+   marker is what `waitForLoadingComplete()` (`frontend/test/e2e/helpers/wait-helpers.ts`) actually
+   matches on.
+
+The `StatisticsTab`'s own loading/error handling, the `Success: false`/`if (!response.ok) throw`
+logic in `queryFn`, the `useEffect` gating `refetchRunningJobs()` on `activeTab === 'grid'`, and all
+backend/OpenAPI-generated files were left untouched, per the task's explicit scope.
+
+## Files created/modified
+
+- `frontend/src/api/hooks/useIssuedInvoices.ts` — added `UseIssuedInvoicesListOptions` interface;
+  `useIssuedInvoicesList` takes an optional second `options` argument; added
+  `enabled: options?.enabled ?? true` to the `useQuery({...})` config.
+- `frontend/src/pages/customer/IssuedInvoicesPage.tsx` — call site now passes
+  `{ enabled: activeTab === 'grid' }`; deleted the page-level `if (loading)`/`if (error)`
+  early-return blocks; added `data-loading="true"` to the grid tab's loading container.
+
+## Tests
+
+- `cd frontend && npm run build` — passed, "Compiled successfully." (no new errors; only
+  pre-existing `caniuse-lite`/bundle-size informational warnings unrelated to this change).
+- `cd frontend && npm run lint` — ran across the whole repo; there are 148 pre-existing
+  errors/14 warnings in unrelated test files (e.g. `testing-library/no-node-access`,
+  `testing-library/no-wait-for-multiple-assertions` in various `__tests__` files across
+  `marketing/`, `financial-overview/`, `terminal/`, etc.) that are baseline issues, not introduced
+  by this change. Verified via `npm run lint 2>&1 | grep -A5 "IssuedInvoicesPage\|useIssuedInvoices"`
+  that neither of the two files touched by this task appears anywhere in the lint output — i.e.
+  zero new lint errors/warnings from this diff.
+- E2E: **not runnable in this sandbox** — no live backend/browser available. Per the task's
+  validation guidance, the 29 specs under `frontend/test/e2e/issued-invoices/` should be confirmed
+  on the next nightly staging run (`./scripts/run-playwright-tests.sh`) per CLAUDE.md's E2E
+  validation rule (nightly suite, not part of PR CI). This was not run and is not claimed as
+  validated here.
+
+Note: `node_modules` was not present in this worktree checkout; it was symlinked from the primary
+worktree (`/home/user/Anela.Heblo/frontend/node_modules`) to run build/lint, after confirming both
+worktrees share an identical `package-lock.json`. `node_modules` is gitignored, so this has no
+effect on the commit.
+
+## How to verify
+
+1. `cd frontend && npm run build && npm run lint` — confirm clean build and no lint errors on the
+   two changed files.
+2. Manual/dev check: load `/customer/issued-invoices` with the Network tab open — confirm
+   `GET /api/invoices` is not issued until "Seznam" is clicked, and that the header (`Vydané
+   faktury`) and both tab buttons render immediately regardless of that request's timing.
+3. Switch Statistics → Seznam → Statistics → Seznam again within 5 minutes and confirm only one
+   `GET /api/invoices` request is logged (React Query `staleTime` cache reuse).
+4. Confirm the "Načítání faktur..." spinner and "Chyba při načítání faktur" message only ever
+   appear inside the grid tab's content region (with `data-loading="true"` present on the spinner
+   container), never full-page.
+5. On the next nightly run, confirm all 29 specs in `frontend/test/e2e/issued-invoices/` pass.
+
+## Notes
+
+- No deviations from the task spec. The call-site edit places the new `{ enabled: activeTab === 'grid' }`
+  argument on the same line as the closing `}` of the filters object (`}, { enabled: activeTab ===
+  'grid' });`) rather than the multi-line form shown in the task's illustrative snippet — purely
+  cosmetic, functionally identical, and confirmed lint-clean.
+- The diff is scoped to exactly the two files named in the task (`useIssuedInvoices.ts`,
+  `IssuedInvoicesPage.tsx`); `git diff --stat` on the `frontend/` path shows only those two files,
+  no unrelated formatting changes.
+- `artifacts/feat-3541/state.json` was modified by the surrounding pipeline tooling (not by this
+  implementation) and was deliberately left unstaged, per instructions to scope `git add` to
+  `frontend/` only.
+
+## Status
+DONE

--- a/artifacts/feat-3541/review/decouple-issued-invoices-shell-from-grid-loading.r1.md
+++ b/artifacts/feat-3541/review/decouple-issued-invoices-shell-from-grid-loading.r1.md
@@ -1,0 +1,61 @@
+# Code Review: decouple-issued-invoices-shell-from-grid-loading
+
+## Summary
+
+Reviewed the real diff (`git show HEAD`, commit `0e92470`) against the task spec and re-read the
+full current contents of both touched files. The implementation matches the spec's exact code
+guidance closely:
+
+- `useIssuedInvoices.ts`: added `UseIssuedInvoicesListOptions { enabled?: boolean }`, second
+  optional `options` param on `useIssuedInvoicesList`, `enabled: options?.enabled ?? true` added to
+  the `useQuery` config. `queryKey` (still keyed only on `filters`), `queryFn` body, `staleTime`,
+  and `gcTime` are byte-for-byte unchanged. `useIssuedInvoiceDetail` and its existing `enabled:
+  !!invoiceId` pattern are untouched.
+- `IssuedInvoicesPage.tsx`: call site now passes `{ enabled: activeTab === 'grid' }` as second arg
+  (line 84). The page-level `if (loading) return …` / `if (error) return …` blocks (former lines
+  314–334) are fully deleted — confirmed by reading the current file: nothing between the
+  `getSyncStatusIcon` helper (ends ~line 312) and the `StatisticsTab` component (~line 314) now
+  short-circuits rendering. `loading`/`error` remain destructured from the hook (lines 70–71) and
+  are used exclusively inside the `activeTab === 'grid'` ternary (lines 569–582), which is
+  otherwise untouched (same JSX/messages as the previously-dead branch described in the spec).
+  `data-loading="true"` was added to exactly the grid tab's loading container (line 570) and not to
+  `StatisticsTab`'s separate loading block (lines 316–325), matching the spec's explicit
+  "do not add it to `StatisticsTab`" instruction. `Loader2`/`AlertCircle` imports remain used in
+  multiple other places in the file (import modal, statistics tab, status badges), so no orphaned
+  imports resulted from the deletion.
+- Scope: `git show HEAD --stat` confirms only the two named files are touched — no unrelated
+  formatting, no backend files, no `wait-helpers.ts` changes. The `if (!response.ok) throw new
+  Error(...)` response handling in `queryFn` is verified identical to spec description (line 83–85
+  of the current file); the `Success: false` swallowing issue was correctly left untouched, per
+  Decision 4 being out of scope.
+- `useEffect` gating `refetchRunningJobs()` on `activeTab === 'grid'` (lines 191–195) and
+  `useIssuedInvoiceSyncStats` usage are untouched, as required.
+
+Independently re-ran validation rather than trusting the implementation summary:
+- `npm run build` → "Compiled successfully." (only pre-existing caniuse-lite/bundle-size
+  informational warnings, no errors).
+- `npx eslint src/pages/customer/IssuedInvoicesPage.tsx src/api/hooks/useIssuedInvoices.ts` →
+  empty output, i.e. zero errors/warnings on the two changed files.
+- Confirmed via grep that `useIssuedInvoicesList` has only one call site in the whole `frontend/src`
+  tree (the page itself), so the "any other caller keeps eager-fetch behavior" claim, while true by
+  construction (`options?.enabled ?? true` defaults to `true`), isn't currently exercised by a
+  second caller — not a defect, just a note that the backward-compat guarantee is currently
+  untested by any other real usage.
+
+No functional requirement, architecture-guidance point, or acceptance criterion in the task spec is
+violated. E2E validation is correctly deferred to the nightly staging run per CLAUDE.md and the
+task's own validation-steps section, and is not claimed as run in the implementation summary.
+
+## Review Result: PASS
+
+### task: decouple-issued-invoices-shell-from-grid-loading
+**Status:** PASS
+
+## Docs to Update
+None required by this task.
+
+## Overall Notes
+- The single stylistic deviation the implementer flagged themselves (call-site `enabled` option
+  placed on the same line as the closing `}` of the filters object rather than the spec's
+  illustrative multi-line form) is functionally identical and not a compliance issue.
+- No other issues found.

--- a/artifacts/feat-3541/spec.r1.md
+++ b/artifacts/feat-3541/spec.r1.md
@@ -1,0 +1,142 @@
+# Specification: Fix Issued Invoices page shell blocked by grid-data loading (Seznam tab never appears in E2E)
+
+## Summary
+
+The nightly E2E regression run (#191, `main@738a99c`) failed 29 tests in the `issued-invoices` module because `button:has-text("Seznam")`, `h1:has-text("Vydané faktury")`, and `button:has-text("Statistiky")` all time out after 30s. Code inspection of `IssuedInvoicesPage.tsx` found the root architectural defect: the entire page shell (heading + tab bar) is gated behind the **grid tab's** data fetch (`useIssuedInvoicesList`), even though the page defaults to the **Statistics** tab and the fetch is unconditional. Combined with the frontend having no client-side request timeout on API calls, any slowness in the `GET /api/invoices` response — however caused — makes the whole page appear frozen on a spinner with no heading or tabs, which is exactly the failure signature reported.
+
+## Background
+
+`frontend/src/pages/customer/IssuedInvoicesPage.tsx` renders the "Vydané faktury" page with two tabs: "Statistiky" (default) and "Seznam" (grid). The component eagerly calls two independent data hooks on mount regardless of which tab is active:
+
+- `useIssuedInvoicesList(...)` (grid data) — `IssuedInvoicesPage.tsx:68-84`
+- `useIssuedInvoiceSyncStats(...)` (statistics data) — `IssuedInvoicesPage.tsx:87-95`
+
+The component has a **page-level** early return keyed off the grid query's `loading`/`error` state, placed *before* the JSX that renders the `<h1>` heading and the tab `<nav>`:
+
+```tsx
+// IssuedInvoicesPage.tsx:314-334
+if (loading) {
+  return (
+    <div className="flex items-center justify-center h-64">
+      ...
+      <div className="text-gray-500 ...">Načítání faktur...</div>
+    </div>
+  );
+}
+
+if (error) {
+  return (
+    <div className="flex items-center justify-center h-64">
+      ...
+      <div>Chyba při načítání faktur: {error.message}</div>
+    </div>
+  );
+}
+```
+
+The heading and tab bar only appear in the JSX returned starting at `IssuedInvoicesPage.tsx:405` (`return (<div className="flex flex-col w-full" ...>`), which contains:
+- `<h1>Vydané faktury</h1>` — line 431
+- "Statistiky" tab button — lines 437-447
+- "Seznam" tab button — lines 448-458
+
+Because the early returns at lines 314-334 happen first, **the heading and both tab buttons are unreachable for as long as the grid list query is loading or errored** — regardless of which tab the user is on. `activeTab` defaults to `'statistics'` (line 31), so on first page load the grid data isn't even needed yet, but its fetch still blocks the entire shell.
+
+This exactly explains all three timeout signatures in the bug report:
+1. `button:has-text("Seznam")` never appears (brief's primary signature, `filters.spec.ts:34`).
+2. `h1:has-text("Vydané faktury")` never appears (page never reaches its main return).
+3. `button:has-text("Statistiky")` never appears (same reason — collateral damage from a tab-bar-wide gate keyed to one tab's data).
+
+A secondary, compounding factor: neither the `useIssuedInvoicesList` fetch (`frontend/src/api/hooks/useIssuedInvoices.ts:69`) nor the shared authenticated fetch wrapper (`frontend/src/api/client.ts:283-292`, used by `getAuthenticatedApiClient()`) attaches an `AbortSignal`/timeout to the `fetch()` call. `getApiConfig()` (`client.ts:465-471`) defines a `timeout: 30000` value, but nothing consumes it to actually abort a hung request. So if the `GET /api/invoices` request is slow or hangs on staging, there is no client-side ceiling — the spinner (and therefore the whole page, per the bug above) can hang indefinitely, until Playwright's own 30s action-wait gives up.
+
+The backend endpoint the grid query calls (`GET /api/invoices` → `InvoicesController.GetInvoicesList` → `GetIssuedInvoicesListHandler` → `IssuedInvoiceRepository.GetPaginatedAsync`) was inspected and found to be a plain EF Core/PostgreSQL query set (count + skip/take) with supporting indexes on `InvoiceDate`, `LastSyncTime`, `IsSynced`, `ErrorType`, and `CustomerName` (`IssuedInvoiceConfiguration.cs:128-142`). It makes **no external Shoptet/ABRA calls** in the read path — those only happen in the invoice *import* flow (`EnqueueImportInvoicesRequest`, the daily Hangfire jobs). No feature flag gates this page or its API calls (verified via grep across the page, hooks, and controller). So the *why is it slow on staging* question could not be conclusively answered by static code review; see Open Questions.
+
+One candidate external cause was investigated and largely ruled out: `DailyInvoiceImportCzkJob`/`DailyInvoiceImportEurJob` (`backend/src/.../Infrastructure/Jobs/DailyInvoiceImport{Czk,Eur}Job.cs`) write to the same `IssuedInvoices` table and do call Shoptet, running at cron `15 4 * * *` / `0 4 * * *`. However, the nightly workflow (`.github/workflows/e2e-nightly-regression.yml`) starts at `0 1 * * *` (1:00 AM UTC), and Playwright's `globalTimeout` is 60 minutes (`frontend/playwright.config.ts:83`), so the full "all modules, 1 worker" run must finish by roughly 2:10 AM UTC — well before the 4:00-4:15 AM UTC import jobs. `issued-invoices` is also the 2nd of 9 projects Playwright discovers (`playwright.config.ts:86-131`), so it runs early in that window. A lock/contention overlap with the import jobs is therefore unlikely to be the trigger, though it cannot be fully excluded without the actual run's timestamps (GitHub Actions access was unavailable in this investigation — see Open Questions).
+
+## Functional Requirements
+
+### FR-1: Root cause diagnosis (this investigation)
+
+Document the confirmed defect and rank hypotheses for why the underlying request is slow enough to exceed the 30s E2E wait.
+
+**Findings:**
+- **Confirmed code defect:** `IssuedInvoicesPage.tsx:314-334` — page-level `loading`/`error` early return, keyed to the grid-tab-only `useIssuedInvoicesList` query, sits above the JSX (line 405 onward) that renders the `<h1>` and tab `<nav>` (lines 429-461). This blocks the whole page shell on one tab's data, regardless of `activeTab`.
+- **Confirmed contributing factor:** no client-side fetch timeout/`AbortSignal` anywhere in the request path (`useIssuedInvoices.ts:69`, `client.ts:283-292`), so a slow/hung backend response has no client-enforced ceiling.
+- **Backend read path is external-call-free:** `GetIssuedInvoicesListHandler.cs`, `IssuedInvoiceRepository.GetPaginatedAsync` (`IssuedInvoiceRepository.cs:76-145`) are DB-only, with indexes present. Not proven to be the source of the actual multi-second-plus delay from static review alone.
+- **Daily Shoptet import jobs are an unlikely but not fully excluded contributor** — see Background for the timing analysis.
+- **No feature flag involvement** confirmed via search.
+
+**Acceptance criteria:**
+- The investigation notes above are available to the architect/dev phase without re-discovery (file/line citations included).
+- Any follow-up diagnostic needed to pin the exact backend latency cause (e.g., App Insights query, staging DB row count) is called out explicitly rather than guessed at (see Open Questions).
+
+### FR-2: Page shell must render independently of tab-specific data loading
+
+The `<h1>Vydané faktury</h1>` heading and the "Statistiky"/"Seznam" tab buttons must render as soon as the page mounts, without waiting for any per-tab data fetch to resolve. Loading and error states must be scoped to the content area of the active tab only, matching the pattern already used correctly inside `StatisticsTab` (`IssuedInvoicesPage.tsx:337-358`, whose `syncStatsLoading`/`syncStatsError` handling is self-contained) and the grid tab's own inline loading/error block (`IssuedInvoicesPage.tsx:591-604`, which is currently dead code for this purpose since the outer early return at lines 314-334 pre-empts it).
+
+Concretely: remove (or relocate) the page-level `if (loading) return ...` / `if (error) return ...` block at `IssuedInvoicesPage.tsx:314-334` so it no longer gates the return at line 405. The grid tab already has its own scoped loading/error rendering at lines 591-604 that can take over this responsibility for the grid tab only.
+
+**Acceptance criteria:**
+- On page load, with the grid-list API call artificially delayed or failing, the `<h1>Vydané faktury</h1>` and both tab buttons ("Statistiky", "Seznam") are visible and clickable immediately (no dependency on the grid query's resolution).
+- Switching to the "Seznam" tab while the grid query is still loading shows a loading indicator scoped to the grid panel only (consistent with current lines 591-604 behavior), not a full-page blank/spinner state.
+- The existing "Statistiky" tab loading/error behavior (`StatisticsTab`, lines 337-358) is unaffected.
+- All 29 previously-failing `issued-invoices` E2E specs (`filters.spec.ts`, `pagination.spec.ts`, `sorting.spec.ts`, `status-badges.spec.ts`, `navigation.spec.ts`) pass against staging.
+
+### FR-3: Bound API requests with a client-side timeout
+
+Add an explicit timeout/`AbortSignal` to the fetch calls used by `useIssuedInvoicesList` (`useIssuedInvoices.ts:69`) and, ideally, to the shared `authenticatedHttp.fetch` wrapper in `getAuthenticatedApiClient()` (`client.ts:283-292`), using the existing `getApiConfig().timeout` value (`client.ts:469`) that is currently defined but unused. This is a defense-in-depth fix, independent of FR-2: even with FR-2 in place, a genuinely hung backend request should surface as a bounded, user-visible error rather than an indefinite spinner in the grid panel.
+
+**Acceptance criteria:**
+- A backend response that never resolves causes the affected query to fail with a client-observable error within the configured timeout window (not indefinitely).
+- Existing successful requests (well under the timeout) are unaffected.
+- Scope check: confirm whether other hooks sharing `getAuthenticatedApiClient()`/`authenticatedHttp.fetch` should also get this timeout, or whether it should be opt-in per hook — see Open Questions.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+- The Issued Invoices page shell (heading + tabs) must be interactive within the existing app shell's normal load budget, independent of grid/statistics data latency.
+- `GET /api/invoices` (default, unfiltered, first page) should be confirmed to respond within a low-single-digit-second budget on staging under normal conditions; if it does not, that is a separate backend performance issue to investigate (see Open Questions) — FR-2/FR-3 make the UI resilient to it either way but do not by themselves fix a genuinely slow backend.
+
+### NFR-2: Security
+
+- No change in authentication/authorization surface. `GetInvoicesList` continues to require the same auth as today; no new endpoints introduced.
+
+## Data Model
+
+No data model changes. Relevant existing entities:
+- `IssuedInvoice` (`backend/src/Anela.Heblo.Domain/Features/Invoices/`), mapped via `IssuedInvoiceConfiguration.cs` to `public.IssuedInvoices`, with indexes on `InvoiceDate`, `LastSyncTime`, `IsSynced`, `ErrorType`, `CustomerName`.
+- `IssuedInvoiceSyncStats` — aggregate computed on demand by `GetSyncStatsAsync` (`IssuedInvoiceRepository.cs:35-58`), not persisted.
+
+## API / Interface Design
+
+No API contract changes required for FR-2 (frontend-only fix). Data flow as traced:
+
+1. `IssuedInvoicesPage` mounts → unconditionally calls `useIssuedInvoicesList(...)` (`useIssuedInvoices.ts:23-88`) and `useIssuedInvoiceSyncStats(...)`.
+2. `useIssuedInvoicesList` builds `GET /api/invoices?pageNumber=...&pageSize=...&sortBy=...` and fetches via `getAuthenticatedApiClient().http.fetch` (bypassing the generated client's typed method, calling `.fetch` directly — `useIssuedInvoices.ts:66-74`).
+3. `InvoicesController.GetInvoicesList` (`InvoicesController.cs:25-32`) → MediatR → `GetIssuedInvoicesListHandler.Handle` (`GetIssuedInvoicesListHandler.cs:29-80`) → `IssuedInvoiceRepository.GetPaginatedAsync` (`IssuedInvoiceRepository.cs:76-145`) → PostgreSQL via EF Core.
+4. Response resolves `loading=false` in the `useQuery` result; only then does `IssuedInvoicesPage` fall through past the line 314-334 early return to render the shell.
+
+If FR-3 is implemented, the fetch call at step 2 gains a bounded `AbortSignal`/timeout so step 4 always resolves (success or bounded failure) within a fixed window.
+
+## Dependencies
+
+- **PostgreSQL** (via EF Core) — sole backing store for `GET /api/invoices` and `GET /api/invoices/stats`; no external system in this read path.
+- **Azure Entra ID / MSAL** — auth token acquisition for `getAuthenticatedApiClient()`; not implicated by this investigation (other modules' E2E tests were not reported failing in the same run, per the brief, which is inconsistent with a global auth issue).
+- **Shoptet / ABRA Flexi** — used only by the invoice *import* path (`EnqueueImportInvoicesRequest`, `DailyInvoiceImportCzkJob`/`DailyInvoiceImportEurJob`), not by the list/stats read path this bug affects. Investigated as a possible indirect cause (DB contention during import) and found unlikely to overlap with when `issued-invoices` E2E tests run, per the nightly workflow's timing (see Background).
+- **GitHub Actions nightly workflow** (`.github/workflows/e2e-nightly-regression.yml`) — deploys `main` to staging (`heblo-test` Web App, restarted) immediately before the E2E run, then polls `/health/ready`. A cold-start effect immediately after this restart is plausible but not confirmed (see Open Questions).
+
+## Out of Scope
+
+- Any change to the actual backend query performance (e.g., adding a covering index, query rewrite) — not warranted by evidence gathered here; revisit only if staging diagnostics (Open Questions) show the DB query itself is slow.
+- Changing the daily invoice import job schedule or the nightly E2E workflow's cron/timing.
+- Broader adoption of client-side fetch timeouts across all API hooks beyond `useIssuedInvoicesList` (FR-3 scope should be decided during implementation planning).
+- Retrying/backoff strategy changes for React Query beyond what's already configured globally (`retry: 1` in `frontend/src/App.tsx:104-112`).
+
+## Open Questions
+
+1. **What is the actual staging latency of `GET /api/invoices` at the time of the failing run?** This investigation could not access GitHub Actions run #191 (`gh run view` returned "GitHub access is not enabled for this session") or staging Application Insights, so the *magnitude and cause* of the underlying delay (cold start after the pre-test deploy/restart, DB connection pool warm-up, genuinely slow query, or something else) remains unconfirmed. Recommend pulling App Insights request duration for `GET /api/invoices` on staging around the run-#191 timeframe, and/or staging Postgres slow-query log, before finalizing FR-2/FR-3 as a complete fix versus a resiliency improvement that masks a real backend regression.
+2. **Should FR-3's client-side timeout apply to all `getAuthenticatedApiClient()`-backed requests, or only to `useIssuedInvoicesList`?** Applying it broadly is more consistent but is a larger blast-radius change; scoping it narrowly is safer but leaves the same "unbounded spinner" risk in other pages. Assumption for this spec: start narrow (this hook only) unless the architect phase decides otherwise.
+3. **Is the nightly workflow's pre-test `az webapp restart` (`e2e-nightly-regression.yml:94-97`) followed by a long enough warm-up before tests begin?** The workflow does poll `/health/ready` (up to 20×15s) before starting tests, which should cover basic warm-up, but does not specifically warm the `IssuedInvoices` table's first query. Worth confirming whether `/health/ready` exercises a DB round-trip equivalent to the invoices query.
+4. Git history in this worktree is squashed per-feature by the AgentHarness pipeline (verified: the entire `IssuedInvoicesPage.tsx`, `useIssuedInvoices.ts`, and `IssuedInvoiceRepository.cs` appear as full-file additions in a single unrelated commit, `bd2efd3`, "#3519: Split GridLayouts..."), so no meaningful "recent regression commit" could be identified via `git log`/`git blame` in this environment. If the real repository (outside this worktree) has non-squashed history, re-running blame there against `IssuedInvoicesPage.tsx:314-334` may pinpoint when the page-level gating was introduced.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3541/spec.r1.md
+++ b/artifacts/feat-3541/spec.r1.md
@@ -1,142 +1,134 @@
-# Specification: Fix Issued Invoices page shell blocked by grid-data loading (Seznam tab never appears in E2E)
+# Specification: Fix Issued Invoices page shell blocked by grid-data loading (Seznam tab never appears)
 
 ## Summary
 
-The nightly E2E regression run (#191, `main@738a99c`) failed 29 tests in the `issued-invoices` module because `button:has-text("Seznam")`, `h1:has-text("Vydané faktury")`, and `button:has-text("Statistiky")` all time out after 30s. Code inspection of `IssuedInvoicesPage.tsx` found the root architectural defect: the entire page shell (heading + tab bar) is gated behind the **grid tab's** data fetch (`useIssuedInvoicesList`), even though the page defaults to the **Statistics** tab and the fetch is unconditional. Combined with the frontend having no client-side request timeout on API calls, any slowness in the `GET /api/invoices` response — however caused — makes the whole page appear frozen on a spinner with no heading or tabs, which is exactly the failure signature reported.
+29 nightly E2E tests in the `issued-invoices` module fail on staging because the "Seznam" (Grid) tab button, the "Vydané faktury" heading, and even the "Statistiky" tab never render within the 30s Playwright timeout. Root cause: `IssuedInvoicesPage.tsx` gates rendering of the **entire page shell** (heading + tab navigation) behind the loading state of the grid/list data query (`useIssuedInvoicesList`), even though the default active tab is "Statistiky" and does not need that data at all. Any slowness, hang, or delay in the `/api/invoices` call — the exact cause of which still needs to be confirmed on staging — leaves the user (and the E2E tests) staring at a bare "Načítání faktur..." spinner indefinitely, with no tab bar to interact with.
 
 ## Background
 
-`frontend/src/pages/customer/IssuedInvoicesPage.tsx` renders the "Vydané faktury" page with two tabs: "Statistiky" (default) and "Seznam" (grid). The component eagerly calls two independent data hooks on mount regardless of which tab is active:
+`IssuedInvoicesPage` (`frontend/src/pages/customer/IssuedInvoicesPage.tsx`) was added whole in commit `bd2efd3` (2026-07-07) together with its E2E coverage in `frontend/test/e2e/issued-invoices/*.spec.ts`. The component fetches two independent datasets on mount, unconditionally, regardless of which tab is active:
 
-- `useIssuedInvoicesList(...)` (grid data) — `IssuedInvoicesPage.tsx:68-84`
-- `useIssuedInvoiceSyncStats(...)` (statistics data) — `IssuedInvoicesPage.tsx:87-95`
+- `useIssuedInvoicesList(...)` (`frontend/src/api/hooks/useIssuedInvoices.ts`) — powers the **Grid** ("Seznam") tab. Calls `GET /api/invoices`.
+- `useIssuedInvoiceSyncStats(...)` (`frontend/src/api/hooks/useIssuedInvoiceSyncStats.ts`) — powers the **Statistics** ("Statistiky") tab, which is the default (`activeTab` initial state is `'statistics'`).
 
-The component has a **page-level** early return keyed off the grid query's `loading`/`error` state, placed *before* the JSX that renders the `<h1>` heading and the tab `<nav>`:
+The component's render logic has this shape (lines 314–334 and 405+):
 
 ```tsx
-// IssuedInvoicesPage.tsx:314-334
-if (loading) {
-  return (
-    <div className="flex items-center justify-center h-64">
-      ...
-      <div className="text-gray-500 ...">Načítání faktur...</div>
-    </div>
-  );
+if (loading) {               // loading === useIssuedInvoicesList().isLoading
+  return <...spinner only, no header, no tabs...>;
 }
-
 if (error) {
-  return (
-    <div className="flex items-center justify-center h-64">
-      ...
-      <div>Chyba při načítání faktur: {error.message}</div>
-    </div>
-  );
+  return <...error only, no header, no tabs...>;
 }
+return (
+  <div>
+    {/* h1 "Vydané faktury" + tab nav (Statistiky / Seznam) rendered here */}
+    ...
+  </div>
+);
 ```
 
-The heading and tab bar only appear in the JSX returned starting at `IssuedInvoicesPage.tsx:405` (`return (<div className="flex flex-col w-full" ...>`), which contains:
-- `<h1>Vydané faktury</h1>` — line 431
-- "Statistiky" tab button — lines 437-447
-- "Seznam" tab button — lines 448-458
+Because `loading` reflects the **list** query and is checked before the tab bar is returned at all, the page header and tab navigation cannot appear until `/api/invoices` resolves — even for a user who only wants Statistics, and even though `useIssuedInvoiceSyncStats` has its own independent loading/error handling scoped inside `StatisticsTab`. There is no `enabled` flag on `useIssuedInvoicesList`, so it always fires on mount regardless of `activeTab`.
 
-Because the early returns at lines 314-334 happen first, **the heading and both tab buttons are unreachable for as long as the grid list query is loading or errored** — regardless of which tab the user is on. `activeTab` defaults to `'statistics'` (line 31), so on first page load the grid data isn't even needed yet, but its fetch still blocks the entire shell.
+The nightly run (`#191`, commit `738a99c`, target `https://heblo.stg.anela.cz`) shows all `issued-invoices` specs timing out waiting for `button:has-text("Seznam")` (and, in a subset of cases, `h1:has-text("Vydané faktury")` / `button:has-text("Statistiky")`), which is consistent with this blocking-render architecture combined with the list request taking longer than 30s (or failing to resolve) on staging.
 
-This exactly explains all three timeout signatures in the bug report:
-1. `button:has-text("Seznam")` never appears (brief's primary signature, `filters.spec.ts:34`).
-2. `h1:has-text("Vydané faktury")` never appears (page never reaches its main return).
-3. `button:has-text("Statistiky")` never appears (same reason — collateral damage from a tab-bar-wide gate keyed to one tab's data).
+A secondary contributing factor confirmed in code: `waitForLoadingComplete()` (`frontend/test/e2e/helpers/wait-helpers.ts`) looks for `[data-loading="true"], .loading, .spinner, [aria-busy="true"]`, none of which `IssuedInvoicesPage` renders (its loading UI is a plain `<div>` with a `Loader2` icon and Czech text). This helper is already known to return immediately without actually waiting (see the inline comment in `wait-helpers.ts` documenting the same issue for `CatalogList`, and the workaround comment on `filters.spec.ts` test 4). It masks — rather than causes — the present failure, but the `beforeEach` block in `filters.spec.ts` (lines 6–36) does NOT rely on `waitForLoadingComplete` for the initial page-shell wait; it uses an explicit `Promise.race` between the loading-text disappearing and the Grid tab becoming visible, with a clear error path. That defensive coding proves the test authors already anticipated this exact failure mode — the assertion is correct; the application under test is the one that's broken.
 
-A secondary, compounding factor: neither the `useIssuedInvoicesList` fetch (`frontend/src/api/hooks/useIssuedInvoices.ts:69`) nor the shared authenticated fetch wrapper (`frontend/src/api/client.ts:283-292`, used by `getAuthenticatedApiClient()`) attaches an `AbortSignal`/timeout to the `fetch()` call. `getApiConfig()` (`client.ts:465-471`) defines a `timeout: 30000` value, but nothing consumes it to actually abort a hung request. So if the `GET /api/invoices` request is slow or hangs on staging, there is no client-side ceiling — the spinner (and therefore the whole page, per the bug above) can hang indefinitely, until Playwright's own 30s action-wait gives up.
-
-The backend endpoint the grid query calls (`GET /api/invoices` → `InvoicesController.GetInvoicesList` → `GetIssuedInvoicesListHandler` → `IssuedInvoiceRepository.GetPaginatedAsync`) was inspected and found to be a plain EF Core/PostgreSQL query set (count + skip/take) with supporting indexes on `InvoiceDate`, `LastSyncTime`, `IsSynced`, `ErrorType`, and `CustomerName` (`IssuedInvoiceConfiguration.cs:128-142`). It makes **no external Shoptet/ABRA calls** in the read path — those only happen in the invoice *import* flow (`EnqueueImportInvoicesRequest`, the daily Hangfire jobs). No feature flag gates this page or its API calls (verified via grep across the page, hooks, and controller). So the *why is it slow on staging* question could not be conclusively answered by static code review; see Open Questions.
-
-One candidate external cause was investigated and largely ruled out: `DailyInvoiceImportCzkJob`/`DailyInvoiceImportEurJob` (`backend/src/.../Infrastructure/Jobs/DailyInvoiceImport{Czk,Eur}Job.cs`) write to the same `IssuedInvoices` table and do call Shoptet, running at cron `15 4 * * *` / `0 4 * * *`. However, the nightly workflow (`.github/workflows/e2e-nightly-regression.yml`) starts at `0 1 * * *` (1:00 AM UTC), and Playwright's `globalTimeout` is 60 minutes (`frontend/playwright.config.ts:83`), so the full "all modules, 1 worker" run must finish by roughly 2:10 AM UTC — well before the 4:00-4:15 AM UTC import jobs. `issued-invoices` is also the 2nd of 9 projects Playwright discovers (`playwright.config.ts:86-131`), so it runs early in that window. A lock/contention overlap with the import jobs is therefore unlikely to be the trigger, though it cannot be fully excluded without the actual run's timestamps (GitHub Actions access was unavailable in this investigation — see Open Questions).
+This is a bug-fix task: correct the coupling between page-shell rendering and per-tab data loading, and confirm/address why `/api/invoices` is slow or hanging on staging. It is not a new feature.
 
 ## Functional Requirements
 
-### FR-1: Root cause diagnosis (this investigation)
+### FR-1: Decouple page shell (heading + tab navigation) from grid-data loading state
 
-Document the confirmed defect and rank hypotheses for why the underlying request is slow enough to exceed the 30s E2E wait.
-
-**Findings:**
-- **Confirmed code defect:** `IssuedInvoicesPage.tsx:314-334` — page-level `loading`/`error` early return, keyed to the grid-tab-only `useIssuedInvoicesList` query, sits above the JSX (line 405 onward) that renders the `<h1>` and tab `<nav>` (lines 429-461). This blocks the whole page shell on one tab's data, regardless of `activeTab`.
-- **Confirmed contributing factor:** no client-side fetch timeout/`AbortSignal` anywhere in the request path (`useIssuedInvoices.ts:69`, `client.ts:283-292`), so a slow/hung backend response has no client-enforced ceiling.
-- **Backend read path is external-call-free:** `GetIssuedInvoicesListHandler.cs`, `IssuedInvoiceRepository.GetPaginatedAsync` (`IssuedInvoiceRepository.cs:76-145`) are DB-only, with indexes present. Not proven to be the source of the actual multi-second-plus delay from static review alone.
-- **Daily Shoptet import jobs are an unlikely but not fully excluded contributor** — see Background for the timing analysis.
-- **No feature flag involvement** confirmed via search.
+The `h1` "Vydané faktury" heading and the tab navigation bar (both "Statistiky" and "Seznam" buttons) must render as soon as the component mounts, independent of `useIssuedInvoicesList`'s `isLoading`/`error` state. The top-level `if (loading) return ...` / `if (error) return ...` guards currently at lines 314–334 of `IssuedInvoicesPage.tsx` must be removed or narrowed so they no longer short-circuit before the shared header/tab JSX.
 
 **Acceptance criteria:**
-- The investigation notes above are available to the architect/dev phase without re-discovery (file/line citations included).
-- Any follow-up diagnostic needed to pin the exact backend latency cause (e.g., App Insights query, staging DB row count) is called out explicitly rather than guessed at (see Open Questions).
+- On initial page load (default tab = Statistics), the `h1:has-text("Vydané faktury")` and both tab buttons (`button:has-text("Statistiky")`, `button:has-text("Seznam")`) are visible within a small, bounded time (see NFR-1) even if `/api/invoices` has not yet returned.
+- This holds regardless of whether the list request is slow, fails, or is still pending.
 
-### FR-2: Page shell must render independently of tab-specific data loading
+### FR-2: Only fetch grid list data when the Grid tab is active (or has been activated)
 
-The `<h1>Vydané faktury</h1>` heading and the "Statistiky"/"Seznam" tab buttons must render as soon as the page mounts, without waiting for any per-tab data fetch to resolve. Loading and error states must be scoped to the content area of the active tab only, matching the pattern already used correctly inside `StatisticsTab` (`IssuedInvoicesPage.tsx:337-358`, whose `syncStatsLoading`/`syncStatsError` handling is self-contained) and the grid tab's own inline loading/error block (`IssuedInvoicesPage.tsx:591-604`, which is currently dead code for this purpose since the outer early return at lines 314-334 pre-empts it).
-
-Concretely: remove (or relocate) the page-level `if (loading) return ...` / `if (error) return ...` block at `IssuedInvoicesPage.tsx:314-334` so it no longer gates the return at line 405. The grid tab already has its own scoped loading/error rendering at lines 591-604 that can take over this responsibility for the grid tab only.
+`useIssuedInvoicesList` must not fire an eager network request while the user is on the Statistics tab and has never opened the Grid tab. Gate the query with an `enabled` option tied to `activeTab === 'grid'` (React Query supports lazy/conditional fetching this way), consistent with how `refetchRunningJobs` is already only triggered when `activeTab === 'grid'` (existing `useEffect` at lines 191–195).
 
 **Acceptance criteria:**
-- On page load, with the grid-list API call artificially delayed or failing, the `<h1>Vydané faktury</h1>` and both tab buttons ("Statistiky", "Seznam") are visible and clickable immediately (no dependency on the grid query's resolution).
-- Switching to the "Seznam" tab while the grid query is still loading shows a loading indicator scoped to the grid panel only (consistent with current lines 591-604 behavior), not a full-page blank/spinner state.
-- The existing "Statistiky" tab loading/error behavior (`StatisticsTab`, lines 337-358) is unaffected.
-- All 29 previously-failing `issued-invoices` E2E specs (`filters.spec.ts`, `pagination.spec.ts`, `sorting.spec.ts`, `status-badges.spec.ts`, `navigation.spec.ts`) pass against staging.
+- With the network panel open, loading the page with the default Statistics tab active issues no request to `/api/invoices`.
+- Switching to the Seznam tab for the first time triggers exactly one `/api/invoices` request (existing filter/sort/pagination-triggered refetches are unaffected).
+- Switching back to Statistics and then back to Grid does not re-fetch if data is still within `staleTime` (existing React Query caching behavior preserved).
 
-### FR-3: Bound API requests with a client-side timeout
+### FR-3: Scope the list-loading and list-error UI to the Grid tab content area only
 
-Add an explicit timeout/`AbortSignal` to the fetch calls used by `useIssuedInvoicesList` (`useIssuedInvoices.ts:69`) and, ideally, to the shared `authenticatedHttp.fetch` wrapper in `getAuthenticatedApiClient()` (`client.ts:283-292`), using the existing `getApiConfig().timeout` value (`client.ts:469`) that is currently defined but unused. This is a defense-in-depth fix, independent of FR-2: even with FR-2 in place, a genuinely hung backend request should surface as a bounded, user-visible error rather than an indefinite spinner in the grid panel.
+The "Načítání faktur..." spinner and the "Chyba při načítání faktur" error message must only replace the **Grid tab's content region** (inside the `activeTab === 'grid'` branch, where equivalent loading/error UI already exists at lines 591–604), not the whole page. Remove the now-redundant top-level loading/error blocks entirely once FR-1 is implemented, since the in-tab-content copies already exist and are functionally equivalent.
 
 **Acceptance criteria:**
-- A backend response that never resolves causes the affected query to fail with a client-observable error within the configured timeout window (not indefinitely).
-- Existing successful requests (well under the timeout) are unaffected.
-- Scope check: confirm whether other hooks sharing `getAuthenticatedApiClient()`/`authenticatedHttp.fetch` should also get this timeout, or whether it should be opt-in per hook — see Open Questions.
+- While `/api/invoices` is pending, the Grid tab (once selected) shows the existing scoped spinner inside the data-grid container; the header and tab bar remain interactive and clickable throughout.
+- The Statistics tab is fully usable (cards, chart) while the Grid tab's data is loading or has errored, and vice versa.
+
+### FR-4: Add/confirm a machine-readable loading marker for E2E stability
+
+Add a `data-loading="true"` attribute (or equivalent, e.g. `aria-busy="true"`) to the Grid tab's loading container so `waitForLoadingComplete()` (`frontend/test/e2e/helpers/wait-helpers.ts`) works as intended instead of silently no-op'ing. This does not fix the root cause by itself but prevents the same class of "test looks like it waited but didn't" failure recurring here, consistent with the precedent already documented in `wait-helpers.ts` for the Catalog module.
+
+**Acceptance criteria:**
+- `waitForLoadingComplete(page)` called while the Grid tab is fetching actually blocks until the spinner is gone (verified by a short artificial delay in a local/dev run, or by code inspection confirming the selector now matches).
+- No existing `waitForTimeout` workarounds in `filters.spec.ts` are required to be removed as part of this fix (they may remain until a separate test-cleanup pass), but no NEW arbitrary timeouts should be introduced to compensate for this bug.
+
+### FR-5: Diagnose and address the underlying `/api/invoices` slowness/hang on staging
+
+Independent of the frontend architecture fix (FR-1–FR-3), determine why `GET /api/invoices` took long enough (or failed to resolve) to blow a 30s Playwright timeout on staging during run #191. `GetIssuedInvoicesListHandler` (`backend/src/Anela.Heblo.Application/Features/Invoices/UseCases/GetIssuedInvoicesList/GetIssuedInvoicesListHandler.cs`) delegates directly to `IIssuedInvoiceRepository.GetPaginatedAsync` — a straightforward paginated DB query with no obvious N+1 or synchronous external (Shoptet) call in the request path — so the delay is not self-evident from the handler alone and needs to be confirmed with staging logs/APM (see Open Questions).
+
+Additionally, note that `GetIssuedInvoicesListHandler`'s `catch` block returns `Success = false` with an `ErrorCode`, but `InvoicesController.GetInvoicesList` always returns `Ok(result)` (HTTP 200) regardless of `Success`. The frontend hook (`useIssuedInvoices.ts`) only treats non-2xx responses as errors (`if (!response.ok) throw ...`); it never inspects `data.success`/`data.errorCode`. A backend business-logic failure is therefore currently swallowed as an empty list rather than surfaced as an error — this does not explain the 30s timeout (loading would resolve, just with empty data) but is a related correctness gap worth fixing in the same change since it affects the same code path and the same error-handling story tested by `filters.spec.ts`'s `beforeEach`.
+
+**Acceptance criteria:**
+- A concrete cause for the staging timeout is identified and documented (e.g., slow query due to missing index, connection pool exhaustion, cold start, auth/token acquisition stall in `getAuthenticatedApiClient()`, or transient staging incident) — see Open Questions for how this investigation should be scoped.
+- `useIssuedInvoicesList`'s fetch wrapper (or the handler/controller) is updated so a `Success: false` response is surfaced as an error state in the UI (`error` from `useIssuedInvoicesList`) rather than silently rendering as zero rows.
 
 ## Non-Functional Requirements
 
 ### NFR-1: Performance
 
-- The Issued Invoices page shell (heading + tabs) must be interactive within the existing app shell's normal load budget, independent of grid/statistics data latency.
-- `GET /api/invoices` (default, unfiltered, first page) should be confirmed to respond within a low-single-digit-second budget on staging under normal conditions; if it does not, that is a separate backend performance issue to investigate (see Open Questions) — FR-2/FR-3 make the UI resilient to it either way but do not by themselves fix a genuinely slow backend.
+- Page shell (heading + tab bar) must be interactive within the app's existing FCP/render budget for other pages in this module (no explicit SLA previously existed for this page; use "same order of magnitude as other Customer-module pages," i.e., well under 2s under normal staging conditions), independent of any single tab's data-fetch latency.
+- `GET /api/invoices` at default page size (20) should complete in line with other paginated list endpoints in the app (existing precedent, e.g., `/api/catalog`); no new explicit SLA is introduced by this fix, but the investigation in FR-5 should record the observed p50/p95 latency on staging for future regression comparison.
 
 ### NFR-2: Security
 
-- No change in authentication/authorization surface. `GetInvoicesList` continues to require the same auth as today; no new endpoints introduced.
+No change to authentication/authorization. The page continues to rely on the existing MSAL-based `getAuthenticatedApiClient()` flow; no new endpoints or data exposure are introduced. If FR-5's investigation finds the hang is caused by token acquisition stalling, that must be fixed within the existing auth flow, not worked around by weakening auth.
 
 ## Data Model
 
-No data model changes. Relevant existing entities:
-- `IssuedInvoice` (`backend/src/Anela.Heblo.Domain/Features/Invoices/`), mapped via `IssuedInvoiceConfiguration.cs` to `public.IssuedInvoices`, with indexes on `InvoiceDate`, `LastSyncTime`, `IsSynced`, `ErrorType`, `CustomerName`.
-- `IssuedInvoiceSyncStats` — aggregate computed on demand by `GetSyncStatsAsync` (`IssuedInvoiceRepository.cs:35-58`), not persisted.
+No data model changes. Existing entities involved:
+- `IssuedInvoiceDto` / `GetIssuedInvoicesListResponse` (paginated list, `Items`, `TotalCount`, `PageNumber`, `PageSize`, `Success`, `ErrorCode`, `Params`).
+- `GetIssuedInvoiceSyncStatsResponse` (aggregate counts used by the Statistics tab, unaffected by this fix).
 
 ## API / Interface Design
 
-No API contract changes required for FR-2 (frontend-only fix). Data flow as traced:
+No API contract changes required for FR-1–FR-4 (purely frontend rendering/query-gating changes). FR-5 may result in:
+- A backend fix (query optimization, index, or removal of an accidental synchronous blocking call) with no change to the `GET /api/invoices` request/response shape.
+- Optionally, the controller/handler being adjusted so failure responses are distinguishable by HTTP status or the frontend hook is adjusted to check `data.success` before treating a 200 response as a success — this is a contract-compatible change (`GetIssuedInvoicesListResponse` already carries `Success`/`ErrorCode`; only the frontend's handling of it changes, unless the team prefers to also change the controller to return a non-2xx status on `Success: false`, which would be a breaking-ish change to confirm with the team — see Open Questions).
 
-1. `IssuedInvoicesPage` mounts → unconditionally calls `useIssuedInvoicesList(...)` (`useIssuedInvoices.ts:23-88`) and `useIssuedInvoiceSyncStats(...)`.
-2. `useIssuedInvoicesList` builds `GET /api/invoices?pageNumber=...&pageSize=...&sortBy=...` and fetches via `getAuthenticatedApiClient().http.fetch` (bypassing the generated client's typed method, calling `.fetch` directly — `useIssuedInvoices.ts:66-74`).
-3. `InvoicesController.GetInvoicesList` (`InvoicesController.cs:25-32`) → MediatR → `GetIssuedInvoicesListHandler.Handle` (`GetIssuedInvoicesListHandler.cs:29-80`) → `IssuedInvoiceRepository.GetPaginatedAsync` (`IssuedInvoiceRepository.cs:76-145`) → PostgreSQL via EF Core.
-4. Response resolves `loading=false` in the `useQuery` result; only then does `IssuedInvoicesPage` fall through past the line 314-334 early return to render the shell.
-
-If FR-3 is implemented, the fetch call at step 2 gains a bounded `AbortSignal`/timeout so step 4 always resolves (success or bounded failure) within a fixed window.
+UI flow (post-fix):
+1. User navigates to `/customer/issued-invoices`.
+2. Header ("Vydané faktury") and tab bar (Statistiky / Seznam) render immediately.
+3. Statistics tab (default) loads its own data independently; Grid tab's query is not fired yet.
+4. User clicks "Seznam" → Grid tab's query fires (first time only) → scoped spinner shows inside the grid container → data renders or a scoped error message renders, without ever hiding the header/tab bar.
 
 ## Dependencies
 
-- **PostgreSQL** (via EF Core) — sole backing store for `GET /api/invoices` and `GET /api/invoices/stats`; no external system in this read path.
-- **Azure Entra ID / MSAL** — auth token acquisition for `getAuthenticatedApiClient()`; not implicated by this investigation (other modules' E2E tests were not reported failing in the same run, per the brief, which is inconsistent with a global auth issue).
-- **Shoptet / ABRA Flexi** — used only by the invoice *import* path (`EnqueueImportInvoicesRequest`, `DailyInvoiceImportCzkJob`/`DailyInvoiceImportEurJob`), not by the list/stats read path this bug affects. Investigated as a possible indirect cause (DB contention during import) and found unlikely to overlap with when `issued-invoices` E2E tests run, per the nightly workflow's timing (see Background).
-- **GitHub Actions nightly workflow** (`.github/workflows/e2e-nightly-regression.yml`) — deploys `main` to staging (`heblo-test` Web App, restarted) immediately before the E2E run, then polls `/health/ready`. A cold-start effect immediately after this restart is plausible but not confirmed (see Open Questions).
+- `@tanstack/react-query` `enabled` option (already used elsewhere in the codebase; no new dependency).
+- Existing E2E infrastructure: `frontend/test/e2e/helpers/e2e-auth-helper.ts` (`navigateToIssuedInvoices`), `frontend/test/e2e/helpers/wait-helpers.ts` (`waitForLoadingComplete`), staging environment `https://heblo.stg.anela.cz`.
+- Staging observability (App Insights / logs / whatever APM the project uses) to complete FR-5's diagnosis — not confirmed which tool is available; see Open Questions.
 
 ## Out of Scope
 
-- Any change to the actual backend query performance (e.g., adding a covering index, query rewrite) — not warranted by evidence gathered here; revisit only if staging diagnostics (Open Questions) show the DB query itself is slow.
-- Changing the daily invoice import job schedule or the nightly E2E workflow's cron/timing.
-- Broader adoption of client-side fetch timeouts across all API hooks beyond `useIssuedInvoicesList` (FR-3 scope should be decided during implementation planning).
-- Retrying/backoff strategy changes for React Query beyond what's already configured globally (`retry: 1` in `frontend/src/App.tsx:104-112`).
+- Rewriting `filters.spec.ts` / `pagination.spec.ts` / `sorting.spec.ts` / `status-badges.spec.ts` / `navigation.spec.ts` beyond what's needed to keep them passing against the fixed component (e.g., no requirement to remove the existing `waitForTimeout(500)` stabilization waits called out in the tests, or to redesign the `Promise.race` pattern in `filters.spec.ts`'s `beforeEach` — it already correctly detects the failure mode and should keep working once the app is fixed).
+- General cleanup of `waitForLoadingComplete`'s known unreliability across the whole E2E suite (only the Issued Invoices page's markers are addressed here, per FR-4).
+- Broader refactor of `IssuedInvoicesPage.tsx` (e.g., splitting into subcomponents, moving state to a reducer) beyond what FR-1–FR-3 require.
+- Changing the `IssuedInvoicesFilters`/pagination/sorting behavior itself — those are assumed to work correctly once the page actually renders (that's what the 29 failing tests are trying to verify, but the failures are 100% attributable to the tab bar never appearing, not to filter/sort/pagination logic itself).
+- Any changes to the Shoptet invoice sync/import pipeline (`ShoptetInvoiceClient`, `ShoptetApiInvoiceSource`) unless FR-5's investigation specifically implicates them.
 
 ## Open Questions
 
-1. **What is the actual staging latency of `GET /api/invoices` at the time of the failing run?** This investigation could not access GitHub Actions run #191 (`gh run view` returned "GitHub access is not enabled for this session") or staging Application Insights, so the *magnitude and cause* of the underlying delay (cold start after the pre-test deploy/restart, DB connection pool warm-up, genuinely slow query, or something else) remains unconfirmed. Recommend pulling App Insights request duration for `GET /api/invoices` on staging around the run-#191 timeframe, and/or staging Postgres slow-query log, before finalizing FR-2/FR-3 as a complete fix versus a resiliency improvement that masks a real backend regression.
-2. **Should FR-3's client-side timeout apply to all `getAuthenticatedApiClient()`-backed requests, or only to `useIssuedInvoicesList`?** Applying it broadly is more consistent but is a larger blast-radius change; scoping it narrowly is safer but leaves the same "unbounded spinner" risk in other pages. Assumption for this spec: start narrow (this hook only) unless the architect phase decides otherwise.
-3. **Is the nightly workflow's pre-test `az webapp restart` (`e2e-nightly-regression.yml:94-97`) followed by a long enough warm-up before tests begin?** The workflow does poll `/health/ready` (up to 20×15s) before starting tests, which should cover basic warm-up, but does not specifically warm the `IssuedInvoices` table's first query. Worth confirming whether `/health/ready` exercises a DB round-trip equivalent to the invoices query.
-4. Git history in this worktree is squashed per-feature by the AgentHarness pipeline (verified: the entire `IssuedInvoicesPage.tsx`, `useIssuedInvoices.ts`, and `IssuedInvoiceRepository.cs` appear as full-file additions in a single unrelated commit, `bd2efd3`, "#3519: Split GridLayouts..."), so no meaningful "recent regression commit" could be identified via `git log`/`git blame` in this environment. If the real repository (outside this worktree) has non-squashed history, re-running blame there against `IssuedInvoicesPage.tsx:314-334` may pinpoint when the page-level gating was introduced.
+1. **FR-5 root cause confirmation**: What staging observability is available to confirm the actual `/api/invoices` response time during run #191 (App Insights request duration, container logs, DB slow-query log)? Assumption made for this spec: the investigating engineer will check staging logs/APM around the run's timestamp; if no APM exists, add temporary timing logs around `GetPaginatedAsync` as a stopgap and re-run the nightly suite to capture fresh data.
+2. **Failure-response contract change**: Should `InvoicesController.GetInvoicesList` start returning a non-2xx status when `Success: false` (breaking-ish, but simpler for all consumers), or should `useIssuedInvoicesList` be changed to check `data.success` on an otherwise-200 response (backward compatible, more code paths to update)? Assumption made for this spec: prefer the frontend-side fix (check `data.success`) to avoid changing an existing contract other consumers might depend on — flag for confirmation with the developer before implementation.
+3. Is there a known reason `/api/invoices` specifically (vs. `/api/invoices/stats`) would be slower on staging right now (e.g., recent data volume growth from a bulk import, a missing index after a recent migration)? Nothing in the repo history reviewed here points to a specific culprit; this needs a live staging check, not just static code review.
+4. Should FR-2's tab-gated fetching also apply retroactively to `useIssuedInvoiceSyncStats` (i.e., should Statistics tab data similarly wait for `activeTab === 'statistics'`)? Out of scope as stated above since Statistics is the default tab and its query firing eagerly on mount is intentional/harmless to this bug, but worth flagging in case the team wants full tab-lazy-loading symmetry.
 
 ## Status: HAS_QUESTIONS

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-09T00:22:07.462605Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "decouple-issued-invoices-shell-from-grid-loading",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-09T00:39:11.174117Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-09T00:39:11.482886Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-09T00:27:15.084973Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-09T00:28:15.194975Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3541",
+  "issue_number": 3541,
+  "created_at": "2026-07-09T00:15:14.879086Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-09T00:29:59.897025Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-09T00:30:15.250418Z"
     }
   },
   "tasks": [
     {
       "name": "decouple-issued-invoices-shell-from-grid-loading",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-09T00:30:15.476315Z"
     }
   ]
 }

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-09T00:22:07.462605Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-09T00:27:15.084973Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-09T00:28:15.194975Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-09T00:29:59.897025Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3541/state.json
+++ b/artifacts/feat-3541/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-09T00:29:59.897025Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-09T00:30:15.250418Z"
+      "status": "completed",
+      "updated_at": "2026-07-09T00:39:11.174117Z"
     }
   },
   "tasks": [
     {
       "name": "decouple-issued-invoices-shell-from-grid-loading",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-09T00:30:15.476315Z"
+      "updated_at": "2026-07-09T00:39:05.707692Z"
     }
   ]
 }

--- a/artifacts/feat-3541/task-context/decouple-issued-invoices-shell-from-grid-loading.md
+++ b/artifacts/feat-3541/task-context/decouple-issued-invoices-shell-from-grid-loading.md
@@ -1,0 +1,243 @@
+### task: decouple-issued-invoices-shell-from-grid-loading
+
+**Goal**
+
+Make the Issued Invoices page header (`<h1>Vydané faktury</h1>`) and tab navigation
+(Statistiky / Seznam buttons) render immediately on mount, independent of the grid/list data
+query's loading or error state, and stop that query from firing at all until the user opens the
+Seznam tab. This fixes 29 nightly E2E specs in `frontend/test/e2e/issued-invoices/` that currently
+time out because the tab bar never appears while `GET /api/invoices` is pending or slow.
+
+**Context**
+
+Root cause (confirmed in the current worktree, exact line numbers verified):
+
+`frontend/src/pages/customer/IssuedInvoicesPage.tsx` calls `useIssuedInvoicesList(...)` at the page
+level (lines 68–84) and, before returning the shell JSX, has:
+
+```tsx
+// lines 314–323
+if (loading) {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="flex items-center space-x-2">
+        <Loader2 className="h-5 w-5 animate-spin text-indigo-500" />
+        <div className="text-gray-500 dark:text-graphite-muted">Načítání faktur...</div>
+      </div>
+    </div>
+  );
+}
+
+// lines 325–334
+if (error) {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="flex items-center space-x-2 text-red-600 dark:text-red-400">
+        <AlertCircle className="h-5 w-5" />
+        <div>Chyba při načítání faktur: {error.message}</div>
+      </div>
+    </div>
+  );
+}
+```
+
+`loading`/`error` here are destructured from `useIssuedInvoicesList` (the **grid** query, line 70
+`isLoading: loading`, line 71 `error`). `activeTab` defaults to `'statistics'` (line 31), but these
+guards run unconditionally before the `<h1>` (line 431) and tab `<nav>` (lines 435–460) are
+reached — so the whole page is held hostage by a query for data the default-tab user never asked
+for.
+
+The fix does **not** need new JSX: an equivalent, correctly-scoped loading/error block already
+exists — currently dead code — inside the `activeTab === 'grid'` branch at lines 591–604:
+
+```tsx
+{loading ? (
+  <div className="flex items-center justify-center h-64">
+    <div className="flex items-center space-x-2">
+      <Loader2 className="h-5 w-5 animate-spin text-indigo-500" />
+      <div className="text-gray-500 dark:text-graphite-muted">Načítání faktur...</div>
+    </div>
+  </div>
+) : error ? (
+  <div className="flex items-center justify-center h-64">
+    <div className="flex items-center space-x-2 text-red-600 dark:text-red-400">
+      <AlertCircle className="h-5 w-5" />
+      <div>Chyba při načítání faktur: {(error as Error)?.message || 'Neočekávaná chyba'}</div>
+    </div>
+  </div>
+) : (
+  ... table ...
+)}
+```
+
+This becomes live and reachable once the page-level guard is removed (arch review Decision 1,
+Option 1 — delete outright, do not narrow the condition, do not extract a new `GridTab` component;
+Options 2 and 3 were explicitly rejected as reintroducing coupling / over-scoping a surgical fix).
+
+`useIssuedInvoicesList` (`frontend/src/api/hooks/useIssuedInvoices.ts`, lines 22–88) has no
+`enabled` gate today — it always fires on mount. The design doc specifies the exact new shape
+(arch review Decision 2, design doc "Component Design" section):
+
+```ts
+export interface UseIssuedInvoicesListOptions {
+  enabled?: boolean;
+}
+
+export const useIssuedInvoicesList = (
+  filters: IssuedInvoicesFilters,
+  options?: UseIssuedInvoicesListOptions,
+) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.issuedInvoices, filters],   // UNCHANGED — do not append options/enabled
+    queryFn: async (): Promise<IGetIssuedInvoicesListResponse> => { /* unchanged body */ },
+    enabled: options?.enabled ?? true,                    // NEW
+    staleTime: 5 * 60 * 1000,                              // unchanged
+    gcTime: 10 * 60 * 1000,                                // unchanged
+  });
+};
+```
+
+Critical constraint (design doc, "Interfaces and Contracts" + arch review Decision 2 rationale):
+`enabled` must be a **second, optional** parameter — never folded into `IssuedInvoicesFilters` and
+never appended to `queryKey`. Doing either would change the cache key and break FR-2's acceptance
+criterion that switching back to Grid within `staleTime` (5 min) does not refetch. Default
+(`options` omitted or `options.enabled` omitted) must be `true`, so any other current or future
+caller of `useIssuedInvoicesList` keeps today's eager-fetch behavior with no changes required at
+that call site. This mirrors the existing internal pattern already in the same file:
+`useIssuedInvoiceDetail` (line 116) already does `enabled: !!invoiceId`.
+
+The page's call site (lines 68–84) passes the new option:
+
+```tsx
+} = useIssuedInvoicesList(
+  {
+    pageNumber,
+    pageSize,
+    sortBy,
+    sortDescending,
+    invoiceId: invoiceIdFilter.trim() || undefined,
+    customerName: customerNameFilter.trim() || undefined,
+    invoiceDateFrom: invoiceDateFrom ? new Date(invoiceDateFrom).toISOString() : undefined,
+    invoiceDateTo: invoiceDateTo ? new Date(invoiceDateTo).toISOString() : undefined,
+    showOnlyUnsynced,
+    showOnlyWithErrors,
+  },
+  { enabled: activeTab === 'grid' },   // NEW second argument
+);
+```
+
+This is the same gating precedent already used in this file for `refetchRunningJobs` at the
+existing `useEffect` (lines 191–195: `if (activeTab === 'grid') { refetchRunningJobs(); }`) — not a
+new pattern for this component.
+
+Finally, per spec FR-4 and arch review Decision 3, add a `data-loading="true"` marker to the
+now-reachable loading container (line 592) so `waitForLoadingComplete()`
+(`frontend/test/e2e/helpers/wait-helpers.ts`, lines 81–92) — which matches
+`[data-loading="true"], .loading, .spinner, [aria-busy="true"]` and currently silently no-ops
+because none of those match — actually blocks. This is a documented, known class of bug in this
+same helper file (see the long comment at lines 94–130 describing the identical issue for the
+Catalog module); this task only fixes the marker for the Issued Invoices grid, not the helper's
+general reliability (out of scope per spec).
+
+**Files to modify**
+
+1. `frontend/src/api/hooks/useIssuedInvoices.ts`
+2. `frontend/src/pages/customer/IssuedInvoicesPage.tsx`
+
+No new files. No backend files. No test-helper files (`wait-helpers.ts` itself is not modified —
+only the component markup that helper reads).
+
+**Implementation steps**
+
+1. In `frontend/src/api/hooks/useIssuedInvoices.ts`:
+   a. Add `export interface UseIssuedInvoicesListOptions { enabled?: boolean; }` above
+      `useIssuedInvoicesList` (after the `IssuedInvoicesFilters` interface, line 20).
+   b. Change the `useIssuedInvoicesList` signature from
+      `(filters: IssuedInvoicesFilters)` to
+      `(filters: IssuedInvoicesFilters, options?: UseIssuedInvoicesListOptions)`.
+   c. Add `enabled: options?.enabled ?? true,` to the `useQuery({...})` options object (alongside
+      the existing `staleTime`/`gcTime`, line 85–86 area). Do not touch `queryKey` (line 25) or
+      `queryFn` (lines 26–84).
+
+2. In `frontend/src/pages/customer/IssuedInvoicesPage.tsx`:
+   a. Update the `useIssuedInvoicesList(...)` call site (lines 73–84) to pass
+      `{ enabled: activeTab === 'grid' }` as the second argument, per the exact snippet above.
+   b. Delete the page-level `if (loading) { return ...; }` block (lines 314–323) in full.
+   c. Delete the page-level `if (error) { return ...; }` block (lines 325–334) in full.
+   d. Add `data-loading="true"` to the loading container inside the `activeTab === 'grid'` branch
+      (the outermost `<div className="flex items-center justify-center h-64">` at line 592, the
+      one wrapping the `Loader2`/"Načítání faktur..." markup — do **not** add it to the
+      `StatisticsTab`'s equivalent loading block at line 340, which is out of scope; only the grid
+      tab's marker is required by FR-4).
+   e. Verify (visually re-read the file after edits) that the grid tab's loading/error/content
+      ternary at (previously) lines 591–620 is otherwise untouched, and that no other reference to
+      the deleted top-level `loading`/`error` guards remains (the `loading`/`error` variables
+      themselves stay — they're still used inside the `activeTab === 'grid'` ternary and are still
+      destructured from the hook at lines 68–71).
+
+3. Do not modify: `StatisticsTab` inline component (lines 337–358), the `useEffect` at lines
+   191–195, `useIssuedInvoiceSyncStats` usage (unconditional/eager, unchanged per spec Open
+   Question 4 being explicitly out of scope), `IssuedInvoicesFilters` interface, any backend file,
+   any OpenAPI-generated client file.
+
+4. Do not add the `data.success` check to `useIssuedInvoicesList`'s `queryFn` — that is the
+   Decision-4 follow-up, explicitly deferred to a separate PR. The `if (!response.ok) throw ...`
+   at line 76–78 of `useIssuedInvoices.ts` stays exactly as-is.
+
+**Tests to write/update**
+
+No new E2E spec files are required — the 29 existing specs in
+`frontend/test/e2e/issued-invoices/` (`filters.spec.ts`, `navigation.spec.ts`,
+`status-badges.spec.ts`, `sorting.spec.ts`, `pagination.spec.ts`) already assert the tab bar and
+heading appear; they are expected to pass once this fix lands, with no spec-file edits needed (per
+spec's Out of Scope: do not redesign the `Promise.race` pattern in `filters.spec.ts`'s
+`beforeEach`, lines 6–36, or remove existing `waitForTimeout` stabilization waits — they already
+correctly detect the failure mode and should simply start passing).
+
+Validation steps for the developer:
+1. Local/dev manual check: load `/customer/issued-invoices` with the Network tab open — confirm
+   `GET /api/invoices` is **not** issued until the "Seznam" tab is clicked, and that the header +
+   both tab buttons are visible immediately regardless of that request's timing (per spec FR-1/FR-2
+   acceptance criteria). If feasible, artificially delay `/api/invoices` locally (e.g., a dev-only
+   network throttle or a temporary `await new Promise(r => setTimeout(r, 5000))` in a local branch
+   only, never committed) to confirm the shell still renders and only the grid panel shows the
+   scoped spinner.
+2. Run the full `issued-invoices` module E2E suite locally/against a reachable backend per
+   `docs/testing/playwright-e2e-testing.md` (using `navigateToApp()`-based auth, not
+   `createE2EAuthSession()` alone) and confirm all 29 specs pass. If a local run against staging
+   isn't feasible in this environment, this must be confirmed on the next nightly E2E run
+   (`./scripts/run-playwright-tests.sh` against staging, per CLAUDE.md) — do not claim the fix is
+   validated on staging without that run's evidence.
+3. Confirm switching Statistics → Seznam → Statistics → Seznam again within 5 minutes does not
+   re-issue `GET /api/invoices` a second time (React Query `staleTime` cache reuse, FR-2's third
+   acceptance criterion) — observable via the Network tab (only one request logged across the
+   round trip).
+
+**Acceptance criteria**
+
+- `h1:has-text("Vydané faktury")` and both `button:has-text("Statistiky")` /
+  `button:has-text("Seznam")` render immediately on mount, regardless of `/api/invoices`'s timing,
+  failure, or hang state (spec FR-1).
+- No `GET /api/invoices` request fires while the default Statistics tab is active and Grid has
+  never been opened; exactly one request fires on first switch to Seznam; no duplicate request on
+  toggling back to Grid within `staleTime` (spec FR-2).
+- The "Načítání faktur..." spinner and "Chyba při načítání faktur" message only ever appear inside
+  the Grid tab's content region, never full-page; the header and tab bar remain visible and
+  clickable at all times, including while the Grid tab is loading or erroring (spec FR-3).
+- The Grid tab's loading container carries `data-loading="true"`, and `waitForLoadingComplete()`
+  actually waits for it to disappear rather than no-op'ing (spec FR-4).
+- `useIssuedInvoicesList`'s `queryKey` and cache behavior (`staleTime`, `gcTime`) are byte-for-byte
+  unchanged; `IssuedInvoicesFilters` interface is unchanged; no wire/API contract changes.
+- The `Success: false` response-swallowing issue (arch review Decision 4) is **not** touched in
+  this change — `useIssuedInvoicesList`'s `queryFn` response handling (the `if (!response.ok)
+  throw` check) is identical before and after this task's diff.
+- No backend files (`GetIssuedInvoicesListHandler.cs`, `InvoicesController.cs`,
+  `IssuedInvoiceRepository`) are modified.
+- All 29 existing specs under `frontend/test/e2e/issued-invoices/` pass against the fixed
+  component (confirmed locally where possible; confirmed on the next nightly staging run per
+  CLAUDE.md's E2E validation rule — the nightly suite is not part of PR CI).
+- `npm run build` and `npm run lint` both pass with no new errors or warnings introduced by this
+  change (per CLAUDE.md's mandatory validation-before-completion rule).
+- The diff touches only `frontend/src/api/hooks/useIssuedInvoices.ts` and
+  `frontend/src/pages/customer/IssuedInvoicesPage.tsx` — no unrelated formatting, comment, or
+  adjacent-code changes (CLAUDE.md "surgical changes" rule).

--- a/artifacts/feat-3541/task-plan.r1.md
+++ b/artifacts/feat-3541/task-plan.r1.md
@@ -1,0 +1,264 @@
+# Implementation Task Plan: Fix Issued Invoices page shell blocked by grid-data loading
+
+Source documents: `artifacts/feat-3541/spec.r1.md`, `artifacts/feat-3541/arch-review.r1.md`,
+`artifacts/feat-3541/design.r1.md`. All three agree this is a small, surgical frontend fix
+(Decisions 1–3 in the arch review). This plan defines **one** task because the two files that
+change (`useIssuedInvoices.ts` and `IssuedInvoicesPage.tsx`) are tightly coupled — the page's call
+site cannot compile/pass without the hook's new `options` parameter existing first, and both edits
+are reviewed together as a single before/after behavior change. Splitting them into separate PRs
+would leave an intermediate broken state with no independent value. There is no meaningful second
+task to extract without violating the "keep it tight" instruction.
+
+**Explicitly excluded from this task** (per arch review Decision 4 and spec's Out of Scope): the
+`Success: false` swallowing bug in `useIssuedInvoicesList` (i.e., adding a `if (!data.success) throw`
+check mirroring `useIssuedInvoiceSyncStats.ts:53`) and the FR-5 backend latency diagnosis. Do not
+touch `useIssuedInvoices.ts`'s response-handling logic beyond adding the `enabled` option. Do not
+touch `GetIssuedInvoicesListHandler.cs` or `InvoicesController.cs`. These are tracked as a separate
+follow-up per the architect's explicit decision to keep this PR's diff to the rendering/query-gating
+defect only.
+
+---
+
+### task: decouple-issued-invoices-shell-from-grid-loading
+
+**Goal**
+
+Make the Issued Invoices page header (`<h1>Vydané faktury</h1>`) and tab navigation
+(Statistiky / Seznam buttons) render immediately on mount, independent of the grid/list data
+query's loading or error state, and stop that query from firing at all until the user opens the
+Seznam tab. This fixes 29 nightly E2E specs in `frontend/test/e2e/issued-invoices/` that currently
+time out because the tab bar never appears while `GET /api/invoices` is pending or slow.
+
+**Context**
+
+Root cause (confirmed in the current worktree, exact line numbers verified):
+
+`frontend/src/pages/customer/IssuedInvoicesPage.tsx` calls `useIssuedInvoicesList(...)` at the page
+level (lines 68–84) and, before returning the shell JSX, has:
+
+```tsx
+// lines 314–323
+if (loading) {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="flex items-center space-x-2">
+        <Loader2 className="h-5 w-5 animate-spin text-indigo-500" />
+        <div className="text-gray-500 dark:text-graphite-muted">Načítání faktur...</div>
+      </div>
+    </div>
+  );
+}
+
+// lines 325–334
+if (error) {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="flex items-center space-x-2 text-red-600 dark:text-red-400">
+        <AlertCircle className="h-5 w-5" />
+        <div>Chyba při načítání faktur: {error.message}</div>
+      </div>
+    </div>
+  );
+}
+```
+
+`loading`/`error` here are destructured from `useIssuedInvoicesList` (the **grid** query, line 70
+`isLoading: loading`, line 71 `error`). `activeTab` defaults to `'statistics'` (line 31), but these
+guards run unconditionally before the `<h1>` (line 431) and tab `<nav>` (lines 435–460) are
+reached — so the whole page is held hostage by a query for data the default-tab user never asked
+for.
+
+The fix does **not** need new JSX: an equivalent, correctly-scoped loading/error block already
+exists — currently dead code — inside the `activeTab === 'grid'` branch at lines 591–604:
+
+```tsx
+{loading ? (
+  <div className="flex items-center justify-center h-64">
+    <div className="flex items-center space-x-2">
+      <Loader2 className="h-5 w-5 animate-spin text-indigo-500" />
+      <div className="text-gray-500 dark:text-graphite-muted">Načítání faktur...</div>
+    </div>
+  </div>
+) : error ? (
+  <div className="flex items-center justify-center h-64">
+    <div className="flex items-center space-x-2 text-red-600 dark:text-red-400">
+      <AlertCircle className="h-5 w-5" />
+      <div>Chyba při načítání faktur: {(error as Error)?.message || 'Neočekávaná chyba'}</div>
+    </div>
+  </div>
+) : (
+  ... table ...
+)}
+```
+
+This becomes live and reachable once the page-level guard is removed (arch review Decision 1,
+Option 1 — delete outright, do not narrow the condition, do not extract a new `GridTab` component;
+Options 2 and 3 were explicitly rejected as reintroducing coupling / over-scoping a surgical fix).
+
+`useIssuedInvoicesList` (`frontend/src/api/hooks/useIssuedInvoices.ts`, lines 22–88) has no
+`enabled` gate today — it always fires on mount. The design doc specifies the exact new shape
+(arch review Decision 2, design doc "Component Design" section):
+
+```ts
+export interface UseIssuedInvoicesListOptions {
+  enabled?: boolean;
+}
+
+export const useIssuedInvoicesList = (
+  filters: IssuedInvoicesFilters,
+  options?: UseIssuedInvoicesListOptions,
+) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.issuedInvoices, filters],   // UNCHANGED — do not append options/enabled
+    queryFn: async (): Promise<IGetIssuedInvoicesListResponse> => { /* unchanged body */ },
+    enabled: options?.enabled ?? true,                    // NEW
+    staleTime: 5 * 60 * 1000,                              // unchanged
+    gcTime: 10 * 60 * 1000,                                // unchanged
+  });
+};
+```
+
+Critical constraint (design doc, "Interfaces and Contracts" + arch review Decision 2 rationale):
+`enabled` must be a **second, optional** parameter — never folded into `IssuedInvoicesFilters` and
+never appended to `queryKey`. Doing either would change the cache key and break FR-2's acceptance
+criterion that switching back to Grid within `staleTime` (5 min) does not refetch. Default
+(`options` omitted or `options.enabled` omitted) must be `true`, so any other current or future
+caller of `useIssuedInvoicesList` keeps today's eager-fetch behavior with no changes required at
+that call site. This mirrors the existing internal pattern already in the same file:
+`useIssuedInvoiceDetail` (line 116) already does `enabled: !!invoiceId`.
+
+The page's call site (lines 68–84) passes the new option:
+
+```tsx
+} = useIssuedInvoicesList(
+  {
+    pageNumber,
+    pageSize,
+    sortBy,
+    sortDescending,
+    invoiceId: invoiceIdFilter.trim() || undefined,
+    customerName: customerNameFilter.trim() || undefined,
+    invoiceDateFrom: invoiceDateFrom ? new Date(invoiceDateFrom).toISOString() : undefined,
+    invoiceDateTo: invoiceDateTo ? new Date(invoiceDateTo).toISOString() : undefined,
+    showOnlyUnsynced,
+    showOnlyWithErrors,
+  },
+  { enabled: activeTab === 'grid' },   // NEW second argument
+);
+```
+
+This is the same gating precedent already used in this file for `refetchRunningJobs` at the
+existing `useEffect` (lines 191–195: `if (activeTab === 'grid') { refetchRunningJobs(); }`) — not a
+new pattern for this component.
+
+Finally, per spec FR-4 and arch review Decision 3, add a `data-loading="true"` marker to the
+now-reachable loading container (line 592) so `waitForLoadingComplete()`
+(`frontend/test/e2e/helpers/wait-helpers.ts`, lines 81–92) — which matches
+`[data-loading="true"], .loading, .spinner, [aria-busy="true"]` and currently silently no-ops
+because none of those match — actually blocks. This is a documented, known class of bug in this
+same helper file (see the long comment at lines 94–130 describing the identical issue for the
+Catalog module); this task only fixes the marker for the Issued Invoices grid, not the helper's
+general reliability (out of scope per spec).
+
+**Files to modify**
+
+1. `frontend/src/api/hooks/useIssuedInvoices.ts`
+2. `frontend/src/pages/customer/IssuedInvoicesPage.tsx`
+
+No new files. No backend files. No test-helper files (`wait-helpers.ts` itself is not modified —
+only the component markup that helper reads).
+
+**Implementation steps**
+
+1. In `frontend/src/api/hooks/useIssuedInvoices.ts`:
+   a. Add `export interface UseIssuedInvoicesListOptions { enabled?: boolean; }` above
+      `useIssuedInvoicesList` (after the `IssuedInvoicesFilters` interface, line 20).
+   b. Change the `useIssuedInvoicesList` signature from
+      `(filters: IssuedInvoicesFilters)` to
+      `(filters: IssuedInvoicesFilters, options?: UseIssuedInvoicesListOptions)`.
+   c. Add `enabled: options?.enabled ?? true,` to the `useQuery({...})` options object (alongside
+      the existing `staleTime`/`gcTime`, line 85–86 area). Do not touch `queryKey` (line 25) or
+      `queryFn` (lines 26–84).
+
+2. In `frontend/src/pages/customer/IssuedInvoicesPage.tsx`:
+   a. Update the `useIssuedInvoicesList(...)` call site (lines 73–84) to pass
+      `{ enabled: activeTab === 'grid' }` as the second argument, per the exact snippet above.
+   b. Delete the page-level `if (loading) { return ...; }` block (lines 314–323) in full.
+   c. Delete the page-level `if (error) { return ...; }` block (lines 325–334) in full.
+   d. Add `data-loading="true"` to the loading container inside the `activeTab === 'grid'` branch
+      (the outermost `<div className="flex items-center justify-center h-64">` at line 592, the
+      one wrapping the `Loader2`/"Načítání faktur..." markup — do **not** add it to the
+      `StatisticsTab`'s equivalent loading block at line 340, which is out of scope; only the grid
+      tab's marker is required by FR-4).
+   e. Verify (visually re-read the file after edits) that the grid tab's loading/error/content
+      ternary at (previously) lines 591–620 is otherwise untouched, and that no other reference to
+      the deleted top-level `loading`/`error` guards remains (the `loading`/`error` variables
+      themselves stay — they're still used inside the `activeTab === 'grid'` ternary and are still
+      destructured from the hook at lines 68–71).
+
+3. Do not modify: `StatisticsTab` inline component (lines 337–358), the `useEffect` at lines
+   191–195, `useIssuedInvoiceSyncStats` usage (unconditional/eager, unchanged per spec Open
+   Question 4 being explicitly out of scope), `IssuedInvoicesFilters` interface, any backend file,
+   any OpenAPI-generated client file.
+
+4. Do not add the `data.success` check to `useIssuedInvoicesList`'s `queryFn` — that is the
+   Decision-4 follow-up, explicitly deferred to a separate PR. The `if (!response.ok) throw ...`
+   at line 76–78 of `useIssuedInvoices.ts` stays exactly as-is.
+
+**Tests to write/update**
+
+No new E2E spec files are required — the 29 existing specs in
+`frontend/test/e2e/issued-invoices/` (`filters.spec.ts`, `navigation.spec.ts`,
+`status-badges.spec.ts`, `sorting.spec.ts`, `pagination.spec.ts`) already assert the tab bar and
+heading appear; they are expected to pass once this fix lands, with no spec-file edits needed (per
+spec's Out of Scope: do not redesign the `Promise.race` pattern in `filters.spec.ts`'s
+`beforeEach`, lines 6–36, or remove existing `waitForTimeout` stabilization waits — they already
+correctly detect the failure mode and should simply start passing).
+
+Validation steps for the developer:
+1. Local/dev manual check: load `/customer/issued-invoices` with the Network tab open — confirm
+   `GET /api/invoices` is **not** issued until the "Seznam" tab is clicked, and that the header +
+   both tab buttons are visible immediately regardless of that request's timing (per spec FR-1/FR-2
+   acceptance criteria). If feasible, artificially delay `/api/invoices` locally (e.g., a dev-only
+   network throttle or a temporary `await new Promise(r => setTimeout(r, 5000))` in a local branch
+   only, never committed) to confirm the shell still renders and only the grid panel shows the
+   scoped spinner.
+2. Run the full `issued-invoices` module E2E suite locally/against a reachable backend per
+   `docs/testing/playwright-e2e-testing.md` (using `navigateToApp()`-based auth, not
+   `createE2EAuthSession()` alone) and confirm all 29 specs pass. If a local run against staging
+   isn't feasible in this environment, this must be confirmed on the next nightly E2E run
+   (`./scripts/run-playwright-tests.sh` against staging, per CLAUDE.md) — do not claim the fix is
+   validated on staging without that run's evidence.
+3. Confirm switching Statistics → Seznam → Statistics → Seznam again within 5 minutes does not
+   re-issue `GET /api/invoices` a second time (React Query `staleTime` cache reuse, FR-2's third
+   acceptance criterion) — observable via the Network tab (only one request logged across the
+   round trip).
+
+**Acceptance criteria**
+
+- `h1:has-text("Vydané faktury")` and both `button:has-text("Statistiky")` /
+  `button:has-text("Seznam")` render immediately on mount, regardless of `/api/invoices`'s timing,
+  failure, or hang state (spec FR-1).
+- No `GET /api/invoices` request fires while the default Statistics tab is active and Grid has
+  never been opened; exactly one request fires on first switch to Seznam; no duplicate request on
+  toggling back to Grid within `staleTime` (spec FR-2).
+- The "Načítání faktur..." spinner and "Chyba při načítání faktur" message only ever appear inside
+  the Grid tab's content region, never full-page; the header and tab bar remain visible and
+  clickable at all times, including while the Grid tab is loading or erroring (spec FR-3).
+- The Grid tab's loading container carries `data-loading="true"`, and `waitForLoadingComplete()`
+  actually waits for it to disappear rather than no-op'ing (spec FR-4).
+- `useIssuedInvoicesList`'s `queryKey` and cache behavior (`staleTime`, `gcTime`) are byte-for-byte
+  unchanged; `IssuedInvoicesFilters` interface is unchanged; no wire/API contract changes.
+- The `Success: false` response-swallowing issue (arch review Decision 4) is **not** touched in
+  this change — `useIssuedInvoicesList`'s `queryFn` response handling (the `if (!response.ok)
+  throw` check) is identical before and after this task's diff.
+- No backend files (`GetIssuedInvoicesListHandler.cs`, `InvoicesController.cs`,
+  `IssuedInvoiceRepository`) are modified.
+- All 29 existing specs under `frontend/test/e2e/issued-invoices/` pass against the fixed
+  component (confirmed locally where possible; confirmed on the next nightly staging run per
+  CLAUDE.md's E2E validation rule — the nightly suite is not part of PR CI).
+- `npm run build` and `npm run lint` both pass with no new errors or warnings introduced by this
+  change (per CLAUDE.md's mandatory validation-before-completion rule).
+- The diff touches only `frontend/src/api/hooks/useIssuedInvoices.ts` and
+  `frontend/src/pages/customer/IssuedInvoicesPage.tsx` — no unrelated formatting, comment, or
+  adjacent-code changes (CLAUDE.md "surgical changes" rule).

--- a/frontend/src/api/hooks/useIssuedInvoices.ts
+++ b/frontend/src/api/hooks/useIssuedInvoices.ts
@@ -19,8 +19,15 @@ export interface IssuedInvoicesFilters {
   showOnlyWithErrors?: boolean;
 }
 
+export interface UseIssuedInvoicesListOptions {
+  enabled?: boolean;
+}
+
 // Hook for fetching paginated list of issued invoices
-export const useIssuedInvoicesList = (filters: IssuedInvoicesFilters) => {
+export const useIssuedInvoicesList = (
+  filters: IssuedInvoicesFilters,
+  options?: UseIssuedInvoicesListOptions,
+) => {
   return useQuery({
     queryKey: [...QUERY_KEYS.issuedInvoices, filters],
     queryFn: async (): Promise<IGetIssuedInvoicesListResponse> => {
@@ -82,6 +89,7 @@ export const useIssuedInvoicesList = (filters: IssuedInvoicesFilters) => {
       // `new Date(...)` if needed.
       return response.json();
     },
+    enabled: options?.enabled ?? true,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
   });

--- a/frontend/src/pages/customer/IssuedInvoicesPage.tsx
+++ b/frontend/src/pages/customer/IssuedInvoicesPage.tsx
@@ -81,7 +81,7 @@ const IssuedInvoicesPage: React.FC = () => {
     invoiceDateTo: invoiceDateTo ? new Date(invoiceDateTo).toISOString() : undefined,
     showOnlyUnsynced,
     showOnlyWithErrors,
-  });
+  }, { enabled: activeTab === 'grid' });
 
   // Use sync stats API for statistics tab
   const {
@@ -310,28 +310,6 @@ const IssuedInvoicesPage: React.FC = () => {
       </span>
     );
   };
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="flex items-center space-x-2">
-          <Loader2 className="h-5 w-5 animate-spin text-indigo-500" />
-          <div className="text-gray-500 dark:text-graphite-muted">Načítání faktur...</div>
-        </div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="flex items-center space-x-2 text-red-600 dark:text-red-400">
-          <AlertCircle className="h-5 w-5" />
-          <div>Chyba při načítání faktur: {error.message}</div>
-        </div>
-      </div>
-    );
-  }
 
   // Statistics tab component
   const StatisticsTab: React.FC = () => {
@@ -589,7 +567,7 @@ const IssuedInvoicesPage: React.FC = () => {
           {/* Data Grid - Scrollable */}
           <div className="flex-1 bg-white dark:bg-graphite-surface shadow dark:shadow-soft-dark rounded-lg overflow-hidden flex flex-col min-h-0 relative">
             {loading ? (
-              <div className="flex items-center justify-center h-64">
+              <div data-loading="true" className="flex items-center justify-center h-64">
                 <div className="flex items-center space-x-2">
                   <Loader2 className="h-5 w-5 animate-spin text-indigo-500" />
                   <div className="text-gray-500 dark:text-graphite-muted">Načítání faktur...</div>


### PR DESCRIPTION
Closes #3541

## What the issue was

The nightly E2E regression run (#191, `main@738a99c`) failed 29 tests in the `issued-invoices` module. `button:has-text("Seznam")`, `h1:has-text("Vydané faktury")`, and `button:has-text("Statistiky")` all timed out after 30s, indicating the Issued Invoices page shell (heading + tab bar) never rendered.

## How it was fixed / handled

Root cause: `frontend/src/pages/customer/IssuedInvoicesPage.tsx` had a page-level `if (loading) return ...` / `if (error) return ...` guard tied to the grid-tab-only `useIssuedInvoicesList` query, placed *before* the JSX that renders the page heading and tab navigation. Since that query fired unconditionally on mount (even though the page defaults to the Statistics tab), any slowness or hang in `GET /api/invoices` blocked the entire page shell — not just the grid tab's content.

Fix:
- Added an optional `options?: { enabled?: boolean }` second parameter to `useIssuedInvoicesList` (`frontend/src/api/hooks/useIssuedInvoices.ts`), wired to React Query's `enabled` option, defaulting to `true` so no other caller is affected. `queryKey`/`staleTime`/`gcTime` are unchanged.
- `IssuedInvoicesPage.tsx` now passes `{ enabled: activeTab === 'grid' }`, so the grid query only fires once the user actually opens the Seznam tab.
- Removed the page-level `if (loading)`/`if (error)` early returns; the grid tab's own already-existing scoped loading/error block (previously unreachable dead code) now takes over that responsibility for the grid tab only.
- Added `data-loading="true"` to the grid tab's loading container so the E2E helper `waitForLoadingComplete()` can actually detect it.

Scope was kept deliberately tight (single surgical fix): a related `Success: false`-response-swallowing bug and the question of *why* `GET /api/invoices` was slow enough to hit the 30s timeout on staging were investigated but explicitly deferred to a follow-up, since diagnosing actual staging latency requires Application Insights/log access this pipeline doesn't have. This fix makes the UI resilient regardless of that underlying cause.

Verified locally: `npm run build` compiles cleanly, `eslint` on the two changed files reports zero errors/warnings. The 29 previously-failing E2E specs should now pass; per this repo's testing strategy, E2E confirmation happens on the next nightly run (not part of PR CI).

## Artifacts

Brief, spec, architecture review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3541/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUvF3W8AycwqKwg6AsJcWh)_