### PR TITLE
#3594: fix trace snippet source in GatherContextStep

### DIFF
--- a/artifacts/feat-3594/arch-review.r1.md
+++ b/artifacts/feat-3594/arch-review.r1.md
@@ -1,0 +1,7 @@
+# Architecture review — feat-3594
+
+No architectural concerns. The change is confined to `GatherContextStep`, a single pipeline step within `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline`. It does not cross module boundaries, does not touch DTOs/contracts, and does not alter persistence shape (`ArticleGenerationStep.OutputJson` remains a free-form JSON blob).
+
+`deduplicatedWeb` is already computed on the line immediately above the fix site, so no new dependency or additional query is introduced — this is purely correcting which already-materialized variable feeds the trace serialization.
+
+Approved as scoped.

--- a/artifacts/feat-3594/brief.md
+++ b/artifacts/feat-3594/brief.md
@@ -1,0 +1,39 @@
+## Module
+Article
+
+## Finding
+`GatherContextStep.ExecuteAsync` deduplicates web snippets before storing them in the pipeline context, but records the **pre-deduplication** list in the `OutputJson` written to `ArticleGenerationStep` (the trace):
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs:65–71
+var deduplicatedWeb = DeduplicateByUrl(webSnippets);
+
+context.ContextSnippets = [.. kbSnippets, .. deduplicatedWeb];   // deduped — used by downstream steps
+context.StyleGuideText = styleGuideText;
+
+var allSnippets = kbSnippets.Concat(webSnippets).ToList();        // NOT deduped — written to trace
+return (true, (object?)new { snippets = allSnippets, styleGuideLength = styleGuideText?.Length });
+```
+
+`allSnippets` concatenates `webSnippets` (raw) instead of `deduplicatedWeb`. The `OutputJson` stored in the `ArticleGenerationStep` row therefore shows a higher snippet count than what the `AggregateFactsStep` and `WriteArticleStep` actually processed. For example, if 3 web queries each returned the same top result URL, the trace logs 3 web snippets but the context carries 1.
+
+## Why it matters
+The article trace (`GET /api/Articles/{id}/trace`) is the primary diagnostic tool for investigating why an article cited (or failed to cite) specific sources. When the logged snippet count doesn't match the context that downstream steps received, the trace actively misleads:
+
+- A developer reviewing a low-source-diversity article might check the trace, see "17 snippets gathered", and conclude the steps had plenty of context — when the actual deduplicated context was 9 snippets.
+- Conversely, the dedup might be removing too aggressively: the trace won't surface this because it shows the pre-dedup list.
+
+## Suggested fix
+Use `deduplicatedWeb` (already computed on line 65) in the trace output, so what's logged matches what the pipeline consumed:
+
+```csharp
+// Line 70 — change webSnippets → deduplicatedWeb
+var allSnippets = kbSnippets.Concat(deduplicatedWeb).ToList();
+return (true, (object?)new { snippets = allSnippets, styleGuideLength = styleGuideText?.Length });
+```
+
+One-line change, no behaviour change to article generation itself.
+
+---
+_Filed by daily arch-review routine on 2026-07-11._
+_Source: GitHub issue #3594._

--- a/artifacts/feat-3594/code-review.r1.md
+++ b/artifacts/feat-3594/code-review.r1.md
@@ -1,0 +1,10 @@
+# Code review — feat-3594
+
+## Scope
+`GatherContextStep.cs` (1-line fix) and `GatherContextStepTests.cs` (1 new regression test).
+
+## Findings
+None. The change matches the suggested fix exactly, does not alter `context.ContextSnippets` (the data actually consumed downstream), and is covered by a new test that would have failed pre-fix (asserts trace snippet count == deduplicated count, not raw count).
+
+## Verdict
+Approved — no correctness, security, or style issues.

--- a/artifacts/feat-3594/design.r1.md
+++ b/artifacts/feat-3594/design.r1.md
@@ -1,0 +1,7 @@
+# Design — feat-3594
+
+No design work needed beyond the spec: swap the source list feeding the trace's `snippets` field from `webSnippets` to the already-deduplicated `deduplicatedWeb`, so the count matches `context.ContextSnippets`.
+
+```csharp
+var allSnippets = kbSnippets.Concat(deduplicatedWeb).ToList();
+```

--- a/artifacts/feat-3594/impl/fix-trace-snippet-source.r1.md
+++ b/artifacts/feat-3594/impl/fix-trace-snippet-source.r1.md
@@ -1,0 +1,21 @@
+# Implementation — fix-trace-snippet-source (r1)
+
+## Change
+`backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs:70`
+
+```diff
+- var allSnippets = kbSnippets.Concat(webSnippets).ToList();
++ var allSnippets = kbSnippets.Concat(deduplicatedWeb).ToList();
+```
+
+## Test
+Added `ExecuteAsync_DuplicateWebUrls_TraceOutputMatchesDeduplicatedSnippets` to
+`backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs`. It
+captures the `ArticleGenerationStep` passed to `IArticleRepository.UpdateStepAsync`,
+parses `OutputJson`, and asserts the `snippets` array length is 1 (deduplicated)
+rather than 2 (raw), for two web hits sharing the same URL.
+
+## Verification
+- `dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — 0 errors.
+- `dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter FullyQualifiedName~GatherContextStepTests` — 7/7 passed.
+- `dotnet format Anela.Heblo.sln --verify-no-changes` on both touched files — no changes needed.

--- a/artifacts/feat-3594/spec.r1.md
+++ b/artifacts/feat-3594/spec.r1.md
@@ -1,0 +1,17 @@
+# Spec — feat-3594
+
+## Problem
+`GatherContextStep.ExecuteAsync` (backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs) writes a mismatched snippet count to the `ArticleGenerationStep.OutputJson` trace: it deduplicates web snippets by URL for `context.ContextSnippets` (line 65–67, consumed by `AggregateFactsStep`/`WriteArticleStep`), but the trace payload on line 70 concatenates the **raw, pre-deduplication** `webSnippets` list instead of the already-computed `deduplicatedWeb`.
+
+## Scope
+Single-file, single-line fix. No API contract change, no schema change, no behavior change to article generation — only the diagnostic trace payload changes to reflect reality.
+
+## Acceptance criteria
+1. `GatherContextStep.cs` line 70 uses `deduplicatedWeb` instead of `webSnippets` when building `allSnippets` for the trace.
+2. `context.ContextSnippets` (the actual pipeline data flow) is unchanged — already correct.
+3. A regression test asserts the recorded `ArticleGenerationStep.OutputJson.snippets` array length matches the deduplicated count when duplicate web URLs are returned.
+4. Existing `GatherContextStepTests` continue to pass unmodified.
+
+## Out of scope
+- Any change to `DeduplicateByUrl` semantics.
+- Any change to `GetArticleTraceHandler` or the trace API response shape.

--- a/artifacts/feat-3594/task-plan.r1.md
+++ b/artifacts/feat-3594/task-plan.r1.md
@@ -1,0 +1,7 @@
+### task: fix-trace-snippet-source
+
+Change `GatherContextStep.ExecuteAsync` (backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs:70) to build the trace `allSnippets` list from `deduplicatedWeb` instead of `webSnippets`.
+
+Add a regression test in `GatherContextStepTests` asserting the recorded `ArticleGenerationStep.OutputJson` snippet count matches the deduplicated count for duplicate web URLs.
+
+Verify: `dotnet build`, `dotnet test --filter FullyQualifiedName~GatherContextStepTests`, `dotnet format --verify-no-changes` on the touched files.

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
@@ -67,7 +67,7 @@ public class GatherContextStep
                 context.ContextSnippets = [.. kbSnippets, .. deduplicatedWeb];
                 context.StyleGuideText = styleGuideText;
 
-                var allSnippets = kbSnippets.Concat(webSnippets).ToList();
+                var allSnippets = kbSnippets.Concat(deduplicatedWeb).ToList();
                 return (true, (object?)new { snippets = allSnippets, styleGuideLength = styleGuideText?.Length });
             },
             ct);

--- a/backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs
@@ -169,6 +169,42 @@ public class GatherContextStepTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_DuplicateWebUrls_TraceOutputMatchesDeduplicatedSnippets()
+    {
+        var repo = new Mock<IArticleRepository>();
+        repo.Setup(r => r.AddStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        repo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        ArticleGenerationStep? recordedStep = null;
+        repo.Setup(r => r.UpdateStepAsync(It.IsAny<ArticleGenerationStep>(), It.IsAny<CancellationToken>()))
+            .Callback<ArticleGenerationStep, CancellationToken>((step, _) => recordedStep = step)
+            .Returns(Task.CompletedTask);
+
+        var step = new GatherContextStep(
+            _knowledgeSource.Object, _webSearch.Object, _styleGuideSource.Object,
+            Options.Create(_options), NullLogger<GatherContextStep>.Instance, new PipelineStepRecorder(repo.Object));
+
+        _webSearch
+            .Setup(w => w.SearchAsync(It.IsAny<string>(), It.IsAny<WebSearchOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WebSearchResult
+            {
+                Hits = new List<WebSearchHit>
+                {
+                    new() { Title = "First", Url = "https://example.com/page", Snippet = "first" },
+                    new() { Title = "Duplicate", Url = "https://example.com/page", Snippet = "second" }
+                }
+            });
+
+        var context = CreateContext(useKb: false, useWeb: true, "query");
+
+        await step.ExecuteAsync(context, default);
+
+        recordedStep.Should().NotBeNull();
+        recordedStep!.OutputJson.Should().NotBeNull();
+        using var doc = System.Text.Json.JsonDocument.Parse(recordedStep.OutputJson!);
+        doc.RootElement.GetProperty("snippets").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_StyleGuideConfigured_LoadsTextViaContract()
     {
         const string driveId = "drive-1";


### PR DESCRIPTION
Closes #3594

## What the issue was
`GatherContextStep.ExecuteAsync` deduplicates web snippets by URL before storing them in `context.ContextSnippets` (the data actually consumed by `AggregateFactsStep`/`WriteArticleStep`), but the diagnostic trace written to `ArticleGenerationStep.OutputJson` concatenated the **raw, pre-deduplication** `webSnippets` list instead. This made the article trace (`GET /api/Articles/{id}/trace`) report a higher snippet count than what the pipeline actually processed whenever web search results shared a URL — actively misleading anyone diagnosing citation/source issues.

## How it was fixed
One-line change in `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`: build the trace's `allSnippets` list from the already-computed `deduplicatedWeb` variable instead of `webSnippets`. No change to `context.ContextSnippets` or downstream pipeline behavior — only the trace payload now matches reality.

Added a regression test (`ExecuteAsync_DuplicateWebUrls_TraceOutputMatchesDeduplicatedSnippets`) that captures the `ArticleGenerationStep` recorded via `IArticleRepository.UpdateStepAsync`, parses `OutputJson`, and asserts the `snippets` array length equals the deduplicated count (1) rather than the raw count (2) for two web hits sharing a URL.

## Verification
- `dotnet build` — 0 errors
- `dotnet test --filter FullyQualifiedName~GatherContextStepTests` — 7/7 passed (including the new regression test)
- `dotnet format --verify-no-changes` on touched files — no changes needed

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3594/` in this branch.

## Code review

# Code review — feat-3594

## Scope
`GatherContextStep.cs` (1-line fix) and `GatherContextStepTests.cs` (1 new regression test).

## Findings
None. The change matches the suggested fix exactly, does not alter `context.ContextSnippets` (the data actually consumed downstream), and is covered by a new test that would have failed pre-fix (asserts trace snippet count == deduplicated count, not raw count).

## Verdict
Approved — no correctness, security, or style issues.


---
_Generated by [Claude Code](https://claude.ai/code/session_014khdiQNhFPuqeW6dM8etgZ)_