### PR TITLE
#3591: implementation

### DIFF
--- a/artifacts/feat-3591/arch-review.r1.md
+++ b/artifacts/feat-3591/arch-review.r1.md
@@ -1,0 +1,57 @@
+# Architecture Review: Remove unused `FileSizeBytes` from KnowledgeBase document upload
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a pure dead-code removal within a single vertical slice (`KnowledgeBase/UseCases/UploadDocument`). It touches exactly two files — the request DTO and the controller that constructs it — and does not cross module boundaries, change persistence, or alter the public API contract. It aligns cleanly with the project's Vertical Slice Architecture and the "DTOs are never shared or global" rule in `docs/architecture/development_guidelines.md`: `UploadDocumentRequest` is owned entirely by the KnowledgeBase module, so shrinking its surface has zero blast radius on other modules.
+
+Repo-wide verification confirms the spec's claims:
+- `FileSizeBytes` on `UploadDocumentRequest` (`backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs:11`) is set only once, in `KnowledgeBaseController.UploadDocument` (`backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs:144`), and read nowhere — `UploadDocumentHandler.cs` only consumes `FileStream`, `ContentType`, `Filename`, and `DocumentType`.
+- No test in `backend/test/Anela.Heblo.Tests/KnowledgeBase/**` references `FileSizeBytes` (confirmed via direct grep against `UploadDocumentHandlerTests.cs` and `KnowledgeBaseControllerTests.cs` — zero matches).
+- All other repo-wide `FileSizeBytes` hits belong to unrelated, actively-used fields: `Photobank.Photo`/`PhotoDto`/`PhotobankGraphService`/`PhotobankIndexJob`, `Leaflet.UploadLeafletRequest`, `FileStorage.DownloadFromUrlResponse`/`Handler`, `Catalog.ProductExportDownloadJob`, plus EF Core migration snapshots for the `Photo` entity's own `FileSizeBytes` column (unrelated to this change, must not be touched). None of these are in the KnowledgeBase upload path.
+
+No other consumer, serializer, or downstream type (`IndexDocumentRequest`, `KnowledgeBaseDocument`) references the field. Removal is safe and behavior-neutral.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. The change removes one property and one assignment inside the existing `UploadDocument` use case slice:
+- `Anela.Heblo.API.Controllers.KnowledgeBaseController` (API layer, constructs `UploadDocumentRequest`)
+- `Anela.Heblo.Application.Features.KnowledgeBase.UseCases.UploadDocument.UploadDocumentRequest` (Application layer, MediatR request DTO)
+
+### Key Design Decisions
+
+#### Decision 1: Remove vs. keep-for-future-use
+**Options considered:**
+1. Remove the property and its assignment now (per brief/spec).
+2. Keep it as a documented placeholder for a future max-upload-size check.
+
+**Chosen approach:** Remove it now (option 1), matching the spec.
+
+**Rationale:** Project convention is explicit YAGNI — speculative future use is not a valid reason to retain dead code (per the brief and general project norms). If size validation is needed later, it can be reintroduced at that point with an actual consumer, avoiding drift between the stored value and its (currently nonexistent) usage.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No structural changes. Modify exactly two existing files:
+1. `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs` — delete line 11 (`public long FileSizeBytes { get; set; }`).
+2. `backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs` — delete line 144 (`FileSizeBytes = file.Length,`) inside the `UploadDocument` action's `UploadDocumentRequest` initializer.
+
+### Interfaces and Contracts
+- `UploadDocumentRequest` (internal MediatR request, not an OpenAPI-exposed type since it's constructed server-side from `IFormFile`) loses one member. No client-facing contract changes: the `multipart/form-data` endpoint still accepts `file` and `documentType`; `UploadDocumentResponse` is untouched.
+- No OpenAPI/TypeScript client regeneration is needed — `UploadDocumentRequest` is not bound via `[FromBody]`/`[FromQuery]` from the client, it's built server-side, so it isn't part of the generated client surface.
+
+### Data Flow
+Unchanged except for the removal of a value that was never read: `IFormFile` → controller (drops `file.Length`) → `UploadDocumentRequest` (no longer carries size) → `UploadDocumentHandler` → `IndexDocumentRequest`/`KnowledgeBaseDocument` (already had no size field). No downstream step observes a behavior difference.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Hidden reflection-based or serialization-based consumer of `FileSizeBytes` not caught by static grep | Low | `dotnet build` will fail loudly if any C# reference remains; grep across `.cs`/`.ts`/`.tsx` already found none in the KnowledgeBase path. |
+| Future need for upload size limits reintroduces the same pattern | Low | Out of scope per spec; noted as a natural follow-up if/when size validation is required — should be added with real enforcement logic, not a dormant field. |
+
+## Specification Amendments
+None. The spec is accurate, self-contained, and already verified against the codebase (FR-1/FR-2/FR-3 match the actual file contents and line numbers found during this review).
+
+## Prerequisites
+None. Implementation can start immediately — it is a two-line deletion in two files with no dependencies.

--- a/artifacts/feat-3591/brief.md
+++ b/artifacts/feat-3591/brief.md
@@ -1,0 +1,33 @@
+## Module
+KnowledgeBase
+
+## Finding
+`UploadDocumentRequest.FileSizeBytes` is populated by the controller but never consumed anywhere in the handler or downstream code.
+
+**Set in the controller** (`backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs`, line 144):
+```csharp
+var request = new UploadDocumentRequest
+{
+    FileStream = stream,
+    Filename = file.FileName,
+    ContentType = file.ContentType,
+    FileSizeBytes = file.Length,   // ← set here
+    DocumentType = parsedDocumentType,
+};
+```
+
+**Declared in the request** (`backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs`, line 11):
+```csharp
+public long FileSizeBytes { get; set; }
+```
+
+`UploadDocumentHandler` reads `request.FileStream`, `request.ContentType`, `request.Filename`, and `request.DocumentType` — but never `request.FileSizeBytes`. The `KnowledgeBaseDocument` entity has no `FileSizeBytes` field, nor does `IndexDocumentRequest` or any other type in the pipeline.
+
+## Why it matters
+Dead request properties violate YAGNI, mislead future readers into thinking the value is used (or cause them to check multiple files looking for its consumer), and will silently drift from the actual file size if the controller code is ever refactored. Per project rules, speculative future use is not a reason to keep dead code.
+
+## Suggested fix
+Remove the property from `UploadDocumentRequest` and the corresponding assignment in `KnowledgeBaseController.UploadDocument`. If file-size validation (e.g. a maximum upload limit) is added in the future, it can be introduced at that point.
+
+---
+_Filed by daily arch-review routine on 2026-07-10._

--- a/artifacts/feat-3591/code-review.r1.md
+++ b/artifacts/feat-3591/code-review.r1.md
@@ -1,0 +1,9 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+No leftover `file.Length` reference — it was only used for the removed assignment, matching FR-2's acceptance criteria. The change is a clean, complete dead-code removal with no other call sites, no test impact, and no external contract change.

--- a/artifacts/feat-3591/design.r1.md
+++ b/artifacts/feat-3591/design.r1.md
@@ -1,0 +1,27 @@
+# Design: Remove unused `FileSizeBytes` from KnowledgeBase document upload
+
+## Component Design
+
+No new or restructured components. This is a shrink-the-surface change to two existing members of the `KnowledgeBase/UseCases/UploadDocument` vertical slice; their responsibilities and collaborators are otherwise unchanged.
+
+- **`Anela.Heblo.API.Controllers.KnowledgeBaseController.UploadDocument`** (API layer)
+  Responsibility: accept the `multipart/form-data` upload (`file`, `documentType`), construct an `UploadDocumentRequest`, dispatch it via MediatR.
+  Contract change: the `UploadDocumentRequest` object initializer drops the `FileSizeBytes = file.Length` line. `file.Length` is read nowhere else in the action after removal. The action's own signature, route, and accepted form fields are unchanged.
+
+- **`Anela.Heblo.Application.Features.KnowledgeBase.UseCases.UploadDocument.UploadDocumentRequest`** (Application layer, internal MediatR request)
+  Responsibility: carry `FileStream`, `ContentType`, `Filename`, `DocumentType` from controller to handler.
+  Contract change: loses the `public long FileSizeBytes { get; set; }` member. Since this type is constructed server-side (not `[FromBody]`/`[FromQuery]`-bound), it is not part of the generated OpenAPI/TypeScript client surface — removing the member requires no client regeneration and has no client-visible contract.
+
+- **`UploadDocumentHandler`, `UploadDocumentResponse`, `IndexDocumentRequest`, `IndexDocumentHandler`, `KnowledgeBaseDocument`**
+  Unaffected. None of these types read or expose `FileSizeBytes` today; none gain or lose members as part of this change. They are listed here only to record that their boundaries are explicitly untouched.
+
+No cross-module impact: `FileSizeBytes` usages in Photobank, Leaflet, and FileStorage are separate, unrelated fields on unrelated types and are out of scope.
+
+## Data Schemas
+
+No schema changes of any kind:
+
+- **Database / entity schema**: unchanged. `KnowledgeBaseDocument` has no `FileSizeBytes` column today and none is introduced.
+- **Public API request/response shapes**: unchanged. `POST /api/knowledgebase/documents/upload` continues to accept `multipart/form-data` with fields `file` and `documentType`, and returns the existing `UploadDocumentResponse` shape.
+- **Internal DTO shape**: `UploadDocumentRequest` (server-side-only, not OpenAPI-exposed) loses the `FileSizeBytes: long` member; this is the only shape delta in the entire change, and it is invisible outside the API/Application layer boundary.
+- **Event/message payloads**: none exist in this flow; none are affected.

--- a/artifacts/feat-3591/impl/remove-filesizebytes-dead-property.r1.md
+++ b/artifacts/feat-3591/impl/remove-filesizebytes-dead-property.r1.md
@@ -1,0 +1,34 @@
+# Implementation: remove-filesizebytes-dead-property
+
+## What was implemented
+Removed the dead `FileSizeBytes` property from `UploadDocumentRequest` and its corresponding assignment in `KnowledgeBaseController.UploadDocument`. A repo-wide grep confirmed no other code in the KnowledgeBase upload path reads or references this property; the property was purely write-only (set from `file.Length` but never consumed by the handler or anywhere downstream).
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs` — removed `public long FileSizeBytes { get; set; }`
+- `backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs` — removed `FileSizeBytes = file.Length,` from the `UploadDocumentRequest` object initializer in the `UploadDocument` action
+
+## Tests
+- `dotnet build Anela.Heblo.sln` from repo root — succeeded, 0 errors (250 pre-existing warnings, none related to this change).
+- `dotnet format Anela.Heblo.sln --include <the two changed files> --verify-no-changes` — passed with no formatting diffs.
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBase"` — 231 passed, 15 failed, 246 total. All 15 failures are in `KnowledgeBaseRepositoryIntegrationTests` and fail with `System.ArgumentException: Docker is either not running or misconfigured` (Testcontainers trying to spin up a PostgreSQL container). This is a pre-existing sandbox/environment limitation (no Docker daemon available here) — unrelated to this change. No test references `FileSizeBytes` in the KnowledgeBase feature, and no test failure relates to `UploadDocumentRequest` or `UploadDocument`.
+
+## How to verify
+1. `git show 99797d5` (or `git diff` on the two files) to see the two-line removal.
+2. `dotnet build Anela.Heblo.sln` from the repo root to confirm compilation.
+3. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBase"` on a machine with Docker available to get a clean pass including the integration tests.
+4. Confirm via `grep -rn FileSizeBytes backend/src/Anela.Heblo.Application/Features/KnowledgeBase backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs` that no references remain.
+
+## Notes
+- Did not touch `FileSizeBytes` usages in Photobank, Leaflet, or FileStorage — those are separate, unrelated features per the task instructions, and grep confirmed they were left untouched.
+- The 15 `KnowledgeBaseRepositoryIntegrationTests` failures are pre-existing infrastructure gaps (no Docker/testcontainers support in this sandbox), not caused by this change. They fail identically on a clean checkout of this branch before these edits (same error, same test names, same count), so this is environmental, not a regression.
+- `artifacts/feat-3591/state.json` was modified by the pipeline harness during this session (task status tracking); it was intentionally left unstaged/uncommitted since it's pipeline-managed state, not part of this code change.
+
+## PR Summary
+Removes the dead `FileSizeBytes` property from `UploadDocumentRequest` in the KnowledgeBase upload use case, along with its assignment in `KnowledgeBaseController.UploadDocument`. The property was set from `file.Length` on every upload but never read by the handler or any other consumer — a pure two-line dead-code deletion with no behavioral change. Verified via `dotnet build` (0 errors), `dotnet format --verify-no-changes` (clean), and the KnowledgeBase test suite (231/246 passing; the 15 failures are pre-existing Docker-dependent integration tests unrelated to this change).
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs` — removed unused `FileSizeBytes` property
+- `backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs` — removed the now-unneeded `FileSizeBytes = file.Length,` assignment in `UploadDocument`
+
+## Status
+DONE

--- a/artifacts/feat-3591/review/remove-filesizebytes-dead-property.r1.md
+++ b/artifacts/feat-3591/review/remove-filesizebytes-dead-property.r1.md
@@ -1,0 +1,26 @@
+# Code Review: Remove unused FileSizeBytes from KnowledgeBase document upload
+
+## Summary
+This is a clean, minimal two-line deletion exactly matching the task context's scope: the dead `FileSizeBytes` property is removed from `UploadDocumentRequest`, and its corresponding `file.Length` assignment is removed from `KnowledgeBaseController.UploadDocument`. The actual diff matches the impl summary precisely, no unrelated files were touched, and a repo-wide grep confirms no dangling references remain.
+
+## Review Result: PASS
+
+### task: remove-filesizebytes-dead-property
+**Status:** PASS
+
+All acceptance criteria verified against `git show 99797d5`:
+- `UploadDocumentRequest` no longer declares `FileSizeBytes` (confirmed in diff, line removed).
+- `KnowledgeBaseController.UploadDocument` no longer assigns `FileSizeBytes = file.Length,` (confirmed in diff).
+- `UploadDocumentResponse`, `IndexDocumentRequest`, `IndexDocumentHandler`, `KnowledgeBaseDocument` are untouched — diff stat shows only the two intended files, 1 deletion each.
+- No other reference to `FileSizeBytes` remains anywhere under the KnowledgeBase feature, the controller, or its tests (verified via grep against the worktree).
+- Unrelated `FileSizeBytes` usages in Photobank/Leaflet/FileStorage and EF migration snapshots were correctly left untouched.
+- Impl summary reports `dotnet build` success (0 errors) and `dotnet format --verify-no-changes` clean; KnowledgeBase test suite passes except for 15 pre-existing Docker/Testcontainers-dependent integration test failures unrelated to this change (plausible given the change touches no persistence or test infrastructure). Not independently re-run in this review, but the change is trivial enough (pure dead-property deletion, no logic touched) that this is not a concern.
+- `file.Length` is a property access on `IFormFile`, not a local variable, so its removal from the initializer cannot leave an unused-variable warning — correctly reasoned in the task context and correctly handled.
+
+No issues found.
+
+## Docs to Update
+None. This is a private, dead-code cleanup with no change to public API contracts, request/response shape, or system behavior — nothing in the documented architecture, feature specs, or API client surface is affected.
+
+## Overall Notes
+Textbook example of a scoped, surgical dead-code removal task executed correctly: the diff contains exactly the two lines the task context specified, nothing more, nothing less, with verification (grep, build, format, tests) performed and honestly reported including the pre-existing environmental test limitation.

--- a/artifacts/feat-3591/spec.r1.md
+++ b/artifacts/feat-3591/spec.r1.md
@@ -1,0 +1,59 @@
+# Specification: Remove unused `FileSizeBytes` from KnowledgeBase document upload
+
+## Summary
+`UploadDocumentRequest.FileSizeBytes` is set by `KnowledgeBaseController.UploadDocument` but never read by `UploadDocumentHandler` or anything downstream. This spec removes the dead property and its assignment, eliminating a misleading, unused field with no behavior change to the upload flow.
+
+## Background
+During a code audit of the KnowledgeBase module, `UploadDocumentRequest.FileSizeBytes` was found to be populated from `IFormFile.Length` in the controller but never consumed by `UploadDocumentHandler`, which only reads `FileStream`, `ContentType`, `Filename`, and `DocumentType`. The value does not propagate to `IndexDocumentRequest` or to the `KnowledgeBaseDocument` entity, which has no corresponding field. Verification against the current codebase confirms this is a true dead property (not merely under-documented): no size limit, size validation, or size persistence logic exists anywhere in the KnowledgeBase upload pipeline. Per project convention (YAGNI, no speculative future use), dead request properties should be removed rather than retained "just in case."
+
+Note: `FileSizeBytes` is a legitimate, actively-used field in other unrelated modules (Photobank, Leaflet, FileStorage) — this change is scoped strictly to the KnowledgeBase upload request/controller and does not touch those.
+
+## Functional Requirements
+
+### FR-1: Remove `FileSizeBytes` from `UploadDocumentRequest`
+Delete the `public long FileSizeBytes { get; set; }` property (line 11) from `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs`.
+
+**Acceptance criteria:**
+- `UploadDocumentRequest` no longer declares a `FileSizeBytes` member.
+- `UploadDocumentHandler` and `UploadDocumentResponse` are unaffected (they already do not reference this property).
+
+### FR-2: Remove the corresponding assignment in the controller
+Delete the `FileSizeBytes = file.Length,` line (line 144) from the `UploadDocumentRequest` object-initializer in `backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs` (`UploadDocument` action).
+
+**Acceptance criteria:**
+- The controller no longer references `FileSizeBytes` anywhere.
+- `file.Length` is not read or used elsewhere in the action after removal (confirmed: it was only used for this assignment).
+
+### FR-3: No behavior change to the upload API
+The `POST documents/upload` endpoint's external contract (accepted `multipart/form-data` fields: `file`, `documentType`) and response shape (`UploadDocumentResponse`) must remain unchanged. This is purely an internal dead-code removal.
+
+**Acceptance criteria:**
+- No changes to `UploadDocumentResponse`, `IndexDocumentRequest`, `IndexDocumentHandler`, or `KnowledgeBaseDocument`.
+- Existing upload requests/responses (as exercised by `UploadDocumentHandlerTests.cs` and `KnowledgeBaseControllerTests.cs`) continue to pass without modification, unless those tests explicitly set `FileSizeBytes` on the request (verified: they do not — no matches found in `backend/test/Anela.Heblo.Tests/KnowledgeBase`).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+N/A — no measurable performance impact; removing an unused field/assignment is a no-op at runtime.
+
+### NFR-2: Security
+N/A — no security-relevant behavior involved (no size validation exists before or after this change; none is being added or removed in terms of enforcement).
+
+## Data Model
+No data model changes. `KnowledgeBaseDocument` (entity) has no `FileSizeBytes` field today and none is being added.
+
+## API / Interface Design
+No public API changes. The `POST /api/knowledgebase/documents/upload` endpoint's request (multipart form: `file`, `documentType`) and response (`UploadDocumentResponse`) contracts are unchanged; this is an internal-only cleanup of an unused C# property.
+
+## Dependencies
+None. Self-contained change within `Anela.Heblo.Application` (KnowledgeBase UseCases) and `Anela.Heblo.API` (KnowledgeBaseController).
+
+## Out of Scope
+- Adding file-size validation or a maximum upload size limit (explicitly deferred per the brief's suggested fix — can be introduced later if/when needed).
+- Any changes to the Photobank, Leaflet, or FileStorage modules' `FileSizeBytes` usage — those are legitimate, unrelated usages and must not be touched.
+- Any changes to `IndexDocumentRequest`, `IndexDocumentHandler`, or `KnowledgeBaseDocument`.
+
+## Open Questions
+None. Verified directly against the current codebase: `UploadDocumentHandler.cs` (backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentHandler.cs) confirms `FileSizeBytes` is never read, and no test in `backend/test/Anela.Heblo.Tests/KnowledgeBase` references it, so no test changes are anticipated. Standard validation gates (`dotnet build`, `dotnet format`, affected tests) apply per project rules.
+
+## Status: COMPLETE

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-11T06:56:42.116838Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T06:56:55.504567Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T06:57:32.634206Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3591",
+  "issue_number": 3591,
+  "created_at": "2026-07-11T06:15:29.562967Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-11T06:19:52.663948Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T06:20:13.147389Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T06:56:42.116838Z"
     }
   },
   "tasks": [
     {
       "name": "remove-filesizebytes-dead-property",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-11T06:20:13.362045Z"
+      "updated_at": "2026-07-11T06:56:36.559139Z"
     }
   ]
 }

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-11T06:19:52.663948Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-11T06:20:13.147389Z"
     }
   },
   "tasks": [
     {
       "name": "remove-filesizebytes-dead-property",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-11T06:20:13.362045Z"
     }
   ]
 }

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-11T06:56:42.116838Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-11T06:56:55.504567Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T06:15:56.832398Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T06:17:05.932318Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-11T06:17:06.223348Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-11T06:19:08.794764Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T06:19:08.986427Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T06:19:52.663948Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "remove-filesizebytes-dead-property",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-11T06:15:56.832398Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-11T06:17:05.932318Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T06:17:06.223348Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T06:18:23.157793Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-11T06:18:36.549633Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3591/state.json
+++ b/artifacts/feat-3591/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-11T06:18:23.157793Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T06:18:36.549633Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T06:19:08.794764Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-11T06:19:08.986427Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3591/task-context/remove-filesizebytes-dead-property.md
+++ b/artifacts/feat-3591/task-context/remove-filesizebytes-dead-property.md
@@ -1,0 +1,32 @@
+### task: remove-filesizebytes-dead-property
+
+**Goal:** Delete the dead `FileSizeBytes` property from `UploadDocumentRequest` and its corresponding assignment in `KnowledgeBaseController.UploadDocument`, with no other behavior change to the upload flow.
+
+**Context:** `UploadDocumentRequest.FileSizeBytes` is populated in `KnowledgeBaseController.UploadDocument` from `IFormFile.Length` but is never read by `UploadDocumentHandler` (which only consumes `FileStream`, `ContentType`, `Filename`, `DocumentType`), never propagated to `IndexDocumentRequest`, and has no corresponding field on the `KnowledgeBaseDocument` entity. Repo-wide verification (spec + arch-review) confirms this is genuinely dead code: no size validation, size limit, or size persistence exists anywhere in the KnowledgeBase upload pipeline, and no test references the property. This is a pure two-line deletion across two files within a single vertical slice (`KnowledgeBase/UseCases/UploadDocument`) — no module boundary crossing, no persistence change, no public API contract change.
+
+`FileSizeBytes` is a separate, legitimate, actively-used field in unrelated modules (Photobank, Leaflet, FileStorage) and in EF Core migration snapshots for the `Photo` entity — do not touch any of those; this change is scoped strictly to the KnowledgeBase upload request/controller.
+
+`UploadDocumentRequest` is a server-side-constructed MediatR request (not `[FromBody]`/`[FromQuery]`-bound), so it is not part of the generated OpenAPI/TypeScript client surface — no client regeneration is needed.
+
+**Files to create/modify:**
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs` — delete the `public long FileSizeBytes { get; set; }` property (line 11).
+- `backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs` — delete the `FileSizeBytes = file.Length,` line (line 144) from the `UploadDocumentRequest` object initializer inside the `UploadDocument` action. Confirm `file.Length` is not used elsewhere in the action after this removal; if it becomes unused, no further action is needed since it's a property access, not a variable declaration.
+
+**Implementation steps:**
+1. Open `UploadDocumentRequest.cs` and remove the `FileSizeBytes` property declaration.
+2. Open `KnowledgeBaseController.cs`, locate the `UploadDocument` action, and remove the `FileSizeBytes = file.Length,` line from the `UploadDocumentRequest` object initializer.
+3. Search the codebase (`backend/`) for any other reference to `UploadDocumentRequest.FileSizeBytes` to confirm none remain (none are expected per spec/arch-review verification).
+4. Run `dotnet build` to confirm no compile errors (a stray reference would fail the build).
+5. Run `dotnet format` to ensure formatting stays clean after the deletions.
+
+**Tests to write:**
+No new tests are required; this is pure removal of a property nothing reads. Verify the existing KnowledgeBase test suite (`UploadDocumentHandlerTests.cs`, `KnowledgeBaseControllerTests.cs` in `backend/test/Anela.Heblo.Tests/KnowledgeBase`) still passes unmodified, since no test references `FileSizeBytes`.
+
+**Acceptance criteria:**
+- `UploadDocumentRequest` no longer declares a `FileSizeBytes` member (FR-1).
+- `UploadDocumentHandler` and `UploadDocumentResponse` are unaffected and unchanged (FR-1).
+- The controller no longer references `FileSizeBytes` anywhere, and `file.Length` is not read or used elsewhere in the `UploadDocument` action after removal (FR-2).
+- The `POST /api/knowledgebase/documents/upload` endpoint's external contract (accepted `multipart/form-data` fields: `file`, `documentType`) and response shape (`UploadDocumentResponse`) remain unchanged (FR-3).
+- No changes made to `UploadDocumentResponse`, `IndexDocumentRequest`, `IndexDocumentHandler`, or `KnowledgeBaseDocument` (FR-3).
+- Existing tests in `UploadDocumentHandlerTests.cs` and `KnowledgeBaseControllerTests.cs` pass without modification (FR-3).
+- `dotnet build` and `dotnet format` succeed with no errors.

--- a/artifacts/feat-3591/task-plan.r1.md
+++ b/artifacts/feat-3591/task-plan.r1.md
@@ -1,0 +1,34 @@
+# Task Plan: Remove unused `FileSizeBytes` from KnowledgeBase document upload
+
+### task: remove-filesizebytes-dead-property
+
+**Goal:** Delete the dead `FileSizeBytes` property from `UploadDocumentRequest` and its corresponding assignment in `KnowledgeBaseController.UploadDocument`, with no other behavior change to the upload flow.
+
+**Context:** `UploadDocumentRequest.FileSizeBytes` is populated in `KnowledgeBaseController.UploadDocument` from `IFormFile.Length` but is never read by `UploadDocumentHandler` (which only consumes `FileStream`, `ContentType`, `Filename`, `DocumentType`), never propagated to `IndexDocumentRequest`, and has no corresponding field on the `KnowledgeBaseDocument` entity. Repo-wide verification (spec + arch-review) confirms this is genuinely dead code: no size validation, size limit, or size persistence exists anywhere in the KnowledgeBase upload pipeline, and no test references the property. This is a pure two-line deletion across two files within a single vertical slice (`KnowledgeBase/UseCases/UploadDocument`) — no module boundary crossing, no persistence change, no public API contract change.
+
+`FileSizeBytes` is a separate, legitimate, actively-used field in unrelated modules (Photobank, Leaflet, FileStorage) and in EF Core migration snapshots for the `Photo` entity — do not touch any of those; this change is scoped strictly to the KnowledgeBase upload request/controller.
+
+`UploadDocumentRequest` is a server-side-constructed MediatR request (not `[FromBody]`/`[FromQuery]`-bound), so it is not part of the generated OpenAPI/TypeScript client surface — no client regeneration is needed.
+
+**Files to create/modify:**
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs` — delete the `public long FileSizeBytes { get; set; }` property (line 11).
+- `backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs` — delete the `FileSizeBytes = file.Length,` line (line 144) from the `UploadDocumentRequest` object initializer inside the `UploadDocument` action. Confirm `file.Length` is not used elsewhere in the action after this removal; if it becomes unused, no further action is needed since it's a property access, not a variable declaration.
+
+**Implementation steps:**
+1. Open `UploadDocumentRequest.cs` and remove the `FileSizeBytes` property declaration.
+2. Open `KnowledgeBaseController.cs`, locate the `UploadDocument` action, and remove the `FileSizeBytes = file.Length,` line from the `UploadDocumentRequest` object initializer.
+3. Search the codebase (`backend/`) for any other reference to `UploadDocumentRequest.FileSizeBytes` to confirm none remain (none are expected per spec/arch-review verification).
+4. Run `dotnet build` to confirm no compile errors (a stray reference would fail the build).
+5. Run `dotnet format` to ensure formatting stays clean after the deletions.
+
+**Tests to write:**
+No new tests are required; this is pure removal of a property nothing reads. Verify the existing KnowledgeBase test suite (`UploadDocumentHandlerTests.cs`, `KnowledgeBaseControllerTests.cs` in `backend/test/Anela.Heblo.Tests/KnowledgeBase`) still passes unmodified, since no test references `FileSizeBytes`.
+
+**Acceptance criteria:**
+- `UploadDocumentRequest` no longer declares a `FileSizeBytes` member (FR-1).
+- `UploadDocumentHandler` and `UploadDocumentResponse` are unaffected and unchanged (FR-1).
+- The controller no longer references `FileSizeBytes` anywhere, and `file.Length` is not read or used elsewhere in the `UploadDocument` action after removal (FR-2).
+- The `POST /api/knowledgebase/documents/upload` endpoint's external contract (accepted `multipart/form-data` fields: `file`, `documentType`) and response shape (`UploadDocumentResponse`) remain unchanged (FR-3).
+- No changes made to `UploadDocumentResponse`, `IndexDocumentRequest`, `IndexDocumentHandler`, or `KnowledgeBaseDocument` (FR-3).
+- Existing tests in `UploadDocumentHandlerTests.cs` and `KnowledgeBaseControllerTests.cs` pass without modification (FR-3).
+- `dotnet build` and `dotnet format` succeed with no errors.

--- a/backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/KnowledgeBaseController.cs
@@ -141,7 +141,6 @@ public class KnowledgeBaseController : BaseApiController
             FileStream = stream,
             Filename = file.FileName,
             ContentType = file.ContentType,
-            FileSizeBytes = file.Length,
             DocumentType = parsedDocumentType,
         };
         var result = await _mediator.Send(request, ct);

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/UploadDocument/UploadDocumentRequest.cs
@@ -8,6 +8,5 @@ public class UploadDocumentRequest : IRequest<UploadDocumentResponse>
     public Stream FileStream { get; set; } = default!;
     public string Filename { get; set; } = default!;
     public string ContentType { get; set; } = default!;
-    public long FileSizeBytes { get; set; }
     public DocumentType DocumentType { get; set; } = DocumentType.KnowledgeBase;
 }


### PR DESCRIPTION
Closes #3591

## What the issue was
`UploadDocumentRequest.FileSizeBytes` was populated by `KnowledgeBaseController.UploadDocument` from `IFormFile.Length`, but never read anywhere — not by `UploadDocumentHandler`, not by `IndexDocumentRequest`, and `KnowledgeBaseDocument` has no corresponding field. It was a write-only, dead property that misleads readers into thinking the value is used somewhere downstream.

## How it was fixed / handled
Removed the dead property (`UploadDocumentRequest.cs`) and its corresponding assignment (`KnowledgeBaseController.cs`) — a pure two-line deletion, no other behavior change. Verified via repo-wide grep that no other reference to `FileSizeBytes` exists in the KnowledgeBase upload path (unrelated `FileSizeBytes` usages in Photobank, Leaflet, and FileStorage were left untouched). `dotnet build` succeeds with 0 errors, `dotnet format --verify-no-changes` is clean, and the KnowledgeBase test suite passes (the only failures are 15 pre-existing Docker/Testcontainers-dependent integration tests, unrelated to this change and unavailable in this sandbox).

This went through the full pipeline (spec → architecture review → design → task plan → implementation → task review → final whole-branch code review), all of which passed clean.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3591/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

No leftover `file.Length` reference — it was only used for the removed assignment, matching FR-2's acceptance criteria. The change is a clean, complete dead-code removal with no other call sites, no test impact, and no external contract change.


---
_Generated by [Claude Code](https://claude.ai/code/session_011CPUD8Sbd8iYUBpD76u2tm)_