### PR TITLE
#3567: Fix onSuccess invalidation key in useEnqueueInvoiceImport

### DIFF
--- a/artifacts/feat-3567/arch-review.r1.md
+++ b/artifacts/feat-3567/arch-review.r1.md
@@ -1,0 +1,97 @@
+# Architecture Review: Fix onSuccess invalidation key in useEnqueueInvoiceImport
+
+## Skip Design: true
+
+This is a purely internal frontend logic fix — correcting one React Query invalidation key in a data-fetching hook. There are no new or changed visual components, screens, layouts, or design decisions. The existing `InvoiceImportJobTracker` UI is untouched; only the timing/correctness of its cache refresh improves. No design work is required.
+
+## Architectural Fit Assessment
+
+The fix aligns cleanly with existing patterns and requires no architectural change.
+
+Verified against the codebase:
+- **Query-key convention.** `QUERY_KEYS` is a centralized const map in `frontend/src/api/client.ts` (`invoices: ["invoices"]` at line 500). The file `useAsyncInvoiceImport.ts` already defines and exports the canonical sub-key factory `invoiceImportQueryKeys` (lines 123–128) with `all()`, `jobs()`, `jobStatus(jobId)`, and `runningJobs()`. The bug is simply that `onSuccess` (line 40) hand-writes a literal `[...QUERY_KEYS.invoices, "jobs"]` that diverges from the factory-produced key the query actually registers under (`[...QUERY_KEYS.invoices, "import", "jobs", "running"]`, line 92). React Query prefix-matching never matches, so the invalidation is a silent no-op.
+- **Integration points.** The single integration point is React Query's cache. The mutation (`useEnqueueInvoiceImport`) invalidates; the query (`useRunningInvoiceImportJobs`) consumes. Both live in the same file. No other module reads or writes these keys — `invoiceImportQueryKeys` is exported for external use, but the fix does not depend on external consumers.
+- **No test coverage exists.** There is no `useAsyncInvoiceImport.test.ts` (confirmed via glob and directory listing). This is the one gap worth addressing (see Specification Amendments).
+
+The spec's preferred implementation (`invoiceImportQueryKeys.jobs()`) is the correct, idiomatic choice: it produces the factory-derived key and prefix-matches both the running-jobs and per-job-status queries.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+useEnqueueInvoiceImport (mutation)
+        │  POST /api/invoices/import/enqueue-async
+        │
+        └─ onSuccess ──► queryClient.invalidateQueries({
+                              queryKey: invoiceImportQueryKeys.jobs()   ← FIX
+                          })
+                              │  prefix = ["invoices","import","jobs"]
+                              ▼
+        ┌───────────────────────────────────────────────┐
+        │  React Query cache (prefix match)              │
+        │   • ["invoices","import","jobs","running"]  ◄──┤ useRunningInvoiceImportJobs
+        │   • ["invoices","import","jobs","status",id]◄──┤ useInvoiceImportJobStatus
+        └───────────────────────────────────────────────┘
+                              │ triggers refetch
+                              ▼
+                   InvoiceImportJobTracker (UI, unchanged)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Use the broad `jobs()` prefix rather than the narrow `runningJobs()` key
+**Options considered:**
+- (a) `invoiceImportQueryKeys.runningJobs()` — invalidates only the running-jobs list.
+- (b) `invoiceImportQueryKeys.jobs()` — invalidates all import-job queries (running + status).
+
+**Chosen approach:** (b) `invoiceImportQueryKeys.jobs()`.
+
+**Rationale:** After enqueue, the intent is to refresh the job view. `jobs()` is the broadest correct choice and matches the original comment's intent ("show the new job"). The extra cost is negligible — the status query already polls at `refetchInterval: 2000` and running-jobs at `5000`; both are lightweight. Consistent with the spec's stated preference. If a reviewer prefers minimal blast radius, `runningJobs()` is an acceptable narrower fallback and satisfies all acceptance criteria.
+
+#### Decision 2: Use the factory, never a literal
+**Options considered:** hand-written array literal vs. `invoiceImportQueryKeys` factory.
+**Chosen approach:** Factory (`invoiceImportQueryKeys.jobs()`).
+**Rationale:** The bug's root cause is a literal drifting out of sync with the query registration. Using the factory makes the invalidation key structurally impossible to diverge from the query key. This is the single most important constraint in the spec (acceptance criterion: key must come from the factory, not a literal).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. The change is confined to:
+- `frontend/src/api/hooks/useAsyncInvoiceImport.ts` — lines 38–41, the `onSuccess` body.
+
+Recommended new file (see amendments):
+- `frontend/src/api/hooks/useAsyncInvoiceImport.test.ts` — a focused regression test.
+
+### Interfaces and Contracts
+No interface changes. Public hook signatures (`useEnqueueInvoiceImport`, `useInvoiceImportJobStatus`, `useRunningInvoiceImportJobs`) and the `invoiceImportQueryKeys` factory are unchanged. The exact edit:
+
+```typescript
+onSuccess: () => {
+  queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() });
+},
+```
+
+The stale literal `[...QUERY_KEYS.invoices, "jobs"]` must no longer appear. `invoiceImportQueryKeys` is already defined in the same module (below the hook); because `onSuccess` is a closure invoked at runtime, referencing the const defined later in module scope is safe (it is initialized at module load, long before any mutation resolves). No import changes needed.
+
+### Data Flow
+1. User enqueues import → `mutationFn` POSTs to `/api/invoices/import/enqueue-async`.
+2. On HTTP success → `onSuccess` calls `invalidateQueries` with prefix `["invoices","import","jobs"]`.
+3. React Query marks the running-jobs entry (and any active job-status entry) stale and refetches.
+4. `useRunningInvoiceImportJobs` refetches `/api/invoices/import/running-jobs`; the new job renders in `InvoiceImportJobTracker` immediately, independent of the 5s poll.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Bug silently reintroduced by future edits (literal drift) | Low | Fix uses the factory; add a regression test asserting the enqueued-mutation `onSuccess` invalidates a key that prefix-matches `runningJobs()`. |
+| Broad `jobs()` prefix causes unexpected extra refetches | Very Low | Only two lightweight, already-polling queries share the prefix; incremental cost is one refetch. Acceptable per NFR-1. |
+| Reviewer disagreement on broad vs. narrow key | Very Low | Both are spec-acceptable; default to `jobs()`, note `runningJobs()` as fallback. |
+
+## Specification Amendments
+
+1. **Add a regression test (recommended, not currently in spec's required scope).** No test file exists for this hook. The spec's acceptance criteria are behavioral ("cache entry is invalidated and refetched") but leave verification manual. Add `frontend/src/api/hooks/useAsyncInvoiceImport.test.ts` that renders `useEnqueueInvoiceImport` with a `QueryClient`, spies on `queryClient.invalidateQueries`, resolves the mutation, and asserts it was called with a key equal to `invoiceImportQueryKeys.jobs()` (or that the key prefix-matches `invoiceImportQueryKeys.runningJobs()`). This locks in the fix and guards against literal drift — the exact failure mode this bug represents. This is the only substantive addition; the spec otherwise fully and correctly describes the fix.
+
+2. **No other amendments.** The spec's Out-of-Scope boundaries (no refactor of the other queries to consume the factory, no polling/staleTime changes, no component/backend changes) are architecturally sound and should be honored to keep the change surgical.
+
+## Prerequisites
+None. No migrations, config, feature flags, or infrastructure. The `invoiceImportQueryKeys` factory the fix depends on already exists in the target file. The change is a one-line edit plus an optional test, buildable and testable with the existing frontend toolchain (`npm run build`, `npm run lint`, `npm test`).

--- a/artifacts/feat-3567/brief.md
+++ b/artifacts/feat-3567/brief.md
@@ -1,0 +1,44 @@
+## Module
+Invoices
+
+## Finding
+In `frontend/src/api/hooks/useAsyncInvoiceImport.ts`, the `useEnqueueInvoiceImport` mutation's `onSuccess` callback attempts to invalidate the running-jobs query after an import is enqueued:
+
+```typescript
+// line 40 — useAsyncInvoiceImport.ts
+onSuccess: () => {
+  // Invalidate running jobs queries to show the new job
+  queryClient.invalidateQueries({ queryKey: [...QUERY_KEYS.invoices, "jobs"] });
+},
+```
+
+However, `useRunningInvoiceImportJobs` (line 92 of the same file) registers its cache entry under a different key:
+
+```typescript
+queryKey: [...QUERY_KEYS.invoices, "import", "jobs", "running"]
+```
+
+React Query's prefix-matching means `[...QUERY_KEYS.invoices, "jobs"]` will never match `[...QUERY_KEYS.invoices, "import", "jobs", "running"]`. The running-jobs cache entry is therefore **not invalidated** on success, and the new job doesn't appear immediately in the UI.
+
+The file already exports a canonical key factory at the bottom (`invoiceImportQueryKeys.runningJobs()`) that returns the correct key, but it isn't used in `onSuccess`.
+
+## Why it matters
+The `InvoiceImportJobTracker` relies on an immediate cache refresh to show the new job entry. The `refetchInterval: 5000` poll on `useRunningInvoiceImportJobs` means the job becomes visible within 5 seconds regardless, but the intentional immediate invalidation silently does nothing — a latent source of confusion when the polling interval changes or is removed.
+
+## Suggested fix
+Replace the incorrect key with the exported canonical factory:
+
+```typescript
+onSuccess: () => {
+  queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.runningJobs() });
+},
+```
+
+Or use the broader prefix that covers all import job queries:
+
+```typescript
+queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() });
+```
+
+---
+_Filed by daily arch-review routine on 2026-07-08._

--- a/artifacts/feat-3567/code-review.r1.md
+++ b/artifacts/feat-3567/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/src/api/hooks/useAsyncInvoiceImport.ts:50,92` — `useInvoiceImportJobStatus` and `useRunningInvoiceImportJobs` still build their `queryKey` as hand-written array literals (`[...QUERY_KEYS.invoices, "import", "jobs", "status", jobId || ""]` / `[...QUERY_KEYS.invoices, "import", "jobs", "running"]`) instead of using `invoiceImportQueryKeys.jobStatus(jobId)` / `.runningJobs()`, which are already exported a few lines below. Noted as out-of-scope in the spec, but worth a quick follow-up so the query definitions and the invalidation call share one source of truth.

--- a/artifacts/feat-3567/design.r1.md
+++ b/artifacts/feat-3567/design.r1.md
@@ -1,0 +1,21 @@
+# Design: Fix onSuccess invalidation key in useEnqueueInvoiceImport
+
+## Component Design
+
+`useEnqueueInvoiceImport` (`frontend/src/api/hooks/useAsyncInvoiceImport.ts`) — a React Query mutation hook that POSTs to `/api/invoices/import/enqueue-async`. Its `onSuccess` callback changes from calling `invalidateQueries` with a hand-written literal key to calling it with the module's existing `invoiceImportQueryKeys.jobs()` factory method:
+
+```typescript
+onSuccess: () => {
+  queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() });
+},
+```
+
+No new components, no signature changes. `invoiceImportQueryKeys`, `useRunningInvoiceImportJobs`, and `useInvoiceImportJobStatus` are consumed as-is; only the argument passed to `invalidateQueries` changes.
+
+## Data Schemas
+
+No schema or payload changes. React Query cache keys involved (unchanged in structure, only the invalidation call now targets the correct prefix):
+
+- `invoiceImportQueryKeys.jobs()` → `[...QUERY_KEYS.invoices, "import", "jobs"]` (invalidation target)
+- `invoiceImportQueryKeys.runningJobs()` → `[...QUERY_KEYS.invoices, "import", "jobs", "running"]` (query invalidated via prefix match)
+- `invoiceImportQueryKeys.jobStatus(jobId)` → `[...QUERY_KEYS.invoices, "import", "jobs", "status", jobId]` (also matched via prefix, incidental)

--- a/artifacts/feat-3567/impl/fix-invalidation-key-and-add-test.r1.md
+++ b/artifacts/feat-3567/impl/fix-invalidation-key-and-add-test.r1.md
@@ -1,0 +1,72 @@
+# Implementation: fix-invalidation-key-and-add-test
+
+## What was implemented
+Fixed the `onSuccess` handler of `useEnqueueInvoiceImport` in
+`frontend/src/api/hooks/useAsyncInvoiceImport.ts`, which was invalidating the
+React Query cache with the literal key `["invoices", "jobs"]`. That key never
+prefix-matched the running-jobs query key
+`["invoices", "import", "jobs", "running"]` registered by
+`useRunningInvoiceImportJobs` (they diverge right after `"invoices"`), so the
+running-jobs list never refreshed after a new import was enqueued.
+
+The fix replaces the ad-hoc literal with the module's existing canonical key
+factory, `invoiceImportQueryKeys.jobs()`, which returns
+`["invoices", "import", "jobs"]` — a true prefix of both the running-jobs key
+and the per-job-status key (`["invoices", "import", "jobs", "status", jobId]`).
+
+A regression test was added that renders the mutation hook, spies on the
+`QueryClient`'s `invalidateQueries`, resolves the mutation, and asserts:
+- the invalidation call used `invoiceImportQueryKeys.jobs()` exactly,
+- the old broken literal `["invoices", "jobs"]` was never used,
+- `invoiceImportQueryKeys.runningJobs()` is indeed a prefix-extension of
+  `invoiceImportQueryKeys.jobs()` (making the "why this matters" point
+  concrete in the test itself).
+
+Note: the task context assumed
+`frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts` was a new
+file, but it already existed with a full suite of tests covering
+`useInvoiceImportJobStatus` / `useRunningInvoiceImportJobs` polling behavior
+(`describe('useAsyncInvoiceImport - Job Polling Logic', ...)`). Rather than
+overwrite it, the new test was added as an additional `describe` block in
+the same file, reusing the project's existing shared test helpers
+(`createMockApiClient`, `mockAuthenticatedApiClient`,
+`createQueryClientWrapper` from `frontend/src/api/testUtils.ts`) to match the
+established style of the pre-existing tests in that file, rather than the
+bespoke `jest.mock`/manual-wrapper approach sketched in the task context.
+
+## Files created/modified
+- `frontend/src/api/hooks/useAsyncInvoiceImport.ts` — one-line fix: `onSuccess` now calls `queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() })` instead of the stale literal `[...QUERY_KEYS.invoices, "jobs"]`.
+- `frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts` — added a new `describe('useEnqueueInvoiceImport onSuccess invalidation', ...)` block (existing polling-logic tests untouched); also removed a pre-existing unused import (`getAuthenticatedApiClient`) that ESLint flagged as dead code in this file.
+
+## Tests
+- `frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts`:
+  - Pre-existing: `useInvoiceImportJobStatus` and `useRunningInvoiceImportJobs` polling-interval and stale-time behavior (7 tests, unchanged, still passing).
+  - New: `useEnqueueInvoiceImport onSuccess invalidation` — verifies the mutation's `onSuccess` invalidates the cache with `invoiceImportQueryKeys.jobs()`, not the old broken literal, and that this key is a true prefix of the running-jobs key.
+- Confirmed the new test fails against the pre-fix code (invalidateQueries called with `['invoices', 'jobs']` instead of the expected key) and passes after the fix.
+
+## How to verify
+```
+cd frontend
+CI=true npm test -- useAsyncInvoiceImport --watchAll=false   # 8/8 tests pass
+npm run lint                                                  # no new errors in changed files
+npm run build                                                 # compiles successfully
+```
+
+## Notes
+- The task context's literal test-file template assumed the file didn't exist yet; it did, with unrelated valuable tests, so the test was appended as a new `describe` block using the project's established `testUtils` helpers instead of the from-scratch mocking shown in the task context. This is a deviation from the literal task text but preserves existing test coverage and follows repo conventions (surgical, matches existing style).
+- Removed one pre-existing unused import (`getAuthenticatedApiClient`) from the test file as a minimal drive-by cleanup, since it was flagged by `npm run lint` in the very file being touched and had zero usages before or after this change.
+- Full-project `npm run lint` shows ~148 pre-existing errors/warnings across unrelated files (testing-library rule violations, an unused import in `CatalogList.test.tsx`, etc.) — none of these are in the two files changed by this task, and none were introduced by this change.
+- No changes were made to `artifacts/feat-3567/state.json` (it had a pre-existing modification from the pipeline before this task started, left as-is).
+
+## PR Summary
+
+### Changes
+- Fixed `useEnqueueInvoiceImport`'s `onSuccess` handler in `frontend/src/api/hooks/useAsyncInvoiceImport.ts` to invalidate the React Query cache using the canonical `invoiceImportQueryKeys.jobs()` factory instead of a stale, non-matching literal key (`["invoices", "jobs"]`), which meant the running-jobs list never refreshed after enqueuing a new invoice import.
+- Added a regression test in `frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts` asserting the correct invalidation key is used and the old broken key is not.
+
+### Test plan
+- `cd frontend && CI=true npm test -- useAsyncInvoiceImport --watchAll=false` — all 8 tests pass.
+- `npm run lint` and `npm run build` — no new errors introduced.
+
+## Status
+DONE

--- a/artifacts/feat-3567/review/fix-invalidation-key-and-add-test.r1.md
+++ b/artifacts/feat-3567/review/fix-invalidation-key-and-add-test.r1.md
@@ -1,0 +1,27 @@
+# Code Review: Fix onSuccess invalidation key in useEnqueueInvoiceImport
+
+## Summary
+The implementation replaces the stale literal `[...QUERY_KEYS.invoices, "jobs"]` with the canonical `invoiceImportQueryKeys.jobs()` factory in `useEnqueueInvoiceImport`'s `onSuccess`, exactly as required by FR-1 and the arch review's Decision 1/2. The developer deviated from the task context's literal test-file scaffold (writing a new file with bespoke `jest.mock`) by instead appending a new `describe` block to the pre-existing `useAsyncInvoiceImport.test.ts`, reusing the file's established `testUtils` helpers — a reasonable, lower-risk choice since the "new file" premise in the task context was factually wrong (the file already existed with 7 passing tests). Independent verification confirms the diff matches the summary and all 8 tests pass.
+
+## Review Result: PASS
+
+### task: fix-invalidation-key-and-add-test
+**Status:** PASS
+
+**Verification performed:**
+- `git show 0e64b53`: diff touches exactly the two expected files. The hook change is a single line: `queryClient.invalidateQueries({ queryKey: [...QUERY_KEYS.invoices, "jobs"] })` → `queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() })`. No other lines in `useAsyncInvoiceImport.ts` changed — `mutationFn`, URL, request body, error handling, other hooks, and the `invoiceImportQueryKeys` factory itself are untouched, satisfying FR-1's "no other behavior changed" criterion and the spec's Out-of-Scope constraints.
+- `QUERY_KEYS` import remains in the file and is still used (lines 50, 92 of `useAsyncInvoiceImport.ts`, in `useInvoiceImportJobStatus` and `useRunningInvoiceImportJobs`). Confirmed no other file in `frontend/src` references the stale `["invoices", "jobs"]` literal.
+- Test file diff: the pre-existing `describe('useAsyncInvoiceImport - Job Polling Logic', ...)` block (7 tests) is untouched aside from an added import (`useEnqueueInvoiceImport`, `invoiceImportQueryKeys`) and removal of an unused `getAuthenticatedApiClient` direct import (dead code, correctly flagged by lint and safely removable since the test uses the `client` module mock + `testUtils` helpers instead). A new `describe('useEnqueueInvoiceImport onSuccess invalidation', ...)` block asserts: (a) `invalidateQueries` was called with `invoiceImportQueryKeys.jobs()` exactly, (b) the stale `['invoices', 'jobs']` literal was never used, (c) `runningJobs()` is a true prefix-extension of `jobs()`. This satisfies the arch review's Specification Amendment #1 and FR-1's acceptance criteria.
+- Ran `cd frontend && CI=true npm test -- useAsyncInvoiceImport --watchAll=false` myself: **8/8 tests pass**, matching the implementation summary's claim exactly.
+- Ran `npx eslint` on both changed files directly: zero errors/warnings, consistent with the summary's claim that the ~148 pre-existing lint issues elsewhere are unrelated.
+- The chosen `jobs()` (broad) key over `runningJobs()` (narrow) matches the spec's explicitly preferred implementation and the arch review's Decision 1.
+
+No functional requirement is unmet, no architecture guidance is contradicted, the required regression test exists and passes, and no correctness bugs were found. The deviation from the task context's literal test scaffold is justified (the file already existed) and does not weaken coverage — assertions are equivalent or stronger (it also checks the prefix relationship) than what the task context specified.
+
+## Docs to Update
+None. This is an internal bug fix with no public API, UI, or architecture surface change; no doc in `docs/` references this invalidation key.
+
+## Overall Notes
+- The task context's assumption that `useAsyncInvoiceImport.test.ts` was a new file was incorrect; the developer's summary transparently flagged this and adapted correctly rather than silently overwriting existing coverage.
+- Minor, non-blocking observation: the new test's `wrongKey` comparison uses `JSON.stringify` equality inside `.some(...)`, which is slightly more verbose than necessary but functionally correct and harmless.
+- The drive-by removal of the unused `getAuthenticatedApiClient` import in the test file is a minimal, justified cleanup (dead code in a file already being edited, flagged by lint) and does not violate the "surgical changes" principle in any meaningful way.

--- a/artifacts/feat-3567/spec.r1.md
+++ b/artifacts/feat-3567/spec.r1.md
@@ -1,0 +1,81 @@
+# Specification: Fix onSuccess invalidation key in useEnqueueInvoiceImport
+
+## Summary
+The `useEnqueueInvoiceImport` mutation in `frontend/src/api/hooks/useAsyncInvoiceImport.ts` invalidates React Query caches on success using the key `[...QUERY_KEYS.invoices, "jobs"]`, which does not prefix-match the running-jobs query registered under `[...QUERY_KEYS.invoices, "import", "jobs", "running"]`. As a result the intended immediate cache invalidation is a silent no-op. This is a small, self-contained bug fix: replace the incorrect key with the exported canonical key factory so the running-jobs query is actually invalidated when a new import is enqueued.
+
+## Background
+When a user enqueues an async invoice import, the `useEnqueueInvoiceImport` mutation's `onSuccess` callback is meant to invalidate the running-jobs query so the newly created job appears in the `InvoiceImportJobTracker` UI immediately, without waiting for the next poll.
+
+React Query invalidation uses prefix matching on the query key array. The key currently passed to `invalidateQueries` — `[...QUERY_KEYS.invoices, "jobs"]` — inserts `"jobs"` directly after the invoices prefix, whereas `useRunningInvoiceImportJobs` registers its cache entry under `[...QUERY_KEYS.invoices, "import", "jobs", "running"]` (`"import"` comes before `"jobs"`). Because the segment sequences diverge at the first position after the invoices prefix, the invalidation key never matches the running-jobs entry, so nothing is invalidated.
+
+The functional impact is currently masked: `useRunningInvoiceImportJobs` sets `refetchInterval: 5000`, so the new job becomes visible within ~5 seconds regardless of the broken invalidation. However, the intentional immediate refresh silently does nothing today, and the defect becomes user-visible if the poll interval is lengthened or removed. The file already exports a canonical key factory (`invoiceImportQueryKeys`, lines 123-128) whose `runningJobs()` and `jobs()` helpers return the correct keys, but `onSuccess` does not use it.
+
+## Functional Requirements
+
+### FR-1: Correct the onSuccess invalidation key
+The `onSuccess` callback of `useEnqueueInvoiceImport` must invalidate the running-jobs query using a key that prefix-matches `[...QUERY_KEYS.invoices, "import", "jobs", "running"]`. The fix must use the exported canonical key factory rather than a hand-written literal, so the key stays in sync with the query definition.
+
+Preferred implementation — invalidate the broad job prefix so all import-job queries (running jobs and any job-status entries) are refreshed:
+
+```typescript
+onSuccess: () => {
+  queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() });
+},
+```
+
+`invoiceImportQueryKeys.jobs()` returns `[...QUERY_KEYS.invoices, "import", "jobs"]`, which prefix-matches both the running-jobs query and the per-job status query — the broadest correct choice and consistent with the original intent of refreshing the job view after enqueue.
+
+Acceptable narrower alternative — invalidate only the running-jobs query:
+
+```typescript
+onSuccess: () => {
+  queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.runningJobs() });
+},
+```
+
+**Acceptance criteria:**
+- After `useEnqueueInvoiceImport` resolves successfully, the cache entry for `useRunningInvoiceImportJobs` (key `[...QUERY_KEYS.invoices, "import", "jobs", "running"]`) is invalidated and refetched.
+- The invalidation key is produced by the `invoiceImportQueryKeys` factory (`.jobs()` or `.runningJobs()`), not a hand-written array literal.
+- The stale literal `[...QUERY_KEYS.invoices, "jobs"]` no longer appears in `onSuccess`.
+- No other behavior of the hook (mutation function, URL, request body, error handling) is changed.
+
+### FR-2: Immediate visibility of the enqueued job
+With the corrected key, an enqueued job must appear in the running-jobs list via invalidation-triggered refetch, independent of the `refetchInterval` poll.
+
+**Acceptance criteria:**
+- With `refetchInterval` polling hypothetically disabled, enqueuing an import still causes the new job to appear in the running-jobs list within one refetch cycle triggered by the `onSuccess` invalidation.
+- The existing `refetchInterval: 5000` poll remains unchanged and continues to function as a fallback.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. The change triggers one additional (already-intended) refetch of the running-jobs endpoint per successful enqueue. If the broad `jobs()` prefix is used, any active job-status query is also refetched; these are lightweight polled queries already refetching on short intervals, so the incremental cost is negligible.
+
+### NFR-2: Security
+No security impact. No change to authentication, authorization, request payloads, endpoints, or data exposure. The mutation continues to use `getAuthenticatedApiClient()` and the same `/api/invoices/import/enqueue-async` endpoint.
+
+## Data Model
+No data model changes. Relevant runtime cache entities (React Query keys), unchanged by this fix except for correcting which key is invalidated:
+- Enqueue mutation → `POST /api/invoices/import/enqueue-async`
+- Running jobs query → key `[...QUERY_KEYS.invoices, "import", "jobs", "running"]` → `GET /api/invoices/import/running-jobs`
+- Job status query → key `[...QUERY_KEYS.invoices, "import", "jobs", "status", jobId]` → `GET /api/invoices/import/job-status/{jobId}`
+- Canonical key factory `invoiceImportQueryKeys`: `all()`, `jobs()`, `jobStatus(jobId)`, `runningJobs()`
+
+## API / Interface Design
+No API surface change. This is an internal frontend fix confined to the `onSuccess` callback of `useEnqueueInvoiceImport` in `frontend/src/api/hooks/useAsyncInvoiceImport.ts`. Public hook signatures and their return types are unchanged.
+
+## Dependencies
+- `@tanstack/react-query` — `useMutation`, `useQueryClient`, `invalidateQueries` prefix-matching semantics.
+- Existing exports within the same file: `QUERY_KEYS.invoices` and the `invoiceImportQueryKeys` factory.
+- No new libraries, services, or external dependencies.
+
+## Out of Scope
+- Refactoring the other query keys in the file (`useInvoiceImportJobStatus`, `useRunningInvoiceImportJobs`) to consume the `invoiceImportQueryKeys` factory. Desirable for consistency but not required for this fix; may be noted for a follow-up.
+- Changing polling intervals, `staleTime`, or `gcTime` on any query.
+- Any change to the `InvoiceImportJobTracker` component or backend endpoints.
+- Changes to the mutation's request/response handling or error surface.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3567",
+  "issue_number": 3567,
+  "created_at": "2026-07-09T09:14:14.203417Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-09T09:16:29.644047Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-09T09:16:29.644047Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-09T09:18:23.673168Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-09T09:21:50.624418Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-09T09:22:08.425492Z"
     }
   },
   "tasks": [
     {
       "name": "fix-invalidation-key-and-add-test",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-09T09:22:08.617753Z"
     }
   ]
 }

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-invalidation-key-and-add-test",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-09T09:18:23.673168Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-09T09:19:12.782722Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-09T09:34:02.578291Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-09T09:34:06.748613Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-09T09:19:12.782722Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-09T09:21:50.624418Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3567/state.json
+++ b/artifacts/feat-3567/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-09T09:21:50.624418Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-09T09:22:08.425492Z"
+      "status": "completed",
+      "updated_at": "2026-07-09T09:34:02.578291Z"
     }
   },
   "tasks": [
     {
       "name": "fix-invalidation-key-and-add-test",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-09T09:22:08.617753Z"
+      "updated_at": "2026-07-09T09:33:56.419026Z"
     }
   ]
 }

--- a/artifacts/feat-3567/task-context/fix-invalidation-key-and-add-test.md
+++ b/artifacts/feat-3567/task-context/fix-invalidation-key-and-add-test.md
@@ -1,0 +1,180 @@
+### task: fix-invalidation-key-and-add-test
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useAsyncInvoiceImport.ts:38-41` (the `onSuccess` body of `useEnqueueInvoiceImport`)
+- Test: `frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts` (new file)
+
+**Context — current code (`frontend/src/api/hooks/useAsyncInvoiceImport.ts`):**
+
+The mutation hook `useEnqueueInvoiceImport` currently ends with:
+
+```typescript
+    onSuccess: () => {
+      // Invalidate running jobs queries to show the new job
+      queryClient.invalidateQueries({ queryKey: [...QUERY_KEYS.invoices, "jobs"] });
+    },
+```
+
+The literal `[...QUERY_KEYS.invoices, "jobs"]` produces `["invoices", "jobs"]`, but `useRunningInvoiceImportJobs` registers under `["invoices", "import", "jobs", "running"]`. The sequences diverge at the segment after `"invoices"` (`"jobs"` vs `"import"`), so React Query's prefix match never fires.
+
+The module already exports the canonical factory (lines 123-128):
+
+```typescript
+export const invoiceImportQueryKeys = {
+  all: () => [...QUERY_KEYS.invoices, "import"],
+  jobs: () => [...QUERY_KEYS.invoices, "import", "jobs"] as const,
+  jobStatus: (jobId: string) => [...QUERY_KEYS.invoices, "import", "jobs", "status", jobId] as const,
+  runningJobs: () => [...QUERY_KEYS.invoices, "import", "jobs", "running"] as const,
+};
+```
+
+`invoiceImportQueryKeys.jobs()` returns `["invoices", "import", "jobs"]`, which prefix-matches both the running-jobs query (`[..., "running"]`) and the per-job status query (`[..., "status", jobId]`). It is defined below the hook in module scope, but `onSuccess` is a runtime closure, so referencing it is safe (the const is initialized at module load, long before any mutation resolves). No import changes are needed — `invoiceImportQueryKeys` is in the same module and `QUERY_KEYS` stays imported (still used elsewhere in the file).
+
+**Steps:**
+
+- [ ] Step 1: Write the failing regression test. Create `frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts` with exactly the following content. It renders `useEnqueueInvoiceImport` under a real `QueryClient`, spies on that client's `invalidateQueries`, resolves the mutation, and asserts the invalidation key equals `invoiceImportQueryKeys.jobs()` (and therefore prefix-matches `runningJobs()`). It also asserts the stale literal `["invoices", "jobs"]` is NOT used. This test fails against the current code because `onSuccess` passes `["invoices", "jobs"]`.
+
+```typescript
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  useEnqueueInvoiceImport,
+  invoiceImportQueryKeys,
+} from '../useAsyncInvoiceImport';
+import { getAuthenticatedApiClient } from '../../client';
+
+// Mock the API client module used by the hook.
+jest.mock('../../client', () => {
+  const actual = jest.requireActual('../../client');
+  return {
+    ...actual,
+    getAuthenticatedApiClient: jest.fn(),
+  };
+});
+
+const mockGetAuthenticatedApiClient =
+  getAuthenticatedApiClient as jest.MockedFunction<typeof getAuthenticatedApiClient>;
+
+const mockFetch = jest.fn();
+
+describe('useEnqueueInvoiceImport onSuccess invalidation', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockGetAuthenticatedApiClient.mockResolvedValue({
+      baseUrl: 'http://api',
+      http: { fetch: mockFetch },
+    } as any);
+
+    // Successful enqueue response.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ jobId: 'job-123', success: true }),
+    });
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it('invalidates using the invoiceImportQueryKeys.jobs() factory key', async () => {
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useEnqueueInvoiceImport(), { wrapper });
+
+    result.current.mutate({} as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // The invalidation key must be the factory-derived jobs() key,
+    // i.e. ["invoices", "import", "jobs"].
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invoiceImportQueryKeys.jobs(),
+    });
+
+    // The factory key must prefix-match the running-jobs query key.
+    const jobsKey = invoiceImportQueryKeys.jobs();
+    const runningKey = invoiceImportQueryKeys.runningJobs();
+    expect(runningKey.slice(0, jobsKey.length)).toEqual([...jobsKey]);
+
+    // Guard against literal drift: the stale ["invoices", "jobs"] literal
+    // must never be used.
+    const usedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
+    expect(usedKeys).not.toContainEqual(['invoices', 'jobs']);
+  });
+});
+```
+
+- [ ] Step 2: Run the test to confirm it fails for the right reason. From the `frontend` directory run:
+
+```bash
+cd frontend && npm test -- useAsyncInvoiceImport --watchAll=false
+```
+
+Expected: the test fails at the `expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: invoiceImportQueryKeys.jobs() })` assertion, because the current `onSuccess` calls `invalidateQueries` with `["invoices", "jobs"]` instead of `["invoices", "import", "jobs"]`. Confirm the failure message shows the received key as `["invoices", "jobs"]`. If the test errors for an unrelated reason (module resolution, mock shape), fix the test before proceeding — do not touch the hook yet.
+
+- [ ] Step 3: Apply the one-line fix. In `frontend/src/api/hooks/useAsyncInvoiceImport.ts`, replace the `onSuccess` body of `useEnqueueInvoiceImport` (lines 38-41). Change:
+
+```typescript
+    onSuccess: () => {
+      // Invalidate running jobs queries to show the new job
+      queryClient.invalidateQueries({ queryKey: [...QUERY_KEYS.invoices, "jobs"] });
+    },
+```
+
+to:
+
+```typescript
+    onSuccess: () => {
+      // Invalidate running jobs queries to show the new job
+      queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() });
+    },
+```
+
+Do not change anything else: the `mutationFn`, the URL, the request body, error handling, the other hooks, and the `invoiceImportQueryKeys` factory definition all stay exactly as they are. Do not remove the `QUERY_KEYS` import (it remains in use by the other queries and by the factory).
+
+- [ ] Step 4: Run the test to confirm it passes.
+
+```bash
+cd frontend && npm test -- useAsyncInvoiceImport --watchAll=false
+```
+
+Expected: all assertions pass — the invalidation key now equals `invoiceImportQueryKeys.jobs()` (`["invoices", "import", "jobs"]`), it prefix-matches `runningJobs()`, and the stale `["invoices", "jobs"]` literal is absent.
+
+- [ ] Step 5: Run lint and build to confirm no regressions.
+
+```bash
+cd frontend && npm run lint && npm run build
+```
+
+Expected: both succeed with no new errors or warnings attributable to the change. If the build's auto-generated OpenAPI client step runs, it should be unaffected (no API surface changed).
+
+- [ ] Step 6: Commit the change.
+
+```bash
+cd /home/user/worktrees/feature-3567-Invoices-Onsuccess-Invalidation-Key-In-Useenqueuei && git add frontend/src/api/hooks/useAsyncInvoiceImport.ts frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts && git commit -m "Fix onSuccess invalidation key in useEnqueueInvoiceImport
+
+Replace the hand-written literal [...QUERY_KEYS.invoices, \"jobs\"], which
+never prefix-matched the running-jobs query key, with the canonical
+invoiceImportQueryKeys.jobs() factory. Enqueuing an async invoice import
+now correctly invalidates and refetches the running-jobs query instead of
+relying solely on the 5s poll. Add a regression test guarding against
+literal drift.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01CHPDWDzWHTMettkeH5MZkK"
+```
+
+Expected: commit succeeds on the feature branch with exactly two files staged.

--- a/artifacts/feat-3567/task-plan.r1.md
+++ b/artifacts/feat-3567/task-plan.r1.md
@@ -1,0 +1,190 @@
+# Fix onSuccess Invalidation Key in useEnqueueInvoiceImport Implementation Plan
+
+**Goal:** Correct the React Query cache invalidation key in the `onSuccess` callback of `useEnqueueInvoiceImport` so that enqueuing an async invoice import actually invalidates (and refetches) the running-jobs query. Today the hand-written literal `[...QUERY_KEYS.invoices, "jobs"]` never prefix-matches the query registered under `[...QUERY_KEYS.invoices, "import", "jobs", "running"]`, making the intended immediate refresh a silent no-op. Replace the literal with the existing `invoiceImportQueryKeys.jobs()` factory method and add a regression test guarding against literal drift.
+
+**Architecture:** Purely internal frontend fix. Single file changed (`frontend/src/api/hooks/useAsyncInvoiceImport.ts`), one new test file added (`frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts`). No backend, no component, no interface, no schema changes. React Query prefix-matching is the only integration point; both the invalidating mutation and the consuming query live in the same module. The `invoiceImportQueryKeys` factory the fix depends on already exists in the target file (lines 123-128).
+
+**Tech Stack:** TypeScript, React, `@tanstack/react-query` (`useMutation`, `useQueryClient`, `invalidateQueries` prefix-matching), Jest + `@testing-library/react` (`renderHook`, `waitFor`, `QueryClientProvider`). Test files live under `frontend/src/api/hooks/__tests__/`.
+
+---
+
+### task: fix-invalidation-key-and-add-test
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useAsyncInvoiceImport.ts:38-41` (the `onSuccess` body of `useEnqueueInvoiceImport`)
+- Test: `frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts` (new file)
+
+**Context — current code (`frontend/src/api/hooks/useAsyncInvoiceImport.ts`):**
+
+The mutation hook `useEnqueueInvoiceImport` currently ends with:
+
+```typescript
+    onSuccess: () => {
+      // Invalidate running jobs queries to show the new job
+      queryClient.invalidateQueries({ queryKey: [...QUERY_KEYS.invoices, "jobs"] });
+    },
+```
+
+The literal `[...QUERY_KEYS.invoices, "jobs"]` produces `["invoices", "jobs"]`, but `useRunningInvoiceImportJobs` registers under `["invoices", "import", "jobs", "running"]`. The sequences diverge at the segment after `"invoices"` (`"jobs"` vs `"import"`), so React Query's prefix match never fires.
+
+The module already exports the canonical factory (lines 123-128):
+
+```typescript
+export const invoiceImportQueryKeys = {
+  all: () => [...QUERY_KEYS.invoices, "import"],
+  jobs: () => [...QUERY_KEYS.invoices, "import", "jobs"] as const,
+  jobStatus: (jobId: string) => [...QUERY_KEYS.invoices, "import", "jobs", "status", jobId] as const,
+  runningJobs: () => [...QUERY_KEYS.invoices, "import", "jobs", "running"] as const,
+};
+```
+
+`invoiceImportQueryKeys.jobs()` returns `["invoices", "import", "jobs"]`, which prefix-matches both the running-jobs query (`[..., "running"]`) and the per-job status query (`[..., "status", jobId]`). It is defined below the hook in module scope, but `onSuccess` is a runtime closure, so referencing it is safe (the const is initialized at module load, long before any mutation resolves). No import changes are needed — `invoiceImportQueryKeys` is in the same module and `QUERY_KEYS` stays imported (still used elsewhere in the file).
+
+**Steps:**
+
+- [ ] Step 1: Write the failing regression test. Create `frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts` with exactly the following content. It renders `useEnqueueInvoiceImport` under a real `QueryClient`, spies on that client's `invalidateQueries`, resolves the mutation, and asserts the invalidation key equals `invoiceImportQueryKeys.jobs()` (and therefore prefix-matches `runningJobs()`). It also asserts the stale literal `["invoices", "jobs"]` is NOT used. This test fails against the current code because `onSuccess` passes `["invoices", "jobs"]`.
+
+```typescript
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  useEnqueueInvoiceImport,
+  invoiceImportQueryKeys,
+} from '../useAsyncInvoiceImport';
+import { getAuthenticatedApiClient } from '../../client';
+
+// Mock the API client module used by the hook.
+jest.mock('../../client', () => {
+  const actual = jest.requireActual('../../client');
+  return {
+    ...actual,
+    getAuthenticatedApiClient: jest.fn(),
+  };
+});
+
+const mockGetAuthenticatedApiClient =
+  getAuthenticatedApiClient as jest.MockedFunction<typeof getAuthenticatedApiClient>;
+
+const mockFetch = jest.fn();
+
+describe('useEnqueueInvoiceImport onSuccess invalidation', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockGetAuthenticatedApiClient.mockResolvedValue({
+      baseUrl: 'http://api',
+      http: { fetch: mockFetch },
+    } as any);
+
+    // Successful enqueue response.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ jobId: 'job-123', success: true }),
+    });
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it('invalidates using the invoiceImportQueryKeys.jobs() factory key', async () => {
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useEnqueueInvoiceImport(), { wrapper });
+
+    result.current.mutate({} as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // The invalidation key must be the factory-derived jobs() key,
+    // i.e. ["invoices", "import", "jobs"].
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invoiceImportQueryKeys.jobs(),
+    });
+
+    // The factory key must prefix-match the running-jobs query key.
+    const jobsKey = invoiceImportQueryKeys.jobs();
+    const runningKey = invoiceImportQueryKeys.runningJobs();
+    expect(runningKey.slice(0, jobsKey.length)).toEqual([...jobsKey]);
+
+    // Guard against literal drift: the stale ["invoices", "jobs"] literal
+    // must never be used.
+    const usedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
+    expect(usedKeys).not.toContainEqual(['invoices', 'jobs']);
+  });
+});
+```
+
+- [ ] Step 2: Run the test to confirm it fails for the right reason. From the `frontend` directory run:
+
+```bash
+cd frontend && npm test -- useAsyncInvoiceImport --watchAll=false
+```
+
+Expected: the test fails at the `expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: invoiceImportQueryKeys.jobs() })` assertion, because the current `onSuccess` calls `invalidateQueries` with `["invoices", "jobs"]` instead of `["invoices", "import", "jobs"]`. Confirm the failure message shows the received key as `["invoices", "jobs"]`. If the test errors for an unrelated reason (module resolution, mock shape), fix the test before proceeding — do not touch the hook yet.
+
+- [ ] Step 3: Apply the one-line fix. In `frontend/src/api/hooks/useAsyncInvoiceImport.ts`, replace the `onSuccess` body of `useEnqueueInvoiceImport` (lines 38-41). Change:
+
+```typescript
+    onSuccess: () => {
+      // Invalidate running jobs queries to show the new job
+      queryClient.invalidateQueries({ queryKey: [...QUERY_KEYS.invoices, "jobs"] });
+    },
+```
+
+to:
+
+```typescript
+    onSuccess: () => {
+      // Invalidate running jobs queries to show the new job
+      queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() });
+    },
+```
+
+Do not change anything else: the `mutationFn`, the URL, the request body, error handling, the other hooks, and the `invoiceImportQueryKeys` factory definition all stay exactly as they are. Do not remove the `QUERY_KEYS` import (it remains in use by the other queries and by the factory).
+
+- [ ] Step 4: Run the test to confirm it passes.
+
+```bash
+cd frontend && npm test -- useAsyncInvoiceImport --watchAll=false
+```
+
+Expected: all assertions pass — the invalidation key now equals `invoiceImportQueryKeys.jobs()` (`["invoices", "import", "jobs"]`), it prefix-matches `runningJobs()`, and the stale `["invoices", "jobs"]` literal is absent.
+
+- [ ] Step 5: Run lint and build to confirm no regressions.
+
+```bash
+cd frontend && npm run lint && npm run build
+```
+
+Expected: both succeed with no new errors or warnings attributable to the change. If the build's auto-generated OpenAPI client step runs, it should be unaffected (no API surface changed).
+
+- [ ] Step 6: Commit the change.
+
+```bash
+cd /home/user/worktrees/feature-3567-Invoices-Onsuccess-Invalidation-Key-In-Useenqueuei && git add frontend/src/api/hooks/useAsyncInvoiceImport.ts frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts && git commit -m "Fix onSuccess invalidation key in useEnqueueInvoiceImport
+
+Replace the hand-written literal [...QUERY_KEYS.invoices, \"jobs\"], which
+never prefix-matched the running-jobs query key, with the canonical
+invoiceImportQueryKeys.jobs() factory. Enqueuing an async invoice import
+now correctly invalidates and refetches the running-jobs query instead of
+relying solely on the 5s poll. Add a regression test guarding against
+literal drift.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01CHPDWDzWHTMettkeH5MZkK"
+```
+
+Expected: commit succeeds on the feature branch with exactly two files staged.

--- a/frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts
+++ b/frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts
@@ -2,9 +2,10 @@ import { renderHook, waitFor } from '@testing-library/react';
 import {
     useInvoiceImportJobStatus,
     useRunningInvoiceImportJobs,
+    useEnqueueInvoiceImport,
+    invoiceImportQueryKeys,
 } from '../useAsyncInvoiceImport';
 import type { IBackgroundJobInfo } from '../../generated/api-client';
-import { getAuthenticatedApiClient } from '../../client';
 import { createMockApiClient, mockAuthenticatedApiClient, createQueryClientWrapper, setupFakeTimers } from '../../testUtils';
 
 // Mock the API client
@@ -246,5 +247,73 @@ describe('useAsyncInvoiceImport - Job Polling Logic', () => {
             expect(JOB_STATUS_INTERVAL).toBe(2000);
             expect(RUNNING_JOBS_INTERVAL).toBe(5000);
         });
+    });
+});
+
+describe('useEnqueueInvoiceImport onSuccess invalidation', () => {
+    let mockFetch: jest.Mock;
+    let mockClient: any;
+
+    beforeEach(() => {
+        const mock = createMockApiClient();
+        mockClient = mock.mockClient;
+        mockFetch = mock.mockFetch;
+        mockAuthenticatedApiClient(mockClient);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should invalidate queries with invoiceImportQueryKeys.jobs() on success', async () => {
+        // Arrange
+        const mockResponse: any = {
+            jobId: 'job-123',
+            success: true
+        };
+
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse
+        });
+
+        const { wrapper, queryClient } = createQueryClientWrapper();
+        const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+        // Act
+        const { result } = renderHook(
+            () => useEnqueueInvoiceImport(),
+            { wrapper }
+        );
+
+        result.current.mutate({} as any);
+
+        await waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        // Assert
+        expect(invalidateSpy).toHaveBeenCalled();
+
+        // Verify that the correct key was used (invoiceImportQueryKeys.jobs())
+        const expectedKey = invoiceImportQueryKeys.jobs();
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: expectedKey });
+
+        // Assert the wrong key was NOT used
+        const wrongKey = ['invoices', 'jobs'];
+        const wasWrongKeyUsed = invalidateSpy.mock.calls.some(call => {
+            const callKey = call[0]?.queryKey;
+            return Array.isArray(callKey) &&
+                   JSON.stringify(callKey) === JSON.stringify(wrongKey);
+        });
+        expect(wasWrongKeyUsed).toBe(false);
+
+        // Verify that runningJobs key is a prefix-extension of jobs key
+        const jobsKey = invoiceImportQueryKeys.jobs();
+        const runningJobsKey = invoiceImportQueryKeys.runningJobs();
+        const runningJobsPrefix = runningJobsKey.slice(0, jobsKey.length);
+        expect(runningJobsPrefix).toEqual(jobsKey);
+
+        invalidateSpy.mockRestore();
     });
 });

--- a/frontend/src/api/hooks/useAsyncInvoiceImport.ts
+++ b/frontend/src/api/hooks/useAsyncInvoiceImport.ts
@@ -37,7 +37,7 @@ export const useEnqueueInvoiceImport = () => {
     },
     onSuccess: () => {
       // Invalidate running jobs queries to show the new job
-      queryClient.invalidateQueries({ queryKey: [...QUERY_KEYS.invoices, "jobs"] });
+      queryClient.invalidateQueries({ queryKey: invoiceImportQueryKeys.jobs() });
     },
   });
 };


### PR DESCRIPTION
Closes #3567

## What the issue was

In `frontend/src/api/hooks/useAsyncInvoiceImport.ts`, the `useEnqueueInvoiceImport` mutation's `onSuccess` callback invalidated the React Query cache using a hand-written literal key `[...QUERY_KEYS.invoices, "jobs"]`. That key never prefix-matches the running-jobs query, which is registered under `[...QUERY_KEYS.invoices, "import", "jobs", "running"]` (`useRunningInvoiceImportJobs`). Because the segment sequences diverge right after the `"invoices"` prefix, the intended invalidation silently did nothing — the `refetchInterval: 5000` poll masked the bug by refreshing the list within 5 seconds anyway, but the immediate refresh never actually fired.

## How it was fixed / handled

Replaced the stale literal with the module's existing canonical key factory, `invoiceImportQueryKeys.jobs()`, which returns `[...QUERY_KEYS.invoices, "import", "jobs"]` — a true prefix of both the running-jobs key and the per-job-status key. This is a one-line change with no other behavior modified.

Added a regression test (`frontend/src/api/hooks/__tests__/useAsyncInvoiceImport.test.ts`) that renders the mutation hook, spies on `invalidateQueries`, resolves the mutation, and asserts the invalidation key is the factory-derived `jobs()` key (and not the old broken literal). The test was appended to the existing test file for this hook (which already covered polling behavior for the two query hooks), reusing the project's established `testUtils.ts` mocking helpers.

Verified: `npm test -- useAsyncInvoiceImport` (8/8 pass), `npm run lint` (no new errors), `npm run build` (compiles).

## Artifacts
- Brief, spec, architecture review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3567/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `frontend/src/api/hooks/useAsyncInvoiceImport.ts:50,92` — `useInvoiceImportJobStatus` and `useRunningInvoiceImportJobs` still build their `queryKey` as hand-written array literals instead of using `invoiceImportQueryKeys.jobStatus(jobId)` / `.runningJobs()`, which are already exported a few lines below. Out of scope for this fix per the spec, but worth a follow-up so the query definitions and the invalidation call share one source of truth.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CHPDWDzWHTMettkeH5MZkK)_