### PR TITLE
#3601: Remove dead UploadLeafletRequest.FileSizeBytes property

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
@@ -100,7 +100,6 @@ public class LeafletController : BaseApiController
             FileStream = stream,
             Filename = file.FileName,
             ContentType = file.ContentType,
-            FileSizeBytes = file.Length,
         }, ct);
         return HandleResponse(result);
     }

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/UploadLeaflet/UploadLeafletRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/UploadLeaflet/UploadLeafletRequest.cs
@@ -7,5 +7,4 @@ public class UploadLeafletRequest : IRequest<UploadLeafletResponse>
     public Stream FileStream { get; set; } = default!;
     public string Filename { get; set; } = default!;
     public string ContentType { get; set; } = default!;
-    public long FileSizeBytes { get; set; }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/UploadLeafletHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/UploadLeafletHandlerTests.cs
@@ -60,7 +60,6 @@ public class UploadLeafletHandlerTests
             FileStream = CreatePdfStream(new byte[] { 1, 2, 3 }),
             Filename = "test.pdf",
             ContentType = "application/pdf",
-            FileSizeBytes = 3,
         };
 
         // Act
@@ -82,7 +81,6 @@ public class UploadLeafletHandlerTests
             FileStream = CreatePdfStream(new byte[] { 1, 2, 3 }),
             Filename = "archive.zip",
             ContentType = "application/zip",
-            FileSizeBytes = 3,
         };
 
         // Act
@@ -125,7 +123,6 @@ public class UploadLeafletHandlerTests
             FileStream = CreatePdfStream(new byte[] { 1, 2, 3 }),
             Filename = "file.pdf",
             ContentType = "application/octet-stream",
-            FileSizeBytes = 3,
         };
 
         // Act
@@ -150,7 +147,6 @@ public class UploadLeafletHandlerTests
             FileStream = CreatePdfStream(new byte[] { 1, 2, 3 }),
             Filename = "test.pdf",
             ContentType = "application/pdf",
-            FileSizeBytes = 3,
         };
 
         // Act & Assert
@@ -185,7 +181,6 @@ public class UploadLeafletHandlerTests
             FileStream = CreatePdfStream(new byte[] { 10, 20, 30 }),
             Filename = "report.pdf",
             ContentType = "application/pdf",
-            FileSizeBytes = 3,
         };
 
         // Act


### PR DESCRIPTION
Closes #3601

## What the issue was
`UploadLeafletRequest.FileSizeBytes` was populated by `LeafletController.UploadDocument` (`FileSizeBytes = file.Length`) but never read anywhere — not by `UploadLeafletHandler`, and no downstream type (`IndexLeafletRequest`, `LeafletDocument`, or any service) had a `FileSizeBytes` field. This is the same dead-property pattern previously found and fixed in the KnowledgeBase module (#3591).

## How it was fixed / handled
- Removed the `FileSizeBytes` property from `UploadLeafletRequest`.
- Removed the corresponding `FileSizeBytes = file.Length` assignment in `LeafletController.UploadDocument`.
- Removed the now-unused `FileSizeBytes = 3` assignments from `UploadLeafletHandlerTests`.
- Verified `dotnet build` succeeds with 0 errors and `UploadLeafletHandlerTests` (5/5) pass.

No behavior change — this only removes a dead request property, per the suggested fix in the issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT4HPfTR1ThvnyH3eRqy7Z)_