### PR TITLE
fix: drop GetPackageLabelPdf polling 404s from App Insights request telemetry

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationInsightsExtensions.cs
@@ -70,6 +70,7 @@ public static class ApplicationInsightsExtensions
         services.AddApplicationInsightsTelemetryProcessor<HomeAssistantDependencyTelemetryFilter>();
         services.AddApplicationInsightsTelemetryProcessor<AzureBlobConflictTelemetryFilter>();
         services.AddApplicationInsightsTelemetryProcessor<McpProductNotFoundTelemetryFilter>();
+        services.AddApplicationInsightsTelemetryProcessor<LabelPollNotFoundTelemetryFilter>();
 
         // Configure sampling (more aggressive for cost savings)
         services.Configure<TelemetryConfiguration>((config) =>

--- a/backend/src/Anela.Heblo.API/Infrastructure/Telemetry/LabelPollNotFoundTelemetryFilter.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Telemetry/LabelPollNotFoundTelemetryFilter.cs
@@ -1,0 +1,57 @@
+using Anela.Heblo.API.Controllers;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Anela.Heblo.API.Telemetry;
+
+/// <summary>
+/// Drops the benign HTTP 404 request telemetry emitted while the packaging SPA polls
+/// <c>GET .../packages/{n}/label.pdf</c> for a carrier label that is not ready yet.
+///
+/// When a package is being shipped, the frontend readiness loop
+/// (<c>frontend/src/components/baleni/printLabelPdf.ts</c>) repeatedly requests the label PDF.
+/// Until the carrier has generated the label, the endpoint legitimately answers 404, so a single
+/// print produces a burst of expected 404s. The auto-collected request-tracking module records
+/// each of these as a <em>failed</em> <see cref="RequestTelemetry"/>, flooding the App Insights
+/// Failures blade even though nothing actually failed.
+///
+/// Every in-loop poll carries the <see cref="PackagingController.LabelPollHeader"/>
+/// (<c>X-Label-Poll</c>) header; the final post-timeout confirmation request deliberately omits it.
+/// This filter therefore drops only header-tagged polling 404s and leaves the genuine, un-tagged
+/// final 404 (a truly stuck label) intact as a real failure signal.
+///
+/// Mirrors the established <see cref="AzureBlobConflictTelemetryFilter"/> pattern.
+/// </summary>
+public sealed class LabelPollNotFoundTelemetryFilter : ITelemetryProcessor
+{
+    private const string NotFoundResponseCode = "404";
+
+    private readonly ITelemetryProcessor _next;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public LabelPollNotFoundTelemetryFilter(
+        ITelemetryProcessor next,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+    }
+
+    public void Process(ITelemetry item)
+    {
+        if (item is RequestTelemetry request
+            && string.Equals(request.ResponseCode, NotFoundResponseCode, StringComparison.Ordinal)
+            && IsLabelPoll())
+        {
+            // Expected transient 404 during the SPA's label-readiness poll — not an application failure.
+            return;
+        }
+
+        _next.Process(item);
+    }
+
+    private bool IsLabelPoll() =>
+        _httpContextAccessor.HttpContext?.Request.Headers
+            .ContainsKey(PackagingController.LabelPollHeader) ?? false;
+}

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/Telemetry/LabelPollNotFoundTelemetryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/Telemetry/LabelPollNotFoundTelemetryFilterTests.cs
@@ -1,0 +1,98 @@
+using Anela.Heblo.API.Telemetry;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Moq;
+
+namespace Anela.Heblo.Tests.Infrastructure.Telemetry;
+
+public class LabelPollNotFoundTelemetryFilterTests
+{
+    private const string LabelPollHeader = "X-Label-Poll";
+
+    private readonly Mock<ITelemetryProcessor> _next = new();
+
+    private LabelPollNotFoundTelemetryFilter CreateFilter(bool withPollHeader)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (withPollHeader)
+        {
+            httpContext.Request.Headers[LabelPollHeader] = "1";
+        }
+
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.SetupGet(a => a.HttpContext).Returns(httpContext);
+
+        return new LabelPollNotFoundTelemetryFilter(_next.Object, accessor.Object);
+    }
+
+    [Fact]
+    public void Process_DropsPolling404()
+    {
+        var filter = CreateFilter(withPollHeader: true);
+        var request = new RequestTelemetry { ResponseCode = "404", Success = false };
+
+        filter.Process(request);
+
+        _next.Verify(n => n.Process(It.IsAny<ITelemetry>()), Times.Never);
+    }
+
+    [Fact]
+    public void Process_ForwardsFinal404WithoutPollHeader()
+    {
+        var filter = CreateFilter(withPollHeader: false);
+        var request = new RequestTelemetry { ResponseCode = "404", Success = false };
+
+        filter.Process(request);
+
+        _next.Verify(n => n.Process(request), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsSuccessfulRequestWithPollHeader()
+    {
+        var filter = CreateFilter(withPollHeader: true);
+        var request = new RequestTelemetry { ResponseCode = "200", Success = true };
+
+        filter.Process(request);
+
+        _next.Verify(n => n.Process(request), Times.Once);
+    }
+
+    [Fact]
+    public void Process_Forwards404FromUnrelatedRequestWithoutHeader()
+    {
+        var filter = CreateFilter(withPollHeader: false);
+        var request = new RequestTelemetry { ResponseCode = "404", Success = false };
+
+        filter.Process(request);
+
+        _next.Verify(n => n.Process(request), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsNonRequestTelemetry()
+    {
+        var filter = CreateFilter(withPollHeader: true);
+        var trace = new TraceTelemetry("hello");
+
+        filter.Process(trace);
+
+        _next.Verify(n => n.Process(trace), Times.Once);
+    }
+
+    [Fact]
+    public void Process_ForwardsWhenHttpContextIsNull()
+    {
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.SetupGet(a => a.HttpContext).Returns((HttpContext?)null);
+        var filter = new LabelPollNotFoundTelemetryFilter(_next.Object, accessor.Object);
+        var request = new RequestTelemetry { ResponseCode = "404", Success = false };
+
+        filter.Process(request);
+
+        _next.Verify(n => n.Process(request), Times.Once);
+    }
+}


### PR DESCRIPTION
## Problem
The App Insights Failures blade keeps showing a flood of 404s for `GET Packaging/GetPackageLabelPdf`, which are expected transient responses while the SPA polls for a carrier label that is not ready yet. Yesterday's fix (`0e0ba7350`) only downgraded ILogger lines, so the auto-collected `RequestTelemetry` module still recorded each polling 404 as a failed request.

## Fix
Adds `LabelPollNotFoundTelemetryFilter` (an `ITelemetryProcessor` mirroring the existing `AzureBlobConflictTelemetryFilter`) that drops `RequestTelemetry` for 404s carrying the `X-Label-Poll` header, and registers it in `ApplicationInsightsExtensions`. The genuine, header-less final 404 (a truly stuck label) is preserved as a real failure signal, and the endpoint's HTTP behavior is unchanged. Covered by 6 unit tests.