### PR TITLE
#3578: fix null username fallback in journal soft-delete

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/DeleteJournalEntry/DeleteJournalEntryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/DeleteJournalEntry/DeleteJournalEntryHandler.cs
@@ -48,7 +48,7 @@ namespace Anela.Heblo.Application.Features.Journal.UseCases.DeleteJournalEntry
             // Check if user owns the entry (for now, allow all authenticated users to delete)
             // In production, you might want to restrict this to the original author
 
-            entry.SoftDelete(currentUser.Id, currentUser.Name);
+            entry.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User");
             await _journalRepository.UpdateAsync(entry, cancellationToken);
             await _journalRepository.SaveChangesAsync(cancellationToken);
 

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/DeleteJournalEntryHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/DeleteJournalEntryHandlerTests.cs
@@ -244,4 +244,52 @@ public class DeleteJournalEntryHandlerTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_WhenCurrentUserNameIsNull_FallsBackToUnknownUser()
+    {
+        // Arrange
+        var entryId = 1;
+        var userId = "user123";
+        var request = new DeleteJournalEntryRequest { Id = entryId };
+
+        var currentUser = new CurrentUser(
+            Id: userId,
+            Name: null,
+            Email: null,
+            IsAuthenticated: true
+        );
+
+        var existingEntry = new JournalEntry
+        {
+            Id = entryId,
+            Title = "Test Entry",
+            Content = "Test content",
+            CreatedByUserId = userId
+        };
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(currentUser);
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(entryId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingEntry);
+
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<JournalEntry>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        existingEntry.DeletedByUsername.Should().Be("Unknown User");
+        existingEntry.ModifiedByUsername.Should().Be("Unknown User");
+    }
 }


### PR DESCRIPTION
Closes #3578

## What the issue was
`DeleteJournalEntryHandler` passed `currentUser.Name` directly to `JournalEntry.SoftDelete` without a null-coalescing fallback, unlike the sibling `CreateJournalEntryHandler` and `UpdateJournalEntryHandler`, which both fall back to `"Unknown User"` when the display name is null. `SoftDelete` assigns the argument to both `DeletedByUsername` and `ModifiedByUsername`, so a user without a display name produced `null` audit columns on delete while every other mutation used `"Unknown User"`.

## How it was fixed
Changed `DeleteJournalEntryHandler.cs:51` to `entry.SoftDelete(currentUser.Id, currentUser.Name ?? "Unknown User")`, matching the existing pattern in the Create/Update handlers. Added a regression test (`Handle_WhenCurrentUserNameIsNull_FallsBackToUnknownUser`) to `DeleteJournalEntryHandlerTests.cs` asserting both `DeletedByUsername` and `ModifiedByUsername` fall back to `"Unknown User"` when the current user has no display name.

## Validation
- `dotnet build` — 0 errors
- `dotnet format --verify-no-changes` — clean
- `dotnet test` filtered to `DeleteJournalEntryHandlerTests` — 6/6 passed (including the new regression test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PUhKLHWfgngaz4TnMedEZY)_