### PR TITLE
#3607: Align GiftSettings module boundaries with Logistics

### DIFF
--- a/artifacts/feat-3607/arch-review.r1.md
+++ b/artifacts/feat-3607/arch-review.r1.md
@@ -1,0 +1,130 @@
+# Architecture Review: Align GiftSettings Module Boundaries with Logistics
+
+## Skip Design: true
+
+This is a pure backend namespace/folder move — no new or changed UI components, screens, or visual behavior. Frontend (`frontend/src/api/hooks/useGiftSetting.ts`) is untouched, and the HTTP contract is byte-for-byte identical.
+
+## Architectural Fit Assessment
+
+This refactor closes a real layer-boundary inconsistency, and the spec's Option B decision is correct and well-supported. I independently verified the two load-bearing claims:
+
+1. **The `GiftPackageManufacture` precedent is exact.** Its Application layer lives at `Features/Logistics/UseCases/GiftPackageManufacture/` with its own `GiftPackageManufactureModule.cs` (`AddGiftPackageManufactureModule()`), registered in `ApplicationModule.cs` immediately alongside `services.AddGiftSettingsModule();` (line 93 vs. line 111). Domain sits at `Domain/Features/Logistics/GiftPackageManufacture/`, persistence at `Persistence/Logistics/GiftPackageManufacture/`. This is a currently-compiling, currently-tested three-layer-aligned shape — exactly the target for GiftSettings.
+
+2. **`ModuleBoundariesTests.cs` already models Logistics as the namespace trio** `Anela.Heblo.Domain.Features.Logistics` / `Anela.Heblo.Application.Features.Logistics` / `Anela.Heblo.Persistence.Logistics` in the `Catalog -> Logistics` (line 490-496) and `ExpeditionList -> Logistics` (line 556-562) boundary checks, and `ShoptetApiAdaptersLogisticsAllowlist` (line 299-300) already allowlists `Anela.Heblo.Domain.Features.Logistics.GiftSettings.IGiftSettingRepository`/`GiftSetting` as Logistics-owned. Moving the Application layer under the same prefix makes GiftSettings visible to these checks for the first time, with no allowlist changes anticipated (the only import is `ICurrentUserService`, already a sanctioned cross-cutting dependency per ADR-005, not owned by any of Manufacture/Catalog/Purchase).
+
+No disagreement with the spec's decision. This review's job is to pin down the exact mechanics.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Domain/Features/Logistics/GiftSettings/            [UNCHANGED]
+  GiftSetting.cs, IGiftSettingRepository.cs
+
+Persistence/Logistics/GiftSettings/                 [UNCHANGED]
+  GiftSettingConfiguration.cs, GiftSettingRepository.cs
+
+Application/Features/Logistics/UseCases/GiftSettings/   [NEW LOCATION]
+  GiftSettingsModule.cs
+  Dto/GiftSettingDto.cs
+  UseCases/GetGiftSetting/{GetGiftSettingQuery,GetGiftSettingHandler}.cs
+  UseCases/SetGiftSetting/{SetGiftSettingCommand,SetGiftSettingHandler,
+                           SetGiftSettingResponse,SetGiftSettingValidator}.cs
+
+API/Controllers/GiftSettingsController.cs           [using-only change]
+  route api/gift-settings unchanged
+
+Application/ApplicationModule.cs                    [using-only change]
+  AddGiftSettingsModule() call site unchanged (line 111)
+
+Test/Application/GiftSettings/                      [UNCHANGED location, using-only change]
+  Get/SetGiftSettingHandlerTests.cs, SetGiftSettingValidatorTests.cs
+```
+
+This mirrors `GiftPackageManufacture`'s already-working shape 1:1 — same folder depth (`Logistics/UseCases/{Feature}/`), same per-feature module class, same flat test folder despite nested source (confirmed: `test/.../Application/GiftPackageManufacture/` is flat while its production code lives under `Logistics/UseCases/GiftPackageManufacture/`).
+
+### Key Design Decisions
+
+#### Decision 1: Confirm Option B over Option A
+**Options considered:** A (promote GiftSettings to a fully standalone module across all 3 layers) vs. B (fold Application into Logistics, matching Domain/Persistence which already live there).
+**Chosen approach:** B, as specified.
+**Rationale:** Domain and Persistence already encode "GiftSettings belongs to Logistics" and are exercised as such by `ShoptetApiAdaptersLogisticsAllowlist`. Reversing that (Option A) would require touching Domain, Persistence, `ApplicationDbContext`, and a migration namespace change for zero functional gain, and would fight the architecture test suite's existing model rather than complete it. B is strictly lower blast radius and directly precedented.
+
+#### Decision 2: Test folder stays flat (`Test/Application/GiftSettings/`), not nested
+**Options considered:** Mirror the new source nesting (`Test/Application/Logistics/GiftSettings/`) vs. keep the existing flat `Test/Application/GiftSettings/` folder.
+**Chosen approach:** Keep flat, per spec FR-6.
+**Rationale:** Verified precedent — `backend/test/Anela.Heblo.Tests/Application/GiftPackageManufacture/` is flat by feature name today even though its production counterpart is nested three levels under `Logistics/UseCases/GiftPackageManufacture/`. This is the established test-layout convention in this repo; don't invent a new one for this move. Only the test files' `using` statements and any fully-qualified references change — the C# namespace `Anela.Heblo.Tests.Application.GiftSettings` (the test project's own namespace, independent of production namespaces) is unaffected.
+
+#### Decision 3: `GiftSettingsModule.cs` keeps its extension method name and registration order
+**Options considered:** Rename `AddGiftSettingsModule()` to something Logistics-prefixed, or relocate the call site next to other Logistics registrations.
+**Chosen approach:** Keep the method name and call site exactly as-is (line 111 in `ApplicationModule.cs`); only the `using` import changes from `Anela.Heblo.Application.Features.GiftSettings` to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings`.
+**Rationale:** `GiftPackageManufactureModule` isn't renamed to indicate Logistics ownership either (`AddGiftPackageManufactureModule()`, not `AddLogisticsGiftPackageManufactureModule()`) — the namespace conveys ownership, not the method name. Renaming would be gratuitous churn outside the spec's stated scope ("surgical changes" per CLAUDE.md), and reordering the call site is explicitly called out as optional/cosmetic in FR-3, not required.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Move (git mv, preserving history) these 8 files, with matching subfolder structure, from
+`backend/src/Anela.Heblo.Application/Features/GiftSettings/` to
+`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/`:
+
+- `GiftSettingsModule.cs`
+- `Dto/GiftSettingDto.cs`
+- `UseCases/GetGiftSetting/GetGiftSettingQuery.cs`
+- `UseCases/GetGiftSetting/GetGiftSettingHandler.cs`
+- `UseCases/SetGiftSetting/SetGiftSettingCommand.cs`
+- `UseCases/SetGiftSetting/SetGiftSettingHandler.cs`
+- `UseCases/SetGiftSetting/SetGiftSettingResponse.cs`
+- `UseCases/SetGiftSetting/SetGiftSettingValidator.cs`
+
+After the move, delete the now-empty `Application/Features/GiftSettings/` directory tree.
+
+In every moved file, change the `namespace` declaration from `Anela.Heblo.Application.Features.GiftSettings[.Sub]` to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings[.Sub]`. Internal cross-references between these files (e.g. `GetGiftSettingHandler.cs` importing `Dto`, `SetGiftSettingHandler.cs` importing `SetGiftSettingCommand`'s namespace implicitly via same-folder) need their `using` statements updated to the new prefix — concretely:
+- `GetGiftSettingHandler.cs`: `using Anela.Heblo.Application.Features.GiftSettings.Dto;` → `...Logistics.UseCases.GiftSettings.Dto;`
+- `GetGiftSettingQuery.cs`: same Dto using change.
+- `SetGiftSettingHandler.cs`: `using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;` → drop or update (it's in the same namespace after the move — verify no self-referential using is left dangling).
+- `GiftSettingsModule.cs`: `using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;` → `...Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;`
+
+Do **not** touch (already correctly reference Logistics-owned Domain/Persistence types, unaffected by this move):
+- `using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` (in `SetGiftSettingHandler.cs`, `GetGiftSettingHandler.cs`)
+- `using Anela.Heblo.Persistence.Logistics.GiftSettings;` (in `GiftSettingsModule.cs`)
+
+### Interfaces and Contracts
+
+No public interface or contract changes. `IGiftSettingRepository`, `GiftSetting`, `GiftSettingDto`, `GetGiftSettingQuery`, `SetGiftSettingCommand`, `SetGiftSettingResponse` keep identical members and shapes — only their C# namespace changes for the four Application-layer types. The MediatR `IRequestHandler<TRequest, TResponse>` wiring is unaffected since both request and handler move together.
+
+### Data Flow
+
+Unchanged. `GET /api/gift-settings` → `GetGiftSettingQuery` (now in `Logistics.UseCases.GiftSettings`) → `GetGiftSettingHandler` → `IGiftSettingRepository.GetAsync()` (Domain/Persistence, untouched) → `GiftSettingDto`. `PUT /api/gift-settings` follows the same path through `SetGiftSettingCommand`/`SetGiftSettingHandler`/`ICurrentUserService`/`IGiftSettingRepository.SaveAsync()`. Only the fully-qualified type names in the middle of this chain change; wire shapes, route, and DI resolution graph do not.
+
+### Files requiring `using`-only edits (no move)
+
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs` — two `using` lines (`GetGiftSetting`, `SetGiftSetting` sub-namespaces).
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — line 36 `using Anela.Heblo.Application.Features.GiftSettings;` → `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;`. Consider moving this using line to sit near line 31 (`...Logistics.UseCases.GiftPackageManufacture;`) for readability, though not required. Line 111 `services.AddGiftSettingsModule();` call itself is unchanged.
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs` — 2 using lines (`.Dto`, `.UseCases.GetGiftSetting`).
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs` — 1 using line (`.UseCases.SetGiftSetting`).
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs` — 1 using line (`.UseCases.SetGiftSetting`).
+
+After edits, grep the whole repo for `Anela.Heblo.Application.Features.GiftSettings` (old namespace, not `Domain.Features.Logistics.GiftSettings` or `Persistence.Logistics.GiftSettings`, which are correct and must stay) to confirm zero remaining references.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Grep-and-replace across namespace catches false positives, e.g. accidentally touching `Domain.Features.Logistics.GiftSettings` or `Persistence.Logistics.GiftSettings` strings | Low | Match the exact prefix `Anela.Heblo.Application.Features.GiftSettings` (with trailing `.` or `;` or end-of-line), not the bare word `GiftSettings`; verify Domain/Persistence `using` lines are byte-identical before/after via `git diff` |
+| `ModuleBoundariesTests.cs`'s `Logistics -> Manufacture`/`Logistics -> Catalog`/`Logistics_types_should_not_reference_Purchase_owned_namespaces` checks now scan GiftSettings types for the first time and could fail on an unexpected reference | Low | GiftSettings' only external dependency is `ICurrentUserService` (`Domain.Features.Users`), not Manufacture/Catalog/Purchase-owned; run the full `ModuleBoundariesTests` suite after the move as the primary verification step, not just a build |
+| OpenAPI-generated TypeScript client silently changes operation IDs or schema names if C# namespace leaks into Swagger operation naming | Low | FR-4's acceptance criterion (byte-for-byte identical OpenAPI spec for GiftSettings endpoints) should be checked by diffing the generated spec before/after; ASP.NET Core route/controller/DTO class names (not namespaces) drive Swashbuckle operation IDs by default in this codebase, so risk is low but worth a concrete diff, not just an assumption |
+| Leftover empty `Application/Features/GiftSettings/` directory or stray `.cs` file missed in the move | Low | `find backend/src/Anela.Heblo.Application/Features/GiftSettings -type f` should return nothing after the move; delete the directory explicitly |
+
+## Specification Amendments
+
+None required — the spec (FR-1 through FR-6) is implementation-ready as written and matches what I found in the actual files. One clarification worth calling out explicitly to the implementer (not a spec defect, just easy to miss): `SetGiftSettingHandler.cs` currently has a self-referential `using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;` at its top even though the file itself declares that same namespace — this is a redundant using in the current code (harmless, likely IDE-generated) that will need updating to the new namespace or can be dropped entirely as dead weight; either is acceptable since it doesn't change behavior.
+
+## Prerequisites
+
+None. No new infrastructure, config, feature flags, or migrations are needed — this is a self-contained rename executable in a single PR. Confirm before merging:
+- `dotnet build` produces zero errors/new warnings (FR-2 acceptance criterion).
+- `dotnet test --filter Anela.Heblo.Tests.Architecture.ModuleBoundariesTests` passes without allowlist changes (FR-5).
+- `dotnet test --filter FullyQualifiedName~GiftSettings` passes with the same test count as before the move (FR-6).
+- `git diff --stat` shows changes confined to the 8 moved files (as renames), `ApplicationModule.cs`, `GiftSettingsController.cs`, and the 3 test files — nothing under `Domain/`, `Persistence/`, migrations, or `frontend/` (FR-4).

--- a/artifacts/feat-3607/brief.md
+++ b/artifacts/feat-3607/brief.md
@@ -1,0 +1,34 @@
+## Module
+Logistics / GiftSettings
+
+## Finding
+The domain entities for GiftSettings are nested under the Logistics module:
+- `backend/src/Anela.Heblo.Domain/Features/Logistics/GiftSettings/GiftSetting.cs`
+- `backend/src/Anela.Heblo.Domain/Features/Logistics/GiftSettings/IGiftSettingRepository.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/GiftSettings/GiftSettingConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/GiftSettings/GiftSettingRepository.cs`
+
+But the application and API layers treat GiftSettings as an independent module:
+- `backend/src/Anela.Heblo.Application/Features/GiftSettings/` (standalone folder, own `GiftSettingsModule.cs`)
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs` (route: `/api/gift-settings`, separate from `/api/logistics/...`)
+
+The split means that domain-layer ownership (Logistics) contradicts application-layer ownership (standalone GiftSettings). The persistence layer follows the domain (`Logistics/GiftSettings/`), but the application layer does not.
+
+## Why it matters
+Future code changes to GiftSettings lack a clear placement rule: does new logic belong in `Features/Logistics/` or `Features/GiftSettings/`? Developers following the domain structure will place code in one place; those following the application structure will place it in another. This boundary ambiguity is exactly what vertical-slice architecture is meant to prevent.
+
+The `SetGiftSettingHandler` imports `using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` (line 2), making the logical coupling to Logistics visible at the application layer even though the folder structure denies it.
+
+## Suggested fix
+Pick one canonical boundary and align all layers:
+
+**Option A — make GiftSettings a full standalone module:**
+Move domain types to `Domain/Features/GiftSettings/` and persistence to `Persistence/GiftSettings/`. Update namespaces. This is the larger change but produces the cleanest separation.
+
+**Option B — merge GiftSettings back into Logistics application layer:**
+Move `Application/Features/GiftSettings/` contents into `Application/Features/Logistics/` (e.g. under a `GiftSettings/` subfolder, matching the domain structure). Update the controller routing if needed. No domain or persistence changes required.
+
+In either case, the goal is: domain, persistence, application, and API all agree on which module owns GiftSettings.
+
+---
+_Filed by daily arch-review routine on 2026-07-12._

--- a/artifacts/feat-3607/code-review.r1.md
+++ b/artifacts/feat-3607/code-review.r1.md
@@ -1,0 +1,36 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+## Summary
+This is a pure, mechanical namespace/folder relocation of the GiftSettings Application layer from
+`Anela.Heblo.Application.Features.GiftSettings` to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings`,
+matching the `GiftPackageManufacture` precedent already established in the codebase. The 14-file
+diff is exactly what the spec describes: 8 files moved (via `git mv`, with namespace/using lines
+updated) plus 5 call-site files (`GiftSettingsController.cs`, `ApplicationModule.cs`, and 3 test
+files) with `using` directives updated to match. No class/interface/member names, method bodies,
+routes, DI registration call sites, or public contracts changed.
+
+Verified against the spec's acceptance criteria:
+- FR-1/FR-2: all 8 files moved, no old-namespace references remain anywhere in the repo, build succeeds with 0 errors.
+- FR-3: `services.AddGiftSettingsModule();` in `ApplicationModule.cs` is untouched — only its `using` line changed.
+- FR-4: no changes to Domain, Persistence, migrations, the controller's route/attributes, or any frontend file.
+- FR-5: all 28 `ModuleBoundariesTests` pass with zero allowlist changes.
+- FR-6: all 13 GiftSettings tests pass unchanged; test file layout stays flat per the existing `GiftPackageManufacture` precedent.
+
+No logic was touched in any moved file — every diff hunk is a `namespace`/`using` line change only.
+
+## Docs to Update
+None — this is an internal backend namespace reorganization with no change to public behavior,
+CLI commands, or documented architecture patterns. (The arch-review finding this closes was itself
+filed as a GitHub issue, not a docs update.)
+
+## Overall Notes
+The 66 failures observed in the full `dotnet test` run are pre-existing integration tests that
+require live external resources (Postgres, Flexi ERP, Shoptet API, Graph/KnowledgeBase) unavailable
+in this sandbox — none reference GiftSettings, Logistics, or any file in this diff. They are out of
+scope for this change.

--- a/artifacts/feat-3607/design.r1.md
+++ b/artifacts/feat-3607/design.r1.md
@@ -1,0 +1,70 @@
+# Design: Align GiftSettings Module Boundaries with Logistics
+
+## Component Design
+
+This is a pure namespace/folder relocation of the GiftSettings Application layer. No component behavior, responsibility, or public shape changes — only the C# namespace and physical location of the Application-layer types move, to match the `GiftPackageManufacture` precedent and close the gap identified by `ModuleBoundariesTests.cs`.
+
+### Relocated components (`Application/Features/GiftSettings/` → `Application/Features/Logistics/UseCases/GiftSettings/`)
+
+- **`GiftSettingsModule`** (`GiftSettingsModule.cs`)
+  Responsibility: DI registration extension (`AddGiftSettingsModule()`) — registers `IGiftSettingRepository` → `GiftSettingRepository`, the `SetGiftSettingCommand` FluentValidation validator, and binds the `ValidationBehavior` pipeline.
+  Contract change: namespace only, `Anela.Heblo.Application.Features.GiftSettings` → `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings`. Extension method name, signature, and registration contents are unchanged. Its internal `using` of `Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting` updates to `...Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting`. Its `using Anela.Heblo.Persistence.Logistics.GiftSettings;` is untouched (already correct).
+
+- **`GiftSettingDto`** (`Dto/GiftSettingDto.cs`)
+  Responsibility: flat read projection of the `GiftSetting` aggregate for the `GET` response.
+  Contract change: namespace only, `...Features.GiftSettings.Dto` → `...Features.Logistics.UseCases.GiftSettings.Dto`. Members unchanged.
+
+- **`GetGiftSettingQuery` / `GetGiftSettingHandler`** (`UseCases/GetGiftSetting/`)
+  Responsibility: MediatR query + handler that reads the singleton `GiftSetting` row via `IGiftSettingRepository.GetAsync()` and maps it to `GiftSettingDto`.
+  Contract change: namespace only. `using` of the Dto namespace updates to the new prefix. `using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` is untouched.
+
+- **`SetGiftSettingCommand` / `SetGiftSettingHandler` / `SetGiftSettingResponse` / `SetGiftSettingValidator`** (`UseCases/SetGiftSetting/`)
+  Responsibility: MediatR command + handler that validates and persists updated `IsEnabled` / `ThresholdCzk` / `Text`, resolving the acting user via `ICurrentUserService` and upserting through `IGiftSettingRepository.SaveAsync()`; validator enforces field constraints (e.g. `Text` max 50 chars); response follows the shared `BaseResponse` shape (`Success` / `ErrorCode` / `Params`).
+  Contract change: namespace only. The existing redundant self-referential `using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;` in `SetGiftSettingHandler.cs` is either updated to the new namespace or dropped (dead weight, no behavior impact — implementer's choice per arch review).
+
+### Unchanged components (call-site `using`-only edits)
+
+- **`GiftSettingsController`** (`API/Controllers/GiftSettingsController.cs`) — route (`api/gift-settings`), HTTP verbs, and `[FeatureAuthorize(Feature.Warehouse_Logistics[, AccessLevel.Write])]` attributes unchanged. Only its `using` directives for `GetGiftSetting`/`SetGiftSetting` sub-namespaces are updated to the new prefix.
+- **`ApplicationModule`** (`Application/ApplicationModule.cs`) — `services.AddGiftSettingsModule();` call site and its position in the registration sequence unchanged. Only the `using Anela.Heblo.Application.Features.GiftSettings;` import is updated (optionally relocated adjacent to the `GiftPackageManufacture` using line for readability — cosmetic, not required).
+- **`GiftSetting` / `IGiftSettingRepository`** (`Domain/Features/Logistics/GiftSettings/`) — untouched; already namespaced under `Anela.Heblo.Domain.Features.Logistics.GiftSettings`.
+- **`GiftSettingConfiguration` / `GiftSettingRepository`** (`Persistence/Logistics/GiftSettings/`) — untouched; already namespaced under `Anela.Heblo.Persistence.Logistics.GiftSettings`.
+- **Test files** (`test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs`, `SetGiftSettingHandlerTests.cs`, `SetGiftSettingValidatorTests.cs`) — folder location stays flat (matches the `GiftPackageManufacture` test-layout precedent); only `using` references to the moved production types are updated. Test assertions, arrangements, and mocks are unchanged.
+
+### Post-move architecture boundary
+
+After the move, `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings*` falls under the existing `Anela.Heblo.Application.Features.Logistics` prefix already modeled by `ModuleBoundariesTests.cs` (`Catalog -> Logistics`, `ExpeditionList -> Logistics`, `ShoptetApi Adapters -> Logistics`, `Logistics -> Manufacture`, `Logistics -> Catalog`, `Logistics_types_should_not_reference_Purchase_owned_namespaces`). GiftSettings' only cross-module dependency, `ICurrentUserService` (`Anela.Heblo.Domain.Features.Users`), is already sanctioned per ADR-005 and is not Manufacture/Catalog/Purchase-owned, so no allowlist changes are expected. If an unexpected cross-module reference surfaces, resolve it via the existing contract-inversion pattern or add a justified allowlist entry — never suppress silently.
+
+## Data Schemas
+
+No data model, database schema, migration, or wire-contract changes. Included for reference (unchanged):
+
+### Domain entity — `GiftSetting` (`Domain/Features/Logistics/GiftSettings/GiftSetting.cs`)
+
+Singleton-style aggregate (`Id` is always `1`), mapped to table `public.GiftSettings` via `GiftSettingConfiguration`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `Id` | int | always `1` |
+| `IsEnabled` | bool | |
+| `ThresholdCzk` | decimal | |
+| `Text` | string | max 50 chars |
+| `ModifiedAt` | `DateTimeOffset?` | nullable |
+| `ModifiedBy` | string? | nullable |
+
+`IGiftSettingRepository`: `GetAsync()` (returns the single row, or `GiftSetting.CreateDefault()` if none exists), `SaveAsync(GiftSetting)` (upsert against the single row).
+
+### API shapes (namespace relocates, wire shape identical)
+
+- `GET /api/gift-settings` → `GetGiftSettingQuery` (MediatR request, no parameters) → `GiftSettingDto` (flat projection of `GiftSetting`: `IsEnabled`, `ThresholdCzk`, `Text`, `ModifiedAt`, `ModifiedBy`).
+- `PUT /api/gift-settings` (requires `AccessLevel.Write` on `Feature.Warehouse_Logistics`) → `SetGiftSettingCommand` (`IsEnabled`, `ThresholdCzk`, `Text`) → `SetGiftSettingResponse` (`BaseResponse`: `Success`, `ErrorCode`, `Params`).
+
+Namespace relocation only:
+
+| Type | Old namespace | New namespace |
+|---|---|---|
+| `GiftSettingsModule` | `Anela.Heblo.Application.Features.GiftSettings` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings` |
+| `GiftSettingDto` | `Anela.Heblo.Application.Features.GiftSettings.Dto` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto` |
+| `GetGiftSettingQuery`, `GetGiftSettingHandler` | `Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting` |
+| `SetGiftSettingCommand`, `SetGiftSettingHandler`, `SetGiftSettingResponse`, `SetGiftSettingValidator` | `Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting` |
+
+The generated OpenAPI spec and TypeScript client must be byte-for-byte identical for GiftSettings operations — Swashbuckle derives operation IDs and schema names from controller/DTO class names and route, not C# namespaces, so this relocation has no effect on the public contract.

--- a/artifacts/feat-3607/impl/relocate-giftsettings-application-files.r1.md
+++ b/artifacts/feat-3607/impl/relocate-giftsettings-application-files.r1.md
@@ -1,0 +1,38 @@
+# Implementation: relocate-giftsettings-application-files
+
+## What was implemented
+Moved the 8 Application-layer GiftSettings files from
+`backend/src/Anela.Heblo.Application/Features/GiftSettings/` to
+`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/` using `git mv`
+to preserve history, then updated each file's `namespace` declaration (and the one internal
+`using` reference in `GiftSettingsModule.cs`) to match the new location. No logic, method
+bodies, or public API surfaces were changed. The old `Features/GiftSettings/` directory tree
+no longer exists.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/GiftSettingsModule.cs` — moved; updated `using` for `SetGiftSetting` namespace and module `namespace` declaration
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto/GiftSettingDto.cs` — moved; updated `namespace` declaration
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs` — moved; updated `using` for `Dto` namespace and `namespace` declaration
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs` — moved; updated `using` for `Dto` namespace and `namespace` declaration
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs` — moved; updated `namespace` declaration
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs` — moved; updated `namespace` declaration
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs` — moved; updated `namespace` declaration
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs` — moved; updated `namespace` declaration
+
+## Tests
+None expected for this task — pure file move with namespace-only changes, no logic touched.
+
+## How to verify
+1. `find backend/src/Anela.Heblo.Application/Features/GiftSettings -type f` — should produce no output (directory no longer exists).
+2. `find backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings -type f` — should list the same 8 files at their new paths.
+3. `grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/` — should produce no output (old namespace string fully removed from the moved files).
+4. `git log --follow -- backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs` — should show history preserved through the move (rename detected for most files; see Notes for one exception).
+5. `dotnet build` on `backend/` is expected to **fail** at this point (see Notes) — this is expected and will be resolved by the next task in the pipeline.
+
+## Notes
+- As explicitly called out in the task context file, **the build is expected to be broken** after this task. Call sites outside the 8 moved files — `ApplicationModule.cs`, the GiftSettings controller, and test files — still reference the old namespace `Anela.Heblo.Application.Features.GiftSettings.*`. These are fixed in the next task in the pipeline; no attempt was made to fix them here, per instructions.
+- Git's rename similarity detection recognized 7 of the 8 moved files as renames in `git status`/`git show --stat` output. `GetGiftSettingQuery.cs` (an 8-line file) was recorded as a delete + new file instead of a rename, because the namespace/using edit reduced its content similarity below git's default 50% rename-detection threshold. This is purely a display/heuristic artifact of `git diff`'s similarity index — the file was moved via `git mv` identically to the others, and `git log --follow` still recovers its full history. No functional difference.
+- No changes were made to any file outside the 8 listed above. An unrelated pre-existing modification to `artifacts/feat-3607/state.json` was left unstaged/uncommitted, since it is not part of this task's scope.
+
+## Status
+DONE

--- a/artifacts/feat-3607/impl/update-call-sites-and-namespaces.r1.md
+++ b/artifacts/feat-3607/impl/update-call-sites-and-namespaces.r1.md
@@ -1,0 +1,37 @@
+# Implementation: update-call-sites-and-namespaces
+
+## What was implemented
+Updated the `using`/namespace references in the 5 remaining call sites that pointed at the old
+`Anela.Heblo.Application.Features.GiftSettings` namespace, following the relocation of the
+Application layer to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings` done in
+the previous task. No route, DI registration name, or test logic changed — namespace/using lines
+only.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs` — updated the two `using` directives for `GetGiftSetting`/`SetGiftSetting` use cases to the new namespace
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — updated the `using Anela.Heblo.Application.Features.GiftSettings;` directive; the `services.AddGiftSettingsModule();` call site is unchanged
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs` — updated `using` directives for `Dto` and `GetGiftSetting`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs` — updated `using` directive for `SetGiftSetting`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs` — updated `using` directive for `SetGiftSetting`
+
+## Tests
+Ran `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Application.GiftSettings"`:
+```
+Test Run Successful.
+Total tests: 13
+     Passed: 13
+ Total time: 1.7676 Seconds
+```
+All 13 GiftSettings tests (5 validator, 2 GetGiftSetting handler, 6 SetGiftSetting handler) pass — matching the pre-move test count exactly.
+
+## How to verify
+1. `dotnet build Anela.Heblo.sln` from the repo root — `Build succeeded.`, `0 Error(s)`.
+2. `grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" --include="*.cs" backend/` — no output (old namespace fully removed).
+3. `grep -rn "Anela\.Heblo\.Domain\.Features\.Logistics\.GiftSettings\|Anela\.Heblo\.Persistence\.Logistics\.GiftSettings" --include="*.cs" backend/ | wc -l` — non-zero (Domain/Persistence references untouched, as required).
+4. `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Application.GiftSettings"` — 13/13 pass.
+
+## Notes
+`dotnet build` produces one pre-existing, unrelated warning (`MSB3073`, exit code 134) from the `Anela.Heblo.AccessMatrixGen` post-build tool failing to parse `access-matrix.generated.json`. This is an environment/tooling issue orthogonal to this change — verified independently that it is not caused by the GiftSettings namespace move (the tool crashes trying to read a JSON file unrelated to GiftSettings, before any GiftSettings-specific compilation step). Build still reports `0 Error(s)` and succeeds overall. No new C# compiler warnings were introduced by this task's edits.
+
+## Status
+DONE

--- a/artifacts/feat-3607/impl/verify-architecture-boundary-tests.r1.md
+++ b/artifacts/feat-3607/impl/verify-architecture-boundary-tests.r1.md
@@ -1,0 +1,55 @@
+# Implementation: verify-architecture-boundary-tests
+
+## What was implemented
+Verification-only task — no production code changes. Ran the architecture boundary test suite,
+the full backend test suite, and confirmed the diff scope, per the task's acceptance criteria.
+
+## Files created/modified
+None. This task is verification-only; the previous two tasks' commits already contain the
+complete fix. No allowlist changes were required in `ModuleBoundariesTests.cs`.
+
+## Tests
+
+**1. Architecture boundary tests** (`dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Architecture.ModuleBoundariesTests"`):
+```
+Test Run Successful.
+Total tests: 28
+     Passed: 28
+```
+All rules pass with zero allowlist changes, including the FR-5-listed checks: `Catalog -> Logistics`, `ExpeditionList -> Logistics`, `ShoptetApi Adapters -> Logistics`, `Logistics -> Manufacture`, `Logistics -> Catalog`, `Logistics_types_should_not_reference_Purchase_owned_namespaces`.
+
+**2. Full backend test suite** (`dotnet test Anela.Heblo.sln`):
+```
+Failed!  - Failed: 66, Passed: 5667, Skipped: 4, Total: 5737 (Anela.Heblo.Tests.dll)
+```
+All 66 failures are pre-existing integration tests requiring real external resources unavailable
+in this sandbox (no live Postgres/Flexi/Shoptet/Graph connections) — e.g.
+`FlexiCatalogSalesClientIntegrationTests`, `ShoptetApiInvoiceSourceIntegrationTests`,
+`LeafletRepositoryIntegrationTests`, `KnowledgeBaseRepositoryIntegrationTests`,
+`GridLayoutRepositoryUpsertIntegrationTests`, `BankStatementImportRepositoryIntegrationTests`,
+`ArticleRepositoryFeedbackProjectionSqlTests`, etc. None reference GiftSettings, Logistics, or
+any file touched by this branch — confirmed by name and by module. The GiftSettings-specific
+suite (13 tests, verified in the previous task) and all 28 architecture boundary tests pass.
+
+**3. Diff scope** (`git diff --stat $(git merge-base main HEAD)...HEAD -- backend frontend`):
+Confined to exactly the 14 expected changes: the 8 moved+renamespaced Application files (shown
+as add/delete pairs for the one file below git's rename-similarity threshold, renames for the
+rest) plus the 5 call-site files (`GiftSettingsController.cs`, `ApplicationModule.cs`, 3 test
+files). Nothing under `Domain/`, `Persistence/`, `Migrations/`, or `frontend/` appears.
+
+**4. Old-namespace grep** (`grep -rln "Anela\.Heblo\.Application\.Features\.GiftSettings\b" --include="*.cs" backend/`):
+No matches (exit code 1) — fully clean repo-wide.
+
+**5. Build** (`dotnet build Anela.Heblo.sln`):
+`Build succeeded.`, `0 Error(s)` (one pre-existing, unrelated `AccessMatrixGen` tool warning noted in the previous task).
+
+## How to verify
+Re-run the 5 commands above from the repo root.
+
+## Notes
+No allowlist entry was needed in `ModuleBoundariesTests.cs` — the spec's expected outcome (FR-5).
+The 66 unrelated integration-test failures are a pre-existing environmental condition of this
+sandbox (no live external service connections) and out of scope for this refactor.
+
+## Status
+DONE

--- a/artifacts/feat-3607/review/relocate-giftsettings-application-files.r1.md
+++ b/artifacts/feat-3607/review/relocate-giftsettings-application-files.r1.md
@@ -1,0 +1,34 @@
+# Code Review: relocate-giftsettings-application-files
+
+## Summary
+The 8 Application-layer GiftSettings files were moved via `git mv` to
+`Features/Logistics/UseCases/GiftSettings/` exactly as specified, with only the `namespace`
+declarations and the single internal `using` reference (in `GiftSettingsModule.cs`) updated.
+Spot-checks of `GiftSettingsModule.cs`, `GetGiftSettingQuery.cs`, and `SetGiftSettingHandler.cs`
+show namespaces/usings match the task's "After" state verbatim, with no logic or method-body
+changes. The old `Features/GiftSettings/` directory no longer exists, no old-namespace string
+remains in the moved files, and the commit is present with exactly the 8 files touched.
+
+## Review Result: PASS
+
+### task: relocate-giftsettings-application-files
+**Status:** PASS
+
+## Verification performed
+- `find backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings -type f` lists exactly the 8 expected files at their new paths.
+- `ls backend/src/Anela.Heblo.Application/Features/GiftSettings` confirms the old directory no longer exists.
+- `grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/` returns no matches — no lingering old-namespace references in the moved files.
+- Read the full contents of `GiftSettingsModule.cs`, `GetGiftSettingQuery.cs`, and `SetGiftSettingHandler.cs` — namespace/using lines match the task spec's "After" blocks exactly; method bodies (`AddGiftSettingsModule`, `Handle`, etc.) are byte-for-byte unchanged aside from the namespace edits.
+- `git log --oneline -3` shows commit `b339fb2 "Move GiftSettings Application layer under Logistics.UseCases"` on top of the task-context/planning commits.
+- `git show --stat HEAD` confirms only the 8 GiftSettings files are touched (one, `GetGiftSettingQuery.cs`, shows as delete+add rather than a detected rename due to git's similarity heuristic on an 8-line file — noted correctly by the developer as a cosmetic artifact, not a functional issue).
+- `git status --short` shows only a pre-existing unrelated unstaged change to `artifacts/feat-3607/state.json`, correctly left out of this task's commit.
+
+Per the reviewer instructions for this task, the expected build failure (call sites in
+`ApplicationModule.cs`, the controller, and tests still referencing the old namespace) is
+explicitly out of scope for this task and was not flagged.
+
+## Docs to Update
+None.
+
+## Overall Notes
+Clean, surgical move with no scope creep. The developer's implementation summary is accurate and transparent about the one git-heuristic quirk (delete+add vs. rename detection for the short `GetGiftSettingQuery.cs` file), which has no functional impact since `git mv` was used and `git log --follow` still recovers history.

--- a/artifacts/feat-3607/review/update-call-sites-and-namespaces.r1.md
+++ b/artifacts/feat-3607/review/update-call-sites-and-namespaces.r1.md
@@ -1,0 +1,26 @@
+# Code Review: update-call-sites-and-namespaces
+
+## Summary
+The commit `c8ebb26` ("Update GiftSettings call sites to new Logistics.UseCases namespace") touches exactly the 5 files specified in the task context, with no unrelated changes. All `using` directives now correctly reference `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings...`, the `services.AddGiftSettingsModule();` call site in `ApplicationModule.cs` is unchanged, the old namespace is fully gone from the codebase, and the Domain/Persistence namespaces remain untouched (45 matches).
+
+## Review Result: PASS
+
+### task: update-call-sites-and-namespaces
+**Status:** PASS
+
+## Verification performed
+- `git log --oneline -3` confirms commit `c8ebb26` "Update GiftSettings call sites to new Logistics.UseCases namespace" exists.
+- `git show --stat c8ebb26` shows exactly 5 files changed: `GiftSettingsController.cs`, `ApplicationModule.cs`, `GetGiftSettingHandlerTests.cs`, `SetGiftSettingHandlerTests.cs`, `SetGiftSettingValidatorTests.cs` — matching the task spec exactly, no unrelated files.
+- Read each of the 5 files at HEAD:
+  - `GiftSettingsController.cs` lines 1-2 use the new `Logistics.UseCases.GiftSettings.UseCases.{GetGiftSetting,SetGiftSetting}` namespace.
+  - `ApplicationModule.cs` line 36 uses `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;` in the same position (between `CarrierCooling` and `WeatherForecast` usings, unchanged ordering); line 111 `services.AddGiftSettingsModule();` is unchanged.
+  - `GetGiftSettingHandlerTests.cs`, `SetGiftSettingHandlerTests.cs`, `SetGiftSettingValidatorTests.cs` all updated their `using` directives to the new namespace; the test project's own `namespace Anela.Heblo.Tests.Application.GiftSettings;` declarations are untouched, as required.
+- `grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" --include="*.cs" backend/` returns no output — old namespace fully removed.
+- `grep -rn "Anela\.Heblo\.Domain\.Features\.Logistics\.GiftSettings\|Anela\.Heblo\.Persistence\.Logistics\.GiftSettings" --include="*.cs" backend/ | wc -l` returns 45 — Domain/Persistence namespaces are untouched, as required.
+- Confirmed `[Fact]` counts in the 3 test files: 2 (Get) + 6 (Set handler) + 5 (validator) = 13, matching the reported `dotnet test` result of 13/13 passed in the r1 implementation summary.
+
+## Docs to Update
+None — this is a mechanical namespace-alignment change with no user-facing or architectural documentation impact.
+
+## Overall Notes
+Implementation matches the task context precisely: surgical, minimal diff, correct namespace mapping, DI registration and routes untouched, and test discovery/count verified. No issues found.

--- a/artifacts/feat-3607/spec.r1.md
+++ b/artifacts/feat-3607/spec.r1.md
@@ -1,0 +1,131 @@
+# Specification: Align GiftSettings Module Boundaries with Logistics
+
+## Summary
+The `GiftSettings` feature currently has its domain (`Domain/Features/Logistics/GiftSettings/`) and persistence (`Persistence/Logistics/GiftSettings/`) code nested under the `Logistics` module, while its application layer (`Application/Features/GiftSettings/`) lives as an independent top-level module. This specification defines the refactor to relocate `Application/Features/GiftSettings/` into `Application/Features/Logistics/UseCases/GiftSettings/`, matching the pattern already established by the `GiftPackageManufacture` sub-feature, so all four layers agree that GiftSettings is owned by Logistics. No domain, persistence, database, or public HTTP contract changes are required.
+
+## Background
+This work item originates from a daily architecture-review finding (`artifacts/feat-3607/brief.md`, filed 2026-07-12) that identified a layer-boundary mismatch: `SetGiftSettingHandler` (in the standalone `Application/Features/GiftSettings/` folder) imports `Anela.Heblo.Domain.Features.Logistics.GiftSettings`, exposing a hidden coupling to Logistics that the Application-layer folder structure denies. The brief offered two remediation options:
+- **Option A**: promote GiftSettings to a fully standalone module (move domain + persistence out of `Logistics/` too).
+- **Option B**: merge `Application/Features/GiftSettings/` into `Application/Features/Logistics/`, matching the existing domain/persistence nesting.
+
+**Decision: Option B.** Reasoning, based on inspecting this repository's actual conventions rather than the brief's summary alone:
+
+1. **Direct structural precedent already exists and was chosen deliberately.** `GiftPackageManufacture` is the closest analog to `GiftSettings` — another Logistics sub-feature with its own settings/business logic. Its domain lives at `Domain/Features/Logistics/GiftPackageManufacture/`, its persistence at `Persistence/Logistics/GiftPackageManufacture/`, and — critically — its **application layer also lives nested**, at `Application/Features/Logistics/UseCases/GiftPackageManufacture/`, with its own `GiftPackageManufactureModule.cs` registered as a standalone call (`services.AddGiftPackageManufactureModule();`) in `ApplicationModule.cs`, sitting right next to `services.AddGiftSettingsModule();`. This is exactly the target shape Option B describes, and it is a live, working, tested pattern — not a hypothetical one.
+
+2. **The architecture test suite already models "Logistics" as three co-located namespace prefixes.** `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` repeatedly defines the Logistics module boundary as the trio `"Anela.Heblo.Domain.Features.Logistics"`, `"Anela.Heblo.Application.Features.Logistics"`, `"Anela.Heblo.Persistence.Logistics"` (see the `Catalog -> Logistics`, `ExpeditionList -> Logistics`, and `ShoptetApi Adapters -> Logistics` boundary tests). The same file's `ShoptetApiAdaptersLogisticsAllowlist` already allowlists `Anela.Heblo.Domain.Features.Logistics.GiftSettings.IGiftSettingRepository` and `...GiftSetting` as Logistics-owned types being referenced from outside. In other words, the enforced architecture tests already treat GiftSettings' domain types as part of "Logistics" — moving the application layer under `Application.Features.Logistics` closes the one layer these tests don't yet cover, rather than fighting the test suite's existing model.
+
+3. **A competing, weaker precedent exists and was consciously ruled out.** `CarrierCooling` and `WeatherForecast` also have domain/persistence nested under `Logistics` (`Domain/Features/Logistics/CarrierCooling` etc.) while keeping a fully standalone Application module and dedicated controller — the same "split" GiftSettings has today. If this split were followed instead, it would argue for Option A. It is called out explicitly here as an **out-of-scope, pre-existing sibling inconsistency** (see Open Questions) rather than silently ignored, but it does not outweigh point 1: `GiftPackageManufacture` is the more specific, more recently established, and more completely-resolved precedent for "a Logistics sub-feature with its own settings and its own module," and matches the literal folder guidance in `docs/architecture/filesystem.md` ("For complex domains, use subfolders: `{Feature}/{Subdomain}/`" — documented for the Domain layer and mirrored in Application via `UseCases/{Subdomain}/`).
+
+4. **Lower blast radius, matching the "surgical changes" principle.** GiftSettings has no dedicated frontend OpenAPI client usage — `frontend/src/api/hooks/useGiftSetting.ts` builds its own absolute URL (`${apiClient.baseUrl}/api/gift-settings`) via raw `fetch`, not generated client methods. Since the HTTP contract does not need to change under Option B, this refactor is a pure backend namespace/folder move: no frontend changes, no OpenAPI client regeneration, no route change, no migration changes (EF configuration only needs a namespace update, not a schema change).
+
+Separately, `docs/architecture/filesystem.md` shows every other Logistics sub-feature with its own dedicated controller and route (`CarrierCoolingController` → `/api/carrier-cooling`, `StockTakingController`, `TransportBoxController` → `/api/transport-boxes`, `WeatherForecastController` → `/api/weather-forecast`) even though their domain is Logistics-owned. `GiftSettingsController` keeping its own controller and `/api/gift-settings` route (rather than merging into `LogisticsController`, which only `GiftPackageManufacture` does) is consistent with that broader precedent, so the API layer is **not** changed by this work.
+
+## Functional Requirements
+
+### FR-1: Relocate the GiftSettings Application layer under Logistics
+Move all files under `backend/src/Anela.Heblo.Application/Features/GiftSettings/` into `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/`, preserving internal structure:
+- `Dto/GiftSettingDto.cs`
+- `UseCases/GetGiftSetting/GetGiftSettingHandler.cs`, `GetGiftSettingQuery.cs`
+- `UseCases/SetGiftSetting/SetGiftSettingCommand.cs`, `SetGiftSettingHandler.cs`, `SetGiftSettingResponse.cs`, `SetGiftSettingValidator.cs`
+- `GiftSettingsModule.cs`
+
+All namespaces change from `Anela.Heblo.Application.Features.GiftSettings*` to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings*`, mirroring `Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture*`.
+
+**Acceptance criteria:**
+- No file remains under `Anela.Heblo.Application/Features/GiftSettings/`.
+- All moved types compile under the `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings` namespace tree.
+- Class/interface/member names, public shapes, and behavior are unchanged (rename is namespace/folder-only, not a rewrite).
+
+### FR-2: Update all call sites referencing the old namespace
+Update `using` directives and fully-qualified references in:
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs`
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` (the `using Anela.Heblo.Application.Features.GiftSettings;` import; the `services.AddGiftSettingsModule();` call itself is unchanged)
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs`
+
+Any other reference to `Anela.Heblo.Application.Features.GiftSettings` found via repo-wide search must also be updated.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds with zero errors and zero new warnings.
+- A repo-wide search for `Anela.Heblo.Application.Features.GiftSettings` (old namespace) returns no matches outside of historical/migration files that don't reference C# namespaces.
+
+### FR-3: Preserve DI registration semantics
+`GiftSettingsModule.AddGiftSettingsModule()` keeps its current signature and registrations (`IGiftSettingRepository` → `GiftSettingRepository`, the `SetGiftSettingCommand` validator, and the `ValidationBehavior` pipeline binding). Only its namespace changes. `ApplicationModule.AddApplicationServices()` continues to call `services.AddGiftSettingsModule();` at the same point in the registration sequence (no reordering required, though placing it adjacent to `services.AddGiftPackageManufactureModule();` is acceptable for readability since both are Logistics sub-feature modules).
+
+**Acceptance criteria:**
+- The DI container resolves `IGiftSettingRepository`, the `SetGiftSettingCommand` validator, and the validation pipeline behavior exactly as before the move.
+- Existing module-wiring/integration tests that exercise GiftSettings DI resolution pass unchanged in behavior.
+
+### FR-4: Leave Domain, Persistence, and API layers unchanged
+No changes to:
+- `backend/src/Anela.Heblo.Domain/Features/Logistics/GiftSettings/GiftSetting.cs`, `IGiftSettingRepository.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/GiftSettings/GiftSettingConfiguration.cs`, `GiftSettingRepository.cs` (these already reference `Anela.Heblo.Domain.Features.Logistics.GiftSettings`, which is unaffected by this move)
+- `backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs` (`DbSet<GiftSetting> GiftSettings`)
+- EF Core migrations (no schema change; table `public.GiftSettings` is untouched)
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs` route (`api/gift-settings`), HTTP verbs, and request/response wire shapes
+- `frontend/src/api/hooks/useGiftSetting.ts` and any other frontend code (the controller route and DTO shape are unchanged, so the frontend requires no changes)
+
+**Acceptance criteria:**
+- `git diff` shows no changes to Domain, Persistence, Migrations, `GiftSettingsController.cs` (beyond the `using` statement in FR-2), or any `frontend/` file.
+- The OpenAPI spec generated from the API project is byte-for-byte identical for the GiftSettings endpoints (same route, same request/response schema names and shapes).
+
+### FR-5: Keep architecture boundary tests green and aligned with the new structure
+`backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` already treats `Anela.Heblo.Application.Features.Logistics` as one of the three Logistics namespace prefixes in several boundary checks (`Catalog -> Logistics`, `ExpeditionList -> Logistics`, `ShoptetApi Adapters -> Logistics`, and `Logistics -> Manufacture` / `Logistics -> Catalog` / `Logistics_types_should_not_reference_Purchase_owned_namespaces`). After the move, `GiftSettings` Application types fall under this prefix and are subject to these checks for the first time.
+
+**Acceptance criteria:**
+- All existing tests in `ModuleBoundariesTests.cs` pass without modification to allowlists (GiftSettings has no known cross-module references beyond `ICurrentUserService`, which is an already-sanctioned dependency per ADR-005 and is not Logistics/Manufacture/Catalog/Purchase-owned).
+- If a new, legitimate cross-module reference is surfaced by this move, it is either resolved via the existing contract-inversion pattern (see `development_guidelines.md`'s `ILeafletKnowledgeSource` example) or added to the relevant allowlist with a one-line justification comment, following the existing allowlist style in the file — never silently suppressed.
+
+### FR-6: Preserve test coverage
+The three existing test files (`GetGiftSettingHandlerTests.cs`, `SetGiftSettingHandlerTests.cs`, `SetGiftSettingValidatorTests.cs`) continue to exist under `backend/test/Anela.Heblo.Tests/Application/GiftSettings/` (test folder layout is flat by feature name in this project regardless of source nesting — see `Application/GiftPackageManufacture/` as precedent, which stays flat even though its source lives under `Logistics/UseCases/GiftPackageManufacture/`). Only their `using`/namespace references to production types change.
+
+**Acceptance criteria:**
+- All three test files pass with zero test logic changes (assertions, arrangements, and mocked dependencies identical).
+- Test discovery and `dotnet test` count for the GiftSettings suite is unchanged before/after the move.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected — this is a pure namespace/folder reorganization with no change to algorithms, queries, or I/O patterns. No new database round-trips, no new allocations of note.
+
+### NFR-2: Security
+No change. `GiftSettingsController` retains its existing `[FeatureAuthorize(Feature.Warehouse_Logistics)]` / `[FeatureAuthorize(Feature.Warehouse_Logistics, AccessLevel.Write)]` attributes unchanged. `SetGiftSettingHandler` continues to resolve the current user via `ICurrentUserService` inside the handler per ADR-005 (already compliant; not part of this change).
+
+### NFR-3: Backward compatibility
+The public HTTP contract (`GET /api/gift-settings`, `PUT /api/gift-settings`, request/response JSON shapes) must remain byte-for-byte identical, since it is consumed by a hand-rolled frontend hook that is out of scope for this change and by the auto-generated OpenAPI client (regenerating the client must produce no diff for GiftSettings operations).
+
+## Data Model
+No data model changes. For reference, the existing (unchanged) model:
+
+- **`GiftSetting`** (`Domain/Features/Logistics/GiftSettings/GiftSetting.cs`) — singleton-style aggregate (`Id` is always `1`), fields: `IsEnabled` (bool), `ThresholdCzk` (decimal), `Text` (string, max 50 chars), `ModifiedAt` (nullable `DateTimeOffset`), `ModifiedBy` (nullable string). Mapped to table `public.GiftSettings` via `GiftSettingConfiguration`.
+- **`IGiftSettingRepository`** — `GetAsync()` (returns the single row or `GiftSetting.CreateDefault()` if none exists), `SaveAsync(GiftSetting)` (upsert against the single row).
+- **`GiftSettingDto`** (moves from `Application.Features.GiftSettings.Dto` to `Application.Features.Logistics.UseCases.GiftSettings.Dto`) — flat projection of the entity for the `GET` response.
+
+## API / Interface Design
+No change to the external HTTP surface:
+- `GET /api/gift-settings` → `GetGiftSettingQuery` → `GiftSettingDto`
+- `PUT /api/gift-settings` (requires write access) → `SetGiftSettingCommand` (`IsEnabled`, `ThresholdCzk`, `Text`) → `SetGiftSettingResponse` (`BaseResponse` with `Success`/`ErrorCode`/`Params`)
+
+Internal (backend-only) change:
+- MediatR request/response/handler namespaces move from `Anela.Heblo.Application.Features.GiftSettings.*` to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.*`.
+- `GiftSettingsModule` namespace moves from `Anela.Heblo.Application.Features.GiftSettings` to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings`; the `AddGiftSettingsModule()` extension method name and call site in `ApplicationModule.cs` are unchanged.
+
+## Dependencies
+- No new external libraries or services.
+- Depends on existing MediatR, FluentValidation, and EF Core wiring already in place.
+- Depends on `ICurrentUserService` (`Anela.Heblo.Domain.Features.Users`) for identity resolution in `SetGiftSettingHandler`, unchanged.
+
+## Out of Scope
+- Any change to `Domain/Features/Logistics/GiftSettings/` or `Persistence/Logistics/GiftSettings/` (these already match the target Logistics ownership and are untouched).
+- Any change to `GiftSettingsController.cs` beyond its `using` directives (route, verbs, and authorization attributes stay as-is).
+- Merging `GiftSettingsController` into `LogisticsController` (rejected — see Background; would diverge from the `CarrierCooling`/`StockTaking`/`TransportBox`/`WeatherForecast` precedent of dedicated per-feature controllers for Logistics sub-features).
+- Any change to `frontend/src/api/hooks/useGiftSetting.ts` or other frontend code.
+- Resolving the analogous domain/application "split" that also exists for `CarrierCooling` and `WeatherForecast` (flagged as a related, pre-existing inconsistency — see Open Questions).
+- Any database schema or migration change.
+- Phase 2 persistence work (per-module `DbContext`) referenced in `docs/architecture/development_guidelines.md` — unrelated to this fix.
+
+## Open Questions
+1. `CarrierCooling` and `WeatherForecast` have the identical domain/persistence-under-Logistics-but-standalone-application "split" that this spec fixes for `GiftSettings`. Should a follow-up arch-review item be filed to apply the same `GiftPackageManufacture`-style consolidation to those two features for full repo-wide consistency, or is the split acceptable for "simple" (1-3 use case) Logistics sub-features that keep their own controller? Assumption made for this spec: those two are explicitly out of scope here and should be tracked as a separate decision, since resolving them is not required to close this specific arch-review finding.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-13T05:30:41.795723Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T05:30:50.546530Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T05:31:40.269523Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T05:31:48.593548Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-13T05:24:20.798725Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T05:24:24.671469Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T05:30:41.795723Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T05:30:50.546530Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -28,15 +28,15 @@
   "tasks": [
     {
       "name": "relocate-giftsettings-application-files",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-13T05:35:28.228437Z"
+      "updated_at": "2026-07-13T05:39:05.973756Z"
     },
     {
       "name": "update-call-sites-and-namespaces",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-13T05:39:09.679264Z"
     },
     {
       "name": "verify-architecture-boundary-tests",

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -6,11 +6,11 @@
   "phases": {
     "analyzing": {
       "status": "completed",
-      "updated_at": "2026-07-13T05:24:02.529893Z"
+      "updated_at": "2026-07-13T05:24:20.798725Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T05:24:24.671469Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T05:35:08.793230Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T05:35:28.040894Z"
     }
   },
   "tasks": [
     {
       "name": "relocate-giftsettings-application-files",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-13T05:35:28.228437Z"
     },
     {
       "name": "update-call-sites-and-namespaces",

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -34,15 +34,15 @@
     },
     {
       "name": "update-call-sites-and-namespaces",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-13T05:39:09.679264Z"
+      "updated_at": "2026-07-13T06:10:50.145417Z"
     },
     {
       "name": "verify-architecture-boundary-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-13T06:10:53.877835Z"
     }
   ]
 }

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-13T07:00:21.189964Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-13T07:00:27.949409Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -17,13 +17,32 @@
       "updated_at": "2026-07-13T05:31:40.269523Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T05:31:48.593548Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T05:35:08.793230Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "relocate-giftsettings-application-files",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "update-call-sites-and-namespaces",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    },
+    {
+      "name": "verify-architecture-boundary-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-13T07:00:21.189964Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T07:00:27.949409Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T07:00:55.059202Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3607",
+  "issue_number": 3607,
+  "created_at": "2026-07-13T05:14:33.393783Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-13T05:24:02.529893Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3607/state.json
+++ b/artifacts/feat-3607/state.json
@@ -21,8 +21,8 @@
       "updated_at": "2026-07-13T05:35:08.793230Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T05:35:28.040894Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T07:00:21.189964Z"
     }
   },
   "tasks": [
@@ -40,9 +40,9 @@
     },
     {
       "name": "verify-architecture-boundary-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-13T06:10:53.877835Z"
+      "updated_at": "2026-07-13T07:00:12.820132Z"
     }
   ]
 }

--- a/artifacts/feat-3607/task-context/relocate-giftsettings-application-files.md
+++ b/artifacts/feat-3607/task-context/relocate-giftsettings-application-files.md
@@ -1,0 +1,286 @@
+### task: relocate-giftsettings-application-files
+
+Move the 8 Application-layer files to their new location and update only their `namespace` /
+internal `using` lines. No logic changes.
+
+**Step 1 — Confirm starting state (baseline check).**
+
+Run:
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+find backend/src/Anela.Heblo.Application/Features/GiftSettings -type f
+```
+Expected output (8 lines, order may vary):
+```
+backend/src/Anela.Heblo.Application/Features/GiftSettings/GiftSettingsModule.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/Dto/GiftSettingDto.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs
+```
+
+**Step 2 — Create the new directory tree and git-mv each file, preserving history.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+mkdir -p backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto
+mkdir -p backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting
+mkdir -p backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/GiftSettingsModule.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/GiftSettingsModule.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/Dto/GiftSettingDto.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto/GiftSettingDto.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs
+```
+
+**Step 3 — Delete the now-empty old directory tree.**
+
+```
+find backend/src/Anela.Heblo.Application/Features/GiftSettings -type f
+```
+Expected: no output (empty). Then remove leftover empty directories:
+```
+find backend/src/Anela.Heblo.Application/Features/GiftSettings -type d -empty -delete
+```
+Verify the whole tree is gone:
+```
+ls backend/src/Anela.Heblo.Application/Features/GiftSettings 2>&1
+```
+Expected: `ls: cannot access '...': No such file or directory`.
+
+**Step 4 — Edit `GiftSettingsModule.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/GiftSettingsModule.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Common.Behaviors;
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Persistence.Logistics.GiftSettings;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.GiftSettings;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Common.Behaviors;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Persistence.Logistics.GiftSettings;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;
+```
+The rest of the file (the `AddGiftSettingsModule` method body) is unchanged — do not touch the
+`using Anela.Heblo.Persistence.Logistics.GiftSettings;` or
+`using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` lines, they are already correct.
+
+Use the Edit tool with `old_string` set to the two changed lines
+(`using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;` and
+`namespace Anela.Heblo.Application.Features.GiftSettings;`) replaced individually with their
+"After" counterparts above.
+
+**Step 5 — Edit `Dto/GiftSettingDto.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto/GiftSettingDto.cs`
+
+Before (line 1):
+```csharp
+namespace Anela.Heblo.Application.Features.GiftSettings.Dto;
+```
+
+After (line 1):
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+```
+No other lines in this file change.
+
+**Step 6 — Edit `UseCases/GetGiftSetting/GetGiftSettingQuery.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.Dto;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+```
+The rest of the file (`public sealed class GetGiftSettingQuery : IRequest<GiftSettingDto> { }`) is
+unchanged.
+
+**Step 7 — Edit `UseCases/GetGiftSetting/GetGiftSettingHandler.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.Dto;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+```
+Do not touch `using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` — already correct. The
+rest of the class body (`GetGiftSettingHandler`, constructor, `Handle` method) is unchanged.
+
+**Step 8 — Edit `UseCases/SetGiftSetting/SetGiftSettingCommand.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs`
+
+Before:
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Class body (`IsEnabled`, `ThresholdCzk`, `Text` properties) is unchanged.
+
+**Step 9 — Edit `UseCases/SetGiftSetting/SetGiftSettingHandler.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Do not touch `using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` or
+`using Anela.Heblo.Domain.Features.Users;` — already correct. The entire `Handle` method body
+(validation branches, `GiftSetting` construction, `_repository.SaveAsync` call) is unchanged.
+
+**Step 10 — Edit `UseCases/SetGiftSetting/SetGiftSettingResponse.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+`public sealed class SetGiftSettingResponse : BaseResponse { }` is unchanged.
+
+**Step 11 — Edit `UseCases/SetGiftSetting/SetGiftSettingValidator.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs`
+
+Before:
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+The validator body (`RuleFor`/`When` rules) is unchanged.
+
+**Step 12 — Verify no old-namespace references remain in the moved files.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/
+```
+Expected: no output (empty — the grep matches zero lines because the old namespace string no
+longer appears anywhere in the moved files).
+
+**Step 13 — Commit.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git add backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings backend/src/Anela.Heblo.Application/Features/GiftSettings
+git status
+```
+Confirm `git status` shows the 8 files as renames (`renamed:`) from
+`Features/GiftSettings/...` to `Features/Logistics/UseCases/GiftSettings/...`, and nothing under
+`Domain/`, `Persistence/`, or `frontend/`. Then:
+```
+git commit -m "Move GiftSettings Application layer under Logistics.UseCases
+
+Relocates backend/src/Anela.Heblo.Application/Features/GiftSettings/ to
+Features/Logistics/UseCases/GiftSettings/, matching the GiftPackageManufacture
+precedent. Namespace-only change; no behavior or contract changes."
+```
+(Note: this task does not yet build — call sites in `ApplicationModule.cs`, the controller, and
+the test files still reference the old namespace. That is fixed in the next task.)
+
+---
+

--- a/artifacts/feat-3607/task-context/update-call-sites-and-namespaces.md
+++ b/artifacts/feat-3607/task-context/update-call-sites-and-namespaces.md
@@ -1,0 +1,166 @@
+### task: update-call-sites-and-namespaces
+
+Update the 5 files that reference the old `Anela.Heblo.Application.Features.GiftSettings`
+namespace but are not themselves moved: the controller, `ApplicationModule.cs`, and the 3 test
+files. After this task the solution must build cleanly.
+
+**Step 1 — Edit `GiftSettingsController.cs`.**
+
+File: `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs`
+
+Before (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+No other line in this file changes — route (`api/gift-settings`), `[FeatureAuthorize(...)]`
+attributes, and method bodies (`GetGiftSetting`, `SetGiftSetting`) stay exactly as-is.
+
+**Step 2 — Edit `ApplicationModule.cs`.**
+
+File: `backend/src/Anela.Heblo.Application/ApplicationModule.cs`
+
+Before (line 36):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings;
+```
+
+After (line 36):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;
+```
+Do **not** change line 111 (`services.AddGiftSettingsModule();`) — the extension method name and
+call-site position are unchanged per spec FR-3. Do not reorder the `using` line relative to its
+neighbors (keep surgical — the design doc notes reordering next to the
+`GiftPackageManufacture` using is optional/cosmetic, and is skipped here to minimize the diff).
+
+**Step 3 — Edit `GetGiftSettingHandlerTests.cs`.**
+
+File: `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs`
+
+Before (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.Dto;
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+```
+
+After (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+```
+Do not change line 8 (`namespace Anela.Heblo.Tests.Application.GiftSettings;`) — this is the
+test project's own namespace (independent of production code, stays flat per spec FR-6) and is
+out of scope. Do not change any assertions or arrangements.
+
+**Step 4 — Edit `SetGiftSettingHandlerTests.cs`.**
+
+File: `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs`
+
+Before (line 1):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After (line 1):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Do not change line 9 (`namespace Anela.Heblo.Tests.Application.GiftSettings;`) or any test
+method body.
+
+**Step 5 — Edit `SetGiftSettingValidatorTests.cs`.**
+
+File: `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs`
+
+Before (line 1):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After (line 1):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Do not change line 6 (`namespace Anela.Heblo.Tests.Application.GiftSettings;`) or any test
+method body.
+
+**Step 6 — Repo-wide search for any remaining old-namespace reference.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" --include="*.cs" backend/
+```
+Expected: no output (empty). If any match remains outside the 5 files above, update it using the
+same before/after mapping in the table in the plan intro, then re-run this grep until it is
+empty.
+
+Also confirm the Domain/Persistence namespaces (which look similar but must NOT be touched) are
+still present and unchanged:
+```
+grep -rn "Anela\.Heblo\.Domain\.Features\.Logistics\.GiftSettings\|Anela\.Heblo\.Persistence\.Logistics\.GiftSettings" --include="*.cs" backend/ | wc -l
+```
+Expected: a non-zero count (these lines must still exist, unmodified, in
+`GetGiftSettingHandler.cs`, `SetGiftSettingHandler.cs`, `GiftSettingsModule.cs`, and the 2 test
+files that assert against the `GiftSetting`/`IGiftSettingRepository` domain types).
+
+**Step 7 — Build the solution.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet build
+```
+Expected: `Build succeeded.` with `0 Error(s)`. If there are new warnings not present before this
+change, investigate — FR-2's acceptance criterion requires zero new warnings. (Pre-existing
+warnings unrelated to GiftSettings are out of scope.)
+
+**Step 8 — Run `dotnet format` (per CLAUDE.md validation requirement).**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet format --verify-no-changes
+```
+If this reports formatting differences confined to the moved/edited files (e.g. whitespace), run
+`dotnet format` without `--verify-no-changes` to apply fixes, then re-run `dotnet build` to
+confirm it still succeeds.
+
+**Step 9 — Run the GiftSettings test suite and confirm the same test count as before the move.**
+
+Confirm the suite passes and the count matches the known fixture set: `GetGiftSettingHandlerTests`
+has 2 `[Fact]` methods, `SetGiftSettingHandlerTests` has 6 `[Fact]` methods, and
+`SetGiftSettingValidatorTests` has 5 `[Fact]` methods — 13 tests total:
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Application.GiftSettings" --logger "console;verbosity=normal"
+```
+Expected: `Passed! - Failed: 0, Passed: 13, Skipped: 0, Total: 13` (or the equivalent summary
+line — exact count must be 13; if it differs, one of the 3 test files was not discovered
+correctly and its namespace/using edits must be re-checked).
+
+**Step 10 — Commit.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git add backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs \
+        backend/src/Anela.Heblo.Application/ApplicationModule.cs \
+        backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs
+git status
+git commit -m "Update GiftSettings call sites to new Logistics.UseCases namespace
+
+Updates using directives in GiftSettingsController, ApplicationModule, and the
+3 GiftSettings test files to reference the relocated
+Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings namespace.
+No behavior, route, or DI registration changes."
+```
+
+---
+

--- a/artifacts/feat-3607/task-context/verify-architecture-boundary-tests.md
+++ b/artifacts/feat-3607/task-context/verify-architecture-boundary-tests.md
@@ -1,0 +1,94 @@
+### task: verify-architecture-boundary-tests
+
+Run the full backend test suite, with particular attention to
+`ModuleBoundariesTests.cs` (which now scans GiftSettings Application types under the
+`Anela.Heblo.Application.Features.Logistics` prefix for the first time), and confirm the overall
+diff is confined to what the spec allows.
+
+**Step 1 — Run the architecture boundary tests in isolation.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Architecture.ModuleBoundariesTests" --logger "console;verbosity=normal"
+```
+Expected: all tests in this class pass, in particular (per spec FR-5) these tests that treat
+`Anela.Heblo.Application.Features.Logistics` as part of the Logistics namespace trio must still
+pass with **no allowlist changes**:
+- `Catalog -> Logistics` (uses `CatalogLogisticsAllowlist`)
+- `ExpeditionList -> Logistics` (uses `ExpeditionListLogisticsAllowlist`)
+- `ShoptetApi Adapters -> Logistics` (uses `ShoptetApiAdaptersLogisticsAllowlist`)
+- `Logistics -> Manufacture` (uses `LogisticsAllowlist`)
+- `Logistics -> Catalog` (uses `LogisticsCatalogAllowlist`)
+- `Logistics_types_should_not_reference_Purchase_owned_namespaces`
+
+If any of these fail with a new violation, the failure message will name the offending
+`SourceType -> TargetType` pair. GiftSettings' only legitimate cross-module dependency is
+`Anela.Heblo.Domain.Features.Users.ICurrentUserService` (used in `SetGiftSettingHandler`), which
+is not Manufacture/Catalog/Purchase-owned and should not trigger any of the above checks. If a
+different, unexpected reference is flagged:
+- Do not silently add it to an allowlist without justification.
+- Check whether it can be resolved via the existing contract-inversion pattern described in
+  `docs/architecture/development_guidelines.md` (the `ILeafletKnowledgeSource` example).
+- If an allowlist addition is genuinely warranted, add a one-line comment in
+  `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` following the existing
+  style (see the comment above `LogisticsAllowlist` at line 29 or `ExpeditionListLogisticsAllowlist`
+  at line 240 for the expected format), and re-run this step until green. This should not be
+  necessary for this specific move — treat any occurrence as a signal to stop and investigate
+  before proceeding, since FR-5's acceptance criterion expects zero allowlist changes.
+
+**Step 2 — Run the full backend test suite.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet test
+```
+Expected: `Passed!` summary with `Failed: 0`. Compare the total test count against the count on
+`main` before this branch's changes (via `git log`/CI history if available) to confirm no tests
+were lost or silently skipped during the move — the GiftSettings suite specifically must still
+report 13 passing tests (2 + 6 + 5, per the previous task's Step 9).
+
+**Step 3 — Confirm the diff is confined to the expected files.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git diff --stat main...HEAD
+```
+Expected: only these paths appear, with the 8 moved files shown as renames:
+- `backend/src/Anela.Heblo.Application/Features/GiftSettings/...` → `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/...` (8 files, renamed)
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs`
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs`
+
+Nothing under `backend/src/Anela.Heblo.Domain/`, `backend/src/Anela.Heblo.Persistence/`, any
+`Migrations/` folder, or `frontend/` should appear. If anything else shows up, investigate before
+proceeding — per spec FR-4, those layers must be byte-for-byte unchanged.
+
+**Step 4 — Confirm zero remaining old-namespace references repo-wide (final check).**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings\b" --include="*.cs" .
+```
+Expected: no output. (This re-runs the FR-2 acceptance check as a final gate, now against the
+entire repository rather than just `backend/`.)
+
+**Step 5 — Confirm `dotnet build` is still clean after all edits.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet build
+```
+Expected: `Build succeeded.`, `0 Error(s)`.
+
+**Step 6 — No commit in this task unless Step 1's allowlist branch was exercised.**
+
+This task is verification-only. If Step 1 required no allowlist change (the expected outcome),
+there is nothing new to commit — the previous two tasks' commits already contain the complete
+fix. If an allowlist entry genuinely had to be added in Step 1, commit it separately:
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "Add justified allowlist entry surfaced by GiftSettings Logistics move"
+```

--- a/artifacts/feat-3607/task-plan.r1.md
+++ b/artifacts/feat-3607/task-plan.r1.md
@@ -1,0 +1,599 @@
+# Implementation Plan: Align GiftSettings Module Boundaries with Logistics
+
+## Goal
+
+Relocate `backend/src/Anela.Heblo.Application/Features/GiftSettings/` (8 files) into
+`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/`, changing only
+namespaces and `using` directives so that the Application layer for GiftSettings joins its
+Domain (`Domain/Features/Logistics/GiftSettings/`) and Persistence
+(`Persistence/Logistics/GiftSettings/`) counterparts under the `Logistics` module — exactly
+mirroring the existing `GiftPackageManufacture` precedent
+(`Application/Features/Logistics/UseCases/GiftPackageManufacture/`).
+
+This is a pure namespace/folder move. No behavior, no public HTTP contract, no DI registration
+semantics, no Domain/Persistence code, and no frontend code changes. Reference source docs:
+`artifacts/feat-3607/spec.r1.md`, `artifacts/feat-3607/arch-review.r1.md`,
+`artifacts/feat-3607/design.r1.md`.
+
+### Files in scope
+
+Moved (git mv), namespace changed:
+1. `backend/src/Anela.Heblo.Application/Features/GiftSettings/GiftSettingsModule.cs`
+2. `backend/src/Anela.Heblo.Application/Features/GiftSettings/Dto/GiftSettingDto.cs`
+3. `backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs`
+4. `backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs`
+5. `backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs`
+6. `backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs`
+7. `backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs`
+8. `backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs`
+
+Not moved, `using`-only edits:
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs`
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs`
+
+Untouched (confirmed already correct, must show zero diff): `Domain/Features/Logistics/GiftSettings/*`, `Persistence/Logistics/GiftSettings/*`, `ApplicationDbContext.cs`, all EF migrations, `frontend/**`.
+
+Namespace mapping used throughout this plan:
+
+| Old namespace | New namespace |
+|---|---|
+| `Anela.Heblo.Application.Features.GiftSettings` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings` |
+| `Anela.Heblo.Application.Features.GiftSettings.Dto` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto` |
+| `Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting` |
+| `Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting` | `Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting` |
+
+Note: none of the 8 source files under the current `GiftSettings/` tree contain a stray
+self-referential `using` for their own namespace (verified by reading each file) — no dead-`using`
+cleanup is needed beyond the mechanical namespace substitution below.
+
+---
+
+### task: relocate-giftsettings-application-files
+
+Move the 8 Application-layer files to their new location and update only their `namespace` /
+internal `using` lines. No logic changes.
+
+**Step 1 — Confirm starting state (baseline check).**
+
+Run:
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+find backend/src/Anela.Heblo.Application/Features/GiftSettings -type f
+```
+Expected output (8 lines, order may vary):
+```
+backend/src/Anela.Heblo.Application/Features/GiftSettings/GiftSettingsModule.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/Dto/GiftSettingDto.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs
+backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs
+```
+
+**Step 2 — Create the new directory tree and git-mv each file, preserving history.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+mkdir -p backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto
+mkdir -p backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting
+mkdir -p backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/GiftSettingsModule.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/GiftSettingsModule.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/Dto/GiftSettingDto.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto/GiftSettingDto.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs
+
+git mv backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs \
+       backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs
+```
+
+**Step 3 — Delete the now-empty old directory tree.**
+
+```
+find backend/src/Anela.Heblo.Application/Features/GiftSettings -type f
+```
+Expected: no output (empty). Then remove leftover empty directories:
+```
+find backend/src/Anela.Heblo.Application/Features/GiftSettings -type d -empty -delete
+```
+Verify the whole tree is gone:
+```
+ls backend/src/Anela.Heblo.Application/Features/GiftSettings 2>&1
+```
+Expected: `ls: cannot access '...': No such file or directory`.
+
+**Step 4 — Edit `GiftSettingsModule.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/GiftSettingsModule.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Common.Behaviors;
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Persistence.Logistics.GiftSettings;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.GiftSettings;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Common.Behaviors;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Persistence.Logistics.GiftSettings;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;
+```
+The rest of the file (the `AddGiftSettingsModule` method body) is unchanged — do not touch the
+`using Anela.Heblo.Persistence.Logistics.GiftSettings;` or
+`using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` lines, they are already correct.
+
+Use the Edit tool with `old_string` set to the two changed lines
+(`using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;` and
+`namespace Anela.Heblo.Application.Features.GiftSettings;`) replaced individually with their
+"After" counterparts above.
+
+**Step 5 — Edit `Dto/GiftSettingDto.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto/GiftSettingDto.cs`
+
+Before (line 1):
+```csharp
+namespace Anela.Heblo.Application.Features.GiftSettings.Dto;
+```
+
+After (line 1):
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+```
+No other lines in this file change.
+
+**Step 6 — Edit `UseCases/GetGiftSetting/GetGiftSettingQuery.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.Dto;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+```
+The rest of the file (`public sealed class GetGiftSettingQuery : IRequest<GiftSettingDto> { }`) is
+unchanged.
+
+**Step 7 — Edit `UseCases/GetGiftSetting/GetGiftSettingHandler.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.Dto;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+```
+Do not touch `using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` — already correct. The
+rest of the class body (`GetGiftSettingHandler`, constructor, `Handle` method) is unchanged.
+
+**Step 8 — Edit `UseCases/SetGiftSetting/SetGiftSettingCommand.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs`
+
+Before:
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Class body (`IsEnabled`, `ThresholdCzk`, `Text` properties) is unchanged.
+
+**Step 9 — Edit `UseCases/SetGiftSetting/SetGiftSettingHandler.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Do not touch `using Anela.Heblo.Domain.Features.Logistics.GiftSettings;` or
+`using Anela.Heblo.Domain.Features.Users;` — already correct. The entire `Handle` method body
+(validation branches, `GiftSetting` construction, `_repository.SaveAsync` call) is unchanged.
+
+**Step 10 — Edit `UseCases/SetGiftSetting/SetGiftSettingResponse.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs`
+
+Before:
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+`public sealed class SetGiftSettingResponse : BaseResponse { }` is unchanged.
+
+**Step 11 — Edit `UseCases/SetGiftSetting/SetGiftSettingValidator.cs` at its new path.**
+
+File: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs`
+
+Before:
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After:
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+The validator body (`RuleFor`/`When` rules) is unchanged.
+
+**Step 12 — Verify no old-namespace references remain in the moved files.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/
+```
+Expected: no output (empty — the grep matches zero lines because the old namespace string no
+longer appears anywhere in the moved files).
+
+**Step 13 — Commit.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git add backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings backend/src/Anela.Heblo.Application/Features/GiftSettings
+git status
+```
+Confirm `git status` shows the 8 files as renames (`renamed:`) from
+`Features/GiftSettings/...` to `Features/Logistics/UseCases/GiftSettings/...`, and nothing under
+`Domain/`, `Persistence/`, or `frontend/`. Then:
+```
+git commit -m "Move GiftSettings Application layer under Logistics.UseCases
+
+Relocates backend/src/Anela.Heblo.Application/Features/GiftSettings/ to
+Features/Logistics/UseCases/GiftSettings/, matching the GiftPackageManufacture
+precedent. Namespace-only change; no behavior or contract changes."
+```
+(Note: this task does not yet build — call sites in `ApplicationModule.cs`, the controller, and
+the test files still reference the old namespace. That is fixed in the next task.)
+
+---
+
+### task: update-call-sites-and-namespaces
+
+Update the 5 files that reference the old `Anela.Heblo.Application.Features.GiftSettings`
+namespace but are not themselves moved: the controller, `ApplicationModule.cs`, and the 3 test
+files. After this task the solution must build cleanly.
+
+**Step 1 — Edit `GiftSettingsController.cs`.**
+
+File: `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs`
+
+Before (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+No other line in this file changes — route (`api/gift-settings`), `[FeatureAuthorize(...)]`
+attributes, and method bodies (`GetGiftSetting`, `SetGiftSetting`) stay exactly as-is.
+
+**Step 2 — Edit `ApplicationModule.cs`.**
+
+File: `backend/src/Anela.Heblo.Application/ApplicationModule.cs`
+
+Before (line 36):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings;
+```
+
+After (line 36):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;
+```
+Do **not** change line 111 (`services.AddGiftSettingsModule();`) — the extension method name and
+call-site position are unchanged per spec FR-3. Do not reorder the `using` line relative to its
+neighbors (keep surgical — the design doc notes reordering next to the
+`GiftPackageManufacture` using is optional/cosmetic, and is skipped here to minimize the diff).
+
+**Step 3 — Edit `GetGiftSettingHandlerTests.cs`.**
+
+File: `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs`
+
+Before (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.Dto;
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+```
+
+After (lines 1-2):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+```
+Do not change line 8 (`namespace Anela.Heblo.Tests.Application.GiftSettings;`) — this is the
+test project's own namespace (independent of production code, stays flat per spec FR-6) and is
+out of scope. Do not change any assertions or arrangements.
+
+**Step 4 — Edit `SetGiftSettingHandlerTests.cs`.**
+
+File: `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs`
+
+Before (line 1):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After (line 1):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Do not change line 9 (`namespace Anela.Heblo.Tests.Application.GiftSettings;`) or any test
+method body.
+
+**Step 5 — Edit `SetGiftSettingValidatorTests.cs`.**
+
+File: `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs`
+
+Before (line 1):
+```csharp
+using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+```
+
+After (line 1):
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
+```
+Do not change line 6 (`namespace Anela.Heblo.Tests.Application.GiftSettings;`) or any test
+method body.
+
+**Step 6 — Repo-wide search for any remaining old-namespace reference.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings" --include="*.cs" backend/
+```
+Expected: no output (empty). If any match remains outside the 5 files above, update it using the
+same before/after mapping in the table in the plan intro, then re-run this grep until it is
+empty.
+
+Also confirm the Domain/Persistence namespaces (which look similar but must NOT be touched) are
+still present and unchanged:
+```
+grep -rn "Anela\.Heblo\.Domain\.Features\.Logistics\.GiftSettings\|Anela\.Heblo\.Persistence\.Logistics\.GiftSettings" --include="*.cs" backend/ | wc -l
+```
+Expected: a non-zero count (these lines must still exist, unmodified, in
+`GetGiftSettingHandler.cs`, `SetGiftSettingHandler.cs`, `GiftSettingsModule.cs`, and the 2 test
+files that assert against the `GiftSetting`/`IGiftSettingRepository` domain types).
+
+**Step 7 — Build the solution.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet build
+```
+Expected: `Build succeeded.` with `0 Error(s)`. If there are new warnings not present before this
+change, investigate — FR-2's acceptance criterion requires zero new warnings. (Pre-existing
+warnings unrelated to GiftSettings are out of scope.)
+
+**Step 8 — Run `dotnet format` (per CLAUDE.md validation requirement).**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet format --verify-no-changes
+```
+If this reports formatting differences confined to the moved/edited files (e.g. whitespace), run
+`dotnet format` without `--verify-no-changes` to apply fixes, then re-run `dotnet build` to
+confirm it still succeeds.
+
+**Step 9 — Run the GiftSettings test suite and confirm the same test count as before the move.**
+
+Confirm the suite passes and the count matches the known fixture set: `GetGiftSettingHandlerTests`
+has 2 `[Fact]` methods, `SetGiftSettingHandlerTests` has 6 `[Fact]` methods, and
+`SetGiftSettingValidatorTests` has 5 `[Fact]` methods — 13 tests total:
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Application.GiftSettings" --logger "console;verbosity=normal"
+```
+Expected: `Passed! - Failed: 0, Passed: 13, Skipped: 0, Total: 13` (or the equivalent summary
+line — exact count must be 13; if it differs, one of the 3 test files was not discovered
+correctly and its namespace/using edits must be re-checked).
+
+**Step 10 — Commit.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git add backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs \
+        backend/src/Anela.Heblo.Application/ApplicationModule.cs \
+        backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs
+git status
+git commit -m "Update GiftSettings call sites to new Logistics.UseCases namespace
+
+Updates using directives in GiftSettingsController, ApplicationModule, and the
+3 GiftSettings test files to reference the relocated
+Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings namespace.
+No behavior, route, or DI registration changes."
+```
+
+---
+
+### task: verify-architecture-boundary-tests
+
+Run the full backend test suite, with particular attention to
+`ModuleBoundariesTests.cs` (which now scans GiftSettings Application types under the
+`Anela.Heblo.Application.Features.Logistics` prefix for the first time), and confirm the overall
+diff is confined to what the spec allows.
+
+**Step 1 — Run the architecture boundary tests in isolation.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Architecture.ModuleBoundariesTests" --logger "console;verbosity=normal"
+```
+Expected: all tests in this class pass, in particular (per spec FR-5) these tests that treat
+`Anela.Heblo.Application.Features.Logistics` as part of the Logistics namespace trio must still
+pass with **no allowlist changes**:
+- `Catalog -> Logistics` (uses `CatalogLogisticsAllowlist`)
+- `ExpeditionList -> Logistics` (uses `ExpeditionListLogisticsAllowlist`)
+- `ShoptetApi Adapters -> Logistics` (uses `ShoptetApiAdaptersLogisticsAllowlist`)
+- `Logistics -> Manufacture` (uses `LogisticsAllowlist`)
+- `Logistics -> Catalog` (uses `LogisticsCatalogAllowlist`)
+- `Logistics_types_should_not_reference_Purchase_owned_namespaces`
+
+If any of these fail with a new violation, the failure message will name the offending
+`SourceType -> TargetType` pair. GiftSettings' only legitimate cross-module dependency is
+`Anela.Heblo.Domain.Features.Users.ICurrentUserService` (used in `SetGiftSettingHandler`), which
+is not Manufacture/Catalog/Purchase-owned and should not trigger any of the above checks. If a
+different, unexpected reference is flagged:
+- Do not silently add it to an allowlist without justification.
+- Check whether it can be resolved via the existing contract-inversion pattern described in
+  `docs/architecture/development_guidelines.md` (the `ILeafletKnowledgeSource` example).
+- If an allowlist addition is genuinely warranted, add a one-line comment in
+  `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` following the existing
+  style (see the comment above `LogisticsAllowlist` at line 29 or `ExpeditionListLogisticsAllowlist`
+  at line 240 for the expected format), and re-run this step until green. This should not be
+  necessary for this specific move — treat any occurrence as a signal to stop and investigate
+  before proceeding, since FR-5's acceptance criterion expects zero allowlist changes.
+
+**Step 2 — Run the full backend test suite.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet test
+```
+Expected: `Passed!` summary with `Failed: 0`. Compare the total test count against the count on
+`main` before this branch's changes (via `git log`/CI history if available) to confirm no tests
+were lost or silently skipped during the move — the GiftSettings suite specifically must still
+report 13 passing tests (2 + 6 + 5, per the previous task's Step 9).
+
+**Step 3 — Confirm the diff is confined to the expected files.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git diff --stat main...HEAD
+```
+Expected: only these paths appear, with the 8 moved files shown as renames:
+- `backend/src/Anela.Heblo.Application/Features/GiftSettings/...` → `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/...` (8 files, renamed)
+- `backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs`
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs`
+
+Nothing under `backend/src/Anela.Heblo.Domain/`, `backend/src/Anela.Heblo.Persistence/`, any
+`Migrations/` folder, or `frontend/` should appear. If anything else shows up, investigate before
+proceeding — per spec FR-4, those layers must be byte-for-byte unchanged.
+
+**Step 4 — Confirm zero remaining old-namespace references repo-wide (final check).**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+grep -rn "Anela\.Heblo\.Application\.Features\.GiftSettings\b" --include="*.cs" .
+```
+Expected: no output. (This re-runs the FR-2 acceptance check as a final gate, now against the
+entire repository rather than just `backend/`.)
+
+**Step 5 — Confirm `dotnet build` is still clean after all edits.**
+
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities/backend
+dotnet build
+```
+Expected: `Build succeeded.`, `0 Error(s)`.
+
+**Step 6 — No commit in this task unless Step 1's allowlist branch was exercised.**
+
+This task is verification-only. If Step 1 required no allowlist change (the expected outcome),
+there is nothing new to commit — the previous two tasks' commits already contain the complete
+fix. If an allowlist entry genuinely had to be added in Step 1, commit it separately:
+```
+cd /home/user/worktrees/feature-3607-Arch-Review-Logistics-Giftsettings-Domain-Entities
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "Add justified allowlist entry surfaced by GiftSettings Logistics move"
+```

--- a/backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/GiftSettingsController.cs
@@ -1,5 +1,5 @@
-using Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
-using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Authorization;
 using MediatR;

--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -33,7 +33,7 @@ using Anela.Heblo.Application.Features.Manufacture;
 using Anela.Heblo.Application.Features.OrgChart;
 using Anela.Heblo.Application.Features.PackingMaterials;
 using Anela.Heblo.Application.Features.CarrierCooling;
-using Anela.Heblo.Application.Features.GiftSettings;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;
 using Anela.Heblo.Application.Features.WeatherForecast;
 using Anela.Heblo.Application.Features.DataQuality;
 using Anela.Heblo.Application.Features.Photobank;

--- a/backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
@@ -1,8 +1,0 @@
-using Anela.Heblo.Application.Features.GiftSettings.Dto;
-using MediatR;
-
-namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
-
-public sealed class GetGiftSettingQuery : IRequest<GiftSettingDto>
-{
-}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto/GiftSettingDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/Dto/GiftSettingDto.cs
@@ -1,4 +1,4 @@
-namespace Anela.Heblo.Application.Features.GiftSettings.Dto;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
 
 public sealed class GiftSettingDto
 {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/GiftSettingsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/GiftSettingsModule.cs
@@ -1,12 +1,12 @@
 using Anela.Heblo.Application.Common.Behaviors;
-using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
 using Anela.Heblo.Persistence.Logistics.GiftSettings;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Anela.Heblo.Application.Features.GiftSettings;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings;
 
 public static class GiftSettingsModule
 {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingHandler.cs
@@ -1,8 +1,8 @@
-using Anela.Heblo.Application.Features.GiftSettings.Dto;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
 using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
 using MediatR;
 
-namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
 
 public sealed class GetGiftSettingHandler : IRequestHandler<GetGiftSettingQuery, GiftSettingDto>
 {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/GetGiftSetting/GetGiftSettingQuery.cs
@@ -1,0 +1,8 @@
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
+
+public sealed class GetGiftSettingQuery : IRequest<GiftSettingDto>
+{
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingCommand.cs
@@ -1,6 +1,6 @@
 using MediatR;
 
-namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 
 public sealed class SetGiftSettingCommand : IRequest<SetGiftSettingResponse>
 {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingHandler.cs
@@ -3,7 +3,7 @@ using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
 
-namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 
 public sealed class SetGiftSettingHandler : IRequestHandler<SetGiftSettingCommand, SetGiftSettingResponse>
 {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingResponse.cs
@@ -1,6 +1,6 @@
 using Anela.Heblo.Application.Shared;
 
-namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 
 public sealed class SetGiftSettingResponse : BaseResponse
 {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftSettings/UseCases/SetGiftSetting/SetGiftSettingValidator.cs
@@ -1,6 +1,6 @@
 using FluentValidation;
 
-namespace Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 
 public sealed class SetGiftSettingValidator : AbstractValidator<SetGiftSettingCommand>
 {

--- a/backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/GiftSettings/GetGiftSettingHandlerTests.cs
@@ -1,5 +1,5 @@
-using Anela.Heblo.Application.Features.GiftSettings.Dto;
-using Anela.Heblo.Application.Features.GiftSettings.UseCases.GetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.Dto;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.GetGiftSetting;
 using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
 using FluentAssertions;
 using Moq;

--- a/backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingHandlerTests.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Logistics.GiftSettings;
 using Anela.Heblo.Domain.Features.Users;

--- a/backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/GiftSettings/SetGiftSettingValidatorTests.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Application.Features.GiftSettings.UseCases.SetGiftSetting;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftSettings.UseCases.SetGiftSetting;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using Xunit;


### PR DESCRIPTION
Closes #3607

## What the issue was
The `GiftSettings` feature's domain (`Domain/Features/Logistics/GiftSettings/`) and persistence (`Persistence/Logistics/GiftSettings/`) layers were nested under the `Logistics` module, while its Application layer (`Application/Features/GiftSettings/`) lived as an independent, standalone module with its own `GiftSettingsModule.cs` and controller route. This layer-boundary mismatch meant domain-layer ownership (Logistics) contradicted application-layer ownership (standalone), giving developers no clear rule for where new GiftSettings logic belongs.

## How it was fixed / handled
Chose **Option B** from the arch-review finding (merge the Application layer into Logistics), based on the existing `GiftPackageManufacture` sub-feature, which already has this exact three-layer-aligned shape (domain, persistence, *and* application all nested under `Logistics`), and on `ModuleBoundariesTests.cs`, which already treats `Anela.Heblo.Application.Features.Logistics` as one of the three canonical Logistics namespace prefixes.

This was a pure namespace/folder relocation with no behavior change:
1. Moved the 8 files under `Application/Features/GiftSettings/` to `Application/Features/Logistics/UseCases/GiftSettings/` via `git mv`, updating only namespace/using declarations.
2. Updated the 5 remaining call sites referencing the old namespace (`GiftSettingsController.cs`, `ApplicationModule.cs`, and the 3 GiftSettings test files).
3. Verified: `dotnet build` succeeds with 0 errors, all 13 GiftSettings tests pass unchanged, all 28 `ModuleBoundariesTests` pass with zero allowlist changes, and the diff is confined to exactly these 14 files (no changes to Domain, Persistence, migrations, the controller's route/auth attributes, or any frontend file).

## Artifacts
Brief, spec, arch-review, design, task plan, impl, review, and final code-review markdown are committed under `artifacts/feat-3607/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

This is a pure, mechanical namespace/folder relocation of the GiftSettings Application layer, matching the `GiftPackageManufacture` precedent already established in the codebase. No logic was touched in any moved file — every diff hunk is a `namespace`/`using` line change only. All spec acceptance criteria (FR-1 through FR-6) were verified against the actual repository state.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sp8rMA2rV1S5AMsLDbWdi)_