### PR TITLE
#3610: extract duplicated gift-package metric calculation into a helper

### DIFF
--- a/artifacts/feat-3610/arch-review.r1.md
+++ b/artifacts/feat-3610/arch-review.r1.md
@@ -1,0 +1,77 @@
+# Architecture Review: Extract duplicated gift package metric calculation into a shared helper
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a same-class, private-method extraction inside `GiftPackageManufactureService` (`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs`). No module boundary, DTO, contract, or public interface (`IGiftPackageManufactureService`) is touched. The class already follows the "extract shared calculation into a `private static` helper" pattern for `CalculateSeverity` (lines 341–356) and `CalculateStockCoveragePercent` (lines 358–369); this change simply applies the same pattern one level up, composing those two helpers into a third. There is no architectural risk — this is intra-file hygiene, fully consistent with the codebase's existing conventions and `docs/architecture/development_guidelines.md` (no new module, no DTO/contract change, no persistence change).
+
+Existing test coverage in `backend/test/Anela.Heblo.Tests/Features/Logistics/GiftPackageManufactureServiceTests.cs` exercises `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` through the public interface, so the refactor is verifiable by running the existing suite unmodified — no new test infrastructure is needed.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. Single file, single class:
+
+```
+GiftPackageManufactureService
+├── GetAvailableGiftPackagesAsync   (public) -- calls ComputePackageMetrics (new)
+├── GetGiftPackageDetailAsync       (public) -- calls ComputePackageMetrics (new)
+├── CreateManufactureAsync          (public) -- unchanged
+├── DisassembleGiftPackageAsync     (public) -- unchanged
+├── ResolveDateRange                (private) -- unchanged
+├── ComputePackageMetrics           (private, NEW) -- calls CalculateSeverity + CalculateStockCoveragePercent
+├── CalculateSeverity               (private static) -- unchanged
+└── CalculateStockCoveragePercent   (private static) -- unchanged
+```
+
+### Key Design Decisions
+
+#### Decision 1: Tuple-returning private method vs. a dedicated result type
+**Options considered:**
+- (a) `private static` method returning a named-tuple `(decimal dailySales, int suggestedQuantity, GiftPackageSeverity severity, decimal stockCoveragePercent)`, as specified in brief and spec.
+- (b) A small internal record/class (e.g. `PackageMetrics`) returned instead of a tuple.
+
+**Chosen approach:** (a), per spec FR-1.
+
+**Rationale:** The four values are consumed once each, immediately deconstructed into locals that already exist at both call sites (`dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent`), and never cross a method/class boundary beyond this file. A tuple is the lowest-ceremony option and matches C# idioms already used elsewhere in this codebase for small private multi-value returns (see `ResolveDateRange`'s `(DateTime From, DateTime To, int Days)`). Introducing a new type for a private, single-file helper would be disproportionate. Note: the tuple element names in the spec (`dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent`) match `ResolveDateRange`'s pattern of using named tuple elements for readability at the call site — keep that consistent.
+
+#### Decision 2: `private static` vs `private` instance method
+**Options considered:** instance method vs. `static`.
+
+**Chosen approach:** `private static`, matching `CalculateSeverity` and `CalculateStockCoveragePercent`.
+
+**Rationale:** `ComputePackageMetrics` has no dependency on instance state (`_manufactureClient`, `_catalogSource`, etc.) — it's a pure function of its three parameters, calling only the two existing static helpers. Marking it `static` is free (no behavior change, no test impact) and keeps the class's convention that pure calculation helpers are static while I/O-bound methods are instance methods. This also makes the helper trivially unit-testable in isolation later if ever needed, without needing to construct the service's dependencies.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Add the method to the existing file, placed after `ResolveDateRange` and before `CalculateSeverity` (or immediately after `CalculateStockCoveragePercent`) — anywhere in the private-helpers block at the bottom of the class (lines 334–370) is acceptable; spec suggests grouping it alongside the other private helpers.
+
+### Interfaces and Contracts
+No public interface changes. New private signature only:
+
+```csharp
+private static (decimal dailySales, int suggestedQuantity, GiftPackageSeverity severity, decimal stockCoveragePercent)
+    ComputePackageMetrics(LogisticsCatalogItem product, decimal salesCoefficient, int daysDiff)
+```
+
+Call sites deconstruct directly:
+```csharp
+var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+    ComputePackageMetrics(product, salesCoefficient, daysDiff);
+```
+
+### Data Flow
+Unchanged. `product` (a `LogisticsCatalogItem`), `salesCoefficient`, and `daysDiff` (from `ResolveDateRange`) flow into the new helper exactly as they currently flow inline into the duplicated block; the four returned values feed the same `GiftPackageDto` construction as before, in both `GetAvailableGiftPackagesAsync` (per-item, in a loop) and `GetGiftPackageDetailAsync` (single item, then BOM/ingredient loading continues unchanged after the helper call).
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Subtle arithmetic reordering changes rounding/decimal precision | Low | Preserve the exact two-step computation (`totalSalesInPeriod` then `dailySales`) as shown in spec FR-1, or verify the single-expression form is bit-for-bit equivalent for `decimal` arithmetic (it is, since `decimal` division/multiplication associativity here doesn't change results) before collapsing to one line; existing tests will catch any drift. |
+| Regression in either call site during manual find-replace | Low | Existing tests in `GiftPackageManufactureServiceTests.cs` cover both public methods; run them post-refactor as the acceptance gate (spec FR-4). |
+
+## Specification Amendments
+None. The spec is complete, correctly scoped, and matches the codebase's existing patterns. No architectural changes are needed to it.
+
+## Prerequisites
+None. No migrations, config, or infrastructure changes required — implementation can start immediately.

--- a/artifacts/feat-3610/brief.md
+++ b/artifacts/feat-3610/brief.md
@@ -1,0 +1,57 @@
+## Module
+Logistics / GiftPackageManufacture
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs`
+
+The same ~10-line block that derives `dailySales`, `suggestedQuantity`, `severity`, and `stockCoveragePercent` from a catalog product appears verbatim in two methods:
+
+**`GetAvailableGiftPackagesAsync` (lines ~55–65):**
+```csharp
+var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
+var dailySales = totalSalesInPeriod / daysDiff;
+var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
+var severity = CalculateSeverity(
+    (int)product.AvailableStock, suggestedQuantity, product.StockMinSetup);
+var stockCoveragePercent = CalculateStockCoveragePercent(
+    (int)product.AvailableStock, dailySales, product.OptimalStockDaysSetup);
+```
+
+**`GetGiftPackageDetailAsync` (lines ~106–121):**
+```csharp
+var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
+var dailySales = totalSalesInPeriod / daysDiff;
+var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
+var severity = CalculateSeverity(
+    (int)product.AvailableStock, suggestedQuantity, product.StockMinSetup);
+var stockCoveragePercent = CalculateStockCoveragePercent(
+    (int)product.AvailableStock, dailySales, product.OptimalStockDaysSetup);
+```
+
+The only difference between the two methods is that `GetGiftPackageDetailAsync` additionally loads BOM ingredients. The core DTO-mapping logic is identical.
+
+## Why it matters
+If the sales formula or severity thresholds ever change, the same fix must be applied in two places. The existing `CalculateSeverity` and `CalculateStockCoveragePercent` private helpers show the author already extracted shared calculations — the remaining duplication is inconsistent with that pattern.
+
+## Suggested fix
+Extract a private helper that takes the catalog item and the computed parameters and returns the metric fields, then call it from both methods:
+
+```csharp
+private (decimal dailySales, int suggestedQuantity, GiftPackageSeverity severity, decimal stockCoveragePercent)
+    ComputePackageMetrics(LogisticsCatalogItem product, decimal salesCoefficient, int daysDiff)
+{
+    var dailySales = (decimal)product.TotalSoldInPeriod * salesCoefficient / daysDiff;
+    var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
+    return (
+        dailySales,
+        suggestedQuantity,
+        CalculateSeverity((int)product.AvailableStock, suggestedQuantity, product.StockMinSetup),
+        CalculateStockCoveragePercent((int)product.AvailableStock, dailySales, product.OptimalStockDaysSetup)
+    );
+}
+```
+
+Replace the duplicated blocks in both public methods with a single call to `ComputePackageMetrics`.
+
+---
+_Filed by daily arch-review routine on 2026-07-12._

--- a/artifacts/feat-3610/code-review.r1.md
+++ b/artifacts/feat-3610/code-review.r1.md
@@ -1,0 +1,16 @@
+## Review Result: CLEAN
+
+Pure extract-method refactor of `GiftPackageManufactureService`: the duplicated `dailySales`/`suggestedQuantity`/`severity`/`stockCoveragePercent` computation block from `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` is consolidated into a new `private static ComputePackageMetrics(LogisticsGiftPackageItem product, decimal salesCoefficient, int daysDiff)` helper, placed alongside the other private calculation helpers (`ResolveDateRange`, `CalculateSeverity`, `CalculateStockCoveragePercent`) as required by the spec.
+
+Verified:
+- Both call sites' `product` locals are actually `LogisticsGiftPackageItem` (from `ILogisticsCatalogSource.GetGiftPackageSetsAsync`/`GetGiftPackageAsync`), matching the helper's parameter type, so it compiles cleanly. The spec's pseudocode used `LogisticsCatalogItem`, but the implementer correctly used the real type instead — not a defect.
+- Arithmetic order is byte-for-byte identical to the original two call sites (`totalSalesInPeriod` → `dailySales` → `suggestedQuantity` → `severity`/`stockCoveragePercent`), so results are unchanged for all inputs.
+- Both call sites deconstruct the returned tuple into the same four fields and use them identically in `GiftPackageDto` construction — no field mapping changed.
+- `CreateManufactureAsync` and `DisassembleGiftPackageAsync` are untouched, as required (out of scope).
+- `dotnet build` on `Anela.Heblo.Application` succeeds with 0 errors (134 pre-existing warnings, none introduced by this change, none in the touched file).
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3610/impl/extract-compute-package-metrics-helper.r1.md
+++ b/artifacts/feat-3610/impl/extract-compute-package-metrics-helper.r1.md
@@ -1,0 +1,28 @@
+# Implementation: extract-compute-package-metrics-helper
+
+## What was implemented
+Extracted the duplicated ~15-line metric-calculation block (`dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent`) that appeared verbatim in both `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` into a single private static helper `ComputePackageMetrics`, matching the existing private-helper pattern (`CalculateSeverity`, `CalculateStockCoveragePercent`) already in the class. Both call sites now deconstruct the tuple returned by the helper. No formula changes, no public signature changes, no DTO changes.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs` — added `ComputePackageMetrics` private static helper near the other private helpers; replaced both duplicated blocks with a call to it.
+
+## Tests
+- `dotnet build Anela.Heblo.sln` — 0 errors (95 pre-existing warnings, unrelated to this change).
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GiftPackageManufactureServiceTests" --no-build` — Passed: 10, Failed: 0.
+
+## How to verify
+1. `dotnet build Anela.Heblo.sln`
+2. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GiftPackageManufactureServiceTests"`
+3. `git diff` the service file — confirm both call sites now use `ComputePackageMetrics` and the arithmetic is byte-identical to before.
+
+## Notes
+No deviations from the plan. The helper's parameter type is `LogisticsGiftPackageItem` (the actual product type used in this file), matching the existing method signatures.
+
+## PR Summary
+Removes duplicated gift-package metric-calculation logic from `GiftPackageManufactureService` by extracting it into a single `ComputePackageMetrics` private helper, called from both `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync`. Pure refactor with no behavior change; verified by the existing `GiftPackageManufactureServiceTests` suite (10/10 passing) and a clean build.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs` — extracted `ComputePackageMetrics` helper, removed duplication at both call sites
+
+## Status
+DONE

--- a/artifacts/feat-3610/review/extract-compute-package-metrics-helper.r1.md
+++ b/artifacts/feat-3610/review/extract-compute-package-metrics-helper.r1.md
@@ -1,0 +1,19 @@
+# Code Review: Extract ComputePackageMetrics Helper
+
+## Summary
+The refactor extracts the duplicated metric-calculation block from `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` into a single private static `ComputePackageMetrics` helper, exactly as specified. The arithmetic is byte-identical to the original (verified via `git show`), both call sites deconstruct the same tuple, and the build/tests pass independently verified. No public signatures, DTOs, or formulas changed.
+
+## Review Result: PASS
+
+### task: extract-compute-package-metrics-helper
+**Status:** PASS
+
+## Docs to Update
+None.
+
+## Overall Notes
+- Independently re-ran `dotnet build Anela.Heblo.sln` — 0 errors (pre-existing warnings only, none touching this file).
+- Independently re-ran `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GiftPackageManufactureServiceTests" --no-build` — Passed: 10, Failed: 0. Confirms the implementer's claim.
+- Inspected the actual commit (`a55a560`): both call sites replace the ~16-line duplicated block with a 2-line tuple deconstruction calling `ComputePackageMetrics`; the new helper reproduces the original two-step arithmetic (`totalSalesInPeriod` → `dailySales`) verbatim and delegates to the untouched `CalculateSeverity`/`CalculateStockCoveragePercent` methods. `CreateManufactureAsync`, `DisassembleGiftPackageAsync`, and `ResolveDateRange` are untouched, matching the "do not touch" list in the task spec.
+- One deliberate, correct deviation from the task spec's literal text: the spec's example code used `LogisticsCatalogItem` as the helper's parameter type, but the actual `product` variables at both call sites (from `ILogisticsCatalogSource.GetGiftPackageSetsAsync`/`GetGiftPackageAsync`) are `LogisticsGiftPackageItem`. The implementer correctly used `LogisticsGiftPackageItem`, which is required for the code to compile — using the spec's literal type name would have been a build error. This is a sensible correction of an inaccuracy in the spec's illustrative snippet, not a functional or architectural deviation, and does not warrant revision.
+- No `using` changes were needed, consistent with the spec's expectation.

--- a/artifacts/feat-3610/spec.r1.md
+++ b/artifacts/feat-3610/spec.r1.md
@@ -1,0 +1,91 @@
+# Specification: Extract duplicated gift package metric calculation into a shared helper
+
+## Summary
+`GiftPackageManufactureService` computes `dailySales`, `suggestedQuantity`, `severity`, and `stockCoveragePercent` from a catalog product using an identical ~10-line block in both `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync`. This refactor extracts that block into a single private helper method so the calculation logic exists in exactly one place, matching the pattern already used for `CalculateSeverity` and `CalculateStockCoveragePercent`.
+
+## Background
+This is a code-quality finding from the daily arch-review routine (2026-07-12), not a bug or a behavior change request. The duplication risks silent drift: if the sales/severity formula changes, a developer could update one call site and miss the other. `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` differ only in that the latter additionally loads BOM ingredients; the metric-derivation logic itself is identical and self-contained (pure function of `product`, `salesCoefficient`, `daysDiff`).
+
+## Functional Requirements
+
+### FR-1: Extract `ComputePackageMetrics` private helper
+Add a private method to `GiftPackageManufactureService` that encapsulates the duplicated calculation block:
+
+```csharp
+private (decimal dailySales, int suggestedQuantity, GiftPackageSeverity severity, decimal stockCoveragePercent)
+    ComputePackageMetrics(LogisticsCatalogItem product, decimal salesCoefficient, int daysDiff)
+{
+    var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
+    var dailySales = totalSalesInPeriod / daysDiff;
+    var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
+    return (
+        dailySales,
+        suggestedQuantity,
+        CalculateSeverity((int)product.AvailableStock, suggestedQuantity, product.StockMinSetup),
+        CalculateStockCoveragePercent((int)product.AvailableStock, dailySales, product.OptimalStockDaysSetup)
+    );
+}
+```
+
+The helper must be placed alongside the other private calculation helpers (`ResolveDateRange`, `CalculateSeverity`, `CalculateStockCoveragePercent`) near the bottom of the class, following existing ordering/style conventions.
+
+**Acceptance criteria:**
+- The tuple-returning signature matches the brief's suggested fix (field names: `dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent`).
+- Method is `private`, non-static is acceptable since it calls the existing static helpers, but it may be marked `static` if it has no instance state dependency (it doesn't) — either is acceptable as long as it compiles cleanly; prefer `private static` for consistency with `CalculateSeverity`/`CalculateStockCoveragePercent`.
+- No change to the arithmetic: `dailySales = (decimal)product.TotalSoldInPeriod * salesCoefficient / daysDiff` must produce bit-for-bit identical results to the current two-step computation (order of operations preserved).
+
+### FR-2: Replace duplicated block in `GetAvailableGiftPackagesAsync`
+Replace lines ~54–71 (the `totalSalesInPeriod`/`dailySales`/`suggestedQuantity`/`severity`/`stockCoveragePercent` block and its comments) with a single call:
+
+```csharp
+var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+    ComputePackageMetrics(product, salesCoefficient, daysDiff);
+```
+
+The rest of the loop body (construction of `GiftPackageDto`) is unchanged.
+
+**Acceptance criteria:**
+- `GetAvailableGiftPackagesAsync` no longer contains inline computation of these four values.
+- `GiftPackageDto` fields (`DailySales`, `SuggestedQuantity`, `Severity`, `StockCoveragePercent`) are populated from the deconstructed tuple exactly as before.
+
+### FR-3: Replace duplicated block in `GetGiftPackageDetailAsync`
+Replace lines ~105–122 with the same helper call pattern as FR-2, using this method's local `product` and `daysDiff` variables. The rest of the method (BOM/ingredient loading, `GiftPackageDto` construction) is unchanged.
+
+**Acceptance criteria:**
+- `GetGiftPackageDetailAsync` no longer contains inline computation of these four values.
+- All downstream usages (`giftPackage.DailySales`, `.SuggestedQuantity`, `.Severity`, `.StockCoveragePercent`) still receive correct values via the deconstructed tuple.
+
+### FR-4: No behavior change
+This is a pure refactor. Public method signatures, return types, DTO shapes, and computed values must be unchanged for all existing inputs.
+
+**Acceptance criteria:**
+- Existing unit/integration tests covering `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` (if any) pass unmodified.
+- `dotnet build` succeeds with no new warnings introduced by the refactor.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable impact expected; this is a same-process method extraction with no additional allocations beyond a single tuple return per call (negligible).
+
+### NFR-2: Security
+Not applicable — no change to auth, data access, or external inputs.
+
+## Data Model
+No changes. `LogisticsCatalogItem`, `GiftPackageDto`, and `GiftPackageSeverity` are unchanged.
+
+## API / Interface Design
+No public API, controller, or DTO changes. The refactor is confined to a new private method within `GiftPackageManufactureService` and its two call sites.
+
+## Dependencies
+None beyond the existing file's current dependencies (`GiftPackageSeverity`, `LogisticsCatalogItem`, existing private helpers `CalculateSeverity` and `CalculateStockCoveragePercent`).
+
+## Out of Scope
+- Any change to the formula for `dailySales`, `suggestedQuantity`, `severity`, or `stockCoveragePercent`.
+- Refactoring `GetGiftPackageDetailAsync`'s BOM/ingredient-loading logic.
+- Refactoring `CreateManufactureAsync` or `DisassembleGiftPackageAsync`.
+- Adding new unit tests (existing test coverage, if present, should simply continue to pass; adding coverage is optional and left to implementer discretion but not required by this spec).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "extract-compute-package-metrics-helper",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T07:18:58.315568Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T07:19:10.409529Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T07:33:04.002732Z"
     }
   },
   "tasks": [
     {
       "name": "extract-compute-package-metrics-helper",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-13T07:19:10.598165Z"
+      "updated_at": "2026-07-13T07:32:59.020957Z"
     }
   ]
 }

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T07:16:42.356232Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-13T07:33:04.002732Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T07:33:10.385766Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T07:39:10.931683Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-13T07:33:04.002732Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-13T07:33:10.385766Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3610",
+  "issue_number": 3610,
+  "created_at": "2026-07-13T07:14:35.121518Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-13T07:16:42.356232Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T07:17:40.643041Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T07:18:58.315568Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T07:19:10.409529Z"
     }
   },
   "tasks": [
     {
       "name": "extract-compute-package-metrics-helper",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-13T07:19:10.598165Z"
     }
   ]
 }

--- a/artifacts/feat-3610/state.json
+++ b/artifacts/feat-3610/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-13T07:17:40.643041Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T07:17:58.719709Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T07:18:58.315568Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3610/task-context/extract-compute-package-metrics-helper.md
+++ b/artifacts/feat-3610/task-context/extract-compute-package-metrics-helper.md
@@ -1,0 +1,66 @@
+
+#### Goal
+Eliminate the duplicated ~10-line metric-calculation block (`dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent`) that currently exists identically in both `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` in `GiftPackageManufactureService`. Extract it into a single private static helper method `ComputePackageMetrics`, call it from both places, and verify there is zero behavior change.
+
+This is a pure refactor — no formula changes, no public signature changes, no DTO changes.
+
+#### Files
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs` (only file touched)
+
+#### Approach
+
+1. **Add the new private helper method**, placed in the private-helpers block near the bottom of the class (after `ResolveDateRange`, alongside `CalculateSeverity` and `CalculateStockCoveragePercent` — e.g. immediately before `CalculateSeverity`, around what is currently line 341):
+
+```csharp
+private static (decimal dailySales, int suggestedQuantity, GiftPackageSeverity severity, decimal stockCoveragePercent)
+    ComputePackageMetrics(LogisticsCatalogItem product, decimal salesCoefficient, int daysDiff)
+{
+    var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
+    var dailySales = totalSalesInPeriod / daysDiff;
+    var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
+    return (
+        dailySales,
+        suggestedQuantity,
+        CalculateSeverity((int)product.AvailableStock, suggestedQuantity, product.StockMinSetup),
+        CalculateStockCoveragePercent((int)product.AvailableStock, dailySales, product.OptimalStockDaysSetup)
+    );
+}
+```
+
+   Preserve the exact two-step arithmetic (`totalSalesInPeriod` then `dailySales`) — do not collapse into a single expression, to keep the diff minimal and match the spec exactly. Mark it `private static`, matching `CalculateSeverity`/`CalculateStockCoveragePercent`.
+
+2. **Replace the duplicated block in `GetAvailableGiftPackagesAsync`** (currently lines 54–71, inside the `foreach (var product in setProducts)` loop): delete the inline computation of `totalSalesInPeriod`, `dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent` (including their comments), and replace with:
+
+```csharp
+var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+    ComputePackageMetrics(product, salesCoefficient, daysDiff);
+```
+
+   The subsequent `GiftPackageDto` construction (lines 73–85 currently) is untouched — it already references `dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent` by these exact names.
+
+3. **Replace the duplicated block in `GetGiftPackageDetailAsync`** (currently lines 105–122, after the `product == null` check): delete the same inline computation and comments, replace with:
+
+```csharp
+var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+    ComputePackageMetrics(product, salesCoefficient, daysDiff);
+```
+
+   The subsequent `GiftPackageDto` construction (lines 125–137 currently, which also sets `Ingredients`) and all code after it (BOM/ingredient loading) is untouched.
+
+4. **Do not touch**: `CreateManufactureAsync`, `DisassembleGiftPackageAsync`, `ResolveDateRange`, `CalculateSeverity`, `CalculateStockCoveragePercent` — leave these exactly as-is. `CalculateSeverity` and `CalculateStockCoveragePercent` are called *from* the new helper but their own bodies do not change.
+
+5. Double-check no `using` changes are needed (all referenced types — `GiftPackageSeverity`, `LogisticsCatalogItem` — are already in scope in this file).
+
+#### Verification
+
+- Run the existing test suite scoped to this service:
+  ```
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GiftPackageManufactureServiceTests"
+  ```
+  All tests in `backend/test/Anela.Heblo.Tests/Features/Logistics/GiftPackageManufactureServiceTests.cs` must pass unmodified — do not edit the test file.
+- Run a full backend build to confirm no new warnings/errors:
+  ```
+  cd backend && dotnet build
+  ```
+- Run `dotnet format` (or the repo's configured formatting check) per CLAUDE.md validation requirements before declaring the task done.
+- Manually diff the final file against the original to confirm the only changes are: the new `ComputePackageMetrics` method, and the two call-site replacements — no formula/arithmetic changes, no DTO or public signature changes.

--- a/artifacts/feat-3610/task-plan.r1.md
+++ b/artifacts/feat-3610/task-plan.r1.md
@@ -1,0 +1,69 @@
+# Implementation Plan: Extract duplicated gift package metric calculation into a shared helper
+
+### task: extract-compute-package-metrics-helper
+
+#### Goal
+Eliminate the duplicated ~10-line metric-calculation block (`dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent`) that currently exists identically in both `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` in `GiftPackageManufactureService`. Extract it into a single private static helper method `ComputePackageMetrics`, call it from both places, and verify there is zero behavior change.
+
+This is a pure refactor — no formula changes, no public signature changes, no DTO changes.
+
+#### Files
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs` (only file touched)
+
+#### Approach
+
+1. **Add the new private helper method**, placed in the private-helpers block near the bottom of the class (after `ResolveDateRange`, alongside `CalculateSeverity` and `CalculateStockCoveragePercent` — e.g. immediately before `CalculateSeverity`, around what is currently line 341):
+
+```csharp
+private static (decimal dailySales, int suggestedQuantity, GiftPackageSeverity severity, decimal stockCoveragePercent)
+    ComputePackageMetrics(LogisticsCatalogItem product, decimal salesCoefficient, int daysDiff)
+{
+    var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
+    var dailySales = totalSalesInPeriod / daysDiff;
+    var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
+    return (
+        dailySales,
+        suggestedQuantity,
+        CalculateSeverity((int)product.AvailableStock, suggestedQuantity, product.StockMinSetup),
+        CalculateStockCoveragePercent((int)product.AvailableStock, dailySales, product.OptimalStockDaysSetup)
+    );
+}
+```
+
+   Preserve the exact two-step arithmetic (`totalSalesInPeriod` then `dailySales`) — do not collapse into a single expression, to keep the diff minimal and match the spec exactly. Mark it `private static`, matching `CalculateSeverity`/`CalculateStockCoveragePercent`.
+
+2. **Replace the duplicated block in `GetAvailableGiftPackagesAsync`** (currently lines 54–71, inside the `foreach (var product in setProducts)` loop): delete the inline computation of `totalSalesInPeriod`, `dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent` (including their comments), and replace with:
+
+```csharp
+var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+    ComputePackageMetrics(product, salesCoefficient, daysDiff);
+```
+
+   The subsequent `GiftPackageDto` construction (lines 73–85 currently) is untouched — it already references `dailySales`, `suggestedQuantity`, `severity`, `stockCoveragePercent` by these exact names.
+
+3. **Replace the duplicated block in `GetGiftPackageDetailAsync`** (currently lines 105–122, after the `product == null` check): delete the same inline computation and comments, replace with:
+
+```csharp
+var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+    ComputePackageMetrics(product, salesCoefficient, daysDiff);
+```
+
+   The subsequent `GiftPackageDto` construction (lines 125–137 currently, which also sets `Ingredients`) and all code after it (BOM/ingredient loading) is untouched.
+
+4. **Do not touch**: `CreateManufactureAsync`, `DisassembleGiftPackageAsync`, `ResolveDateRange`, `CalculateSeverity`, `CalculateStockCoveragePercent` — leave these exactly as-is. `CalculateSeverity` and `CalculateStockCoveragePercent` are called *from* the new helper but their own bodies do not change.
+
+5. Double-check no `using` changes are needed (all referenced types — `GiftPackageSeverity`, `LogisticsCatalogItem` — are already in scope in this file).
+
+#### Verification
+
+- Run the existing test suite scoped to this service:
+  ```
+  cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GiftPackageManufactureServiceTests"
+  ```
+  All tests in `backend/test/Anela.Heblo.Tests/Features/Logistics/GiftPackageManufactureServiceTests.cs` must pass unmodified — do not edit the test file.
+- Run a full backend build to confirm no new warnings/errors:
+  ```
+  cd backend && dotnet build
+  ```
+- Run `dotnet format` (or the repo's configured formatting check) per CLAUDE.md validation requirements before declaring the task done.
+- Manually diff the final file against the original to confirm the only changes are: the new `ComputePackageMetrics` method, and the two call-site replacements — no formula/arithmetic changes, no DTO or public signature changes.

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs
@@ -51,24 +51,8 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
 
         foreach (var product in setProducts)
         {
-            // Calculate daily sales from sales history using the actual date range
-            var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
-            var dailySales = totalSalesInPeriod / daysDiff;
-
-            // Calculate suggested quantity: DailySales * OverstockOptimal
-            var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
-
-            // Calculate severity based on new rules
-            var severity = CalculateSeverity(
-                (int)product.AvailableStock,
-                suggestedQuantity,
-                product.StockMinSetup);
-
-            // Calculate stock coverage percentage: (AvailableStock / (DailySales * OverstockOptimal)) * 100
-            var stockCoveragePercent = CalculateStockCoveragePercent(
-                (int)product.AvailableStock,
-                dailySales,
-                product.OptimalStockDaysSetup);
+            var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+                ComputePackageMetrics(product, salesCoefficient, daysDiff);
 
             var giftPackage = new GiftPackageDto
             {
@@ -102,24 +86,8 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
             throw new ArgumentException($"Gift package '{giftPackageCode}' not found or is not a set product");
         }
 
-        // Calculate daily sales from sales history using the actual date range
-        var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
-        var dailySales = totalSalesInPeriod / daysDiff;
-
-        // Calculate suggested quantity: DailySales * OverstockOptimal
-        var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
-
-        // Calculate severity based on new rules
-        var severity = CalculateSeverity(
-            (int)product.AvailableStock,
-            suggestedQuantity,
-            product.StockMinSetup);
-
-        // Calculate stock coverage percentage: (AvailableStock / (DailySales * OverstockOptimal)) * 100
-        var stockCoveragePercent = CalculateStockCoveragePercent(
-            (int)product.AvailableStock,
-            dailySales,
-            product.OptimalStockDaysSetup);
+        var (dailySales, suggestedQuantity, severity, stockCoveragePercent) =
+            ComputePackageMetrics(product, salesCoefficient, daysDiff);
 
         // Create the detailed gift package with ingredients
         var giftPackage = new GiftPackageDto
@@ -336,6 +304,20 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
         var to = toDate ?? _timeProvider.GetUtcNow().DateTime;
         var from = fromDate ?? to.AddYears(-1);
         return (from, to, Math.Max((to - from).Days, 1));
+    }
+
+    private static (decimal dailySales, int suggestedQuantity, GiftPackageSeverity severity, decimal stockCoveragePercent)
+        ComputePackageMetrics(LogisticsGiftPackageItem product, decimal salesCoefficient, int daysDiff)
+    {
+        var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
+        var dailySales = totalSalesInPeriod / daysDiff;
+        var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
+        return (
+            dailySales,
+            suggestedQuantity,
+            CalculateSeverity((int)product.AvailableStock, suggestedQuantity, product.StockMinSetup),
+            CalculateStockCoveragePercent((int)product.AvailableStock, dailySales, product.OptimalStockDaysSetup)
+        );
     }
 
     private static GiftPackageSeverity CalculateSeverity(int availableStock, int suggestedQuantity, int overstockMinimal)


### PR DESCRIPTION
Closes #3610

## What the issue was
`GiftPackageManufactureService.GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` both contained the same ~15-line block that derives `dailySales`, `suggestedQuantity`, `severity`, and `stockCoveragePercent` from a catalog product. If the sales formula or severity thresholds ever changed, the fix had to be applied in two places, and the duplication was inconsistent with the class's existing pattern of extracting shared calculations into private helpers (`CalculateSeverity`, `CalculateStockCoveragePercent`).

## How it was fixed / handled
Extracted a new private static helper, `ComputePackageMetrics(LogisticsGiftPackageItem product, decimal salesCoefficient, int daysDiff)`, that returns the four computed fields as a tuple, placed alongside the other private helpers. Both call sites now deconstruct the helper's return value instead of repeating the calculation. This is a pure refactor — the arithmetic order is preserved exactly, so results are unchanged for all inputs; no public signatures, DTOs, or other methods were touched.

Verified with `dotnet build` (0 errors) and the existing `GiftPackageManufactureServiceTests` suite (10/10 passing).

## Artifacts
- Brief, spec, arch-review, task plan, impl, and review markdown are committed under `artifacts/feat-3610/` in this branch.

## Code review

## Review Result: CLEAN

Pure extract-method refactor of `GiftPackageManufactureService`: the duplicated `dailySales`/`suggestedQuantity`/`severity`/`stockCoveragePercent` computation block from `GetAvailableGiftPackagesAsync` and `GetGiftPackageDetailAsync` is consolidated into a new `private static ComputePackageMetrics(LogisticsGiftPackageItem product, decimal salesCoefficient, int daysDiff)` helper, placed alongside the other private calculation helpers (`ResolveDateRange`, `CalculateSeverity`, `CalculateStockCoveragePercent`) as required by the spec.

Verified:
- Both call sites' `product` locals are actually `LogisticsGiftPackageItem`, matching the helper's parameter type, so it compiles cleanly.
- Arithmetic order is byte-for-byte identical to the original two call sites, so results are unchanged for all inputs.
- Both call sites deconstruct the returned tuple into the same four fields and use them identically — no field mapping changed.
- `CreateManufactureAsync` and `DisassembleGiftPackageAsync` are untouched, as required (out of scope).
- `dotnet build` succeeds with 0 errors (pre-existing warnings only, none introduced).

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBvnnKVYP5Mvksjd31Z8wP)_