### PR TITLE
#3614: Add unit test coverage for GetTransportBoxesHandler state-filter routing

### DIFF
--- a/artifacts/feat-3614/arch-review.r1.md
+++ b/artifacts/feat-3614/arch-review.r1.md
@@ -1,0 +1,129 @@
+# Architecture Review: GetTransportBoxesHandler state-filter unit tests
+
+## Skip Design: true
+
+This is a backend-only test-authoring task. There is no new production code, no new endpoint, no UI/UX surface, and no schema change — confirmed by reading `GetTransportBoxesHandler.cs` directly: it is a 35-line MediatR handler with a pure branching/mapping concern. Design review is not applicable.
+
+## Architectural Fit Assessment
+
+The task is a straight fit with zero architectural risk: add one new xUnit test class to an existing, well-established test module. I read the target handler (`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxes/GetTransportBoxesHandler.cs`) and the sibling test (`backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxByIdHandlerTests.cs`) — the sibling establishes exactly the stack, style, and mocking approach this task should reuse:
+
+- xUnit `[Fact]`/`[Theory]`, Moq for `ITransportBoxRepository` and `ILogger<T>`, FluentAssertions.
+- A **real** `MapperConfiguration` built from `TransportBoxMappingProfile` via `NullLoggerFactory.Instance` (not a mocked `IMapper`) — the same instance construction should be copy-pasted into the new test class.
+- Domain objects (`TransportBox`) are constructed through their public API (`new TransportBox()`, `.Open(...)`) rather than reflection or object initializers on private setters — confirmed this handler's tests don't need full `TransportBox` state (only pass-through/mapping matters), so simpler construction is fine here, detailed below.
+
+This matches `docs/architecture/testing-strategy.md`: MediatR handlers are explicitly "Required" for unit testing, the stack (xUnit/Moq/FluentAssertions) matches exactly, and the guidance to test "business logic... not implementation details" supports asserting on the repository call arguments (the only observable seam, since `stateFilter`/`isActiveFilter` are handler-local variables).
+
+No architectural amendment is needed. The existing `ITransportBoxRepository.GetPagedListAsync` signature (confirmed in `backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/ITransportBoxRepository.cs`) is stable and matches what the spec describes:
+
+```csharp
+Task<(IList<TransportBox> items, int totalCount)> GetPagedListAsync(
+    int skip, int take, string? code = null, TransportBoxState? state = null,
+    string? productCode = null, string? sortBy = null, bool sortDescending = false,
+    bool isActiveFilter = false);
+```
+
+`TransportBoxState` enum (confirmed) contains `New, Opened, InTransit, Received, InSwap, Stocked, Closed, Error, Reserve, Quarantine` — `Opened` and `Closed` (not `Open`, as the brief's shorthand suggested) are the two stable, semantically distinct members to use for the enum-parsing test cases. **This is a spec amendment** — see below.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. One new test class is added alongside its sibling in the existing test module:
+
+```
+backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/
+├── GetTransportBoxByIdHandlerTests.cs   (existing, pattern source)
+└── GetTransportBoxesHandlerTests.cs     (new — this task)
+```
+
+The class under test and its collaborators are unchanged:
+
+```
+GetTransportBoxesHandlerTests
+        │ (Moq)              │ (Moq)                    │ (real, via TransportBoxMappingProfile)
+        ▼                    ▼                           ▼
+ITransportBoxRepository   ILogger<GetTransportBoxesHandler>   IMapper
+        └──────────────┬──────────────────────────────────────┘
+                        ▼
+              GetTransportBoxesHandler.Handle(request, ct)
+                        ▼
+              GetTransportBoxesResponse
+```
+
+### Key Design Decisions
+
+#### Decision 1: Assert on repository call arguments, not just the response DTO
+**Options considered:**
+(a) Assert only on `GetTransportBoxesResponse` fields.
+(b) Use `Mock.Verify` / `It.Is<>` matchers on the `GetPagedListAsync` call to assert `state` and `isActiveFilter` directly.
+
+**Chosen approach:** (b), as the spec requires. `stateFilter` and `isActiveFilter` are handler-local variables never exposed on the response — the mocked repository call is the only observable seam for the filter-routing logic (FR-1). The mapper/response fields (FR-2) should still be asserted separately in the happy-path test(s), since that's the only way to verify the mapping/pass-through half of the handler.
+
+**Rationale:** Confirmed by reading the handler — `stateFilter`/`isActiveFilter` do not flow anywhere except into the repository call. Testing only the response would leave the actual filter-selection logic (the coverage gap named in the brief) unverified by anything other than incidental side effects.
+
+#### Decision 2: Use `Opened`/`Closed` as the two enum test values, not `Open`
+**Options considered:** The brief/spec draft used `TransportBoxState.Open` as an example. The actual enum (confirmed from source) has no `Open` member — it has `Opened`.
+
+**Chosen approach:** Use `Opened` and `Closed` as the two representative enum values in `[Theory]`/`[InlineData]` cases.
+
+**Rationale:** `Open` does not compile — `Enum.TryParse<TransportBoxState>("Open", true, out _)` would return `false`, which actually happens to still validate the "unparseable" branch by accident, not the "valid enum" branch the spec intends. Using the real member names is required for the test to do what FR-1 describes.
+
+#### Decision 3: Construct `TransportBox` instances only where the happy-path/mapping test needs a populated domain object; use minimal/empty construction for the filter-routing tests
+**Options considered:** (a) Build fully realistic `TransportBox` domain objects via `.Open(...)` for every test case, matching `GetTransportBoxByIdHandlerTests`. (b) For the pure filter-routing cases (FR-1), return an empty/trivial `IList<TransportBox>` from the mocked repository since the routing logic doesn't touch the returned items at all; reserve realistic domain construction for the FR-2 happy-path/mapping test.
+
+**Chosen approach:** (b). FR-1 tests care only about what arguments reach `GetPagedListAsync` — the mocked return value can be `(new List<TransportBox>(), 0)` in every FR-1 case. FR-2's happy-path test is where a realistic non-empty `IList<TransportBox>` (built via `.Open(...)`, mirroring the sibling test) and a `totalCount` distinct from `items.Count` are needed to exercise the mapper and response construction.
+
+**Rationale:** Keeps FR-1 tests focused and fast (matches NFR-1), avoids redundant domain setup that mirrors sibling test boilerplate without adding value, and keeps the two concerns (routing vs. mapping) clearly separated in the test file — one `[Theory]` for routing, one or two `[Fact]`s for pass-through/mapping.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New file only, exact path per spec (confirmed no such file exists yet):
+
+```
+backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs
+```
+
+Namespace: `Anela.Heblo.Tests.Features.Logistics.Transport` (matches the sibling file). No changes to any `.csproj` — `Anela.Heblo.Tests` already references xUnit, Moq, FluentAssertions, and AutoMapper (confirmed via the sibling test compiling against these).
+
+### Interfaces and Contracts
+
+No new interfaces. Test against the existing:
+- `GetTransportBoxesHandler.Handle(GetTransportBoxesRequest, CancellationToken)`
+- `ITransportBoxRepository.GetPagedListAsync(int skip, int take, string? code, TransportBoxState? state, string? productCode, string? sortBy, bool sortDescending, bool isActiveFilter)` — mock via `Mock<ITransportBoxRepository>`, set up with `It.IsAny<...>()` for unconstrained args and `It.Is<TransportBoxState?>(...)` / exact values for the args under test, then `Verify(...)` with matching matchers.
+- `TransportBoxMappingProfile` — construct real `IMapper` exactly as in the sibling file:
+```csharp
+var config = new MapperConfiguration(cfg =>
+{
+    cfg.AddProfile<TransportBoxMappingProfile>();
+}, NullLoggerFactory.Instance);
+var mapper = config.CreateMapper();
+```
+
+### Data Flow
+
+For FR-1 (filter routing), each test:
+1. Arrange: `_repositoryMock.Setup(x => x.GetPagedListAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<TransportBoxState?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<bool>())).ReturnsAsync((new List<TransportBox>(), 0));`
+2. Act: call `_handler.Handle(new GetTransportBoxesRequest { State = <case> }, CancellationToken.None)`.
+3. Assert: `_repositoryMock.Verify(x => x.GetPagedListAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), <expected TransportBoxState? matcher>, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(), <expected isActiveFilter bool>), Times.Once);`
+
+For FR-2 (pass-through + mapping), one test verifies `Skip/Take/Code/ProductCode/SortBy/SortDescending` reach the repository call unchanged, and one test verifies a populated `(items, totalCount)` repository result flows through the real mapper into `response.Items`/`TotalCount`/`Skip`/`Take` correctly (these can be the same test or two, developer's judgment — spec allows either).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Using nonexistent `TransportBoxState.Open` (per brief) instead of `Opened` | Low | Already caught here — use `Opened`/`Closed`, confirmed against actual enum source. |
+| Loose `It.IsAny<>` on all params could mask a real regression in an unrelated param | Low | Only loosen params not under test in a given case; always pin the 1-2 params the test name claims to verify. |
+| Coverage tool counts lines differently than expected, still under 60% after this suite | Low | Spec's NFR-3 already anticipates near-100% coverage from these cases (handler is ~35 lines); no further action needed unless CI proves otherwise. |
+
+## Specification Amendments
+
+1. **Enum member name correction**: Replace all references to `TransportBoxState.Open` in the spec/brief with `TransportBoxState.Opened` — confirmed via direct read of `backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/TransportBoxState.cs`. The FR-1 acceptance criteria's `"Open"` test case must use the string `"Opened"` and assert `TransportBoxState.Opened`.
+2. No other amendments. All other spec details (file path, mocking approach, mapper usage, FR/NFR breakdown) were verified against the actual codebase and are accurate as written.
+
+## Prerequisites
+
+N/A — no migrations, config, or infrastructure changes. The target handler, repository interface, mapping profile, and test project all already exist and compile; the new test file can be added and run immediately with `dotnet test backend/test/Anela.Heblo.Tests/ --filter GetTransportBoxesHandlerTests`.

--- a/artifacts/feat-3614/brief.md
+++ b/artifacts/feat-3614/brief.md
@@ -1,0 +1,31 @@
+# [coverage-gap] Logistics/GetTransportBoxesHandler: "ACTIVE" special-case state filter untested
+
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxes/GetTransportBoxesHandler.cs`
+
+## Coverage
+Line coverage: 20.0% (filter threshold: 60%)
+
+## What's not tested
+The handler implements a three-way state-filter routing that is entirely uncovered:
+
+1. **`State == "ACTIVE"` (case-insensitive)** → sets `isActiveFilter = true`, meaning "all boxes except Closed" — this is a special business rule, not an enum value.
+2. **Parseable enum string** → sets `stateFilter` to the matching `TransportBoxState`, `isActiveFilter` stays false.
+3. **Null/empty `State`** → both flags stay at their defaults; no filter applied.
+
+Both `stateFilter` and `isActiveFilter` are forwarded to `GetPagedListAsync`. If the `ACTIVE` branch were accidentally removed or the string comparison changed (e.g., using `==` instead of `OrdinalIgnoreCase`), the main transport-box list view would silently return an empty or wrong result set with no error.
+
+## Why it matters
+The "ACTIVE" filter is the default view for the logistics transport-box screen. A regression here would show an empty list to users without any error indication.
+
+## Suggested approach
+Unit tests with a mocked `ITransportBoxRepository`, covering:
+- `State = "ACTIVE"` → assert `isActiveFilter=true` passed to repository (not a parsed enum)
+- `State = "active"` → same (case-insensitivity)
+- `State = "Open"` → assert `stateFilter = TransportBoxState.Open`, `isActiveFilter = false`
+- `State = null` / `State = ""` → assert both flags are default
+
+~1–2 hours effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-13. Based on CI run #28968007617 (06d109fe5edcb456730222410f64385606100b1b)._

--- a/artifacts/feat-3614/code-review.r1.md
+++ b/artifacts/feat-3614/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs:52` — The `_repositoryMock.Setup(...).ReturnsAsync((new List<TransportBox>(), 0))` boilerplate for `GetPagedListAsync` is repeated verbatim in the `[Theory]` test and in `Handle_ForwardsAllPassThroughParametersToRepository` (lines 80-84). Could be hoisted into the constructor as a default stub (overridden only in `Handle_MapsRepositoryResultIntoResponse`, which needs a different return value), trimming a few duplicated lines.

--- a/artifacts/feat-3614/design.r1.md
+++ b/artifacts/feat-3614/design.r1.md
@@ -1,0 +1,7 @@
+# Design: Unit test coverage for GetTransportBoxesHandler state-filter logic
+
+## Skipped
+
+The architecture review (`arch-review.r1.md`) set `Skip Design: true` — this is a
+backend-only unit-test addition with no new or changed UI components, screens,
+layouts, or visual design decisions. No design artifact is required.

--- a/artifacts/feat-3614/impl/add-transport-boxes-handler-tests.r1.md
+++ b/artifacts/feat-3614/impl/add-transport-boxes-handler-tests.r1.md
@@ -1,0 +1,37 @@
+# Implementation: add-transport-boxes-handler-tests
+
+## What was implemented
+Added a new xUnit test class covering the previously-untested `State` filter
+routing logic in `GetTransportBoxesHandler.Handle`, plus request pass-through
+and response-mapping behavior, per `task-plan.r1.md`.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` — new test file with a `[Theory]` covering all 8 state-filter routing cases and two `[Fact]`s covering parameter pass-through and response mapping.
+
+## Tests
+- `Handle_StateFilter_RoutesExpectedArgumentsToRepository` (`[Theory]`, 8 `[InlineData]` cases): `"ACTIVE"`, `"active"`, `"Opened"`, `"closed"`, `null`, `""`, `"   "`, `"NotARealState"` — asserts the exact `state`/`isActiveFilter` arguments reaching `ITransportBoxRepository.GetPagedListAsync` via `Mock.Verify`.
+- `Handle_ForwardsAllPassThroughParametersToRepository`: asserts `Skip`, `Take`, `Code`, `ProductCode`, `SortBy`, `SortDescending` are forwarded verbatim.
+- `Handle_MapsRepositoryResultIntoResponse`: asserts `Items`/`TotalCount`/`Skip`/`Take` are populated correctly from a real `TransportBoxMappingProfile`-backed mapper, using a `totalCount` distinct from `items.Count`.
+
+## How to verify
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests"
+```
+Expected: `Passed! - Failed: 0, Passed: 10, Skipped: 0`.
+
+`dotnet format Anela.Heblo.sln --verify-no-changes` reports no violations for the new file.
+
+The full suite (`dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`) was also run: 76 pre-existing failures, all in Postgres/Testcontainers-backed integration and SQL-shape tests (`*IntegrationTests`, `*SqlShapeTests`) — this sandbox has no Docker daemon available (`docker ps` fails to connect to the socket), so these fail regardless of this change. None reference `Logistics`, `TransportBox`, or `GetTransportBoxes`. No regression was introduced by this change.
+
+## Notes
+- The architect caught that the spec's example enum value `TransportBoxState.Open` does not exist — the real member is `Opened`. The planner already corrected this in `task-plan.r1.md`, and the test code uses `TransportBoxState.Opened`/`TransportBoxState.Closed` throughout.
+- No production code was modified — this is a test-only change, per FR-3's scope (no bug was found in the handler during implementation).
+
+## PR Summary
+Adds unit test coverage for `GetTransportBoxesHandler`'s `State` filter routing, the piece of logic flagged as untested by the coverage-gap issue: the special-case `"ACTIVE"` string (meaning "all boxes except Closed"), parseable `TransportBoxState` enum values, and the null/empty/unparseable fallthrough. The new test class also covers request parameter pass-through and response mapping so the file's coverage isn't limited to just the `if/else if` branch. No production code changed — the existing handler behavior was confirmed correct by these tests, not fixed.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` — new test file, 10 test cases (1 theory with 8 inline cases + 2 facts)
+
+## Status
+DONE

--- a/artifacts/feat-3614/review/add-transport-boxes-handler-tests.r1.md
+++ b/artifacts/feat-3614/review/add-transport-boxes-handler-tests.r1.md
@@ -1,0 +1,20 @@
+# Code Review: add-transport-boxes-handler-tests
+
+## Summary
+The implementation adds exactly the test class specified in the task context, with no production code changes. Independently re-running the filtered test suite confirms `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`, matching the developer's claim exactly. Every acceptance criterion in the plan (state-filter branching, parameter pass-through, response mapping) is backed by a real, passing test case that exercises the actual handler logic and repository interface signature.
+
+## Review Result: PASS
+
+### task: add-transport-boxes-handler-tests
+**Status:** PASS
+
+## Overall Notes
+Verification performed directly against the worktree, not the developer's summary:
+
+- Read the actual test file `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` — it matches the task-context plan verbatim: one `[Theory]` with 8 `[InlineData]` cases (`"ACTIVE"`, `"active"`, `"Opened"`, `"closed"`, `null`, `""`, `"   "`, `"NotARealState"`) verifying `state`/`isActiveFilter` arguments reaching `ITransportBoxRepository.GetPagedListAsync`, plus two `[Fact]`s for parameter pass-through and response mapping.
+- Read the actual handler `GetTransportBoxesHandler.cs` — confirmed the `if (Equals("ACTIVE", OrdinalIgnoreCase)) ... else if (Enum.TryParse<TransportBoxState>(..., true, ...))` branching logic is exactly what the theory's 8 cases exercise, including the case-insensitivity proofs (`"active"` lowercase, `"closed"` lowercase) and the null/empty/whitespace/unparseable fallthrough.
+- Ran `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests"` myself in the worktree: `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10` — matches the developer's reported result exactly, no discrepancy.
+- Ran `git show --stat HEAD`: only `GetTransportBoxesHandlerTests.cs` (139 insertions) is in the commit — confirms no production code was modified, satisfying FR-3 (test-only scope, no silent bugfix).
+- Mock setup uses the real 8-parameter `GetPagedListAsync` signature and a real `MapperConfiguration`/`TransportBoxMappingProfile`-backed `IMapper`, consistent with NFR-1 (fast, mocked, no I/O) and the architecture's stated mocking approach.
+
+No issues found. No documentation updates are needed for this test-only change.

--- a/artifacts/feat-3614/spec.r1.md
+++ b/artifacts/feat-3614/spec.r1.md
@@ -1,0 +1,101 @@
+# Specification: Unit test coverage for GetTransportBoxesHandler state-filter logic
+
+## Summary
+`GetTransportBoxesHandler.Handle` contains an uncovered three-way branch that translates the incoming `State` string filter into either the special-case "active" flag, a parsed `TransportBoxState` enum, or no filter at all. This task adds a focused unit test suite covering that branch and the surrounding mapping/response behavior, raising line coverage above the 60% threshold. No production code changes are expected unless a real defect is discovered while writing tests (none is currently confirmed).
+
+## Background
+Coverage-gap tooling flagged `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxes/GetTransportBoxesHandler.cs` at 20% line coverage (CI run #28968007617). The uncovered logic is the `State` filter routing in `Handle`:
+
+```csharp
+TransportBoxState? stateFilter = null;
+bool isActiveFilter = false;
+
+if (!string.IsNullOrWhiteSpace(request.State))
+{
+    if (request.State.Equals("ACTIVE", StringComparison.OrdinalIgnoreCase))
+    {
+        isActiveFilter = true;             // "all boxes except Closed" — business rule, not an enum
+    }
+    else if (Enum.TryParse<TransportBoxState>(request.State, true, out var parsedState))
+    {
+        stateFilter = parsedState;
+    }
+}
+```
+
+This is the default view for the logistics transport-box screen. Both `stateFilter` and `isActiveFilter` are forwarded as separate parameters to `_repository.GetPagedListAsync(...)`. A silent regression here (e.g. `==` instead of `OrdinalIgnoreCase`, or the branch removed) would make the default box list appear empty or wrong with no exception thrown — hence the priority on locking this behavior down with tests.
+
+## Functional Requirements
+
+### FR-1: Cover the `State` filter branching in `GetTransportBoxesHandler.Handle`
+Add xUnit tests (mirroring the existing style in `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxByIdHandlerTests.cs`: Moq for `ITransportBoxRepository`/`ILogger`, a real `AutoMapper` instance built from `TransportBoxMappingProfile`) exercising every branch of the filter logic, asserting on the exact arguments passed to `ITransportBoxRepository.GetPagedListAsync`.
+
+**Acceptance criteria:**
+- `State = "ACTIVE"` → repository is invoked with `state: null` and `isActiveFilter: true`.
+- `State = "active"` (lowercase) → same result as above, proving `OrdinalIgnoreCase` is exercised (not `==` or `OrdinalIgnoreCase`-adjacent case-sensitive comparison).
+- `State = "AcTiVe"` (mixed case) is acceptable as an additional/alternative case-insensitivity proof if preferred over the lowercase variant — at minimum one non-uppercase casing must be tested.
+- `State = "Open"` (a valid `TransportBoxState` enum member) → repository is invoked with `state: TransportBoxState.Open` and `isActiveFilter: false`.
+- A second valid enum value with different casing (e.g. `"closed"` or `"CLOSED"`) → repository is invoked with `state: TransportBoxState.Closed` and `isActiveFilter: false`, confirming `Enum.TryParse` is case-insensitive too.
+- `State = null` → repository is invoked with `state: null` and `isActiveFilter: false`.
+- `State = ""` (empty string) → repository is invoked with `state: null` and `isActiveFilter: false`.
+- `State = "   "` (whitespace-only) → repository is invoked with `state: null` and `isActiveFilter: false` (exercises `IsNullOrWhiteSpace`, distinct from the empty-string case).
+- `State = "NotARealState"` (unparseable, non-"ACTIVE" string) → repository is invoked with `state: null` and `isActiveFilter: false` (falls through both branches silently — current behavior, not to be "fixed" as part of this task since it's out of scope per the brief).
+- Use `_repositoryMock.Verify(x => x.GetPagedListAsync(..., state, ..., isActiveFilter), Times.Once)` (or equivalent `It.Is<>` matchers) rather than only asserting on the response DTO, since `stateFilter`/`isActiveFilter` are local variables not exposed on `GetTransportBoxesResponse` — the repository call is the only observable seam.
+
+### FR-2: Cover request pass-through and response mapping (supporting coverage, not the primary gap)
+While the state-filter branch is the named gap, the handler's remaining ~80% of uncovered lines includes the pass-through of `Skip`, `Take`, `Code`, `ProductCode`, `SortBy`, `SortDescending` to the repository, and the mapping of returned items/`totalCount` into `GetTransportBoxesResponse`. At least one "happy path" test should cover this to push coverage comfortably past the 60% threshold and avoid a narrow test suite that covers only the `if/else if` but leaves other lines (mapper call, response construction) still cold.
+
+**Acceptance criteria:**
+- One test asserts that `request.Skip`, `request.Take`, `request.Code`, `request.ProductCode`, `request.SortBy`, `request.SortDescending` are forwarded verbatim to `GetPagedListAsync`.
+- One test asserts that the response's `Items`, `TotalCount`, `Skip`, `Take` are populated correctly from the repository result and the mapper output (a non-empty `IList<TransportBox>` mapped to non-empty `List<TransportBoxDto>`, plus a `totalCount` distinct from the returned item count, e.g. paged scenario where `totalCount > items.Count`).
+
+### FR-3 (conditional): Fix the state-filter bug only if discovered
+The brief and coverage-gap issue explicitly scope this task to writing tests, not fixing a bug — no defect is currently confirmed in this handler. If, while writing the tests in FR-1, the actual behavior diverges from the documented/expected behavior (e.g. case-sensitivity is broken, or the "ACTIVE" branch behaves differently than described), do not silently "fix" it in this task. Instead:
+
+**Acceptance criteria:**
+- If a genuine discrepancy is found, write a test that documents the *current actual* behavior (so the suite passes and coverage improves), and flag the discrepancy explicitly in the PR description / handoff notes rather than changing production code, unless the fix is a trivial one-line change directly requested for confirmation — in which case note it in Open Questions before proceeding (see below; in practice for this file no such bug is expected since the code was read directly and matches the brief's description).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — this is a unit test addition with mocked dependencies. Tests must run in-process with no I/O and should execute in well under 100ms each.
+
+### NFR-2: Security
+Not applicable — no auth, no new data exposure, no production code paths change.
+
+### NFR-3: Coverage target
+Line coverage for `GetTransportBoxesHandler.cs` must rise from 20.0% to at least the 60% filter threshold; realistically, given the handler is ~35 lines of logic, the acceptance criteria above (all filter branches + one full happy-path pass-through/mapping test) should bring coverage to at or near 100%.
+
+### NFR-4: Consistency with existing test conventions
+New tests must live in `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` (new file, following the sibling `GetTransportBoxByIdHandlerTests.cs` naming/location pattern) and use the same stack already established in that folder: xUnit (`[Fact]`/`[Theory]`), Moq (`Mock<ITransportBoxRepository>`, `Mock<ILogger<GetTransportBoxesHandler>>`), FluentAssertions for assertions, and a real `MapperConfiguration`/`TransportBoxMappingProfile`-backed `IMapper` (not a mocked mapper) so `TransportBoxDto` mapping is genuinely exercised. `[Theory]`/`[InlineData]` is preferred over repeated `[Fact]`s for the parallel state-string cases in FR-1 to keep the suite compact.
+
+## Data Model
+N/A — no schema, entity, or contract changes. Tests will construct `TransportBox` domain instances via existing public API (e.g. `new TransportBox()` + `.Open(...)`, matching the pattern in `GetTransportBoxByIdHandlerTests.cs`) or via object initializers where sufficient, and `GetTransportBoxesRequest`/`GetTransportBoxesResponse` DTOs as-is.
+
+## API / Interface Design
+N/A — no endpoint, controller, or contract changes. The only "interface" under test is the existing `IRequestHandler<GetTransportBoxesRequest, GetTransportBoxesResponse>.Handle` method and its collaboration with `ITransportBoxRepository.GetPagedListAsync`:
+
+```csharp
+Task<(IList<TransportBox> items, int totalCount)> GetPagedListAsync(
+    int skip, int take, string? code = null, TransportBoxState? state = null,
+    string? productCode = null, string? sortBy = null, bool sortDescending = false,
+    bool isActiveFilter = false);
+```
+
+## Dependencies
+- `ITransportBoxRepository` (mocked via Moq).
+- `TransportBoxMappingProfile` (real AutoMapper profile, already used by sibling tests) for `TransportBox` → `TransportBoxDto` mapping.
+- `TransportBoxState` enum (must contain at least two distinct, stable members — e.g. `Open`, `Closed` — to use in FR-1's enum-parsing test cases; confirm exact member names in `Anela.Heblo.Domain.Features.Logistics.Transport.TransportBoxState` before writing `[InlineData]`).
+- No new NuGet packages; all test infra (xUnit, Moq, FluentAssertions) already referenced by `Anela.Heblo.Tests`.
+
+## Out of Scope
+- Fixing any bug in the state-filter logic (no bug is confirmed as of this reading of the handler; see FR-3).
+- Testing `ITransportBoxRepository`'s own implementation of `GetPagedListAsync` (its filtering/query logic is a repository concern, out of this handler-level test).
+- Integration/E2E tests against a real database or the `TransportBoxController` HTTP layer — this task is unit-test-only, at the handler level.
+- Any other coverage-gap issues in the Logistics module or elsewhere — this spec covers only `GetTransportBoxesHandler.cs`.
+- Adding a `[Theory]` explosion for every `TransportBoxState` enum value — two representative values (one non-Closed, one Closed) are sufficient per FR-1.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-13T11:18:11.923843Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T11:19:56.981999Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T11:23:32.877535Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T11:23:52.643016Z"
     }
   },
   "tasks": [
     {
       "name": "add-transport-boxes-handler-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-13T11:23:52.834104Z"
     }
   ]
 }

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-13T11:20:12.426358Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T11:23:32.877535Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3614",
+  "issue_number": 3614,
+  "created_at": "2026-07-13T11:15:32.592465Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-13T11:18:11.923843Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-transport-boxes-handler-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-13T12:36:14.638849Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-13T12:36:20.167843Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-13T11:19:56.981999Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T11:20:12.426358Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T11:23:32.877535Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T11:23:52.643016Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T12:36:14.638849Z"
     }
   },
   "tasks": [
     {
       "name": "add-transport-boxes-handler-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-13T11:23:52.834104Z"
+      "updated_at": "2026-07-13T12:36:08.552884Z"
     }
   ]
 }

--- a/artifacts/feat-3614/state.json
+++ b/artifacts/feat-3614/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-13T12:36:14.638849Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T12:36:20.167843Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T12:58:02.470272Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3614/task-context/add-transport-boxes-handler-tests.md
+++ b/artifacts/feat-3614/task-context/add-transport-boxes-handler-tests.md
@@ -1,0 +1,239 @@
+### task: add-transport-boxes-handler-tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` (same file — no separate test runner file)
+
+No production files are modified. The handler under test is `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxes/GetTransportBoxesHandler.cs` (read-only reference).
+
+- [ ] **Step 1: Write the failing test file skeleton with constructor setup**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` with the class shell, mirroring `GetTransportBoxByIdHandlerTests.cs`'s constructor pattern (real `MapperConfiguration` + `NullLoggerFactory.Instance`, Moq for repository and logger):
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxes;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Logistics.Transport;
+
+public class GetTransportBoxesHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly Mock<ILogger<GetTransportBoxesHandler>> _loggerMock;
+    private readonly GetTransportBoxesHandler _handler;
+
+    public GetTransportBoxesHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _loggerMock = new Mock<ILogger<GetTransportBoxesHandler>>();
+
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<TransportBoxMappingProfile>();
+        }, NullLoggerFactory.Instance);
+        var mapper = config.CreateMapper();
+
+        _handler = new GetTransportBoxesHandler(_loggerMock.Object, _repositoryMock.Object, mapper);
+    }
+}
+```
+
+This alone will not compile as a meaningful test yet (no `[Fact]`/`[Theory]` present) — that is expected; the next step adds the first real test.
+
+- [ ] **Step 2: Add the FR-1 `[Theory]` covering all state-filter routing branches**
+
+Add this inside the class body, directly below the constructor:
+
+```csharp
+    [Theory]
+    [InlineData("ACTIVE", null, true)]
+    [InlineData("active", null, true)]
+    [InlineData("Opened", TransportBoxState.Opened, false)]
+    [InlineData("closed", TransportBoxState.Closed, false)]
+    [InlineData(null, null, false)]
+    [InlineData("", null, false)]
+    [InlineData("   ", null, false)]
+    [InlineData("NotARealState", null, false)]
+    public async Task Handle_StateFilter_RoutesExpectedArgumentsToRepository(
+        string? state, TransportBoxState? expectedState, bool expectedIsActiveFilter)
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((new List<TransportBox>(), 0));
+
+        var request = new GetTransportBoxesRequest { State = state };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(x => x.GetPagedListAsync(
+            It.IsAny<int>(),
+            It.IsAny<int>(),
+            It.IsAny<string>(),
+            expectedState,
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<bool>(),
+            expectedIsActiveFilter),
+            Times.Once);
+    }
+```
+
+This single `[Theory]` covers every FR-1 acceptance criterion: `"ACTIVE"` uppercase, `"active"` lowercase (proves `OrdinalIgnoreCase`, not `==`), a valid enum member (`"Opened"`), a second valid enum member with different casing (`"closed"` → `TransportBoxState.Closed`, proving `Enum.TryParse` case-insensitivity), `null`, empty string, whitespace-only, and an unparseable non-"ACTIVE" string — each asserting the exact `state`/`isActiveFilter` arguments reaching `GetPagedListAsync` via `Mock.Verify`, matching the mocking approach the arch review specified (Decision 1).
+
+- [ ] **Step 3: Run the theory to verify it passes against current handler behavior**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests.Handle_StateFilter_RoutesExpectedArgumentsToRepository"`
+
+Expected: `Passed! - Failed: 0, Passed: 8, Skipped: 0` (8 `[InlineData]` cases). If any case fails, do not "fix" the handler — per spec FR-3, only a test-writing task is in scope; a genuine discrepancy would need to be flagged, not patched, unless it's the trivial spec/enum-name correction already applied above. No discrepancy is expected here since the handler was read directly and matches this behavior.
+
+- [ ] **Step 4: Add the FR-2 pass-through test (Skip/Take/Code/ProductCode/SortBy/SortDescending forwarded verbatim)**
+
+Add this `[Fact]` after the theory:
+
+```csharp
+    [Fact]
+    public async Task Handle_ForwardsAllPassThroughParametersToRepository()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((new List<TransportBox>(), 0));
+
+        var request = new GetTransportBoxesRequest
+        {
+            Skip = 20,
+            Take = 10,
+            Code = "B001",
+            ProductCode = "P123",
+            SortBy = "Code",
+            SortDescending = true
+        };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(x => x.GetPagedListAsync(
+            20,
+            10,
+            "B001",
+            null,
+            "P123",
+            "Code",
+            true,
+            false),
+            Times.Once);
+    }
+```
+
+`State` is left unset on the request (defaults to `null`), so the expected `state` argument is `null` and `isActiveFilter` is `false` — isolating this test to only the pass-through concern, not the filter-routing concern already covered by Step 2's theory.
+
+- [ ] **Step 5: Run the pass-through test to verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests.Handle_ForwardsAllPassThroughParametersToRepository"`
+
+Expected: `Passed! - Failed: 0, Passed: 1, Skipped: 0`
+
+- [ ] **Step 6: Add the FR-2 mapping test (repository result → response mapping via the real mapper)**
+
+Add this `[Fact]` after the pass-through test:
+
+```csharp
+    [Fact]
+    public async Task Handle_MapsRepositoryResultIntoResponse()
+    {
+        // Arrange — use public API to build realistic TransportBox instances (mirrors GetTransportBoxByIdHandlerTests.cs)
+        var box1 = new TransportBox();
+        box1.Open("B001", DateTime.UtcNow, "user");
+
+        var box2 = new TransportBox();
+        box2.Open("B002", DateTime.UtcNow, "user");
+
+        var items = new List<TransportBox> { box1, box2 };
+        const int totalCount = 25; // distinct from items.Count (2), simulating a paged scenario
+
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((items, totalCount));
+
+        var request = new GetTransportBoxesRequest { Skip = 10, Take = 2 };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(2);
+        result.Items[0].Code.Should().Be("B001");
+        result.Items[1].Code.Should().Be("B002");
+        result.Items[0].State.Should().Be(nameof(TransportBoxState.Opened));
+        result.TotalCount.Should().Be(totalCount);
+        result.Skip.Should().Be(10);
+        result.Take.Should().Be(2);
+    }
+```
+
+This exercises the real `TransportBoxMappingProfile` (item mapping, `State` enum-to-string conversion) and the response construction (`Items`, `TotalCount`, `Skip`, `Take`), with `totalCount` (25) deliberately distinct from `items.Count` (2) per the spec's FR-2 acceptance criteria.
+
+- [ ] **Step 7: Run the full new test class**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests"`
+
+Expected: `Passed! - Failed: 0, Passed: 10, Skipped: 0` (8 theory cases + 2 facts).
+
+- [ ] **Step 8: Run the full backend test suite to confirm no regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+
+Expected: all tests pass (no failures introduced elsewhere; this is a pure test-file addition with no production code touched).
+
+- [ ] **Step 9: Build and format check**
+
+Run: `dotnet build Anela.Heblo.sln`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` (or pre-existing warning count unchanged).
+
+Run: `dotnet format Anela.Heblo.sln --verify-no-changes`
+Expected: no formatting violations reported for the new file. If violations are reported, run `dotnet format Anela.Heblo.sln` to auto-fix, then re-run Step 7's test command to confirm the fix didn't alter behavior.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs
+git commit -m "test: add coverage for GetTransportBoxesHandler state-filter branching"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- FR-1 (state-filter branching, all listed cases including OrdinalIgnoreCase and Enum.TryParse case-insensitivity proofs) → Step 2's `[Theory]`, 8 `[InlineData]` cases, one per spec bullet.
+- FR-2 (pass-through of Skip/Take/Code/ProductCode/SortBy/SortDescending; response mapping of Items/TotalCount/Skip/Take) → Step 4 (pass-through) and Step 6 (mapping), matching the spec's two separate acceptance-criteria bullets.
+- FR-3 (no silent bugfix) → explicitly called out in Step 3; no discrepancy is expected or introduced, and no production file is in the Files list.
+- NFR-1 (fast, mocked, no I/O) → all tests use `Mock<ITransportBoxRepository>`, no real DB/network calls.
+- NFR-2 (security, N/A) → nothing added that touches auth or data exposure.
+- NFR-3 (coverage ≥60%, realistically ~100%) → all branches of the `if/else if` in `Handle` are hit by Step 2's 8 cases; the mapper call and response construction lines are hit by Step 4 and Step 6. No line in the handler is left uncovered.
+- NFR-4 (test conventions: file path, namespace, xUnit/Moq/FluentAssertions, real mapper, `[Theory]`/`[InlineData]` preferred over repeated `[Fact]`s) → file path and namespace match the spec exactly; stack matches the sibling file; Step 2 uses one `[Theory]` instead of 8 separate `[Fact]`s.
+- Data Model / API sections (N/A, existing `TransportBox`/`GetPagedListAsync` signature) → confirmed against actual source in this session; test code uses the real 8-parameter `GetPagedListAsync` signature and the real `TransportBox.Open(boxCode, date, userName)` public API.
+- Out of Scope items (no repository implementation tests, no controller/E2E tests, no bugfix, no full enum explosion) → none of these appear in the plan; only 2 enum values (`Opened`, `Closed`) are used, matching the spec's explicit cap.
+
+No spec requirement is missing a corresponding step.
+
+**2. Placeholder scan:** No "TBD"/"TODO"/"add appropriate handling" language appears in any step. Every code block is complete, compilable C# (verified against the actual handler signature, repository interface, DTOs, and mapping profile read directly from the worktree in this session) — no pseudocode.
+
+**3. Type consistency:** `GetTransportBoxesRequest.State` is `string?`; `GetTransportBoxesHandler`'s constructor signature `(ILogger<GetTransportBoxesHandler>, ITransportBoxRepository, IMapper)` matches the sibling handler's constructor shape and the actual source. `ITransportBoxRepository.GetPagedListAsync`'s 8-parameter order (`skip, take, code, state, productCode, sortBy, sortDescending, isActiveFilter`) is used identically across Steps 2, 4, and 6, matching both the interface definition and the existing `ChangeTransportBoxStateHandlerTests.cs` mock-setup precedent in this same test project. `TransportBoxDto.Code`/`State`/`Items` property names match `TransportBoxDto.cs` exactly. `TransportBoxState.Opened`/`TransportBoxState.Closed` (not the spec's placeholder `Open`) are used consistently in every step that references the enum.

--- a/artifacts/feat-3614/task-plan.r1.md
+++ b/artifacts/feat-3614/task-plan.r1.md
@@ -1,0 +1,251 @@
+# GetTransportBoxesHandler Coverage Gap — Implementation Plan
+
+**Goal:** Add an xUnit test suite for `GetTransportBoxesHandler.Handle` that exercises every branch of the `State` filter routing logic (ACTIVE / enum-parse / fallthrough) plus request pass-through and response mapping, raising `GetTransportBoxesHandler.cs` line coverage from 20% to at or near 100%.
+
+**Architecture:** No production code changes. One new test file, `GetTransportBoxesHandlerTests.cs`, added to the existing `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/` folder, following the exact stack and conventions of the sibling `GetTransportBoxByIdHandlerTests.cs`: xUnit `[Fact]`/`[Theory]`, Moq for `ITransportBoxRepository`/`ILogger<T>`, a real `MapperConfiguration` built from `TransportBoxMappingProfile`, and FluentAssertions for assertions. The filter-routing behavior is verified via `Mock.Verify` on the exact arguments passed to `ITransportBoxRepository.GetPagedListAsync`, since `stateFilter`/`isActiveFilter` are handler-local variables never exposed on the response DTO.
+
+**Tech Stack:** .NET 8, xUnit 2.9.2, Moq 4.20.72, FluentAssertions 6.12.0, AutoMapper (via `TransportBoxMappingProfile`), MediatR.
+
+**Note on spec correction:** The spec's example enum value `TransportBoxState.Open` does not exist in the codebase. The actual enum (`backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/TransportBoxState.cs`) is `New, Opened, InTransit, Received, InSwap, Stocked, Closed, Error, Reserve, Quarantine`. All test code below uses the real member names `Opened` and `Closed`.
+
+---
+
+### task: add-transport-boxes-handler-tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` (same file — no separate test runner file)
+
+No production files are modified. The handler under test is `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxes/GetTransportBoxesHandler.cs` (read-only reference).
+
+- [ ] **Step 1: Write the failing test file skeleton with constructor setup**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs` with the class shell, mirroring `GetTransportBoxByIdHandlerTests.cs`'s constructor pattern (real `MapperConfiguration` + `NullLoggerFactory.Instance`, Moq for repository and logger):
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxes;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Logistics.Transport;
+
+public class GetTransportBoxesHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly Mock<ILogger<GetTransportBoxesHandler>> _loggerMock;
+    private readonly GetTransportBoxesHandler _handler;
+
+    public GetTransportBoxesHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _loggerMock = new Mock<ILogger<GetTransportBoxesHandler>>();
+
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<TransportBoxMappingProfile>();
+        }, NullLoggerFactory.Instance);
+        var mapper = config.CreateMapper();
+
+        _handler = new GetTransportBoxesHandler(_loggerMock.Object, _repositoryMock.Object, mapper);
+    }
+}
+```
+
+This alone will not compile as a meaningful test yet (no `[Fact]`/`[Theory]` present) — that is expected; the next step adds the first real test.
+
+- [ ] **Step 2: Add the FR-1 `[Theory]` covering all state-filter routing branches**
+
+Add this inside the class body, directly below the constructor:
+
+```csharp
+    [Theory]
+    [InlineData("ACTIVE", null, true)]
+    [InlineData("active", null, true)]
+    [InlineData("Opened", TransportBoxState.Opened, false)]
+    [InlineData("closed", TransportBoxState.Closed, false)]
+    [InlineData(null, null, false)]
+    [InlineData("", null, false)]
+    [InlineData("   ", null, false)]
+    [InlineData("NotARealState", null, false)]
+    public async Task Handle_StateFilter_RoutesExpectedArgumentsToRepository(
+        string? state, TransportBoxState? expectedState, bool expectedIsActiveFilter)
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((new List<TransportBox>(), 0));
+
+        var request = new GetTransportBoxesRequest { State = state };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(x => x.GetPagedListAsync(
+            It.IsAny<int>(),
+            It.IsAny<int>(),
+            It.IsAny<string>(),
+            expectedState,
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<bool>(),
+            expectedIsActiveFilter),
+            Times.Once);
+    }
+```
+
+This single `[Theory]` covers every FR-1 acceptance criterion: `"ACTIVE"` uppercase, `"active"` lowercase (proves `OrdinalIgnoreCase`, not `==`), a valid enum member (`"Opened"`), a second valid enum member with different casing (`"closed"` → `TransportBoxState.Closed`, proving `Enum.TryParse` case-insensitivity), `null`, empty string, whitespace-only, and an unparseable non-"ACTIVE" string — each asserting the exact `state`/`isActiveFilter` arguments reaching `GetPagedListAsync` via `Mock.Verify`, matching the mocking approach the arch review specified (Decision 1).
+
+- [ ] **Step 3: Run the theory to verify it passes against current handler behavior**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests.Handle_StateFilter_RoutesExpectedArgumentsToRepository"`
+
+Expected: `Passed! - Failed: 0, Passed: 8, Skipped: 0` (8 `[InlineData]` cases). If any case fails, do not "fix" the handler — per spec FR-3, only a test-writing task is in scope; a genuine discrepancy would need to be flagged, not patched, unless it's the trivial spec/enum-name correction already applied above. No discrepancy is expected here since the handler was read directly and matches this behavior.
+
+- [ ] **Step 4: Add the FR-2 pass-through test (Skip/Take/Code/ProductCode/SortBy/SortDescending forwarded verbatim)**
+
+Add this `[Fact]` after the theory:
+
+```csharp
+    [Fact]
+    public async Task Handle_ForwardsAllPassThroughParametersToRepository()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((new List<TransportBox>(), 0));
+
+        var request = new GetTransportBoxesRequest
+        {
+            Skip = 20,
+            Take = 10,
+            Code = "B001",
+            ProductCode = "P123",
+            SortBy = "Code",
+            SortDescending = true
+        };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(x => x.GetPagedListAsync(
+            20,
+            10,
+            "B001",
+            null,
+            "P123",
+            "Code",
+            true,
+            false),
+            Times.Once);
+    }
+```
+
+`State` is left unset on the request (defaults to `null`), so the expected `state` argument is `null` and `isActiveFilter` is `false` — isolating this test to only the pass-through concern, not the filter-routing concern already covered by Step 2's theory.
+
+- [ ] **Step 5: Run the pass-through test to verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests.Handle_ForwardsAllPassThroughParametersToRepository"`
+
+Expected: `Passed! - Failed: 0, Passed: 1, Skipped: 0`
+
+- [ ] **Step 6: Add the FR-2 mapping test (repository result → response mapping via the real mapper)**
+
+Add this `[Fact]` after the pass-through test:
+
+```csharp
+    [Fact]
+    public async Task Handle_MapsRepositoryResultIntoResponse()
+    {
+        // Arrange — use public API to build realistic TransportBox instances (mirrors GetTransportBoxByIdHandlerTests.cs)
+        var box1 = new TransportBox();
+        box1.Open("B001", DateTime.UtcNow, "user");
+
+        var box2 = new TransportBox();
+        box2.Open("B002", DateTime.UtcNow, "user");
+
+        var items = new List<TransportBox> { box1, box2 };
+        const int totalCount = 25; // distinct from items.Count (2), simulating a paged scenario
+
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((items, totalCount));
+
+        var request = new GetTransportBoxesRequest { Skip = 10, Take = 2 };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(2);
+        result.Items[0].Code.Should().Be("B001");
+        result.Items[1].Code.Should().Be("B002");
+        result.Items[0].State.Should().Be(nameof(TransportBoxState.Opened));
+        result.TotalCount.Should().Be(totalCount);
+        result.Skip.Should().Be(10);
+        result.Take.Should().Be(2);
+    }
+```
+
+This exercises the real `TransportBoxMappingProfile` (item mapping, `State` enum-to-string conversion) and the response construction (`Items`, `TotalCount`, `Skip`, `Take`), with `totalCount` (25) deliberately distinct from `items.Count` (2) per the spec's FR-2 acceptance criteria.
+
+- [ ] **Step 7: Run the full new test class**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetTransportBoxesHandlerTests"`
+
+Expected: `Passed! - Failed: 0, Passed: 10, Skipped: 0` (8 theory cases + 2 facts).
+
+- [ ] **Step 8: Run the full backend test suite to confirm no regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+
+Expected: all tests pass (no failures introduced elsewhere; this is a pure test-file addition with no production code touched).
+
+- [ ] **Step 9: Build and format check**
+
+Run: `dotnet build Anela.Heblo.sln`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` (or pre-existing warning count unchanged).
+
+Run: `dotnet format Anela.Heblo.sln --verify-no-changes`
+Expected: no formatting violations reported for the new file. If violations are reported, run `dotnet format Anela.Heblo.sln` to auto-fix, then re-run Step 7's test command to confirm the fix didn't alter behavior.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs
+git commit -m "test: add coverage for GetTransportBoxesHandler state-filter branching"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- FR-1 (state-filter branching, all listed cases including OrdinalIgnoreCase and Enum.TryParse case-insensitivity proofs) → Step 2's `[Theory]`, 8 `[InlineData]` cases, one per spec bullet.
+- FR-2 (pass-through of Skip/Take/Code/ProductCode/SortBy/SortDescending; response mapping of Items/TotalCount/Skip/Take) → Step 4 (pass-through) and Step 6 (mapping), matching the spec's two separate acceptance-criteria bullets.
+- FR-3 (no silent bugfix) → explicitly called out in Step 3; no discrepancy is expected or introduced, and no production file is in the Files list.
+- NFR-1 (fast, mocked, no I/O) → all tests use `Mock<ITransportBoxRepository>`, no real DB/network calls.
+- NFR-2 (security, N/A) → nothing added that touches auth or data exposure.
+- NFR-3 (coverage ≥60%, realistically ~100%) → all branches of the `if/else if` in `Handle` are hit by Step 2's 8 cases; the mapper call and response construction lines are hit by Step 4 and Step 6. No line in the handler is left uncovered.
+- NFR-4 (test conventions: file path, namespace, xUnit/Moq/FluentAssertions, real mapper, `[Theory]`/`[InlineData]` preferred over repeated `[Fact]`s) → file path and namespace match the spec exactly; stack matches the sibling file; Step 2 uses one `[Theory]` instead of 8 separate `[Fact]`s.
+- Data Model / API sections (N/A, existing `TransportBox`/`GetPagedListAsync` signature) → confirmed against actual source in this session; test code uses the real 8-parameter `GetPagedListAsync` signature and the real `TransportBox.Open(boxCode, date, userName)` public API.
+- Out of Scope items (no repository implementation tests, no controller/E2E tests, no bugfix, no full enum explosion) → none of these appear in the plan; only 2 enum values (`Opened`, `Closed`) are used, matching the spec's explicit cap.
+
+No spec requirement is missing a corresponding step.
+
+**2. Placeholder scan:** No "TBD"/"TODO"/"add appropriate handling" language appears in any step. Every code block is complete, compilable C# (verified against the actual handler signature, repository interface, DTOs, and mapping profile read directly from the worktree in this session) — no pseudocode.
+
+**3. Type consistency:** `GetTransportBoxesRequest.State` is `string?`; `GetTransportBoxesHandler`'s constructor signature `(ILogger<GetTransportBoxesHandler>, ITransportBoxRepository, IMapper)` matches the sibling handler's constructor shape and the actual source. `ITransportBoxRepository.GetPagedListAsync`'s 8-parameter order (`skip, take, code, state, productCode, sortBy, sortDescending, isActiveFilter`) is used identically across Steps 2, 4, and 6, matching both the interface definition and the existing `ChangeTransportBoxStateHandlerTests.cs` mock-setup precedent in this same test project. `TransportBoxDto.Code`/`State`/`Items` property names match `TransportBoxDto.cs` exactly. `TransportBoxState.Opened`/`TransportBoxState.Closed` (not the spec's placeholder `Open`) are used consistently in every step that references the enum.

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs
@@ -1,0 +1,139 @@
+using Anela.Heblo.Application.Features.Logistics;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxes;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Logistics.Transport;
+
+public class GetTransportBoxesHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly Mock<ILogger<GetTransportBoxesHandler>> _loggerMock;
+    private readonly GetTransportBoxesHandler _handler;
+
+    public GetTransportBoxesHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _loggerMock = new Mock<ILogger<GetTransportBoxesHandler>>();
+
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<TransportBoxMappingProfile>();
+        }, NullLoggerFactory.Instance);
+        var mapper = config.CreateMapper();
+
+        _handler = new GetTransportBoxesHandler(_loggerMock.Object, _repositoryMock.Object, mapper);
+    }
+
+    [Theory]
+    [InlineData("ACTIVE", null, true)]
+    [InlineData("active", null, true)]
+    [InlineData("Opened", TransportBoxState.Opened, false)]
+    [InlineData("closed", TransportBoxState.Closed, false)]
+    [InlineData(null, null, false)]
+    [InlineData("", null, false)]
+    [InlineData("   ", null, false)]
+    [InlineData("NotARealState", null, false)]
+    public async Task Handle_StateFilter_RoutesExpectedArgumentsToRepository(
+        string? state, TransportBoxState? expectedState, bool expectedIsActiveFilter)
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((new List<TransportBox>(), 0));
+
+        var request = new GetTransportBoxesRequest { State = state };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(x => x.GetPagedListAsync(
+            It.IsAny<int>(),
+            It.IsAny<int>(),
+            It.IsAny<string>(),
+            expectedState,
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<bool>(),
+            expectedIsActiveFilter),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ForwardsAllPassThroughParametersToRepository()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((new List<TransportBox>(), 0));
+
+        var request = new GetTransportBoxesRequest
+        {
+            Skip = 20,
+            Take = 10,
+            Code = "B001",
+            ProductCode = "P123",
+            SortBy = "Code",
+            SortDescending = true
+        };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(x => x.GetPagedListAsync(
+            20,
+            10,
+            "B001",
+            null,
+            "P123",
+            "Code",
+            true,
+            false),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MapsRepositoryResultIntoResponse()
+    {
+        // Arrange — use public API to build realistic TransportBox instances (mirrors GetTransportBoxByIdHandlerTests.cs)
+        var box1 = new TransportBox();
+        box1.Open("B001", DateTime.UtcNow, "user");
+
+        var box2 = new TransportBox();
+        box2.Open("B002", DateTime.UtcNow, "user");
+
+        var items = new List<TransportBox> { box1, box2 };
+        const int totalCount = 25; // distinct from items.Count (2), simulating a paged scenario
+
+        _repositoryMock
+            .Setup(x => x.GetPagedListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<TransportBoxState?>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync((items, totalCount));
+
+        var request = new GetTransportBoxesRequest { Skip = 10, Take = 2 };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(2);
+        result.Items[0].Code.Should().Be("B001");
+        result.Items[1].Code.Should().Be("B002");
+        result.Items[0].State.Should().Be(nameof(TransportBoxState.Opened));
+        result.TotalCount.Should().Be(totalCount);
+        result.Skip.Should().Be(10);
+        result.Take.Should().Be(2);
+    }
+}


### PR DESCRIPTION
Closes #3614

## What the issue was
`GetTransportBoxesHandler.Handle` (the handler behind the default logistics transport-box list view) had only 20% line coverage. The uncovered logic was a three-way `State` filter routing branch:

- `State == "ACTIVE"` (case-insensitive) → a special business rule ("all boxes except Closed"), not an enum value — sets `isActiveFilter = true`.
- A parseable `TransportBoxState` enum string → sets `stateFilter` to that enum value.
- Null/empty/unparseable → no filter applied.

Both `stateFilter` and `isActiveFilter` are forwarded to `ITransportBoxRepository.GetPagedListAsync`, and a silent regression in this routing (e.g. `==` instead of `OrdinalIgnoreCase`, or the `ACTIVE` branch being removed) would make the default box list appear empty or wrong with no error — a real risk since `ACTIVE` is the default view for the logistics screen.

## How it was fixed / handled
Added `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs`, a new xUnit test class (no production code changes) covering:

- A `[Theory]` with 8 `[InlineData]` cases exercising every branch of the state-filter routing (`"ACTIVE"`, `"active"`, a valid enum value in two different casings, `null`, `""`, whitespace-only, and an unparseable string), verified via `Mock.Verify` on the exact arguments passed to `ITransportBoxRepository.GetPagedListAsync` (the only observable seam, since `stateFilter`/`isActiveFilter` are handler-local variables).
- A `[Fact]` confirming `Skip`/`Take`/`Code`/`ProductCode`/`SortBy`/`SortDescending` are forwarded verbatim to the repository.
- A `[Fact]` confirming the repository result is correctly mapped into `GetTransportBoxesResponse` via the real `TransportBoxMappingProfile`.

During review, the architect caught that the coverage-gap issue's example enum value `TransportBoxState.Open` doesn't exist in the codebase — the real member is `Opened` — and the plan/tests were corrected to use the actual enum member names. No bug was found in the handler; existing behavior is now locked down by tests, not changed.

All 10 new tests pass. The full backend suite was also run: 76 pre-existing failures, all in Postgres/Testcontainers-backed integration and SQL-shape tests unrelated to this change — this sandbox has no Docker daemon available, so those fail regardless of this PR's diff. None reference Logistics/TransportBox.

## Artifacts
Brief, spec, architecture review, design (skipped — backend-only), task plan, impl, and review markdown are committed under `artifacts/feat-3614/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxesHandlerTests.cs:52` — The `_repositoryMock.Setup(...).ReturnsAsync((new List<TransportBox>(), 0))` boilerplate for `GetPagedListAsync` is repeated verbatim in the `[Theory]` test and in `Handle_ForwardsAllPassThroughParametersToRepository`. Could be hoisted into the constructor as a default stub, trimming a few duplicated lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XphiLBm58zW9GyyZ3h4CDz)_