### PR TITLE
#3600: batch LeafletChunk inserts into a single multi-row INSERT

### DIFF
--- a/artifacts/feat-3600/arch-review.r1.md
+++ b/artifacts/feat-3600/arch-review.r1.md
@@ -1,0 +1,133 @@
+# Architecture Review: Batch LeafletChunk inserts in AddChunksAsync
+
+## Skip Design: true
+
+Backend-only performance refactor of a single repository method. No UI components, screens, layouts, or visual decisions are involved. No public contract, schema, or caller-visible behavior changes.
+
+## Architectural Fit Assessment
+
+The change fits cleanly into the existing pattern and requires no new architecture. It is a localized rewrite of one method body.
+
+Relevant grounding from the codebase:
+
+- **Target:** `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs`, method `AddChunksAsync` (lines 23–53). It obtains the underlying `NpgsqlConnection` from the shared `ApplicationDbContext`, opens it if closed, then loops one `NpgsqlCommand` per chunk. Everything but the loop stays.
+- **Raw-SQL rationale is real and documented.** `LeafletChunkConfiguration` (`backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletChunkConfiguration.cs:18`) calls `builder.Ignore(x => x.Embedding)` — EF does not map the pgvector column, so the embedding must be written via raw Npgsql with `Pgvector.Vector`. This confirms the "raw SQL is necessary, the per-row loop is not" framing.
+- **Column list must mirror EF mapping.** The gotcha at `memory/gotchas/raw-sql-insert-must-match-ef-mapping.md` records a real prior incident (silent `Summary = ""` data loss) and names this exact method. The existing inline comment (line 34) referencing that file must survive the rewrite. The correct column set is `("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")`.
+- **A sibling method has the identical anti-pattern.** `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs` `AddChunksAsync` (lines 24–53) is the same per-row loop against `KnowledgeBaseChunks`. It is explicitly out of scope for feat-3600 but is the obvious next candidate; keeping the two shaped identically eases a future parallel fix. Do **not** touch it in this change.
+- **No abstraction layer to disturb.** `ILeafletDocumentRepository` exposes `AddChunksAsync(IEnumerable<LeafletChunk>, CancellationToken)`; the signature is unchanged, so no interface, DI registration (`LeafletModule`), or caller changes are needed.
+
+Conclusion: the suggested fix in the brief/spec is the right shape and is consistent with every convention in this codebase. Proceed as specified.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+LeafletIndexingService / LeafletIngestionJob (Application)
+        │  calls AddChunksAsync(chunks)
+        ▼
+ILeafletDocumentRepository  (Domain contract — unchanged)
+        ▼
+LeafletDocumentRepository.AddChunksAsync  (Persistence — THIS CHANGE)
+        │  1. chunks.ToList()
+        │  2. if empty → return (no command)
+        │  3. get NpgsqlConnection from ApplicationDbContext, open if closed
+        │  4. for each batch of ≤ BatchSize chunks:
+        │        build one multi-row INSERT ... VALUES (row0),(row1),...
+        │        + ON CONFLICT ("Id") DO NOTHING
+        │        bind uniquely-named params per row (Embedding → new Vector(...))
+        │        ExecuteNonQueryAsync(ct)   ← one round trip per batch
+        ▼
+PostgreSQL "LeafletChunks" (pgvector vector(1536) column)
+```
+
+Only the boxed method body changes. Everything above and below the box is untouched.
+
+### Key Design Decisions
+
+#### Decision 1: Multi-row parameterised INSERT vs. NpgsqlBinaryImporter (COPY)
+
+**Options considered:**
+- (A) Single multi-row `INSERT ... VALUES (…),(…)` with per-row bound parameters.
+- (B) Binary COPY via `NpgsqlBinaryImporter` (`connection.BeginBinaryImport`).
+
+**Chosen approach:** (A) multi-row parameterised INSERT.
+
+**Rationale:** COPY does not support `ON CONFLICT ... DO NOTHING`; preserving idempotent re-ingestion (FR-3, and covered by an existing integration test) would require a staging-table + merge dance that dwarfs the value. Expected batch sizes are tens of chunks (a 30k-word brochure ≈ 38 chunks), where INSERT-vs-COPY throughput is indistinguishable — the win here is round-trip count (N → 1), not raw copy bandwidth. The spec explicitly places COPY out of scope. Confirmed correct.
+
+#### Decision 2: Parameter-limit safety via a fixed batch size
+
+**Options considered:**
+- (A) Assume chunk counts are always small; emit one command.
+- (B) Chunk the input into batches sized by a compile-time constant so a single command never approaches Npgsql's 65,535-parameter ceiling.
+
+**Chosen approach:** (B), with a named constant.
+
+**Rationale:** 7 params/row → hard ceiling ≈ 9,362 rows/command. Realistic input is far below that, but a pathological document must not throw `NpgsqlException`. A conservative constant (e.g. `MaxRowsPerBatch = 1000`, ~7,000 params — comfortably under the limit and well within a readable SQL string) makes the method total-over-input-size without a per-input guard. Realistic inputs (≤ ~100 chunks) still emit exactly one command, satisfying FR-1 and FR-6 simultaneously.
+
+#### Decision 3: Parameter binding — reuse the existing `AddWithValue` + `Vector` approach
+
+**Options considered:** typed `NpgsqlParameter` construction vs. the current `AddWithValue`.
+
+**Chosen approach:** keep `AddWithValue`, wrapping `Embedding` as `new Vector(chunk.Embedding)` exactly as today, just with indexed names (`id0`, `doc0`, …).
+
+**Rationale:** minimal diff, matches the established convention in both this method and `SearchSimilarAsync`. The pgvector data-source is already configured with `UseVector()` (see the integration test setup), so `Vector` binds correctly. No reason to change the binding mechanism.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Single edit:
+
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs` — replace the body of `AddChunksAsync` (lines 25–52). Add one `private const int` for the batch size at class scope.
+
+Add/adjust tests in the existing file:
+
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs` (Testcontainers `pgvector/pgvector:pg16`, already exercises `AddChunksAsync` for single-chunk, idempotency, and multi-chunk search). Note this test schema declares `Embedding vector(3)` — multi-row inserts with 3-dim vectors work identically to 1536-dim, so the existing harness is sufficient. No production `vector(1536)` dependency in tests.
+
+### Interfaces and Contracts
+
+Unchanged. Signature stays:
+
+```csharp
+Task AddChunksAsync(IEnumerable<LeafletChunk> chunks, CancellationToken ct = default)
+```
+
+Invariants the implementation must hold:
+- Column list and order: `("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")` — mirror `LeafletChunkConfiguration`; keep the `memory/gotchas/raw-sql-insert-must-match-ef-mapping.md` comment.
+- Trailing `ON CONFLICT ("Id") DO NOTHING` on every emitted command.
+- Every value bound as a parameter; only fixed, code-generated placeholder names (`@id{i}`) may be interpolated into SQL text (NFR-2). Never concatenate chunk field values.
+- `ct` passed to `OpenAsync` and every `ExecuteNonQueryAsync`.
+- Do not close/dispose the connection — it is owned by `ApplicationDbContext` (NFR-3). The current code correctly never disposes it; preserve that.
+- Empty input → return before building/executing any command (FR-5).
+
+### Data Flow
+
+1. Caller (`LeafletIndexingService` / `LeafletIngestionJob`) produces `LeafletChunk` list (with embeddings) and calls `AddChunksAsync`.
+2. Method materializes to a list; if empty, returns.
+3. Acquires the DbContext's `NpgsqlConnection`, opens if closed.
+4. For each slice of ≤ `MaxRowsPerBatch` chunks: build one INSERT via `StringBuilder`, append `(@id{i},@doc{i},…)` per row, bind indexed params (wrap `Embedding` in `Vector`), append `ON CONFLICT DO NOTHING`, `ExecuteNonQueryAsync(ct)`.
+5. Rows land in `LeafletChunks`; already-present `Id`s are skipped by conflict clause. Read paths (`SearchSimilarAsync`, `GetChunkByIdAsync`) are unaffected.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Column list drifts from EF mapping again (repeat of the `Summary` incident) | High | Keep the exact 7-column list and the inline gotcha comment; existing `AddChunksAsync_PersistsSummary` integration test guards `Summary`. |
+| Parameter placeholder / value index mismatch when generating `@id{i}` names | Medium | Bind params in the same loop that appends the placeholder; add a multi-chunk (≥2) round-trip test asserting all rows persist with correct per-row values. |
+| Exceeding Npgsql's 65,535-param limit on pathological documents | Low | Fixed `MaxRowsPerBatch` constant well under the ceiling; loop over batches. |
+| Embedding written as string/array instead of `vector` | Medium | Reuse `new Vector(chunk.Embedding)` binding (unchanged); existing `SearchSimilarAsync` test verifies vector semantics end-to-end. |
+| Idempotency regression (double-insert throws) | Medium | Retain `ON CONFLICT ("Id") DO NOTHING` on every command; existing `AddChunksAsync_IsIdempotent_WhenCalledTwiceWithSameId` test guards it. |
+| Empty-input emits invalid `VALUES ()` SQL | Low | Early return on empty list (FR-5); add a test asserting no throw and no rows for empty input. |
+| Accidentally disposing the DbContext-owned connection | Low | Do not wrap the connection in `await using`; only the command is disposed. Matches current code. |
+
+## Specification Amendments
+
+None required — the spec is complete, accurate, and consistent with the codebase. Two clarifying notes for the implementer (not spec changes):
+
+1. **Batch constant naming/value.** The spec leaves the threshold as "safe" (FR-6). Recommend a named `private const int MaxRowsPerBatch = 1000;` (≈7,000 params) rather than computing against 65,535 at runtime — simpler, obviously safe, and keeps generated SQL readable. Any value ≤ ~9,000 satisfies the requirement.
+2. **Test additions.** Current integration tests cover single-chunk persist, idempotency, and 2-chunk search, but none asserts the FR-1 "exactly one command / one round trip" property or a batch with N ≥ 3 preserving per-row values. Add: (a) a multi-chunk (e.g. 5) insert asserting all rows present with correct distinct values, and (b) an empty-input no-op test. The "exactly one round trip" claim is hard to assert against Testcontainers without command interception; treat it as covered by construction (single `ExecuteNonQueryAsync` per batch) plus the multi-row correctness test, rather than adding a mock-based counting harness.
+
+## Prerequisites
+
+None. No migration, schema, config, infrastructure, or new NuGet dependency. `Npgsql` and `Pgvector` are already referenced; the pgvector extension and `vector(1536)` column already exist. Implementation can start immediately.

--- a/artifacts/feat-3600/brief.md
+++ b/artifacts/feat-3600/brief.md
@@ -1,0 +1,67 @@
+# [arch-review] Leaflet: AddChunksAsync inserts chunks one-by-one in a loop instead of batching
+
+## Module
+Leaflet
+
+## Finding
+`LeafletDocumentRepository.AddChunksAsync` creates and executes a separate `NpgsqlCommand` for each chunk in a sequential loop:
+
+```csharp
+// backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs:25–52
+foreach (var chunk in chunkList)
+{
+    await using var cmd = new NpgsqlCommand(
+        """
+        INSERT INTO "LeafletChunks" ("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")
+        VALUES (@id, @documentId, @chunkIndex, @content, @summary, @wordCount, @embedding)
+        ON CONFLICT ("Id") DO NOTHING
+        """,
+        connection);
+    // parameters bound...
+    await cmd.ExecuteNonQueryAsync(ct);
+}
+```
+
+For a document that produces N chunks, this is N sequential database round trips. The chunking parameters (`ChunkSize = 800 words`, `ChunkOverlap = 80 words`) mean a 10 000-word PDF produces ~13 chunks, and a long marketing brochure of 30 000 words produces ~38 chunks — 38 individual round trips.
+
+The raw-Npgsql approach is necessary because EF Core cannot natively handle pgvector's `vector(1536)` type via `AddRange`, but the per-row loop is not. Npgsql supports a multi-row parameterised `INSERT` (single command with N value rows) or the binary copy protocol (`NpgsqlBinaryImporter`) for bulk data.
+
+## Why it matters
+Every OneDrive ingestion and every manual upload pays this cost. A 30-chunk document takes ~38 DB round trips instead of ~1. Over a slow or saturated connection (Azure SQL networking within a single region is fast but not free), this compounds with the sequential `await` pattern: chunk 2's insert cannot start until chunk 1's round trip completes.
+
+## Suggested fix
+Build a single multi-row `INSERT` statement with all chunk rows, parameterised per-row:
+
+```csharp
+var sb = new StringBuilder(
+    """
+    INSERT INTO "LeafletChunks" ("Id","DocumentId","ChunkIndex","Content","Summary","WordCount","Embedding")
+    VALUES
+    """);
+
+await using var cmd = new NpgsqlCommand();
+cmd.Connection = connection;
+
+for (var i = 0; i < chunkList.Count; i++)
+{
+    if (i > 0) sb.Append(',');
+    sb.Append($"(@id{i},@doc{i},@ci{i},@content{i},@summary{i},@wc{i},@emb{i})");
+    var c = chunkList[i];
+    cmd.Parameters.AddWithValue($"id{i}", c.Id);
+    cmd.Parameters.AddWithValue($"doc{i}", c.DocumentId);
+    cmd.Parameters.AddWithValue($"ci{i}", c.ChunkIndex);
+    cmd.Parameters.AddWithValue($"content{i}", c.Content);
+    cmd.Parameters.AddWithValue($"summary{i}", c.Summary);
+    cmd.Parameters.AddWithValue($"wc{i}", c.WordCount);
+    cmd.Parameters.AddWithValue($"emb{i}", new Vector(c.Embedding));
+}
+
+sb.Append(""" ON CONFLICT ("Id") DO NOTHING""");
+cmd.CommandText = sb.ToString();
+await cmd.ExecuteNonQueryAsync(ct);
+```
+
+Or use `NpgsqlBinaryImporter` for even better throughput on large batches. Either approach reduces N round trips to 1.
+
+---
+_Filed by daily arch-review routine on 2026-07-11._

--- a/artifacts/feat-3600/design.r1.md
+++ b/artifacts/feat-3600/design.r1.md
@@ -1,0 +1,53 @@
+# Design: Batch LeafletChunk inserts in AddChunksAsync
+
+## Component Design
+
+No new components. One method body is rewritten; everything around it (interface, DI, callers) is untouched.
+
+- **`LeafletDocumentRepository.AddChunksAsync`** (`backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs`, currently lines 23–53)
+  Signature unchanged: `Task AddChunksAsync(IEnumerable<LeafletChunk> chunks, CancellationToken ct = default)`.
+  Responsibility: persist a batch of `LeafletChunk` rows for a document in as few round trips as possible, preserving idempotency and pgvector binding.
+  New internal shape:
+  1. `var list = chunks.ToList();` — if `list.Count == 0`, return immediately (no command built or executed).
+  2. Acquire the `NpgsqlConnection` from `ApplicationDbContext` exactly as today; open it if closed; never dispose/close it here (connection lifecycle owned by the DbContext).
+  3. Split `list` into slices of at most `MaxRowsPerBatch` rows (new `private const int MaxRowsPerBatch = 1000;` at class scope).
+  4. For each slice, build one `NpgsqlCommand` via `StringBuilder`:
+     - Column list fixed as `("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")`, matching `LeafletChunkConfiguration`. Retain the existing inline comment referencing `memory/gotchas/raw-sql-insert-must-match-ef-mapping.md`.
+     - Append one `(@id{i}, @doc{i}, @idx{i}, @content{i}, @summary{i}, @wc{i}, @emb{i})` group per row in the slice, `i` being the row's index within that slice (each slice restarts its own local parameter numbering, so no command ever needs more than `MaxRowsPerBatch * 7` parameters).
+     - Bind each parameter with `AddWithValue` in the same loop that appends its placeholder, so index and value never drift apart. `Embedding` is wrapped as `new Pgvector.Vector(chunk.Embedding)`, unchanged from today.
+     - Append a single trailing `ON CONFLICT ("Id") DO NOTHING` for the whole statement.
+     - `await cmd.ExecuteNonQueryAsync(ct)` — one call per slice/batch.
+  5. Realistic inputs (tens of chunks) always take the single-slice path: one `ExecuteNonQueryAsync` call total. Only pathological inputs (> ~1000 chunks) incur `ceil(N / MaxRowsPerBatch)` calls.
+
+- **Callers** (`LeafletIndexingService` / ingestion job) — no change; they call `AddChunksAsync(chunks)` exactly as before.
+- **`ILeafletDocumentRepository`** — no change.
+- **`KnowledgeBaseRepository.AddChunksAsync`** — explicitly out of scope; not touched, left with its existing per-row loop for a possible future, separate fix.
+
+## Data Schemas
+
+No schema change. Documented here only to confirm the INSERT shape matches the existing table exactly.
+
+**Table: `LeafletChunks`**
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | `uuid` (PK) | one param per row, e.g. `@id0` |
+| `DocumentId` | `uuid` (FK → `LeafletDocuments`) | `@doc0` |
+| `ChunkIndex` | `int` | `@idx0` |
+| `Content` | `text` | `@content0` |
+| `Summary` | `text` | `@summary0` |
+| `WordCount` | `int` | `@wc0` |
+| `Embedding` | `vector(1536)` (pgvector) | `@emb0`, bound as `new Pgvector.Vector(chunk.Embedding)` |
+
+Generated SQL shape (illustrative, 2-row batch):
+
+```sql
+INSERT INTO "LeafletChunks"
+    ("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")
+VALUES
+    (@id0, @doc0, @idx0, @content0, @summary0, @wc0, @emb0),
+    (@id1, @doc1, @idx1, @content1, @summary1, @wc1, @emb1)
+ON CONFLICT ("Id") DO NOTHING;
+```
+
+No API request/response shapes or event payloads are affected — this is a private repository-method internal to the persistence layer, invoked in-process with no wire contract.

--- a/artifacts/feat-3600/impl/batch-leaflet-addchunks-insert.r1.md
+++ b/artifacts/feat-3600/impl/batch-leaflet-addchunks-insert.r1.md
@@ -1,0 +1,37 @@
+# Implementation: batch-leaflet-addchunks-insert
+
+## What was implemented
+Replaced the per-chunk `NpgsqlCommand` loop in `LeafletDocumentRepository.AddChunksAsync` with a single multi-row parameterised `INSERT`, batched at `MaxRowsPerBatch = 1000` rows to stay comfortably under Npgsql's 65,535-parameter ceiling. An N-chunk document now issues `ceil(N / 1000)` round trips instead of N. Empty input now returns immediately instead of opening a connection for no work.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs` — `AddChunksAsync` rewritten to build one `VALUES (...), (...), ...` INSERT per batch; added `using System.Text;` and the `MaxRowsPerBatch` constant. The exact 7-column list (`Id, DocumentId, ChunkIndex, Content, Summary, WordCount, Embedding`), the `ON CONFLICT ("Id") DO NOTHING` clause, the `Pgvector.Vector` binding, and the inline comment referencing `memory/gotchas/raw-sql-insert-must-match-ef-mapping.md` are all preserved verbatim.
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs` — added `AddChunksAsync_PersistsAllRows_WhenMultipleChunks` (5 chunks, asserts every row's Id/ChunkIndex/Content/Summary/WordCount persisted correctly and in order) and `AddChunksAsync_IsNoOp_WhenInputEmpty` (empty enumerable throws nothing and inserts nothing).
+
+## Tests
+- `LeafletRepositoryIntegrationTests` (13 tests total, including the 2 new ones) are Testcontainers-based (`pgvector/pgvector:pg16`) and require a Docker daemon.
+- **Environment-gated:** this sandbox has no Docker daemon (`docker ps` → "failed to connect to the docker API ... no such file or directory"). All 13 tests in the class — including the 11 pre-existing ones — fail identically at the constructor with `Docker is either not running or misconfigured`, confirming this is an environment limitation, not a regression introduced by this change.
+- `dotnet build` succeeded with 0 errors for both `Anela.Heblo.Persistence.csproj` and `Anela.Heblo.Tests.csproj` (only pre-existing, unrelated nullable-reference warnings in other files).
+- `dotnet format` on `Anela.Heblo.Persistence.csproj` made no additional changes beyond the hand-written diff.
+
+## How to verify
+In an environment with Docker available:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletRepositoryIntegrationTests"
+```
+Expect all 13 tests green, including `AddChunksAsync_PersistsAllRows_WhenMultipleChunks` and `AddChunksAsync_IsNoOp_WhenInputEmpty`.
+
+## Notes
+- The original per-row implementation was already functionally correct, so this is a pure performance/round-trip-count refactor; the new tests are correctness guards for the rewrite (multi-row batching, empty-input no-op) rather than regression tests for a prior bug.
+- `KnowledgeBaseRepository.cs` (which has the identical anti-pattern per the architect's finding) was left untouched — explicitly out of scope for this issue.
+- Integration test execution could not be verified in this sandbox due to the missing Docker daemon; CI (which does have Docker) should be treated as the real gate for this class.
+
+## PR Summary
+Batches the per-chunk raw-SQL `INSERT` loop in `LeafletDocumentRepository.AddChunksAsync` into a single multi-row parameterised `INSERT` per 1000-row batch, cutting an N-chunk document's DB round trips from N to `ceil(N/1000)` (effectively 1 for any realistic document). The exact 7-column list, `ON CONFLICT DO NOTHING` idempotency, and `Pgvector` embedding binding are preserved unchanged, per the documented gotcha that raw-SQL inserts must stay in sync with the EF mapping. Adds two integration tests covering multi-chunk persistence correctness and empty-input handling.
+
+### Changes
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs` — batched multi-row INSERT rewrite of `AddChunksAsync`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs` — two new integration tests
+
+## Status
+DONE_WITH_CONCERNS

--- a/artifacts/feat-3600/review/batch-leaflet-addchunks-insert.r1.md
+++ b/artifacts/feat-3600/review/batch-leaflet-addchunks-insert.r1.md
@@ -1,0 +1,58 @@
+# Code Review: batch-leaflet-addchunks-insert
+
+## Summary
+The implementation correctly replaces the per-chunk `NpgsqlCommand` loop with a single parameterised multi-row `INSERT` per batch (MaxRowsPerBatch=1000), cutting N round trips to ceil(N/1000). All critical requirements are satisfied: the 7-column list, `ON CONFLICT` idempotency, `Pgvector` embedding binding, cancellation token propagation, connection lifecycle preservation, and the gotcha-reference comment are all present and correct. Two well-structured integration tests with proper assertions cover multi-chunk persistence and empty-input handling. Build and format both succeed cleanly.
+
+## Review Result: PASS
+
+### task: batch-leaflet-addchunks-insert
+**Status:** PASS
+
+## Detailed Findings
+
+### Spec Compliance
+- **7-column list** (line 43): Exact match required — `("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")` preserved in correct order ✓
+- **ON CONFLICT clause** (line 63): `ON CONFLICT ("Id") DO NOTHING` terminates the SQL, ensuring idempotency (FR-3) ✓
+- **Vector binding** (line 60): `new Vector(chunk.Embedding)` used correctly; never a string or raw array ✓
+- **CancellationToken propagation**: 
+  - `OpenAsync(ct)` at line 35 ✓
+  - `ExecuteNonQueryAsync(ct)` at line 66 ✓
+- **Connection lifecycle** (line 33): Obtained from `_context.Database.GetDbConnection()`, not disposed in this method; only the `NpgsqlCommand` is disposed via `await using` at line 45 ✓
+- **Gotcha-reference comment** (line 41): `// Column list MUST mirror LeafletChunkConfiguration. See memory/gotchas/raw-sql-insert-must-match-ef-mapping.md` preserved verbatim ✓
+- **Empty input early return** (lines 30–31): Returns immediately if `chunkList.Count == 0`, preventing invalid `VALUES ()` SQL (FR-5) ✓
+
+### Architecture
+- **using directive** (line 1): `using System.Text;` added for `StringBuilder` ✓
+- **Batch constant** (line 14): `MaxRowsPerBatch = 1000` with correct ceiling math (7 params/row × 1000 rows = 7,000 params, well under Npgsql's 65,535 limit) ✓
+- **Batching logic** (lines 37–67): 
+  - `Skip(offset).Take(MaxRowsPerBatch)` correctly slices in-memory list
+  - Parameter indices restart at 0 per batch (no cross-batch collision risk)
+  - Placeholder names (`@id{i}`, `@documentId{i}`, etc.) and parameter values added in same loop iteration — impossible to drift ✓
+- **SQL injection prevention**: All values parameterized via `AddWithValue`. No string concatenation of chunk field values into SQL. Fixed, code-generated placeholder names only. ✓
+
+### Test Coverage
+- **AddChunksAsync_PersistsAllRows_WhenMultipleChunks** (lines 175–213):
+  - Correct: Creates 5 distinct chunks with varying ChunkIndex, Content, Summary, WordCount
+  - Correct: Asserts count = 5 and all fields match (Id, ChunkIndex, Content, Summary, WordCount)
+  - Correct: Ordered by ChunkIndex to ensure row identity
+  - ✓
+- **AddChunksAsync_IsNoOp_WhenInputEmpty** (lines 216–232):
+  - Correct: Passes `Array.Empty<LeafletChunk>()`
+  - Correct: Asserts no exception thrown and no rows inserted
+  - ✓
+
+### Build & Format
+- **dotnet build** Anela.Heblo.Persistence.csproj: **0 errors** (warnings are pre-existing in unrelated files) ✓
+- **dotnet format --verify-no-changes**: Clean (no additional formatting needed) ✓
+
+### Files Changed
+- Only the two intended files modified (verified via `git diff --name-only HEAD~1 HEAD`):
+  - `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs`
+  - `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs`
+- No unintended changes to `KnowledgeBaseRepository.cs` or other out-of-scope files ✓
+
+### Test Execution Environment Note
+Integration tests require Docker/Testcontainers and cannot execute in this sandbox (confirmed: "Docker is either not running or misconfigured"). All 13 tests in the class (11 pre-existing + 2 new) fail identically at container startup, confirming this is an **environment limitation**, not a regression. Code-level test logic is correct upon inspection. Real verification gate is CI (which has Docker available).
+
+## Overall Notes
+This is a well-executed performance refactor with excellent attention to the documented gotchas. The multi-row batching is sound, parameter binding is safe from SQL injection, and the test suite properly validates multi-chunk persistence and empty-input handling. No issues identified.

--- a/artifacts/feat-3600/spec.r1.md
+++ b/artifacts/feat-3600/spec.r1.md
@@ -1,0 +1,111 @@
+# Specification: Batch LeafletChunk inserts in AddChunksAsync
+
+## Summary
+`LeafletDocumentRepository.AddChunksAsync` currently inserts each `LeafletChunk` with its own `NpgsqlCommand` inside a sequential `foreach` loop, producing N database round trips per document (~38 for a 30 000-word brochure). This spec defines replacing that loop with a single parameterised multi-row `INSERT`, reducing the write to one round trip while preserving the existing idempotent (`ON CONFLICT DO NOTHING`) semantics, the pgvector column handling, and the EF-mapping-aligned column list. This is a performance refactor of one method; no public contract, schema, or behavior visible to callers changes.
+
+## Background
+Leaflet documents (PDFs, marketing brochures) are ingested via OneDrive sync and manual upload. Each document is split into chunks (`ChunkSize = 800` words, `ChunkOverlap = 80` words) and each chunk carries a `vector(1536)` embedding stored in the `LeafletChunks` table via the pgvector extension.
+
+Raw Npgsql is used (rather than EF `AddRange`) because EF Core cannot natively bind pgvector's `vector(1536)` type. That constraint justifies raw SQL, but not the per-row loop: because each insert is `await`ed before the next begins, chunk *i*+1's round trip cannot start until chunk *i* completes. Every ingestion pays this sequential cost. A daily arch-review routine flagged the method (finding filed 2026-07-11).
+
+The current implementation (`backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs`, lines 23–53) obtains the underlying `NpgsqlConnection` from the shared `ApplicationDbContext`, opens it if needed, then loops. The fix stays within this method — connection acquisition, opening logic, and method signature remain unchanged.
+
+## Functional Requirements
+
+### FR-1: Single multi-row INSERT for all chunks
+Replace the per-chunk `foreach`/`NpgsqlCommand`/`ExecuteNonQueryAsync` loop with a single `NpgsqlCommand` whose `CommandText` is one `INSERT ... VALUES (row1), (row2), ..., (rowN)` statement, with each row bound to its own uniquely-named parameters.
+
+**Acceptance criteria:**
+- Inserting a document that produces N chunks (N ≥ 1) issues exactly one `ExecuteNonQueryAsync` call (one server round trip for the insert), verifiable by test double or command counting.
+- All N chunks are persisted with identical column values to the previous implementation (byte-for-byte equivalent rows).
+- The parameter values for each row are bound via distinct parameter names (e.g. `@id0..@idN-1`) so no value collision occurs.
+
+### FR-2: Preserve column list and EF-mapping alignment
+The `INSERT` column list must remain exactly `("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")`, in that order, mirroring `LeafletChunkConfiguration`. The inline comment / reference to `memory/gotchas/raw-sql-insert-must-match-ef-mapping.md` must be retained (updated wording is acceptable, but the caveat must not be lost).
+
+**Acceptance criteria:**
+- Column list and order are unchanged from the current statement.
+- The gotcha reference is present in the resulting code.
+
+### FR-3: Preserve idempotency via ON CONFLICT
+The statement must retain `ON CONFLICT ("Id") DO NOTHING` so that re-ingesting a document (same chunk `Id`s) is a no-op for already-present rows and does not throw.
+
+**Acceptance criteria:**
+- Calling `AddChunksAsync` twice with the same chunk set does not throw and results in exactly one copy of each chunk row.
+- A partially-overlapping batch (some new `Id`s, some existing) inserts only the new rows.
+
+### FR-4: Correct pgvector embedding binding
+Each chunk's `Embedding` (`float[]`) must be wrapped as `new Pgvector.Vector(chunk.Embedding)` and bound to the `Embedding` parameter, exactly as the current code does, so the `vector(1536)` column is populated correctly.
+
+**Acceptance criteria:**
+- Persisted `Embedding` values are identical to those written by the current implementation for the same input.
+- No implicit string/array serialization of the embedding occurs; the `Vector` type is used.
+
+### FR-5: Handle empty and single-element inputs safely
+When the input enumerable is empty, the method must not execute an invalid `INSERT ... VALUES` (empty values list) statement; it should be a no-op (return without executing a command). A single chunk must produce a valid one-row insert.
+
+**Acceptance criteria:**
+- `AddChunksAsync(empty)` completes without throwing and issues no INSERT command.
+- `AddChunksAsync(single chunk)` inserts exactly that one row.
+
+### FR-6: Respect PostgreSQL parameter limit for large documents
+A single Npgsql command supports at most 65 535 bound parameters. With 7 parameters per row, one command can hold ~9 362 rows — far above realistic chunk counts (tens per document). To remain safe for pathological inputs, the implementation must not exceed the parameter limit in a single command: if the chunk count would produce more than a safe threshold of parameters, split into multiple multi-row `INSERT` commands (batches).
+
+**Acceptance criteria:**
+- For realistic inputs (≤ ~100 chunks) a single command is used.
+- An input large enough to exceed the parameter limit (e.g. > 9 000 chunks) is split into multiple commands, each within the limit, and all rows are still inserted. (This path may be covered by a bounded batch-size constant rather than an explicit huge-input test.)
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+For a document of N chunks, the insert must reduce from N sequential round trips to 1 (or `ceil(N / batchSize)` for oversized inputs). No new per-row `await` in the hot path. Target: a 38-chunk document performs a single insert round trip. Memory overhead (the built SQL string plus parameters) is O(N) and acceptable for expected chunk counts.
+
+### NFR-2: Security
+No change to the security posture. All values remain bound as parameters — no chunk field is concatenated into SQL text. The only interpolation into the SQL string is the fixed, code-generated parameter placeholders (e.g. `@id0`), never user/content data. SQL injection surface stays at zero.
+
+### NFR-3: Reliability / correctness
+Behavior on conflict, ordering of columns, and the eager-commit semantics of the surrounding ingestion flow are unchanged. The method continues to use the connection obtained from `ApplicationDbContext` and must not alter the connection lifecycle (do not close a connection the DbContext owns).
+
+## Data Model
+No schema change.
+
+- **LeafletChunks** — `Id` (Guid, PK), `DocumentId` (Guid, FK → LeafletDocuments), `ChunkIndex` (int), `Content` (text), `Summary` (text), `WordCount` (int), `Embedding` (`vector(1536)`, pgvector). Column list and order are fixed by `LeafletChunkConfiguration`.
+- **LeafletDocuments** — parent; unchanged by this work.
+
+Relationship: one `LeafletDocument` has many `LeafletChunk` rows via `DocumentId`.
+
+## API / Interface Design
+No public API change. The affected method signature is unchanged:
+
+```csharp
+Task AddChunksAsync(IEnumerable<LeafletChunk> chunks, CancellationToken ct = default)
+```
+
+Internal shape after the change (illustrative):
+- Materialize `chunks.ToList()`.
+- If empty, return.
+- Acquire and open the `NpgsqlConnection` from the DbContext (unchanged).
+- Build one `INSERT` with a `StringBuilder`, appending `(@id{i},@doc{i},...)` per row and `ON CONFLICT ("Id") DO NOTHING` at the end; bind uniquely-named parameters per row (wrapping `Embedding` in `Vector`).
+- If chunk count exceeds the safe per-command threshold, loop over batches, each its own command.
+- `await cmd.ExecuteNonQueryAsync(ct)` once per command.
+
+`ct` must continue to be passed to `OpenAsync` and `ExecuteNonQueryAsync`.
+
+## Dependencies
+- **Npgsql** — already referenced; `NpgsqlCommand`, parameter binding.
+- **Pgvector** (`Pgvector.Vector`) — already referenced; embedding binding.
+- **pgvector** PostgreSQL extension — already installed for the `vector(1536)` column.
+- **ApplicationDbContext** / EF Core — used only to obtain the underlying connection (unchanged).
+- No new NuGet packages.
+
+## Out of Scope
+- Switching to the binary COPY protocol (`NpgsqlBinaryImporter`). The multi-row `INSERT` is sufficient for expected batch sizes and preserves `ON CONFLICT` semantics, which `COPY` does not support directly. Binary import may be reconsidered later if profiling shows a need, but it is not part of this change.
+- Wrapping the inserts in an explicit transaction. Current behavior does not; introducing transactional semantics is a separate decision (see Open Questions — resolved by keeping existing behavior).
+- Any change to chunking parameters, embedding generation, the ingestion pipeline, or other repository methods.
+- Schema, migration, or `LeafletChunkConfiguration` changes.
+- Frontend changes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-12T07:20:18.956866Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-12T07:21:01.754162Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-12T07:21:01.754162Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-12T07:23:25.494229Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-12T07:18:14.881547Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-12T07:20:18.956866Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-12T07:23:25.494229Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-12T07:23:36.672408Z"
     }
   },
   "tasks": [
     {
       "name": "batch-leaflet-addchunks-insert",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-12T07:23:36.844002Z"
     }
   ]
 }

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-12T07:23:25.494229Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-12T07:23:36.672408Z"
+      "status": "completed",
+      "updated_at": "2026-07-12T07:38:30.313199Z"
     }
   },
   "tasks": [
     {
       "name": "batch-leaflet-addchunks-insert",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-12T07:23:36.844002Z"
+      "updated_at": "2026-07-12T07:38:25.352531Z"
     }
   ]
 }

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-12T07:18:14.881547Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "batch-leaflet-addchunks-insert",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3600/state.json
+++ b/artifacts/feat-3600/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3600",
+  "issue_number": 3600,
+  "created_at": "2026-07-12T07:16:19.153111Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3600/task-context/batch-leaflet-addchunks-insert.md
+++ b/artifacts/feat-3600/task-context/batch-leaflet-addchunks-insert.md
@@ -1,0 +1,197 @@
+### task: batch-leaflet-addchunks-insert
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs:1-53` (add `using System.Text;`, add `MaxRowsPerBatch` const, rewrite `AddChunksAsync` body lines 23-53)
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs` (add two `[Fact]` methods)
+
+**Context you must preserve (do not deviate):**
+- Column list MUST stay exactly `("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")` in that order — it mirrors `LeafletChunkConfiguration`. Dropping/reordering a column caused a real silent-data-loss incident (`Summary = ""`); see `memory/gotchas/raw-sql-insert-must-match-ef-mapping.md`. The inline comment referencing that file MUST survive the rewrite.
+- `ON CONFLICT ("Id") DO NOTHING` MUST terminate every emitted command (idempotency, FR-3).
+- `Embedding` MUST be bound as `new Vector(chunk.Embedding)` (FR-4) — never a string/array.
+- `ct` MUST be passed to `OpenAsync` and every `ExecuteNonQueryAsync`.
+- Do NOT close/dispose the connection (it is owned by the DbContext). Only the `NpgsqlCommand` is disposed (via `await using`).
+- Empty input → return before building/executing any command (FR-5).
+
+- [ ] **Step 1: Write the two failing integration tests first (TDD red).**
+  Open `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs`. Add these two `[Fact]` methods anywhere inside the class (e.g. after `AddChunksAsync_IsIdempotent_WhenCalledTwiceWithSameId`, before line 174). The existing test schema declares `Embedding vector(3)`, so use 3-element embeddings — multi-row inserts behave identically at any dimension.
+
+  ```csharp
+      [Fact]
+      public async Task AddChunksAsync_PersistsAllRows_WhenMultipleChunks()
+      {
+          // Arrange
+          var doc = MakeDocument("multi-chunk-test.pdf", "leaflet-hash-010");
+          await _repository.AddDocumentAsync(doc);
+
+          var chunks = Enumerable.Range(0, 5)
+              .Select(i => new LeafletChunk
+              {
+                  Id = Guid.NewGuid(),
+                  DocumentId = doc.Id,
+                  ChunkIndex = i,
+                  Content = $"Content {i}",
+                  Summary = $"Summary {i}",
+                  WordCount = i + 1,
+                  Embedding = [0.1f * i, 0.2f * i, 0.3f * i]
+              })
+              .ToList();
+
+          // Act: single call inserts all five rows in one multi-row INSERT
+          await _repository.AddChunksAsync(chunks);
+
+          // Assert: every row persisted with its own distinct values
+          var stored = await _context.LeafletChunks
+              .AsNoTracking()
+              .Where(c => c.DocumentId == doc.Id)
+              .OrderBy(c => c.ChunkIndex)
+              .ToListAsync();
+
+          Assert.Equal(5, stored.Count);
+          for (var i = 0; i < 5; i++)
+          {
+              Assert.Equal(chunks[i].Id, stored[i].Id);
+              Assert.Equal(i, stored[i].ChunkIndex);
+              Assert.Equal($"Content {i}", stored[i].Content);
+              Assert.Equal($"Summary {i}", stored[i].Summary);
+              Assert.Equal(i + 1, stored[i].WordCount);
+          }
+      }
+
+      [Fact]
+      public async Task AddChunksAsync_IsNoOp_WhenInputEmpty()
+      {
+          // Arrange
+          var doc = MakeDocument("empty-input-test.pdf", "leaflet-hash-011");
+          await _repository.AddDocumentAsync(doc);
+
+          // Act: empty enumerable must not throw and must issue no INSERT
+          var exception = await Record.ExceptionAsync(
+              () => _repository.AddChunksAsync(Array.Empty<LeafletChunk>()));
+
+          // Assert
+          Assert.Null(exception);
+          var rows = await _context.LeafletChunks
+              .Where(c => c.DocumentId == doc.Id)
+              .ToListAsync();
+          Assert.Empty(rows);
+      }
+  ```
+  Note: `System.Linq` is already available via the file's usings/implicit usings (the file already uses LINQ `.Where`/`.Select`). If `Enumerable` does not resolve, add `using System.Linq;` at the top.
+
+- [ ] **Step 2: Verify the new tests compile and the multi-row test FAILS against the current per-row loop.**
+  Run only the two new tests:
+  ```bash
+  cd /home/user/worktrees/feature-3600-Arch-Review-Leaflet-Addchunksasync-Inserts-Chunks
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~AddChunksAsync_PersistsAllRows_WhenMultipleChunks|FullyQualifiedName~AddChunksAsync_IsNoOp_WhenInputEmpty"
+  ```
+  Expectation: this is the TDD red step. The current implementation actually inserts each chunk in its own command, so `AddChunksAsync_PersistsAllRows_WhenMultipleChunks` and `AddChunksAsync_IsNoOp_WhenInputEmpty` may already pass functionally — they are correctness guards for the refactor, not a behavior change. If Testcontainers/Docker is unavailable in the environment and the tests error at container startup rather than assertion, record that and proceed to implement; the real gate is Step 5 (all tests green after the rewrite). Do NOT weaken the assertions to make them pass.
+
+- [ ] **Step 3: Add the `using System.Text;` directive.**
+  In `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs`, the current usings (lines 1-4) are:
+  ```csharp
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using Microsoft.EntityFrameworkCore;
+  using Npgsql;
+  using Pgvector;
+  ```
+  Add `using System.Text;` so `StringBuilder` resolves. Resulting block:
+  ```csharp
+  using System.Text;
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using Microsoft.EntityFrameworkCore;
+  using Npgsql;
+  using Pgvector;
+  ```
+
+- [ ] **Step 4: Add the batch-size constant and rewrite `AddChunksAsync`.**
+  Add the constant immediately after the `_context` field (after line 10). Replace the entire current `AddChunksAsync` method (lines 23-53) with the batched implementation below. Use exact string replacement.
+
+  Add the constant next to the existing field:
+  ```csharp
+      private readonly ApplicationDbContext _context;
+
+      // 7 params/row × 1000 rows = 7,000 params — comfortably under Npgsql's 65,535 ceiling.
+      private const int MaxRowsPerBatch = 1000;
+  ```
+
+  Replace the method body (old code = current lines 23-53) with:
+  ```csharp
+      public async Task AddChunksAsync(IEnumerable<LeafletChunk> chunks, CancellationToken ct = default)
+      {
+          var chunkList = chunks.ToList();
+          if (chunkList.Count == 0)
+              return;
+
+          var connection = (NpgsqlConnection)_context.Database.GetDbConnection();
+          if (connection.State != System.Data.ConnectionState.Open)
+              await connection.OpenAsync(ct);
+
+          for (var offset = 0; offset < chunkList.Count; offset += MaxRowsPerBatch)
+          {
+              var batch = chunkList.Skip(offset).Take(MaxRowsPerBatch).ToList();
+
+              // Column list MUST mirror LeafletChunkConfiguration. See memory/gotchas/raw-sql-insert-must-match-ef-mapping.md
+              var sql = new StringBuilder(
+                  "INSERT INTO \"LeafletChunks\" (\"Id\", \"DocumentId\", \"ChunkIndex\", \"Content\", \"Summary\", \"WordCount\", \"Embedding\") VALUES ");
+
+              await using var cmd = new NpgsqlCommand { Connection = connection };
+
+              for (var i = 0; i < batch.Count; i++)
+              {
+                  var chunk = batch[i];
+                  if (i > 0)
+                      sql.Append(", ");
+                  sql.Append($"(@id{i}, @documentId{i}, @chunkIndex{i}, @content{i}, @summary{i}, @wordCount{i}, @embedding{i})");
+
+                  cmd.Parameters.AddWithValue($"id{i}", chunk.Id);
+                  cmd.Parameters.AddWithValue($"documentId{i}", chunk.DocumentId);
+                  cmd.Parameters.AddWithValue($"chunkIndex{i}", chunk.ChunkIndex);
+                  cmd.Parameters.AddWithValue($"content{i}", chunk.Content);
+                  cmd.Parameters.AddWithValue($"summary{i}", chunk.Summary);
+                  cmd.Parameters.AddWithValue($"wordCount{i}", chunk.WordCount);
+                  cmd.Parameters.AddWithValue($"embedding{i}", new Vector(chunk.Embedding));
+              }
+
+              sql.Append(" ON CONFLICT (\"Id\") DO NOTHING");
+              cmd.CommandText = sql.ToString();
+
+              await cmd.ExecuteNonQueryAsync(ct);
+          }
+      }
+  ```
+  Rationale for the details:
+  - Empty-list early return satisfies FR-5 (no invalid `VALUES ()`).
+  - Per-batch local parameter numbering (`i` restarts at 0 per slice) keeps any single command ≤ `MaxRowsPerBatch × 7` params (FR-6).
+  - Placeholder text is appended in the same loop iteration that binds the matching parameter, so index/value can never drift (mitigates the placeholder-mismatch risk).
+  - Only fixed, code-generated placeholder names (`@id{i}`) are interpolated into SQL; no chunk field value is ever concatenated (NFR-2).
+  - Column list, `ON CONFLICT`, `Vector` binding, connection lifecycle, and `ct` propagation are all preserved.
+
+- [ ] **Step 5: Build, format, and run the full Leaflet integration test class (TDD green).**
+  ```bash
+  cd /home/user/worktrees/feature-3600-Arch-Review-Leaflet-Addchunksasync-Inserts-Chunks
+  dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  dotnet format backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~LeafletRepositoryIntegrationTests"
+  ```
+  Expectation: build succeeds, formatting clean, and all `LeafletRepositoryIntegrationTests` pass — the two new tests plus the existing guards (`AddChunksAsync_PersistsSummary` proves the `Summary` column stays in the list, `AddChunksAsync_IsIdempotent_WhenCalledTwiceWithSameId` proves `ON CONFLICT` survives, `SearchSimilarAsync_*` prove the `Vector` embedding binding still works end-to-end). If Docker/Testcontainers is unavailable and the integration tests cannot start a container, note that these are environment-gated and confirm at minimum that `dotnet build` (both src and test projects) succeeds; do not mark the task complete on a build-only basis if the test harness is runnable.
+
+- [ ] **Step 6: Confirm no unintended changes and commit.**
+  Verify the diff touches only the two files above, `KnowledgeBaseRepository.cs` is untouched (explicitly out of scope), and the gotcha comment is present in the new code.
+  ```bash
+  cd /home/user/worktrees/feature-3600-Arch-Review-Leaflet-Addchunksasync-Inserts-Chunks
+  git diff --stat
+  git add backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs \
+          backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs
+  git commit -m "Batch LeafletChunk inserts into a single multi-row INSERT
+
+Replace the per-chunk NpgsqlCommand loop in AddChunksAsync with one
+parameterised multi-row INSERT per batch (MaxRowsPerBatch=1000), cutting
+N round trips to one. Preserves the exact 7-column list, ON CONFLICT
+idempotency, and Pgvector embedding binding. Adds multi-chunk and
+empty-input integration tests.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WRZWyCwJ1fyeA2SMEwi2Mi"
+  ```

--- a/artifacts/feat-3600/task-plan.r1.md
+++ b/artifacts/feat-3600/task-plan.r1.md
@@ -1,0 +1,207 @@
+# Task Plan: Batch LeafletChunk inserts in AddChunksAsync
+
+**Goal:** Replace the per-chunk `foreach`/`NpgsqlCommand` loop in `LeafletDocumentRepository.AddChunksAsync` with a single parameterised multi-row `INSERT` (batched under the Npgsql parameter ceiling), reducing N round trips to one per batch while preserving column order, idempotency, and pgvector binding.
+
+**Architecture:** Localized rewrite of one method body in the Persistence layer. The method still obtains the underlying `NpgsqlConnection` from the shared `ApplicationDbContext`, opens it if closed, and never disposes it. The only structural addition is a class-scope `private const int MaxRowsPerBatch` and a `System.Text.StringBuilder`-built multi-row `VALUES` clause with per-row indexed parameter names. No interface, DI, schema, caller, or sibling-repository change.
+
+**Tech Stack:** .NET 8, Npgsql (raw `NpgsqlCommand` + `AddWithValue`), Pgvector (`Pgvector.Vector` for the `vector(1536)` column), EF Core (`ApplicationDbContext` for connection acquisition only), xUnit + Testcontainers (`pgvector/pgvector:pg16`) for integration tests.
+
+---
+
+### task: batch-leaflet-addchunks-insert
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs:1-53` (add `using System.Text;`, add `MaxRowsPerBatch` const, rewrite `AddChunksAsync` body lines 23-53)
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs` (add two `[Fact]` methods)
+
+**Context you must preserve (do not deviate):**
+- Column list MUST stay exactly `("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")` in that order — it mirrors `LeafletChunkConfiguration`. Dropping/reordering a column caused a real silent-data-loss incident (`Summary = ""`); see `memory/gotchas/raw-sql-insert-must-match-ef-mapping.md`. The inline comment referencing that file MUST survive the rewrite.
+- `ON CONFLICT ("Id") DO NOTHING` MUST terminate every emitted command (idempotency, FR-3).
+- `Embedding` MUST be bound as `new Vector(chunk.Embedding)` (FR-4) — never a string/array.
+- `ct` MUST be passed to `OpenAsync` and every `ExecuteNonQueryAsync`.
+- Do NOT close/dispose the connection (it is owned by the DbContext). Only the `NpgsqlCommand` is disposed (via `await using`).
+- Empty input → return before building/executing any command (FR-5).
+
+- [ ] **Step 1: Write the two failing integration tests first (TDD red).**
+  Open `backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs`. Add these two `[Fact]` methods anywhere inside the class (e.g. after `AddChunksAsync_IsIdempotent_WhenCalledTwiceWithSameId`, before line 174). The existing test schema declares `Embedding vector(3)`, so use 3-element embeddings — multi-row inserts behave identically at any dimension.
+
+  ```csharp
+      [Fact]
+      public async Task AddChunksAsync_PersistsAllRows_WhenMultipleChunks()
+      {
+          // Arrange
+          var doc = MakeDocument("multi-chunk-test.pdf", "leaflet-hash-010");
+          await _repository.AddDocumentAsync(doc);
+
+          var chunks = Enumerable.Range(0, 5)
+              .Select(i => new LeafletChunk
+              {
+                  Id = Guid.NewGuid(),
+                  DocumentId = doc.Id,
+                  ChunkIndex = i,
+                  Content = $"Content {i}",
+                  Summary = $"Summary {i}",
+                  WordCount = i + 1,
+                  Embedding = [0.1f * i, 0.2f * i, 0.3f * i]
+              })
+              .ToList();
+
+          // Act: single call inserts all five rows in one multi-row INSERT
+          await _repository.AddChunksAsync(chunks);
+
+          // Assert: every row persisted with its own distinct values
+          var stored = await _context.LeafletChunks
+              .AsNoTracking()
+              .Where(c => c.DocumentId == doc.Id)
+              .OrderBy(c => c.ChunkIndex)
+              .ToListAsync();
+
+          Assert.Equal(5, stored.Count);
+          for (var i = 0; i < 5; i++)
+          {
+              Assert.Equal(chunks[i].Id, stored[i].Id);
+              Assert.Equal(i, stored[i].ChunkIndex);
+              Assert.Equal($"Content {i}", stored[i].Content);
+              Assert.Equal($"Summary {i}", stored[i].Summary);
+              Assert.Equal(i + 1, stored[i].WordCount);
+          }
+      }
+
+      [Fact]
+      public async Task AddChunksAsync_IsNoOp_WhenInputEmpty()
+      {
+          // Arrange
+          var doc = MakeDocument("empty-input-test.pdf", "leaflet-hash-011");
+          await _repository.AddDocumentAsync(doc);
+
+          // Act: empty enumerable must not throw and must issue no INSERT
+          var exception = await Record.ExceptionAsync(
+              () => _repository.AddChunksAsync(Array.Empty<LeafletChunk>()));
+
+          // Assert
+          Assert.Null(exception);
+          var rows = await _context.LeafletChunks
+              .Where(c => c.DocumentId == doc.Id)
+              .ToListAsync();
+          Assert.Empty(rows);
+      }
+  ```
+  Note: `System.Linq` is already available via the file's usings/implicit usings (the file already uses LINQ `.Where`/`.Select`). If `Enumerable` does not resolve, add `using System.Linq;` at the top.
+
+- [ ] **Step 2: Verify the new tests compile and the multi-row test FAILS against the current per-row loop.**
+  Run only the two new tests:
+  ```bash
+  cd /home/user/worktrees/feature-3600-Arch-Review-Leaflet-Addchunksasync-Inserts-Chunks
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~AddChunksAsync_PersistsAllRows_WhenMultipleChunks|FullyQualifiedName~AddChunksAsync_IsNoOp_WhenInputEmpty"
+  ```
+  Expectation: this is the TDD red step. The current implementation actually inserts each chunk in its own command, so `AddChunksAsync_PersistsAllRows_WhenMultipleChunks` and `AddChunksAsync_IsNoOp_WhenInputEmpty` may already pass functionally — they are correctness guards for the refactor, not a behavior change. If Testcontainers/Docker is unavailable in the environment and the tests error at container startup rather than assertion, record that and proceed to implement; the real gate is Step 5 (all tests green after the rewrite). Do NOT weaken the assertions to make them pass.
+
+- [ ] **Step 3: Add the `using System.Text;` directive.**
+  In `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs`, the current usings (lines 1-4) are:
+  ```csharp
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using Microsoft.EntityFrameworkCore;
+  using Npgsql;
+  using Pgvector;
+  ```
+  Add `using System.Text;` so `StringBuilder` resolves. Resulting block:
+  ```csharp
+  using System.Text;
+  using Anela.Heblo.Domain.Features.Leaflet;
+  using Microsoft.EntityFrameworkCore;
+  using Npgsql;
+  using Pgvector;
+  ```
+
+- [ ] **Step 4: Add the batch-size constant and rewrite `AddChunksAsync`.**
+  Add the constant immediately after the `_context` field (after line 10). Replace the entire current `AddChunksAsync` method (lines 23-53) with the batched implementation below. Use exact string replacement.
+
+  Add the constant next to the existing field:
+  ```csharp
+      private readonly ApplicationDbContext _context;
+
+      // 7 params/row × 1000 rows = 7,000 params — comfortably under Npgsql's 65,535 ceiling.
+      private const int MaxRowsPerBatch = 1000;
+  ```
+
+  Replace the method body (old code = current lines 23-53) with:
+  ```csharp
+      public async Task AddChunksAsync(IEnumerable<LeafletChunk> chunks, CancellationToken ct = default)
+      {
+          var chunkList = chunks.ToList();
+          if (chunkList.Count == 0)
+              return;
+
+          var connection = (NpgsqlConnection)_context.Database.GetDbConnection();
+          if (connection.State != System.Data.ConnectionState.Open)
+              await connection.OpenAsync(ct);
+
+          for (var offset = 0; offset < chunkList.Count; offset += MaxRowsPerBatch)
+          {
+              var batch = chunkList.Skip(offset).Take(MaxRowsPerBatch).ToList();
+
+              // Column list MUST mirror LeafletChunkConfiguration. See memory/gotchas/raw-sql-insert-must-match-ef-mapping.md
+              var sql = new StringBuilder(
+                  "INSERT INTO \"LeafletChunks\" (\"Id\", \"DocumentId\", \"ChunkIndex\", \"Content\", \"Summary\", \"WordCount\", \"Embedding\") VALUES ");
+
+              await using var cmd = new NpgsqlCommand { Connection = connection };
+
+              for (var i = 0; i < batch.Count; i++)
+              {
+                  var chunk = batch[i];
+                  if (i > 0)
+                      sql.Append(", ");
+                  sql.Append($"(@id{i}, @documentId{i}, @chunkIndex{i}, @content{i}, @summary{i}, @wordCount{i}, @embedding{i})");
+
+                  cmd.Parameters.AddWithValue($"id{i}", chunk.Id);
+                  cmd.Parameters.AddWithValue($"documentId{i}", chunk.DocumentId);
+                  cmd.Parameters.AddWithValue($"chunkIndex{i}", chunk.ChunkIndex);
+                  cmd.Parameters.AddWithValue($"content{i}", chunk.Content);
+                  cmd.Parameters.AddWithValue($"summary{i}", chunk.Summary);
+                  cmd.Parameters.AddWithValue($"wordCount{i}", chunk.WordCount);
+                  cmd.Parameters.AddWithValue($"embedding{i}", new Vector(chunk.Embedding));
+              }
+
+              sql.Append(" ON CONFLICT (\"Id\") DO NOTHING");
+              cmd.CommandText = sql.ToString();
+
+              await cmd.ExecuteNonQueryAsync(ct);
+          }
+      }
+  ```
+  Rationale for the details:
+  - Empty-list early return satisfies FR-5 (no invalid `VALUES ()`).
+  - Per-batch local parameter numbering (`i` restarts at 0 per slice) keeps any single command ≤ `MaxRowsPerBatch × 7` params (FR-6).
+  - Placeholder text is appended in the same loop iteration that binds the matching parameter, so index/value can never drift (mitigates the placeholder-mismatch risk).
+  - Only fixed, code-generated placeholder names (`@id{i}`) are interpolated into SQL; no chunk field value is ever concatenated (NFR-2).
+  - Column list, `ON CONFLICT`, `Vector` binding, connection lifecycle, and `ct` propagation are all preserved.
+
+- [ ] **Step 5: Build, format, and run the full Leaflet integration test class (TDD green).**
+  ```bash
+  cd /home/user/worktrees/feature-3600-Arch-Review-Leaflet-Addchunksasync-Inserts-Chunks
+  dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  dotnet format backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~LeafletRepositoryIntegrationTests"
+  ```
+  Expectation: build succeeds, formatting clean, and all `LeafletRepositoryIntegrationTests` pass — the two new tests plus the existing guards (`AddChunksAsync_PersistsSummary` proves the `Summary` column stays in the list, `AddChunksAsync_IsIdempotent_WhenCalledTwiceWithSameId` proves `ON CONFLICT` survives, `SearchSimilarAsync_*` prove the `Vector` embedding binding still works end-to-end). If Docker/Testcontainers is unavailable and the integration tests cannot start a container, note that these are environment-gated and confirm at minimum that `dotnet build` (both src and test projects) succeeds; do not mark the task complete on a build-only basis if the test harness is runnable.
+
+- [ ] **Step 6: Confirm no unintended changes and commit.**
+  Verify the diff touches only the two files above, `KnowledgeBaseRepository.cs` is untouched (explicitly out of scope), and the gotcha comment is present in the new code.
+  ```bash
+  cd /home/user/worktrees/feature-3600-Arch-Review-Leaflet-Addchunksasync-Inserts-Chunks
+  git diff --stat
+  git add backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs \
+          backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs
+  git commit -m "Batch LeafletChunk inserts into a single multi-row INSERT
+
+Replace the per-chunk NpgsqlCommand loop in AddChunksAsync with one
+parameterised multi-row INSERT per batch (MaxRowsPerBatch=1000), cutting
+N round trips to one. Preserves the exact 7-column list, ON CONFLICT
+idempotency, and Pgvector embedding binding. Adds multi-chunk and
+empty-input integration tests.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WRZWyCwJ1fyeA2SMEwi2Mi"
+  ```

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentRepository.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Anela.Heblo.Domain.Features.Leaflet;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
@@ -8,6 +9,9 @@ namespace Anela.Heblo.Persistence.Features.Leaflet;
 public class LeafletDocumentRepository : ILeafletDocumentRepository
 {
     private readonly ApplicationDbContext _context;
+
+    // 7 params/row × 1000 rows = 7,000 params — comfortably under Npgsql's 65,535 ceiling.
+    private const int MaxRowsPerBatch = 1000;
 
     public LeafletDocumentRepository(ApplicationDbContext context)
     {
@@ -23,30 +27,41 @@ public class LeafletDocumentRepository : ILeafletDocumentRepository
     public async Task AddChunksAsync(IEnumerable<LeafletChunk> chunks, CancellationToken ct = default)
     {
         var chunkList = chunks.ToList();
+        if (chunkList.Count == 0)
+            return;
 
         var connection = (NpgsqlConnection)_context.Database.GetDbConnection();
         if (connection.State != System.Data.ConnectionState.Open)
             await connection.OpenAsync(ct);
 
-        foreach (var chunk in chunkList)
+        for (var offset = 0; offset < chunkList.Count; offset += MaxRowsPerBatch)
         {
-            var embedding = new Vector(chunk.Embedding);
-            // Column list MUST mirror LeafletChunkConfiguration. See memory/gotchas/raw-sql-insert-must-match-ef-mapping.md
-            await using var cmd = new NpgsqlCommand(
-                """
-                INSERT INTO "LeafletChunks" ("Id", "DocumentId", "ChunkIndex", "Content", "Summary", "WordCount", "Embedding")
-                VALUES (@id, @documentId, @chunkIndex, @content, @summary, @wordCount, @embedding)
-                ON CONFLICT ("Id") DO NOTHING
-                """,
-                connection);
+            var batch = chunkList.Skip(offset).Take(MaxRowsPerBatch).ToList();
 
-            cmd.Parameters.AddWithValue("id", chunk.Id);
-            cmd.Parameters.AddWithValue("documentId", chunk.DocumentId);
-            cmd.Parameters.AddWithValue("chunkIndex", chunk.ChunkIndex);
-            cmd.Parameters.AddWithValue("content", chunk.Content);
-            cmd.Parameters.AddWithValue("summary", chunk.Summary);
-            cmd.Parameters.AddWithValue("wordCount", chunk.WordCount);
-            cmd.Parameters.AddWithValue("embedding", embedding);
+            // Column list MUST mirror LeafletChunkConfiguration. See memory/gotchas/raw-sql-insert-must-match-ef-mapping.md
+            var sql = new StringBuilder(
+                "INSERT INTO \"LeafletChunks\" (\"Id\", \"DocumentId\", \"ChunkIndex\", \"Content\", \"Summary\", \"WordCount\", \"Embedding\") VALUES ");
+
+            await using var cmd = new NpgsqlCommand { Connection = connection };
+
+            for (var i = 0; i < batch.Count; i++)
+            {
+                var chunk = batch[i];
+                if (i > 0)
+                    sql.Append(", ");
+                sql.Append($"(@id{i}, @documentId{i}, @chunkIndex{i}, @content{i}, @summary{i}, @wordCount{i}, @embedding{i})");
+
+                cmd.Parameters.AddWithValue($"id{i}", chunk.Id);
+                cmd.Parameters.AddWithValue($"documentId{i}", chunk.DocumentId);
+                cmd.Parameters.AddWithValue($"chunkIndex{i}", chunk.ChunkIndex);
+                cmd.Parameters.AddWithValue($"content{i}", chunk.Content);
+                cmd.Parameters.AddWithValue($"summary{i}", chunk.Summary);
+                cmd.Parameters.AddWithValue($"wordCount{i}", chunk.WordCount);
+                cmd.Parameters.AddWithValue($"embedding{i}", new Vector(chunk.Embedding));
+            }
+
+            sql.Append(" ON CONFLICT (\"Id\") DO NOTHING");
+            cmd.CommandText = sql.ToString();
 
             await cmd.ExecuteNonQueryAsync(ct);
         }

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Integration/LeafletRepositoryIntegrationTests.cs
@@ -172,6 +172,66 @@ public class LeafletRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task AddChunksAsync_PersistsAllRows_WhenMultipleChunks()
+    {
+        // Arrange
+        var doc = MakeDocument("multi-chunk-test.pdf", "leaflet-hash-010");
+        await _repository.AddDocumentAsync(doc);
+
+        var chunks = Enumerable.Range(0, 5)
+            .Select(i => new LeafletChunk
+            {
+                Id = Guid.NewGuid(),
+                DocumentId = doc.Id,
+                ChunkIndex = i,
+                Content = $"Content {i}",
+                Summary = $"Summary {i}",
+                WordCount = i + 1,
+                Embedding = [0.1f * i, 0.2f * i, 0.3f * i]
+            })
+            .ToList();
+
+        // Act: single call inserts all five rows in one multi-row INSERT
+        await _repository.AddChunksAsync(chunks);
+
+        // Assert: every row persisted with its own distinct values
+        var stored = await _context.LeafletChunks
+            .AsNoTracking()
+            .Where(c => c.DocumentId == doc.Id)
+            .OrderBy(c => c.ChunkIndex)
+            .ToListAsync();
+
+        Assert.Equal(5, stored.Count);
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.Equal(chunks[i].Id, stored[i].Id);
+            Assert.Equal(i, stored[i].ChunkIndex);
+            Assert.Equal($"Content {i}", stored[i].Content);
+            Assert.Equal($"Summary {i}", stored[i].Summary);
+            Assert.Equal(i + 1, stored[i].WordCount);
+        }
+    }
+
+    [Fact]
+    public async Task AddChunksAsync_IsNoOp_WhenInputEmpty()
+    {
+        // Arrange
+        var doc = MakeDocument("empty-input-test.pdf", "leaflet-hash-011");
+        await _repository.AddDocumentAsync(doc);
+
+        // Act: empty enumerable must not throw and must issue no INSERT
+        var exception = await Record.ExceptionAsync(
+            () => _repository.AddChunksAsync(Array.Empty<LeafletChunk>()));
+
+        // Assert
+        Assert.Null(exception);
+        var rows = await _context.LeafletChunks
+            .Where(c => c.DocumentId == doc.Id)
+            .ToListAsync();
+        Assert.Empty(rows);
+    }
+
+    [Fact]
     public async Task AddDocumentAndChunks_CanBeRetrievedByHash()
     {
         // Arrange


### PR DESCRIPTION
Closes #3600

## What the issue was
`LeafletDocumentRepository.AddChunksAsync` inserted each chunk of a leaflet document via a separate `NpgsqlCommand` in a sequential loop — N chunks meant N sequential database round trips. A 30-chunk document (a typical long marketing brochure) took ~38 round trips instead of ~1, and this cost was paid on every OneDrive ingestion and manual upload.

## How it was fixed / handled
Rewrote `AddChunksAsync` to build a single multi-row parameterised `INSERT` per batch of up to 1000 rows (`MaxRowsPerBatch = 1000`, comfortably under Npgsql's 65,535-parameter ceiling), cutting an N-chunk document down to `ceil(N/1000)` round trips (effectively 1 for any realistic document).

The exact 7-column list (`Id, DocumentId, ChunkIndex, Content, Summary, WordCount, Embedding`), the `ON CONFLICT ("Id") DO NOTHING` idempotency clause, and the `Pgvector.Vector` embedding binding are all preserved unchanged, per the project's documented gotcha (`memory/gotchas/raw-sql-insert-must-match-ef-mapping.md`) that raw-SQL inserts must stay in sync with the EF mapping — the inline comment referencing that file is preserved in the new code.

Added two integration tests: `AddChunksAsync_PersistsAllRows_WhenMultipleChunks` (5-chunk batch, asserts every row persists with correct values and order) and `AddChunksAsync_IsNoOp_WhenInputEmpty` (empty input issues no INSERT and throws nothing).

**Verification:** `dotnet build` and `dotnet format` both succeeded cleanly for the touched projects. The `LeafletRepositoryIntegrationTests` class (Testcontainers/Docker-based) could not be executed in this sandbox — no Docker daemon is available here, and all 13 tests in the class (11 pre-existing + 2 new) fail identically at the constructor with a Docker-connectivity error, confirming this is an environment limitation rather than a regression. CI (which has Docker) should be treated as the real gate for this test class.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3600/` in this branch.

## Code review

# Code Review: batch-leaflet-addchunks-insert

## Summary
The implementation fully satisfies the specification. All critical requirements are present and correct: the 7-column list is preserved in order, `ON CONFLICT` idempotency is intact, `Pgvector` embedding binding uses the correct `new Vector()` constructor, cancellation tokens are propagated to all async operations, the connection lifecycle is properly managed (only the command is disposed), the gotcha-reference comment survives, empty input returns early, and the batch size constant (1000 rows) is correctly sized.

## Review Result: PASS

### task: batch-leaflet-addchunks-insert
**Status:** PASS

## Overall Notes
Both integration tests are well-structured with proper assertions covering multi-chunk persistence and empty-input handling. The build succeeded with zero errors and formatting is clean. No unintended file changes detected. Integration test execution was environment-gated (no Docker daemon in the review sandbox); CI is the real gate for `LeafletRepositoryIntegrationTests`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRZWyCwJ1fyeA2SMEwi2Mi)_