### PR TITLE
#3580: implementation

### DIFF
--- a/artifacts/feat-3580/arch-review.r1.md
+++ b/artifacts/feat-3580/arch-review.r1.md
@@ -1,0 +1,108 @@
+# Architecture Review: Deduplicate PurchaseOrderHistory → PurchaseOrderHistoryDto Mapping
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a pure internal refactor confined to a single vertical slice (`Purchase`) and does not cross module boundaries, change any contract shape, or touch persistence. It fits the existing codebase conventions exactly:
+
+- `PurchaseOrderHistoryDto.cs` (`backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderHistoryDto.cs`) is currently a plain class with only auto-properties — no mapping logic at all.
+- The sibling DTO in the same folder, `PurchaseOrderLineDto.cs`, already implements exactly the pattern this spec proposes: a `public static PurchaseOrderLineDto FromLine(PurchaseOrderLine line, string? catalogNote = null)` single-expression factory using an object initializer.
+- The same "static `FromX` factory on the DTO" pattern also exists outside Purchase (`Features/Marketing/Contracts/MarketingActionDto.cs`), confirming this is an established, repeated convention in the codebase rather than a one-off — so introducing `FromDomain` on `PurchaseOrderHistoryDto` raises the module's internal consistency rather than inventing something new.
+- Per `docs/architecture/development_guidelines.md` ("📬 Contracts and DTOs Rules"), DTOs live in each module's own `Contracts/` folder and are not shared globally — the proposed change keeps the factory local to `PurchaseOrderHistoryDto` in `Features/Purchase/Contracts/`, so it does not violate module ownership.
+- Per project-wide rule (CLAUDE.md / dev guidelines): DTOs must remain plain C# classes, never `record`s, because of OpenAPI client generation quirks. `PurchaseOrderHistoryDto` is already a class and stays a class — the factory is an ordinary static method, not a change of type kind. No risk here, just confirming the constraint isn't violated.
+
+No new component, dependency, or interface is introduced at the module level. This is a leaf-level code-quality fix.
+
+## Proposed Architecture
+
+### Component Overview
+No structural/component change. Within the existing `Purchase` module:
+
+```
+Features/Purchase/
+├── Contracts/
+│   ├── PurchaseOrderHistoryDto.cs   <- gains FromDomain(PurchaseOrderHistory) static factory
+│   └── PurchaseOrderLineDto.cs      <- existing FromLine(...) factory (reference pattern)
+└── UseCases/
+    ├── CreatePurchaseOrder/CreatePurchaseOrderHandler.cs        <- call site, updated
+    ├── GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs      <- call site, updated
+    └── GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs <- call site, updated
+```
+
+Data flow direction is unchanged: `PurchaseOrderHistory` (domain, `Domain/Features/Purchase/PurchaseOrderHistory.cs`) → `PurchaseOrderHistoryDto` (contract). The only change is *where* the mapping expression is defined (once, on the DTO) versus *where it's invoked* (three call sites, now via method-group reference).
+
+### Key Design Decisions
+
+#### Decision 1: Static factory on the DTO vs. alternatives
+**Options considered:**
+1. Static factory method `FromDomain` on `PurchaseOrderHistoryDto` (mirrors `PurchaseOrderLineDto.FromLine`).
+2. A dedicated mapper/extension class (e.g. `PurchaseOrderHistoryMapper.ToDto(...)`).
+3. AutoMapper profile for `PurchaseOrderHistory → PurchaseOrderHistoryDto`.
+
+**Chosen approach:** Option 1, exactly as specified.
+
+**Rationale:** The module already has a working precedent (`FromLine`) one file away; introducing a second mapping mechanism (extension class or AutoMapper) for the same module would create inconsistency rather than resolve it. AutoMapper is listed in the dev guidelines as "optional, for complex mappings" — this is a flat six-field 1:1 copy, the simplest case, so a hand-written factory is proportionate. Matching the established local convention is the deciding factor, not a general preference for one mapping style.
+
+#### Decision 2: Method-group syntax at call sites
+**Options considered:** `.Select(h => PurchaseOrderHistoryDto.FromDomain(h))` (lambda wrapping) vs. `.Select(PurchaseOrderHistoryDto.FromDomain)` (method-group reference).
+
+**Chosen approach:** Method-group reference, as specified in brief/spec.
+
+**Rationale:** `PurchaseOrderLineDto.FromLine` is called via lambda at its two call sites only because it takes a second parameter (`catalogNote`) that varies per site — that's not the case here. Since `FromDomain` takes exactly one argument matching `Select`'s delegate signature, the method-group form is shorter and equally clear. No functional difference; purely a style choice consistent with idiomatic C#.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files or folders. Modify in place:
+- `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderHistoryDto.cs`
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs`
+
+### Interfaces and Contracts
+```csharp
+// PurchaseOrderHistoryDto.cs
+using Anela.Heblo.Domain.Features.Purchase;
+
+namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+public class PurchaseOrderHistoryDto
+{
+    public int Id { get; set; }
+    public string Action { get; set; } = null!;
+    public string? OldValue { get; set; }
+    public string? NewValue { get; set; }
+    public DateTime ChangedAt { get; set; }
+    public string ChangedBy { get; set; } = null!;
+
+    public static PurchaseOrderHistoryDto FromDomain(PurchaseOrderHistory h) =>
+        new()
+        {
+            Id = h.Id,
+            Action = h.Action,
+            OldValue = h.OldValue,
+            NewValue = h.NewValue,
+            ChangedAt = h.ChangedAt,
+            ChangedBy = h.ChangedBy
+        };
+}
+```
+No public interface signatures change elsewhere — `FromDomain` is additive. The three handlers' `Handle(...)` signatures, response DTOs, and MediatR contracts are untouched.
+
+### Data Flow
+Unchanged end-to-end: repository loads `PurchaseOrder`/`PurchaseOrderHistory` entities → handler maps each entry via `PurchaseOrderHistoryDto.FromDomain` → resulting list is assigned to the response DTO's `History`/`Items` property, with `GetPurchaseOrderByIdHandler` additionally applying `.OrderByDescending(h => h.ChangedAt)` *after* the `Select`, on the DTO — this ordering step must remain exactly where it is (post-mapping), since moving it before mapping or dropping it would be a behavior change outside this refactor's scope.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Reordering `.OrderByDescending` relative to `.Select` in `GetPurchaseOrderByIdHandler` changes result order or introduces a subtle bug | Low | Keep `.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt)` in that exact sequence — spec already pins this down explicitly; implementer should not "simplify" further |
+| Missed call site leaves an inconsistent third mapping in place | Low | Acceptance criterion in spec (`grep for "new PurchaseOrderHistoryDto"` under `UseCases/` returns nothing) is a cheap, mechanical verification step — run it before marking done |
+| Existing unit tests (`CreatePurchaseOrderHandlerTests.cs`, `GetPurchaseOrderHistoryHandlerTests.cs`, and `GetPurchaseOrderById` tests if present) don't cover all six fields, masking a copy-paste mistake in the new factory | Low | Tests already assert on `History`/`Items` output today, per spec's own acceptance criteria (must pass unmodified) — no new test is strictly required, but a quick manual diff of the six fields against the domain entity is worth the 30 seconds |
+
+None of these rise above "low" — the change has no runtime behavior surface beyond what's already covered by existing tests.
+
+## Specification Amendments
+None. The spec is complete, correctly scoped, and consistent with the codebase's actual conventions as verified above (the `FromLine` reference pattern, the DTO location/ownership rule, and the class-not-record constraint all line up with what's proposed). No additions needed.
+
+## Prerequisites
+None. No migrations, config, or infrastructure changes — this can be implemented immediately against the current `main`/feature branch state.

--- a/artifacts/feat-3580/brief.md
+++ b/artifacts/feat-3580/brief.md
@@ -1,0 +1,71 @@
+## Module
+Purchase
+
+## Finding
+The manual mapping from `PurchaseOrderHistory` (domain entity) to `PurchaseOrderHistoryDto` (contract) is copy-pasted verbatim in three handlers:
+
+```csharp
+// CreatePurchaseOrderHandler.cs:114–121
+var history = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
+{
+    Id = h.Id,
+    Action = h.Action,
+    OldValue = h.OldValue,
+    NewValue = h.NewValue,
+    ChangedAt = h.ChangedAt,
+    ChangedBy = h.ChangedBy
+}).ToList();
+
+// GetPurchaseOrderByIdHandler.cs:71–79
+History = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
+{
+    Id = h.Id,
+    Action = h.Action,
+    OldValue = h.OldValue,
+    NewValue = h.NewValue,
+    ChangedAt = h.ChangedAt,
+    ChangedBy = h.ChangedBy
+}).OrderByDescending(h => h.ChangedAt).ToList(),
+
+// GetPurchaseOrderHistoryHandler.cs:38–47
+var items = history.Select(h => new PurchaseOrderHistoryDto
+{
+    Id = h.Id,
+    Action = h.Action,
+    OldValue = h.OldValue,
+    NewValue = h.NewValue,
+    ChangedAt = h.ChangedAt,
+    ChangedBy = h.ChangedBy,
+}).ToList();
+```
+
+`PurchaseOrderLineDto` already solves the same problem cleanly with a static factory:
+`backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderLineDto.cs:17` — `public static PurchaseOrderLineDto FromLine(PurchaseOrderLine line, string? catalogNote = null)`
+
+`PurchaseOrderHistoryDto` lacks the equivalent.
+
+## Why it matters
+If `PurchaseOrderHistory` gains a new field (or any field is renamed), all three mapping sites must be updated in sync. One missed site produces silently incorrect API responses. Because the duplication is purely mechanical, it offers no information benefit — three identical blocks are harder to diff than one canonical source.
+
+## Suggested fix
+Add a static factory to `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderHistoryDto.cs`:
+
+```csharp
+public static PurchaseOrderHistoryDto FromDomain(PurchaseOrderHistory h) => new()
+{
+    Id = h.Id,
+    Action = h.Action,
+    OldValue = h.OldValue,
+    NewValue = h.NewValue,
+    ChangedAt = h.ChangedAt,
+    ChangedBy = h.ChangedBy
+};
+```
+
+Then replace all three mapping sites:
+- `CreatePurchaseOrderHandler.cs:114` → `.Select(PurchaseOrderHistoryDto.FromDomain)`
+- `GetPurchaseOrderByIdHandler.cs:71` → `.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt)`
+- `GetPurchaseOrderHistoryHandler.cs:38` → `.Select(PurchaseOrderHistoryDto.FromDomain)`
+
+---
+_Filed by daily arch-review routine on 2026-07-10._

--- a/artifacts/feat-3580/code-review.r1.md
+++ b/artifacts/feat-3580/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3580/impl/dedup-history-dto-mapping.r1.md
+++ b/artifacts/feat-3580/impl/dedup-history-dto-mapping.r1.md
@@ -1,0 +1,35 @@
+# Implementation: dedup-history-dto-mapping
+
+## What was implemented
+Added a static factory `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)` mirroring the existing `PurchaseOrderLineDto.FromLine` pattern, and replaced the three duplicated inline `new PurchaseOrderHistoryDto { ... }` mapping blocks in the Purchase handlers with calls to it. No behavior change — all six fields (`Id`, `Action`, `OldValue`, `NewValue`, `ChangedAt`, `ChangedBy`) map 1:1 as before, and the `.OrderByDescending(h => h.ChangedAt)` step in `GetPurchaseOrderByIdHandler` is preserved immediately after `.Select(...)`.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderHistoryDto.cs` — added `using Anela.Heblo.Domain.Features.Purchase;` and the `FromDomain` static factory.
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs` — replaced inline mapping with `.Select(PurchaseOrderHistoryDto.FromDomain)`.
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs` — replaced inline mapping with `.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt)`.
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs` — replaced inline mapping with `.Select(PurchaseOrderHistoryDto.FromDomain)`.
+
+## Tests
+No new tests required (per spec's Out of Scope — pure mechanical refactor, output shape unchanged). Ran existing suites unmodified:
+- `CreatePurchaseOrderHandlerTests` — 10/10 passed.
+- `GetPurchaseOrderHistoryHandlerTests` — 4/4 passed.
+No dedicated `GetPurchaseOrderByIdHandlerTests.cs` exists in the repo.
+
+## How to verify
+1. `grep -rn "new PurchaseOrderHistoryDto" backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/` — zero matches.
+2. `dotnet build Anela.Heblo.sln` — succeeds (0 errors).
+3. `dotnet format Anela.Heblo.sln` — no additional diff.
+4. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CreatePurchaseOrderHandlerTests"` and `--filter "FullyQualifiedName~GetPurchaseOrderHistoryHandlerTests"` — both pass.
+
+## Notes
+None. Change is confined exactly to the four files named in the task plan; `PurchaseOrderLineDto.cs` and the domain entity were not touched.
+
+## PR Summary
+Deduplicated the `PurchaseOrderHistory` → `PurchaseOrderHistoryDto` mapping that was copy-pasted verbatim across three handlers by adding a static `PurchaseOrderHistoryDto.FromDomain` factory, mirroring the existing `PurchaseOrderLineDto.FromLine` convention. All three call sites now delegate to the single factory; behavior and output are unchanged.
+
+### Changes
+- `Contracts/PurchaseOrderHistoryDto.cs` — added `FromDomain` static factory.
+- `UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs`, `UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs`, `UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs` — replaced inline mapping with `.Select(PurchaseOrderHistoryDto.FromDomain)`.
+
+## Status
+DONE

--- a/artifacts/feat-3580/review/dedup-history-dto-mapping.r1.md
+++ b/artifacts/feat-3580/review/dedup-history-dto-mapping.r1.md
@@ -1,0 +1,22 @@
+# Code Review: dedup-history-dto-mapping
+
+## Summary
+The implementation adds `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)` as a single-expression static factory mirroring `PurchaseOrderLineDto.FromLine`'s style, and replaces all three duplicated inline mapping blocks in `CreatePurchaseOrderHandler`, `GetPurchaseOrderByIdHandler`, and `GetPurchaseOrderHistoryHandler` with calls to it. The diff is confined exactly to the four files specified, the `.OrderByDescending(h => h.ChangedAt)` ordering is preserved immediately after `.Select(...)` in `GetPurchaseOrderByIdHandler`, and no other lines were touched.
+
+## Review Result: PASS
+
+### task: dedup-history-dto-mapping
+**Status:** PASS
+
+## Overall Notes
+Independent verification performed against the committed diff (`git show bc91130e`) rather than relying solely on the implementation summary:
+- `grep -rn "new PurchaseOrderHistoryDto" backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/` returns zero matches — the only remaining construction is inside `FromDomain` in `Contracts/`.
+- `FromDomain` maps all six fields (`Id`, `Action`, `OldValue`, `NewValue`, `ChangedAt`, `ChangedBy`) 1:1 with no transformation, matching the spec exactly.
+- `GetPurchaseOrderByIdHandler`'s critical ordering constraint is satisfied: `.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt).ToList()` — mapping strictly before ordering.
+- The added `PurchaseOrderHistoryDto.cs` file retains the pre-existing no-trailing-newline convention, consistent with `PurchaseOrderLineDto.cs` in the same folder — not a stray diff artifact.
+- `dotnet build Anela.Heblo.sln` succeeds with 0 errors (pre-existing nullable-reference warnings in unrelated test files are unchanged by this diff).
+- `dotnet test ... --filter "FullyQualifiedName~CreatePurchaseOrderHandlerTests|FullyQualifiedName~GetPurchaseOrderHistoryHandlerTests"` passes: 14/14 (0 failed), confirming behavior-preserving refactor. No `GetPurchaseOrderByIdHandlerTests.cs` exists in the repo, consistent with the spec's note.
+- No test files were modified, per the "run unmodified" requirement.
+- `PurchaseOrderLineDto.cs` and the domain entity `PurchaseOrderHistory.cs` were left untouched, as required.
+
+No documentation updates are needed — this is a self-contained internal refactor with no behavior or contract change.

--- a/artifacts/feat-3580/spec.r1.md
+++ b/artifacts/feat-3580/spec.r1.md
@@ -1,0 +1,87 @@
+# Specification: Deduplicate PurchaseOrderHistory → PurchaseOrderHistoryDto Mapping
+
+## Summary
+The mapping from the `PurchaseOrderHistory` domain entity to `PurchaseOrderHistoryDto` is copy-pasted verbatim across three MediatR handlers in the Purchase module. This spec introduces a single static factory method, `PurchaseOrderHistoryDto.FromDomain`, and updates all three call sites to use it, following the existing `PurchaseOrderLineDto.FromLine` pattern already established in the same module.
+
+## Background
+`PurchaseOrderLineDto` already solves the identical problem with a static factory method (`FromLine`). `PurchaseOrderHistoryDto` has no equivalent, so each handler that needs to map history entries re-implements the same six-field assignment inline. If `PurchaseOrderHistory` gains, loses, or renames a field, all three sites must be updated in lockstep; a missed site silently produces incorrect API responses. This is a pure mechanical refactor with no behavior change — it centralizes the mapping logic to a single source of truth.
+
+## Functional Requirements
+
+### FR-1: Add `PurchaseOrderHistoryDto.FromDomain` static factory
+Add a static factory method to `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderHistoryDto.cs` that maps a `PurchaseOrderHistory` domain entity to a `PurchaseOrderHistoryDto`, mirroring the style of `PurchaseOrderLineDto.FromLine`:
+
+```csharp
+public static PurchaseOrderHistoryDto FromDomain(PurchaseOrderHistory h) => new()
+{
+    Id = h.Id,
+    Action = h.Action,
+    OldValue = h.OldValue,
+    NewValue = h.NewValue,
+    ChangedAt = h.ChangedAt,
+    ChangedBy = h.ChangedBy
+};
+```
+
+This requires adding a `using Anela.Heblo.Domain.Features.Purchase;` import to the contract file (the same namespace `PurchaseOrderLineDto.cs` already imports for `PurchaseOrderLine`).
+
+**Acceptance criteria:**
+- `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)` exists as a `public static` method returning a new `PurchaseOrderHistoryDto`.
+- All six properties (`Id`, `Action`, `OldValue`, `NewValue`, `ChangedAt`, `ChangedBy`) are mapped 1:1 with no transformation, exactly matching the three existing inline blocks.
+- Signature and body style match `PurchaseOrderLineDto.FromLine` (single-expression static factory using object initializer).
+
+### FR-2: Replace the three duplicated mapping sites with calls to the factory
+Replace each inline `Select(h => new PurchaseOrderHistoryDto { ... })` block with `Select(PurchaseOrderHistoryDto.FromDomain)`, preserving all surrounding logic (ordering, assignment target) exactly as-is:
+
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs` (lines 114–122, inside `MapToResponse`): `purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).ToList()`
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs` (lines 71–79): `purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt).ToList()`
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs` (lines 37–47): `history.Select(PurchaseOrderHistoryDto.FromDomain).ToList()`
+
+**Acceptance criteria:**
+- No handler in the Purchase module constructs a `PurchaseOrderHistoryDto` via an inline object initializer (`new PurchaseOrderHistoryDto { ... }`) anymore — a search for `new PurchaseOrderHistoryDto` under `Features/Purchase/UseCases/` returns no matches.
+- All three handlers compile and their existing unit tests (`CreatePurchaseOrderHandlerTests.cs`, `GetPurchaseOrderHistoryHandlerTests.cs`, and any covering `GetPurchaseOrderByIdHandler`) pass unmodified, since output shape and values are identical to before.
+- `GetPurchaseOrderByIdHandler`'s `OrderByDescending(h => h.ChangedAt)` ordering step is preserved exactly (applied after the `Select`, on the DTO's `ChangedAt`, not moved or altered).
+- No other change to method signatures, logging, response construction, or unrelated code in the three handler files.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact expected; this is a like-for-like replacement of an inline lambda with a static method reference in a `Select`. No new allocations, loops, or I/O introduced.
+
+### NFR-2: Security
+None. No change to data exposed, authorization, or input handling — the DTO shape and field values are unchanged.
+
+## Data Model
+No changes to `PurchaseOrderHistory` (domain entity) or `PurchaseOrderHistoryDto` (contract) fields. `PurchaseOrderHistoryDto` gains one static method; its data shape is unchanged:
+
+| Field | Type | Source |
+|---|---|---|
+| Id | int | `PurchaseOrderHistory.Id` |
+| Action | string | `PurchaseOrderHistory.Action` |
+| OldValue | string? | `PurchaseOrderHistory.OldValue` |
+| NewValue | string? | `PurchaseOrderHistory.NewValue` |
+| ChangedAt | DateTime | `PurchaseOrderHistory.ChangedAt` |
+| ChangedBy | string | `PurchaseOrderHistory.ChangedBy` |
+
+## API / Interface Design
+No API contract changes. This is an internal mapping refactor; JSON shape returned by `CreatePurchaseOrder`, `GetPurchaseOrderById`, and `GetPurchaseOrderHistory` endpoints is byte-for-byte identical before and after.
+
+New internal interface:
+```csharp
+public static PurchaseOrderHistoryDto PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)
+```
+
+## Dependencies
+- `PurchaseOrderHistory` domain entity (`backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrderHistory.cs`) — read-only dependency, no changes needed.
+- Existing `PurchaseOrderLineDto.FromLine` pattern as the style reference (no code dependency, just precedent).
+
+## Out of Scope
+- Any change to `PurchaseOrderHistory`, `PurchaseOrderLineDto`, or other Purchase contracts/entities.
+- Introducing a general-purpose mapping library (e.g., AutoMapper) for this or other DTOs.
+- Any change to the three handlers' business logic, logging, error handling, or response structure beyond the mapping call site.
+- Adding new unit tests specifically for `FromDomain` (existing handler tests already exercise it indirectly); adding a small dedicated test is left to implementer discretion but is not required by this spec.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-10T09:20:04.478529Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-10T09:20:20.434160Z"
+      "status": "completed",
+      "updated_at": "2026-07-10T10:21:42.903353Z"
     }
   },
   "tasks": [
     {
       "name": "dedup-history-dto-mapping",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-10T09:20:20.609410Z"
+      "updated_at": "2026-07-10T10:21:34.862877Z"
     }
   ]
 }

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-10T09:15:34.188096Z"
+      "status": "completed",
+      "updated_at": "2026-07-10T09:16:44.754154Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-10T09:16:44.930095Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-10T09:15:34.188096Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3580",
+  "issue_number": 3580,
+  "created_at": "2026-07-10T09:15:01.515487Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -9,16 +9,16 @@
       "updated_at": "2026-07-10T09:16:44.754154Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-10T09:16:44.930095Z"
+      "status": "completed",
+      "updated_at": "2026-07-10T09:18:23.591812Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-10T09:18:33.719755Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-10T09:18:33.949193Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-10T09:18:33.719755Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-10T09:18:33.949193Z"
+      "status": "completed",
+      "updated_at": "2026-07-10T09:20:04.478529Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "dedup-history-dto-mapping",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-10T10:21:42.903353Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-10T10:23:34.272808Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-10T10:21:42.903353Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-10T10:23:34.272808Z"
+      "status": "completed",
+      "updated_at": "2026-07-10T10:23:34.624704Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3580/state.json
+++ b/artifacts/feat-3580/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-10T09:20:04.478529Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-10T09:20:20.434160Z"
     }
   },
   "tasks": [
     {
       "name": "dedup-history-dto-mapping",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-10T09:20:20.609410Z"
     }
   ]
 }

--- a/artifacts/feat-3580/task-context/dedup-history-dto-mapping.md
+++ b/artifacts/feat-3580/task-context/dedup-history-dto-mapping.md
@@ -1,0 +1,126 @@
+### task: dedup-history-dto-mapping
+
+**Goal:** Add `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)` as a static factory and replace the three duplicated inline `new PurchaseOrderHistoryDto { ... }` mapping blocks with calls to it, with zero behavior change.
+
+**Files to change (all under `backend/src/Anela.Heblo.Application/Features/Purchase/`):**
+
+1. `Contracts/PurchaseOrderHistoryDto.cs`
+   Current content:
+   ```csharp
+   namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+   public class PurchaseOrderHistoryDto
+   {
+       public int Id { get; set; }
+       public string Action { get; set; } = null!;
+       public string? OldValue { get; set; }
+       public string? NewValue { get; set; }
+       public DateTime ChangedAt { get; set; }
+       public string ChangedBy { get; set; } = null!;
+   }
+   ```
+   Change to:
+   ```csharp
+   using Anela.Heblo.Domain.Features.Purchase;
+
+   namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+   public class PurchaseOrderHistoryDto
+   {
+       public int Id { get; set; }
+       public string Action { get; set; } = null!;
+       public string? OldValue { get; set; }
+       public string? NewValue { get; set; }
+       public DateTime ChangedAt { get; set; }
+       public string ChangedBy { get; set; } = null!;
+
+       public static PurchaseOrderHistoryDto FromDomain(PurchaseOrderHistory h) =>
+           new()
+           {
+               Id = h.Id,
+               Action = h.Action,
+               OldValue = h.OldValue,
+               NewValue = h.NewValue,
+               ChangedAt = h.ChangedAt,
+               ChangedBy = h.ChangedBy
+           };
+   }
+   ```
+   This mirrors `Contracts/PurchaseOrderLineDto.cs`'s `FromLine` factory (same file, same folder) — match its style exactly (single-expression static factory, object initializer, same brace/indentation conventions already in this file).
+
+2. `UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs` — inside the private `MapToResponse` method, currently at lines 114–122:
+   ```csharp
+   var history = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
+   {
+       Id = h.Id,
+       Action = h.Action,
+       OldValue = h.OldValue,
+       NewValue = h.NewValue,
+       ChangedAt = h.ChangedAt,
+       ChangedBy = h.ChangedBy
+   }).ToList();
+   ```
+   Replace with:
+   ```csharp
+   var history = purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).ToList();
+   ```
+   Do not touch anything else in `MapToResponse` (the `lines` assignment above it and the `CreatePurchaseOrderResponse` construction below it stay exactly as-is).
+
+3. `UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs` — inside the `GetPurchaseOrderByIdResponse` object initializer, currently at lines 71–79:
+   ```csharp
+   History = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
+   {
+       Id = h.Id,
+       Action = h.Action,
+       OldValue = h.OldValue,
+       NewValue = h.NewValue,
+       ChangedAt = h.ChangedAt,
+       ChangedBy = h.ChangedBy
+   }).OrderByDescending(h => h.ChangedAt).ToList(),
+   ```
+   Replace with:
+   ```csharp
+   History = purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt).ToList(),
+   ```
+   Critical: keep `.OrderByDescending(h => h.ChangedAt)` immediately after `.Select(...)`, in that order, operating on the DTO's `ChangedAt` — do not reorder relative to `Select`, drop it, or move it before the mapping. This is called out explicitly as a risk in the arch review.
+
+4. `UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs` — currently at lines 37–47:
+   ```csharp
+   var items = history
+       .Select(h => new PurchaseOrderHistoryDto
+       {
+           Id = h.Id,
+           Action = h.Action,
+           OldValue = h.OldValue,
+           NewValue = h.NewValue,
+           ChangedAt = h.ChangedAt,
+           ChangedBy = h.ChangedBy,
+       })
+       .ToList();
+   ```
+   Replace with:
+   ```csharp
+   var items = history
+       .Select(PurchaseOrderHistoryDto.FromDomain)
+       .ToList();
+   ```
+
+**Do not change:** method signatures, logging calls, response construction, ordering/assignment of any other field, or any file not listed above. `PurchaseOrderLineDto.cs` and `PurchaseOrderHistory.cs` (domain entity) are read-only references — do not modify them.
+
+**Acceptance criteria:**
+- `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)` exists as a `public static` single-expression factory, matching `PurchaseOrderLineDto.FromLine`'s style, mapping all six fields (`Id`, `Action`, `OldValue`, `NewValue`, `ChangedAt`, `ChangedBy`) 1:1 with no transformation.
+- `grep -rn "new PurchaseOrderHistoryDto" backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/` returns no matches (the only remaining construction is inside `FromDomain` itself, in `Contracts/`).
+- `GetPurchaseOrderByIdHandler`'s `.Select(...).OrderByDescending(h => h.ChangedAt).ToList()` sequence is preserved exactly (mapping first, ordering second).
+- No other lines in the three handler files change (verify via `git diff` — only the mapping blocks and, in `PurchaseOrderHistoryDto.cs`, the added `using` and factory method should appear).
+
+**Verification steps (run from the `backend/` directory unless noted):**
+1. `grep -rn "new PurchaseOrderHistoryDto" ../backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/` (or equivalent path from repo root: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/`) — expect zero matches.
+2. `dotnet build Anela.Heblo.sln` from the repo root (`/home/user/worktrees/feature-3580-Arch-Review-Purchase-Purchaseorderhistorydto-Mappi`) — must succeed with no new warnings/errors.
+3. `dotnet format Anela.Heblo.sln` from the repo root — apply and ensure no unexpected formatting diffs beyond the intended edits.
+4. Run the existing unit tests unmodified and confirm they pass:
+   - `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CreatePurchaseOrderHandlerTests"`
+   - `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetPurchaseOrderHistoryHandlerTests"`
+   - Note: no dedicated `GetPurchaseOrderByIdHandlerTests.cs` currently exists in the repo (confirmed absent at plan time) — nothing to run for that handler beyond the build succeeding; do not add a new test file, per the spec's "Out of Scope" section (new tests for `FromDomain` are explicitly not required).
+5. Do not modify any test file — the spec requires all existing tests to pass **unmodified**, since output shape/values are unchanged.
+
+**Definition of done:** all four verification steps pass, `git diff` shows changes confined to the four files listed above, and no unrelated code (logging, response shape, other handlers) was touched.

--- a/artifacts/feat-3580/task-plan.r1.md
+++ b/artifacts/feat-3580/task-plan.r1.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Deduplicate PurchaseOrderHistory → PurchaseOrderHistoryDto Mapping
+
+Source artifacts: `artifacts/feat-3580/spec.r1.md`, `artifacts/feat-3580/arch-review.r1.md`.
+Skip Design: true (pure backend refactor, no UI). Single task — scope is small and mechanical.
+
+### task: dedup-history-dto-mapping
+
+**Goal:** Add `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)` as a static factory and replace the three duplicated inline `new PurchaseOrderHistoryDto { ... }` mapping blocks with calls to it, with zero behavior change.
+
+**Files to change (all under `backend/src/Anela.Heblo.Application/Features/Purchase/`):**
+
+1. `Contracts/PurchaseOrderHistoryDto.cs`
+   Current content:
+   ```csharp
+   namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+   public class PurchaseOrderHistoryDto
+   {
+       public int Id { get; set; }
+       public string Action { get; set; } = null!;
+       public string? OldValue { get; set; }
+       public string? NewValue { get; set; }
+       public DateTime ChangedAt { get; set; }
+       public string ChangedBy { get; set; } = null!;
+   }
+   ```
+   Change to:
+   ```csharp
+   using Anela.Heblo.Domain.Features.Purchase;
+
+   namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+   public class PurchaseOrderHistoryDto
+   {
+       public int Id { get; set; }
+       public string Action { get; set; } = null!;
+       public string? OldValue { get; set; }
+       public string? NewValue { get; set; }
+       public DateTime ChangedAt { get; set; }
+       public string ChangedBy { get; set; } = null!;
+
+       public static PurchaseOrderHistoryDto FromDomain(PurchaseOrderHistory h) =>
+           new()
+           {
+               Id = h.Id,
+               Action = h.Action,
+               OldValue = h.OldValue,
+               NewValue = h.NewValue,
+               ChangedAt = h.ChangedAt,
+               ChangedBy = h.ChangedBy
+           };
+   }
+   ```
+   This mirrors `Contracts/PurchaseOrderLineDto.cs`'s `FromLine` factory (same file, same folder) — match its style exactly (single-expression static factory, object initializer, same brace/indentation conventions already in this file).
+
+2. `UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs` — inside the private `MapToResponse` method, currently at lines 114–122:
+   ```csharp
+   var history = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
+   {
+       Id = h.Id,
+       Action = h.Action,
+       OldValue = h.OldValue,
+       NewValue = h.NewValue,
+       ChangedAt = h.ChangedAt,
+       ChangedBy = h.ChangedBy
+   }).ToList();
+   ```
+   Replace with:
+   ```csharp
+   var history = purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).ToList();
+   ```
+   Do not touch anything else in `MapToResponse` (the `lines` assignment above it and the `CreatePurchaseOrderResponse` construction below it stay exactly as-is).
+
+3. `UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs` — inside the `GetPurchaseOrderByIdResponse` object initializer, currently at lines 71–79:
+   ```csharp
+   History = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
+   {
+       Id = h.Id,
+       Action = h.Action,
+       OldValue = h.OldValue,
+       NewValue = h.NewValue,
+       ChangedAt = h.ChangedAt,
+       ChangedBy = h.ChangedBy
+   }).OrderByDescending(h => h.ChangedAt).ToList(),
+   ```
+   Replace with:
+   ```csharp
+   History = purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt).ToList(),
+   ```
+   Critical: keep `.OrderByDescending(h => h.ChangedAt)` immediately after `.Select(...)`, in that order, operating on the DTO's `ChangedAt` — do not reorder relative to `Select`, drop it, or move it before the mapping. This is called out explicitly as a risk in the arch review.
+
+4. `UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs` — currently at lines 37–47:
+   ```csharp
+   var items = history
+       .Select(h => new PurchaseOrderHistoryDto
+       {
+           Id = h.Id,
+           Action = h.Action,
+           OldValue = h.OldValue,
+           NewValue = h.NewValue,
+           ChangedAt = h.ChangedAt,
+           ChangedBy = h.ChangedBy,
+       })
+       .ToList();
+   ```
+   Replace with:
+   ```csharp
+   var items = history
+       .Select(PurchaseOrderHistoryDto.FromDomain)
+       .ToList();
+   ```
+
+**Do not change:** method signatures, logging calls, response construction, ordering/assignment of any other field, or any file not listed above. `PurchaseOrderLineDto.cs` and `PurchaseOrderHistory.cs` (domain entity) are read-only references — do not modify them.
+
+**Acceptance criteria:**
+- `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)` exists as a `public static` single-expression factory, matching `PurchaseOrderLineDto.FromLine`'s style, mapping all six fields (`Id`, `Action`, `OldValue`, `NewValue`, `ChangedAt`, `ChangedBy`) 1:1 with no transformation.
+- `grep -rn "new PurchaseOrderHistoryDto" backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/` returns no matches (the only remaining construction is inside `FromDomain` itself, in `Contracts/`).
+- `GetPurchaseOrderByIdHandler`'s `.Select(...).OrderByDescending(h => h.ChangedAt).ToList()` sequence is preserved exactly (mapping first, ordering second).
+- No other lines in the three handler files change (verify via `git diff` — only the mapping blocks and, in `PurchaseOrderHistoryDto.cs`, the added `using` and factory method should appear).
+
+**Verification steps (run from the `backend/` directory unless noted):**
+1. `grep -rn "new PurchaseOrderHistoryDto" ../backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/` (or equivalent path from repo root: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/`) — expect zero matches.
+2. `dotnet build Anela.Heblo.sln` from the repo root (`/home/user/worktrees/feature-3580-Arch-Review-Purchase-Purchaseorderhistorydto-Mappi`) — must succeed with no new warnings/errors.
+3. `dotnet format Anela.Heblo.sln` from the repo root — apply and ensure no unexpected formatting diffs beyond the intended edits.
+4. Run the existing unit tests unmodified and confirm they pass:
+   - `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CreatePurchaseOrderHandlerTests"`
+   - `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetPurchaseOrderHistoryHandlerTests"`
+   - Note: no dedicated `GetPurchaseOrderByIdHandlerTests.cs` currently exists in the repo (confirmed absent at plan time) — nothing to run for that handler beyond the build succeeding; do not add a new test file, per the spec's "Out of Scope" section (new tests for `FromDomain` are explicitly not required).
+5. Do not modify any test file — the spec requires all existing tests to pass **unmodified**, since output shape/values are unchanged.
+
+**Definition of done:** all four verification steps pass, `git diff` shows changes confined to the four files listed above, and no unrelated code (logging, response shape, other handlers) was touched.

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderHistoryDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/PurchaseOrderHistoryDto.cs
@@ -1,3 +1,5 @@
+using Anela.Heblo.Domain.Features.Purchase;
+
 namespace Anela.Heblo.Application.Features.Purchase.Contracts;
 
 public class PurchaseOrderHistoryDto
@@ -8,4 +10,15 @@ public class PurchaseOrderHistoryDto
     public string? NewValue { get; set; }
     public DateTime ChangedAt { get; set; }
     public string ChangedBy { get; set; } = null!;
+
+    public static PurchaseOrderHistoryDto FromDomain(PurchaseOrderHistory h) =>
+        new()
+        {
+            Id = h.Id,
+            Action = h.Action,
+            OldValue = h.OldValue,
+            NewValue = h.NewValue,
+            ChangedAt = h.ChangedAt,
+            ChangedBy = h.ChangedBy
+        };
 }

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/CreatePurchaseOrderHandler.cs
@@ -111,15 +111,7 @@ public class CreatePurchaseOrderHandler : IRequestHandler<CreatePurchaseOrderReq
     {
         var lines = purchaseOrder.Lines.Select(line => PurchaseOrderLineDto.FromLine(line)).ToList();
 
-        var history = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
-        {
-            Id = h.Id,
-            Action = h.Action,
-            OldValue = h.OldValue,
-            NewValue = h.NewValue,
-            ChangedAt = h.ChangedAt,
-            ChangedBy = h.ChangedBy
-        }).ToList();
+        var history = purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).ToList();
 
         return new CreatePurchaseOrderResponse
         {

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs
@@ -68,15 +68,7 @@ public class GetPurchaseOrderByIdHandler : IRequestHandler<GetPurchaseOrderByIdR
             Lines = purchaseOrder.Lines.Select(l =>
                 PurchaseOrderLineDto.FromLine(l, materialLookup.TryGetValue(l.MaterialId, out var material) ? material.Note : null)
             ).ToList(),
-            History = purchaseOrder.History.Select(h => new PurchaseOrderHistoryDto
-            {
-                Id = h.Id,
-                Action = h.Action,
-                OldValue = h.OldValue,
-                NewValue = h.NewValue,
-                ChangedAt = h.ChangedAt,
-                ChangedBy = h.ChangedBy
-            }).OrderByDescending(h => h.ChangedAt).ToList(),
+            History = purchaseOrder.History.Select(PurchaseOrderHistoryDto.FromDomain).OrderByDescending(h => h.ChangedAt).ToList(),
             CreatedAt = purchaseOrder.CreatedAt,
             CreatedBy = purchaseOrder.CreatedBy,
             UpdatedAt = purchaseOrder.UpdatedAt,

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseOrderHistory/GetPurchaseOrderHistoryHandler.cs
@@ -35,15 +35,7 @@ public class GetPurchaseOrderHistoryHandler : IRequestHandler<GetPurchaseOrderHi
         var history = await _repository.GetHistoryAsync(request.Id, cancellationToken);
 
         var items = history
-            .Select(h => new PurchaseOrderHistoryDto
-            {
-                Id = h.Id,
-                Action = h.Action,
-                OldValue = h.OldValue,
-                NewValue = h.NewValue,
-                ChangedAt = h.ChangedAt,
-                ChangedBy = h.ChangedBy,
-            })
+            .Select(PurchaseOrderHistoryDto.FromDomain)
             .ToList();
 
         _logger.LogInformation("Returning {Count} history entries for purchase order {Id}", items.Count, request.Id);


### PR DESCRIPTION
Closes #3580

## What the issue was
The manual mapping from `PurchaseOrderHistory` (domain entity) to `PurchaseOrderHistoryDto` (contract) was copy-pasted verbatim across three MediatR handlers in the Purchase module: `CreatePurchaseOrderHandler`, `GetPurchaseOrderByIdHandler`, and `GetPurchaseOrderHistoryHandler`. `PurchaseOrderLineDto` already solved the same problem with a static `FromLine` factory, but `PurchaseOrderHistoryDto` had no equivalent — so any future field change to `PurchaseOrderHistory` would require updating three separate call sites in sync, with a missed site silently producing incorrect API responses.

## How it was fixed / handled
Added a static factory `PurchaseOrderHistoryDto.FromDomain(PurchaseOrderHistory h)`, mirroring the existing `PurchaseOrderLineDto.FromLine` pattern in the same folder, mapping all six fields (`Id`, `Action`, `OldValue`, `NewValue`, `ChangedAt`, `ChangedBy`) 1:1 with no transformation. Replaced all three inline mapping blocks with `.Select(PurchaseOrderHistoryDto.FromDomain)`, preserving the `.OrderByDescending(h => h.ChangedAt)` step in `GetPurchaseOrderByIdHandler` exactly where it was (applied after the mapping). This is a pure mechanical refactor with no behavior or contract change — verified via `dotnet build`, a grep for any remaining inline `new PurchaseOrderHistoryDto` constructions (zero matches), and the existing unit test suites (`CreatePurchaseOrderHandlerTests`, `GetPurchaseOrderHistoryHandlerTests`) passing unmodified.

## Artifacts
Brief, spec, architecture review, task plan, impl, and review markdown are committed under `artifacts/feat-3580/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01FnezsHfPYN5oxkAckjagGs)_