### PR TITLE
#3593: implementation

### DIFF
--- a/artifacts/feat-3593/arch-review.r1.md
+++ b/artifacts/feat-3593/arch-review.r1.md
@@ -1,0 +1,108 @@
+# Architecture Review: Introduce interfaces for Article generation pipeline steps
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a textbook Dependency Inversion refactor, entirely internal to the Application layer of one module (`Article`). It touches no contracts, no controllers, no DTOs, and no cross-module boundaries, so it aligns cleanly with the Vertical Slice conventions in `docs/architecture/development_guidelines.md` and `docs/architecture/filesystem.md`:
+
+- The five step classes already live under `Features/Article/UseCases/Generate/Pipeline/`, which is the correct home for use-case-internal collaborators (not `Services/`, since these are single-purpose pipeline stages, not feature-wide services).
+- `ArticleModule.cs` is the correct — and only — place for the DI binding change (ADR-004: bindings live in the owning module, and this isn't even a repository binding, so ADR-004 doesn't strictly apply, but the same "one module owns its own wiring" principle holds).
+- Confirmed via `grep` that the only consumer of `GenerateArticleJob` outside its own file is `GenerateArticleHandler.cs`, which enqueues it as `_backgroundJobClient.Enqueue<GenerateArticleJob>(...)`. Hangfire resolves `GenerateArticleJob` itself from the container and injects its constructor dependencies — it never touches the step types directly. Registering the five steps as `AddScoped<IXStep, XStep>()` instead of `AddScoped<XStep>()` is fully transparent to Hangfire's job activation.
+- Confirmed via `grep` that `PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep` are directly `new`'d only in three test files (`PlanQueriesStepTests.cs`, `GatherContextStepTests.cs`, `AggregateFactsStepTests.cs`, `ValidateFactsStepTests.cs`, `WriteArticleStepTests.cs`, `SourceEnrichmentIntegrationTests.cs`) and in `GenerateArticleJobTests.cs`. All of these construct the concrete class directly (`new PlanQueriesStep(...)`), which remains valid after the class additionally implements an interface — adding `: IPlanQueriesStep` to a class signature is purely additive and does not break any existing direct-instantiation test.
+- There is no existing "one interface per pipeline step" precedent elsewhere in the codebase (`grep -rl "interface I.*Step"` returned nothing), so this establishes a new but unsurprising micro-pattern: a single-method interface named after its one implementation, matching the existing convention of `I{Entity}Service` / `I{Entity}Repository` pairs already used throughout the codebase (see `IOrderService` example in `development_guidelines.md`).
+
+No architectural objection. This is low-risk, additive, and does not require any spec amendment on structural grounds.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+GenerateArticleHandler (MediatR handler)
+        │  BackgroundJobClient.Enqueue<GenerateArticleJob>(...)
+        ▼
+GenerateArticleJob (Hangfire job, resolved by concrete type from DI)
+        │  constructor now depends on 5 interfaces, not 5 concretions
+        ▼
+ IPlanQueriesStep ──▶ PlanQueriesStep
+ IGatherContextStep ──▶ GatherContextStep
+ IAggregateFactsStep ──▶ AggregateFactsStep
+ IValidateFactsStep ──▶ ValidateFactsStep
+ IWriteArticleStep ──▶ WriteArticleStep
+        │  (each concrete step still depends on PipelineStepRecorder concretely — unchanged, out of scope)
+        ▼
+ArticlePipelineContext (shared mutable state, unchanged)
+```
+
+`GenerateArticleJob` remains the only consumer of the five new interfaces; each interface has exactly one production implementation. This is DIP applied at the narrowest possible seam — introducing an interface *only* where a test-time substitution boundary is needed, not speculatively across the whole pipeline (e.g. `PipelineStepRecorder` correctly stays concrete, per spec's Out of Scope section — it's an internal collaborator of each step, not of the job).
+
+### Key Design Decisions
+
+#### Decision 1: One interface per step vs. one shared `IPipelineStep` interface
+**Options considered:**
+- (a) Single shared `IPipelineStep { Task ExecuteAsync(ArticlePipelineContext, CancellationToken); }` interface implemented by all five classes.
+- (b) Five distinct, per-step interfaces (`IPlanQueriesStep`, `IGatherContextStep`, etc.), each with an identical single-method signature, as specified.
+
+**Chosen approach:** (b), per the spec.
+
+**Rationale:** `GenerateArticleJob`'s constructor pins each step to an exact position and role in the fixed five-stage pipeline (order matters: plan → gather → aggregate → validate → write). A shared `IPipelineStep` would make the constructor `IPipelineStep, IPipelineStep, IPipelineStep, IPipelineStep, IPipelineStep`, which is ambiguous for DI resolution (five services registered against the same interface — `AddScoped<IPipelineStep, PlanQueriesStep>()` five times would collide, requiring keyed services or an ordered collection injection) and would let a future developer swap two steps' registration order by accident with the compiler unable to catch it. Distinct interfaces keep constructor-parameter-to-role mapping compiler-checked and keep the DI registration unambiguous with plain `AddScoped<TInterface, TImpl>()`. The minor duplication (five near-identical one-method interfaces) is the correct trade for explicitness here — this is not a case where a shared abstraction reduces real duplication, since each interface has exactly one implementation and one call site.
+
+#### Decision 2: Interface file placement
+**Options considered:**
+- (a) Interfaces in their own files (e.g. `IPlanQueriesStep.cs`) alongside the class file.
+- (b) Interface declared in the same file as its implementing class (as the spec/brief propose).
+
+**Chosen approach:** (b) — interface and implementation share one file per step.
+
+**Rationale:** The spec explicitly resolves this under "Open Questions" as an assumption, and it matches the brief's own code sample. This deviates from the more common C# convention of one type per file, but for a single-consumer, single-implementor interface that exists purely as a test seam, co-location keeps the change footprint minimal (5 files touched, not 10) and keeps the interface visually next to its only implementation, making it obvious this isn't a general-purpose abstraction. This is a defensible, narrow exception — do not generalize it to interfaces with multiple implementations or multiple consumers elsewhere in the codebase.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files or directories. Modify in place:
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs` — add `IPlanQueriesStep` interface + `: IPlanQueriesStep` on the class.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs` — same pattern for `IGatherContextStep`.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs` — same pattern for `IAggregateFactsStep`.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs` — same pattern for `IValidateFactsStep`.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs` — same pattern for `IWriteArticleStep`.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs` — constructor/field types only (lines 13–17, 22–26).
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs` — lines 26–30, add interface to each `AddScoped<...>` call.
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs` — rework `CreateJob(...)` to take `Mock<IXStep>`/`.Object` per FR-5.
+
+### Interfaces and Contracts
+
+Each interface: exactly one method, identical signature across all five:
+
+```csharp
+public interface IPlanQueriesStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+```
+
+This is a private, module-internal contract — it does **not** belong in `Features/Article/Contracts/` (that folder is for cross-module or cross-use-case DTOs/interfaces per `development_guidelines.md`'s Contracts rules; these step interfaces have a single consumer inside one use case and are correctly scoped to `Pipeline/`, not promoted to `Contracts/`).
+
+### Data Flow
+
+Unchanged. `ArticlePipelineContext` continues to flow by reference through each `ExecuteAsync` call in the same fixed order (`PlanQueries → GatherContext → AggregateFacts → ValidateFacts → [status: Writing] → WriteArticle`); only the compile-time type of each dependency at the `GenerateArticleJob` constructor boundary changes, from concrete class to interface.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A future developer adds a second implementation of one of these interfaces (e.g. a dev-mode no-op step) and registers it without updating the others, silently changing pipeline behavior for one stage only | Low | Out of scope per spec; NFR-3 already flags this. If it happens, it should be a deliberate, reviewed change — not blocked architecturally, just noted here so reviewers watch for it. |
+| Test file (`GenerateArticleJobTests.cs`) still references now-unused `Mock<IChatClient>`, `Mock<IArticleKnowledgeSource>`, `Mock<IWebSearchClient>`, `Mock<IArticleStyleGuideSource>`, and `CreateNoOpRecorder()` after the refactor, producing dead test scaffolding | Low | Spec FR-5 already calls this out explicitly with acceptance criteria to remove unused mocks/usings; enforce during code review — `dotnet build` will not catch unused private fields, only unused `using` directives under nullable/analyzer settings if configured. |
+| `WriteArticleStep` mock in the happy-path test must mutate `context` (`GeneratedTitle`, `GeneratedHtml`, `SourceRefs`) via `Callback<>`, which is easy to get subtly wrong (e.g. forgetting `SourceRefs` defaults to empty list vs. null, breaking the `foreach` in `RunAsync`) | Low | Spec already specifies this exact requirement (FR-5); implementer should initialize `SourceRefs` to a concrete list matching the existing JSON fixture's `sources_used`, mirroring today's real-step behavior being replaced. |
+| Five near-identical interfaces could be mistaken for copy-paste error (wrong interface implemented by wrong class) | Low | Compiler enforces correctness at the `GenerateArticleJob` constructor call site — a mismatched interface/class pairing fails to compile since `ArticleModule.cs`'s `AddScoped<IPlanQueriesStep, GatherContextStep>()` (hypothetical mistake) would fail resolution only if `GatherContextStep` doesn't implement `IPlanQueriesStep`, which it won't. No runtime risk. |
+
+## Specification Amendments
+
+None required. The spec (FR-1 through FR-5, NFR-1 through NFR-3) is architecturally sound, internally consistent with existing module boundary and DI conventions, and its explicit "Out of Scope" section correctly excludes speculative extensions (alternate implementations, `PipelineStepRecorder` interface extraction, step-internals changes). The "Open Questions: None" / co-located-interface assumption is reasonable and matches the brief.
+
+One clarifying note for the implementer, not a spec change: when removing unused mocks/usings from `GenerateArticleJobTests.cs` per FR-5, double-check `SourceEnrichmentIntegrationTests.cs` and the five per-step `*StepTests.cs` files independently — they construct the concrete step classes directly and are unaffected by this refactor, but they share the same `_chat`/`_knowledgeSource`/`_webSearch`/`_styleGuideSource` mock-field naming convention, so a search-and-replace across files risks touching the wrong file. Confirmed by inspection these are separate test classes in separate files, each with their own private mock fields — no shared base class — so this is a low-risk note, not a blocker.
+
+## Prerequisites
+
+None. No migrations, no config, no new infrastructure. This can be implemented directly against `main`/the current branch state. Standard validation gates apply before completion: `dotnet build`, `dotnet format`, and `dotnet test` for `Anela.Heblo.Tests` (per NFR-2 and this repo's global validation rules).

--- a/artifacts/feat-3593/brief.md
+++ b/artifacts/feat-3593/brief.md
@@ -1,0 +1,46 @@
+## Module
+Article
+
+## Finding
+`GenerateArticleJob` takes all five pipeline steps as concrete class dependencies rather than interfaces:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs:17–35
+public GenerateArticleJob(
+    IArticleRepository repository,
+    PlanQueriesStep planQueries,       // concrete class
+    GatherContextStep gatherContext,   // concrete class
+    AggregateFactsStep aggregateFacts, // concrete class
+    ValidateFactsStep validateFacts,   // concrete class
+    WriteArticleStep writeArticle,     // concrete class
+    ILogger logger)
+```
+
+None of the step classes have a matching interface, and `ExecuteAsync` on each step is neither `virtual` nor `abstract`. This means Moq (or any substitute-based test double) cannot intercept `ExecuteAsync`, so the method cannot be replaced with a test double at the type level.
+
+This has a concrete cost in `GenerateArticleJobTests.cs` (lines 42–59): to test the job's orchestration logic (status transitions, error handling, source persistence), the tests must construct real `PlanQueriesStep`, `GatherContextStep`, etc. instances with mocked inner dependencies (`IChatClient`, `IArticleKnowledgeSource`, `IWebSearchClient`). For example, to test what happens when only `AggregateFactsStep` throws, the test must wire up a real `PlanQueriesStep` that successfully parses a valid JSON query plan from `_chat`, then arrange `_chat` to throw on the second call. The job's error-handling path cannot be tested independently of the steps' JSON parsing logic.
+
+The DI registrations in `ArticleModule.cs` (lines 25–30) mirror the same pattern — each step is bound as a concrete type with no interface.
+
+## Why it matters
+Violates the Dependency Inversion Principle: the high-level orchestrator (`GenerateArticleJob`) depends on low-level concretions, not abstractions. Side-effects:
+
+- **Testability**: the job's orchestration logic (status transitions, exception handling, `MarkAsFailed`/`MarkAsGenerated` calls) can only be exercised through the real step implementations. A targeted unit test for "job marks article as Failed when a step throws" requires a successfully-completed prior step, not just a stub that does nothing.
+- **Replaceability**: swapping a step implementation (e.g. a `MockPlanQueriesStep` in a dev environment) requires changing both the DI registration *and* the constructor signature of `GenerateArticleJob`.
+
+## Suggested fix
+Introduce a minimal interface per step with a single method:
+
+```csharp
+public interface IPlanQueriesStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public class PlanQueriesStep : IPlanQueriesStep { ... }
+```
+
+Apply the same pattern to `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, and `WriteArticleStep`. Update `GenerateArticleJob`'s constructor and `ArticleModule.cs` DI bindings accordingly. The job tests can then use `Mock` to isolate each test case to exactly the orchestration behaviour under test.
+
+---
+_Filed by daily arch-review routine on 2026-07-11._

--- a/artifacts/feat-3593/code-review.r1.md
+++ b/artifacts/feat-3593/code-review.r1.md
@@ -1,0 +1,19 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+## Notes
+Reviewed `git diff 7e19113c0693fa945f43e79b6e8cd6e940b4572c...HEAD -- backend` (7 files, ~140 lines). This is a mechanical, behavior-preserving refactor:
+
+- Each of the five pipeline step classes (`PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep`) gains a co-located single-method interface (`Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`) and now implements it. Method bodies are untouched.
+- `GenerateArticleJob`'s fields/constructor parameters are retyped from the concrete step classes to the new interfaces; constructor body and `RunAsync` orchestration logic are untouched.
+- `ArticleModule.cs` DI registrations are updated from `AddScoped<XStep>()` to `AddScoped<IXStep, XStep>()`; `GenerateArticleJob` itself stays registered as a concrete type (still resolved directly by Hangfire, unaffected by this change).
+- `GenerateArticleJobTests.cs` is reworked to mock the five step interfaces directly instead of constructing real step instances wired to mocked leaf dependencies (`IChatClient`, `IArticleKnowledgeSource`, `IWebSearchClient`, `IArticleStyleGuideSource`). Test behavior (status transitions, error propagation, source persistence) is preserved and now isolated from each step's internal JSON-parsing logic.
+
+Confirmed at each task stage (both task reviews, `add-pipeline-step-interfaces-and-wire-di.r1.md` review and `rework-generatearticlejobtests-to-mock-interfaces.r1.md` review): `dotnet build` succeeds with 0 errors, all 4 `GenerateArticleJobTests` pass, `dotnet format --verify-no-changes` reports no diffs, and a repo-wide grep confirms no other consumer depends on the concrete step types outside the now-updated test files.
+
+No correctness issues found. No advisory cleanups — the change is minimal and matches the plan exactly.

--- a/artifacts/feat-3593/design.r1.md
+++ b/artifacts/feat-3593/design.r1.md
@@ -1,0 +1,83 @@
+# Design: Introduce interfaces for Article generation pipeline steps
+
+## Component Design
+
+This is a Dependency Inversion refactor confined to the `Article` module's Application layer. No new components are introduced; five existing pipeline step classes each gain a matching single-method interface, and their two consumers (`GenerateArticleJob` and `ArticleModule` DI registration) are updated to depend on the interfaces instead of the concrete classes.
+
+### Pipeline step interfaces
+
+Each of the five pipeline steps gets one interface, declared in the same file as its implementing class, in namespace `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline`:
+
+| Interface | Implementation | File |
+|---|---|---|
+| `IPlanQueriesStep` | `PlanQueriesStep` | `.../Pipeline/PlanQueriesStep.cs` |
+| `IGatherContextStep` | `GatherContextStep` | `.../Pipeline/GatherContextStep.cs` |
+| `IAggregateFactsStep` | `AggregateFactsStep` | `.../Pipeline/AggregateFactsStep.cs` |
+| `IValidateFactsStep` | `ValidateFactsStep` | `.../Pipeline/ValidateFactsStep.cs` |
+| `IWriteArticleStep` | `WriteArticleStep` | `.../Pipeline/WriteArticleStep.cs` |
+
+Each interface exposes exactly one method:
+
+```csharp
+Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+```
+
+Design intent (see `arch-review.r1.md` Decision 1): five distinct interfaces rather than one shared `IPipelineStep`, because `GenerateArticleJob`'s constructor pins each step to a fixed position in the pipeline (plan → gather → aggregate → validate → write). Distinct interfaces keep constructor-parameter-to-role mapping compiler-checked and keep `AddScoped<TInterface, TImpl>()` registrations unambiguous — a shared interface would require keyed/collection-based DI resolution for no benefit, since each interface has exactly one implementation and one call site.
+
+Each interface is a narrow, module-internal test seam — it does **not** belong in `Features/Article/Contracts/` (reserved for cross-module/cross-use-case contracts per `development_guidelines.md`). No properties or additional methods are added beyond `ExecuteAsync`.
+
+### `GenerateArticleJob`
+
+Responsibility unchanged: orchestrates the fixed five-step pipeline against a shared `ArticlePipelineContext`, transitions article status (including to `Writing` before the write step), persists results, and maps failures to `Failed` status with `ErrorMessage`.
+
+Only the constructor's dependency *types* change — from concrete classes to interfaces — plus the corresponding private field types. Constructor parameter order/names, and the entire `RunAsync` method body (call order, status transitions, exception handling, `Source` mapping), are unchanged:
+
+```csharp
+public GenerateArticleJob(
+    IArticleRepository repository,
+    IPlanQueriesStep planQueries,
+    IGatherContextStep gatherContext,
+    IAggregateFactsStep aggregateFacts,
+    IValidateFactsStep validateFacts,
+    IWriteArticleStep writeArticle,
+    ILogger<GenerateArticleJob> logger)
+```
+
+Class remains `[AutomaticRetry(Attempts = 0)] public sealed class GenerateArticleJob`, still resolved by Hangfire from the DI container by its own concrete type (Hangfire never touches the step interfaces directly — confirmed in arch review via `GenerateArticleHandler.cs`'s `_backgroundJobClient.Enqueue<GenerateArticleJob>(...)`).
+
+### `ArticleModule` (DI wiring)
+
+Each step's registration changes from self-binding to interface binding:
+
+```csharp
+services.AddScoped<IPlanQueriesStep, PlanQueriesStep>();
+services.AddScoped<IGatherContextStep, GatherContextStep>();
+services.AddScoped<IAggregateFactsStep, AggregateFactsStep>();
+services.AddScoped<IValidateFactsStep, ValidateFactsStep>();
+services.AddScoped<IWriteArticleStep, WriteArticleStep>();
+```
+
+`PipelineStepRecorder` and `GenerateArticleJob` registrations are unchanged. `PipelineStepRecorder` stays a concrete, internal collaborator of each step class — it is not a dependency of `GenerateArticleJob` and is explicitly out of scope for interface extraction.
+
+### `GenerateArticleJobTests`
+
+Test-only component change: `CreateJob(...)` is reworked to accept `Mock<IPlanQueriesStep>`, `Mock<IGatherContextStep>`, `Mock<IAggregateFactsStep>`, `Mock<IValidateFactsStep>`, `Mock<IWriteArticleStep>` (or their `.Object`s), replacing construction of real step instances wired with mocked leaf dependencies (`IChatClient`, `IArticleKnowledgeSource`, `IWebSearchClient`, `IArticleStyleGuideSource`) and the no-op `PipelineStepRecorder`.
+
+Per-test mocking behavior:
+- Default mocks are successful no-ops (`ExecuteAsync` completes without mutating `context`).
+- `RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted`: `Mock<IWriteArticleStep>` is set up with a `Callback<ArticlePipelineContext, CancellationToken>` that sets `context.GeneratedTitle`, `context.GeneratedHtml`, and `context.SourceRefs` (initialized to a concrete list, not left null/default) so the job's post-call reads off `context` behave as today.
+- `RunAsync_StepThrows_StatusFailedAndErrorMessageSet`: `Mock<IAggregateFactsStep>.Setup(...).ThrowsAsync(new InvalidOperationException("LLM blew up"))`, with `IPlanQueriesStep` mocked as a successful no-op — no chat/JSON setup required.
+- `RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown`: `Mock<IPlanQueriesStep>` (first-invoked step) throws `OperationCanceledException` directly.
+- `RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState`: unaffected by step type; `CreateJob()` call simplified along with the others.
+
+Once no test in the file exercises a real step implementation, `Mock<IChatClient>`, `Mock<IArticleKnowledgeSource>`, `Mock<IWebSearchClient>`, `Mock<IArticleStyleGuideSource>`, and `CreateNoOpRecorder()`/`PipelineStepRecorder` wiring are removed along with unused `using` statements. The five per-step `*StepTests.cs` files and `SourceEnrichmentIntegrationTests.cs` are untouched — they instantiate the concrete step classes directly, which remains valid since implementing an interface is additive.
+
+## Data Schemas
+
+No data model, database, HTTP/controller, or persisted-payload changes. `ArticlePipelineContext` (`.../Pipeline/ArticlePipelineContext.cs`) keeps its existing shape and continues to flow by reference through each step's `ExecuteAsync` in the same fixed order:
+
+```
+PlanQueries → GatherContext → AggregateFacts → ValidateFacts → [status: Writing] → WriteArticle
+```
+
+Only the compile-time dependency type at the `GenerateArticleJob` constructor boundary changes (concrete class → interface); no wire format, event payload, or entity schema is affected.

--- a/artifacts/feat-3593/impl/add-pipeline-step-interfaces-and-wire-di.r1.md
+++ b/artifacts/feat-3593/impl/add-pipeline-step-interfaces-and-wire-di.r1.md
@@ -1,0 +1,44 @@
+# Implementation: add-pipeline-step-interfaces-and-wire-di
+
+## What was implemented
+Extracted single-method interfaces (`IPlanQueriesStep`, `IGatherContextStep`, `IAggregateFactsStep`, `IValidateFactsStep`, `IWriteArticleStep`) for the five Article generation pipeline step classes, each exposing `Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`. Each concrete step class now implements its corresponding interface. `GenerateArticleJob`'s constructor and field declarations were updated to depend on the interfaces instead of the concrete step classes, and `ArticleModule`'s DI registrations were updated to register each interface-to-implementation mapping (`services.AddScoped<IXStep, XStep>()`) instead of registering the concrete classes directly.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs` — added `IPlanQueriesStep` interface; `PlanQueriesStep` now implements it
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs` — added `IGatherContextStep` interface; `GatherContextStep` now implements it
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs` — added `IAggregateFactsStep` interface; `AggregateFactsStep` now implements it
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs` — added `IValidateFactsStep` interface; `ValidateFactsStep` now implements it
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs` — added `IWriteArticleStep` interface; `WriteArticleStep` now implements it
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs` — field declarations and constructor parameters changed from concrete step types to their interface types; constructor body and `RunAsync` unchanged
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs` — DI registrations for the five steps changed from `services.AddScoped<XStep>()` to `services.AddScoped<IXStep, XStep>()`
+
+## Tests
+No test files were changed. Verified via `grep` (per task instructions) that the only other references to the five concrete step type names are in `PlanQueriesStepTests.cs`, `GatherContextStepTests.cs`, `AggregateFactsStepTests.cs`, `ValidateFactsStepTests.cs`, `WriteArticleStepTests.cs`, and `SourceEnrichmentIntegrationTests.cs` — all of which construct the concrete classes directly via `new XStep(...)`, which remains valid since implementing an interface is purely additive. `GenerateArticleJobTests.cs` was also excluded from that grep sweep per task instructions (handled in a follow-up task) and continues to compile since concrete classes now satisfy the interface-typed constructor parameters.
+
+## How to verify
+```bash
+cd backend
+dotnet build ../Anela.Heblo.sln   # or: cd .. && dotnet build Anela.Heblo.sln
+dotnet format ../Anela.Heblo.sln --verify-no-changes --include <touched files>
+```
+Both were run from the repo root against `Anela.Heblo.sln` and passed: build completed with 0 errors (250 pre-existing warnings, unrelated to this change), and `dotnet format --verify-no-changes` produced no diffs for the seven touched files.
+
+## Notes
+- The task context's example `dotnet build` / `dotnet format` invocations assumed a project/solution file directly under `backend/`, but the actual solution file `Anela.Heblo.sln` lives at the repo root. Both commands were run against that solution file instead; behavior and outcome are unaffected.
+- `artifacts/feat-3593/state.json` showed as modified in `git status` before and after this task's changes — it was not touched by this task and was intentionally left out of the commit (matches instructions: only the seven specified files were staged and committed).
+- No deviations from the specified interface shapes, file paths, or DI wiring.
+
+## PR Summary
+This change introduces single-method interfaces for each of the five steps in the Article generation pipeline (plan queries, gather context, aggregate facts, validate facts, write article) and updates `GenerateArticleJob` to depend on those interfaces rather than concrete classes, with `ArticleModule` registering the corresponding DI mappings. This is a pure dependency-inversion refactor with no behavioral changes — method bodies, orchestration logic, and constructor bodies are untouched; only declared types changed. Verified via `dotnet build` (0 errors) and `dotnet format --verify-no-changes` (no diffs) against the root `Anela.Heblo.sln`. A repo-wide grep confirmed no other consumers depend on the concrete step types in a way this refactor would break, aside from existing per-step unit tests and an integration test that construct the concrete classes directly (still valid, since implementing an interface is additive).
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs` — added `IPlanQueriesStep`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs` — added `IGatherContextStep`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs` — added `IAggregateFactsStep`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs` — added `IValidateFactsStep`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs` — added `IWriteArticleStep`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs` — constructor/fields now use interface types
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs` — DI registrations now map interface to implementation
+
+## Status
+DONE

--- a/artifacts/feat-3593/impl/rework-generatearticlejobtests-to-mock-interfaces.r1.md
+++ b/artifacts/feat-3593/impl/rework-generatearticlejobtests-to-mock-interfaces.r1.md
@@ -1,0 +1,31 @@
+# Implementation: rework-generatearticlejobtests-to-mock-interfaces
+
+## What was implemented
+Reworked `GenerateArticleJobTests.cs` to mock the five new pipeline-step interfaces (`IPlanQueriesStep`, `IGatherContextStep`, `IAggregateFactsStep`, `IValidateFactsStep`, `IWriteArticleStep`) directly with `Mock<T>` fields instead of constructing real step instances wired to mocked leaf dependencies (`IChatClient`, `IArticleKnowledgeSource`, `IWebSearchClient`, `IArticleStyleGuideSource`). A constructor now defaults all five step mocks to a no-op `Task.CompletedTask` so each test only needs to override the specific step(s) relevant to its scenario. `CreateJob()` is now a no-arg method that wires the five mocks directly into `GenerateArticleJob`. The happy-path test sets the expected output via a `Callback` on the `WriteArticleStep` mock; the "step throws" and cancellation tests set up the relevant step mock to throw directly instead of arranging JSON responses through a shared `IChatClient` mock.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs` — replaced leaf-dependency mocks and `CreateNoOpRecorder()`/`SetupChatResponses()` helpers with direct step-interface mocks; rewrote all three test cases (happy path, step-throws, cancellation) to drive behavior through the step mocks.
+
+## Tests
+`GenerateArticleJobTests.cs` — all 4 existing tests (`RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted`, the step-throws test, the cancellation test, and one additional existing test) continue to cover the job's orchestration logic (status transitions, error handling, source persistence), now isolated from the steps' internal JSON-parsing logic.
+
+## How to verify
+```bash
+cd /home/user/worktrees/feature-3593-Arch-Review-Article-Generatearticlejob-Depends-On
+dotnet build Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GenerateArticleJobTests"
+dotnet format Anela.Heblo.sln --verify-no-changes --include backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
+```
+All pass: build succeeds with 0 errors, 4/4 tests pass, no formatting diffs.
+
+## Notes
+None — implementation matches the task context's before/after code exactly. Task 1's interface types (already committed in `4570e3b`) were used as-is; no changes were needed to `GenerateArticleJob.cs`, the step classes, or `ArticleModule.cs` for this task.
+
+## PR Summary
+Reworks the Article-generation orchestration tests to mock the new per-step interfaces directly rather than constructing real step implementations wired to mocked leaf dependencies. This isolates `GenerateArticleJobTests` from each step's internal JSON-parsing/LLM-call logic, so a test like "job marks article Failed when a step throws" only needs to arrange that one step mock to throw — no need to first wire up a successful upstream step via a fake `IChatClient` response.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs` — mocks step interfaces directly; removed now-unused `IChatClient`/`IArticleKnowledgeSource`/`IWebSearchClient`/`IArticleStyleGuideSource`/`ArticleOptions` test scaffolding.
+
+## Status
+DONE

--- a/artifacts/feat-3593/review/add-pipeline-step-interfaces-and-wire-di.r1.md
+++ b/artifacts/feat-3593/review/add-pipeline-step-interfaces-and-wire-di.r1.md
@@ -1,0 +1,24 @@
+# Code Review: add-pipeline-step-interfaces-and-wire-di
+
+## Summary
+The implementation matches the task spec verbatim: five single-method interfaces (`IPlanQueriesStep`, `IGatherContextStep`, `IAggregateFactsStep`, `IValidateFactsStep`, `IWriteArticleStep`) were added co-located with their implementing classes, `GenerateArticleJob`'s constructor/fields were retyped to the interfaces with the constructor body and `RunAsync` left untouched, and `ArticleModule.cs`'s DI registrations were updated to `AddScoped<IXStep, XStep>()`. This is a clean, low-risk dependency-inversion refactor with no behavioral change.
+
+## Review Result: PASS
+
+### task: add-pipeline-step-interfaces-and-wire-di
+**Status:** PASS
+
+## Docs to Update
+(none)
+
+## Overall Notes
+Verification performed directly against commit `4570e3b` in the worktree:
+- `git show 4570e3b --stat` / full diff: exactly the 7 files listed in the spec were touched, diff content matches the spec's before/after snippets character-for-character (interface + `: IXStep` added, DI registrations swapped to two-arg `AddScoped`, `GenerateArticleJob` field/constructor-parameter types changed with constructor body and `RunAsync` untouched).
+- `dotnet build Anela.Heblo.sln` from repo root: succeeded, 0 errors, 250 warnings (pre-existing, unrelated to this change — consistent with the developer's summary).
+- `dotnet format Anela.Heblo.sln --verify-no-changes --include <7 touched files>`: no diffs reported.
+- Re-ran the spec's repo-wide grep sweep for the five concrete step type names outside the touched files: results are exactly the expected set — the five per-step `*StepTests.cs` files and `SourceEnrichmentIntegrationTests.cs`, all constructing concrete classes directly via `new XStep(...)`, which remains valid since implementing an interface is purely additive. No undocumented consumers found.
+- Each interface's `ExecuteAsync` signature (`Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`) matches the corresponding class's existing method signature exactly, confirmed by direct inspection of all five files.
+- `GenerateArticleJobTests.cs` was correctly left untouched — the task spec explicitly scopes that file's rework to a follow-up task, and it still compiles today since concrete step classes satisfy the new interface-typed constructor parameters.
+- `git status --short` shows only an unrelated, pre-existing modification to `artifacts/feat-3593/state.json`, which the developer correctly left out of the commit.
+
+This follows arch-review.r1.md's guidance precisely: per-step interfaces (not a shared `IPipelineStep`), interfaces co-located in the same file as their implementation, and DI wiring confined to `ArticleModule.cs`. No functional, architectural, or completeness issues found.

--- a/artifacts/feat-3593/review/rework-generatearticlejobtests-to-mock-interfaces.r1.md
+++ b/artifacts/feat-3593/review/rework-generatearticlejobtests-to-mock-interfaces.r1.md
@@ -1,0 +1,21 @@
+# Code Review: rework-generatearticlejobtests-to-mock-interfaces
+
+## Summary
+The implementation reworks `GenerateArticleJobTests.cs` to mock the five pipeline-step interfaces (`IPlanQueriesStep`, `IGatherContextStep`, `IAggregateFactsStep`, `IValidateFactsStep`, `IWriteArticleStep`) directly rather than constructing real step instances wired to mocked leaf dependencies. The diff matches the task spec's literal before/after code blocks exactly, and all now-unused helpers, mocks, and usings were removed as instructed.
+
+## Review Result: PASS
+
+### task: rework-generatearticlejobtests-to-mock-interfaces
+**Status:** PASS
+
+## Docs to Update
+(None — this is a test-only refactor with no doc-affecting behavior change.)
+
+## Overall Notes
+- Verified `git diff 4570e3b..8d9336b -- backend/` touches only `backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs` (42 insertions, 78 deletions), matching the spec's single-file scope.
+- Field declarations, constructor no-op setup, `CreateJob()`, and the three reworked tests (`RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted`, `RunAsync_StepThrows_StatusFailedAndErrorMessageSet`, `RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown`) all match the spec's literal replacement text verbatim. `RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState` was left untouched as instructed. `CreateNoOpRecorder()` and `SetupChatResponses()` were fully removed. Using directives were trimmed to drop `Contracts`, `Shared.WebSearch`, `Microsoft.Extensions.AI`, and `Microsoft.Extensions.Options`, exactly as specified.
+- `dotnet build Anela.Heblo.sln` succeeds with 0 errors (only pre-existing, unrelated nullable warnings elsewhere in the test project).
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GenerateArticleJobTests"` — all 4 tests pass.
+- Ran the full `Anela.Heblo.Tests` suite: 5667 passed, 66 failed, 4 skipped. All 66 failures are `System.ArgumentException: Docker is either not running or misconfigured` from Testcontainers-based Postgres integration tests (Bank, KnowledgeBase, Leaflet, Smartsupp, GridLayouts, Purchase, Photobank, MeetingTasks, Invoices, Catalog, and two Article persistence SQL-shape tests) — a pre-existing environment limitation (no Docker daemon in this sandbox), unrelated to this change. None of the failures touch `GenerateArticleJobTests` or the five per-step `*StepTests.cs`/`SourceEnrichmentIntegrationTests.cs` files, confirming no regression.
+- `dotnet format Anela.Heblo.sln --verify-no-changes --include backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs` produced no output and exited 0 — no formatting diffs.
+- Note: the initial `dotnet test` invocation in this review session hung indefinitely (a build-time `Generating access matrix artifacts...` step in `Anela.Heblo.AccessMatrixGen` threw an unhandled `JsonException`, apparently from concurrent/stale MSBuild node reuse after a prior `dotnet build`). This was resolved by killing stray `dotnet`/`MSBuild`/`VBCSCompiler` processes and re-running with `--no-build` against the already-built solution. This is an environment/tooling flake unrelated to the code change under review and not a defect in this task's implementation.

--- a/artifacts/feat-3593/spec.r1.md
+++ b/artifacts/feat-3593/spec.r1.md
@@ -1,0 +1,158 @@
+# Specification: Introduce interfaces for Article generation pipeline steps
+
+## Summary
+`GenerateArticleJob` currently depends on five concrete pipeline step classes (`PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep`) instead of abstractions, and none of those classes expose a mockable, non-virtual `ExecuteAsync`. This forces `GenerateArticleJobTests` to construct real step instances (with mocked inner dependencies) even when a test only cares about the job's own orchestration logic. This spec introduces a minimal interface per step, updates the job and DI registrations to depend on those interfaces, and simplifies the existing job tests to use interface mocks.
+
+## Background
+`GenerateArticleJob.RunAsync` (`backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`) orchestrates a fixed five-step pipeline against a shared `ArticlePipelineContext`: `PlanQueriesStep` → `GatherContextStep` → `AggregateFactsStep` → `ValidateFactsStep` → (status transition to `Writing`) → `WriteArticleStep`. Each step's constructor dependency in `GenerateArticleJob` is the concrete class, and `ExecuteAsync` is a plain (non-virtual) instance method, so Moq cannot generate a proxy for it — there is no seam to substitute a step with a test double.
+
+`GenerateArticleJobTests.cs` (`backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs`) works around this today by building real step instances via `CreateJob(...)`, wired with mocked leaf dependencies (`Mock<IChatClient>`, `Mock<IArticleKnowledgeSource>`, `Mock<IWebSearchClient>`, `Mock<IArticleStyleGuideSource>`) and a real `PipelineStepRecorder` backed by a no-op repository mock. To test "job marks article as `Failed` when a step throws" (`RunAsync_StepThrows_StatusFailedAndErrorMessageSet`), the test must first make `PlanQueriesStep` succeed by returning valid JSON from the chat mock, then make the second chat call throw so `AggregateFactsStep` fails — coupling a job-orchestration test to `PlanQueriesStep`'s JSON-parsing behavior.
+
+This is a pure Dependency Inversion refactor: introduce one interface per step, make each step class implement it, and change `GenerateArticleJob` and the DI container (`ArticleModule.cs`) to depend on the interfaces. No pipeline business logic changes.
+
+## Functional Requirements
+
+### FR-1: Define one interface per pipeline step
+For each of the five step classes, define a matching interface with a single method, following the pattern from the brief:
+
+```csharp
+public interface IPlanQueriesStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+```
+
+Required interfaces (method signature identical for all — `Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`):
+- `IPlanQueriesStep` (for `PlanQueriesStep`)
+- `IGatherContextStep` (for `GatherContextStep`)
+- `IAggregateFactsStep` (for `AggregateFactsStep`)
+- `IValidateFactsStep` (for `ValidateFactsStep`)
+- `IWriteArticleStep` (for `WriteArticleStep`)
+
+**Acceptance criteria:**
+- Each interface lives in `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/`, in the same file as its implementing class (matching the brief's example), in namespace `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline`.
+- Each interface declares exactly one method: `Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`.
+- No other members (properties, additional methods) are added to the interfaces.
+
+### FR-2: Step classes implement their interface
+Each of the five step classes declares itself as implementing the matching interface (e.g. `public class PlanQueriesStep : IPlanQueriesStep`). No change to constructor parameters, field layout, or method bodies of the step classes — this is a signature-only addition.
+
+**Acceptance criteria:**
+- `PlanQueriesStep : IPlanQueriesStep`, `GatherContextStep : IGatherContextStep`, `AggregateFactsStep : IAggregateFactsStep`, `ValidateFactsStep : IValidateFactsStep`, `WriteArticleStep : IWriteArticleStep`.
+- `ExecuteAsync` on each class keeps its current implementation (JSON parsing, retry logic, recorder wrapping, fallback behavior) unchanged.
+- No other public or private members of the step classes change.
+
+### FR-3: `GenerateArticleJob` depends on the step interfaces, not the concrete classes
+Update `GenerateArticleJob`'s constructor and private fields to use `IPlanQueriesStep`, `IGatherContextStep`, `IAggregateFactsStep`, `IValidateFactsStep`, `IWriteArticleStep` in place of the concrete class types. `RunAsync`'s orchestration logic (call order, status transitions, exception handling, `Source` mapping) is unchanged.
+
+**Acceptance criteria:**
+- Constructor signature parameter types are the five interfaces (order and names otherwise unchanged) plus the existing `IArticleRepository` and `ILogger<GenerateArticleJob>` parameters.
+- `RunAsync` method body is byte-for-byte unchanged (only field/parameter *types* change).
+- The class still compiles as `[AutomaticRetry(Attempts = 0)]` `public sealed class GenerateArticleJob`.
+
+### FR-4: DI registrations bind interface to implementation
+Update `ArticleModule.cs` (`backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs`, lines 25–30) so each step is registered as `services.AddScoped<IXStep, XStep>()` instead of `services.AddScoped<XStep>()`.
+
+**Acceptance criteria:**
+- `services.AddScoped<IPlanQueriesStep, PlanQueriesStep>();`
+- `services.AddScoped<IGatherContextStep, GatherContextStep>();`
+- `services.AddScoped<IAggregateFactsStep, AggregateFactsStep>();`
+- `services.AddScoped<IValidateFactsStep, ValidateFactsStep>();`
+- `services.AddScoped<IWriteArticleStep, WriteArticleStep>();`
+- `PipelineStepRecorder` and `GenerateArticleJob` registrations are unchanged (`services.AddScoped<PipelineStepRecorder>();` and `services.AddScoped<GenerateArticleJob>();`).
+- The app builds and resolves `GenerateArticleJob` from the DI container without runtime resolution errors (verified via existing integration/build checks — Hangfire resolves job instances through the same container).
+
+### FR-5: Simplify `GenerateArticleJobTests` to mock the step interfaces directly
+Rework `GenerateArticleJobTests.cs` so `CreateJob(...)` accepts `Mock<IPlanQueriesStep>`, `Mock<IGatherContextStep>`, `Mock<IAggregateFactsStep>`, `Mock<IValidateFactsStep>`, `Mock<IWriteArticleStep>` (or their `.Object`s) instead of constructing real step instances. Default mocks should behave as successful no-ops (`ExecuteAsync` completes without mutating `context`, unless a test needs to mutate context fields the job reads afterward — see below).
+
+Specifically:
+- `RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted` needs the `WriteArticleStep` mock to set `context.GeneratedTitle`, `context.GeneratedHtml`, and `context.SourceRefs` (since the job reads these directly off `context` after calling the step) — do this via `Mock<IWriteArticleStep>.Setup(...).Callback<ArticlePipelineContext, CancellationToken>((ctx, ct) => { ctx.GeneratedTitle = ...; ... })` or equivalent, rather than relying on real `WriteArticleStep` JSON parsing.
+- `RunAsync_StepThrows_StatusFailedAndErrorMessageSet` should mock `IAggregateFactsStep.ExecuteAsync` to throw `InvalidOperationException("LLM blew up")` directly — no `IChatClient`/JSON setup needed at all. `_chat`, `_knowledgeSource`, `_webSearch`, `_styleGuideSource` mocks (and their setups) can be removed from the test class entirely once no test still exercises the real step implementations. Confirm no other test in the file (or the pipeline step unit tests, if any exist) still needs them before removing.
+- `RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown` should mock the first-invoked step (`IPlanQueriesStep`) to throw `OperationCanceledException` directly.
+- `RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState` is unaffected by which step type is used since no step is invoked; simplify its `CreateJob()` call along with the others.
+- `PipelineStepRecorder` and its no-op repository wiring (`CreateNoOpRecorder`) are no longer needed by `GenerateArticleJobTests` once steps are mocked at the interface level (the recorder is an internal collaborator of the concrete step classes, not of the job) — remove it if no longer referenced.
+
+**Acceptance criteria:**
+- All four existing test methods pass with unchanged assertions (status, title, HTML, sources, `SaveChangesAsync` call counts, `ErrorMessage`).
+- No test in `GenerateArticleJobTests.cs` constructs a real `PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, or `WriteArticleStep`.
+- `RunAsync_StepThrows_StatusFailedAndErrorMessageSet` no longer depends on `PlanQueriesStep`'s JSON query-plan parsing to reach the `AggregateFactsStep` failure — it mocks `IAggregateFactsStep` to throw directly, with `IPlanQueriesStep` mocked as a successful no-op.
+- If `Mock<IChatClient>`, `Mock<IArticleKnowledgeSource>`, `Mock<IWebSearchClient>`, `Mock<IArticleStyleGuideSource>` become unused after this change, they are removed from the test class along with their `using` statements if applicable.
+- `dotnet test` for the `Anela.Heblo.Tests` project passes with no new warnings about unused mocks/fields.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavior parity
+This is a pure refactor. No change to article generation behavior, prompts, retry logic, JSON parsing, fallback handling, or persisted data. `RunAsync`'s method body must not change beyond field/parameter type annotations.
+
+### NFR-2: Build and test integrity
+- `dotnet build` succeeds for the whole solution (interfaces must not break any other consumer of the step classes — a repo-wide search for direct references to the five concrete step type names outside `ArticleModule.cs`, `GenerateArticleJob.cs`, and their own files should be done before finalizing the change, in case something elsewhere depends on the concrete type rather than the interface).
+- `dotnet format` produces no diffs.
+- All existing tests in `Anela.Heblo.Tests` (not just `GenerateArticleJobTests`) continue to pass, including any tests that directly exercise `PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, or `WriteArticleStep` in isolation (these should continue instantiating the concrete classes directly — introducing the interface does not require changing tests that already target the concrete step in isolation).
+
+### NFR-3: No behavioral coupling to test doubles in production
+The new interfaces are used only for the production DI graph (`ArticleModule.cs`) and are implemented by exactly one class each in production code. No additional "null object" or alternate implementation is introduced by this change (e.g. no `MockPlanQueriesStep` for dev environments — that is out of scope, see below).
+
+## Data Model
+No data model changes. `ArticlePipelineContext` (`backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ArticlePipelineContext.cs`) remains the shared mutable state object passed by reference through each step's `ExecuteAsync`; its shape is unchanged.
+
+## API / Interface Design
+
+New interfaces (all in namespace `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline`):
+
+```csharp
+public interface IPlanQueriesStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public interface IGatherContextStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public interface IAggregateFactsStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public interface IValidateFactsStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public interface IWriteArticleStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+```
+
+`GenerateArticleJob` constructor signature after the change:
+
+```csharp
+public GenerateArticleJob(
+    IArticleRepository repository,
+    IPlanQueriesStep planQueries,
+    IGatherContextStep gatherContext,
+    IAggregateFactsStep aggregateFacts,
+    IValidateFactsStep validateFacts,
+    IWriteArticleStep writeArticle,
+    ILogger<GenerateArticleJob> logger)
+```
+
+No HTTP/controller/UI-facing API surface changes — this is entirely internal to the Article module's Application layer.
+
+## Dependencies
+- Existing: Moq (already used in `GenerateArticleJobTests.cs`), Microsoft.Extensions.DependencyInjection (`ArticleModule.cs`), Hangfire (`GenerateArticleJob` is invoked as a Hangfire job — must remain resolvable from the DI container; no interface-based change affects Hangfire's job activation since it resolves `GenerateArticleJob` itself, not the interfaces, from the container).
+- No new packages or external services introduced.
+
+## Out of Scope
+- Adding an interface for `PipelineStepRecorder` — it is an internal collaborator of each step, not a dependency of `GenerateArticleJob`, and is unaffected by this change.
+- Any new alternate step implementation (e.g. a "mock"/no-op step for dev/staging environments) — the brief mentions this as a downstream benefit, not a requirement of this change.
+- Any change to step internals: JSON parsing, retry logic (`ChatRetry`), prompt construction, fallback/rescue logic, or the `ArticlePipelineContext` shape.
+- Adding unit tests for the individual step classes' internal logic beyond what already exists.
+- Splitting the interface definitions into separate files from their implementing classes (see Open Questions — resolved via assumption, not a blocker).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-11T08:17:54.222030Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-11T08:19:48.939741Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-11T08:17:54.222030Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-11T09:22:48.911257Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-11T09:22:55.576323Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -25,5 +25,18 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-pipeline-step-interfaces-and-wire-di",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "rework-generatearticlejobtests-to-mock-interfaces",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-11T08:23:42.318549Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-11T08:24:09.124553Z"
     }
   },
   "tasks": [
     {
       "name": "add-pipeline-step-interfaces-and-wire-di",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-11T08:24:09.306955Z"
     },
     {
       "name": "rework-generatearticlejobtests-to-mock-interfaces",

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "add-pipeline-step-interfaces-and-wire-di",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-11T08:24:09.306955Z"
+      "updated_at": "2026-07-11T08:31:46.931571Z"
     },
     {
       "name": "rework-generatearticlejobtests-to-mock-interfaces",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-11T08:31:50.324473Z"
     }
   ]
 }

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-11T08:23:42.318549Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T08:24:09.124553Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T09:22:48.911257Z"
     }
   },
   "tasks": [
@@ -34,9 +34,9 @@
     },
     {
       "name": "rework-generatearticlejobtests-to-mock-interfaces",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-11T08:31:50.324473Z"
+      "updated_at": "2026-07-11T09:22:43.970206Z"
     }
   ]
 }

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-11T08:20:41.592496Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-11T08:23:42.318549Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3593",
+  "issue_number": 3593,
+  "created_at": "2026-07-11T08:15:01.790548Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-11T08:19:48.939741Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-11T08:20:41.592496Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3593/state.json
+++ b/artifacts/feat-3593/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-11T09:22:48.911257Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-11T09:22:55.576323Z"
+      "status": "completed",
+      "updated_at": "2026-07-11T09:28:38.448575Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3593/task-context/add-pipeline-step-interfaces-and-wire-di.md
+++ b/artifacts/feat-3593/task-context/add-pipeline-step-interfaces-and-wire-di.md
@@ -1,0 +1,212 @@
+### task: add-pipeline-step-interfaces-and-wire-di
+
+**Files:**
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs`
+
+**Steps:**
+
+- [ ] In `PlanQueriesStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class PlanQueriesStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IPlanQueriesStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class PlanQueriesStep : IPlanQueriesStep
+  {
+  ```
+
+- [ ] In `GatherContextStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class GatherContextStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IGatherContextStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class GatherContextStep : IGatherContextStep
+  {
+  ```
+
+- [ ] In `AggregateFactsStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class AggregateFactsStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IAggregateFactsStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class AggregateFactsStep : IAggregateFactsStep
+  {
+  ```
+
+- [ ] In `ValidateFactsStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class ValidateFactsStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IValidateFactsStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class ValidateFactsStep : IValidateFactsStep
+  {
+  ```
+
+- [ ] In `WriteArticleStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class WriteArticleStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IWriteArticleStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class WriteArticleStep : IWriteArticleStep
+  {
+  ```
+
+- [ ] Verify each step class's own `ExecuteAsync` method already matches the interface signature exactly (`Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`) so no further changes to the class bodies are needed. (Confirmed by inspection during planning — all five already use this exact signature; this is a read-only sanity check, not an edit.)
+
+- [ ] In `GenerateArticleJob.cs`, replace the field declarations:
+  ```csharp
+  private readonly IArticleRepository _repository;
+  private readonly PlanQueriesStep _planQueries;
+  private readonly GatherContextStep _gatherContext;
+  private readonly AggregateFactsStep _aggregateFacts;
+  private readonly ValidateFactsStep _validateFacts;
+  private readonly WriteArticleStep _writeArticle;
+  private readonly ILogger<GenerateArticleJob> _logger;
+
+  public GenerateArticleJob(
+      IArticleRepository repository,
+      PlanQueriesStep planQueries,
+      GatherContextStep gatherContext,
+      AggregateFactsStep aggregateFacts,
+      ValidateFactsStep validateFacts,
+      WriteArticleStep writeArticle,
+      ILogger<GenerateArticleJob> logger)
+  {
+  ```
+  with:
+  ```csharp
+  private readonly IArticleRepository _repository;
+  private readonly IPlanQueriesStep _planQueries;
+  private readonly IGatherContextStep _gatherContext;
+  private readonly IAggregateFactsStep _aggregateFacts;
+  private readonly IValidateFactsStep _validateFacts;
+  private readonly IWriteArticleStep _writeArticle;
+  private readonly ILogger<GenerateArticleJob> _logger;
+
+  public GenerateArticleJob(
+      IArticleRepository repository,
+      IPlanQueriesStep planQueries,
+      IGatherContextStep gatherContext,
+      IAggregateFactsStep aggregateFacts,
+      IValidateFactsStep validateFacts,
+      IWriteArticleStep writeArticle,
+      ILogger<GenerateArticleJob> logger)
+  {
+  ```
+  Do not touch the constructor body (`_repository = repository; ...`) or `RunAsync` — they are unchanged (field names, assignment order, and all orchestration logic stay byte-for-byte identical; only the declared types above change).
+
+- [ ] In `ArticleModule.cs`, replace:
+  ```csharp
+  services.AddScoped<PipelineStepRecorder>();
+  services.AddScoped<PlanQueriesStep>();
+  services.AddScoped<GatherContextStep>();
+  services.AddScoped<AggregateFactsStep>();
+  services.AddScoped<ValidateFactsStep>();
+  services.AddScoped<WriteArticleStep>();
+  services.AddScoped<GenerateArticleJob>();
+  ```
+  with:
+  ```csharp
+  services.AddScoped<PipelineStepRecorder>();
+  services.AddScoped<IPlanQueriesStep, PlanQueriesStep>();
+  services.AddScoped<IGatherContextStep, GatherContextStep>();
+  services.AddScoped<IAggregateFactsStep, AggregateFactsStep>();
+  services.AddScoped<IValidateFactsStep, ValidateFactsStep>();
+  services.AddScoped<IWriteArticleStep, WriteArticleStep>();
+  services.AddScoped<GenerateArticleJob>();
+  ```
+
+- [ ] Search the repo for any other direct references to the five concrete step type names outside the files already touched in this task and the test files that will be handled in the next task, to confirm nothing else depends on the concrete type in a way this refactor would break:
+  ```bash
+  cd backend
+  grep -rn "PlanQueriesStep\|GatherContextStep\|AggregateFactsStep\|ValidateFactsStep\|WriteArticleStep" --include=*.cs src/ test/ | grep -v "UseCases/Generate/Pipeline/PlanQueriesStep.cs\|UseCases/Generate/Pipeline/GatherContextStep.cs\|UseCases/Generate/Pipeline/AggregateFactsStep.cs\|UseCases/Generate/Pipeline/ValidateFactsStep.cs\|UseCases/Generate/Pipeline/WriteArticleStep.cs\|UseCases/Generate/GenerateArticleJob.cs\|Features/Article/ArticleModule.cs\|GenerateArticleJobTests.cs"
+  ```
+  Expected result: only the five per-step test files (`PlanQueriesStepTests.cs`, `GatherContextStepTests.cs`, `AggregateFactsStepTests.cs`, `ValidateFactsStepTests.cs`, `WriteArticleStepTests.cs`) and `SourceEnrichmentIntegrationTests.cs`, all of which construct the concrete class directly via `new XStep(...)` — this remains valid since implementing an interface is purely additive, so no changes are needed to those files. If any other file appears, stop and investigate before proceeding — that would indicate an undocumented consumer not accounted for in `arch-review.r1.md`.
+
+- [ ] Build the backend to confirm the interface introduction and DI rewiring compile cleanly:
+  ```bash
+  cd backend
+  dotnet build
+  ```
+  Expect a clean build with no errors. (`GenerateArticleJobTests.cs` will still reference the concrete step types in `CreateJob(...)` at this point — that continues to compile because the concrete classes still exist unchanged and their constructors are untouched; only the `GenerateArticleJob` constructor call inside `CreateJob` now binds concrete instances to interface-typed parameters, which is valid since each concrete class implements its interface.)
+
+- [ ] Run `dotnet format` and confirm no diffs:
+  ```bash
+  cd backend
+  dotnet format --verify-no-changes
+  ```
+
+- [ ] Commit:
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs
+  git commit -m "Introduce per-step interfaces for Article generation pipeline and wire DI"
+  ```
+
+---
+

--- a/artifacts/feat-3593/task-context/rework-generatearticlejobtests-to-mock-interfaces.md
+++ b/artifacts/feat-3593/task-context/rework-generatearticlejobtests-to-mock-interfaces.md
@@ -1,0 +1,364 @@
+### task: rework-generatearticlejobtests-to-mock-interfaces
+
+**Files:**
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs`
+
+**Steps:**
+
+- [ ] Replace the field declarations at the top of the class:
+  ```csharp
+  public class GenerateArticleJobTests
+  {
+      private readonly Mock<IArticleRepository> _repository = new();
+      private readonly Mock<IChatClient> _chat = new();
+      private readonly Mock<IArticleKnowledgeSource> _knowledgeSource = new();
+      private readonly Mock<IWebSearchClient> _webSearch = new();
+      private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
+      private readonly ArticleOptions _options = new();
+  ```
+  with:
+  ```csharp
+  public class GenerateArticleJobTests
+  {
+      private readonly Mock<IArticleRepository> _repository = new();
+      private readonly Mock<IPlanQueriesStep> _planQueries = new();
+      private readonly Mock<IGatherContextStep> _gatherContext = new();
+      private readonly Mock<IAggregateFactsStep> _aggregateFacts = new();
+      private readonly Mock<IValidateFactsStep> _validateFacts = new();
+      private readonly Mock<IWriteArticleStep> _writeArticle = new();
+  ```
+  (`ArticleOptions _options`, `IChatClient`, `IArticleKnowledgeSource`, `IWebSearchClient`, and `IArticleStyleGuideSource` mocks are dropped — they were only needed to construct real step instances, which no longer happens in this file.)
+
+- [ ] Set up the five new step mocks as successful no-ops by default, right after the field declarations (before `CreateArticle`), by initializing them in the constructor. Add a constructor:
+  ```csharp
+  public GenerateArticleJobTests()
+  {
+      _planQueries.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _gatherContext.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _aggregateFacts.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _validateFacts.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _writeArticle.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+  }
+  ```
+  Place this directly after the field declarations block, before `CreateArticle()`.
+
+- [ ] Remove the `CreateNoOpRecorder()` helper entirely (it is only used to construct real step instances, which no longer happens):
+  ```csharp
+  private static PipelineStepRecorder CreateNoOpRecorder()
+  {
+      var repo = new Mock<IArticleRepository>();
+      repo.Setup(r => r.AddStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+      repo.Setup(r => r.UpdateStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+      repo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+      return new PipelineStepRecorder(repo.Object);
+  }
+  ```
+  Delete this method entirely.
+
+- [ ] Replace `CreateJob(...)`:
+  ```csharp
+  private GenerateArticleJob CreateJob(
+      PlanQueriesStep? planQueries = null,
+      GatherContextStep? gatherContext = null,
+      AggregateFactsStep? aggregateFacts = null,
+      ValidateFactsStep? validateFacts = null,
+      WriteArticleStep? writeArticle = null)
+  {
+      var optionsWrapper = Options.Create(_options);
+      var recorder = CreateNoOpRecorder();
+      return new GenerateArticleJob(
+          _repository.Object,
+          planQueries ?? new PlanQueriesStep(_chat.Object, optionsWrapper, NullLogger<PlanQueriesStep>.Instance, recorder),
+          gatherContext ?? new GatherContextStep(_knowledgeSource.Object, _webSearch.Object, _styleGuideSource.Object, optionsWrapper, NullLogger<GatherContextStep>.Instance, recorder),
+          aggregateFacts ?? new AggregateFactsStep(_chat.Object, optionsWrapper, NullLogger<AggregateFactsStep>.Instance, recorder),
+          validateFacts ?? new ValidateFactsStep(_chat.Object, optionsWrapper, NullLogger<ValidateFactsStep>.Instance, recorder),
+          writeArticle ?? new WriteArticleStep(_chat.Object, optionsWrapper, NullLogger<WriteArticleStep>.Instance, recorder),
+          NullLogger<GenerateArticleJob>.Instance);
+  }
+  ```
+  with:
+  ```csharp
+  private GenerateArticleJob CreateJob()
+  {
+      return new GenerateArticleJob(
+          _repository.Object,
+          _planQueries.Object,
+          _gatherContext.Object,
+          _aggregateFacts.Object,
+          _validateFacts.Object,
+          _writeArticle.Object,
+          NullLogger<GenerateArticleJob>.Instance);
+  }
+  ```
+
+- [ ] Remove the `SetupChatResponses` helper entirely (no longer used by any test once steps are mocked directly):
+  ```csharp
+  private void SetupChatResponses(params string[] responsesInOrder)
+  {
+      var queue = new Queue<string>(responsesInOrder);
+      _chat
+          .Setup(c => c.GetResponseAsync(
+              It.IsAny<IEnumerable<ChatMessage>>(),
+              It.IsAny<ChatOptions?>(),
+              It.IsAny<CancellationToken>()))
+          .ReturnsAsync(() =>
+          {
+              var text = queue.Count > 0 ? queue.Dequeue() : "{}";
+              return new ChatResponse([new ChatMessage(ChatRole.Assistant, text)]);
+          });
+  }
+  ```
+  Delete this method entirely.
+
+- [ ] Rework `RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted`. Replace:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      SetupChatResponses(
+          // PlanQueries
+          """{"queries":["q1","q2"]}""",
+          // AggregateFacts
+          """{"facts":[{"claim":"Fact A","confidence":0.9,"source_url":null,"source_title":"S"}],"summary":"sum","gaps":null}""",
+          // ValidateFacts
+          """{"validated_facts":[{"fact":"Fact A","note":"good","reliable":true}]}""",
+          // WriteArticle
+          """{"article_title":"Final Title","article_html":"<article>x</article>","sources_used":[{"title":"Src","url":"https://a.com"}]}"""
+      );
+
+      await CreateJob().RunAsync(article.Id, default);
+  ```
+  with:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _writeArticle
+          .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Callback<ArticlePipelineContext, CancellationToken>((ctx, ct) =>
+          {
+              ctx.GeneratedTitle = "Final Title";
+              ctx.GeneratedHtml = "<article>x</article>";
+              ctx.SourceRefs = new List<ArticleSourceRef>
+              {
+                  new("Src", "https://a.com", SourceType.Web, null, null, null, null)
+              };
+          })
+          .Returns(Task.CompletedTask);
+
+      await CreateJob().RunAsync(article.Id, default);
+  ```
+  The rest of the test method (assertions from `article.Status.Should().Be(ArticleStatus.Generated);` through the end) is unchanged — the assertions read off `article`, which is populated the same way regardless of whether a real or mocked `WriteArticleStep` set `context.GeneratedTitle`/`GeneratedHtml`/`SourceRefs`.
+
+- [ ] Rework `RunAsync_StepThrows_StatusFailedAndErrorMessageSet`. Replace:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_StepThrows_StatusFailedAndErrorMessageSet()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      var callCount = 0;
+      _chat
+          .Setup(c => c.GetResponseAsync(
+              It.IsAny<IEnumerable<ChatMessage>>(),
+              It.IsAny<ChatOptions?>(),
+              It.IsAny<CancellationToken>()))
+          .ReturnsAsync(() =>
+          {
+              callCount++;
+              if (callCount == 1)
+              {
+                  // PlanQueries succeeds with valid JSON
+                  return new ChatResponse([new ChatMessage(ChatRole.Assistant, """{"queries":["q1"]}""")]);
+              }
+              // AggregateFacts fails
+              throw new InvalidOperationException("LLM blew up");
+          });
+
+      await CreateJob().RunAsync(article.Id, default);
+
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("LLM blew up");
+  }
+  ```
+  with:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_StepThrows_StatusFailedAndErrorMessageSet()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _aggregateFacts
+          .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("LLM blew up"));
+
+      await CreateJob().RunAsync(article.Id, default);
+
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("LLM blew up");
+  }
+  ```
+  (`_planQueries` stays a successful no-op via the constructor's default setup, so the job reaches `_aggregateFacts.ExecuteAsync` before failing — no `IChatClient`/JSON setup needed at all.)
+
+- [ ] Rework `RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown`. Replace:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _chat
+          .Setup(c => c.GetResponseAsync(
+              It.IsAny<IEnumerable<ChatMessage>>(),
+              It.IsAny<ChatOptions?>(),
+              It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new OperationCanceledException());
+
+      Func<Task> act = () => CreateJob().RunAsync(article.Id, default);
+
+      await act.Should().ThrowAsync<OperationCanceledException>();
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("Job cancelled.");
+  }
+  ```
+  with:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _planQueries
+          .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new OperationCanceledException());
+
+      Func<Task> act = () => CreateJob().RunAsync(article.Id, default);
+
+      await act.Should().ThrowAsync<OperationCanceledException>();
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("Job cancelled.");
+  }
+  ```
+
+- [ ] Leave `RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState` as-is except for the already-updated `CreateJob()` signature (no args) — no other change needed since it returns before any step is invoked:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState()
+  {
+      var id = Guid.NewGuid();
+      _repository
+          .Setup(r => r.GetForUpdateAsync(id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync((DomainArticle?)null);
+
+      await CreateJob().RunAsync(id, default);
+
+      _repository.Verify(
+          r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+          Times.Never);
+  }
+  ```
+  (This method already calls `CreateJob()` with no arguments, so no textual change is required here — confirm it still compiles against the new no-arg `CreateJob()` signature.)
+
+- [ ] Update the `using` directives at the top of the file. Replace:
+  ```csharp
+  using Anela.Heblo.Application.Features.Article;
+  using Anela.Heblo.Application.Features.Article.Contracts;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+  using Anela.Heblo.Application.Shared.WebSearch;
+  using Anela.Heblo.Domain.Features.Article;
+  using FluentAssertions;
+  using Microsoft.Extensions.AI;
+  using Microsoft.Extensions.Logging.Abstractions;
+  using Microsoft.Extensions.Options;
+  using Moq;
+  using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
+  ```
+  with:
+  ```csharp
+  using Anela.Heblo.Application.Features.Article;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+  using Anela.Heblo.Domain.Features.Article;
+  using FluentAssertions;
+  using Microsoft.Extensions.Logging.Abstractions;
+  using Moq;
+  using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
+  ```
+  Rationale: `Anela.Heblo.Application.Features.Article.Contracts` (for `IArticleKnowledgeSource`/`IArticleStyleGuideSource`), `Anela.Heblo.Application.Shared.WebSearch` (for `IWebSearchClient`), `Microsoft.Extensions.AI` (for `IChatClient`/`ChatMessage`/`ChatResponse`/`ChatOptions`), and `Microsoft.Extensions.Options` (for `Options.Create`) are no longer referenced anywhere in the file after the above changes. Keep `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline` — it's still needed for `ArticlePipelineContext`, `ArticleSourceRef`, and the five step interfaces.
+
+- [ ] Build the test project and run the full `GenerateArticleJobTests` suite plus the rest of `Anela.Heblo.Tests`:
+  ```bash
+  cd backend
+  dotnet build
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GenerateArticleJobTests"
+  ```
+  Expect all 4 tests to pass: `RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted`, `RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState`, `RunAsync_StepThrows_StatusFailedAndErrorMessageSet`, `RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown`.
+
+- [ ] Run the full backend test suite to confirm nothing else regressed (including the five per-step `*StepTests.cs` files and `SourceEnrichmentIntegrationTests.cs`, which construct the concrete step classes directly and must be unaffected):
+  ```bash
+  cd backend
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+  ```
+  Expect all tests to pass with no new warnings about unused mocks/fields.
+
+- [ ] Run `dotnet format` and confirm no diffs:
+  ```bash
+  cd backend
+  dotnet format --verify-no-changes
+  ```
+
+- [ ] Commit:
+  ```bash
+  git add backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
+  git commit -m "Rework GenerateArticleJobTests to mock pipeline step interfaces directly"
+  ```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** FR-1 (interfaces defined, co-located, single method) → task 1. FR-2 (step classes implement interface, no other member changes) → task 1. FR-3 (`GenerateArticleJob` depends on interfaces, `RunAsync` body unchanged) → task 1. FR-4 (DI binds interface to implementation, `PipelineStepRecorder`/`GenerateArticleJob` registrations untouched) → task 1. FR-5 (test rework: mock interfaces, happy-path `WriteArticleStep` callback sets `context` fields, `StepThrows` mocks `IAggregateFactsStep` directly with `IPlanQueriesStep` as no-op, `OperationCancelled` mocks `IPlanQueriesStep` directly, `ArticleNotFound` unaffected, unused mocks/recorder removed) → task 2. NFR-1 (behavior parity, `RunAsync` body untouched) → enforced by task 1's exact-replacement instructions. NFR-2 (build/format/test integrity, repo-wide grep for other concrete-type consumers) → both tasks' verification steps. NFR-3 (no alternate implementations introduced) → task 1 registers exactly one implementation per interface, nothing more.
+- **Placeholder scan:** No "TBD", "similar to above", or "add appropriate X" phrasing anywhere in the task steps above — every code block is the literal before/after text, every verification step has a runnable command with an expected outcome.
+- **Type consistency:** `ArticleSourceRef` is a `sealed record` with constructor `(string Title, string? Url, SourceType Type, Guid? ChunkId, double? Confidence, string? Excerpt, string? ValidationNote)` (confirmed by reading `ArticleSourceRef.cs`) — the happy-path callback's positional-constructor call `new("Src", "https://a.com", SourceType.Web, null, null, null, null)` matches this signature exactly, and the resulting values match what the original JSON-driven test asserted (`Sources[0].Title == "Src"`, `.Url == "https://a.com"`, `.Type == SourceType.Web`). `ArticlePipelineContext.SourceRefs` already defaults to `List<ArticleSourceRef> = []` (confirmed by reading `ArticlePipelineContext.cs`), so the default no-op mocks used by the other three tests leave `SourceRefs` as an empty list, matching `RunAsync`'s `foreach (var sourceRef in context.SourceRefs)` with zero iterations — no null-reference risk.
+- **DI/build ordering:** Task 1 is verified with `dotnet build` alone (not `dotnet test`) because at that point `GenerateArticleJobTests.cs` still constructs real step instances via `new PlanQueriesStep(...)` etc. passed into interface-typed constructor parameters — this compiles (each concrete class now implements its interface) even though the test file hasn't been rewritten yet. Task 2 is the only task that changes test behavior/assertions, so it carries the `dotnet test` verification.
+- **Execution handoff:** Skipped — this plan is consumed by an automated pipeline with no human in the loop.

--- a/artifacts/feat-3593/task-plan.r1.md
+++ b/artifacts/feat-3593/task-plan.r1.md
@@ -1,0 +1,597 @@
+# Implementation Plan: Introduce interfaces for Article generation pipeline steps
+
+## Context
+
+`GenerateArticleJob` (`backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`) currently takes the five pipeline step classes (`PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep`) as concrete-type constructor dependencies. None of these classes expose a mockable seam, so `GenerateArticleJobTests.cs` has to build real step instances (with mocked `IChatClient`/`IArticleKnowledgeSource`/`IWebSearchClient`/`IArticleStyleGuideSource`/`PipelineStepRecorder`) even for tests that only care about the job's own orchestration logic.
+
+This plan:
+1. Adds one single-method interface per step (co-located in the step's own file), makes each step class implement it, and switches `GenerateArticleJob` + `ArticleModule.cs` DI registrations to depend on the interfaces.
+2. Reworks `GenerateArticleJobTests.cs` to mock the five interfaces directly instead of constructing real step instances.
+
+This is a pure Dependency Inversion refactor — no behavior, business logic, or `RunAsync` method-body changes (only field/parameter *types* change). See `spec.r1.md` (FR-1 through FR-5, NFR-1 through NFR-3), `arch-review.r1.md`, and `design.r1.md` for the full rationale — no deviations from those documents are introduced here.
+
+## Task Overview
+
+- `task: add-pipeline-step-interfaces-and-wire-di` — define the five interfaces, implement them on the step classes, update `GenerateArticleJob`'s constructor/fields and `ArticleModule.cs`'s DI registrations.
+- `task: rework-generatearticlejobtests-to-mock-interfaces` — rework `GenerateArticleJobTests.cs` to mock the five interfaces directly, dropping the now-unneeded leaf-dependency mocks and no-op recorder.
+
+Each task is independently committable and verifiable via `dotnet build` (task 1) and `dotnet build` + `dotnet test` (task 2).
+
+---
+
+### task: add-pipeline-step-interfaces-and-wire-di
+
+**Files:**
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs`
+
+**Steps:**
+
+- [ ] In `PlanQueriesStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class PlanQueriesStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IPlanQueriesStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class PlanQueriesStep : IPlanQueriesStep
+  {
+  ```
+
+- [ ] In `GatherContextStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class GatherContextStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IGatherContextStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class GatherContextStep : IGatherContextStep
+  {
+  ```
+
+- [ ] In `AggregateFactsStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class AggregateFactsStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IAggregateFactsStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class AggregateFactsStep : IAggregateFactsStep
+  {
+  ```
+
+- [ ] In `ValidateFactsStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class ValidateFactsStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IValidateFactsStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class ValidateFactsStep : IValidateFactsStep
+  {
+  ```
+
+- [ ] In `WriteArticleStep.cs`, replace:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public class WriteArticleStep
+  {
+  ```
+  with:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+  public interface IWriteArticleStep
+  {
+      Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+  }
+
+  public class WriteArticleStep : IWriteArticleStep
+  {
+  ```
+
+- [ ] Verify each step class's own `ExecuteAsync` method already matches the interface signature exactly (`Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`) so no further changes to the class bodies are needed. (Confirmed by inspection during planning — all five already use this exact signature; this is a read-only sanity check, not an edit.)
+
+- [ ] In `GenerateArticleJob.cs`, replace the field declarations:
+  ```csharp
+  private readonly IArticleRepository _repository;
+  private readonly PlanQueriesStep _planQueries;
+  private readonly GatherContextStep _gatherContext;
+  private readonly AggregateFactsStep _aggregateFacts;
+  private readonly ValidateFactsStep _validateFacts;
+  private readonly WriteArticleStep _writeArticle;
+  private readonly ILogger<GenerateArticleJob> _logger;
+
+  public GenerateArticleJob(
+      IArticleRepository repository,
+      PlanQueriesStep planQueries,
+      GatherContextStep gatherContext,
+      AggregateFactsStep aggregateFacts,
+      ValidateFactsStep validateFacts,
+      WriteArticleStep writeArticle,
+      ILogger<GenerateArticleJob> logger)
+  {
+  ```
+  with:
+  ```csharp
+  private readonly IArticleRepository _repository;
+  private readonly IPlanQueriesStep _planQueries;
+  private readonly IGatherContextStep _gatherContext;
+  private readonly IAggregateFactsStep _aggregateFacts;
+  private readonly IValidateFactsStep _validateFacts;
+  private readonly IWriteArticleStep _writeArticle;
+  private readonly ILogger<GenerateArticleJob> _logger;
+
+  public GenerateArticleJob(
+      IArticleRepository repository,
+      IPlanQueriesStep planQueries,
+      IGatherContextStep gatherContext,
+      IAggregateFactsStep aggregateFacts,
+      IValidateFactsStep validateFacts,
+      IWriteArticleStep writeArticle,
+      ILogger<GenerateArticleJob> logger)
+  {
+  ```
+  Do not touch the constructor body (`_repository = repository; ...`) or `RunAsync` — they are unchanged (field names, assignment order, and all orchestration logic stay byte-for-byte identical; only the declared types above change).
+
+- [ ] In `ArticleModule.cs`, replace:
+  ```csharp
+  services.AddScoped<PipelineStepRecorder>();
+  services.AddScoped<PlanQueriesStep>();
+  services.AddScoped<GatherContextStep>();
+  services.AddScoped<AggregateFactsStep>();
+  services.AddScoped<ValidateFactsStep>();
+  services.AddScoped<WriteArticleStep>();
+  services.AddScoped<GenerateArticleJob>();
+  ```
+  with:
+  ```csharp
+  services.AddScoped<PipelineStepRecorder>();
+  services.AddScoped<IPlanQueriesStep, PlanQueriesStep>();
+  services.AddScoped<IGatherContextStep, GatherContextStep>();
+  services.AddScoped<IAggregateFactsStep, AggregateFactsStep>();
+  services.AddScoped<IValidateFactsStep, ValidateFactsStep>();
+  services.AddScoped<IWriteArticleStep, WriteArticleStep>();
+  services.AddScoped<GenerateArticleJob>();
+  ```
+
+- [ ] Search the repo for any other direct references to the five concrete step type names outside the files already touched in this task and the test files that will be handled in the next task, to confirm nothing else depends on the concrete type in a way this refactor would break:
+  ```bash
+  cd backend
+  grep -rn "PlanQueriesStep\|GatherContextStep\|AggregateFactsStep\|ValidateFactsStep\|WriteArticleStep" --include=*.cs src/ test/ | grep -v "UseCases/Generate/Pipeline/PlanQueriesStep.cs\|UseCases/Generate/Pipeline/GatherContextStep.cs\|UseCases/Generate/Pipeline/AggregateFactsStep.cs\|UseCases/Generate/Pipeline/ValidateFactsStep.cs\|UseCases/Generate/Pipeline/WriteArticleStep.cs\|UseCases/Generate/GenerateArticleJob.cs\|Features/Article/ArticleModule.cs\|GenerateArticleJobTests.cs"
+  ```
+  Expected result: only the five per-step test files (`PlanQueriesStepTests.cs`, `GatherContextStepTests.cs`, `AggregateFactsStepTests.cs`, `ValidateFactsStepTests.cs`, `WriteArticleStepTests.cs`) and `SourceEnrichmentIntegrationTests.cs`, all of which construct the concrete class directly via `new XStep(...)` — this remains valid since implementing an interface is purely additive, so no changes are needed to those files. If any other file appears, stop and investigate before proceeding — that would indicate an undocumented consumer not accounted for in `arch-review.r1.md`.
+
+- [ ] Build the backend to confirm the interface introduction and DI rewiring compile cleanly:
+  ```bash
+  cd backend
+  dotnet build
+  ```
+  Expect a clean build with no errors. (`GenerateArticleJobTests.cs` will still reference the concrete step types in `CreateJob(...)` at this point — that continues to compile because the concrete classes still exist unchanged and their constructors are untouched; only the `GenerateArticleJob` constructor call inside `CreateJob` now binds concrete instances to interface-typed parameters, which is valid since each concrete class implements its interface.)
+
+- [ ] Run `dotnet format` and confirm no diffs:
+  ```bash
+  cd backend
+  dotnet format --verify-no-changes
+  ```
+
+- [ ] Commit:
+  ```bash
+  git add backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs \
+          backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs
+  git commit -m "Introduce per-step interfaces for Article generation pipeline and wire DI"
+  ```
+
+---
+
+### task: rework-generatearticlejobtests-to-mock-interfaces
+
+**Files:**
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs`
+
+**Steps:**
+
+- [ ] Replace the field declarations at the top of the class:
+  ```csharp
+  public class GenerateArticleJobTests
+  {
+      private readonly Mock<IArticleRepository> _repository = new();
+      private readonly Mock<IChatClient> _chat = new();
+      private readonly Mock<IArticleKnowledgeSource> _knowledgeSource = new();
+      private readonly Mock<IWebSearchClient> _webSearch = new();
+      private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
+      private readonly ArticleOptions _options = new();
+  ```
+  with:
+  ```csharp
+  public class GenerateArticleJobTests
+  {
+      private readonly Mock<IArticleRepository> _repository = new();
+      private readonly Mock<IPlanQueriesStep> _planQueries = new();
+      private readonly Mock<IGatherContextStep> _gatherContext = new();
+      private readonly Mock<IAggregateFactsStep> _aggregateFacts = new();
+      private readonly Mock<IValidateFactsStep> _validateFacts = new();
+      private readonly Mock<IWriteArticleStep> _writeArticle = new();
+  ```
+  (`ArticleOptions _options`, `IChatClient`, `IArticleKnowledgeSource`, `IWebSearchClient`, and `IArticleStyleGuideSource` mocks are dropped — they were only needed to construct real step instances, which no longer happens in this file.)
+
+- [ ] Set up the five new step mocks as successful no-ops by default, right after the field declarations (before `CreateArticle`), by initializing them in the constructor. Add a constructor:
+  ```csharp
+  public GenerateArticleJobTests()
+  {
+      _planQueries.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _gatherContext.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _aggregateFacts.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _validateFacts.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+      _writeArticle.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Returns(Task.CompletedTask);
+  }
+  ```
+  Place this directly after the field declarations block, before `CreateArticle()`.
+
+- [ ] Remove the `CreateNoOpRecorder()` helper entirely (it is only used to construct real step instances, which no longer happens):
+  ```csharp
+  private static PipelineStepRecorder CreateNoOpRecorder()
+  {
+      var repo = new Mock<IArticleRepository>();
+      repo.Setup(r => r.AddStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+      repo.Setup(r => r.UpdateStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+      repo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+      return new PipelineStepRecorder(repo.Object);
+  }
+  ```
+  Delete this method entirely.
+
+- [ ] Replace `CreateJob(...)`:
+  ```csharp
+  private GenerateArticleJob CreateJob(
+      PlanQueriesStep? planQueries = null,
+      GatherContextStep? gatherContext = null,
+      AggregateFactsStep? aggregateFacts = null,
+      ValidateFactsStep? validateFacts = null,
+      WriteArticleStep? writeArticle = null)
+  {
+      var optionsWrapper = Options.Create(_options);
+      var recorder = CreateNoOpRecorder();
+      return new GenerateArticleJob(
+          _repository.Object,
+          planQueries ?? new PlanQueriesStep(_chat.Object, optionsWrapper, NullLogger<PlanQueriesStep>.Instance, recorder),
+          gatherContext ?? new GatherContextStep(_knowledgeSource.Object, _webSearch.Object, _styleGuideSource.Object, optionsWrapper, NullLogger<GatherContextStep>.Instance, recorder),
+          aggregateFacts ?? new AggregateFactsStep(_chat.Object, optionsWrapper, NullLogger<AggregateFactsStep>.Instance, recorder),
+          validateFacts ?? new ValidateFactsStep(_chat.Object, optionsWrapper, NullLogger<ValidateFactsStep>.Instance, recorder),
+          writeArticle ?? new WriteArticleStep(_chat.Object, optionsWrapper, NullLogger<WriteArticleStep>.Instance, recorder),
+          NullLogger<GenerateArticleJob>.Instance);
+  }
+  ```
+  with:
+  ```csharp
+  private GenerateArticleJob CreateJob()
+  {
+      return new GenerateArticleJob(
+          _repository.Object,
+          _planQueries.Object,
+          _gatherContext.Object,
+          _aggregateFacts.Object,
+          _validateFacts.Object,
+          _writeArticle.Object,
+          NullLogger<GenerateArticleJob>.Instance);
+  }
+  ```
+
+- [ ] Remove the `SetupChatResponses` helper entirely (no longer used by any test once steps are mocked directly):
+  ```csharp
+  private void SetupChatResponses(params string[] responsesInOrder)
+  {
+      var queue = new Queue<string>(responsesInOrder);
+      _chat
+          .Setup(c => c.GetResponseAsync(
+              It.IsAny<IEnumerable<ChatMessage>>(),
+              It.IsAny<ChatOptions?>(),
+              It.IsAny<CancellationToken>()))
+          .ReturnsAsync(() =>
+          {
+              var text = queue.Count > 0 ? queue.Dequeue() : "{}";
+              return new ChatResponse([new ChatMessage(ChatRole.Assistant, text)]);
+          });
+  }
+  ```
+  Delete this method entirely.
+
+- [ ] Rework `RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted`. Replace:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      SetupChatResponses(
+          // PlanQueries
+          """{"queries":["q1","q2"]}""",
+          // AggregateFacts
+          """{"facts":[{"claim":"Fact A","confidence":0.9,"source_url":null,"source_title":"S"}],"summary":"sum","gaps":null}""",
+          // ValidateFacts
+          """{"validated_facts":[{"fact":"Fact A","note":"good","reliable":true}]}""",
+          // WriteArticle
+          """{"article_title":"Final Title","article_html":"<article>x</article>","sources_used":[{"title":"Src","url":"https://a.com"}]}"""
+      );
+
+      await CreateJob().RunAsync(article.Id, default);
+  ```
+  with:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _writeArticle
+          .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .Callback<ArticlePipelineContext, CancellationToken>((ctx, ct) =>
+          {
+              ctx.GeneratedTitle = "Final Title";
+              ctx.GeneratedHtml = "<article>x</article>";
+              ctx.SourceRefs = new List<ArticleSourceRef>
+              {
+                  new("Src", "https://a.com", SourceType.Web, null, null, null, null)
+              };
+          })
+          .Returns(Task.CompletedTask);
+
+      await CreateJob().RunAsync(article.Id, default);
+  ```
+  The rest of the test method (assertions from `article.Status.Should().Be(ArticleStatus.Generated);` through the end) is unchanged — the assertions read off `article`, which is populated the same way regardless of whether a real or mocked `WriteArticleStep` set `context.GeneratedTitle`/`GeneratedHtml`/`SourceRefs`.
+
+- [ ] Rework `RunAsync_StepThrows_StatusFailedAndErrorMessageSet`. Replace:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_StepThrows_StatusFailedAndErrorMessageSet()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      var callCount = 0;
+      _chat
+          .Setup(c => c.GetResponseAsync(
+              It.IsAny<IEnumerable<ChatMessage>>(),
+              It.IsAny<ChatOptions?>(),
+              It.IsAny<CancellationToken>()))
+          .ReturnsAsync(() =>
+          {
+              callCount++;
+              if (callCount == 1)
+              {
+                  // PlanQueries succeeds with valid JSON
+                  return new ChatResponse([new ChatMessage(ChatRole.Assistant, """{"queries":["q1"]}""")]);
+              }
+              // AggregateFacts fails
+              throw new InvalidOperationException("LLM blew up");
+          });
+
+      await CreateJob().RunAsync(article.Id, default);
+
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("LLM blew up");
+  }
+  ```
+  with:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_StepThrows_StatusFailedAndErrorMessageSet()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _aggregateFacts
+          .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new InvalidOperationException("LLM blew up"));
+
+      await CreateJob().RunAsync(article.Id, default);
+
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("LLM blew up");
+  }
+  ```
+  (`_planQueries` stays a successful no-op via the constructor's default setup, so the job reaches `_aggregateFacts.ExecuteAsync` before failing — no `IChatClient`/JSON setup needed at all.)
+
+- [ ] Rework `RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown`. Replace:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _chat
+          .Setup(c => c.GetResponseAsync(
+              It.IsAny<IEnumerable<ChatMessage>>(),
+              It.IsAny<ChatOptions?>(),
+              It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new OperationCanceledException());
+
+      Func<Task> act = () => CreateJob().RunAsync(article.Id, default);
+
+      await act.Should().ThrowAsync<OperationCanceledException>();
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("Job cancelled.");
+  }
+  ```
+  with:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown()
+  {
+      var article = CreateArticle();
+      article.UsedKnowledgeBase = false;
+      article.UsedWebSearch = false;
+      _repository
+          .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync(article);
+
+      _planQueries
+          .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+          .ThrowsAsync(new OperationCanceledException());
+
+      Func<Task> act = () => CreateJob().RunAsync(article.Id, default);
+
+      await act.Should().ThrowAsync<OperationCanceledException>();
+      article.Status.Should().Be(ArticleStatus.Failed);
+      article.ErrorMessage.Should().Be("Job cancelled.");
+  }
+  ```
+
+- [ ] Leave `RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState` as-is except for the already-updated `CreateJob()` signature (no args) — no other change needed since it returns before any step is invoked:
+  ```csharp
+  [Fact]
+  public async Task RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState()
+  {
+      var id = Guid.NewGuid();
+      _repository
+          .Setup(r => r.GetForUpdateAsync(id, It.IsAny<CancellationToken>()))
+          .ReturnsAsync((DomainArticle?)null);
+
+      await CreateJob().RunAsync(id, default);
+
+      _repository.Verify(
+          r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
+          Times.Never);
+  }
+  ```
+  (This method already calls `CreateJob()` with no arguments, so no textual change is required here — confirm it still compiles against the new no-arg `CreateJob()` signature.)
+
+- [ ] Update the `using` directives at the top of the file. Replace:
+  ```csharp
+  using Anela.Heblo.Application.Features.Article;
+  using Anela.Heblo.Application.Features.Article.Contracts;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+  using Anela.Heblo.Application.Shared.WebSearch;
+  using Anela.Heblo.Domain.Features.Article;
+  using FluentAssertions;
+  using Microsoft.Extensions.AI;
+  using Microsoft.Extensions.Logging.Abstractions;
+  using Microsoft.Extensions.Options;
+  using Moq;
+  using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
+  ```
+  with:
+  ```csharp
+  using Anela.Heblo.Application.Features.Article;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate;
+  using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+  using Anela.Heblo.Domain.Features.Article;
+  using FluentAssertions;
+  using Microsoft.Extensions.Logging.Abstractions;
+  using Moq;
+  using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
+  ```
+  Rationale: `Anela.Heblo.Application.Features.Article.Contracts` (for `IArticleKnowledgeSource`/`IArticleStyleGuideSource`), `Anela.Heblo.Application.Shared.WebSearch` (for `IWebSearchClient`), `Microsoft.Extensions.AI` (for `IChatClient`/`ChatMessage`/`ChatResponse`/`ChatOptions`), and `Microsoft.Extensions.Options` (for `Options.Create`) are no longer referenced anywhere in the file after the above changes. Keep `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline` — it's still needed for `ArticlePipelineContext`, `ArticleSourceRef`, and the five step interfaces.
+
+- [ ] Build the test project and run the full `GenerateArticleJobTests` suite plus the rest of `Anela.Heblo.Tests`:
+  ```bash
+  cd backend
+  dotnet build
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GenerateArticleJobTests"
+  ```
+  Expect all 4 tests to pass: `RunAsync_HappyPath_StatusGeneratedAndSourcesPersisted`, `RunAsync_ArticleNotFound_LogsAndReturnsWithoutSavingState`, `RunAsync_StepThrows_StatusFailedAndErrorMessageSet`, `RunAsync_OperationCancelled_StatusFailedAndExceptionRethrown`.
+
+- [ ] Run the full backend test suite to confirm nothing else regressed (including the five per-step `*StepTests.cs` files and `SourceEnrichmentIntegrationTests.cs`, which construct the concrete step classes directly and must be unaffected):
+  ```bash
+  cd backend
+  dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+  ```
+  Expect all tests to pass with no new warnings about unused mocks/fields.
+
+- [ ] Run `dotnet format` and confirm no diffs:
+  ```bash
+  cd backend
+  dotnet format --verify-no-changes
+  ```
+
+- [ ] Commit:
+  ```bash
+  git add backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
+  git commit -m "Rework GenerateArticleJobTests to mock pipeline step interfaces directly"
+  ```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** FR-1 (interfaces defined, co-located, single method) → task 1. FR-2 (step classes implement interface, no other member changes) → task 1. FR-3 (`GenerateArticleJob` depends on interfaces, `RunAsync` body unchanged) → task 1. FR-4 (DI binds interface to implementation, `PipelineStepRecorder`/`GenerateArticleJob` registrations untouched) → task 1. FR-5 (test rework: mock interfaces, happy-path `WriteArticleStep` callback sets `context` fields, `StepThrows` mocks `IAggregateFactsStep` directly with `IPlanQueriesStep` as no-op, `OperationCancelled` mocks `IPlanQueriesStep` directly, `ArticleNotFound` unaffected, unused mocks/recorder removed) → task 2. NFR-1 (behavior parity, `RunAsync` body untouched) → enforced by task 1's exact-replacement instructions. NFR-2 (build/format/test integrity, repo-wide grep for other concrete-type consumers) → both tasks' verification steps. NFR-3 (no alternate implementations introduced) → task 1 registers exactly one implementation per interface, nothing more.
+- **Placeholder scan:** No "TBD", "similar to above", or "add appropriate X" phrasing anywhere in the task steps above — every code block is the literal before/after text, every verification step has a runnable command with an expected outcome.
+- **Type consistency:** `ArticleSourceRef` is a `sealed record` with constructor `(string Title, string? Url, SourceType Type, Guid? ChunkId, double? Confidence, string? Excerpt, string? ValidationNote)` (confirmed by reading `ArticleSourceRef.cs`) — the happy-path callback's positional-constructor call `new("Src", "https://a.com", SourceType.Web, null, null, null, null)` matches this signature exactly, and the resulting values match what the original JSON-driven test asserted (`Sources[0].Title == "Src"`, `.Url == "https://a.com"`, `.Type == SourceType.Web`). `ArticlePipelineContext.SourceRefs` already defaults to `List<ArticleSourceRef> = []` (confirmed by reading `ArticlePipelineContext.cs`), so the default no-op mocks used by the other three tests leave `SourceRefs` as an empty list, matching `RunAsync`'s `foreach (var sourceRef in context.SourceRefs)` with zero iterations — no null-reference risk.
+- **DI/build ordering:** Task 1 is verified with `dotnet build` alone (not `dotnet test`) because at that point `GenerateArticleJobTests.cs` still constructs real step instances via `new PlanQueriesStep(...)` etc. passed into interface-typed constructor parameters — this compiles (each concrete class now implements its interface) even though the test file hasn't been rewritten yet. Task 2 is the only task that changes test behavior/assertions, so it carries the `dotnet test` verification.
+- **Execution handoff:** Skipped — this plan is consumed by an automated pipeline with no human in the loop.

--- a/backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs
@@ -23,11 +23,11 @@ public static class ArticleModule
         services.AddScoped<IArticleAdminRepository, ArticleAdminRepository>();
 
         services.AddScoped<PipelineStepRecorder>();
-        services.AddScoped<PlanQueriesStep>();
-        services.AddScoped<GatherContextStep>();
-        services.AddScoped<AggregateFactsStep>();
-        services.AddScoped<ValidateFactsStep>();
-        services.AddScoped<WriteArticleStep>();
+        services.AddScoped<IPlanQueriesStep, PlanQueriesStep>();
+        services.AddScoped<IGatherContextStep, GatherContextStep>();
+        services.AddScoped<IAggregateFactsStep, AggregateFactsStep>();
+        services.AddScoped<IValidateFactsStep, ValidateFactsStep>();
+        services.AddScoped<IWriteArticleStep, WriteArticleStep>();
         services.AddScoped<GenerateArticleJob>();
 
         return services;

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs
@@ -10,20 +10,20 @@ namespace Anela.Heblo.Application.Features.Article.UseCases.Generate;
 public sealed class GenerateArticleJob
 {
     private readonly IArticleRepository _repository;
-    private readonly PlanQueriesStep _planQueries;
-    private readonly GatherContextStep _gatherContext;
-    private readonly AggregateFactsStep _aggregateFacts;
-    private readonly ValidateFactsStep _validateFacts;
-    private readonly WriteArticleStep _writeArticle;
+    private readonly IPlanQueriesStep _planQueries;
+    private readonly IGatherContextStep _gatherContext;
+    private readonly IAggregateFactsStep _aggregateFacts;
+    private readonly IValidateFactsStep _validateFacts;
+    private readonly IWriteArticleStep _writeArticle;
     private readonly ILogger<GenerateArticleJob> _logger;
 
     public GenerateArticleJob(
         IArticleRepository repository,
-        PlanQueriesStep planQueries,
-        GatherContextStep gatherContext,
-        AggregateFactsStep aggregateFacts,
-        ValidateFactsStep validateFacts,
-        WriteArticleStep writeArticle,
+        IPlanQueriesStep planQueries,
+        IGatherContextStep gatherContext,
+        IAggregateFactsStep aggregateFacts,
+        IValidateFactsStep validateFacts,
+        IWriteArticleStep writeArticle,
         ILogger<GenerateArticleJob> logger)
     {
         _repository = repository;

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
@@ -8,7 +8,12 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class AggregateFactsStep
+public interface IAggregateFactsStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public class AggregateFactsStep : IAggregateFactsStep
 {
     private const int MaxSnippets = 50;
 

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
@@ -7,7 +7,12 @@ using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class GatherContextStep
+public interface IGatherContextStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public class GatherContextStep : IGatherContextStep
 {
     private readonly IArticleKnowledgeSource _knowledgeSource;
     private readonly IWebSearchClient _webSearch;

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
@@ -7,7 +7,12 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class PlanQueriesStep
+public interface IPlanQueriesStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public class PlanQueriesStep : IPlanQueriesStep
 {
     private const int MaxQueries = 8;
 

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
@@ -8,7 +8,12 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class ValidateFactsStep
+public interface IValidateFactsStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public class ValidateFactsStep : IValidateFactsStep
 {
     private readonly IChatClient _chat;
     private readonly ArticleOptions _options;

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
@@ -12,7 +12,12 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class WriteArticleStep
+public interface IWriteArticleStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+
+public class WriteArticleStep : IWriteArticleStep
 {
     private readonly IChatClient _chat;
     private readonly ArticleOptions _options;

--- a/backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
@@ -1,13 +1,9 @@
 using Anela.Heblo.Application.Features.Article;
-using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
-using Anela.Heblo.Application.Shared.WebSearch;
 using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
 
@@ -16,11 +12,25 @@ namespace Anela.Heblo.Tests.Article.Pipeline;
 public class GenerateArticleJobTests
 {
     private readonly Mock<IArticleRepository> _repository = new();
-    private readonly Mock<IChatClient> _chat = new();
-    private readonly Mock<IArticleKnowledgeSource> _knowledgeSource = new();
-    private readonly Mock<IWebSearchClient> _webSearch = new();
-    private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
-    private readonly ArticleOptions _options = new();
+    private readonly Mock<IPlanQueriesStep> _planQueries = new();
+    private readonly Mock<IGatherContextStep> _gatherContext = new();
+    private readonly Mock<IAggregateFactsStep> _aggregateFacts = new();
+    private readonly Mock<IValidateFactsStep> _validateFacts = new();
+    private readonly Mock<IWriteArticleStep> _writeArticle = new();
+
+    public GenerateArticleJobTests()
+    {
+        _planQueries.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _gatherContext.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _aggregateFacts.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _validateFacts.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _writeArticle.Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
 
     private static DomainArticle CreateArticle() =>
         new()
@@ -30,47 +40,16 @@ public class GenerateArticleJobTests
             Status = ArticleStatus.Queued
         };
 
-    private static PipelineStepRecorder CreateNoOpRecorder()
+    private GenerateArticleJob CreateJob()
     {
-        var repo = new Mock<IArticleRepository>();
-        repo.Setup(r => r.AddStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        repo.Setup(r => r.UpdateStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        repo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        return new PipelineStepRecorder(repo.Object);
-    }
-
-    private GenerateArticleJob CreateJob(
-        PlanQueriesStep? planQueries = null,
-        GatherContextStep? gatherContext = null,
-        AggregateFactsStep? aggregateFacts = null,
-        ValidateFactsStep? validateFacts = null,
-        WriteArticleStep? writeArticle = null)
-    {
-        var optionsWrapper = Options.Create(_options);
-        var recorder = CreateNoOpRecorder();
         return new GenerateArticleJob(
             _repository.Object,
-            planQueries ?? new PlanQueriesStep(_chat.Object, optionsWrapper, NullLogger<PlanQueriesStep>.Instance, recorder),
-            gatherContext ?? new GatherContextStep(_knowledgeSource.Object, _webSearch.Object, _styleGuideSource.Object, optionsWrapper, NullLogger<GatherContextStep>.Instance, recorder),
-            aggregateFacts ?? new AggregateFactsStep(_chat.Object, optionsWrapper, NullLogger<AggregateFactsStep>.Instance, recorder),
-            validateFacts ?? new ValidateFactsStep(_chat.Object, optionsWrapper, NullLogger<ValidateFactsStep>.Instance, recorder),
-            writeArticle ?? new WriteArticleStep(_chat.Object, optionsWrapper, NullLogger<WriteArticleStep>.Instance, recorder),
+            _planQueries.Object,
+            _gatherContext.Object,
+            _aggregateFacts.Object,
+            _validateFacts.Object,
+            _writeArticle.Object,
             NullLogger<GenerateArticleJob>.Instance);
-    }
-
-    private void SetupChatResponses(params string[] responsesInOrder)
-    {
-        var queue = new Queue<string>(responsesInOrder);
-        _chat
-            .Setup(c => c.GetResponseAsync(
-                It.IsAny<IEnumerable<ChatMessage>>(),
-                It.IsAny<ChatOptions?>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
-            {
-                var text = queue.Count > 0 ? queue.Dequeue() : "{}";
-                return new ChatResponse([new ChatMessage(ChatRole.Assistant, text)]);
-            });
     }
 
     [Fact]
@@ -83,16 +62,18 @@ public class GenerateArticleJobTests
             .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(article);
 
-        SetupChatResponses(
-            // PlanQueries
-            """{"queries":["q1","q2"]}""",
-            // AggregateFacts
-            """{"facts":[{"claim":"Fact A","confidence":0.9,"source_url":null,"source_title":"S"}],"summary":"sum","gaps":null}""",
-            // ValidateFacts
-            """{"validated_facts":[{"fact":"Fact A","note":"good","reliable":true}]}""",
-            // WriteArticle
-            """{"article_title":"Final Title","article_html":"<article>x</article>","sources_used":[{"title":"Src","url":"https://a.com"}]}"""
-        );
+        _writeArticle
+            .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+            .Callback<ArticlePipelineContext, CancellationToken>((ctx, ct) =>
+            {
+                ctx.GeneratedTitle = "Final Title";
+                ctx.GeneratedHtml = "<article>x</article>";
+                ctx.SourceRefs = new List<ArticleSourceRef>
+                {
+                    new("Src", "https://a.com", SourceType.Web, null, null, null, null)
+                };
+            })
+            .Returns(Task.CompletedTask);
 
         await CreateJob().RunAsync(article.Id, default);
 
@@ -139,23 +120,9 @@ public class GenerateArticleJobTests
             .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(article);
 
-        var callCount = 0;
-        _chat
-            .Setup(c => c.GetResponseAsync(
-                It.IsAny<IEnumerable<ChatMessage>>(),
-                It.IsAny<ChatOptions?>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
-            {
-                callCount++;
-                if (callCount == 1)
-                {
-                    // PlanQueries succeeds with valid JSON
-                    return new ChatResponse([new ChatMessage(ChatRole.Assistant, """{"queries":["q1"]}""")]);
-                }
-                // AggregateFacts fails
-                throw new InvalidOperationException("LLM blew up");
-            });
+        _aggregateFacts
+            .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("LLM blew up"));
 
         await CreateJob().RunAsync(article.Id, default);
 
@@ -173,11 +140,8 @@ public class GenerateArticleJobTests
             .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(article);
 
-        _chat
-            .Setup(c => c.GetResponseAsync(
-                It.IsAny<IEnumerable<ChatMessage>>(),
-                It.IsAny<ChatOptions?>(),
-                It.IsAny<CancellationToken>()))
+        _planQueries
+            .Setup(s => s.ExecuteAsync(It.IsAny<ArticlePipelineContext>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException());
 
         Func<Task> act = () => CreateJob().RunAsync(article.Id, default);


### PR DESCRIPTION
Closes #3593

## What the issue was
`GenerateArticleJob` depended on the five Article-generation pipeline step classes (`PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep`) as concrete types rather than abstractions, violating the Dependency Inversion Principle. Since `ExecuteAsync` on each step was neither `virtual` nor `abstract`, Moq (or any substitute-based test double) could not intercept it, forcing `GenerateArticleJobTests.cs` to construct real step instances wired to mocked leaf dependencies (`IChatClient`, `IArticleKnowledgeSource`, `IWebSearchClient`) just to test the job's own orchestration logic (status transitions, error handling, source persistence).

## How it was fixed / handled
Introduced a co-located single-method interface per pipeline step (`IPlanQueriesStep`, `IGatherContextStep`, `IAggregateFactsStep`, `IValidateFactsStep`, `IWriteArticleStep`), each exposing `Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)`. Each concrete step class now implements its interface. `GenerateArticleJob`'s constructor/fields and `ArticleModule`'s DI registrations were updated to depend on the interfaces instead of the concrete classes (`services.AddScoped<IXStep, XStep>()`). This is a pure dependency-inversion refactor — no behavior change; method bodies, orchestration logic, and constructor bodies are untouched, only declared types changed.

`GenerateArticleJobTests.cs` was then reworked to mock the five step interfaces directly (`Mock<IXStep>`) instead of constructing real step instances with mocked leaf dependencies, isolating the job's orchestration tests from each step's internal JSON-parsing/LLM-call logic.

Verified at every stage: `dotnet build` (0 errors), all 4 `GenerateArticleJobTests` pass, `dotnet format --verify-no-changes` (no diffs), and a repo-wide grep confirmed no other consumer depends on the concrete step types outside the now-updated test files.

## Artifacts
Brief, spec, arch-review, design, task plan, per-task impl/review, and the final whole-branch code review are committed under `artifacts/feat-3593/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

No correctness issues found. The change is minimal and matches the plan exactly — see `artifacts/feat-3593/code-review.r1.md` for the full notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKzb5NWiaVv9PKxXYWtc29)_