### PR TITLE
#3619: Fix BackgroundTasksCard formatDuration multi-day bug, add unit tests

### DIFF
--- a/artifacts/feat-3619/arch-review.r1.md
+++ b/artifacts/feat-3619/arch-review.r1.md
@@ -1,0 +1,144 @@
+# Architecture Review: BackgroundTasksCard — extract & test duration/status helpers, fix multi-day duration bug
+
+## Skip Design: true
+
+No new or changed UI/UX. The three functions being extracted (`formatDuration`, `getTimeUntilNextRun`, `getStatusBadge`) already produce the exact same text and badge markup they produce today — `getStatusBadge`'s JSX (badge `<span>` + icon, Tailwind classes) is moved verbatim into the new module, not redesigned. The only observable behavior change is that `formatDuration` will now render correct day/hour values for spans ≥ 24h instead of a truncated value — a correctness fix to existing text, not a new visual element. Confirmed by reading `frontend/src/components/BackgroundTasksCard.tsx:101-209` in full: no new badge states, no new columns, no new components are introduced.
+
+## Architectural Fit Assessment
+
+This is a pure frontend refactor + bugfix, fully aligned with existing conventions:
+
+- **Extraction pattern precedent**: `frontend/src/components/catalog/detail/charts/ChartHelpers.tsx` already establishes the exact pattern this spec asks for — pure helper functions (some returning primitives, some returning callback objects) extracted from a component-adjacent concern into a sibling `.tsx` module, imported as named exports, tested via a co-located `__tests__/` file (`ChartHelpers.test.ts`). `backgroundTasksHelpers.tsx` follows this precedent directly.
+- **JSX-returning helper precedent**: `getStatusBadge` returns JSX, which is why it needs `.tsx` (not `.ts`). The project doesn't yet have a helper module that itself returns JSX (ChartHelpers returns data/callbacks only), but `frontend/src/components/ui/TagBadge.tsx` + `frontend/src/components/ui/__tests__/TagBadge.test.tsx` establishes the RTL `render()` + `getByText`/`getByTestId` pattern for asserting badge-shaped JSX, which the spec correctly points to for FR-4.
+- **Test co-location convention**: `docs/architecture/filesystem.md` §"Test Organization Structure" mandates `src/components/__tests__/` for React component tests, co-located with the code under test. `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx` satisfies this directly (it's a sibling of `BackgroundTasksCard.tsx`, not nested under a subfolder, matching where the new helpers module itself lives).
+- **No cross-module or contract impact**: `RefreshTaskDto` (from `frontend/src/api/generated/api-client.ts:16201-16208`) is consumed as-is, unchanged. `getStatusBadge`'s parameter type (`task: RefreshTaskDto`) and field usage (`enabled`, `lastExecution?.status`) require no new types per the spec's Data Model section — verified against the generated client, which is correct as written.
+- **No backend involvement**: The bug is purely in client-side parsing of an already-correct .NET `TimeSpan` string; no serialization change, no API contract change.
+
+Net: this task requires no deviation from existing patterns. The only judgment call is precisely how to structure the bugfix logic in `formatDuration`, addressed below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+BackgroundTasksCard.tsx  (unchanged responsibilities: data fetch, grouping,
+                           table rendering, force-refresh/tier-run handlers)
+        │  imports (named)
+        ▼
+backgroundTasksHelpers.tsx  (new sibling module — pure functions only)
+        │  imports
+        ▼
+RefreshTaskDto  (frontend/src/api/generated/api-client.ts — unchanged)
+
+Test coverage:
+frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx
+        │  imports
+        ▼
+backgroundTasksHelpers.tsx  (functions under test)
+```
+
+No new runtime dependency edges are introduced beyond the import from `BackgroundTasksCard.tsx` to the new module and `lucide-react`'s `RefreshCw`/`CheckCircle`/`XCircle` icons (already imported in the component today; `getStatusBadge` moves with them).
+
+### Key Design Decisions
+
+#### Decision 1: `formatDuration` bug-fix strategy — parse days directly, don't re-derive from hours
+
+**Options considered:**
+1. Keep `parts[0] = parseInt(timeSpan.split(":")[0])` and compute `days = Math.floor(hours / 24)` — this is the *existing, broken* approach. `parseInt("1.05")` truncates at the `.`, yielding `1`, so `hours` never reaches a value that makes `Math.floor(hours/24)` meaningful. This option is rejected — it's the bug.
+2. Detect a `.` in `parts[0]`; if present, split `parts[0]` on `.` into `days` and `hours` explicitly; if absent, `days = 0` and `hours = parseInt(parts[0])`. Use `days` directly for the `>= 24h` branch display, not a re-derived value.
+
+**Chosen approach:** Option 2, exactly as prescribed in spec FR-2. Detect the day component structurally (presence of `.` in the segment before the first `:`), not by magnitude (`hours >= 24`), because the source string already tells you unambiguously whether a day component is present — inferring it from a parsed `hours` value is what caused the original bug (parsing `"1.05"` as an integer silently discards the day information before the magnitude check ever runs).
+
+**Rationale:** This makes the fix robust to the exact boundary case that exposed the bug (`hours >= 24` used as a proxy for "has a day component" fails whenever the numeric parse itself is already corrupted). Structural detection (`parts[0].includes(".")`) is a one-line change to the parsing branch and requires no change to the two.NET-originated format assumptions the function already documents in its comment.
+
+**Implementation sketch** (illustrative — developer may phrase differently but must preserve this branching):
+```ts
+export function formatDuration(timeSpan: string): string {
+  // TimeSpan format: "hh:mm:ss" or "dd.hh:mm:ss"
+  const parts = timeSpan.split(":");
+  const firstSegment = parts[0];
+  const minutes = parseInt(parts[1]);
+
+  let days = 0;
+  let hours: number;
+  if (firstSegment.includes(".")) {
+    const [dayPart, hourPart] = firstSegment.split(".");
+    days = parseInt(dayPart);
+    hours = parseInt(hourPart);
+  } else {
+    hours = parseInt(firstSegment);
+  }
+
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  } else if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else {
+    return `${minutes}m`;
+  }
+}
+```
+This satisfies every acceptance criterion in FR-2, including the `"2.00:00:00"` → `"2d 0h"` case (day component present but `hours === 0` still routes through the `days > 0` branch, not the `hours > 0` branch — the original code's `hours >= 24` condition is retired entirely in favor of `days > 0`).
+
+#### Decision 2: File extension and module boundary — single `.tsx` file for all three functions
+
+**Options considered:**
+1. Split into `backgroundTasksHelpers.ts` (for `formatDuration`, `getTimeUntilNextRun`) + a separate `.tsx` file for `getStatusBadge` alone.
+2. Single `backgroundTasksHelpers.tsx` file for all three, per spec FR-1.
+
+**Chosen approach:** Option 2, matching the `ChartHelpers.tsx` precedent (which itself mixes non-JSX and JSX-adjacent exports, e.g. `generateTooltipCallback` returns a plain object, not JSX, alongside pure array-builders, all in one `.tsx` file). Splitting into two files for three closely-related, always-co-imported functions would add navigation overhead without a corresponding benefit — there's no independent reuse case for `getStatusBadge` outside this component today, and TypeScript/CRA's build has no issue with `.tsx` files that mix JSX and non-JSX exports.
+
+**Rationale:** Minimizes file count and import surface in `BackgroundTasksCard.tsx` (`import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "./backgroundTasksHelpers"`), consistent with how `ChartHelpers.tsx` is imported today.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New files:
+- `frontend/src/components/backgroundTasksHelpers.tsx` — the three extracted, exported functions.
+- `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx` — unit tests for all three.
+
+Modified file:
+- `frontend/src/components/BackgroundTasksCard.tsx` — remove the inline definitions of `formatDuration` (lines 101-115), `getTimeUntilNextRun` (lines 129-152), and `getStatusBadge` (lines 154-209); add `import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "./backgroundTasksHelpers";` near the existing imports. `formatDateTime` (lines 117-127) stays inline, untouched, per spec.
+
+No other files are touched. No changes to `TaskHistoryModal`, `useBackgroundRefresh` hooks, or `RefreshTaskDto`.
+
+### Interfaces and Contracts
+
+```ts
+// frontend/src/components/backgroundTasksHelpers.tsx
+import { RefreshTaskDto } from "../api/generated/api-client";
+
+export function formatDuration(timeSpan: string): string;
+
+export function getTimeUntilNextRun(
+  nextScheduledRun: Date | string | undefined | null
+): string;
+
+export function getStatusBadge(task: RefreshTaskDto): JSX.Element | null;
+```
+
+These signatures are unchanged from the current inline closures (they don't currently close over any component state — `formatDuration` and `getTimeUntilNextRun` are pure; `getStatusBadge` only reads its `task` argument), so the extraction is a mechanical cut-paste-import with the `formatDuration` body changed per Decision 1. No adapter/wrapper layer is needed at the call sites in `BackgroundTasksCard.tsx` (4 call sites: `formatDuration` ×3 at lines 345, 349, 359; `getTimeUntilNextRun` ×1 at line 377; `getStatusBadge` ×1 at line 339 — all continue to call the imported functions with identical arguments).
+
+### Data Flow
+
+Unchanged at runtime: `useBackgroundTasks()` → `tasks: RefreshTaskDto[]` → `groupedTasks` (memoized) → per-row render calls `getStatusBadge(task)`, `formatDuration(task.initialDelay!)`, `formatDuration(task.refreshInterval!)`, `formatDuration(task.lastExecution.duration)`, `getTimeUntilNextRun(task.nextScheduledRun)`. The only change is these calls now resolve to imported functions instead of closures defined in the same render scope — no memoization or re-render behavior changes since none of the original functions were wrapped in `useCallback`/`useMemo`.
+
+For tests: `backgroundTasksHelpers.test.tsx` calls the exported functions directly with hand-constructed inputs (TimeSpan strings, `Date`/string/`null`/`undefined` values, minimal `RefreshTaskDto`-shaped fixtures) — no `useBackgroundTasks()` mocking, no `QueryClientProvider` wrapper needed, since these are pure/presentational functions, not the connected component. For `getStatusBadge`, wrap each case in `render(<>{getStatusBadge(fixture)}</>)` (or a trivial functional wrapper component) since RTL's `render` expects a JSX element/component, not a bare function call — a one-line wrapper is sufficient and needs no `QueryClientProvider`, since `getStatusBadge` reads only its `task` argument.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Extraction accidentally alters `getStatusBadge` JSX/Tailwind classes during copy, causing a visual regression | Low | Copy-paste verbatim (no rewrite); FR-4 acceptance criteria assert on visible text per status, catching gross regressions; recommend a quick visual diff (or `npm run build` + manual check of the admin page) before merge since class-level regressions aren't asserted by text-based RTL tests |
+| `getTimeUntilNextRun` tests become flaky if not using fixed/mocked time | Medium | Spec FR-3 already mandates `jest.useFakeTimers().setSystemTime(...)`; enforce in test file — do not construct boundary-adjacent inputs (e.g. "59 vs 60 minutes") relative to real `Date.now()` |
+| `formatDuration` fix changes output for an input shape not covered by the spec's acceptance criteria (e.g. malformed/empty string) | Low | Out of scope per spec — the function has no defensive parsing today (`parseInt` on malformed input already returns `NaN` upstream) and this task doesn't add input validation; do not add new error handling beyond what's specified, to keep the change surgical |
+| Barrel/import path mismatch (`./backgroundTasksHelpers` vs `./backgroundTasksHelpers.tsx`) breaks the build | Low | CRA/webpack resolves `.tsx` extension automatically from `./backgroundTasksHelpers`; matches how `ChartHelpers` is already imported without extension in its consumers — verify with `npm run build` before completion, per repo-wide validation requirement |
+
+## Specification Amendments
+
+None required. The spec (`spec.r1.md`) is implementation-ready as written: FR-1 through FR-4 are unambiguous, the acceptance criteria are concrete and testable, and the file/module layout it prescribes matches verified precedent in the codebase (`ChartHelpers.tsx`, `TagBadge.test.tsx`). The only addition this review makes is the concrete `formatDuration` implementation sketch in Decision 1, to remove any residual ambiguity about "compute total hours as `days * 24 + hours`" vs. "output `days` directly" — the spec already states the correct intent (output `days` directly, don't re-derive), this review just makes the resulting branch structure explicit since the wording in FR-2 paragraph 2 is easy to misread as requiring a `days*24+hours` intermediate value.
+
+## Prerequisites
+
+None. No migrations, no config changes, no new dependencies (`@testing-library/react` and `react-scripts test`/Jest are already in use, per `TagBadge.test.tsx` and `ChartHelpers.test.ts`). Implementation can start immediately.

--- a/artifacts/feat-3619/brief.md
+++ b/artifacts/feat-3619/brief.md
@@ -1,0 +1,37 @@
+## Module / File
+`frontend/src/components/BackgroundTasksCard.tsx`
+
+## Coverage
+Line coverage: 0.0% (filter threshold: 60%)
+
+## What's not tested
+The component contains several pure utility functions with meaningful branching logic, none of which are tested:
+
+### `formatDuration(timeSpan: string)` — probable latent bug
+The function handles two formats: `"hh:mm:ss"` and `"dd.hh:mm:ss"`. It splits on `:` and reads `parts[0]` as `hours`. For a string like `"1.05:30:00"` (1 day, 5 hours, 30 min), `parseInt("1.05")` yields `1` — not 29 (the actual hour count). The `hours >= 24` branch is never reached, so the display would show `"1h 30m"` instead of `"1d 5h"`. This is a **confirmed bug** for any task whose duration or interval exceeds 24 hours.
+
+### `getTimeUntilNextRun(nextScheduledRun)` — 4 branches uncovered
+- Past/overdue → `"Spouští se..."`
+- Future < 60 min → `"za N min"`
+- Future < 24 h → `"za Nh Nm"`
+- Future >= 24 h → `"za Nd Nh"`
+
+### `getStatusBadge(task)` — 5 status paths uncovered
+Disabled, no execution yet, Running, Completed, Failed, Cancelled — each returns a different JSX badge, none asserted.
+
+## Why it matters
+`formatDuration` is shown for every task's `initialDelay` and `refreshInterval`. Any background task scheduled to run less frequently than once a day (e.g. weekly catalog refresh) would display an incorrect duration. Users and operators would see `"1h 30m"` instead of `"1d 5h"` with no indication something is wrong.
+
+## Suggested approach
+Extract `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` into a `backgroundTasksHelpers.ts` module and add unit tests:
+
+- `formatDuration("1.05:30:00")` → `"1d 5h"` (currently broken — this test would fail and surface the bug)
+- `formatDuration("00:30:00")` → `"30m"`
+- `formatDuration("02:15:00")` → `"2h 15m"`
+- `getTimeUntilNextRun` for past, <60 min, <24 h, and >=24 h inputs
+- `getStatusBadge` for each status string
+
+~2–3 hours effort (including fixing the `formatDuration` bug).
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-13. Based on CI run #28968007617 (06d109fe5edcb456730222410f64385606100b1b)._

--- a/artifacts/feat-3619/code-review.r1.md
+++ b/artifacts/feat-3619/code-review.r1.md
@@ -1,0 +1,8 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `frontend/src/components/backgroundTasksHelpers.tsx:283` — `formatDuration` still assumes `parts[1]` is always a valid minutes string; malformed/empty `timeSpan` input would yield `NaN` in the output (e.g. `"NaNm"`). This matches the pre-existing behavior of the inline function being extracted (not a regression), so it's advisory only — could add a guard if hardening this function further is ever in scope.
+- `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx:196` — the "za 1d 5h" test computes its input as `NOW + 29h`, which is a `diffHours` of 29 → `diffDays = 1`, `diffHours % 24 = 5`, so the assertion is correct, but the comment "~29 hours from now" reads slightly indirect versus the boundary being tested (`>= 24h`); a minor readability nit only, no functional issue.

--- a/artifacts/feat-3619/design.r1.md
+++ b/artifacts/feat-3619/design.r1.md
@@ -1,0 +1,8 @@
+# Design: Coverage gap in BackgroundTasksCard: formatDuration bug and untested branches
+
+## Skipped
+
+The architecture review (`arch-review.r1.md`) set `Skip Design: true` — this is a
+frontend bugfix + unit-test addition (extracting existing pure helper functions
+and fixing a formatting bug) with no new or changed UI components, screens,
+layouts, or visual design decisions. No design artifact is required.

--- a/artifacts/feat-3619/impl/extract-backgroundtasks-helpers-and-test.r1.md
+++ b/artifacts/feat-3619/impl/extract-backgroundtasks-helpers-and-test.r1.md
@@ -1,0 +1,47 @@
+# Implementation: extract-backgroundtasks-helpers-and-test
+
+## What was implemented
+Extracted `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` out of `BackgroundTasksCard.tsx` into a new standalone module `backgroundTasksHelpers.tsx`, converting them from inline closures to top-level `export function` declarations. While moving `formatDuration`, fixed the multi-day parsing bug: the old code derived `days` via `Math.floor(hours / 24)` from an `hours` value parsed from `parts[0]`, but `parts[0]` for a multi-day TimeSpan (e.g. `"1.05:30:00"`) is `"1.05"`, which `parseInt` truncates to `1` — so `hours` could never reach 24 and the `days > 0` branch was dead code. The fixed version detects the day component structurally by checking for `"."` in the first segment and splitting it into day/hour parts. `BackgroundTasksCard.tsx` now imports the three functions instead of defining them inline; the four call sites are unchanged. Added a full-coverage Jest/RTL test file for all three functions.
+
+## Files created/modified
+- `frontend/src/components/backgroundTasksHelpers.tsx` — new file; named exports `formatDuration`, `getTimeUntilNextRun`, `getStatusBadge` (with the fixed multi-day logic in `formatDuration`), imports `RefreshTaskDto` and the `RefreshCw`/`CheckCircle`/`XCircle` icons used by `getStatusBadge`.
+- `frontend/src/components/BackgroundTasksCard.tsx` — removed the three inline function definitions (kept `formatDateTime` untouched), added `import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "./backgroundTasksHelpers";`, and removed the now-unused `CheckCircle`/`XCircle` imports from `lucide-react` (`RefreshCw` is still used for loading spinners/buttons and remains imported).
+- `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx` — new test file covering `formatDuration` (6 cases incl. the multi-day fix), `getTimeUntilNextRun` (7 cases using `jest.useFakeTimers()`/`setSystemTime` pinned to `2026-01-01T12:00:00.000Z`, including `undefined`/`null`/string-ISO-input equivalence), and `getStatusBadge` (7 cases via RTL `render`/`screen.getByText`, including the unknown-status → empty-render case).
+
+## Tests
+- `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx` — 20 tests, all passing:
+  - `formatDuration`: `"1.05:30:00"` → `"1d 5h"`, `"00:30:00"` → `"30m"`, `"02:15:00"` → `"2h 15m"`, `"00:00:00"` → `"0m"`, `"23:59:00"` → `"23h 59m"`, `"2.00:00:00"` → `"2d 0h"`.
+  - `getTimeUntilNextRun`: before-now, ~30min, ~90min, ~29h, `undefined`, `null`, and string-ISO-input equivalence to the ~90min `Date` case.
+  - `getStatusBadge`: disabled, enabled/no-lastExecution, Running, Completed, Failed, Cancelled, and unknown-status (asserts `container` is empty).
+
+Ran via: `cd frontend && CI=true npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false` → `Tests: 20 passed, 20 total`.
+
+## How to verify
+1. `cd frontend && npm ci --legacy-peer-deps` (node_modules was not present in the worktree; `npm ci`/`npm install` without `--legacy-peer-deps` fails on a pre-existing `react-i18next` vs `typescript` peer-dependency conflict unrelated to this change).
+2. `CI=true npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false` — 20/20 pass.
+3. `npm run build` — "Compiled successfully," no new TypeScript errors.
+4. `npm run lint` — the repo has 148 pre-existing lint errors (mostly `testing-library/no-node-access` and `no-wait-for-multiple-assertions`) in unrelated test files across the codebase; none appear in `BackgroundTasksCard.tsx`, `backgroundTasksHelpers.tsx`, or the new test file (verified via grep on the full lint output).
+5. `grep -n "Math.floor(hours / 24)" frontend/src/components/BackgroundTasksCard.tsx frontend/src/components/backgroundTasksHelpers.tsx` — no matches, confirming the buggy line is gone.
+6. `grep -n "getStatusBadge(task)\|formatDuration(task\|getTimeUntilNextRun(task" frontend/src/components/BackgroundTasksCard.tsx` — confirms all four call sites are present and unchanged in arguments.
+
+## Notes
+- The worktree had no `node_modules`; initial `npm install`/`npm ci` failed due to a pre-existing `react-i18next@15.7.4` peer dependency on `typescript@^5` conflicting with the pinned `typescript@^4.9.5` in `package.json`. This is unrelated to the task — resolved locally with `npm ci --legacy-peer-deps` purely to run verification; no `package.json`/`package-lock.json` changes were made.
+- `TaskHistoryModal.tsx` has its own separate, differently-signatured local `formatDuration`/`getStatusBadge` (operating on `string`/`log.status` rather than `RefreshTaskDto`). Left untouched per scope — it was not mentioned in the task spec and is a distinct component.
+- No files other than the three specified were modified.
+
+## PR Summary
+Extracts `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` from `BackgroundTasksCard.tsx` into a new `backgroundTasksHelpers.tsx` module as named, independently-testable functions, and adds a full-coverage unit test suite for them.
+
+### Changes
+- New `frontend/src/components/backgroundTasksHelpers.tsx` with the three extracted functions.
+- `formatDuration` bug fix: multi-day TimeSpan strings like `"1.05:30:00"` previously always rendered as `"0d Xh"` because `days` was derived via `Math.floor(hours / 24)` from an hours value that could never reach 24 (the day-prefixed first segment was being `parseInt`'d directly instead of split on `.`). The fix detects days structurally by checking for `.` in the first segment.
+- `BackgroundTasksCard.tsx` now imports the three functions instead of defining them inline; unused `CheckCircle`/`XCircle` `lucide-react` imports removed (`RefreshCw` still used elsewhere in the component).
+- New test file `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx` with 20 tests covering all three functions, including the multi-day fix and edge cases (`undefined`/`null`/string-vs-Date inputs, unknown status).
+
+### Test plan
+- `cd frontend && CI=true npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false` — 20/20 pass.
+- `npm run build` — succeeds, no new TypeScript errors.
+- `npm run lint` — no new lint errors introduced (pre-existing unrelated errors in other test files left untouched).
+
+## Status
+DONE

--- a/artifacts/feat-3619/review/extract-backgroundtasks-helpers-and-test.r1.md
+++ b/artifacts/feat-3619/review/extract-backgroundtasks-helpers-and-test.r1.md
@@ -1,0 +1,28 @@
+# Code Review: BackgroundTasksCard — extract & test duration/status helpers, fix multi-day duration bug
+
+## Summary
+The implementation matches the task spec exactly: `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` were moved verbatim (with the prescribed bug fix) into a new `backgroundTasksHelpers.tsx`, `BackgroundTasksCard.tsx` was updated to import them with all four call sites unchanged, and a full-coverage 20-test Jest/RTL suite was added. I independently ran the tests, `npm run build`, and `eslint` on the touched files, and hand-traced the `formatDuration` fix — everything checks out.
+
+## Review Result: PASS
+
+### task: extract-backgroundtasks-helpers-and-test
+**Status:** PASS
+
+**Verification performed:**
+- Read `frontend/src/components/backgroundTasksHelpers.tsx`: three named `export function` declarations, no default export, correct imports (`RefreshTaskDto` from `../api/generated/api-client`, `RefreshCw`/`CheckCircle`/`XCircle` from `lucide-react`). `getStatusBadge`'s five JSX branches (Vypnuto/Čeká/Běží/Úspěch/Chyba/Zrušeno + `return null` fallback) are copy-paste identical to the original, including all Tailwind classes.
+- Verified `formatDuration`'s bug fix matches the spec's prescribed branch structure byte-for-byte (structural `.` detection via `firstSegment.includes(".")`, no `Math.floor(hours/24)` re-derivation).
+- **Hand-traced `formatDuration("1.05:30:00")`:** `parts = ["1.05","30","00"]` → `firstSegment = "1.05"` → `minutes = 30` → `firstSegment.includes(".")` is true → split on `.` gives `["1","05"]` → `days = 1`, `hours = 5` → `days > 0` branch → returns `"1d 5h"`. Confirmed correct, matches the spec's required output and is not the old dead-code bug.
+- Also traced `"2.00:00:00"` → `days=2, hours=0` → `"2d 0h"` (correct, and correctly distinct from the `hours>0`/`minutes`-only branches for single-day inputs).
+- `git show f181b9db` confirms the diff on `BackgroundTasksCard.tsx`: the three inline closures were removed, `formatDateTime` was left untouched and in place, `CheckCircle`/`XCircle` were removed from the `lucide-react` import while `RefreshCw` was kept (confirmed via grep it's still used at 4 other call sites: loading spinner, running-status badge ×2, refresh button). The new `import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "./backgroundTasksHelpers";` was added.
+- Grep-confirmed all four call sites in `BackgroundTasksCard.tsx` are present and unmodified in arguments: `getStatusBadge(task)`, `formatDuration(task.initialDelay!)`, `formatDuration(task.refreshInterval!)`, `formatDuration(task.lastExecution.duration)`, `getTimeUntilNextRun(task.nextScheduledRun)`.
+- Read the new test file: covers all 6 `formatDuration` cases from the spec (including `"1.05:30:00"` → `"1d 5h"` and `"2.00:00:00"` → `"2d 0h"`), all 7 `getTimeUntilNextRun` cases (fake timers pinned via `beforeEach`/`afterEach`, offsets computed from `NOW` rather than hardcoded, including the string-ISO-input equivalence case), and all 7 `getStatusBadge` cases (RTL render + `screen.getByText`, unknown-status case using `toBeEmptyDOMElement()`) — matching the spec's enumerated cases exactly, including the `jest.useFakeTimers()`/`setSystemTime` pattern prescribed in the spec.
+- **Ran the actual test suite** (`CI=true npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false`): 20/20 passed, matching the developer's report.
+- **Ran `npm run build`**: "Compiled successfully" — confirms `.tsx` extension resolves correctly on import and no unused-import TypeScript errors. (A raw `npx tsc --noEmit` surfaces pre-existing syntax errors inside `node_modules/react-i18next/*.d.ts` from an unrelated `typescript@4.9.5` vs. `react-i18next@15` peer-dependency mismatch already noted by the developer; this is orthogonal to the change and does not surface in the actual CRA build pipeline.)
+- **Ran `eslint`** on all three touched files (`backgroundTasksHelpers.tsx`, `BackgroundTasksCard.tsx`, `backgroundTasksHelpers.test.tsx`): zero errors/warnings, confirming the `CheckCircle`/`XCircle` cleanup left no unused imports.
+- Confirmed via `git diff f241bea3 HEAD --stat` that only the three expected source files (plus the impl artifact markdown) were touched — no unrelated files modified. `Math.floor(hours / 24)` no longer appears anywhere in the touched files.
+- Cross-checked against `arch-review.r1.md` Decision 1 and `spec.r1.md` FR-1 through FR-4: implementation follows the prescribed structural-detection approach and file/module layout (`.tsx` extension, matching `ChartHelpers.tsx` precedent) exactly.
+
+No issues found.
+
+## Overall Notes
+Clean, surgical extraction. The developer correctly left `TaskHistoryModal.tsx`'s separate, differently-signatured local `formatDuration`/`getStatusBadge` untouched, which is consistent with the spec's scope (only `BackgroundTasksCard.tsx`'s three functions were in scope). No docs updates are needed — this is an internal refactor plus bug fix with no change to public behavior, API surface, or operational procedure.

--- a/artifacts/feat-3619/spec.r1.md
+++ b/artifacts/feat-3619/spec.r1.md
@@ -1,0 +1,110 @@
+# Specification: BackgroundTasksCard — extract & test duration/status helpers, fix multi-day duration bug
+
+## Summary
+`BackgroundTasksCard.tsx` has three pure utility functions (`formatDuration`, `getTimeUntilNextRun`, `getStatusBadge`) with 0% test coverage and one confirmed bug: `formatDuration` mis-parses multi-day .NET TimeSpan strings (`"dd.hh:mm:ss"`), showing e.g. `"1h 30m"` instead of `"1d 5h"` for a 1-day-5-hour-30-minute span. This change extracts the three functions into a standalone `backgroundTasksHelpers.ts` module, fixes the parsing bug, and adds unit tests covering all branches.
+
+## Background
+`BackgroundTasksCard` renders the admin table of scheduled background refresh tasks. `formatDuration` is used to display each task's `initialDelay`, `refreshInterval`, and last-execution `duration` (all .NET `TimeSpan` strings serialized as either `"hh:mm:ss"` or `"dd.hh:mm:ss"`). Because the function currently does `parseInt(parts[0])` on the string split by `:`, a value like `"1.05:30:00"` yields `parts[0] === "1.05"`, and `parseInt("1.05")` truncates to `1`, so the `hours >= 24` branch never fires. Any task with a delay/interval/duration of a day or more (e.g. a weekly catalog refresh) renders a misleading short duration with no visible error. This was flagged by the weekly coverage-gap routine (CI run #28968007617) as both a coverage gap and a live bug. The fix and tests are scoped to these three pure functions only; no other behavior of the component changes.
+
+## Functional Requirements
+
+### FR-1: Extract `formatDuration`, `getTimeUntilNextRun`, `getStatusBadge` into `backgroundTasksHelpers.ts`
+Move the three functions out of `BackgroundTasksCard.tsx` into a new sibling module `frontend/src/components/backgroundTasksHelpers.ts` (or `.tsx`, since `getStatusBadge` returns JSX — see note below), exported as named functions. `BackgroundTasksCard.tsx` imports and uses them in place of its inline definitions. `formatDateTime` is out of scope and stays inline (not flagged in the brief, no bug, purely a locale-formatting wrapper).
+
+**Note on file extension:** `getStatusBadge` returns JSX (`<span>...</span>`), so the extracted module must use a `.tsx` extension (`backgroundTasksHelpers.tsx`) to compile under the project's TypeScript/JSX settings — matching the existing precedent of `ChartHelpers.tsx` in `frontend/src/components/catalog/detail/charts/`, which mixes helper logic and JSX-returning functions in one `.tsx` file.
+
+**Acceptance criteria:**
+- `frontend/src/components/backgroundTasksHelpers.tsx` exports `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` as named exports with unchanged signatures (see FR-2/FR-3/FR-4).
+- `BackgroundTasksCard.tsx` no longer defines these three functions inline; it imports them from `./backgroundTasksHelpers` and all four call sites (`formatDuration` x3, `getTimeUntilNextRun` x1, `getStatusBadge` x1) continue to work unmodified.
+- No visual or behavioral change to the rendered component other than the `formatDuration` bug fix in FR-2.
+- `npm run build` and `npm run lint` pass with no new errors.
+
+### FR-2: Fix `formatDuration` multi-day parsing bug
+`formatDuration(timeSpan: string): string` must correctly parse both TimeSpan formats:
+- `"hh:mm:ss"` (e.g. `"02:15:00"`) — no day component.
+- `"dd.hh:mm:ss"` (e.g. `"1.05:30:00"`) — day component present, separated from hours by `.`.
+
+Detect the day component by checking whether `parts[0]` (the substring before the first `:`) contains a `.`. If it does, split it into `days` and `hours` on `.`; otherwise treat `parts[0]` as `hours` with `days = 0`. Total hours for the `>= 24` branch should be computed as `days * 24 + hours` (or equivalently, since days is already parsed, output `days` directly rather than re-deriving it via `Math.floor(hours / 24)`, which was the source of the original bug — the fix must not reintroduce hour-based day derivation from a value that never exceeds 23 in the `hh:mm:ss`-only path).
+
+**Acceptance criteria:**
+- `formatDuration("1.05:30:00")` returns `"1d 5h"`.
+- `formatDuration("00:30:00")` returns `"30m"`.
+- `formatDuration("02:15:00")` returns `"2h 15m"`.
+- `formatDuration("00:00:00")` returns `"0m"`.
+- `formatDuration("23:59:00")` returns `"23h 59m"` (boundary just under 1 day, no day component in input).
+- `formatDuration("2.00:00:00")` returns `"2d 0h"` (exact multiple of 24h expressed with an explicit day component).
+- Existing single-day call sites in `BackgroundTasksCard.tsx` (`initialDelay`, `refreshInterval`, `lastExecution.duration`) are unaffected for values under 24 hours.
+
+### FR-3: Unit tests for `getTimeUntilNextRun`
+Add tests covering all four branches of `getTimeUntilNextRun(nextScheduledRun: Date | string | undefined | null): string`, using a fixed/mocked "now" (e.g. via `jest.useFakeTimers().setSystemTime(...)` or by constructing inputs relative to `new Date()` at test-run time) so tests are deterministic and not flaky near boundaries.
+
+**Acceptance criteria:**
+- Overdue/past timestamp → returns `"Spouští se..."`.
+- Future timestamp < 60 minutes away → returns `"za N min"` with correct `N`.
+- Future timestamp >= 60 minutes and < 24 hours away → returns `"za Nh Nm"` with correct hour/minute split.
+- Future timestamp >= 24 hours away → returns `"za Nd Nh"` with correct day/hour split.
+- `undefined` and `null` inputs → return `"N/A"`.
+- A string-typed date input (as opposed to a `Date` object) is handled identically to a `Date` input (component always passes `nextScheduledRun` as either).
+
+### FR-4: Unit tests for `getStatusBadge`
+Add tests covering all five status paths of `getStatusBadge(task: RefreshTaskDto)`, using React Testing Library's `render` (this function returns JSX, so it must be tested by rendering, not by inspecting a plain return value) and matching the project's existing pattern for JSX-returning helpers/components (e.g. `frontend/src/components/ui/__tests__/TagBadge.test.tsx`).
+
+**Acceptance criteria:**
+- `task.enabled === false` → renders badge with text "Vypnuto".
+- `task.enabled === true`, `task.lastExecution` absent → renders badge with text "Čeká".
+- `task.lastExecution.status === "Running"` → renders badge with text "Běží" (and the spinning refresh icon is present, e.g. via a test id or class check if easily assertable; text assertion is sufficient if icon assertion is impractical).
+- `task.lastExecution.status === "Completed"` → renders badge with text "Úspěch".
+- `task.lastExecution.status === "Failed"` → renders badge with text "Chyba".
+- `task.lastExecution.status === "Cancelled"` → renders badge with text "Zrušeno".
+- An unrecognized status value → component renders `null` (test asserts the container is empty rather than throwing).
+- Minimal `RefreshTaskDto`-shaped test fixtures are constructed per case (only the fields `getStatusBadge` reads: `enabled`, `lastExecution.status`).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — pure synchronous functions with no perceptible performance requirement beyond existing behavior.
+
+### NFR-2: Security
+Not applicable — no new data handling, auth, or external input beyond what the component already receives from `useBackgroundTasks()`.
+
+### NFR-3: Test coverage
+The new `backgroundTasksHelpers.tsx` module should reach effectively full line/branch coverage for the three extracted functions (all branches enumerated in FR-2/FR-3/FR-4), raising `BackgroundTasksCard`'s effective coverage above the 60% filter threshold that flagged this gap. `BackgroundTasksCard.tsx` itself is not required to gain additional direct tests beyond what the extraction naturally shifts into the helper module.
+
+## Data Model
+No changes to data models. `getStatusBadge` consumes the existing `RefreshTaskDto` type (`frontend/src/api/generated/api-client`), specifically `enabled: boolean` and `lastExecution?.status: string`. No new types are introduced; if a shared literal union type for status values (`"Running" | "Completed" | "Failed" | "Cancelled"`) does not already exist in the generated client, do not invent one for this change — keep the existing string comparisons as-is.
+
+## API / Interface Design
+No API or endpoint changes. This is a pure frontend refactor plus a bugfix in client-side display logic.
+
+New module public interface:
+```ts
+// frontend/src/components/backgroundTasksHelpers.tsx
+export function formatDuration(timeSpan: string): string;
+export function getTimeUntilNextRun(
+  nextScheduledRun: Date | string | undefined | null
+): string;
+export function getStatusBadge(task: RefreshTaskDto): JSX.Element | null;
+```
+
+Test file location (following the project's existing `__tests__` convention, e.g. `frontend/src/components/catalog/detail/charts/__tests__/ChartHelpers.test.ts`):
+```
+frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx
+```
+(`.tsx` because `getStatusBadge` tests use React Testing Library's `render`.)
+
+## Dependencies
+- No new third-party dependencies. Uses the project's existing test stack: `react-scripts test` (Jest) and `@testing-library/react` (already used elsewhere, e.g. `TagBadge.test.tsx`).
+- Depends on the existing `RefreshTaskDto` generated type from `frontend/src/api/generated/api-client`.
+
+## Out of Scope
+- `formatDateTime` is not extracted or modified.
+- No changes to `BackgroundTasksCard`'s data fetching, sorting/grouping logic, tier-run/force-refresh handlers, or `TaskHistoryModal`.
+- No backend/API changes — the TimeSpan serialization format itself is not touched, only client-side parsing.
+- No visual/styling changes to the status badges beyond what's needed to keep existing output identical.
+- No broader coverage push for the rest of `BackgroundTasksCard.tsx` (e.g. integration tests for the full table render, loading/error states) — this task targets only the three pure functions named in the brief.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-13T16:20:48.919262Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T16:35:25.404567Z"
     }
   },
   "tasks": [
     {
       "name": "extract-backgroundtasks-helpers-and-test",
-      "status": "pending",
+      "status": "completed",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-13T16:35:20.689296Z"
     }
   ]
 }

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-13T16:35:25.404567Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-13T16:35:29.846722Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-13T16:18:22.109436Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T16:18:44.462642Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T16:18:45.068072Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-13T16:18:45.068072Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T16:20:48.919262Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "extract-backgroundtasks-helpers-and-test",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T16:16:39.243934Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3619",
+  "issue_number": 3619,
+  "created_at": "2026-07-13T16:14:29.531518Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-13T16:35:25.404567Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-13T16:35:29.846722Z"
+      "status": "completed",
+      "updated_at": "2026-07-13T16:36:49.631592Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3619/state.json
+++ b/artifacts/feat-3619/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-13T16:16:39.243934Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-13T16:18:22.109436Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-13T16:18:44.462642Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3619/task-context/extract-backgroundtasks-helpers-and-test.md
+++ b/artifacts/feat-3619/task-context/extract-backgroundtasks-helpers-and-test.md
@@ -1,0 +1,134 @@
+### task: extract-backgroundtasks-helpers-and-test
+
+**Goal:** Move `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` out of `BackgroundTasksCard.tsx` into a new `frontend/src/components/backgroundTasksHelpers.tsx`, fix the `formatDuration` multi-day parsing bug during the move, wire `BackgroundTasksCard.tsx` to import the extracted functions, and add a full-coverage unit test file at `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx`.
+
+#### 1. Create `frontend/src/components/backgroundTasksHelpers.tsx`
+
+New file, named exports, no default export. Import `RefreshTaskDto` from `../api/generated/api-client` and the icon components currently used inside `getStatusBadge` (`RefreshCw`, `CheckCircle`, `XCircle`) from `lucide-react`.
+
+Move these three functions verbatim from `frontend/src/components/BackgroundTasksCard.tsx` (current line numbers, will shift as you edit — use as a locator, not a promise of exact position after other edits in the same file):
+
+- `formatDuration` (currently lines 101–115)
+- `getTimeUntilNextRun` (currently lines 129–152)
+- `getStatusBadge` (currently lines 154–209)
+
+They are currently defined as `const fn = (...) => {...}` closures inside the component body. Convert each to a top-level `export function` declaration (per the spec's public interface) — e.g. `export function formatDuration(timeSpan: string): string { ... }`. Do not change parameter names or add new parameters. `getStatusBadge` keeps its current JSX bodies unmodified — copy-paste the five status branches (`Vypnuto` / disabled, `Čeká` / no lastExecution, `Running` → `Běží`, `Completed` → `Úspěch`, `Failed` → `Chyba`, `Cancelled` → `Zrušeno`, plus the `return null` fallback for unrecognized status) verbatim, including all Tailwind classes and the `RefreshCw`/`CheckCircle`/`XCircle` icons. Do not touch `formatDateTime` — it stays inline in `BackgroundTasksCard.tsx`, untouched.
+
+**Fix `formatDuration`'s multi-day bug while moving it.** Replace the current broken body:
+
+```ts
+const formatDuration = (timeSpan: string): string => {
+  // TimeSpan format: "hh:mm:ss" or "dd.hh:mm:ss"
+  const parts = timeSpan.split(":");
+  const hours = parseInt(parts[0]);
+  const minutes = parseInt(parts[1]);
+
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    return `${days}d ${hours % 24}h`;
+  } else if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else {
+    return `${minutes}m`;
+  }
+};
+```
+
+with (exactly this branch structure, per `arch-review.r1.md` Decision 1 — detect the day component structurally by checking for `.` in the first segment, do not re-derive days from an hours value via `Math.floor(hours/24)`):
+
+```ts
+export function formatDuration(timeSpan: string): string {
+  // TimeSpan format: "hh:mm:ss" or "dd.hh:mm:ss"
+  const parts = timeSpan.split(":");
+  const firstSegment = parts[0];
+  const minutes = parseInt(parts[1]);
+
+  let days = 0;
+  let hours: number;
+  if (firstSegment.includes(".")) {
+    const [dayPart, hourPart] = firstSegment.split(".");
+    days = parseInt(dayPart);
+    hours = parseInt(hourPart);
+  } else {
+    hours = parseInt(firstSegment);
+  }
+
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  } else if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else {
+    return `${minutes}m`;
+  }
+}
+```
+
+#### 2. Update `frontend/src/components/BackgroundTasksCard.tsx`
+
+- Remove the inline definitions of `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` from inside the component body (the three blocks identified above). Leave `formatDateTime` in place, untouched.
+- Add an import near the top of the file (alongside the existing `import TaskHistoryModal from "./TaskHistoryModal";`):
+  ```ts
+  import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "./backgroundTasksHelpers";
+  ```
+- If the `RefreshCw`, `CheckCircle`, `XCircle` imports from `lucide-react` at the top of `BackgroundTasksCard.tsx` become unused after removing `getStatusBadge` (check: `RefreshCw` is still used elsewhere in the component for loading spinners/buttons, so it stays; `CheckCircle` and `XCircle` were only used inside `getStatusBadge` — verify with a search of the file after your edit and remove any of `CheckCircle`/`XCircle` from the `lucide-react` import if no longer referenced, to avoid an unused-import lint error).
+- Do not change any of the four call sites (`getStatusBadge(task)` at the status column; `formatDuration(task.initialDelay!)`, `formatDuration(task.refreshInterval!)`, `formatDuration(task.lastExecution.duration)`; `getTimeUntilNextRun(task.nextScheduledRun)`) — they call the same function names with the same arguments, now resolved via import instead of closure.
+- Do not touch any other logic: data fetching, `groupedTasks` memoization, `handleForceRefresh`, `handleRunTier`, `getTierBadgeColor`, loading/error rendering, or the table JSX.
+
+#### 3. Add `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx`
+
+New test file. Follow the project's Jest + React Testing Library conventions used in `frontend/src/components/ui/__tests__/TagBadge.test.tsx` (RTL `render`/`screen`) and `frontend/src/components/catalog/detail/charts/__tests__/ChartHelpers.test.ts` (plain-function `describe`/`it` blocks, imported via relative path `../backgroundTasksHelpers`). Run via the project's existing test command (`react-scripts test`, e.g. `CI=true npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false` from `frontend/`).
+
+Imports:
+```ts
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "../backgroundTasksHelpers";
+import { RefreshTaskDto, RefreshTaskExecutionLogDto } from "../../api/generated/api-client";
+```
+
+**`describe("formatDuration", ...)`** — one `it` per case, asserting exact return string:
+- `formatDuration("1.05:30:00")` → `"1d 5h"`
+- `formatDuration("00:30:00")` → `"30m"`
+- `formatDuration("02:15:00")` → `"2h 15m"`
+- `formatDuration("00:00:00")` → `"0m"`
+- `formatDuration("23:59:00")` → `"23h 59m"`
+- `formatDuration("2.00:00:00")` → `"2d 0h"`
+
+**`describe("getTimeUntilNextRun", ...)`** — use `jest.useFakeTimers()` with `.setSystemTime(...)` to pin "now" (e.g. `new Date("2026-01-01T12:00:00.000Z")`) in a `beforeEach`, and `jest.useRealTimers()` in an `afterEach`, so the test isn't tied to the current wall-clock date. Cover:
+- A `Date` timestamp before the pinned "now" → `"Spouští se..."`.
+- A `Date` timestamp ~30 minutes after "now" (< 60 min) → `"za 30 min"` (or equivalent computed N — assert the exact expected string given your chosen offset).
+- A `Date` timestamp ~90 minutes after "now" (>= 60 min, < 24h) → `"za 1h 30m"`.
+- A `Date` timestamp ~29 hours after "now" (>= 24h) → `"za 1d 5h"`.
+- `undefined` → `"N/A"`.
+- `null` → `"N/A"`.
+- A string-typed ISO date input equivalent to one of the above `Date` cases (e.g. the 90-minutes-away case passed as `nextRun.toISOString()` instead of a `Date` object) → same result as the `Date` version, proving string inputs are handled identically.
+
+Compute expected offsets from the fixed "now" rather than hardcoding both sides independently, e.g.:
+```ts
+const NOW = new Date("2026-01-01T12:00:00.000Z");
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(NOW);
+});
+afterEach(() => {
+  jest.useRealTimers();
+});
+```
+then build each test's input as `new Date(NOW.getTime() + offsetMs)`.
+
+**`describe("getStatusBadge", ...)`** — construct minimal `RefreshTaskDto` fixtures using the generated client's constructors (only set the fields `getStatusBadge` reads: `enabled`, `lastExecution.status`), and render each via RTL, matching the `TagBadge.test.tsx` pattern of `render(...)` + `screen.getByText(...)`. Since `getStatusBadge` returns `JSX.Element | null` rather than being itself a component, wrap the call in a trivial render, e.g. `render(<>{getStatusBadge(task)}</>)`. Cases:
+- `new RefreshTaskDto({ enabled: false })` → `screen.getByText("Vypnuto")` present.
+- `new RefreshTaskDto({ enabled: true })` (no `lastExecution`) → `screen.getByText("Čeká")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Running" }) })` → `screen.getByText("Běží")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Completed" }) })` → `screen.getByText("Úspěch")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Failed" }) })` → `screen.getByText("Chyba")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Cancelled" }) })` → `screen.getByText("Zrušeno")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "SomeUnknownStatus" }) })` → assert no badge text is rendered; use `const { container } = render(<>{getStatusBadge(task)}</>); expect(container).toBeEmptyDOMElement();` to assert the `null` return renders nothing.
+
+#### Verification
+
+- `cd frontend && npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false` (or `CI=true npm test -- --testPathPattern=backgroundTasksHelpers`) — all new tests pass.
+- `cd frontend && npm run build` — succeeds with no new TypeScript errors (confirms the `.tsx` extension resolves correctly on import from `BackgroundTasksCard.tsx` and no unused-import errors from the `lucide-react` cleanup in step 2).
+- `cd frontend && npm run lint` — no new lint errors (e.g. unused imports, missing return types if the lint config enforces them).
+- Manual/spot check: confirm `BackgroundTasksCard.tsx` no longer contains the string `Math.floor(hours / 24)` (the removed buggy line) and that the file's four call sites for `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` are unchanged in behavior (same arguments passed).
+- No changes to any file other than `frontend/src/components/BackgroundTasksCard.tsx` (edit), `frontend/src/components/backgroundTasksHelpers.tsx` (new), and `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx` (new).

--- a/artifacts/feat-3619/task-plan.r1.md
+++ b/artifacts/feat-3619/task-plan.r1.md
@@ -1,0 +1,144 @@
+# Implementation Plan: BackgroundTasksCard — extract & test duration/status helpers, fix multi-day duration bug
+
+## Overview
+
+Extract three pure functions (`formatDuration`, `getTimeUntilNextRun`, `getStatusBadge`) out of `frontend/src/components/BackgroundTasksCard.tsx` into a new sibling module `frontend/src/components/backgroundTasksHelpers.tsx`, fix the multi-day `formatDuration` parsing bug in the process, and add a unit test file covering all branches of all three functions. This is a single, tightly-coupled unit of work — splitting "extract" from "add tests" would leave an intermediate state where the extracted module has known-untested branches, and the bugfix only makes sense embedded in the extraction. One task.
+
+Full context (read before implementing): `artifacts/feat-3619/spec.r1.md` and `artifacts/feat-3619/arch-review.r1.md`. The architecture review's Decision 1 implementation sketch is authoritative for the `formatDuration` fix; follow it exactly.
+
+---
+
+### task: extract-backgroundtasks-helpers-and-test
+
+**Goal:** Move `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` out of `BackgroundTasksCard.tsx` into a new `frontend/src/components/backgroundTasksHelpers.tsx`, fix the `formatDuration` multi-day parsing bug during the move, wire `BackgroundTasksCard.tsx` to import the extracted functions, and add a full-coverage unit test file at `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx`.
+
+#### 1. Create `frontend/src/components/backgroundTasksHelpers.tsx`
+
+New file, named exports, no default export. Import `RefreshTaskDto` from `../api/generated/api-client` and the icon components currently used inside `getStatusBadge` (`RefreshCw`, `CheckCircle`, `XCircle`) from `lucide-react`.
+
+Move these three functions verbatim from `frontend/src/components/BackgroundTasksCard.tsx` (current line numbers, will shift as you edit — use as a locator, not a promise of exact position after other edits in the same file):
+
+- `formatDuration` (currently lines 101–115)
+- `getTimeUntilNextRun` (currently lines 129–152)
+- `getStatusBadge` (currently lines 154–209)
+
+They are currently defined as `const fn = (...) => {...}` closures inside the component body. Convert each to a top-level `export function` declaration (per the spec's public interface) — e.g. `export function formatDuration(timeSpan: string): string { ... }`. Do not change parameter names or add new parameters. `getStatusBadge` keeps its current JSX bodies unmodified — copy-paste the five status branches (`Vypnuto` / disabled, `Čeká` / no lastExecution, `Running` → `Běží`, `Completed` → `Úspěch`, `Failed` → `Chyba`, `Cancelled` → `Zrušeno`, plus the `return null` fallback for unrecognized status) verbatim, including all Tailwind classes and the `RefreshCw`/`CheckCircle`/`XCircle` icons. Do not touch `formatDateTime` — it stays inline in `BackgroundTasksCard.tsx`, untouched.
+
+**Fix `formatDuration`'s multi-day bug while moving it.** Replace the current broken body:
+
+```ts
+const formatDuration = (timeSpan: string): string => {
+  // TimeSpan format: "hh:mm:ss" or "dd.hh:mm:ss"
+  const parts = timeSpan.split(":");
+  const hours = parseInt(parts[0]);
+  const minutes = parseInt(parts[1]);
+
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    return `${days}d ${hours % 24}h`;
+  } else if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else {
+    return `${minutes}m`;
+  }
+};
+```
+
+with (exactly this branch structure, per `arch-review.r1.md` Decision 1 — detect the day component structurally by checking for `.` in the first segment, do not re-derive days from an hours value via `Math.floor(hours/24)`):
+
+```ts
+export function formatDuration(timeSpan: string): string {
+  // TimeSpan format: "hh:mm:ss" or "dd.hh:mm:ss"
+  const parts = timeSpan.split(":");
+  const firstSegment = parts[0];
+  const minutes = parseInt(parts[1]);
+
+  let days = 0;
+  let hours: number;
+  if (firstSegment.includes(".")) {
+    const [dayPart, hourPart] = firstSegment.split(".");
+    days = parseInt(dayPart);
+    hours = parseInt(hourPart);
+  } else {
+    hours = parseInt(firstSegment);
+  }
+
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  } else if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else {
+    return `${minutes}m`;
+  }
+}
+```
+
+#### 2. Update `frontend/src/components/BackgroundTasksCard.tsx`
+
+- Remove the inline definitions of `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` from inside the component body (the three blocks identified above). Leave `formatDateTime` in place, untouched.
+- Add an import near the top of the file (alongside the existing `import TaskHistoryModal from "./TaskHistoryModal";`):
+  ```ts
+  import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "./backgroundTasksHelpers";
+  ```
+- If the `RefreshCw`, `CheckCircle`, `XCircle` imports from `lucide-react` at the top of `BackgroundTasksCard.tsx` become unused after removing `getStatusBadge` (check: `RefreshCw` is still used elsewhere in the component for loading spinners/buttons, so it stays; `CheckCircle` and `XCircle` were only used inside `getStatusBadge` — verify with a search of the file after your edit and remove any of `CheckCircle`/`XCircle` from the `lucide-react` import if no longer referenced, to avoid an unused-import lint error).
+- Do not change any of the four call sites (`getStatusBadge(task)` at the status column; `formatDuration(task.initialDelay!)`, `formatDuration(task.refreshInterval!)`, `formatDuration(task.lastExecution.duration)`; `getTimeUntilNextRun(task.nextScheduledRun)`) — they call the same function names with the same arguments, now resolved via import instead of closure.
+- Do not touch any other logic: data fetching, `groupedTasks` memoization, `handleForceRefresh`, `handleRunTier`, `getTierBadgeColor`, loading/error rendering, or the table JSX.
+
+#### 3. Add `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx`
+
+New test file. Follow the project's Jest + React Testing Library conventions used in `frontend/src/components/ui/__tests__/TagBadge.test.tsx` (RTL `render`/`screen`) and `frontend/src/components/catalog/detail/charts/__tests__/ChartHelpers.test.ts` (plain-function `describe`/`it` blocks, imported via relative path `../backgroundTasksHelpers`). Run via the project's existing test command (`react-scripts test`, e.g. `CI=true npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false` from `frontend/`).
+
+Imports:
+```ts
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "../backgroundTasksHelpers";
+import { RefreshTaskDto, RefreshTaskExecutionLogDto } from "../../api/generated/api-client";
+```
+
+**`describe("formatDuration", ...)`** — one `it` per case, asserting exact return string:
+- `formatDuration("1.05:30:00")` → `"1d 5h"`
+- `formatDuration("00:30:00")` → `"30m"`
+- `formatDuration("02:15:00")` → `"2h 15m"`
+- `formatDuration("00:00:00")` → `"0m"`
+- `formatDuration("23:59:00")` → `"23h 59m"`
+- `formatDuration("2.00:00:00")` → `"2d 0h"`
+
+**`describe("getTimeUntilNextRun", ...)`** — use `jest.useFakeTimers()` with `.setSystemTime(...)` to pin "now" (e.g. `new Date("2026-01-01T12:00:00.000Z")`) in a `beforeEach`, and `jest.useRealTimers()` in an `afterEach`, so the test isn't tied to the current wall-clock date. Cover:
+- A `Date` timestamp before the pinned "now" → `"Spouští se..."`.
+- A `Date` timestamp ~30 minutes after "now" (< 60 min) → `"za 30 min"` (or equivalent computed N — assert the exact expected string given your chosen offset).
+- A `Date` timestamp ~90 minutes after "now" (>= 60 min, < 24h) → `"za 1h 30m"`.
+- A `Date` timestamp ~29 hours after "now" (>= 24h) → `"za 1d 5h"`.
+- `undefined` → `"N/A"`.
+- `null` → `"N/A"`.
+- A string-typed ISO date input equivalent to one of the above `Date` cases (e.g. the 90-minutes-away case passed as `nextRun.toISOString()` instead of a `Date` object) → same result as the `Date` version, proving string inputs are handled identically.
+
+Compute expected offsets from the fixed "now" rather than hardcoding both sides independently, e.g.:
+```ts
+const NOW = new Date("2026-01-01T12:00:00.000Z");
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(NOW);
+});
+afterEach(() => {
+  jest.useRealTimers();
+});
+```
+then build each test's input as `new Date(NOW.getTime() + offsetMs)`.
+
+**`describe("getStatusBadge", ...)`** — construct minimal `RefreshTaskDto` fixtures using the generated client's constructors (only set the fields `getStatusBadge` reads: `enabled`, `lastExecution.status`), and render each via RTL, matching the `TagBadge.test.tsx` pattern of `render(...)` + `screen.getByText(...)`. Since `getStatusBadge` returns `JSX.Element | null` rather than being itself a component, wrap the call in a trivial render, e.g. `render(<>{getStatusBadge(task)}</>)`. Cases:
+- `new RefreshTaskDto({ enabled: false })` → `screen.getByText("Vypnuto")` present.
+- `new RefreshTaskDto({ enabled: true })` (no `lastExecution`) → `screen.getByText("Čeká")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Running" }) })` → `screen.getByText("Běží")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Completed" }) })` → `screen.getByText("Úspěch")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Failed" }) })` → `screen.getByText("Chyba")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "Cancelled" }) })` → `screen.getByText("Zrušeno")` present.
+- `new RefreshTaskDto({ enabled: true, lastExecution: new RefreshTaskExecutionLogDto({ status: "SomeUnknownStatus" }) })` → assert no badge text is rendered; use `const { container } = render(<>{getStatusBadge(task)}</>); expect(container).toBeEmptyDOMElement();` to assert the `null` return renders nothing.
+
+#### Verification
+
+- `cd frontend && npx react-scripts test src/components/__tests__/backgroundTasksHelpers.test.tsx --watchAll=false` (or `CI=true npm test -- --testPathPattern=backgroundTasksHelpers`) — all new tests pass.
+- `cd frontend && npm run build` — succeeds with no new TypeScript errors (confirms the `.tsx` extension resolves correctly on import from `BackgroundTasksCard.tsx` and no unused-import errors from the `lucide-react` cleanup in step 2).
+- `cd frontend && npm run lint` — no new lint errors (e.g. unused imports, missing return types if the lint config enforces them).
+- Manual/spot check: confirm `BackgroundTasksCard.tsx` no longer contains the string `Math.floor(hours / 24)` (the removed buggy line) and that the file's four call sites for `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` are unchanged in behavior (same arguments passed).
+- No changes to any file other than `frontend/src/components/BackgroundTasksCard.tsx` (edit), `frontend/src/components/backgroundTasksHelpers.tsx` (new), and `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx` (new).

--- a/frontend/src/components/BackgroundTasksCard.tsx
+++ b/frontend/src/components/BackgroundTasksCard.tsx
@@ -8,13 +8,12 @@ import { RefreshTaskDto } from "../api/generated/api-client";
 import {
   RefreshCw,
   Clock,
-  CheckCircle,
-  XCircle,
   AlertTriangle,
   PlayCircle,
   ChevronRight,
 } from "lucide-react";
 import TaskHistoryModal from "./TaskHistoryModal";
+import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "./backgroundTasksHelpers";
 
 const BackgroundTasksCard: React.FC = () => {
   const { data: tasks, isLoading, error } = useBackgroundTasks();
@@ -98,22 +97,6 @@ const BackgroundTasksCard: React.FC = () => {
     }
   };
 
-  const formatDuration = (timeSpan: string): string => {
-    // TimeSpan format: "hh:mm:ss" or "dd.hh:mm:ss"
-    const parts = timeSpan.split(":");
-    const hours = parseInt(parts[0]);
-    const minutes = parseInt(parts[1]);
-
-    if (hours >= 24) {
-      const days = Math.floor(hours / 24);
-      return `${days}d ${hours % 24}h`;
-    } else if (hours > 0) {
-      return `${hours}h ${minutes}m`;
-    } else {
-      return `${minutes}m`;
-    }
-  };
-
   const formatDateTime = (date: Date | string | undefined | null): string => {
     if (!date) return "Nikdy";
     const dateObj = typeof date === 'string' ? new Date(date) : date;
@@ -124,88 +107,6 @@ const BackgroundTasksCard: React.FC = () => {
       hour: "2-digit",
       minute: "2-digit",
     });
-  };
-
-  const getTimeUntilNextRun = (nextScheduledRun: Date | string | undefined | null): string => {
-    if (!nextScheduledRun) return "N/A";
-
-    const now = new Date();
-    const nextRun = typeof nextScheduledRun === 'string' ? new Date(nextScheduledRun) : nextScheduledRun;
-    const diffMs = nextRun.getTime() - now.getTime();
-
-    if (diffMs < 0) {
-      return "Spouští se...";
-    }
-
-    const diffMinutes = Math.floor(diffMs / 60000);
-    if (diffMinutes < 60) {
-      return `za ${diffMinutes} min`;
-    }
-
-    const diffHours = Math.floor(diffMinutes / 60);
-    if (diffHours < 24) {
-      return `za ${diffHours}h ${diffMinutes % 60}m`;
-    }
-
-    const diffDays = Math.floor(diffHours / 24);
-    return `za ${diffDays}d ${diffHours % 24}h`;
-  };
-
-  const getStatusBadge = (task: RefreshTaskDto) => {
-    if (!task.enabled) {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-graphite-surface-2 text-gray-800 dark:text-graphite-muted">
-          Vypnuto
-        </span>
-      );
-    }
-
-    if (!task.lastExecution) {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300">
-          Čeká
-        </span>
-      );
-    }
-
-    const status = task.lastExecution.status;
-
-    if (status === "Running") {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-amber-900/30 text-yellow-800 dark:text-amber-300">
-          <RefreshCw className="w-3 h-3 mr-1 animate-spin" />
-          Běží
-        </span>
-      );
-    }
-
-    if (status === "Completed") {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300">
-          <CheckCircle className="w-3 h-3 mr-1" />
-          Úspěch
-        </span>
-      );
-    }
-
-    if (status === "Failed") {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300">
-          <XCircle className="w-3 h-3 mr-1" />
-          Chyba
-        </span>
-      );
-    }
-
-    if (status === "Cancelled") {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-graphite-surface-2 text-gray-800 dark:text-graphite-muted">
-          Zrušeno
-        </span>
-      );
-    }
-
-    return null;
   };
 
   if (isLoading) {

--- a/frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx
+++ b/frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { formatDuration, getTimeUntilNextRun, getStatusBadge } from "../backgroundTasksHelpers";
+import { RefreshTaskDto, RefreshTaskExecutionLogDto } from "../../api/generated/api-client";
+
+describe("formatDuration", () => {
+  it('formats "1.05:30:00" as "1d 5h"', () => {
+    expect(formatDuration("1.05:30:00")).toBe("1d 5h");
+  });
+
+  it('formats "00:30:00" as "30m"', () => {
+    expect(formatDuration("00:30:00")).toBe("30m");
+  });
+
+  it('formats "02:15:00" as "2h 15m"', () => {
+    expect(formatDuration("02:15:00")).toBe("2h 15m");
+  });
+
+  it('formats "00:00:00" as "0m"', () => {
+    expect(formatDuration("00:00:00")).toBe("0m");
+  });
+
+  it('formats "23:59:00" as "23h 59m"', () => {
+    expect(formatDuration("23:59:00")).toBe("23h 59m");
+  });
+
+  it('formats "2.00:00:00" as "2d 0h"', () => {
+    expect(formatDuration("2.00:00:00")).toBe("2d 0h");
+  });
+});
+
+describe("getTimeUntilNextRun", () => {
+  const NOW = new Date("2026-01-01T12:00:00.000Z");
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns "Spouští se..." for a timestamp before now', () => {
+    const past = new Date(NOW.getTime() - 60 * 1000);
+    expect(getTimeUntilNextRun(past)).toBe("Spouští se...");
+  });
+
+  it('returns "za 30 min" for a timestamp ~30 minutes from now', () => {
+    const nextRun = new Date(NOW.getTime() + 30 * 60 * 1000);
+    expect(getTimeUntilNextRun(nextRun)).toBe("za 30 min");
+  });
+
+  it('returns "za 1h 30m" for a timestamp ~90 minutes from now', () => {
+    const nextRun = new Date(NOW.getTime() + 90 * 60 * 1000);
+    expect(getTimeUntilNextRun(nextRun)).toBe("za 1h 30m");
+  });
+
+  it('returns "za 1d 5h" for a timestamp ~29 hours from now', () => {
+    const nextRun = new Date(NOW.getTime() + 29 * 60 * 60 * 1000);
+    expect(getTimeUntilNextRun(nextRun)).toBe("za 1d 5h");
+  });
+
+  it('returns "N/A" for undefined', () => {
+    expect(getTimeUntilNextRun(undefined)).toBe("N/A");
+  });
+
+  it('returns "N/A" for null', () => {
+    expect(getTimeUntilNextRun(null)).toBe("N/A");
+  });
+
+  it("handles a string-typed ISO date input the same as the equivalent Date object", () => {
+    const nextRun = new Date(NOW.getTime() + 90 * 60 * 1000);
+    expect(getTimeUntilNextRun(nextRun.toISOString())).toBe("za 1h 30m");
+  });
+});
+
+describe("getStatusBadge", () => {
+  it("renders 'Vypnuto' when task is disabled", () => {
+    const task = new RefreshTaskDto({ enabled: false });
+    render(<>{getStatusBadge(task)}</>);
+    expect(screen.getByText("Vypnuto")).toBeInTheDocument();
+  });
+
+  it("renders 'Čeká' when task is enabled with no lastExecution", () => {
+    const task = new RefreshTaskDto({ enabled: true });
+    render(<>{getStatusBadge(task)}</>);
+    expect(screen.getByText("Čeká")).toBeInTheDocument();
+  });
+
+  it("renders 'Běží' when lastExecution status is Running", () => {
+    const task = new RefreshTaskDto({
+      enabled: true,
+      lastExecution: new RefreshTaskExecutionLogDto({ status: "Running" }),
+    });
+    render(<>{getStatusBadge(task)}</>);
+    expect(screen.getByText("Běží")).toBeInTheDocument();
+  });
+
+  it("renders 'Úspěch' when lastExecution status is Completed", () => {
+    const task = new RefreshTaskDto({
+      enabled: true,
+      lastExecution: new RefreshTaskExecutionLogDto({ status: "Completed" }),
+    });
+    render(<>{getStatusBadge(task)}</>);
+    expect(screen.getByText("Úspěch")).toBeInTheDocument();
+  });
+
+  it("renders 'Chyba' when lastExecution status is Failed", () => {
+    const task = new RefreshTaskDto({
+      enabled: true,
+      lastExecution: new RefreshTaskExecutionLogDto({ status: "Failed" }),
+    });
+    render(<>{getStatusBadge(task)}</>);
+    expect(screen.getByText("Chyba")).toBeInTheDocument();
+  });
+
+  it("renders 'Zrušeno' when lastExecution status is Cancelled", () => {
+    const task = new RefreshTaskDto({
+      enabled: true,
+      lastExecution: new RefreshTaskExecutionLogDto({ status: "Cancelled" }),
+    });
+    render(<>{getStatusBadge(task)}</>);
+    expect(screen.getByText("Zrušeno")).toBeInTheDocument();
+  });
+
+  it("renders nothing for an unrecognized status", () => {
+    const task = new RefreshTaskDto({
+      enabled: true,
+      lastExecution: new RefreshTaskExecutionLogDto({ status: "SomeUnknownStatus" }),
+    });
+    const { container } = render(<>{getStatusBadge(task)}</>);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/backgroundTasksHelpers.tsx
+++ b/frontend/src/components/backgroundTasksHelpers.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { RefreshTaskDto } from "../api/generated/api-client";
+import { RefreshCw, CheckCircle, XCircle } from "lucide-react";
+
+export function formatDuration(timeSpan: string): string {
+  // TimeSpan format: "hh:mm:ss" or "dd.hh:mm:ss"
+  const parts = timeSpan.split(":");
+  const firstSegment = parts[0];
+  const minutes = parseInt(parts[1]);
+
+  let days = 0;
+  let hours: number;
+  if (firstSegment.includes(".")) {
+    const [dayPart, hourPart] = firstSegment.split(".");
+    days = parseInt(dayPart);
+    hours = parseInt(hourPart);
+  } else {
+    hours = parseInt(firstSegment);
+  }
+
+  if (days > 0) {
+    return `${days}d ${hours}h`;
+  } else if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else {
+    return `${minutes}m`;
+  }
+}
+
+export function getTimeUntilNextRun(nextScheduledRun: Date | string | undefined | null): string {
+  if (!nextScheduledRun) return "N/A";
+
+  const now = new Date();
+  const nextRun = typeof nextScheduledRun === 'string' ? new Date(nextScheduledRun) : nextScheduledRun;
+  const diffMs = nextRun.getTime() - now.getTime();
+
+  if (diffMs < 0) {
+    return "Spouští se...";
+  }
+
+  const diffMinutes = Math.floor(diffMs / 60000);
+  if (diffMinutes < 60) {
+    return `za ${diffMinutes} min`;
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `za ${diffHours}h ${diffMinutes % 60}m`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+  return `za ${diffDays}d ${diffHours % 24}h`;
+}
+
+export function getStatusBadge(task: RefreshTaskDto) {
+  if (!task.enabled) {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-graphite-surface-2 text-gray-800 dark:text-graphite-muted">
+        Vypnuto
+      </span>
+    );
+  }
+
+  if (!task.lastExecution) {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300">
+        Čeká
+      </span>
+    );
+  }
+
+  const status = task.lastExecution.status;
+
+  if (status === "Running") {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-amber-900/30 text-yellow-800 dark:text-amber-300">
+        <RefreshCw className="w-3 h-3 mr-1 animate-spin" />
+        Běží
+      </span>
+    );
+  }
+
+  if (status === "Completed") {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300">
+        <CheckCircle className="w-3 h-3 mr-1" />
+        Úspěch
+      </span>
+    );
+  }
+
+  if (status === "Failed") {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300">
+        <XCircle className="w-3 h-3 mr-1" />
+        Chyba
+      </span>
+    );
+  }
+
+  if (status === "Cancelled") {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-graphite-surface-2 text-gray-800 dark:text-graphite-muted">
+        Zrušeno
+      </span>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
Closes #3619

## What the issue was
`frontend/src/components/BackgroundTasksCard.tsx` had 0% test coverage on three pure utility functions with meaningful branching logic. `formatDuration` had a confirmed latent bug: for multi-day `TimeSpan` strings like `"1.05:30:00"` (1 day, 5 hours, 30 min), it parsed `parts[0]` (`"1.05"`) directly as `hours` via `parseInt`, which truncates to `1` — so the `hours >= 24` branch could never be reached and the duration displayed as `"1h 30m"` instead of the correct `"1d 5h"`. `getTimeUntilNextRun` (4 branches) and `getStatusBadge` (5 status paths) were also entirely untested.

## How it was fixed / handled
Extracted `formatDuration`, `getTimeUntilNextRun`, and `getStatusBadge` out of `BackgroundTasksCard.tsx` into a new sibling module `frontend/src/components/backgroundTasksHelpers.tsx` as named, independently-testable exports. While moving `formatDuration`, fixed the multi-day bug by detecting the day component structurally (checking for `.` in the first `TimeSpan` segment and splitting it into day/hour parts) instead of re-deriving days from an hours value that could never exceed 23. `BackgroundTasksCard.tsx` now imports the three functions instead of defining them inline; all four call sites are unchanged. Added a 20-test Jest/RTL suite (`frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx`) covering all `formatDuration` cases (including the fixed multi-day case), all `getTimeUntilNextRun` branches (past/near/far future, undefined/null, string vs. Date input, using pinned fake timers), and all `getStatusBadge` status paths.

Ran through the full pipeline: analyst spec → architect review (Skip Design: true — no UI/UX changes) → planner task breakdown → developer implementation → task reviewer (PASS) → whole-branch code reviewer (CLEAN, two non-blocking advisory notes only).

## Artifacts
Brief, spec, arch-review, design (skipped), task-plan, impl, review, and code-review markdown are committed under `artifacts/feat-3619/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `frontend/src/components/backgroundTasksHelpers.tsx:283` — `formatDuration` still assumes `parts[1]` is always a valid minutes string; malformed/empty `timeSpan` input would yield `NaN` in the output (e.g. `"NaNm"`). This matches the pre-existing behavior of the inline function being extracted (not a regression), so it's advisory only — could add a guard if hardening this function further is ever in scope.
- `frontend/src/components/__tests__/backgroundTasksHelpers.test.tsx:196` — the "za 1d 5h" test computes its input as `NOW + 29h`, which is a `diffHours` of 29 → `diffDays = 1`, `diffHours % 24 = 5`, so the assertion is correct, but the comment "~29 hours from now" reads slightly indirect versus the boundary being tested (`>= 24h`); a minor readability nit only, no functional issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8rG2EVFuU1gzcNEwwywrr)_