### PR TITLE
#3599: consolidate GetGenerationStatsAsync into single DB query

### DIFF
--- a/artifacts/feat-3599/arch-review.r1.md
+++ b/artifacts/feat-3599/arch-review.r1.md
@@ -1,0 +1,132 @@
+# Architecture Review: Consolidate `GetGenerationStatsAsync` into a single database query
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a self-contained performance fix to a single repository method inside the `Leaflet` vertical slice. It touches no module boundary, no contract/DTO surface, and no other handler. `LeafletGenerationRepository` sits in `Anela.Heblo.Persistence`, implements `ILeafletGenerationRepository` (defined in `Anela.Heblo.Domain`), and is consumed only by `GetLeafletFeedbackListHandler`. The spec's own scoping (no interface change, no DTO change, no handler change) is correct and should be preserved exactly.
+
+More importantly, this is not a novel pattern for the codebase — it is a repeat of a problem already solved once. `IssuedInvoiceRepository.GetSyncStatsAsync` (`backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceRepository.cs:35-73`) computes a near-identical shape of stats (a total count, two conditional counts, and a max) over one table, using:
+
+```csharp
+var stats = await query
+    .GroupBy(x => 1)
+    .Select(g => new
+    {
+        Total = g.Count(),
+        Synced = g.Count(x => x.IsSynced),
+        WithErrors = g.Count(x => x.ErrorType.HasValue),
+        Critical = g.Count(x => x.ErrorType.HasValue && x.ErrorType != IssuedInvoiceErrorType.InvoicePaired),
+        LastSyncTime = g.Max(x => (DateTime?)x.LastSyncTime)
+    })
+    .FirstOrDefaultAsync(cancellationToken);
+
+if (stats == null) { /* return zeroed struct */ }
+```
+
+This is verified as a single SQL round trip by `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests` (`backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests.cs`), which runs against a real Postgres container (via `PostgresSharedContainerFixture` + `Testcontainers.PostgreSql`) with a `DbCommandInterceptor` counting emitted SQL commands. There is **no** existing use of `FromSqlRaw`/`FromSqlInterpolated` anywhere in the codebase — I grepped the whole `backend/` tree and found zero matches. Introducing raw SQL here would be a new pattern with no precedent, extra maintenance surface (hand-written SQL bypassing the EF change-tracking/translation pipeline), and no compensating benefit, since the LINQ `GroupBy(g => 1)` approach already proven in `IssuedInvoiceRepository` handles exactly this class of problem (multiple independent aggregates + a conditional count) as a single query against Npgsql/PostgreSQL.
+
+**Verdict: adopt the `GroupBy(g => 1)` LINQ projection, mirroring `IssuedInvoiceRepository.GetSyncStatsAsync` verbatim in structure.** Do not use raw SQL — the brief's `FromSqlRaw` suggestion was speculative ("if EF Core cannot translate..."), and the sibling repository proves it can.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. One method body changes:
+
+- `Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs` — `GetGenerationStatsAsync` rewritten to a single `GroupBy(g => 1).Select(...).FirstOrDefaultAsync(...)` query.
+
+No changes to `ILeafletGenerationRepository`, `LeafletFeedbackStats`, `GetLeafletFeedbackListHandler`, or any contract/DTO type.
+
+### Key Design Decisions
+
+#### Decision 1: LINQ `GroupBy(g => 1)` projection vs. `FromSqlRaw`
+
+**Options considered:**
+1. LINQ `GroupBy(g => 1)` with an anonymous-type `Select` (counts + conditional counts + averages), materialized via `FirstOrDefaultAsync`.
+2. `FromSqlRaw`/`FromSqlInterpolated` with the hand-written `FILTER (WHERE ...)` query from the brief, projected into a private keyless entity/DTO.
+
+**Chosen approach:** Option 1 — LINQ `GroupBy(g => 1)`.
+
+**Rationale:**
+- Direct precedent in this codebase (`IssuedInvoiceRepository.GetSyncStatsAsync`) proves EF Core + Npgsql translates `GroupBy(x => 1)` with mixed `Count()`, conditional `Count(predicate)`, and nullable aggregate selectors into a single SQL statement — no `FromSqlRaw` needed.
+- `Count(predicate)` inside a `GroupBy` projection is the LINQ equivalent of the brief's `COUNT(*) FILTER (WHERE ...)` — EF Core's Npgsql provider translates `g.Count(x => cond)` to a `count(...) FILTER (WHERE ...)` or `SUM(CASE WHEN ...)` expression itself; no manual SQL needed to get that behavior.
+- Zero existing `FromSqlRaw`/`FromSqlInterpolated` usage in `backend/` — introducing it here would add a new, unprecedented pattern (raw SQL string vs. LINQ) for no measurable benefit, and raw SQL cannot be exercised at all against the EF In-Memory provider used by the existing `LeafletGenerationRepositoryTests`, forcing every test of this method onto the (slower, container-based) Postgres integration path with no LINQ fallback for quick unit coverage.
+- Keeps the method typed and refactor-safe (column renames caught by the compiler / EF model, not a string).
+
+#### Decision 2: Averages via nullable-selector `Average`, not `Where(...).Average(...)`
+
+**Chosen approach:** Inside the single `GroupBy(g => 1)` group (which contains *all* rows, not a filtered subset), use `g.Average(x => (double?)x.PrecisionScore)` and `g.Average(x => (double?)x.StyleScore)`. LINQ's `Average` over a nullable selector already ignores `null` values in both numerator and denominator, and returns `null` when every value in the group is `null` (or the group is empty) — this reproduces the current `Where(g => g.PrecisionScore != null).AverageAsync(...)` semantics exactly (FR-2, FR-3) without a second filtered subquery. This mirrors how the sibling `GetSyncStatsAsync` already uses `g.Max(x => (DateTime?)x.LastSyncTime)` on a nullable column within the same all-rows group and lets `Max` naturally skip nulls.
+
+#### Decision 3: Empty-table handling via `FirstOrDefaultAsync` null check
+
+**Chosen approach:** `GroupBy(g => 1)` produces zero groups when the underlying query set is empty, so `FirstOrDefaultAsync` returns `null` in that case — exactly the same shape `IssuedInvoiceRepository.GetSyncStatsAsync` already handles (see its `if (stats == null) { return zeroed; }` branch). Copy that guard: if `stats == null`, return `new LeafletFeedbackStats(0, 0, null, null)` directly rather than trying to make the aggregate query itself produce a synthetic zero row.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files/folders required. Single-method edit in place:
+
+```
+backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs
+```
+
+### Interfaces and Contracts
+
+Unchanged. `ILeafletGenerationRepository.GetGenerationStatsAsync(CancellationToken)` keeps its exact signature and return type (`Task<LeafletFeedbackStats>`). `LeafletFeedbackStats` (`backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs`) is an internal domain record consumed only inside the handler that maps it to `LeafletFeedbackStatsDto` — per `docs/architecture/development_guidelines.md`'s DTO rules, the "DTOs are classes, never records" rule applies to contract types in `contracts/`/`Response`/`Request` objects crossing the API boundary, not to this internal domain type, so no conversion is needed (the spec is correct on this point).
+
+### Data Flow
+
+Unchanged: `GET /api/leaflet/feedback/list` → `GetLeafletFeedbackListHandler.Handle` → `GetGenerationsPagedAsync` (1 query) + `GetGenerationStatsAsync` (now 1 query instead of 4) → response mapping. Total DB round trips per request: 5 → 2.
+
+Suggested replacement body (structure only — mirror `IssuedInvoiceRepository.GetSyncStatsAsync`'s shape):
+
+```csharp
+public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
+{
+    var stats = await _context.LeafletGenerations
+        .GroupBy(g => 1)
+        .Select(g => new
+        {
+            Total = g.Count(),
+            WithFeedback = g.Count(x => x.PrecisionScore != null || x.StyleScore != null),
+            AvgPrecision = g.Average(x => (double?)x.PrecisionScore),
+            AvgStyle = g.Average(x => (double?)x.StyleScore),
+        })
+        .FirstOrDefaultAsync(cancellationToken);
+
+    if (stats is null)
+        return new LeafletFeedbackStats(0, 0, null, null);
+
+    return new LeafletFeedbackStats(stats.Total, stats.WithFeedback, stats.AvgPrecision, stats.AvgStyle);
+}
+```
+
+### Test Guidance
+
+- **Existing unit tests** (`backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs`, EF In-Memory provider) are unaffected — they don't currently cover `GetGenerationStatsAsync`. `GroupBy(g => 1)` translates fine against the In-Memory provider (it evaluates client-side), so basic value-correctness tests (empty table, mixed feedback, one-sided feedback) can be added there using the existing `IDisposable` + `UseInMemoryDatabase` pattern already in that file — no new test infrastructure needed for value-correctness coverage (FR-2, FR-3).
+- **Round-trip-count verification** (FR-1, FR-4's "confirms it runs correctly against the project's actual database provider") requires the real Npgsql/PostgreSQL path, since In-Memory doesn't exercise SQL translation or round-trip counting meaningfully. Follow the established convention exactly: add a `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests` class modeled on `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests.cs` —
+  - `[Collection("PostgresIntegration")]`, `IAsyncLifetime`, injecting `PostgresSharedContainerFixture` (`backend/test/Anela.Heblo.Tests/Common/PostgresSharedContainerFixture.cs` — shared Testcontainers Postgres 16 instance, one fresh database per test class via `CreateDatabaseAsync`).
+  - A minimal `CREATE TABLE public."LeafletGenerations" (...)` with only the columns the method touches (`Id`, `PrecisionScore`, `StyleScore`), matching how the invoice/photobank sibling tests scope their schema.
+  - The same `CapturingCommandInterceptor : DbCommandInterceptor` pattern (or extract a shared one if repetition across 4+ SqlShapeTests classes starts to bother you — optional, not required by this spec) registered via `.AddInterceptors(...)` on the `DbContextOptionsBuilder<ApplicationDbContext>.UseNpgsql(...)`.
+  - One fact asserting `interceptor.Commands.Should().HaveCount(1)` after calling `GetGenerationStatsAsync`.
+  - One fact asserting correct values across a representative data set (empty table, all-null-feedback rows, mixed rows, one-sided PrecisionScore/StyleScore-only rows) — covers FR-4's four scenarios in one seeded table plus an empty-table variant.
+
+This satisfies FR-4 without inventing new test infrastructure — it is a direct copy of a pattern already used four times in this test suite (`Invoices`, `Photobank`, `Purchase`, `GridLayouts`/`Smartsupp` variants under the `PostgresIntegration` collection).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `Average` inside `GroupBy(g => 1)` doesn't skip nulls the way `Where(...).AverageAsync(...)` does, subtly changing computed averages | Medium | Covered by Decision 2's reasoning (nullable-selector `Average` semantics are defined to skip nulls) and by FR-2/FR-4 test coverage comparing against representative mixed data sets before/after. |
+| EF Core/Npgsql fails to translate `Count(predicate)` combined with `Average(nullable selector)` in the same `GroupBy` projection into one SQL statement, silently falling back to client-side evaluation (pulling all rows) | Low | Directly mitigated by the SqlShapeTest's `Commands.Should().HaveCount(1)` assertion — if translation fails, that test fails loudly rather than the regression going unnoticed. The sibling `IssuedInvoiceRepository` already proves this combination (`Count()`, `Count(predicate)`, `Max(nullable selector)`) translates as one query; `Average` is the same family of aggregate. |
+| Empty-table / all-null-feedback edge cases regress silently since they're not exercised by current handler-level mocked tests | Low | FR-3's explicit empty-table and all-null test cases, added at the repository level per FR-4, close this gap directly. |
+
+## Specification Amendments
+
+None required — the spec's own "order of preference" (LINQ first, raw SQL only as a fallback) already points at the right answer; this review just resolves the choice concretely in favor of LINQ `GroupBy(g => 1)`, using `IssuedInvoiceRepository.GetSyncStatsAsync` as the concrete template to copy (both for the query shape and for the corresponding `*SqlShapeTests` test class), rather than leaving that choice open for the implementer to redecide.
+
+## Prerequisites
+
+None. `Testcontainers.PostgreSql`, `PostgresSharedContainerFixture`, and the `PostgresIntegration` xUnit collection are already wired up and used by multiple existing test classes — no new package references or fixture scaffolding needed.

--- a/artifacts/feat-3599/brief.md
+++ b/artifacts/feat-3599/brief.md
@@ -1,0 +1,40 @@
+## Module
+Leaflet
+
+## Finding
+`LeafletGenerationRepository.GetGenerationStatsAsync` issues 4 independent async database queries to compute stats that could be returned in a single SQL aggregate:
+
+```csharp
+// backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs:55–67
+var total = await _context.LeafletGenerations.CountAsync(cancellationToken);
+var withFeedback = await _context.LeafletGenerations
+    .CountAsync(g => g.PrecisionScore != null || g.StyleScore != null, cancellationToken);
+var avgPrecision = await _context.LeafletGenerations
+    .Where(g => g.PrecisionScore != null)
+    .AverageAsync(g => (double?)g.PrecisionScore, cancellationToken);
+var avgStyle = await _context.LeafletGenerations
+    .Where(g => g.StyleScore != null)
+    .AverageAsync(g => (double?)g.StyleScore, cancellationToken);
+```
+
+This method is called on every request to `GET /api/leaflet/feedback/list` (inside `GetLeafletFeedbackListHandler.Handle`, line 36), alongside the paged query — so each feedback list page load hits the database 5 times (1 paged query + 4 stats queries) instead of 2.
+
+## Why it matters
+Three unnecessary extra round trips per page load. The four values (`total`, `withFeedback`, `avgPrecision`, `avgStyle`) are independent aggregates over the same table — there is no cross-query dependency that forces sequential execution. PostgreSQL can compute all four in a single scan.
+
+## Suggested fix
+Replace the four calls with a single `FromSqlRaw` (or an equivalent LINQ projection) that returns all four values at once:
+
+```sql
+SELECT
+    COUNT(*) AS total,
+    COUNT(*) FILTER (WHERE "PrecisionScore" IS NOT NULL OR "StyleScore" IS NOT NULL) AS with_feedback,
+    AVG("PrecisionScore") AS avg_precision,
+    AVG("StyleScore") AS avg_style
+FROM "LeafletGenerations";
+```
+
+Alternatively, use a LINQ `GroupBy(g => 1)` projection or a small anonymous-type query with `Select` + `SingleOrDefaultAsync`. Either way, one DB round trip replaces four.
+
+---
+_Filed by daily arch-review routine on 2026-07-11._

--- a/artifacts/feat-3599/code-review.r1.md
+++ b/artifacts/feat-3599/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs:155` — `CapturingCommandInterceptor` is copy-pasted verbatim (identical implementation) into this file and at least four other SQL-shape test classes (`IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests`, `PurchaseOrderRepositoryHistorySqlShapeTests`, `PhotobankRepositoryGetTagsSqlShapeTests`, `ArticleRepositoryFeedbackProjectionSqlTests`). Extracting it once into `Anela.Heblo.Tests.Common` would remove the duplication; not something this PR needs to fix since it follows the established (if repetitive) convention.

--- a/artifacts/feat-3599/design.r1.md
+++ b/artifacts/feat-3599/design.r1.md
@@ -1,0 +1,51 @@
+# Design: Consolidate `GetGenerationStatsAsync` into a single database query
+
+## Component Design
+
+No new components are introduced. This change is scoped to the body of a single existing method; all surrounding boundaries and contracts are unchanged.
+
+- **`LeafletGenerationRepository`** (`backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs`) — implements `ILeafletGenerationRepository`. Its `GetGenerationStatsAsync(CancellationToken)` method is rewritten internally to issue one query instead of four. Responsibility, signature, and return type (`Task<LeafletFeedbackStats>`) are unchanged.
+  - Internal query strategy: `_context.LeafletGenerations.GroupBy(g => 1).Select(...)` producing a single anonymous-type projection (`Total`, `WithFeedback`, `AvgPrecision`, `AvgStyle`), materialized with `FirstOrDefaultAsync`. This mirrors the existing precedent in `IssuedInvoiceRepository.GetSyncStatsAsync` (`backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceRepository.cs:35-73`).
+  - Null-group guard: if the grouped query yields no row (empty table), the method returns `new LeafletFeedbackStats(0, 0, null, null)` directly, rather than relying on the query to synthesize a zero row.
+  - No raw SQL (`FromSqlRaw`/`FromSqlInterpolated`) is used — the LINQ `GroupBy(g => 1)` approach is adopted per the architecture review, as it has direct precedent in the codebase and keeps the query typed and testable against the EF In-Memory provider.
+
+- **`ILeafletGenerationRepository`** (`Anela.Heblo.Domain`) — unchanged. `GetGenerationStatsAsync(CancellationToken)` keeps its exact signature and return type.
+
+- **`GetLeafletFeedbackListHandler`** (`backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs`) — unchanged. Continues to call `GetGenerationsPagedAsync` and `GetGenerationStatsAsync` and map the result into `LeafletFeedbackStatsDto` exactly as before. Total DB round trips per request to `GET /api/leaflet/feedback/list` drop from 5 to 2 (1 paged query + 1 stats query, versus 1 paged query + 4 stats queries previously).
+
+- **Test additions (no new production components):**
+  - Value-correctness tests added to the existing `LeafletGenerationRepositoryTests` (EF In-Memory provider) covering: empty table, all-null-feedback rows, mixed feedback/non-feedback rows, and one-sided (`PrecisionScore`-only or `StyleScore`-only) rows.
+  - A new `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests` class, modeled directly on `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests`, using `PostgresSharedContainerFixture` and a `DbCommandInterceptor` to assert exactly one SQL command is issued, plus value-parity assertions against the same representative data sets on the real Npgsql/PostgreSQL provider.
+
+## Data Schemas
+
+No schema, entity, or contract changes. Included for completeness since the query shape depends on them:
+
+**Underlying table (unchanged):** `LeafletGenerations` — only `Id`, `PrecisionScore` (nullable), and `StyleScore` (nullable) are read by this method.
+
+**Return type (unchanged domain record):**
+```csharp
+public sealed record LeafletFeedbackStats(
+    int TotalGenerations,
+    int TotalWithFeedback,
+    double? AvgPrecisionScore,
+    double? AvgStyleScore);
+```
+
+**Internal query projection shape** (not a persisted or contract type — an anonymous type scoped to the method body):
+```csharp
+new
+{
+    Total = g.Count(),
+    WithFeedback = g.Count(x => x.PrecisionScore != null || x.StyleScore != null),
+    AvgPrecision = g.Average(x => (double?)x.PrecisionScore),
+    AvgStyle = g.Average(x => (double?)x.StyleScore),
+}
+```
+
+**Semantics preserved exactly (FR-2/FR-3):**
+- `Total`: count of all rows.
+- `WithFeedback`: count of rows where `PrecisionScore IS NOT NULL OR StyleScore IS NOT NULL`.
+- `AvgPrecision` / `AvgStyle`: average over non-null values only, `null` when the table is empty or all values in the column are null (nullable-selector `Average` semantics), matching the current `Where(...).AverageAsync(...)` behavior bit-for-bit.
+
+**API / contract surface:** No change. `GET /api/leaflet/feedback/list` continues to return the existing `GetLeafletFeedbackListResponse` shape (including `Stats` as `LeafletFeedbackStatsDto`) with identical values, computed via one fewer round trip.

--- a/artifacts/feat-3599/impl/consolidate-generation-stats-query.r1.md
+++ b/artifacts/feat-3599/impl/consolidate-generation-stats-query.r1.md
@@ -1,0 +1,41 @@
+# Implementation: consolidate-generation-stats-query
+
+## What was implemented
+Rewrote `LeafletGenerationRepository.GetGenerationStatsAsync` to compute `total`, `withFeedback`, `avgPrecision`, and `avgStyle` in a single database round trip using `GroupBy(g => 1)` + an anonymous-type `Select` + `FirstOrDefaultAsync`, replacing the previous four sequential `CountAsync`/`AverageAsync` calls. Public signature, return type (`LeafletFeedbackStats`), and all callers (`GetLeafletFeedbackListHandler`, `ILeafletGenerationRepository`) are unchanged. Added unit tests proving value parity with the old implementation and a new Postgres integration test class proving the single-round-trip guarantee.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs` — `GetGenerationStatsAsync` body replaced with the `GroupBy(g => 1)` single-query shape; null-group guard returns `LeafletFeedbackStats(0, 0, null, null)` for an empty table. No other methods touched.
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs` — added 3 new `[Fact]` methods (EF In-Memory provider): empty-table zeroed stats, all-rows-without-feedback (zero `TotalWithFeedback`, null averages), and mixed rows (asserting exact totals and manually-computed averages for one-sided/both-sided/no-feedback rows).
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs` (new) — Postgres Testcontainers SQL-shape test class modeled on `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests.cs`, using `PostgresSharedContainerFixture` and a `DbCommandInterceptor` to assert exactly one SQL command is emitted, correct values against a real database (5-row seed), and a third fact (`GetGenerationStatsAsync_EmptyTable_ReturnsZeroedStatsWithoutThrowing`) that truncates the table and asserts zeroed/null stats without throwing (option (a) from the task spec).
+
+## Tests
+- `LeafletGenerationRepositoryTests` (EF In-Memory, `--filter "FullyQualifiedName~LeafletGenerationRepositoryTests"`): **6/6 passed** (3 pre-existing + 3 new).
+- `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests` (Postgres Testcontainers, 3 facts): **could not run** in this sandbox — Docker daemon is not reachable (`docker info` reports `failed to connect to the docker API at unix:///var/run/docker.sock ... no such file or directory`). Verified this is a pre-existing environment limitation, not something introduced by this change, by running the sibling `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests` (untouched, pre-existing file) with the same filter — it fails identically with the same Testcontainers/Docker error. Code compiles and follows the proven sibling pattern exactly.
+- `GetLeafletFeedbackListHandlerTests` (regression check, mocks the repository): **15/15 passed**, confirming the handler contract is unchanged.
+- Full `dotnet build` (`Anela.Heblo.sln`): **0 errors** (250 pre-existing warnings, none related to this change).
+- `dotnet format Anela.Heblo.sln --verify-no-changes`: **no diffs reported**.
+
+## How to verify
+```
+cd backend
+dotnet build ../Anela.Heblo.sln
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~LeafletGenerationRepositoryTests" --no-build
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletFeedbackListHandlerTests" --no-build
+# Requires a running Docker daemon:
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests" --no-build
+```
+
+## Notes
+- Docker/Testcontainers is unavailable in this sandbox (`/var/run/docker.sock` does not exist), so the new Postgres-backed SQL-shape tests could not be executed here. This is an environment limitation confirmed against the pre-existing, unmodified sibling test (`IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests`), which fails with the identical Docker connection error — i.e., not a regression or defect introduced by this change. These tests should be run in an environment with Docker (e.g., CI or local dev) before merge to get full confidence on the "exactly one SQL command" assertion.
+- `git diff --stat` (repo root, after staging) confirms only the three intended files changed under `backend/`: `LeafletGenerationRepository.cs`, `LeafletGenerationRepositoryTests.cs`, and the new `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs`. `artifacts/feat-3599/state.json` had pipeline-owned changes present in the working tree but was deliberately left uncommitted, per instructions not to touch `artifacts/`.
+
+## PR Summary
+This change consolidates `LeafletGenerationRepository.GetGenerationStatsAsync` from four sequential database queries into a single round trip, using the same `GroupBy(g => 1)` LINQ aggregation shape already proven in `IssuedInvoiceRepository.GetSyncStatsAsync`. The method is called on every `GET /api/leaflet/feedback/list` request alongside the paged generations query, so this reduces that endpoint from 5 DB round trips to 2 per page load. The public method signature, return type, and all call sites are unchanged — this is a pure internal implementation change. Test coverage was added at two levels: EF In-Memory unit tests in the existing `LeafletGenerationRepositoryTests.cs` proving value parity with the old four-query implementation across empty-table, no-feedback, and mixed-feedback scenarios; and a new Postgres Testcontainers integration test class, `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests`, asserting the query emits exactly one SQL command and returns correct values against a real PostgreSQL database, including an empty-table case. The Postgres-backed tests could not be executed in this sandbox because Docker is unavailable here, but the same limitation was confirmed against an existing, unmodified sibling test class, so it is an environment gap rather than a defect in this change.
+
+### Changes
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs` — `GetGenerationStatsAsync` rewritten to a single `GroupBy(g => 1)` aggregation query instead of four sequential queries.
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs` — added 3 EF In-Memory facts covering empty table, no-feedback rows, and mixed feedback rows.
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs` (new) — Postgres Testcontainers SQL-shape tests: single-SQL-command assertion, real-database value correctness, and empty-table (truncated) zeroed-stats assertion.
+
+## Status
+DONE_WITH_CONCERNS

--- a/artifacts/feat-3599/review/consolidate-generation-stats-query.r1.md
+++ b/artifacts/feat-3599/review/consolidate-generation-stats-query.r1.md
@@ -1,0 +1,21 @@
+# Code Review: consolidate-generation-stats-query
+
+## Summary
+The implementation matches the task spec's prescribed `GroupBy(g => 1)` shape exactly (character-for-character with the spec's sample code) and preserves the method signature, return type, and all null/zero semantics. Independently verified: build succeeds (0 errors), `dotnet format --verify-no-changes` reports no diffs, `LeafletGenerationRepositoryTests` passes 6/6 (3 pre-existing + 3 new), `GetLeafletFeedbackListHandlerTests` passes 15/15 unmodified, and `git diff --stat` against `main` touches only the three intended files plus pipeline artifacts. The Postgres-Testcontainers tests could not be executed in this sandbox (confirmed independently: Docker CLI present but daemon socket absent), which was verified to be a pre-existing environment limitation, not a regression.
+
+## Review Result: PASS
+
+### task: consolidate-generation-stats-query
+**Status:** PASS
+
+## Docs to Update
+None required — this is a pure internal implementation change with no public contract, API, or behavior-visible-to-callers change.
+
+## Overall Notes
+- Verified the new `LeafletGenerationRepository.GetGenerationStatsAsync` body against the spec's mandated code block: identical `GroupBy(g => 1)` → anonymous `Select` (`Count()`, conditional `Count(predicate)`, two nullable-selector `Average`s) → `FirstOrDefaultAsync` → null-group guard returning `LeafletFeedbackStats(0, 0, null, null)`. No other methods in the file were touched.
+- Confirmed via `git diff --stat main...HEAD` that only `LeafletGenerationRepository.cs`, `LeafletGenerationRepositoryTests.cs`, and the new `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs` changed under `backend/` (plus pipeline `artifacts/` bookkeeping files) — satisfies the "no diff outside repository method body and two test files" acceptance criterion.
+- EF In-Memory tests cover exactly the three spec-mandated scenarios (empty table; all-null-scores rows; mixed one-sided/both-sided/no-feedback rows) with correct manual-average assertions. Ran them directly: 6/6 pass.
+- The new SQL-shape test class is modeled closely on the sibling `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests` (same fixture, same `CapturingCommandInterceptor` pattern, same `[Collection("PostgresIntegration")]`/`[Trait("Category","Integration")]` attributes) and additionally implements the empty-table fact via truncation (option (a) from the spec), which is a reasonable and spec-permitted choice.
+- Independently reproduced the Docker-unavailability claim: `docker info` shows the CLI present but `failed to connect to the docker API at unix:///var/run/docker.sock ... no such file or directory` — consistent with the developer's report and the stated review exception for infrastructure-gated tests. Per instructions, this does not block PASS given the test code is well-formed and mirrors the proven sibling pattern.
+- `GetLeafletFeedbackListHandlerTests` (15/15) passing unmodified confirms no regression at the consumer/contract level.
+- `dotnet build` (root `Anela.Heblo.sln`): 0 errors, pre-existing warning count unaffected by this change. `dotnet format --verify-no-changes` (scoped to the three changed files): no diffs.

--- a/artifacts/feat-3599/spec.r1.md
+++ b/artifacts/feat-3599/spec.r1.md
@@ -1,0 +1,102 @@
+# Specification: Consolidate `GetGenerationStatsAsync` into a single database query
+
+## Summary
+`LeafletGenerationRepository.GetGenerationStatsAsync` currently issues four sequential, independent database round trips to compute leaflet feedback statistics. This method is called on every request to `GET /api/leaflet/feedback/list`, so each page load of the feedback list makes 5 DB calls (1 paged query + 4 stats queries) instead of 2. This spec covers rewriting the method to compute all four aggregates in a single query, with no change to its public contract or callers.
+
+## Background
+`GetGenerationStatsAsync` (backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs:55-67) is invoked from `GetLeafletFeedbackListHandler.Handle` (backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs:36) alongside `GetGenerationsPagedAsync`, on every call to the feedback list endpoint. The four values it computes — total row count, count with any feedback, average precision score, average style score — are independent aggregates over the same `LeafletGenerations` table with no cross-query dependency forcing sequential execution. This was flagged by the daily architecture review routine (2026-07-11) as an easy, low-risk performance win: three unnecessary round trips per page load, avoidable with a single aggregate query.
+
+This is a targeted performance fix to one repository method. It does not touch `GetGenerationsPagedAsync`, the handler, the DTOs, or the API contract.
+
+## Functional Requirements
+
+### FR-1: Compute all four stats in a single database round trip
+Rewrite `GetGenerationStatsAsync` so that `total`, `withFeedback`, `avgPrecision`, and `avgStyle` are obtained via one query against `_context.LeafletGenerations` instead of four separate `await`ed calls.
+
+Acceptable implementation approaches (in order of preference, per project conventions favoring LINQ/EF over raw SQL where feasible):
+1. A LINQ `GroupBy(g => 1)` (or equivalent constant-key grouping) projected with `Select` into an anonymous/tuple type, then materialized with `SingleOrDefaultAsync`, handling the empty-table case (see FR-3).
+2. If EF Core cannot translate the required aggregate (e.g., the `FILTER`-style conditional count) into a single SQL query via LINQ, use `FromSqlRaw`/`FromSqlInterpolated` with the query given in the brief:
+   ```sql
+   SELECT
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE "PrecisionScore" IS NOT NULL OR "StyleScore" IS NOT NULL) AS with_feedback,
+       AVG("PrecisionScore") AS avg_precision,
+       AVG("StyleScore") AS avg_style
+   FROM "LeafletGenerations";
+   ```
+   projected into a small private DTO/keyless entity type for materialization.
+
+Whichever approach is used, the query must execute exactly once against the database for this method call.
+
+**Acceptance criteria:**
+- `GetGenerationStatsAsync` results in exactly one round trip to the database (verifiable via EF Core query logging or a DB-call counter in an integration test).
+- The method signature, return type (`Task<LeafletFeedbackStats>`), and the `ILeafletGenerationRepository` interface are unchanged.
+- No changes to `GetGenerationsPagedAsync`, `GetLeafletFeedbackListHandler`, or any DTO/contract type.
+
+### FR-2: Preserve exact existing semantics for all four values
+The four computed values must have bit-for-bit identical semantics to the current implementation for every input state:
+- `TotalGenerations`: count of all rows in `LeafletGenerations`.
+- `TotalWithFeedback`: count of rows where `PrecisionScore IS NOT NULL OR StyleScore IS NOT NULL`.
+- `AvgPrecisionScore`: average of `PrecisionScore` over rows where `PrecisionScore IS NOT NULL` (nulls excluded from both numerator and denominator, matching current `Where(...).AverageAsync(...)` behavior).
+- `AvgStyleScore`: average of `StyleScore` over rows where `StyleScore IS NOT NULL`, same rule.
+
+**Acceptance criteria:**
+- Existing unit tests in `GetLeafletFeedbackListHandlerTests` continue to pass unmodified (they mock the repository, so they validate the handler's use of the returned `LeafletFeedbackStats`, not the query itself).
+- New/updated repository-level tests (see FR-4) confirm value parity with the pre-change four-query implementation across representative data sets.
+
+### FR-3: Correct handling of the empty-table case
+When `LeafletGenerations` has zero rows, the current implementation returns `TotalGenerations = 0`, `TotalWithFeedback = 0`, `AvgPrecisionScore = null`, `AvgStyleScore = null` (EF Core's `AverageAsync` over an empty filtered set with a nullable selector returns `null`, not an exception, and `CountAsync` returns `0`). The consolidated query must reproduce this exact result rather than throwing or returning `0` for the averages.
+
+**Acceptance criteria:**
+- A test against an empty `LeafletGenerations` table returns `LeafletFeedbackStats(0, 0, null, null)` and does not throw.
+- A test where no rows have any feedback (so `PrecisionScore`/`StyleScore` are all null) returns `TotalWithFeedback = 0` and both averages `null`, without throwing.
+
+### FR-4: Test coverage for the new query path
+Add or update tests that exercise the actual database query (not a mocked repository), since the existing handler tests mock `ILeafletGenerationRepository` and would not catch a regression in the SQL/LINQ itself.
+
+**Acceptance criteria:**
+- A repository-level test (using the project's existing EF Core test infrastructure — in-memory provider or test PostgreSQL instance, whichever this project's test suite already uses for repository tests) covers: empty table, table with only feedback-less rows, table with a mix of feedback and non-feedback rows, and a table where only one of `PrecisionScore`/`StyleScore` is populated on some rows.
+- If `FromSqlRaw` is used, a test confirms it runs correctly against the project's actual database provider (PostgreSQL), not just against the EF in-memory provider (which does not support raw SQL translation the same way).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Reduce database round trips for `GetGenerationStatsAsync` from 4 to 1.
+- No regression in query correctness or response time of `GET /api/leaflet/feedback/list` — the change should only reduce latency (fewer round trips), not alter the shape or volume of data returned.
+- No new indexes are required; `LeafletGenerations` is expected to remain a single-table, full-scan aggregate at this data volume. If the table is large enough that a full scan becomes a concern, that is out of scope for this fix (see Out of Scope).
+
+### NFR-2: Security
+- No change to authentication, authorization, or data sensitivity — this is an internal aggregate query with no new fields or exposure surface.
+
+## Data Model
+No schema or entity changes. `LeafletFeedbackStats` (backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs) remains:
+
+```csharp
+public sealed record LeafletFeedbackStats(
+    int TotalGenerations,
+    int TotalWithFeedback,
+    double? AvgPrecisionScore,
+    double? AvgStyleScore);
+```
+
+This is an internal domain type (not a DTO crossing the API boundary directly — `GetLeafletFeedbackListHandler` maps it into `LeafletFeedbackStatsDto`), so per project convention it may remain a record; no conversion to a class is required by this change.
+
+## API / Interface Design
+No public API or contract changes. `GET /api/leaflet/feedback/list` continues to return the same `GetLeafletFeedbackListResponse` shape, including the `Stats` field, with identical values. `ILeafletGenerationRepository.GetGenerationStatsAsync(CancellationToken)` keeps its existing signature. This is purely an internal implementation change to the repository method's query strategy.
+
+## Dependencies
+- Entity Framework Core (existing `ApplicationDbContext`).
+- Npgsql / PostgreSQL, if the `FromSqlRaw` fallback path is used.
+- No new libraries or services.
+
+## Out of Scope
+- Any change to `GetGenerationsPagedAsync` or the overall query count for the feedback list endpoint (still 2 queries: paged + stats).
+- Caching of stats results across requests.
+- Adding indexes or otherwise optimizing the underlying table scan for very large `LeafletGenerations` tables.
+- Changes to `GetLeafletFeedbackListHandler`, `LeafletFeedbackStatsDto`, or any frontend consumer of the feedback list endpoint.
+- Broader refactors of `LeafletGenerationRepository` beyond this one method.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-12T05:17:46.947913Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-12T05:17:47.149829Z"
+      "status": "completed",
+      "updated_at": "2026-07-12T05:20:22.963680Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-12T05:23:00.206937Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-12T05:23:18.240491Z"
     }
   },
   "tasks": [
     {
       "name": "consolidate-generation-stats-query",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-12T05:23:18.415341Z"
     }
   ]
 }

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-12T05:21:11.386464Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-12T05:23:00.206937Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-12T05:20:22.963680Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-12T05:21:11.386464Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "consolidate-generation-stats-query",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-12T05:23:00.206937Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-12T05:23:18.240491Z"
+      "status": "completed",
+      "updated_at": "2026-07-12T05:33:44.974873Z"
     }
   },
   "tasks": [
     {
       "name": "consolidate-generation-stats-query",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-12T05:23:18.415341Z"
+      "updated_at": "2026-07-12T05:33:44.640674Z"
     }
   ]
 }

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3599",
+  "issue_number": 3599,
+  "created_at": "2026-07-12T05:15:34.512807Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-12T05:17:46.947913Z"
+    },
+    "architecting": {
+      "status": "in_progress",
+      "updated_at": "2026-07-12T05:17:47.149829Z"
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3599/state.json
+++ b/artifacts/feat-3599/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-12T05:33:44.974873Z"
+    },
+    "code-review": {
+      "status": "completed",
+      "updated_at": "2026-07-12T05:48:42.259476Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3599/task-context/consolidate-generation-stats-query.md
+++ b/artifacts/feat-3599/task-context/consolidate-generation-stats-query.md
@@ -1,0 +1,230 @@
+### task: consolidate-generation-stats-query
+
+## Goal
+Rewrite `LeafletGenerationRepository.GetGenerationStatsAsync` (backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs:55-67) so it computes all four leaflet-feedback aggregates (`total`, `withFeedback`, `avgPrecision`, `avgStyle`) in exactly one database round trip instead of four sequential queries, with zero change to its public signature, return type, or callers. Add test coverage proving both value-correctness and the single-round-trip guarantee.
+
+## Context
+
+**Why:** `GetGenerationStatsAsync` is called on every `GET /api/leaflet/feedback/list` request (via `GetLeafletFeedbackListHandler.Handle`, backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs:36), alongside `GetGenerationsPagedAsync`. Today that's 5 DB round trips per page load (1 paged + 4 stats); this fix brings it to 2 (1 paged + 1 stats). Flagged by the 2026-07-11 architecture review routine as an easy, low-risk perf win.
+
+**Files to read before starting:**
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs` — file to modify. Current `GetGenerationStatsAsync` (lines 55-67):
+  ```csharp
+  public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
+  {
+      var total = await _context.LeafletGenerations.CountAsync(cancellationToken);
+      var withFeedback = await _context.LeafletGenerations
+          .CountAsync(g => g.PrecisionScore != null || g.StyleScore != null, cancellationToken);
+      var avgPrecision = await _context.LeafletGenerations
+          .Where(g => g.PrecisionScore != null)
+          .AverageAsync(g => (double?)g.PrecisionScore, cancellationToken);
+      var avgStyle = await _context.LeafletGenerations
+          .Where(g => g.StyleScore != null)
+          .AverageAsync(g => (double?)g.StyleScore, cancellationToken);
+      return new LeafletFeedbackStats(total, withFeedback, avgPrecision, avgStyle);
+  }
+  ```
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs` — unchanged return type:
+  ```csharp
+  public sealed record LeafletFeedbackStats(
+      int TotalGenerations,
+      int TotalWithFeedback,
+      double? AvgPrecisionScore,
+      double? AvgStyleScore);
+  ```
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs` — entity read by the query. Relevant columns: `Id` (Guid), `PrecisionScore` (`int?`), `StyleScore` (`int?`). Also has `Topic`, `UserId`, `CreatedAt`, `FeedbackComment` (not touched by this query).
+- `backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceRepository.cs:35-73` — the sibling implementation to mirror structurally (`GroupBy(g => 1)` + conditional `Count`/`Average` + null-group guard).
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests.cs` — the exact template for the new integration test class (Postgres Testcontainers, `DbCommandInterceptor` counting SQL commands, `[Collection("PostgresIntegration")]`).
+- `backend/test/Anela.Heblo.Tests/Common/PostgresSharedContainerFixture.cs` — shared Testcontainers Postgres 16 fixture; call `CreateDatabaseAsync(nameHint)` to get an isolated DB and connection string.
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs` — existing EF In-Memory unit test class for this repository (constructor pattern: `UseInMemoryDatabase($"LeafletGenerationRepositoryTests_{Guid.NewGuid()}")`, `IDisposable`). Add new `[Fact]` methods here.
+
+**Architectural decision (from arch review, binding):** Use LINQ `GroupBy(g => 1)` with an anonymous-type `Select`, materialized via `FirstOrDefaultAsync`. Do **not** use `FromSqlRaw`/`FromSqlInterpolated` — there is zero precedent for raw SQL in this codebase, and the sibling `IssuedInvoiceRepository.GetSyncStatsAsync` already proves EF Core + Npgsql translates this exact shape (mixed `Count()`, conditional `Count(predicate)`, nullable-selector `Average`/`Max`) into one SQL statement.
+
+**Semantics that must be preserved exactly (FR-2, FR-3):**
+- `TotalGenerations` = count of all rows.
+- `TotalWithFeedback` = count where `PrecisionScore != null || StyleScore != null`.
+- `AvgPrecisionScore` = average of non-null `PrecisionScore` values; `null` if none exist (empty table or all-null column) — must NOT throw and must NOT return `0`.
+- `AvgStyleScore` = same rule for `StyleScore`.
+- Empty table → return `LeafletFeedbackStats(0, 0, null, null)` without throwing.
+
+## Steps
+
+1. **Rewrite `GetGenerationStatsAsync`** in `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs` (replace lines 55-67) with:
+   ```csharp
+   public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
+   {
+       var stats = await _context.LeafletGenerations
+           .GroupBy(g => 1)
+           .Select(g => new
+           {
+               Total = g.Count(),
+               WithFeedback = g.Count(x => x.PrecisionScore != null || x.StyleScore != null),
+               AvgPrecision = g.Average(x => (double?)x.PrecisionScore),
+               AvgStyle = g.Average(x => (double?)x.StyleScore),
+           })
+           .FirstOrDefaultAsync(cancellationToken);
+
+       if (stats is null)
+           return new LeafletFeedbackStats(0, 0, null, null);
+
+       return new LeafletFeedbackStats(stats.Total, stats.WithFeedback, stats.AvgPrecision, stats.AvgStyle);
+   }
+   ```
+   Do not touch `SaveGenerationAsync`, `GetGenerationByIdAsync`, `GetGenerationsPagedAsync`, or `UpdateFeedbackAsync` in this file — only the body of `GetGenerationStatsAsync` changes. Do not change `ILeafletGenerationRepository`, `LeafletFeedbackStats`, or `GetLeafletFeedbackListHandler`.
+
+2. **Add value-correctness unit tests** to `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs` (EF In-Memory provider — `GroupBy(g => 1)` evaluates fine against it). Add these `[Fact]` methods to the existing class, following its existing arrange/act/assert style:
+   - `GetGenerationStatsAsync_returns_zeroed_stats_when_table_is_empty` — call on empty context, assert `TotalGenerations == 0`, `TotalWithFeedback == 0`, `AvgPrecisionScore == null`, `AvgStyleScore == null`.
+   - `GetGenerationStatsAsync_returns_zero_with_feedback_and_null_averages_when_no_rows_have_feedback` — seed 2-3 `LeafletGeneration` rows with `PrecisionScore = null, StyleScore = null`, assert `TotalGenerations` matches row count, `TotalWithFeedback == 0`, both averages `null`.
+   - `GetGenerationStatsAsync_computes_correct_totals_and_averages_for_mixed_feedback_rows` — seed a mix: some rows with both scores set (e.g. `PrecisionScore = 4, StyleScore = 5` and `PrecisionScore = 2, StyleScore = 3`), some with neither, some with only `PrecisionScore` set, some with only `StyleScore` set. Assert `TotalGenerations` equals total seeded rows, `TotalWithFeedback` equals count of rows where either score is non-null, `AvgPrecisionScore` equals the manually-computed average of just the non-null `PrecisionScore` values (not counting rows where it's null), and likewise for `AvgStyleScore`.
+   
+   Each new `LeafletGeneration` needs at minimum `Id = Guid.NewGuid()`, `Topic`, `UserId`, `CreatedAt = DateTimeOffset.UtcNow` set (required fields per the existing test file's pattern), plus the `PrecisionScore`/`StyleScore` values under test.
+
+3. **Add the SQL-shape integration test class** `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs`, modeled directly on `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests.cs`:
+   ```csharp
+   using System.Collections.Generic;
+   using System.Data.Common;
+   using System.Threading;
+   using System.Threading.Tasks;
+   using Anela.Heblo.Persistence;
+   using Anela.Heblo.Persistence.Features.Leaflet;
+   using Anela.Heblo.Tests.Common;
+   using FluentAssertions;
+   using Microsoft.EntityFrameworkCore;
+   using Microsoft.EntityFrameworkCore.Diagnostics;
+   using Npgsql;
+   using Xunit;
+
+   namespace Anela.Heblo.Tests.Features.Leaflet;
+
+   [Collection("PostgresIntegration")]
+   [Trait("Category", "Integration")]
+   public class LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests : IAsyncLifetime
+   {
+       private readonly PostgresSharedContainerFixture _fixture;
+       private string _connectionString = null!;
+       private readonly CapturingCommandInterceptor _interceptor = new();
+       private ApplicationDbContext _context = null!;
+       private LeafletGenerationRepository _repository = null!;
+
+       public LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests(PostgresSharedContainerFixture fixture)
+       {
+           _fixture = fixture;
+       }
+
+       public async Task InitializeAsync()
+       {
+           _connectionString = await _fixture.CreateDatabaseAsync("leafletgenerations");
+
+           // Minimal schema — only the columns GetGenerationStatsAsync touches.
+           await using var conn = new NpgsqlConnection(_connectionString);
+           await conn.OpenAsync();
+           await using var cmd = conn.CreateCommand();
+           cmd.CommandText = """
+               CREATE TABLE public."LeafletGenerations" (
+                   "Id"             uuid NOT NULL PRIMARY KEY,
+                   "PrecisionScore" integer NULL,
+                   "StyleScore"     integer NULL
+               );
+
+               INSERT INTO public."LeafletGenerations" ("Id", "PrecisionScore", "StyleScore") VALUES
+                   (gen_random_uuid(), 4,    5),
+                   (gen_random_uuid(), 2,    3),
+                   (gen_random_uuid(), NULL, NULL),
+                   (gen_random_uuid(), 5,    NULL),
+                   (gen_random_uuid(), NULL, 1);
+               """;
+           await cmd.ExecuteNonQueryAsync();
+
+           var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+               .UseNpgsql(_connectionString)
+               .AddInterceptors(_interceptor)
+               .Options;
+
+           _context = new ApplicationDbContext(options);
+           _repository = new LeafletGenerationRepository(_context);
+       }
+
+       public async Task DisposeAsync()
+       {
+           await _context.DisposeAsync();
+       }
+
+       [Fact]
+       public async Task GetGenerationStatsAsync_EmitsExactlyOneSqlCommand()
+       {
+           _interceptor.Reset();
+
+           await _repository.GetGenerationStatsAsync(CancellationToken.None);
+
+           _interceptor.Commands.Should().HaveCount(1);
+       }
+
+       [Fact]
+       public async Task GetGenerationStatsAsync_ReturnsCorrectStatsFromRealDatabase()
+       {
+           _interceptor.Reset();
+
+           var stats = await _repository.GetGenerationStatsAsync(CancellationToken.None);
+
+           stats.TotalGenerations.Should().Be(5);
+           stats.TotalWithFeedback.Should().Be(4, "all rows except the fully-null one have at least one non-null score");
+           stats.AvgPrecisionScore.Should().Be((4 + 2 + 5) / 3.0, "only 3 rows have a non-null PrecisionScore (4, 2, 5)");
+           stats.AvgStyleScore.Should().Be((5 + 3 + 1) / 3.0, "only 3 rows have a non-null StyleScore (5, 3, 1)");
+       }
+
+       private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+       {
+           public List<string> Commands { get; } = new();
+
+           public void Reset() => Commands.Clear();
+
+           public override InterceptionResult<DbDataReader> ReaderExecuting(
+               DbCommand command,
+               CommandEventData eventData,
+               InterceptionResult<DbDataReader> result)
+           {
+               Commands.Add(command.CommandText);
+               return base.ReaderExecuting(command, eventData, result);
+           }
+
+           public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+               DbCommand command,
+               CommandEventData eventData,
+               InterceptionResult<DbDataReader> result,
+               CancellationToken cancellationToken = default)
+           {
+               Commands.Add(command.CommandText);
+               return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+           }
+       }
+   }
+   ```
+   Also add a `[Fact] GetGenerationStatsAsync_EmptyTable_ReturnsZeroedStatsWithoutThrowing` variant: since the fixture's `InitializeAsync` seeds 5 rows for the two facts above, either (a) add a third fact that truncates the table first (`TRUNCATE TABLE public."LeafletGenerations"` via a fresh `NpgsqlConnection`) then asserts `TotalGenerations == 0`, `TotalWithFeedback == 0`, `AvgPrecisionScore == null`, `AvgStyleScore == null`, or (b) give this empty-table case its own dedicated test class with an empty seed. Prefer (a) — a single extra fact in the same class, truncating before calling the repository method — to avoid spinning up a second Postgres database for one assertion.
+
+4. **Run the full backend test suite** for the touched area:
+   ```bash
+   cd backend && dotnet test --filter "FullyQualifiedName~LeafletGeneration"
+   ```
+   Confirm all `LeafletGenerationRepositoryTests` facts pass (EF In-Memory, fast) and both `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests` facts pass (Postgres Testcontainers — requires Docker/Podman available in the environment; this mirrors how `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests` already runs in this suite, so no new environment setup is needed).
+
+5. **Run the existing handler tests** to confirm no regression at the consumer level (they mock the repository, so this just proves the contract didn't change):
+   ```bash
+   cd backend && dotnet test --filter "FullyQualifiedName~GetLeafletFeedbackListHandlerTests"
+   ```
+
+6. **Build and format check** per repo convention:
+   ```bash
+   cd backend && dotnet build && dotnet format --verify-no-changes
+   ```
+
+## Acceptance Criteria
+
+- `GetGenerationStatsAsync` issues exactly one SQL query — verified by `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.GetGenerationStatsAsync_EmitsExactlyOneSqlCommand` asserting `interceptor.Commands.Should().HaveCount(1)`.
+- Method signature `Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken)` and `ILeafletGenerationRepository` are unchanged (no diff outside `LeafletGenerationRepository.cs`'s method body and the two new/updated test files).
+- Value parity with the old four-query implementation confirmed via:
+  - New EF In-Memory facts in `LeafletGenerationRepositoryTests.cs` covering empty table, all-feedback-less rows, and mixed rows (including one-sided `PrecisionScore`-only / `StyleScore`-only rows).
+  - New Postgres integration fact `GetGenerationStatsAsync_ReturnsCorrectStatsFromRealDatabase` confirming exact totals/averages against a real Npgsql/PostgreSQL round trip.
+  - Empty-table fact confirming `LeafletFeedbackStats(0, 0, null, null)` with no exception thrown.
+- `GetLeafletFeedbackListHandlerTests` pass unmodified (they mock `ILeafletGenerationRepository`, so a passing run proves the handler contract is untouched).
+- `dotnet build` succeeds and `dotnet format --verify-no-changes` reports no formatting diffs.
+- No changes to `GetGenerationsPagedAsync`, `GetLeafletFeedbackListHandler`, `LeafletFeedbackStats`, or any DTO/contract type — confirm via `git diff --stat` showing only `LeafletGenerationRepository.cs`, `LeafletGenerationRepositoryTests.cs`, and the new `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs`.

--- a/artifacts/feat-3599/task-plan.r1.md
+++ b/artifacts/feat-3599/task-plan.r1.md
@@ -1,0 +1,232 @@
+# Task Plan: Consolidate `GetGenerationStatsAsync` into a single database query
+
+### task: consolidate-generation-stats-query
+
+## Goal
+Rewrite `LeafletGenerationRepository.GetGenerationStatsAsync` (backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs:55-67) so it computes all four leaflet-feedback aggregates (`total`, `withFeedback`, `avgPrecision`, `avgStyle`) in exactly one database round trip instead of four sequential queries, with zero change to its public signature, return type, or callers. Add test coverage proving both value-correctness and the single-round-trip guarantee.
+
+## Context
+
+**Why:** `GetGenerationStatsAsync` is called on every `GET /api/leaflet/feedback/list` request (via `GetLeafletFeedbackListHandler.Handle`, backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs:36), alongside `GetGenerationsPagedAsync`. Today that's 5 DB round trips per page load (1 paged + 4 stats); this fix brings it to 2 (1 paged + 1 stats). Flagged by the 2026-07-11 architecture review routine as an easy, low-risk perf win.
+
+**Files to read before starting:**
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs` — file to modify. Current `GetGenerationStatsAsync` (lines 55-67):
+  ```csharp
+  public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
+  {
+      var total = await _context.LeafletGenerations.CountAsync(cancellationToken);
+      var withFeedback = await _context.LeafletGenerations
+          .CountAsync(g => g.PrecisionScore != null || g.StyleScore != null, cancellationToken);
+      var avgPrecision = await _context.LeafletGenerations
+          .Where(g => g.PrecisionScore != null)
+          .AverageAsync(g => (double?)g.PrecisionScore, cancellationToken);
+      var avgStyle = await _context.LeafletGenerations
+          .Where(g => g.StyleScore != null)
+          .AverageAsync(g => (double?)g.StyleScore, cancellationToken);
+      return new LeafletFeedbackStats(total, withFeedback, avgPrecision, avgStyle);
+  }
+  ```
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs` — unchanged return type:
+  ```csharp
+  public sealed record LeafletFeedbackStats(
+      int TotalGenerations,
+      int TotalWithFeedback,
+      double? AvgPrecisionScore,
+      double? AvgStyleScore);
+  ```
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs` — entity read by the query. Relevant columns: `Id` (Guid), `PrecisionScore` (`int?`), `StyleScore` (`int?`). Also has `Topic`, `UserId`, `CreatedAt`, `FeedbackComment` (not touched by this query).
+- `backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceRepository.cs:35-73` — the sibling implementation to mirror structurally (`GroupBy(g => 1)` + conditional `Count`/`Average` + null-group guard).
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests.cs` — the exact template for the new integration test class (Postgres Testcontainers, `DbCommandInterceptor` counting SQL commands, `[Collection("PostgresIntegration")]`).
+- `backend/test/Anela.Heblo.Tests/Common/PostgresSharedContainerFixture.cs` — shared Testcontainers Postgres 16 fixture; call `CreateDatabaseAsync(nameHint)` to get an isolated DB and connection string.
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs` — existing EF In-Memory unit test class for this repository (constructor pattern: `UseInMemoryDatabase($"LeafletGenerationRepositoryTests_{Guid.NewGuid()}")`, `IDisposable`). Add new `[Fact]` methods here.
+
+**Architectural decision (from arch review, binding):** Use LINQ `GroupBy(g => 1)` with an anonymous-type `Select`, materialized via `FirstOrDefaultAsync`. Do **not** use `FromSqlRaw`/`FromSqlInterpolated` — there is zero precedent for raw SQL in this codebase, and the sibling `IssuedInvoiceRepository.GetSyncStatsAsync` already proves EF Core + Npgsql translates this exact shape (mixed `Count()`, conditional `Count(predicate)`, nullable-selector `Average`/`Max`) into one SQL statement.
+
+**Semantics that must be preserved exactly (FR-2, FR-3):**
+- `TotalGenerations` = count of all rows.
+- `TotalWithFeedback` = count where `PrecisionScore != null || StyleScore != null`.
+- `AvgPrecisionScore` = average of non-null `PrecisionScore` values; `null` if none exist (empty table or all-null column) — must NOT throw and must NOT return `0`.
+- `AvgStyleScore` = same rule for `StyleScore`.
+- Empty table → return `LeafletFeedbackStats(0, 0, null, null)` without throwing.
+
+## Steps
+
+1. **Rewrite `GetGenerationStatsAsync`** in `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs` (replace lines 55-67) with:
+   ```csharp
+   public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
+   {
+       var stats = await _context.LeafletGenerations
+           .GroupBy(g => 1)
+           .Select(g => new
+           {
+               Total = g.Count(),
+               WithFeedback = g.Count(x => x.PrecisionScore != null || x.StyleScore != null),
+               AvgPrecision = g.Average(x => (double?)x.PrecisionScore),
+               AvgStyle = g.Average(x => (double?)x.StyleScore),
+           })
+           .FirstOrDefaultAsync(cancellationToken);
+
+       if (stats is null)
+           return new LeafletFeedbackStats(0, 0, null, null);
+
+       return new LeafletFeedbackStats(stats.Total, stats.WithFeedback, stats.AvgPrecision, stats.AvgStyle);
+   }
+   ```
+   Do not touch `SaveGenerationAsync`, `GetGenerationByIdAsync`, `GetGenerationsPagedAsync`, or `UpdateFeedbackAsync` in this file — only the body of `GetGenerationStatsAsync` changes. Do not change `ILeafletGenerationRepository`, `LeafletFeedbackStats`, or `GetLeafletFeedbackListHandler`.
+
+2. **Add value-correctness unit tests** to `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs` (EF In-Memory provider — `GroupBy(g => 1)` evaluates fine against it). Add these `[Fact]` methods to the existing class, following its existing arrange/act/assert style:
+   - `GetGenerationStatsAsync_returns_zeroed_stats_when_table_is_empty` — call on empty context, assert `TotalGenerations == 0`, `TotalWithFeedback == 0`, `AvgPrecisionScore == null`, `AvgStyleScore == null`.
+   - `GetGenerationStatsAsync_returns_zero_with_feedback_and_null_averages_when_no_rows_have_feedback` — seed 2-3 `LeafletGeneration` rows with `PrecisionScore = null, StyleScore = null`, assert `TotalGenerations` matches row count, `TotalWithFeedback == 0`, both averages `null`.
+   - `GetGenerationStatsAsync_computes_correct_totals_and_averages_for_mixed_feedback_rows` — seed a mix: some rows with both scores set (e.g. `PrecisionScore = 4, StyleScore = 5` and `PrecisionScore = 2, StyleScore = 3`), some with neither, some with only `PrecisionScore` set, some with only `StyleScore` set. Assert `TotalGenerations` equals total seeded rows, `TotalWithFeedback` equals count of rows where either score is non-null, `AvgPrecisionScore` equals the manually-computed average of just the non-null `PrecisionScore` values (not counting rows where it's null), and likewise for `AvgStyleScore`.
+   
+   Each new `LeafletGeneration` needs at minimum `Id = Guid.NewGuid()`, `Topic`, `UserId`, `CreatedAt = DateTimeOffset.UtcNow` set (required fields per the existing test file's pattern), plus the `PrecisionScore`/`StyleScore` values under test.
+
+3. **Add the SQL-shape integration test class** `backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs`, modeled directly on `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests.cs`:
+   ```csharp
+   using System.Collections.Generic;
+   using System.Data.Common;
+   using System.Threading;
+   using System.Threading.Tasks;
+   using Anela.Heblo.Persistence;
+   using Anela.Heblo.Persistence.Features.Leaflet;
+   using Anela.Heblo.Tests.Common;
+   using FluentAssertions;
+   using Microsoft.EntityFrameworkCore;
+   using Microsoft.EntityFrameworkCore.Diagnostics;
+   using Npgsql;
+   using Xunit;
+
+   namespace Anela.Heblo.Tests.Features.Leaflet;
+
+   [Collection("PostgresIntegration")]
+   [Trait("Category", "Integration")]
+   public class LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests : IAsyncLifetime
+   {
+       private readonly PostgresSharedContainerFixture _fixture;
+       private string _connectionString = null!;
+       private readonly CapturingCommandInterceptor _interceptor = new();
+       private ApplicationDbContext _context = null!;
+       private LeafletGenerationRepository _repository = null!;
+
+       public LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests(PostgresSharedContainerFixture fixture)
+       {
+           _fixture = fixture;
+       }
+
+       public async Task InitializeAsync()
+       {
+           _connectionString = await _fixture.CreateDatabaseAsync("leafletgenerations");
+
+           // Minimal schema — only the columns GetGenerationStatsAsync touches.
+           await using var conn = new NpgsqlConnection(_connectionString);
+           await conn.OpenAsync();
+           await using var cmd = conn.CreateCommand();
+           cmd.CommandText = """
+               CREATE TABLE public."LeafletGenerations" (
+                   "Id"             uuid NOT NULL PRIMARY KEY,
+                   "PrecisionScore" integer NULL,
+                   "StyleScore"     integer NULL
+               );
+
+               INSERT INTO public."LeafletGenerations" ("Id", "PrecisionScore", "StyleScore") VALUES
+                   (gen_random_uuid(), 4,    5),
+                   (gen_random_uuid(), 2,    3),
+                   (gen_random_uuid(), NULL, NULL),
+                   (gen_random_uuid(), 5,    NULL),
+                   (gen_random_uuid(), NULL, 1);
+               """;
+           await cmd.ExecuteNonQueryAsync();
+
+           var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+               .UseNpgsql(_connectionString)
+               .AddInterceptors(_interceptor)
+               .Options;
+
+           _context = new ApplicationDbContext(options);
+           _repository = new LeafletGenerationRepository(_context);
+       }
+
+       public async Task DisposeAsync()
+       {
+           await _context.DisposeAsync();
+       }
+
+       [Fact]
+       public async Task GetGenerationStatsAsync_EmitsExactlyOneSqlCommand()
+       {
+           _interceptor.Reset();
+
+           await _repository.GetGenerationStatsAsync(CancellationToken.None);
+
+           _interceptor.Commands.Should().HaveCount(1);
+       }
+
+       [Fact]
+       public async Task GetGenerationStatsAsync_ReturnsCorrectStatsFromRealDatabase()
+       {
+           _interceptor.Reset();
+
+           var stats = await _repository.GetGenerationStatsAsync(CancellationToken.None);
+
+           stats.TotalGenerations.Should().Be(5);
+           stats.TotalWithFeedback.Should().Be(4, "all rows except the fully-null one have at least one non-null score");
+           stats.AvgPrecisionScore.Should().Be((4 + 2 + 5) / 3.0, "only 3 rows have a non-null PrecisionScore (4, 2, 5)");
+           stats.AvgStyleScore.Should().Be((5 + 3 + 1) / 3.0, "only 3 rows have a non-null StyleScore (5, 3, 1)");
+       }
+
+       private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+       {
+           public List<string> Commands { get; } = new();
+
+           public void Reset() => Commands.Clear();
+
+           public override InterceptionResult<DbDataReader> ReaderExecuting(
+               DbCommand command,
+               CommandEventData eventData,
+               InterceptionResult<DbDataReader> result)
+           {
+               Commands.Add(command.CommandText);
+               return base.ReaderExecuting(command, eventData, result);
+           }
+
+           public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+               DbCommand command,
+               CommandEventData eventData,
+               InterceptionResult<DbDataReader> result,
+               CancellationToken cancellationToken = default)
+           {
+               Commands.Add(command.CommandText);
+               return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+           }
+       }
+   }
+   ```
+   Also add a `[Fact] GetGenerationStatsAsync_EmptyTable_ReturnsZeroedStatsWithoutThrowing` variant: since the fixture's `InitializeAsync` seeds 5 rows for the two facts above, either (a) add a third fact that truncates the table first (`TRUNCATE TABLE public."LeafletGenerations"` via a fresh `NpgsqlConnection`) then asserts `TotalGenerations == 0`, `TotalWithFeedback == 0`, `AvgPrecisionScore == null`, `AvgStyleScore == null`, or (b) give this empty-table case its own dedicated test class with an empty seed. Prefer (a) — a single extra fact in the same class, truncating before calling the repository method — to avoid spinning up a second Postgres database for one assertion.
+
+4. **Run the full backend test suite** for the touched area:
+   ```bash
+   cd backend && dotnet test --filter "FullyQualifiedName~LeafletGeneration"
+   ```
+   Confirm all `LeafletGenerationRepositoryTests` facts pass (EF In-Memory, fast) and both `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests` facts pass (Postgres Testcontainers — requires Docker/Podman available in the environment; this mirrors how `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests` already runs in this suite, so no new environment setup is needed).
+
+5. **Run the existing handler tests** to confirm no regression at the consumer level (they mock the repository, so this just proves the contract didn't change):
+   ```bash
+   cd backend && dotnet test --filter "FullyQualifiedName~GetLeafletFeedbackListHandlerTests"
+   ```
+
+6. **Build and format check** per repo convention:
+   ```bash
+   cd backend && dotnet build && dotnet format --verify-no-changes
+   ```
+
+## Acceptance Criteria
+
+- `GetGenerationStatsAsync` issues exactly one SQL query — verified by `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.GetGenerationStatsAsync_EmitsExactlyOneSqlCommand` asserting `interceptor.Commands.Should().HaveCount(1)`.
+- Method signature `Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken)` and `ILeafletGenerationRepository` are unchanged (no diff outside `LeafletGenerationRepository.cs`'s method body and the two new/updated test files).
+- Value parity with the old four-query implementation confirmed via:
+  - New EF In-Memory facts in `LeafletGenerationRepositoryTests.cs` covering empty table, all-feedback-less rows, and mixed rows (including one-sided `PrecisionScore`-only / `StyleScore`-only rows).
+  - New Postgres integration fact `GetGenerationStatsAsync_ReturnsCorrectStatsFromRealDatabase` confirming exact totals/averages against a real Npgsql/PostgreSQL round trip.
+  - Empty-table fact confirming `LeafletFeedbackStats(0, 0, null, null)` with no exception thrown.
+- `GetLeafletFeedbackListHandlerTests` pass unmodified (they mock `ILeafletGenerationRepository`, so a passing run proves the handler contract is untouched).
+- `dotnet build` succeeds and `dotnet format --verify-no-changes` reports no formatting diffs.
+- No changes to `GetGenerationsPagedAsync`, `GetLeafletFeedbackListHandler`, `LeafletFeedbackStats`, or any DTO/contract type — confirm via `git diff --stat` showing only `LeafletGenerationRepository.cs`, `LeafletGenerationRepositoryTests.cs`, and the new `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs`.

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationRepository.cs
@@ -54,16 +54,21 @@ public class LeafletGenerationRepository : ILeafletGenerationRepository
 
     public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
     {
-        var total = await _context.LeafletGenerations.CountAsync(cancellationToken);
-        var withFeedback = await _context.LeafletGenerations
-            .CountAsync(g => g.PrecisionScore != null || g.StyleScore != null, cancellationToken);
-        var avgPrecision = await _context.LeafletGenerations
-            .Where(g => g.PrecisionScore != null)
-            .AverageAsync(g => (double?)g.PrecisionScore, cancellationToken);
-        var avgStyle = await _context.LeafletGenerations
-            .Where(g => g.StyleScore != null)
-            .AverageAsync(g => (double?)g.StyleScore, cancellationToken);
-        return new LeafletFeedbackStats(total, withFeedback, avgPrecision, avgStyle);
+        var stats = await _context.LeafletGenerations
+            .GroupBy(g => 1)
+            .Select(g => new
+            {
+                Total = g.Count(),
+                WithFeedback = g.Count(x => x.PrecisionScore != null || x.StyleScore != null),
+                AvgPrecision = g.Average(x => (double?)x.PrecisionScore),
+                AvgStyle = g.Average(x => (double?)x.StyleScore),
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (stats is null)
+            return new LeafletFeedbackStats(0, 0, null, null);
+
+        return new LeafletFeedbackStats(stats.Total, stats.WithFeedback, stats.AvgPrecision, stats.AvgStyle);
     }
 
     public async Task<UpdateFeedbackResult> UpdateFeedbackAsync(

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Leaflet;
+using Anela.Heblo.Tests.Common;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet;
+
+[Collection("PostgresIntegration")]
+[Trait("Category", "Integration")]
+public class LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests : IAsyncLifetime
+{
+    private readonly PostgresSharedContainerFixture _fixture;
+    private string _connectionString = null!;
+    private readonly CapturingCommandInterceptor _interceptor = new();
+    private ApplicationDbContext _context = null!;
+    private LeafletGenerationRepository _repository = null!;
+
+    public LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests(PostgresSharedContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _connectionString = await _fixture.CreateDatabaseAsync("leafletgenerations");
+
+        // Minimal schema — only the columns GetGenerationStatsAsync touches.
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE public."LeafletGenerations" (
+                "Id"             uuid NOT NULL PRIMARY KEY,
+                "PrecisionScore" integer NULL,
+                "StyleScore"     integer NULL
+            );
+
+            INSERT INTO public."LeafletGenerations" ("Id", "PrecisionScore", "StyleScore") VALUES
+                (gen_random_uuid(), 4,    5),
+                (gen_random_uuid(), 2,    3),
+                (gen_random_uuid(), NULL, NULL),
+                (gen_random_uuid(), 5,    NULL),
+                (gen_random_uuid(), NULL, 1);
+            """;
+        await cmd.ExecuteNonQueryAsync();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_connectionString)
+            .AddInterceptors(_interceptor)
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new LeafletGenerationRepository(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetGenerationStatsAsync_EmitsExactlyOneSqlCommand()
+    {
+        _interceptor.Reset();
+
+        await _repository.GetGenerationStatsAsync(CancellationToken.None);
+
+        _interceptor.Commands.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetGenerationStatsAsync_ReturnsCorrectStatsFromRealDatabase()
+    {
+        _interceptor.Reset();
+
+        var stats = await _repository.GetGenerationStatsAsync(CancellationToken.None);
+
+        stats.TotalGenerations.Should().Be(5);
+        stats.TotalWithFeedback.Should().Be(4, "all rows except the fully-null one have at least one non-null score");
+        stats.AvgPrecisionScore.Should().Be((4 + 2 + 5) / 3.0, "only 3 rows have a non-null PrecisionScore (4, 2, 5)");
+        stats.AvgStyleScore.Should().Be((5 + 3 + 1) / 3.0, "only 3 rows have a non-null StyleScore (5, 3, 1)");
+    }
+
+    [Fact]
+    public async Task GetGenerationStatsAsync_EmptyTable_ReturnsZeroedStatsWithoutThrowing()
+    {
+        await using (var conn = new NpgsqlConnection(_connectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = """TRUNCATE TABLE public."LeafletGenerations";""";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        _interceptor.Reset();
+
+        var stats = await _repository.GetGenerationStatsAsync(CancellationToken.None);
+
+        stats.TotalGenerations.Should().Be(0);
+        stats.TotalWithFeedback.Should().Be(0);
+        stats.AvgPrecisionScore.Should().BeNull();
+        stats.AvgStyleScore.Should().BeNull();
+    }
+
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        public List<string> Commands { get; } = new();
+
+        public void Reset() => Commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletGenerationRepositoryTests.cs
@@ -84,6 +84,125 @@ public class LeafletGenerationRepositoryTests : IDisposable
         Assert.Equal("great", reloaded.FeedbackComment);
     }
 
+    [Fact]
+    public async Task GetGenerationStatsAsync_returns_zeroed_stats_when_table_is_empty()
+    {
+        // Act
+        var stats = await _repository.GetGenerationStatsAsync(default);
+
+        // Assert
+        Assert.Equal(0, stats.TotalGenerations);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
+
+    [Fact]
+    public async Task GetGenerationStatsAsync_returns_zero_with_feedback_and_null_averages_when_no_rows_have_feedback()
+    {
+        // Arrange
+        _context.LeafletGenerations.AddRange(
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = null,
+                StyleScore = null,
+            },
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = null,
+                StyleScore = null,
+            },
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = null,
+                StyleScore = null,
+            });
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _repository.GetGenerationStatsAsync(default);
+
+        // Assert
+        Assert.Equal(3, stats.TotalGenerations);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
+
+    [Fact]
+    public async Task GetGenerationStatsAsync_computes_correct_totals_and_averages_for_mixed_feedback_rows()
+    {
+        // Arrange
+        _context.LeafletGenerations.AddRange(
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = 4,
+                StyleScore = 5,
+            },
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = 2,
+                StyleScore = 3,
+            },
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = null,
+                StyleScore = null,
+            },
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = 5,
+                StyleScore = null,
+            },
+            new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = "X",
+                UserId = "u1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                PrecisionScore = null,
+                StyleScore = 1,
+            });
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _repository.GetGenerationStatsAsync(default);
+
+        // Assert
+        Assert.Equal(5, stats.TotalGenerations);
+        Assert.Equal(4, stats.TotalWithFeedback);
+        Assert.Equal((4 + 2 + 5) / 3.0, stats.AvgPrecisionScore);
+        Assert.Equal((5 + 3 + 1) / 3.0, stats.AvgStyleScore);
+    }
+
     public void Dispose()
     {
         _context.Dispose();


### PR DESCRIPTION
Closes #3599

## What the issue was
`LeafletGenerationRepository.GetGenerationStatsAsync` issued 4 independent, sequential database queries to compute leaflet feedback statistics (total count, count-with-feedback, average precision score, average style score). This method runs on every `GET /api/leaflet/feedback/list` request, so each page load made 5 DB round trips (1 paged query + 4 stats queries) instead of 2. Flagged by the daily architecture-review routine as an easy, low-risk performance win.

## How it was fixed / handled
Rewrote `GetGenerationStatsAsync` to compute all four aggregates in a single database round trip using a `GroupBy(g => 1)` LINQ projection, mirroring an existing proven pattern already used in this codebase (`IssuedInvoiceRepository.GetSyncStatsAsync`). The method signature, return type (`LeafletFeedbackStats`), and all callers (`ILeafletGenerationRepository`, `GetLeafletFeedbackListHandler`) are unchanged — this is a pure internal implementation change with identical semantics for every input state, including the empty-table case (`LeafletFeedbackStats(0, 0, null, null)`).

Test coverage added at two levels:
- EF In-Memory unit tests in the existing `LeafletGenerationRepositoryTests.cs` proving value parity with the old four-query implementation (empty table, no-feedback rows, mixed feedback rows).
- A new `LeafletGenerationRepositoryGetGenerationStatsSqlShapeTests.cs` Postgres Testcontainers integration test class, modeled on the sibling `IssuedInvoiceRepositoryGetSyncStatsSqlShapeTests`, asserting the query emits exactly one SQL command and returns correct values against a real PostgreSQL database (including an empty-table/truncated case). These Postgres-backed tests could not be executed in the sandbox that built this PR because Docker was unavailable there — verified as a pre-existing environment limitation (the untouched sibling test fails identically), not a defect in this change. They should run normally in CI/local dev with Docker available.

## Artifacts
Brief, spec, architecture review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3599/` in this branch.

## Code review

Full whole-branch review result: **CLEAN** (no blocking correctness findings).

Advisory-only cleanup noted (not required for this PR): `CapturingCommandInterceptor` in the new test file is duplicated verbatim across five SQL-shape test classes in the suite; could be extracted into `Anela.Heblo.Tests.Common`, but this follows the established convention so it wasn't required here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H36bpiD4vroL2UwiPFWCPd)_