### PR TITLE
chore(harness): update AgentHarness to 0.16.3 (copy-based init)

### DIFF
--- a/.claude/skills/oneshot/SKILL.md
+++ b/.claude/skills/oneshot/SKILL.md
@@ -140,13 +140,14 @@ git push -u origin "$BRANCH"
    feature PR without it.
 
    Open the PR (base = the repository default branch, head = `$BRANCH`). Capture
-   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"`
+   the PR URL, then run `.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "$ISSUE_ID"`
    — this script ships beside this skill, so it is always present wherever the skill
-   is installed. It is the guarantee for **both** requirements above. Do not rely on `--label` or the
-   `Closes` template line on `gh pr create` alone; the LLM-filled body and the
-   `--label` flag are both sometimes dropped. The script adds the `agent` label,
-   injects `Closes #{issue_id}` if missing, then hard-fails if it cannot confirm
-   either.
+   is installed. It is the guarantee for **all three** requirements above (label,
+   closing link, and title format). Do not rely on `--label`, the `Closes` template
+   line, or the `--title` on `gh pr create` alone; the LLM-filled body, the `--label`
+   flag, and the title are all sometimes dropped or mangled. The script adds the
+   `agent` label, injects `Closes #{issue_id}` if missing, and normalizes the title
+   to `#{issue_id}: <summary>`, then hard-fails if it cannot confirm all three.
 
    First capture the pipeline's final code review so it can be surfaced on the PR.
    The `## Code review` section carries the whole-branch review run inside the
@@ -163,9 +164,9 @@ PR_URL=$(gh pr create \
   --base master \
   --head "$BRANCH" \
   --label agent \
-  --title "#{issue_id}: implementation" \
+  --title "#${ISSUE_ID}: implementation" \
   --body "$(cat <<EOF
-Closes #{issue_id}
+Closes #${ISSUE_ID}
 
 ## What the issue was
 <description of the feature/problem from the brief>
@@ -179,12 +180,16 @@ ${REVIEW_SECTION}
 EOF
 )")
 
-# MANDATORY: guarantee the `agent` label AND the `Closes #{issue_id}` link.
-# Auto-repairs both if the agent dropped them, then hard-fails if it cannot.
-.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "{issue_id}"
+# MANDATORY: guarantee the `agent` label, the `Closes #<n>` link, AND the
+# `#<n>: <summary>` title format. Auto-repairs all three if the agent dropped
+# or mangled them, then hard-fails if it cannot.
+.claude/skills/oneshot/ensure_pr_linked.sh "$PR_URL" "$ISSUE_ID"
 ```
-   Substitute the real GitHub issue number for `{issue_id}` in both the title
-   and the `Closes #{issue_id}` line (same number used for `ISSUE_ID` above).
+   The title and the `Closes` line use the `${ISSUE_ID}` shell variable set in
+   the **Naming convention** block, so they expand automatically — do not
+   hand-edit them. Substitute the real feature id for the remaining
+   `{issue_id}` artifact-path placeholders (the `artifacts/feat-{issue_id}/…`
+   lines) only.
 
 5. **Mark the issue completed.** Using the `gh` CLI, remove the `agent-wip`
    label and add the `agent-completed` label to the feature's issue:

--- a/.claude/skills/oneshot/ensure_pr_linked.sh
+++ b/.claude/skills/oneshot/ensure_pr_linked.sh
@@ -2,12 +2,13 @@
 # Ensure a harness-opened PR is tied to its tracking issue.
 #
 # Guarantees, idempotently, that the pull request:
-#   1. carries the `agent` label, and
+#   1. carries the `agent` label,
 #   2. links the issue with a closing keyword (`Closes #<n>`) so merging the PR
-#      auto-closes the issue.
+#      auto-closes the issue, and
+#   3. has a title in the defined format `#<issue>: <summary>`.
 #
-# Auto-repairs first (adds the label / injects a `Closes #<n>` line), then
-# verifies. Exits non-zero if it still cannot guarantee both.
+# Auto-repairs first (adds the label / injects a `Closes #<n>` line / normalizes
+# the title), then verifies. Exits non-zero if it still cannot guarantee all three.
 #
 # Usage: ensure_pr_linked.sh <pr-url-or-number> <issue-number>
 set -euo pipefail
@@ -48,4 +49,21 @@ if ! grep -qiE "$CLOSE_LINK" <<<"$body"; then
   fi
 fi
 
-echo "PR $PR linked to issue #$ISSUE with agent label."
+# 3. Guarantee the title follows the defined format: "#<issue>: <summary>".
+TITLE_RE="^#${ISSUE}: .+"
+title=$(gh pr view "$PR" --json title --jq '.title')
+if [[ ! "$title" =~ $TITLE_RE ]]; then
+  # Strip any leading "#<anything>:" prefix (real number or un-substituted
+  # placeholder like "#{issue_id}:"), trim, and keep the remainder as summary.
+  summary=$(sed -E 's/^#[^:]*:[[:space:]]*//' <<<"$title")
+  summary=$(sed -E 's/^[[:space:]]+|[[:space:]]+$//g' <<<"$summary")
+  [[ -z "$summary" ]] && summary="implementation"
+  gh pr edit "$PR" --title "#${ISSUE}: ${summary}"
+  title=$(gh pr view "$PR" --json title --jq '.title')
+  if [[ ! "$title" =~ $TITLE_RE ]]; then
+    echo "ERROR: failed to set title format on $PR" >&2
+    exit 1
+  fi
+fi
+
+echo "PR $PR linked to issue #$ISSUE with agent label and title \"$title\"."

--- a/scripts/setup-cloud-env.sh
+++ b/scripts/setup-cloud-env.sh
@@ -153,31 +153,31 @@ restore_frontend() {
 # 6. AgentHarness (skill-based single-agent harness)
 # ---------------------------------------------------------------------------
 # Two steps: the pip install is repo-independent (runs after install_gh), while
-# linking needs the checked-out repo (runs after require_repo).
+# init needs the checked-out repo (runs after require_repo).
 install_agentharness() {
   log "Installing AgentHarness from GitHub (main branch)..."
   command -v pip >/dev/null 2>&1 || $SUDO apt-get install -y python3-pip || true
   # Ubuntu Noble's system Python is externally managed (PEP 668), so
   # --break-system-packages is required for a system-wide pip install.
-  # --upgrade so each cloud session picks up the latest master (which also
-  # refreshes the symlinked agents/skills linked by init_agentharness below).
+  # --upgrade so each cloud session picks up the latest master; init_agentharness
+  # below then re-copies the shipped agents/skills so the repo tracks that build.
   pip install --break-system-packages --upgrade \
     "git+https://github.com/onpaj/harness.git@master" || true
   ok "AgentHarness installed ($(agentharness --version 2>/dev/null || echo present))"
 }
 
 init_agentharness() {
-  log "Linking AgentHarness agents/skills into the repo (symlink mode)..."
-  # --symlink links each shipped item from the installed package and records the
-  # paths in a managed .gitignore block, so `pip install --upgrade` above keeps
-  # the repo current with nothing to re-commit. --force converts any leftover
-  # committed copies in place (git rm --cached + relink). The init also writes
-  # .env: GITHUB_TOKEN/OWNER/RUNS_REPO are auto-detected from gh auth + the git
-  # remote, so feed blank lines so an un-detected prompt can't stall under
-  # `set -e`. Tolerant (|| true): a missing --symlink option or symlink refusal
-  # must not abort the whole provisioning run.
-  printf '\n\n\n' | agentharness init --symlink --force --dir "${REPO_ROOT}" || true
-  ok "AgentHarness agents/skills linked"
+  log "Copying AgentHarness agents/skills into the repo..."
+  # `init` copies the shipped agent definitions, skills, and pipeline config into
+  # the repo's standard locations (.agents/, .claude/, .pipeline/) — these are
+  # meant to be committed to source control, so a harness upgrade surfaces as a
+  # normal diff to review and commit. --force overwrites the previously committed
+  # copies in place. The init also writes .env: GITHUB_TOKEN/OWNER/RUNS_REPO are
+  # auto-detected from gh auth + the git remote (.env is gitignored), so feed
+  # blank lines so an un-detected prompt can't stall under `set -e`. Tolerant
+  # (|| true): an init hiccup must not abort the whole provisioning run.
+  printf '\n\n\n' | agentharness init --force --dir "${REPO_ROOT}" || true
+  ok "AgentHarness agents/skills copied"
 }
 
 install_playwright() {


### PR DESCRIPTION
## Summary

Updates the bundled **AgentHarness** to `0.16.3` and adapts the cloud session harness to the new distribution model.

AgentHarness 0.16.3 **removes the `--symlink` init mode**. Agent definitions, skills, and pipeline config are now **copied into the repo and committed** (into `.agents/`, `.claude/`, `.pipeline/`), so a harness upgrade shows up as a normal reviewable diff instead of gitignored symlinks.

## Changes

- **`scripts/setup-cloud-env.sh`** — `init_agentharness` no longer passes the removed `--symlink` flag; it now runs `agentharness init --force` (copy mode). Refreshed the comments in `install_agentharness`/`init_agentharness` to describe the copy-and-commit model instead of symlink mode. The `.env` (auto-detected GitHub token) stays gitignored.
- **`.claude/skills/oneshot/SKILL.md`** and **`.claude/skills/oneshot/ensure_pr_linked.sh`** — re-copied from 0.16.3. The oneshot PR helper now also normalizes the PR title to `#<n>: <summary>` (in addition to guaranteeing the `agent` label and the `Closes #<n>` link) and drives title/closing-line from the `$ISSUE_ID` shell variable.

## Validation

- `bash -n scripts/setup-cloud-env.sh` passes.
- `agentharness init --force` runs clean against the checked-out repo; only the two oneshot skill files differ from the previously committed copies.
- Confirmed no secrets (`.env` / token) are included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNuSgd8yhBW7SyePYbR58T)_