### PR TITLE
#3581: use IsExport instead of PageSize=int.MaxValue in LowStockEfficiencyTile

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Purchase/DashboardTiles/LowStockEfficiencyTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/DashboardTiles/LowStockEfficiencyTile.cs
@@ -36,7 +36,7 @@ public class LowStockEfficiencyTile : ITile
             var request = new GetPurchaseStockAnalysisRequest
             {
                 StockStatus = StockStatusFilter.All,
-                PageSize = int.MaxValue
+                IsExport = true
             };
 
             var response = await _mediator.Send(request, cancellationToken);


### PR DESCRIPTION
Closes #3581

## What the issue was
`LowStockEfficiencyTile` fetched all stock analysis items by setting `PageSize = int.MaxValue` on `GetPurchaseStockAnalysisRequest`, instead of using the request's existing `IsExport` flag, which the handler already treats as the correct "return all items without pagination" mechanism.

Using `PageSize = int.MaxValue` bypasses the semantically correct API, produces a misleading `PageSize = 2147483647` in the response metadata, and would silently break if the handler's `[Range(1, 100)]` validation on `PageSize` were ever enforced internally.

## How it was fixed
Replaced `PageSize = int.MaxValue` with `IsExport = true` in `LowStockEfficiencyTile.LoadDataAsync`, matching the suggested fix in the issue. No other behavior changes — `GetPurchaseStockAnalysisHandler` already returns the unpaginated `analysisItems` when `IsExport` is `true`.

## Testing
- `dotnet build` — 0 errors
- `dotnet format --verify-no-changes` on the changed file — clean
- Ran the Purchase and Dashboard-tile test suites (275/276 passed; the 1 failure is an unrelated pre-existing Testcontainers/Docker environment issue, not caused by this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hx83SMedCGJtpbYBYrUB2d)_