### PR TITLE
#3616: Add unit tests for UpdateRuleRequestValidator and BeValidRegex

### DIFF
--- a/artifacts/feat-3616/arch-review.r1.md
+++ b/artifacts/feat-3616/arch-review.r1.md
@@ -1,0 +1,62 @@
+# Architecture Review: Unit tests for UpdateRuleRequestValidator (Photobank)
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure test-authoring task closing a coverage gap on an existing FluentValidation validator. No production code, no contracts, no data flow, and no UI are touched. The validator (`UpdateRuleRequestValidator`) and its dependency (`PhotobankValidationHelpers.BeValidRegex`) already exist and already follow this codebase's established conventions — a `AbstractValidator<T>` registered per use case in `Features/Photobank/Validators/`, tested via `FluentValidation.TestHelper`. The `Anela.Heblo.Tests` project already has direct precedent for this exact shape of validator (`GetPhotosRequestValidatorTests` tests the same `BeValidRegex` dependency via a sibling validator; `BulkAddPhotoTagRequestValidatorTests` follows the same `TestValidate`/`ShouldHaveValidationErrorFor` idiom). `InternalsVisibleTo("Anela.Heblo.Tests")` is already granted on `Anela.Heblo.Application.csproj`, so calling the `internal static` `BeValidRegex` directly requires no project changes. There is nothing architecturally novel here — the work is to add two test files (or one, per the spec's flexibility) in the existing pattern.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. Two test artifacts are added to the existing test project:
+
+- `UpdateRuleRequestValidatorTests` — exercises `UpdateRuleRequestValidator` end-to-end per FR-1.
+- `PhotobankValidationHelpersTests` — exercises `PhotobankValidationHelpers.BeValidRegex` directly per FR-2.
+
+### Key Design Decisions
+
+1. **Two separate test classes, not one.** The spec explicitly allows either placement, but a dedicated `PhotobankValidationHelpersTests` class is the better default: it mirrors the 1:1 file-to-test-class convention already used everywhere else in this test project (`GetPhotosRequestValidatorTests` ↔ `GetPhotosRequestValidator`, etc.), and `PhotobankValidationHelpers` is a shared dependency of *two* validators (`AddRuleRequestValidator` and `UpdateRuleRequestValidator`), so pinning its contract in its own file makes it discoverable and reusable regardless of which validator changes next. Keeping it nested inside `UpdateRuleRequestValidatorTests` would misleadingly suggest the helper is private to that validator.
+2. **Use `[Theory]`/`[InlineData]` for the null/empty/whitespace `BeValidRegex` cases** (mirrors `BulkAddPhotoTagRequestValidatorTests.TagNameEmptyOrWhitespace_FailsValidation`) instead of three near-duplicate `[Fact]`s.
+3. **Assert exact error messages via `WithErrorMessage(...)`** wherever the validator defines a custom message (all rules except `SortOrder`, which has no `.WithMessage()` and should only be asserted via `ShouldHaveValidationErrorFor(x => x.SortOrder)` without a message check) — consistent with `GetPhotosRequestValidatorTests` and `BulkAddPhotoTagRequestValidatorTests`.
+4. **No mocking, no DI container.** The validator is instantiated directly in the test class constructor, matching every existing Photobank validator test.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Add both files under the existing flat Photobank test folder (no subfolders are used elsewhere in this directory):
+
+```
+backend/test/Anela.Heblo.Tests/Features/Photobank/UpdateRuleRequestValidatorTests.cs   (new)
+backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankValidationHelpersTests.cs   (new)
+```
+
+Namespace: `Anela.Heblo.Tests.Features.Photobank` (matches every sibling file).
+
+### Interfaces and Contracts
+
+No new interfaces. Test surface is:
+- `UpdateRuleRequestValidator` (public, existing) — instantiate directly, call `.TestValidate(request)`.
+- `PhotobankValidationHelpers.BeValidRegex(string?)` (internal static, existing) — call directly by fully-qualified static reference; visible to the test assembly via the existing `InternalsVisibleTo`.
+- `UpdateRuleRequest` (existing DTO) — construct with object initializers per case; only vary the field under test, keep all other fields at valid values (per spec's "fully valid request" baseline) to avoid cross-field noise.
+
+### Data Flow
+
+N/A — synchronous, in-memory, no I/O, no DI.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| FluentValidation's `MaximumLength` boundary (500/501 chars) combined with `Must(BeValidRegex)` could produce two errors on the same property if the 501-char test string isn't also a syntactically valid regex prefix, muddying the "single error" assertion. | Low | Build the >500-char `PathPattern` test values from a benign literal (e.g. repeated `"a"`), which is always a valid regex, so only the length rule fires; assert with `ShouldHaveValidationErrorFor` (not `ShouldHaveExactlyOneValidationErrorFor`) to stay robust either way, matching existing tests' style. |
+| Test class name collision or ambiguity between the two new test files if `PhotobankValidationHelpersTests` is later perceived as testing the whole `Validators` folder rather than one helper. | Low | Keep the class scoped strictly to `BeValidRegex` test cases from FR-2's acceptance criteria; do not add unrelated helper tests speculatively. |
+
+## Specification Amendments
+
+None. The spec is complete, unambiguous, and directly actionable; no production code changes are implied or needed.
+
+## Prerequisites
+
+None — `FluentValidation.TestHelper`, `xunit`, and the `InternalsVisibleTo` grant are already in place. No new NuGet packages or project references required.

--- a/artifacts/feat-3616/brief.md
+++ b/artifacts/feat-3616/brief.md
@@ -1,0 +1,34 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs`
+
+## Coverage
+Line coverage: 0.0% (filter threshold: 60%)
+
+## What's not tested
+The validator registers four rule groups, none of which are exercised by any test:
+
+- `Id > 0` — a negative or zero ID passes the API surface undetected
+- `PathPattern` — required, max 500 chars, **and must be a valid regex** via `PhotobankValidationHelpers.BeValidRegex`. The regex check is the most critical: an invalid pattern stored in the database would cause runtime crashes when the photobank tries to compile it for matching.
+- `TagName` — required, max 100 chars
+- `SortOrder >= 0`
+
+The `BeValidRegex` helper itself is also untested (it does not appear in any covered file), making it a silent dependency.
+
+## Why it matters
+If `BeValidRegex` is broken or has an edge-case gap (e.g., it fails to reject catastrophic-backtracking patterns, or returns false for a valid regex), photo tagging rules could either fail to save valid patterns or persist invalid ones that crash the photobank sync at runtime.
+
+## Suggested approach
+Unit tests on `UpdateRuleRequestValidator` directly:
+- Valid request → no validation errors
+- `Id = 0` / `Id = -1` → validation error on Id
+- `PathPattern = ""` / `PathPattern = null` → required error
+- `PathPattern` > 500 chars → length error
+- `PathPattern = "["` (invalid regex) → validation error via `BeValidRegex`
+- `PathPattern = "^[a-z]+"` (valid regex) → no error on PathPattern
+- `TagName = ""` → required error
+- `SortOrder = -1` → validation error
+
+~1 hour effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-13. Based on CI run #28968007617 (06d109fe5edcb456730222410f64385606100b1b)._

--- a/artifacts/feat-3616/code-review.r1.md
+++ b/artifacts/feat-3616/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3616/design.r1.md
+++ b/artifacts/feat-3616/design.r1.md
@@ -1,0 +1,72 @@
+# Design: Unit tests for UpdateRuleRequestValidator (Photobank)
+
+## Component Design
+
+No production components change. Two new xUnit test classes are added to `Anela.Heblo.Tests`, each targeting one existing, untested unit:
+
+### `UpdateRuleRequestValidatorTests`
+- **Path:** `backend/test/Anela.Heblo.Tests/Features/Photobank/UpdateRuleRequestValidatorTests.cs`
+- **Namespace:** `Anela.Heblo.Tests.Features.Photobank`
+- **Responsibility:** Exercise every `RuleFor` clause of `UpdateRuleRequestValidator` (`Id`, `PathPattern`, `TagName`, `SortOrder`) via FluentValidation's `TestValidate`, asserting both failure messages and pass-through (valid/boundary) cases.
+- **Interface under test:** `UpdateRuleRequestValidator` (public, `AbstractValidator<UpdateRuleRequest>`) — instantiated directly in the constructor (no DI, no mocking), matching `GetPhotosRequestValidatorTests`.
+- **Structure:**
+  - Constructor: `_validator = new UpdateRuleRequestValidator();`
+  - `[Fact]` per discrete case (valid baseline, `Id` boundary, `PathPattern` empty/null/too-long/500-boundary/invalid-regex/valid-regex, `TagName` empty/null/too-long, `SortOrder` negative/zero-boundary).
+  - `[Theory]`/`[InlineData]` may be used to collapse near-duplicate cases (e.g. `Id = 0` and `Id = -1`) per the arch review's guidance, but this is a style choice, not a contract.
+  - Each request is built as a fully-valid `UpdateRuleRequest` baseline (`Id = 1`, `PathPattern = "^[a-z]+\\.png$"`, `TagName = "summer"`, `SortOrder = 0`, `IsActive = true`) with only the field under test varied, to avoid cross-field noise (per spec and arch review).
+  - Assertions use `result.ShouldHaveValidationErrorFor(x => x.<Field>).WithErrorMessage("...")` for every rule that defines `.WithMessage(...)`, and `ShouldNotHaveValidationErrorFor` / `ShouldNotHaveAnyValidationErrors` for pass cases. `SortOrder`'s `GreaterThanOrEqualTo(0)` rule has no custom message, so its failure case asserts only `ShouldHaveValidationErrorFor(x => x.SortOrder)` without `WithErrorMessage`.
+
+### `PhotobankValidationHelpersTests`
+- **Path:** `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankValidationHelpersTests.cs`
+- **Namespace:** `Anela.Heblo.Tests.Features.Photobank`
+- **Responsibility:** Exercise `PhotobankValidationHelpers.BeValidRegex(string?)` directly and in isolation, independent of any validator that consumes it.
+- **Interface under test:** `PhotobankValidationHelpers.BeValidRegex` — `internal static bool BeValidRegex(string? pattern)`, called via fully-qualified static reference; visible to the test assembly through the existing `InternalsVisibleTo("Anela.Heblo.Tests")` grant on `Anela.Heblo.Application.csproj` (no project changes needed).
+- **Structure:**
+  - No constructor state needed (static method, no instance fields).
+  - `[Theory]`/`[InlineData(null)]`, `[InlineData("")]`, `[InlineData("   ")]` → assert `BeValidRegex(pattern)` returns `true` (null/empty/whitespace short-circuits to valid).
+  - `[Fact]` → `BeValidRegex("^[a-z]+$")` returns `true`.
+  - `[Theory]`/`[InlineData("[")]`, `[InlineData("(unclosed")]` → assert `BeValidRegex(pattern)` returns `false`.
+
+Both classes follow the existing flat-folder, 1:1 file-to-tested-unit convention already used by `GetPhotosRequestValidatorTests` and `BulkAddPhotoTagRequestValidatorTests` in the same directory — no new folders, base classes, or test utilities are introduced.
+
+## Data Schemas
+
+No database, API, or event schema changes. Tests construct instances of the existing `UpdateRuleRequest` DTO in-memory only:
+
+```csharp
+public class UpdateRuleRequest : IRequest<UpdateRuleResponse>
+{
+    public int Id { get; set; }
+    public string PathPattern { get; set; } = null!;
+    public string TagName { get; set; } = null!;
+    public bool IsActive { get; set; }
+    public int SortOrder { get; set; }
+}
+```
+
+Test input/output "shapes" (in-memory only, not persisted or serialized):
+
+| Case group | Field varied | Input value(s) | Expected `TestValidate` outcome |
+|---|---|---|---|
+| Baseline | — | `Id=1, PathPattern="^[a-z]+\.png$", TagName="summer", SortOrder=0, IsActive=true` | `ShouldNotHaveAnyValidationErrors()` |
+| `Id` | `Id` | `0`, `-1` | error on `Id`, message `"Id must be a positive integer"` |
+| `PathPattern` required | `PathPattern` | `""`, `null` | error on `PathPattern`, message `"PathPattern is required"` |
+| `PathPattern` length | `PathPattern` | 501-char benign literal (e.g. `"a"` × 501) | error on `PathPattern`, message `"PathPattern cannot exceed 500 characters"` |
+| `PathPattern` length boundary | `PathPattern` | 500-char valid-regex literal | `ShouldNotHaveValidationErrorFor(x => x.PathPattern)` |
+| `PathPattern` regex | `PathPattern` | `"["` | error on `PathPattern`, message `"Invalid regular expression pattern."` |
+| `PathPattern` regex valid | `PathPattern` | `"^[a-z]+"` | `ShouldNotHaveValidationErrorFor(x => x.PathPattern)` |
+| `TagName` required | `TagName` | `""`, `null` | error on `TagName`, message `"TagName is required"` |
+| `TagName` length | `TagName` | 101-char string | error on `TagName`, message `"TagName cannot exceed 100 characters"` |
+| `SortOrder` | `SortOrder` | `-1` | error on `SortOrder` (no message assertion) |
+| `SortOrder` boundary | `SortOrder` | `0` | `ShouldNotHaveValidationErrorFor(x => x.SortOrder)` |
+
+`BeValidRegex` input/output (direct helper calls, no DTO involved):
+
+| Input (`pattern`) | Expected return |
+|---|---|
+| `null` | `true` |
+| `""` | `true` |
+| `"   "` | `true` |
+| `"^[a-z]+$"` | `true` |
+| `"["` | `false` |
+| `"(unclosed"` | `false` |

--- a/artifacts/feat-3616/impl/add-updaterulerequestvalidator-tests.r1.md
+++ b/artifacts/feat-3616/impl/add-updaterulerequestvalidator-tests.r1.md
@@ -1,0 +1,44 @@
+# Implementation: add-updaterulerequestvalidator-tests
+
+## What was implemented
+Added unit tests closing the coverage gap on `UpdateRuleRequestValidator` and its dependency
+`PhotobankValidationHelpers.BeValidRegex`. Pure test-authoring task — no production code was
+changed.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Photobank/UpdateRuleRequestValidatorTests.cs` — FluentValidation `TestValidate`-based tests covering every rule in `UpdateRuleRequestValidator` (Id, PathPattern, TagName, SortOrder), including boundary cases (500/501-char PathPattern, 100/101-char TagName, SortOrder 0/-1, Id 0/-1) and regex validity checks.
+- `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankValidationHelpersTests.cs` — direct unit tests for the internal static `PhotobankValidationHelpers.BeValidRegex(string?)` helper (null/empty/whitespace, valid regex, invalid regex).
+
+## Tests
+- `UpdateRuleRequestValidatorTests`:
+  - `ValidRequest_PassesValidation` — baseline fully-valid request produces no errors.
+  - `Id_NotPositive_FailsValidation` (Theory: 0, -1) — asserts `"Id must be a positive integer"`.
+  - `PathPattern_Empty_FailsValidation` (Theory: "", null) — asserts `"PathPattern is required"`.
+  - `PathPattern_TooLong_FailsValidation` (501 chars) — asserts `"PathPattern cannot exceed 500 characters"`.
+  - `PathPattern_MaxLength_PassesValidation` (500 chars, boundary) — no error.
+  - `PathPattern_InvalidRegex_FailsValidation` (`"["`) — asserts `"Invalid regular expression pattern."`.
+  - `PathPattern_ValidRegex_PassesValidation` (`"^[a-z]+"`) — no error.
+  - `TagName_Empty_FailsValidation` (Theory: "", null) — asserts `"TagName is required"`.
+  - `TagName_TooLong_FailsValidation` (101 chars) — asserts `"TagName cannot exceed 100 characters"`.
+  - `SortOrder_Negative_FailsValidation` (-1) — asserts error exists (no custom message on this rule).
+  - `SortOrder_Zero_PassesValidation` (boundary) — no error.
+- `PhotobankValidationHelpersTests`:
+  - `BeValidRegex_NullOrWhitespace_ReturnsTrue` (Theory: null, "", "   ") — returns true.
+  - `BeValidRegex_ValidPattern_ReturnsTrue` (`"^[a-z]+$"`) — returns true.
+  - `BeValidRegex_InvalidPattern_ReturnsFalse` (Theory: `"["`, `"(unclosed"`) — returns false.
+
+Total: 20 new test cases (11 methods across the two files, several parameterized via `[Theory]`).
+
+## How to verify
+1. `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — build succeeds.
+2. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Photobank.UpdateRuleRequestValidatorTests|FullyQualifiedName~Anela.Heblo.Tests.Features.Photobank.PhotobankValidationHelpersTests"` — `Passed! - Failed: 0, Passed: 20, Skipped: 0, Total: 20`.
+3. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — full suite run; the only failures observed (76) are pre-existing Testcontainers/Docker-dependent integration tests (`LeafletRepositoryIntegrationTests`, `AuthorizationIntegrationTests`) that fail because no Docker daemon is available in this sandbox (`docker ps` confirms: "failed to connect to the docker API"). No test under `Features/Photobank` failed or was affected.
+4. `git status --short` shows only the two new test files added (plus a pre-existing, pipeline-managed change to `artifacts/feat-3616/state.json` that predates this task and was left untouched).
+
+## Notes
+- `dotnet format ... --include <the two files>` was run and reported "Format complete" with no diffs, confirming the new files already match the repo's formatting conventions.
+- No production source file was modified; `UpdateRuleRequestValidator.cs`, `PhotobankValidationHelpers.cs`, `UpdateRuleRequest.cs`, and `UpdateRuleHandler.cs` are untouched.
+- `artifacts/feat-3616/state.json` had a pending modification (pipeline status tracking) present before this task started; it was not touched or committed as part of this change.
+
+## Status
+DONE

--- a/artifacts/feat-3616/review/add-updaterulerequestvalidator-tests.r1.md
+++ b/artifacts/feat-3616/review/add-updaterulerequestvalidator-tests.r1.md
@@ -1,0 +1,24 @@
+# Code Review: add-updaterulerequestvalidator-tests
+
+## Summary
+The implementation adds exactly the two files specified, in the correct location, with the exact class/method names, error messages, and boundary cases called out in both the task-context and `spec.r1.md` (FR-1 and FR-2). Every acceptance-criteria bullet maps 1:1 to a test method, request construction follows the "vary one field from a valid baseline" pattern, and style matches the sibling `GetPhotosRequestValidatorTests.cs`. No production file was touched.
+
+## Review Result: PASS
+
+### task: add-updaterulerequestvalidator-tests
+**Status:** PASS
+
+## Docs to Update
+(None)
+
+## Overall Notes
+Verification performed:
+- `git show b435984` confirms the diff adds only the two intended files (`PhotobankValidationHelpersTests.cs`, `UpdateRuleRequestValidatorTests.cs`), 235 lines total, no production files changed.
+- `git status --short` in the worktree shows only `artifacts/feat-3616/state.json` modified — a pre-existing, pipeline-managed file unrelated to this task, consistent with the developer's note.
+- Cross-checked every `RuleFor` clause in `UpdateRuleRequestValidator.cs` (Id `GreaterThan(0)`, PathPattern `NotEmpty`/`MaximumLength(500)`/`Must(BeValidRegex)`, TagName `NotEmpty`/`MaximumLength(100)`, SortOrder `GreaterThanOrEqualTo(0)`) against the test file — every rule and every exact `.WithErrorMessage(...)` string matches verbatim, including the SortOrder case correctly omitting `WithErrorMessage` since that rule has no custom message.
+- Cross-checked `PhotobankValidationHelpers.BeValidRegex` (null/whitespace → true, valid regex → true, `"["` and `"(unclosed"` → false) against `PhotobankValidationHelpersTests.cs` — all FR-2 cases present, and it correctly calls the `internal static` method directly via the existing `InternalsVisibleTo("Anela.Heblo.Tests")` grant (confirmed present in both `Anela.Heblo.Application.csproj` and `AssemblyInfo.cs`).
+- Boundary cases (500 vs 501-char PathPattern, 100 vs 101-char TagName, SortOrder 0 vs -1, Id 0 vs -1) are all present and correctly test both sides of each threshold.
+- Out-of-scope items respected: `AddRuleRequestValidator.cs`, `UpdateRuleHandler`, and the controller were not touched or tested.
+- File placement matches the flat-folder convention (`backend/test/Anela.Heblo.Tests/Features/Photobank/`, no new subfolders), and both new files sit alongside ~29 existing sibling test files in that folder.
+
+Independent dynamic verification (`dotnet test ... --filter ...`) was attempted but could not be completed in this review sandbox: the full solution build (triggered transitively via the test project's references) hit a pre-existing, unrelated failure in a post-build codegen step (`Anela.Heblo.AccessMatrixGen`, wired into `Anela.Heblo.API.csproj`) that throws a `JsonException` parsing an unexpected input in this environment — this occurs after `Anela.Heblo.API` compiles successfully and is unconnected to the Photobank validator/test code under review. Per the task instructions this re-run is optional, and the developer's implementation report already documents a clean `dotnet test` run (`Passed! - Failed: 0, Passed: 20, Skipped: 0, Total: 20`) plus a full-suite run showing no regressions outside pre-existing Docker-dependent integration tests. Combined with the exhaustive static match against the validator/helper source and the spec, this gives high confidence the suite is correct and complete.

--- a/artifacts/feat-3616/spec.r1.md
+++ b/artifacts/feat-3616/spec.r1.md
@@ -1,0 +1,85 @@
+# Specification: Unit tests for UpdateRuleRequestValidator (Photobank)
+
+## Summary
+Add a dedicated unit test suite for `UpdateRuleRequestValidator`, the FluentValidation validator behind the "update photobank tagging rule" use case, which currently has 0% line coverage. The suite must exercise all four validated fields (`Id`, `PathPattern`, `TagName`, `SortOrder`) and, transitively, the previously-untested `PhotobankValidationHelpers.BeValidRegex` helper that backs the `PathPattern` regex check.
+
+## Background
+`UpdateRuleRequestValidator` (`backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs`) validates `UpdateRuleRequest` before a photobank tagging rule is persisted. A weekly coverage-gap scan (CI run #28968007617) flagged this file at 0% line coverage against a 60% threshold. The validator's most consequential rule is that `PathPattern` must be a syntactically valid .NET regex (via `PhotobankValidationHelpers.BeValidRegex`) — an invalid pattern that slips through would be stored and later crash the photobank sync/matching process when compiled at runtime (see `TagRuleMatcher`). `BeValidRegex` itself has no test coverage anywhere in the codebase, making it a silent, unverified dependency. This work is a pure test-authoring task: no production code changes are required or expected.
+
+## Functional Requirements
+
+### FR-1: Test suite for UpdateRuleRequestValidator
+Create `UpdateRuleRequestValidatorTests` covering every `RuleFor` clause defined in `UpdateRuleRequestValidator`, using FluentValidation's `TestValidate` extension (`FluentValidation.TestHelper`), consistent with existing Photobank validator tests (e.g. `GetPhotosRequestValidatorTests`, `BulkAddPhotoTagRequestValidatorTests`).
+
+Rules under test, as implemented in the validator today:
+- `Id`: must be `GreaterThan(0)` — message `"Id must be a positive integer"`.
+- `PathPattern`: `NotEmpty()` — message `"PathPattern is required"`; `MaximumLength(500)` — message `"PathPattern cannot exceed 500 characters"`; `Must(PhotobankValidationHelpers.BeValidRegex)` — message `"Invalid regular expression pattern."`. FluentValidation evaluates chained rules on the same property independently (not short-circuited across separate `.WithMessage()` calls unless empty), so both an empty pattern and an invalid regex pattern must be tested as distinct cases.
+- `TagName`: `NotEmpty()` — message `"TagName is required"`; `MaximumLength(100)` — message `"TagName cannot exceed 100 characters"`.
+- `SortOrder`: `GreaterThanOrEqualTo(0)` (no custom message — default FluentValidation message applies).
+
+**Acceptance criteria:**
+- A fully valid `UpdateRuleRequest` (e.g. `Id = 1`, `PathPattern = "^[a-z]+\\.png$"`, `TagName = "summer"`, `SortOrder = 0`, `IsActive = true`) produces no validation errors (`ShouldNotHaveAnyValidationErrors`).
+- `Id = 0` and `Id = -1` each produce a validation error on `Id` with message `"Id must be a positive integer"`.
+- `PathPattern = ""` and `PathPattern = null` each produce a validation error on `PathPattern` with message `"PathPattern is required"`.
+- `PathPattern` with length 501 (any characters) produces a validation error on `PathPattern` with message `"PathPattern cannot exceed 500 characters"`.
+- `PathPattern` with length exactly 500 (valid regex content) produces no validation error on `PathPattern` (boundary case).
+- `PathPattern = "["` (syntactically invalid regex) produces a validation error on `PathPattern` with message `"Invalid regular expression pattern."`.
+- `PathPattern = "^[a-z]+"` (syntactically valid regex) produces no validation error on `PathPattern`.
+- `TagName = ""` and `TagName = null` each produce a validation error on `TagName` with message `"TagName is required"`.
+- `TagName` with length 101 produces a validation error on `TagName` with message `"TagName cannot exceed 100 characters"`.
+- `SortOrder = -1` produces a validation error on `SortOrder`.
+- `SortOrder = 0` produces no validation error on `SortOrder` (boundary case, since the rule is `>= 0`).
+- Each error-path test asserts the exact error message via `WithErrorMessage(...)` where the validator defines one; tests use `ShouldHaveValidationErrorFor` / `ShouldNotHaveValidationErrorFor` per-property assertions (not just aggregate `IsValid`), matching the pattern in `GetPhotosRequestValidatorTests`.
+
+### FR-2: Test coverage for PhotobankValidationHelpers.BeValidRegex
+Because `BeValidRegex` (`backend/src/Anela.Heblo.Application/Features/Photobank/Validators/PhotobankValidationHelpers.cs`) is `internal static` and has no direct tests anywhere, and the `Anela.Heblo.Application` project already grants `InternalsVisibleTo("Anela.Heblo.Tests")`, add focused unit tests calling it directly (in addition to the indirect coverage from FR-1), so its behavior is verified in isolation from any one validator.
+
+**Acceptance criteria:**
+- `BeValidRegex(null)` returns `true` (helper treats null/whitespace as "nothing to validate").
+- `BeValidRegex("")` and `BeValidRegex("   ")` return `true`.
+- `BeValidRegex("^[a-z]+$")` (valid pattern) returns `true`.
+- `BeValidRegex("[")` (unbalanced bracket, invalid pattern) returns `false`.
+- `BeValidRegex("(unclosed")` (unbalanced parenthesis, invalid pattern) returns `false`.
+- These tests may live in the same test class as FR-1 (e.g. as a nested `BeValidRegex`-focused fact group) or in a separate `PhotobankValidationHelpersTests` class — either satisfies this requirement; the reviewing architect should pick one placement, but a separate class mirroring the helper's own file is preferred for discoverability given the helper is shared by both `AddRuleRequestValidator` and `UpdateRuleRequestValidator`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — these are synchronous, in-memory FluentValidation unit tests with no I/O. Each test must run in well under 100ms; the full new test class should add negligible time to the existing `dotnet test` run.
+
+### NFR-2: Security
+Not applicable — no new production code, no auth, no data sensitivity concerns. `PathPattern` regex validation itself is a defense against runtime crashes/ReDoS-adjacent issues, but scoping a catastrophic-backtracking detector is explicitly out of scope (see Out of Scope).
+
+## Data Model
+No data model changes. Tests operate on the existing `UpdateRuleRequest` DTO (`backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/UpdateRule/UpdateRuleRequest.cs`):
+```
+public class UpdateRuleRequest : IRequest<UpdateRuleResponse>
+{
+    public int Id { get; set; }
+    public string PathPattern { get; set; } = null!;
+    public string TagName { get; set; } = null!;
+    public bool IsActive { get; set; }
+    public int SortOrder { get; set; }
+}
+```
+
+## API / Interface Design
+Not applicable — no controller, endpoint, or contract changes. This is test-only work against an existing internal validator class.
+
+## Dependencies
+- `FluentValidation.TestHelper` (already referenced by `Anela.Heblo.Tests`, used by existing validator test classes).
+- `xunit` (existing test framework in `Anela.Heblo.Tests`).
+- `Anela.Heblo.Application` → `Anela.Heblo.Tests` `InternalsVisibleTo` grant (already present in `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`), required for FR-2 to call the `internal` `PhotobankValidationHelpers.BeValidRegex` directly.
+- No new NuGet packages or project references are required.
+
+## Out of Scope
+- Any change to `UpdateRuleRequestValidator.cs`, `PhotobankValidationHelpers.cs`, `UpdateRuleRequest.cs`, or `UpdateRuleHandler.cs` production logic.
+- Tests for `UpdateRuleHandler` or the controller/endpoint that consumes `UpdateRuleRequest` (handler-level tests are a separate concern and not part of this coverage gap).
+- Defending against catastrophic-backtracking (ReDoS) regex patterns — `BeValidRegex` only checks syntactic validity via `Regex` construction, not runtime safety; adding ReDoS protection would be a separate feature.
+- Tests for `AddRuleRequestValidator` (a sibling validator that also uses `BeValidRegex`) — out of scope unless its own coverage gap is filed separately; FR-2's direct helper tests provide the missing coverage without needing to touch that file.
+- Integration/E2E tests — this is a pure unit-test task at the validator layer.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-13T13:17:34.355153Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T13:18:38.022201Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-13T14:11:49.130218Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-13T14:11:49.458778Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3616",
+  "issue_number": 3616,
+  "created_at": "2026-07-13T13:14:54.147177Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-13T13:16:25.274238Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T13:19:44.855189Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T13:20:05.953681Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T14:11:49.130218Z"
     }
   },
   "tasks": [
     {
       "name": "add-updaterulerequestvalidator-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-13T13:20:06.144414Z"
+      "updated_at": "2026-07-13T14:11:44.745239Z"
     }
   ]
 }

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-13T13:18:38.022201Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T13:19:44.855189Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-13T13:16:25.274238Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T13:17:34.355153Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T13:19:44.855189Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T13:20:05.953681Z"
     }
   },
   "tasks": [
     {
       "name": "add-updaterulerequestvalidator-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-13T13:20:06.144414Z"
     }
   ]
 }

--- a/artifacts/feat-3616/state.json
+++ b/artifacts/feat-3616/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-updaterulerequestvalidator-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3616/task-context/add-updaterulerequestvalidator-tests.md
+++ b/artifacts/feat-3616/task-context/add-updaterulerequestvalidator-tests.md
@@ -1,0 +1,62 @@
+### task: add-updaterulerequestvalidator-tests
+Add unit tests closing the coverage gap on `UpdateRuleRequestValidator` and its dependency `PhotobankValidationHelpers.BeValidRegex`. This is a pure test-authoring task — no production code changes.
+
+**Files to create:**
+
+1. `backend/test/Anela.Heblo.Tests/Features/Photobank/UpdateRuleRequestValidatorTests.cs`
+   - Namespace: `Anela.Heblo.Tests.Features.Photobank`
+   - Class under test: `Anela.Heblo.Application.Features.Photobank.Validators.UpdateRuleRequestValidator` (public `AbstractValidator<UpdateRuleRequest>`, no constructor args — instantiate directly, e.g. `_validator = new UpdateRuleRequestValidator();`).
+   - Request DTO under test: `Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule.UpdateRuleRequest` with settable properties `int Id`, `string PathPattern`, `string TagName`, `bool IsActive`, `int SortOrder`.
+   - Use FluentValidation's `TestValidate` extension (`FluentValidation.TestHelper`, already referenced by the test project) — call `_validator.TestValidate(request)` and assert with `ShouldHaveValidationErrorFor` / `ShouldNotHaveValidationErrorFor` / `ShouldNotHaveAnyValidationErrors`, matching the style of the existing sibling file `backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs` (read this file first for exact conventions: how requests are built, how `WithErrorMessage` is asserted, `[Theory]`/`[InlineData]` usage).
+   - Build every test request from a fully-valid baseline, varying only the field under test, to avoid cross-field noise:
+     ```csharp
+     var request = new UpdateRuleRequest
+     {
+         Id = 1,
+         PathPattern = "^[a-z]+\\.png$",
+         TagName = "summer",
+         SortOrder = 0,
+         IsActive = true
+     };
+     ```
+   - Test cases to implement (one `[Fact]` or a `[Theory]`/`[InlineData]` group per bullet; `[Theory]` may collapse near-duplicate cases such as `Id = 0`/`Id = -1`, per the design doc — this is a style choice):
+     - Baseline: the fully-valid request above produces `ShouldNotHaveAnyValidationErrors()`.
+     - `Id = 0` and `Id = -1`: each produces `ShouldHaveValidationErrorFor(x => x.Id).WithErrorMessage("Id must be a positive integer")`.
+     - `PathPattern = ""` and `PathPattern = null`: each produces `ShouldHaveValidationErrorFor(x => x.PathPattern).WithErrorMessage("PathPattern is required")`.
+     - `PathPattern` = a 501-character benign literal (e.g. `new string('a', 501)` — always a syntactically valid regex, so only the length rule fires): produces `ShouldHaveValidationErrorFor(x => x.PathPattern).WithErrorMessage("PathPattern cannot exceed 500 characters")`.
+     - `PathPattern` = a 500-character valid-regex literal (e.g. `new string('a', 500)`): boundary case, produces `ShouldNotHaveValidationErrorFor(x => x.PathPattern)`.
+     - `PathPattern = "["` (syntactically invalid regex): produces `ShouldHaveValidationErrorFor(x => x.PathPattern).WithErrorMessage("Invalid regular expression pattern.")`.
+     - `PathPattern = "^[a-z]+"` (syntactically valid regex): produces `ShouldNotHaveValidationErrorFor(x => x.PathPattern)`.
+     - `TagName = ""` and `TagName = null`: each produces `ShouldHaveValidationErrorFor(x => x.TagName).WithErrorMessage("TagName is required")`.
+     - `TagName` = a 101-character string: produces `ShouldHaveValidationErrorFor(x => x.TagName).WithErrorMessage("TagName cannot exceed 100 characters")`.
+     - `SortOrder = -1`: produces `ShouldHaveValidationErrorFor(x => x.SortOrder)` (no `WithErrorMessage` — the rule `GreaterThanOrEqualTo(0)` has no custom `.WithMessage()`, so only assert the error exists, not its text).
+     - `SortOrder = 0`: boundary case, produces `ShouldNotHaveValidationErrorFor(x => x.SortOrder)`.
+
+2. `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankValidationHelpersTests.cs`
+   - Namespace: `Anela.Heblo.Tests.Features.Photobank`
+   - Class under test: `Anela.Heblo.Application.Features.Photobank.Validators.PhotobankValidationHelpers.BeValidRegex(string? pattern)` — `internal static bool`, callable directly via fully-qualified static reference (e.g. `PhotobankValidationHelpers.BeValidRegex(pattern)`) because `Anela.Heblo.Application.csproj` already grants `InternalsVisibleTo("Anela.Heblo.Tests")`. No DI, no constructor state needed (static method).
+   - Test cases (no DTO involved, call the helper directly and assert the returned `bool`):
+     - `[Theory]` with `[InlineData(null)]`, `[InlineData("")]`, `[InlineData("   ")]` → assert `BeValidRegex(pattern)` returns `true`.
+     - `[Fact]` → `BeValidRegex("^[a-z]+$")` returns `true`.
+     - `[Theory]` with `[InlineData("[")]`, `[InlineData("(unclosed")]` → assert `BeValidRegex(pattern)` returns `false`.
+
+**Constraints:**
+- Do not modify `UpdateRuleRequestValidator.cs`, `PhotobankValidationHelpers.cs`, `UpdateRuleRequest.cs`, `UpdateRuleHandler.cs`, or any other production file.
+- Do not add tests for `UpdateRuleHandler`, the controller/endpoint, or `AddRuleRequestValidator` — out of scope.
+- No new NuGet packages or project references are required or permitted; `FluentValidation.TestHelper` and `xunit` are already referenced by `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`.
+- Match the existing flat-folder convention: both files go directly in `backend/test/Anela.Heblo.Tests/Features/Photobank/`, no new subfolders.
+
+**Acceptance criteria:**
+- Both new files exist at the paths above, compile, and contain all test cases enumerated.
+- Every acceptance-criteria bullet from `artifacts/feat-3616/spec.r1.md` (FR-1 and FR-2) is covered by at least one test.
+- All new tests pass; no existing test is modified or broken.
+- No production source file is changed (verify with `git status` / `git diff --stat` showing only the two new test files added).
+
+**Verification:**
+1. Build the test project:
+   `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+2. Run only the new tests and confirm all pass (adjust filter names if actual method names differ, but keep the class-name filter):
+   `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Photobank.UpdateRuleRequestValidatorTests|FullyQualifiedName~Anela.Heblo.Tests.Features.Photobank.PhotobankValidationHelpersTests"`
+3. Run the full test project once to confirm no regressions were introduced:
+   `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+4. Confirm no production files changed: `git status --short` should show only the two new test files as additions.

--- a/artifacts/feat-3616/task-plan.r1.md
+++ b/artifacts/feat-3616/task-plan.r1.md
@@ -1,0 +1,64 @@
+# Task Plan: Unit tests for UpdateRuleRequestValidator (Photobank)
+
+### task: add-updaterulerequestvalidator-tests
+Add unit tests closing the coverage gap on `UpdateRuleRequestValidator` and its dependency `PhotobankValidationHelpers.BeValidRegex`. This is a pure test-authoring task — no production code changes.
+
+**Files to create:**
+
+1. `backend/test/Anela.Heblo.Tests/Features/Photobank/UpdateRuleRequestValidatorTests.cs`
+   - Namespace: `Anela.Heblo.Tests.Features.Photobank`
+   - Class under test: `Anela.Heblo.Application.Features.Photobank.Validators.UpdateRuleRequestValidator` (public `AbstractValidator<UpdateRuleRequest>`, no constructor args — instantiate directly, e.g. `_validator = new UpdateRuleRequestValidator();`).
+   - Request DTO under test: `Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule.UpdateRuleRequest` with settable properties `int Id`, `string PathPattern`, `string TagName`, `bool IsActive`, `int SortOrder`.
+   - Use FluentValidation's `TestValidate` extension (`FluentValidation.TestHelper`, already referenced by the test project) — call `_validator.TestValidate(request)` and assert with `ShouldHaveValidationErrorFor` / `ShouldNotHaveValidationErrorFor` / `ShouldNotHaveAnyValidationErrors`, matching the style of the existing sibling file `backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs` (read this file first for exact conventions: how requests are built, how `WithErrorMessage` is asserted, `[Theory]`/`[InlineData]` usage).
+   - Build every test request from a fully-valid baseline, varying only the field under test, to avoid cross-field noise:
+     ```csharp
+     var request = new UpdateRuleRequest
+     {
+         Id = 1,
+         PathPattern = "^[a-z]+\\.png$",
+         TagName = "summer",
+         SortOrder = 0,
+         IsActive = true
+     };
+     ```
+   - Test cases to implement (one `[Fact]` or a `[Theory]`/`[InlineData]` group per bullet; `[Theory]` may collapse near-duplicate cases such as `Id = 0`/`Id = -1`, per the design doc — this is a style choice):
+     - Baseline: the fully-valid request above produces `ShouldNotHaveAnyValidationErrors()`.
+     - `Id = 0` and `Id = -1`: each produces `ShouldHaveValidationErrorFor(x => x.Id).WithErrorMessage("Id must be a positive integer")`.
+     - `PathPattern = ""` and `PathPattern = null`: each produces `ShouldHaveValidationErrorFor(x => x.PathPattern).WithErrorMessage("PathPattern is required")`.
+     - `PathPattern` = a 501-character benign literal (e.g. `new string('a', 501)` — always a syntactically valid regex, so only the length rule fires): produces `ShouldHaveValidationErrorFor(x => x.PathPattern).WithErrorMessage("PathPattern cannot exceed 500 characters")`.
+     - `PathPattern` = a 500-character valid-regex literal (e.g. `new string('a', 500)`): boundary case, produces `ShouldNotHaveValidationErrorFor(x => x.PathPattern)`.
+     - `PathPattern = "["` (syntactically invalid regex): produces `ShouldHaveValidationErrorFor(x => x.PathPattern).WithErrorMessage("Invalid regular expression pattern.")`.
+     - `PathPattern = "^[a-z]+"` (syntactically valid regex): produces `ShouldNotHaveValidationErrorFor(x => x.PathPattern)`.
+     - `TagName = ""` and `TagName = null`: each produces `ShouldHaveValidationErrorFor(x => x.TagName).WithErrorMessage("TagName is required")`.
+     - `TagName` = a 101-character string: produces `ShouldHaveValidationErrorFor(x => x.TagName).WithErrorMessage("TagName cannot exceed 100 characters")`.
+     - `SortOrder = -1`: produces `ShouldHaveValidationErrorFor(x => x.SortOrder)` (no `WithErrorMessage` — the rule `GreaterThanOrEqualTo(0)` has no custom `.WithMessage()`, so only assert the error exists, not its text).
+     - `SortOrder = 0`: boundary case, produces `ShouldNotHaveValidationErrorFor(x => x.SortOrder)`.
+
+2. `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankValidationHelpersTests.cs`
+   - Namespace: `Anela.Heblo.Tests.Features.Photobank`
+   - Class under test: `Anela.Heblo.Application.Features.Photobank.Validators.PhotobankValidationHelpers.BeValidRegex(string? pattern)` — `internal static bool`, callable directly via fully-qualified static reference (e.g. `PhotobankValidationHelpers.BeValidRegex(pattern)`) because `Anela.Heblo.Application.csproj` already grants `InternalsVisibleTo("Anela.Heblo.Tests")`. No DI, no constructor state needed (static method).
+   - Test cases (no DTO involved, call the helper directly and assert the returned `bool`):
+     - `[Theory]` with `[InlineData(null)]`, `[InlineData("")]`, `[InlineData("   ")]` → assert `BeValidRegex(pattern)` returns `true`.
+     - `[Fact]` → `BeValidRegex("^[a-z]+$")` returns `true`.
+     - `[Theory]` with `[InlineData("[")]`, `[InlineData("(unclosed")]` → assert `BeValidRegex(pattern)` returns `false`.
+
+**Constraints:**
+- Do not modify `UpdateRuleRequestValidator.cs`, `PhotobankValidationHelpers.cs`, `UpdateRuleRequest.cs`, `UpdateRuleHandler.cs`, or any other production file.
+- Do not add tests for `UpdateRuleHandler`, the controller/endpoint, or `AddRuleRequestValidator` — out of scope.
+- No new NuGet packages or project references are required or permitted; `FluentValidation.TestHelper` and `xunit` are already referenced by `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`.
+- Match the existing flat-folder convention: both files go directly in `backend/test/Anela.Heblo.Tests/Features/Photobank/`, no new subfolders.
+
+**Acceptance criteria:**
+- Both new files exist at the paths above, compile, and contain all test cases enumerated.
+- Every acceptance-criteria bullet from `artifacts/feat-3616/spec.r1.md` (FR-1 and FR-2) is covered by at least one test.
+- All new tests pass; no existing test is modified or broken.
+- No production source file is changed (verify with `git status` / `git diff --stat` showing only the two new test files added).
+
+**Verification:**
+1. Build the test project:
+   `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+2. Run only the new tests and confirm all pass (adjust filter names if actual method names differ, but keep the class-name filter):
+   `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Photobank.UpdateRuleRequestValidatorTests|FullyQualifiedName~Anela.Heblo.Tests.Features.Photobank.PhotobankValidationHelpersTests"`
+3. Run the full test project once to confirm no regressions were introduced:
+   `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+4. Confirm no production files changed: `git status --short` should show only the two new test files as additions.

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankValidationHelpersTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankValidationHelpersTests.cs
@@ -1,0 +1,42 @@
+using Anela.Heblo.Application.Features.Photobank.Validators;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class PhotobankValidationHelpersTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BeValidRegex_NullOrWhitespace_ReturnsTrue(string? pattern)
+    {
+        // Act
+        var result = PhotobankValidationHelpers.BeValidRegex(pattern);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void BeValidRegex_ValidPattern_ReturnsTrue()
+    {
+        // Act
+        var result = PhotobankValidationHelpers.BeValidRegex("^[a-z]+$");
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("[")]
+    [InlineData("(unclosed")]
+    public void BeValidRegex_InvalidPattern_ReturnsFalse(string pattern)
+    {
+        // Act
+        var result = PhotobankValidationHelpers.BeValidRegex(pattern);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/UpdateRuleRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/UpdateRuleRequestValidatorTests.cs
@@ -1,0 +1,193 @@
+using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
+using Anela.Heblo.Application.Features.Photobank.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class UpdateRuleRequestValidatorTests
+{
+    private readonly UpdateRuleRequestValidator _validator;
+
+    public UpdateRuleRequestValidatorTests()
+    {
+        _validator = new UpdateRuleRequestValidator();
+    }
+
+    private static UpdateRuleRequest ValidRequest()
+    {
+        return new UpdateRuleRequest
+        {
+            Id = 1,
+            PathPattern = "^[a-z]+\\.png$",
+            TagName = "summer",
+            SortOrder = 0,
+            IsActive = true,
+        };
+    }
+
+    [Fact]
+    public void ValidRequest_PassesValidation()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Id_NotPositive_FailsValidation(int id)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Id = id;
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+            .WithErrorMessage("Id must be a positive integer");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void PathPattern_Empty_FailsValidation(string? pathPattern)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.PathPattern = pathPattern!;
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.PathPattern)
+            .WithErrorMessage("PathPattern is required");
+    }
+
+    [Fact]
+    public void PathPattern_TooLong_FailsValidation()
+    {
+        // Arrange — 501 benign chars, always a valid regex, so only the length rule fires
+        var request = ValidRequest();
+        request.PathPattern = new string('a', 501);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.PathPattern)
+            .WithErrorMessage("PathPattern cannot exceed 500 characters");
+    }
+
+    [Fact]
+    public void PathPattern_MaxLength_PassesValidation()
+    {
+        // Arrange — boundary case, exactly 500 chars
+        var request = ValidRequest();
+        request.PathPattern = new string('a', 500);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.PathPattern);
+    }
+
+    [Fact]
+    public void PathPattern_InvalidRegex_FailsValidation()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.PathPattern = "[";
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.PathPattern)
+            .WithErrorMessage("Invalid regular expression pattern.");
+    }
+
+    [Fact]
+    public void PathPattern_ValidRegex_PassesValidation()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.PathPattern = "^[a-z]+";
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.PathPattern);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TagName_Empty_FailsValidation(string? tagName)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.TagName = tagName!;
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.TagName)
+            .WithErrorMessage("TagName is required");
+    }
+
+    [Fact]
+    public void TagName_TooLong_FailsValidation()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.TagName = new string('a', 101);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.TagName)
+            .WithErrorMessage("TagName cannot exceed 100 characters");
+    }
+
+    [Fact]
+    public void SortOrder_Negative_FailsValidation()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.SortOrder = -1;
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert — no custom .WithMessage() on this rule, only assert the error exists
+        result.ShouldHaveValidationErrorFor(x => x.SortOrder);
+    }
+
+    [Fact]
+    public void SortOrder_Zero_PassesValidation()
+    {
+        // Arrange — boundary case
+        var request = ValidRequest();
+        request.SortOrder = 0;
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.SortOrder);
+    }
+}


### PR DESCRIPTION
Closes #3616

## What the issue was
`backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs` had 0% line coverage. None of its four rule groups (`Id > 0`, `PathPattern` required/max-length/valid-regex, `TagName` required/max-length, `SortOrder >= 0`) were exercised by any test. The most critical gap was the `PathPattern` regex check via `PhotobankValidationHelpers.BeValidRegex` — if broken, invalid regex patterns could be persisted and crash the photobank sync at runtime. The `BeValidRegex` helper itself was also untested.

## How it was fixed / handled
Added two new xUnit test files under `backend/test/Anela.Heblo.Tests/Features/Photobank/`, following the existing `FluentValidation.TestHelper` conventions used by sibling validator tests in the same folder:

- `UpdateRuleRequestValidatorTests.cs` — covers all four rule groups: valid request (no errors), `Id` = 0/-1, `PathPattern` empty/null, `PathPattern` over 500 chars (and boundary at exactly 500), invalid regex (`"["`), valid regex, `TagName` empty/null, `TagName` over 100 chars, `SortOrder` negative and boundary zero. Every asserted error message was cross-checked against the validator's actual `.WithErrorMessage()` strings.
- `PhotobankValidationHelpersTests.cs` — covers `BeValidRegex` directly (it's `internal`, exposed to the test project via the existing `InternalsVisibleTo` grant): null/empty/whitespace → true, valid pattern → true, invalid patterns (`"["`, `"(unclosed"`) → false.

No production code was changed — this is a pure test-authoring task. All 20 new tests pass (`dotnet test` filtered run), and `dotnet build`/`dotnet format` were verified clean.

This PR was produced by the AgentHarness autonomous pipeline (analyst → architect → designer → planner → developer → reviewer → whole-branch code review); all intermediate artifacts are committed under `artifacts/feat-3616/`.

## Code review

## Review Result: CLEAN

This is a pure test-authoring PR (no production code changes), adding `PhotobankValidationHelpersTests.cs` and `UpdateRuleRequestValidatorTests.cs`.

Verification performed:
- Cross-checked every asserted `.WithErrorMessage(...)` string against the real validator messages — all match exactly.
- Verified `BeValidRegex`'s null/whitespace short-circuit and exception handling matches the test assertions.
- Confirmed `InternalsVisibleTo("Anela.Heblo.Tests")` exists, so the direct call to the internal `BeValidRegex` compiles.
- Reasoned through FluentValidation's cascade mode for multi-error cases to confirm only the expected rule fires per test.
- Built the test project and ran the two new test classes: all 20 tests pass.

No correctness issues or noteworthy cleanups found.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UsHLJYYkT1PksfhVEx5pp)_