### PR TITLE
#3582: implementation

### DIFF
--- a/artifacts/feat-3582/arch-review.r1.md
+++ b/artifacts/feat-3582/arch-review.r1.md
@@ -1,0 +1,72 @@
+# Architecture Review: Remove dead severity-formatting exports from `usePurchaseStockAnalysis.ts`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is dead-code removal, not feature work. There is no architectural surface to fit: no new module, no new contract, no cross-boundary dependency. The two functions (`getSeverityColorClass`, `getSeverityDisplayText`) are pure, side-effect-free string formatters that happen to be co-located in a React Query hook file but have no relationship to the query logic itself. Verified directly against the working tree:
+
+- `frontend/src/api/hooks/usePurchaseStockAnalysis.ts` exports `usePurchaseStockAnalysisQuery`, the two dead helpers (lines 72–109), then `formatNumber`/`formatCurrency` (lines 112–130), which are genuinely consumed elsewhere.
+- Project-wide grep (`grep -rn "getSeverityColorClass\|getSeverityDisplayText" frontend/src`) returns only the two `export const` definitions at lines 72 and 92 — no import, no call site, no test reference, anywhere in `frontend/src`.
+- `frontend/src/components/pages/PurchaseStockAnalysis.tsx`, the natural consumer, imports `StockSeverity` directly from the generated API client and implements its own inline `getRowColorClass` (line 251) and `getSeverityStripColor` (line 292) — it never delegates to the hook's exports. Removal changes nothing for this page.
+- `getSeverityColorClass` returns light-mode-only classes (e.g. `text-red-600 bg-red-50`, no `dark:` variant), which is a latent ADR-006 violation. Since it's dead code, deleting it is strictly better than fixing it — no reason to invest in dark-mode variants for code nobody calls.
+
+Aligns with YAGNI and the repo's "surgical changes" norm: delete only what's unused, touch nothing else in the file.
+
+## Proposed Architecture
+
+### Component Overview
+No components change. This is a subtraction from one existing file:
+
+```
+frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+├── usePurchaseStockAnalysisQuery   (kept, untouched)
+├── getSeverityColorClass           (DELETE, lines 72-89 + comment)
+├── getSeverityDisplayText          (DELETE, lines 92-109 + comment)
+├── formatNumber                    (kept, untouched)
+└── formatCurrency                  (kept, untouched)
+```
+
+No other file changes. No new files.
+
+### Key Design Decisions
+
+#### Decision 1: Delete vs. fix-and-keep
+**Options considered:**
+1. Delete both functions (spec's proposal).
+2. Keep them but add `dark:` variants to make them ADR-006-compliant "for future use."
+
+**Chosen approach:** Delete.
+
+**Rationale:** Option 2 speculatively maintains code with zero consumers — the definition of YAGNI violation the brief calls out. If a future screen needs severity-to-class/text mapping, it should be written fresh, co-located with its consumer, and reviewed for ADR-006 compliance at that time (as `PurchaseStockAnalysis.tsx` already does independently with its own `getRowColorClass`/`getSeverityStripColor`). Keeping unused code "just in case" is exactly the pattern this codebase's arch-review process exists to catch.
+
+#### Decision 2: Scope of the diff
+**Options considered:**
+1. Remove only the two functions and their preceding comments.
+2. Also touch `formatNumber`/`formatCurrency` or reorganize the file while in there.
+
+**Chosen approach:** Option 1 — strictly the two functions and their comments.
+
+**Rationale:** Matches CLAUDE.md's "surgical changes" rule and FR-3's acceptance criterion that `git diff` show only the two removals. No adjacent cleanup, no reformatting.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No structural change. Edit in place: `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`.
+
+### Interfaces and Contracts
+None affected. `GetPurchaseStockAnalysisRequest`, the re-exported generated types (`StockStatusFilter`, `StockAnalysisSortBy`, `StockSeverity`, `StockAnalysisItemDto`, `LastPurchaseInfoDto`, `StockAnalysisSummaryDto`, `GetPurchaseStockAnalysisResponse`), and `stockAnalysisKeys` are untouched. `usePurchaseStockAnalysisQuery`'s signature and behavior are unchanged.
+
+### Data Flow
+Unaffected — no runtime code path currently calls either function, so no data flow changes.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Hidden consumer missed by grep (e.g. dynamic import, string-based reflection) | Very Low | Grep covers all of `frontend/src` for both exact identifiers; TypeScript's build step (`npm run build`) will fail loudly on any missed static import, and `tsc`/ESLint would flag an unused-import if one existed. |
+| Test file references the removed exports | Very Low | `PurchaseStockAnalysis.test.tsx` was checked in the spec's verification pass; it does not import either function. Run `npm run build` and the existing test suite as a final check per FR-3. |
+
+## Specification Amendments
+None. The spec is complete, correctly scoped, and its acceptance criteria are directly verifiable via `grep` and `git diff`. No architectural gaps were found during review.
+
+## Prerequisites
+None. No migrations, config, or infrastructure changes are needed — this is a self-contained frontend edit ready for immediate implementation.

--- a/artifacts/feat-3582/brief.md
+++ b/artifacts/feat-3582/brief.md
@@ -1,0 +1,33 @@
+## Module
+Purchase
+
+## Finding
+`frontend/src/api/hooks/usePurchaseStockAnalysis.ts` exports two helper functions at lines 72–109 that are never imported anywhere in the codebase:
+
+```typescript
+export const getSeverityColorClass = (severity: StockSeverity | undefined): string => { ... }  // line 72
+export const getSeverityDisplayText = (severity: StockSeverity | undefined): string => { ... }  // line 92
+```
+
+A project-wide search for `getSeverityColorClass` and `getSeverityDisplayText` finds only the definitions — no import or invocation site. Both are dead exports.
+
+Additionally, `getSeverityColorClass` returns hardcoded light-mode-only Tailwind classes (e.g. `"text-red-600 bg-red-50"`) with no `dark:` variants, which would violate ADR-006 if the function were activated:
+
+```typescript
+case StockSeverity.Critical:
+    return "text-red-600 bg-red-50";   // no dark:text-... or dark:bg-...
+case StockSeverity.Low:
+    return "text-orange-600 bg-orange-50";
+// ...
+```
+
+The `PurchaseStockAnalysis.tsx` page, which is the natural consumer, imports `formatNumber` and `formatCurrency` from the same hook but does not import these helpers — it handles severity display with its own inline logic.
+
+## Why it matters
+Dead exports violate YAGNI and silently grow the public surface of the hook, making it harder to understand what callers actually use. `getSeverityColorClass` in particular, if someone copies it as a quick fix, would produce broken dark-mode rendering (breaking ADR-006 on a high-visibility status column).
+
+## Suggested fix
+Remove both functions from `usePurchaseStockAnalysis.ts`. If severity display helpers are genuinely needed in the future, add them when there is a concrete consumer, co-locate them in the component that uses them, and follow ADR-006 by including `dark:` variants (e.g. `"text-red-600 bg-red-50 dark:text-red-400 dark:bg-red-900/30"`).
+
+---
+_Filed by daily arch-review routine on 2026-07-10._

--- a/artifacts/feat-3582/code-review.r1.md
+++ b/artifacts/feat-3582/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3582/design.r1.md
+++ b/artifacts/feat-3582/design.r1.md
@@ -1,0 +1,13 @@
+# Design: Remove dead severity-formatting exports from `usePurchaseStockAnalysis.ts`
+
+No UI or data schema changes are involved. This is a pure dead-code deletion in a single frontend file, with no user-facing surface and no request/response, event, or database shape affected.
+
+## Component Design
+The only change is a subtraction from `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`: delete the two dead exports `getSeverityColorClass` (lines 72–89, plus its preceding comment) and `getSeverityDisplayText` (lines 92–109, plus its preceding comment). Both are pure, side-effect-free string formatters with zero consumers anywhere in `frontend/src` — confirmed by project-wide grep in both the spec and the architecture review.
+
+`usePurchaseStockAnalysisQuery`, `formatNumber`, `formatCurrency`, the re-exported generated types (`StockStatusFilter`, `StockAnalysisSortBy`, `StockSeverity`, `StockAnalysisItemDto`, `LastPurchaseInfoDto`, `StockAnalysisSummaryDto`, `GetPurchaseStockAnalysisResponse`), the `GetPurchaseStockAnalysisRequest` interface, and the `stockAnalysisKeys` query-key factory all remain in the file, untouched.
+
+There is no other consumer to coordinate with: `PurchaseStockAnalysis.tsx`, the natural candidate, never imports either function — it implements its own inline `getRowColorClass` and `getSeverityStripColor` for severity-based styling. The deletion is therefore self-contained to one file, with no interface, contract, or call-site changes elsewhere.
+
+## Data Schemas
+Not applicable — no database, API, or event payload changes.

--- a/artifacts/feat-3582/impl/remove-dead-severity-exports.r1.md
+++ b/artifacts/feat-3582/impl/remove-dead-severity-exports.r1.md
@@ -1,0 +1,36 @@
+# Implementation: remove-dead-severity-exports
+
+## What was implemented
+Removed the two dead exported helper functions `getSeverityColorClass` and `getSeverityDisplayText` (and their preceding comments) from `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`. These had zero consumers anywhere in `frontend/src` — `PurchaseStockAnalysis.tsx` implements its own inline severity styling and never imported either export.
+
+## Files created/modified
+- `frontend/src/api/hooks/usePurchaseStockAnalysis.ts` — deleted the `getSeverityColorClass` and `getSeverityDisplayText` functions plus their two preceding comments and the blank line separating them from the next comment (40 lines removed, no lines added). `usePurchaseStockAnalysisQuery`, `formatNumber`, `formatCurrency`, and all other exports in the file are untouched.
+
+## Tests
+There are no dedicated unit tests for this hook file. Verification was done via:
+- `grep -n "getSeverityColorClass\|getSeverityDisplayText" frontend/src/api/hooks/usePurchaseStockAnalysis.ts` — zero matches (confirmed removed).
+- `grep -n "export const usePurchaseStockAnalysisQuery\|export const formatNumber\|export const formatCurrency" frontend/src/api/hooks/usePurchaseStockAnalysis.ts` — three matches, confirming remaining exports intact.
+- `cd frontend && grep -rn "getSeverityColorClass\|getSeverityDisplayText" src` — zero matches project-wide, confirming no consumers were missed.
+- `git diff -- frontend/src/api/hooks/usePurchaseStockAnalysis.ts` — diff shows only 40 deleted lines (the two functions, their comments, and one blank line), no additions, no other changes.
+- `cd frontend && npm run build` (with `CI=true`) — compiled successfully, no errors.
+- `cd frontend && npm run lint` — 162 pre-existing problems reported, all in unrelated test files (testing-library rules in marketing/, financial-overview/, terminal/, contexts/, leaflet-generator/ test specs); zero issues in `usePurchaseStockAnalysis.ts` (confirmed via `npm run lint 2>&1 | grep -i usePurchaseStockAnalysis` returning no output). Nothing new was introduced by this change.
+
+## How to verify
+1. `cd frontend && npm install --legacy-peer-deps` (node_modules was not pre-installed in this environment; a plain `npm install`/`npm ci` fails due to a pre-existing `react-i18next` peer-dependency conflict against `typescript@4.9.5` — unrelated to this change).
+2. `npm run build` — should compile successfully.
+3. `npm run lint` — should show no errors for `usePurchaseStockAnalysis.ts`.
+4. `git show f4520703979fd7e9cf42e76560e316bd33d4e422` — review the commit diff, should only show the 40 deleted lines in the target file.
+5. `grep -rn "getSeverityColorClass\|getSeverityDisplayText" src` (from `frontend/`) — should return no matches.
+
+## Notes
+- `node_modules` was not present in the worktree; had to run `npm install --legacy-peer-deps` to get `react-scripts`/eslint available for build and lint. This is an existing, unrelated peer-dependency conflict in the repo's `package.json` (react-i18next 15.7.4 wants TypeScript 5, project pins TypeScript 4.9.5) — not something introduced or fixed by this task, flagging for awareness only.
+- `git status` after the commit shows an unrelated pre-existing modification to `artifacts/feat-3582/state.json` in the working tree; this was not touched by this task and was left as-is (appears to be pipeline-managed state).
+
+## PR Summary
+Deleted two dead exported helper functions, `getSeverityColorClass` and `getSeverityDisplayText`, from `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`. Both were confirmed to have zero consumers anywhere in `frontend/src` via project-wide grep before and after the change. `PurchaseStockAnalysis.tsx` implements its own inline severity styling and never referenced either export; `getSeverityColorClass` additionally lacked dark-mode variants, which would have been a latent ADR-006 violation had it ever been wired up. All other exports in the file (`usePurchaseStockAnalysisQuery`, `formatNumber`, `formatCurrency`, and the re-exported generated types) are unaffected. Verified with a scoped `git diff` (40 deletions only), a project-wide grep for the removed identifiers (no matches), `npm run build` (success), and `npm run lint` (no new issues; pre-existing unrelated failures only in test files elsewhere in the codebase).
+
+### Changes
+- `frontend/src/api/hooks/usePurchaseStockAnalysis.ts` — removed dead `getSeverityColorClass` and `getSeverityDisplayText` exports and their comments (40 lines deleted, nothing added).
+
+## Status
+DONE

--- a/artifacts/feat-3582/review/remove-dead-severity-exports.r1.md
+++ b/artifacts/feat-3582/review/remove-dead-severity-exports.r1.md
@@ -1,0 +1,22 @@
+# Code Review: Remove dead severity-formatting exports
+
+## Summary
+The implementation does exactly what the task specifies: deletes `getSeverityColorClass` and `getSeverityDisplayText` (plus their preceding comments and the separating blank line) from `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`, leaving everything else in the file untouched. All verification steps claimed in the implementation summary were independently re-run and confirmed.
+
+## Review Result: PASS
+
+### task: remove-dead-severity-exports
+**Status:** PASS
+
+## Docs to Update
+(None — this is a dead-code removal with no consumer-facing or architectural impact; no README/ADR/CLAUDE.md content references these exports.)
+
+## Overall Notes
+- `git show --stat HEAD` confirms only one file changed: `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`, 40 deletions, 0 additions — exactly matching the spec's `old_string`/`new_string` anchor.
+- The diff removes precisely the two function bodies, their two preceding comments, and the blank line separating them, going directly from the closing `};` of `usePurchaseStockAnalysisQuery` to the `// Helper function to format Czech number` comment — matches the spec's required boundary exactly.
+- Independently re-ran `grep -rn "getSeverityColorClass\|getSeverityDisplayText" src` from `frontend/` — zero matches, confirming no consumers were missed.
+- Independently re-ran the identifier-presence grep — `usePurchaseStockAnalysisQuery`, `formatNumber`, `formatCurrency` all still present, one match each.
+- Independently ran `npx eslint` on the modified file — clean, no output.
+- Independently ran `CI=true npm run build` — compiled successfully with no errors.
+- Working tree is clean for the target file after commit; the only outstanding modification (`artifacts/feat-3582/state.json`) is unrelated pipeline-managed state, as correctly noted in the implementation summary.
+- Commit message accurately describes the change and rationale (zero consumers, verified by grep; incidental note about `getSeverityColorClass` lacking dark-mode variants is informational and doesn't affect scope).

--- a/artifacts/feat-3582/spec.r1.md
+++ b/artifacts/feat-3582/spec.r1.md
@@ -1,0 +1,68 @@
+# Specification: Remove dead severity-formatting exports from `usePurchaseStockAnalysis.ts`
+
+## Summary
+`frontend/src/api/hooks/usePurchaseStockAnalysis.ts` exports two helper functions, `getSeverityColorClass` and `getSeverityDisplayText`, that have zero consumers anywhere in the frontend codebase. This spec covers removing both dead exports to reduce the hook's public surface and eliminate a latent dark-mode violation that would trigger if either function were ever wired up.
+
+## Background
+The Purchase Stock Analysis feature exposes a React Query hook (`usePurchaseStockAnalysisQuery`) in `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`, alongside several standalone helper functions re-exported from the same module: `getSeverityColorClass` (line 72), `getSeverityDisplayText` (line 92), `formatNumber` (line 112), and `formatCurrency` (line 124).
+
+Verification performed against the working tree at `/home/user/worktrees/feature-3582-Arch-Review-Purchase-Getseveritycolorclass-And-Get`:
+
+- Read the full contents of `usePurchaseStockAnalysis.ts`. `getSeverityColorClass` (lines 72–89) and `getSeverityDisplayText` (lines 92–109) are confirmed to exist as described, immediately followed by `formatNumber` and `formatCurrency`.
+- Ran `grep -rn "getSeverityColorClass\|getSeverityDisplayText" frontend/src` — the only two matches in the entire `frontend/src` tree are the two `export const` definitions themselves at lines 72 and 92. No file imports or calls either function. This confirms the brief's claim: both are dead exports with zero consumers.
+- Read `frontend/src/components/pages/PurchaseStockAnalysis.tsx`, the natural consumer page. It imports `StockSeverity` directly from `../../api/generated/api-client` (not the two helpers) and implements its own inline severity-to-styling logic via two locally defined functions: `getRowColorClass` (line 251, row background tinting) and `getSeverityStripColor` (line 292, color strip). Neither delegates to the hook's exported helpers.
+- Confirmed the dark-mode concern: `getSeverityColorClass` returns hardcoded classes such as `"text-red-600 bg-red-50"` with no `dark:` variant. Per `memory/decisions/light-dark-mode-required.md` (which implements ADR-006, defined in `docs/architecture/development_guidelines.md`), every frontend component/function that renders color must have both light and dark styling before it can be considered usable. `getSeverityColorClass` does not meet this bar. Because it is unused, it is not currently a live violation, but it would become one immediately if any future code imported it as-is.
+- `formatNumber` and `formatCurrency`, defined in the same file directly below the two dead exports, are excluded from this change — they are actively imported and used elsewhere (e.g., by `PurchaseStockAnalysis.tsx`) and are out of scope.
+
+This is a pure dead-code removal (YAGNI cleanup) identified during an architecture review pass over the Purchase module. No behavior change is intended for any active code path.
+
+## Functional Requirements
+
+### FR-1: Remove `getSeverityColorClass` export
+Delete the `getSeverityColorClass` function (currently lines 72–89 of `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`), including its preceding comment (`// Helper function to get severity color class`).
+
+**Acceptance criteria:**
+- `getSeverityColorClass` no longer appears anywhere in `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`.
+- A project-wide search (`grep -rn "getSeverityColorClass" frontend/src`) returns zero matches.
+
+### FR-2: Remove `getSeverityDisplayText` export
+Delete the `getSeverityDisplayText` function (currently lines 92–109 of `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`), including its preceding comment (`// Helper function to get severity display text`).
+
+**Acceptance criteria:**
+- `getSeverityDisplayText` no longer appears anywhere in `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`.
+- A project-wide search (`grep -rn "getSeverityDisplayText" frontend/src`) returns zero matches.
+
+### FR-3: Preserve all remaining exports and behavior unchanged
+`usePurchaseStockAnalysisQuery`, `formatNumber`, `formatCurrency`, the re-exported generated types (`StockStatusFilter`, `StockAnalysisSortBy`, `StockSeverity`, `StockAnalysisItemDto`, `LastPurchaseInfoDto`, `StockAnalysisSummaryDto`, `GetPurchaseStockAnalysisResponse`), the `GetPurchaseStockAnalysisRequest` interface, and the `stockAnalysisKeys` query-key factory must remain exactly as they are today — no signature, behavior, or formatting changes beyond removing the two dead functions.
+
+**Acceptance criteria:**
+- `git diff` on `usePurchaseStockAnalysis.ts` shows only the removal of the two functions (and their comments); no other lines are touched.
+- `PurchaseStockAnalysis.tsx` and its test file `frontend/src/components/pages/__tests__/PurchaseStockAnalysis.test.tsx` require no changes and continue to pass, since neither imports the removed functions.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — this is a dead-code removal with no runtime code paths affected. No measurable performance impact (a negligible reduction in bundle size from removing ~18 lines of dead code).
+
+### NFR-2: Security
+Not applicable — no security-sensitive code, data, or auth logic is involved.
+
+## Data Model
+Not applicable — no data model changes. `StockSeverity` enum (from generated API client) is unaffected; it continues to be used by `PurchaseStockAnalysis.tsx`'s own inline severity-styling functions.
+
+## API / Interface Design
+Not applicable — no backend API changes. This is a frontend-only removal of two unused TypeScript function exports; no public component props, hooks signatures, or HTTP endpoints change.
+
+## Dependencies
+- None. This change is self-contained within `frontend/src/api/hooks/usePurchaseStockAnalysis.ts` and has no upstream or downstream dependencies, since the removed functions have no consumers.
+
+## Out of Scope
+- Any change to `formatNumber` or `formatCurrency` in the same file — both are actively used and unaffected.
+- Any change to `PurchaseStockAnalysis.tsx`'s own inline `getRowColorClass` / `getSeverityStripColor` functions, which already implement severity-based coloring independently (including dark-mode-aware classes where applicable) and are not part of this cleanup.
+- Adding dark-mode variants to the removed functions — since they are being deleted rather than activated, ADR-006 compliance work is unnecessary.
+- Broader dead-code audits of other hooks or modules — this spec is scoped to the two named exports in the Purchase module only.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3582",
+  "issue_number": 3582,
+  "created_at": "2026-07-10T11:15:48.600959Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-10T11:19:12.523270Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-10T11:20:32.272963Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-10T11:27:39.532027Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-10T11:27:46.459770Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-10T11:20:32.272963Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-10T11:20:56.300484Z"
     }
   },
   "tasks": [
     {
       "name": "remove-dead-severity-exports",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-10T11:20:56.489546Z"
     }
   ]
 }

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-10T11:17:28.569611Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-10T11:27:39.532027Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-10T11:27:46.459770Z"
+      "status": "completed",
+      "updated_at": "2026-07-10T11:28:26.075345Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-10T11:18:31.950826Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-10T11:19:12.523270Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-10T11:17:28.569611Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-10T11:18:31.950826Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-10T11:20:32.272963Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-10T11:20:56.300484Z"
+      "status": "completed",
+      "updated_at": "2026-07-10T11:27:39.532027Z"
     }
   },
   "tasks": [
     {
       "name": "remove-dead-severity-exports",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-10T11:20:56.489546Z"
+      "updated_at": "2026-07-10T11:27:35.231498Z"
     }
   ]
 }

--- a/artifacts/feat-3582/state.json
+++ b/artifacts/feat-3582/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "remove-dead-severity-exports",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3582/task-context/remove-dead-severity-exports.md
+++ b/artifacts/feat-3582/task-context/remove-dead-severity-exports.md
@@ -1,0 +1,162 @@
+### task: remove-dead-severity-exports
+
+**Files:**
+- Modify: `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`
+
+- [ ] Open `frontend/src/api/hooks/usePurchaseStockAnalysis.ts` and locate the block starting at the comment `// Helper function to get severity color class` (currently line 71) and ending at the closing brace of `getSeverityDisplayText` (currently line 109), followed by a blank line (line 110). This block currently reads:
+
+  ```ts
+  // Helper function to get severity color class
+  export const getSeverityColorClass = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "text-red-600 bg-red-50";
+      case StockSeverity.Low:
+        return "text-orange-600 bg-orange-50";
+      case StockSeverity.Optimal:
+        return "text-green-600 bg-green-50";
+      case StockSeverity.Overstocked:
+        return "text-blue-600 bg-blue-50";
+      case StockSeverity.NotConfigured:
+        return "text-gray-600 bg-gray-50";
+      default:
+        return "text-gray-600 bg-gray-50";
+    }
+  };
+
+  // Helper function to get severity display text
+  export const getSeverityDisplayText = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "Kritický";
+      case StockSeverity.Low:
+        return "Nízký";
+      case StockSeverity.Optimal:
+        return "Optimální";
+      case StockSeverity.Overstocked:
+        return "Přeskladněno";
+      case StockSeverity.NotConfigured:
+        return "Nezkonfigurováno";
+      default:
+        return "Neznámý";
+    }
+  };
+
+  ```
+
+  Delete this entire block (both function definitions, both preceding comments, and the blank line that separates the second function from the next comment). Do not touch anything before or after it — the file must go directly from the closing `};` of `usePurchaseStockAnalysisQuery` straight to the `// Helper function to format Czech number` comment that precedes `formatNumber`.
+
+  Concretely, use this Edit (old_string includes one line of context on each side to anchor the match uniquely):
+
+  old_string:
+  ```
+  };
+
+  // Helper function to get severity color class
+  export const getSeverityColorClass = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "text-red-600 bg-red-50";
+      case StockSeverity.Low:
+        return "text-orange-600 bg-orange-50";
+      case StockSeverity.Optimal:
+        return "text-green-600 bg-green-50";
+      case StockSeverity.Overstocked:
+        return "text-blue-600 bg-blue-50";
+      case StockSeverity.NotConfigured:
+        return "text-gray-600 bg-gray-50";
+      default:
+        return "text-gray-600 bg-gray-50";
+    }
+  };
+
+  // Helper function to get severity display text
+  export const getSeverityDisplayText = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "Kritický";
+      case StockSeverity.Low:
+        return "Nízký";
+      case StockSeverity.Optimal:
+        return "Optimální";
+      case StockSeverity.Overstocked:
+        return "Přeskladněno";
+      case StockSeverity.NotConfigured:
+        return "Nezkonfigurováno";
+      default:
+        return "Neznámý";
+    }
+  };
+
+  // Helper function to format Czech number
+  ```
+
+  new_string:
+  ```
+  };
+
+  // Helper function to format Czech number
+  ```
+
+- [ ] Verify the two removed identifiers no longer appear in the file:
+  ```bash
+  grep -n "getSeverityColorClass\|getSeverityDisplayText" frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  ```
+  Expected: no output (zero matches).
+
+- [ ] Verify `formatNumber` and `formatCurrency` are still present and unchanged, and that the file still exports the query hook:
+  ```bash
+  grep -n "export const usePurchaseStockAnalysisQuery\|export const formatNumber\|export const formatCurrency" frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  ```
+  Expected: three matches, one per identifier.
+
+- [ ] Run a project-wide grep to confirm there are no other references to the removed functions anywhere in the frontend source (there should not be, per the spec/arch-review verification, but this is the final acceptance check from FR-1/FR-2):
+  ```bash
+  cd frontend && grep -rn "getSeverityColorClass\|getSeverityDisplayText" src
+  ```
+  Expected: no output (zero matches). If this reports a match outside the file just edited, stop and investigate before proceeding — it means a consumer was missed by prior analysis.
+
+- [ ] Confirm the diff is scoped exactly as expected (only the two functions and their comments removed, nothing else touched):
+  ```bash
+  git diff -- frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  ```
+  Expected: a diff showing only deleted lines (the two function bodies, their comments, and one blank line) — no added lines, no changes elsewhere in the file.
+
+- [ ] Build the frontend to confirm no broken imports or type errors resulted from the removal:
+  ```bash
+  cd frontend && npm run build
+  ```
+  Expected: build succeeds with no errors.
+
+- [ ] Lint the frontend:
+  ```bash
+  cd frontend && npm run lint
+  ```
+  Expected: lint passes with no new errors.
+
+- [ ] Commit the change:
+  ```bash
+  git add frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  git commit -m "$(cat <<'EOF'
+  Remove dead getSeverityColorClass/getSeverityDisplayText exports
+
+  Both functions had zero consumers anywhere in frontend/src (verified
+  by grep) and getSeverityColorClass additionally lacked dark-mode
+  variants, a latent ADR-006 violation had it ever been wired up.
+  PurchaseStockAnalysis.tsx implements its own inline severity styling
+  and never referenced either export. formatNumber/formatCurrency and
+  all other exports in the file are unaffected.
+
+  Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+  Expected: commit succeeds; `git status` shows a clean working tree for this file.

--- a/artifacts/feat-3582/task-plan.r1.md
+++ b/artifacts/feat-3582/task-plan.r1.md
@@ -1,0 +1,179 @@
+# Implementation Plan: Remove dead severity-formatting exports from `usePurchaseStockAnalysis.ts`
+
+## Context for the engineer
+
+`frontend/src/api/hooks/usePurchaseStockAnalysis.ts` is a React Query hook file for the Purchase Stock Analysis feature. It currently exports two dead helper functions — `getSeverityColorClass` and `getSeverityDisplayText` — that have zero consumers anywhere in `frontend/src`. They sit between the query hook (`usePurchaseStockAnalysisQuery`) and two functions that ARE used (`formatNumber`, `formatCurrency`). This is a pure subtraction: delete the two dead functions and their preceding comments, touch nothing else in the file.
+
+This is confirmed dead code — verified independently by both the spec author and the architecture reviewer via `grep -rn "getSeverityColorClass\|getSeverityDisplayText" frontend/src`, which returns only the two `export const` definitions themselves (no imports, no call sites, no test references). The natural consumer, `frontend/src/components/pages/PurchaseStockAnalysis.tsx`, implements its own inline severity-styling logic (`getRowColorClass`, `getSeverityStripColor`) and never references these two exports.
+
+There is exactly one task. No other files need to change.
+
+## Prerequisites
+
+- Working directory: `/home/user/worktrees/feature-3582-Arch-Review-Purchase-Getseveritycolorclass-And-Get`
+- All commands below are run from the `frontend/` subdirectory unless noted otherwise.
+
+---
+
+### task: remove-dead-severity-exports
+
+**Files:**
+- Modify: `frontend/src/api/hooks/usePurchaseStockAnalysis.ts`
+
+- [ ] Open `frontend/src/api/hooks/usePurchaseStockAnalysis.ts` and locate the block starting at the comment `// Helper function to get severity color class` (currently line 71) and ending at the closing brace of `getSeverityDisplayText` (currently line 109), followed by a blank line (line 110). This block currently reads:
+
+  ```ts
+  // Helper function to get severity color class
+  export const getSeverityColorClass = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "text-red-600 bg-red-50";
+      case StockSeverity.Low:
+        return "text-orange-600 bg-orange-50";
+      case StockSeverity.Optimal:
+        return "text-green-600 bg-green-50";
+      case StockSeverity.Overstocked:
+        return "text-blue-600 bg-blue-50";
+      case StockSeverity.NotConfigured:
+        return "text-gray-600 bg-gray-50";
+      default:
+        return "text-gray-600 bg-gray-50";
+    }
+  };
+
+  // Helper function to get severity display text
+  export const getSeverityDisplayText = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "Kritický";
+      case StockSeverity.Low:
+        return "Nízký";
+      case StockSeverity.Optimal:
+        return "Optimální";
+      case StockSeverity.Overstocked:
+        return "Přeskladněno";
+      case StockSeverity.NotConfigured:
+        return "Nezkonfigurováno";
+      default:
+        return "Neznámý";
+    }
+  };
+
+  ```
+
+  Delete this entire block (both function definitions, both preceding comments, and the blank line that separates the second function from the next comment). Do not touch anything before or after it — the file must go directly from the closing `};` of `usePurchaseStockAnalysisQuery` straight to the `// Helper function to format Czech number` comment that precedes `formatNumber`.
+
+  Concretely, use this Edit (old_string includes one line of context on each side to anchor the match uniquely):
+
+  old_string:
+  ```
+  };
+
+  // Helper function to get severity color class
+  export const getSeverityColorClass = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "text-red-600 bg-red-50";
+      case StockSeverity.Low:
+        return "text-orange-600 bg-orange-50";
+      case StockSeverity.Optimal:
+        return "text-green-600 bg-green-50";
+      case StockSeverity.Overstocked:
+        return "text-blue-600 bg-blue-50";
+      case StockSeverity.NotConfigured:
+        return "text-gray-600 bg-gray-50";
+      default:
+        return "text-gray-600 bg-gray-50";
+    }
+  };
+
+  // Helper function to get severity display text
+  export const getSeverityDisplayText = (
+    severity: StockSeverity | undefined,
+  ): string => {
+    switch (severity) {
+      case StockSeverity.Critical:
+        return "Kritický";
+      case StockSeverity.Low:
+        return "Nízký";
+      case StockSeverity.Optimal:
+        return "Optimální";
+      case StockSeverity.Overstocked:
+        return "Přeskladněno";
+      case StockSeverity.NotConfigured:
+        return "Nezkonfigurováno";
+      default:
+        return "Neznámý";
+    }
+  };
+
+  // Helper function to format Czech number
+  ```
+
+  new_string:
+  ```
+  };
+
+  // Helper function to format Czech number
+  ```
+
+- [ ] Verify the two removed identifiers no longer appear in the file:
+  ```bash
+  grep -n "getSeverityColorClass\|getSeverityDisplayText" frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  ```
+  Expected: no output (zero matches).
+
+- [ ] Verify `formatNumber` and `formatCurrency` are still present and unchanged, and that the file still exports the query hook:
+  ```bash
+  grep -n "export const usePurchaseStockAnalysisQuery\|export const formatNumber\|export const formatCurrency" frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  ```
+  Expected: three matches, one per identifier.
+
+- [ ] Run a project-wide grep to confirm there are no other references to the removed functions anywhere in the frontend source (there should not be, per the spec/arch-review verification, but this is the final acceptance check from FR-1/FR-2):
+  ```bash
+  cd frontend && grep -rn "getSeverityColorClass\|getSeverityDisplayText" src
+  ```
+  Expected: no output (zero matches). If this reports a match outside the file just edited, stop and investigate before proceeding — it means a consumer was missed by prior analysis.
+
+- [ ] Confirm the diff is scoped exactly as expected (only the two functions and their comments removed, nothing else touched):
+  ```bash
+  git diff -- frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  ```
+  Expected: a diff showing only deleted lines (the two function bodies, their comments, and one blank line) — no added lines, no changes elsewhere in the file.
+
+- [ ] Build the frontend to confirm no broken imports or type errors resulted from the removal:
+  ```bash
+  cd frontend && npm run build
+  ```
+  Expected: build succeeds with no errors.
+
+- [ ] Lint the frontend:
+  ```bash
+  cd frontend && npm run lint
+  ```
+  Expected: lint passes with no new errors.
+
+- [ ] Commit the change:
+  ```bash
+  git add frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+  git commit -m "$(cat <<'EOF'
+  Remove dead getSeverityColorClass/getSeverityDisplayText exports
+
+  Both functions had zero consumers anywhere in frontend/src (verified
+  by grep) and getSeverityColorClass additionally lacked dark-mode
+  variants, a latent ADR-006 violation had it ever been wired up.
+  PurchaseStockAnalysis.tsx implements its own inline severity styling
+  and never referenced either export. formatNumber/formatCurrency and
+  all other exports in the file are unaffected.
+
+  Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+  Expected: commit succeeds; `git status` shows a clean working tree for this file.

--- a/frontend/src/api/hooks/usePurchaseStockAnalysis.ts
+++ b/frontend/src/api/hooks/usePurchaseStockAnalysis.ts
@@ -68,46 +68,6 @@ export const usePurchaseStockAnalysisQuery = (
   });
 };
 
-// Helper function to get severity color class
-export const getSeverityColorClass = (
-  severity: StockSeverity | undefined,
-): string => {
-  switch (severity) {
-    case StockSeverity.Critical:
-      return "text-red-600 bg-red-50";
-    case StockSeverity.Low:
-      return "text-orange-600 bg-orange-50";
-    case StockSeverity.Optimal:
-      return "text-green-600 bg-green-50";
-    case StockSeverity.Overstocked:
-      return "text-blue-600 bg-blue-50";
-    case StockSeverity.NotConfigured:
-      return "text-gray-600 bg-gray-50";
-    default:
-      return "text-gray-600 bg-gray-50";
-  }
-};
-
-// Helper function to get severity display text
-export const getSeverityDisplayText = (
-  severity: StockSeverity | undefined,
-): string => {
-  switch (severity) {
-    case StockSeverity.Critical:
-      return "Kritický";
-    case StockSeverity.Low:
-      return "Nízký";
-    case StockSeverity.Optimal:
-      return "Optimální";
-    case StockSeverity.Overstocked:
-      return "Přeskladněno";
-    case StockSeverity.NotConfigured:
-      return "Nezkonfigurováno";
-    default:
-      return "Neznámý";
-  }
-};
-
 // Helper function to format Czech number
 export const formatNumber = (
   value: number | undefined,


### PR DESCRIPTION
Closes #3582

## What the issue was
`frontend/src/api/hooks/usePurchaseStockAnalysis.ts` exported two helper functions, `getSeverityColorClass` and `getSeverityDisplayText`, that had zero consumers anywhere in the codebase. `getSeverityColorClass` additionally returned hardcoded light-mode-only Tailwind classes with no `dark:` variants, which would have violated ADR-006 had it ever been wired up. The natural consumer, `PurchaseStockAnalysis.tsx`, implements its own inline severity-styling logic and never imports either function.

## How it was fixed / handled
Removed both dead exports (and their preceding comments) from `usePurchaseStockAnalysis.ts`. Nothing else in the file was touched — `usePurchaseStockAnalysisQuery`, `formatNumber`, and `formatCurrency` are unaffected. Verified via project-wide grep that no references to either removed function remain, confirmed the frontend still builds and lints cleanly, and ran the change through the full pipeline (spec → architecture review → design → plan → implementation → task review → final whole-branch code review), all of which passed clean.

## Artifacts
- Brief, spec, arch-review, design, task-plan, impl, and review markdown are committed in this branch under `artifacts/feat-3582/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

---
_Generated by [Claude Code](https://claude.ai/code/session_013UAVrZdMAsfQcLj21aX6Lo)_