### PR TITLE
#3634: eliminate N+1 queries in RecurringJobConfiguration seeding

### DIFF
--- a/artifacts/feat-3634/arch-review.r1.md
+++ b/artifacts/feat-3634/arch-review.r1.md
@@ -1,0 +1,147 @@
+# Architecture Review: Eliminate N+1 Queries in RecurringJobConfiguration Seeding
+
+## Skip Design: true
+
+Backend-only performance fix. No UI components, screens, layouts, or visual decisions. There is no user-facing surface — the method runs once at application startup within a DI scope.
+
+## Architectural Fit Assessment
+
+The change fits the existing architecture cleanly and requires no structural work.
+
+- **Scope is a single method body.** Only `RecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync` (lines 40–62) changes. The interface `IRecurringJobConfigurationRepository`, the call site in `ServiceCollectionExtensions.SeedRecurringJobConfigurationsAsync`, the entity, and the DbContext are all untouched.
+- **Repository pattern is respected.** The repository already owns direct `ApplicationDbContext` access (ADR-001, single shared context; ADR-002, generic repository extended per feature). Replacing a per-item `FirstOrDefaultAsync` loop with a single projection query stays entirely within the repository's existing responsibility — no leakage into the Application or API layers.
+- **DI bindings unaffected.** ADR-004 (repository DI bindings live in the owning module) is not touched; no registration changes.
+- **Tests already pin the contract.** `RecurringJobConfigurationRepositoryTests` asserts the two behaviors that must be preserved (9 rows from empty; 9 rows with no duplicate when one pre-exists). These are the acceptance gate and must pass unmodified.
+
+The only real decision is a library-version constraint, addressed below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Application startup
+        │
+        ▼
+ServiceCollectionExtensions.SeedRecurringJobConfigurationsAsync   (unchanged call site)
+        │  resolves all IRecurringJob from DI, passes to ↓
+        ▼
+RecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync   (← the only change)
+        │
+        ├── (1) project default configs from job metadata      [in-memory, unchanged]
+        ├── (2) ONE read: SELECT JobName FROM RecurringJobConfigurations → HashSet<string>
+        ├── (3) foreach missing config: AddAsync + add name to the set  [FR-4 in-set guard]
+        └── (4) ONE SaveChangesAsync
+        │
+        ▼
+ApplicationDbContext → RecurringJobConfigurations table
+```
+
+Read round-trips drop from N to 1; the single write is preserved. Total round-trips: N+1 → 2.
+
+### Key Design Decisions
+
+#### Decision 1: Materialize existing names with `ToListAsync` + `new HashSet<string>`, NOT `ToHashSetAsync`
+
+**Options considered:**
+- (A) `ToHashSetAsync(cancellationToken)` as written in the spec's proposed code.
+- (B) `.Select(c => c.JobName).ToListAsync(cancellationToken)` then `new HashSet<string>(list)`.
+
+**Chosen approach:** Option B.
+
+**Rationale:** This is the concern the spec explicitly flagged for verification, and it is real. The project references `Microsoft.EntityFrameworkCore` **8.0.8** (`backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`). The `ToHashSetAsync` extension method was **not added until EF Core 9.0** — it does not exist in EF Core 8.x. Writing the spec's literal snippet would fail to compile (`dotnet build`). Implementers MUST use the `ToListAsync` + `HashSet` fallback. Do not attempt to upgrade EF Core to obtain `ToHashSetAsync`; a package bump for one convenience method is unjustified risk far outside this fix's scope.
+
+Concretely:
+
+```csharp
+var existingNames = new HashSet<string>(
+    await _context.RecurringJobConfigurations
+        .Select(c => c.JobName)
+        .ToListAsync(cancellationToken));
+```
+
+#### Decision 2: Project `JobName` only, not full entities
+
+**Options considered:** Load full `RecurringJobConfiguration` entities vs. project just `JobName`.
+
+**Chosen approach:** Project `JobName` (`Select(c => c.JobName)`).
+
+**Rationale:** Only the business key is needed to decide insert-or-skip. Projecting a single column avoids materializing/tracking entities the method never mutates, and keeps the read cheap. Matches FR-1's acceptance criterion.
+
+#### Decision 3: Guard in-set duplicates by mutating the same `HashSet` (FR-4)
+
+**Options considered:** Rely only on the DB-loaded set vs. also add each newly-queued name back into the set.
+
+**Chosen approach:** After each `AddAsync`, add the name to `existingNames`.
+
+**Rationale:** Zero-cost defense against a discovered-job collection containing two jobs with the same `JobName` not yet in the DB — prevents queuing two rows with the same key in one `SaveChangesAsync`. Duplicate job names are not expected in practice (jobs are discovered from distinct types), but the guard makes the method robust and satisfies FR-4 without extra data structures.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files, no new types, no moved code.
+
+- **Modify only:** `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs` — the body of `SeedDefaultConfigurationsAsync` (lines 52–61). The `Microsoft.EntityFrameworkCore` using directive is already present (line 2); no new imports needed.
+- **Do not modify:** the interface, the call site, the entity, the DbContext, or the test file.
+
+### Interfaces and Contracts
+
+Unchanged (FR-5). Public signature stays:
+
+```csharp
+Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default);
+```
+
+`cancellationToken` must be threaded to both the read (`ToListAsync`) and the write (`SaveChangesAsync`).
+
+### Data Flow
+
+For the two use cases the tests pin:
+
+1. **Empty table, 9 jobs:** read returns empty set → all 9 filtered configs are `AddAsync`'d (each name added to the set as it goes) → one `SaveChangesAsync` → 9 rows.
+2. **Table already has `purchase-price-recalculation`, 9 jobs:** read returns `{ "purchase-price-recalculation" }` → 8 missing configs added → one `SaveChangesAsync` → 9 rows total, single `purchase-price-recalculation` row.
+
+Reference target shape (compile-safe for EF Core 8):
+
+```csharp
+var defaultConfigurations = jobs.Select(job => new RecurringJobConfiguration(
+    job.Metadata.JobName,
+    job.Metadata.DisplayName,
+    job.Metadata.Description,
+    job.Metadata.CronExpression,
+    job.Metadata.DefaultIsEnabled,
+    "System"
+)).ToArray();
+
+var existingNames = new HashSet<string>(
+    await _context.RecurringJobConfigurations
+        .Select(c => c.JobName)
+        .ToListAsync(cancellationToken));
+
+foreach (var config in defaultConfigurations.Where(c => !existingNames.Contains(c.JobName)))
+{
+    await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+    existingNames.Add(config.JobName);
+}
+
+await _context.SaveChangesAsync(cancellationToken);
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `ToHashSetAsync` used verbatim from spec → build failure on EF Core 8.0.8 | Medium | Use `ToListAsync` + `new HashSet<string>(...)` (Decision 1). This is the single thing that can go wrong; call it out to implementers. |
+| Behavior regression (duplicate insert or missing insert) | Medium | Existing tests `SeedDefaultConfigurationsAsync_WhenEmpty_*` and `_WhenConfigurationsExist_DoesNotDuplicate` must pass unmodified; they are the acceptance gate. |
+| In-memory provider case-sensitivity of `HashSet` vs. DB collation differs | Low | Tests run on the EF InMemory provider; job names are lowercase-hyphenated constants, so ordinal `HashSet` comparison matches both providers. No `StringComparer` change needed; do not add one (out of scope, would alter semantics). |
+| Concurrent multi-instance startup duplicate-key race | Low | Pre-existing under the old code too; explicitly out of scope (NFR-3). Do not add locking/upsert here. |
+
+## Specification Amendments
+
+1. **Amend the API/Interface Design snippet (spec lines 89–91 and the note at line 103).** The proposed code uses `ToHashSetAsync`, which does not exist in EF Core 8.0.8 (this project's version). Replace with the `ToListAsync` + `new HashSet<string>(...)` form shown in Decision 1 / Data Flow. The spec's note already anticipated this ("if not, use `.ToListAsync` ... `new HashSet<string>`"); this review upgrades that conditional to a firm requirement — the fallback is mandatory, not conditional.
+2. **No other amendments.** FR-1 through FR-5, NFRs, Data Model, Out of Scope, and the "no schema change" stance are all sound and require no revision.
+
+## Prerequisites
+
+None. No migrations, no config, no infrastructure, no new packages. The change is self-contained in one method body and validated by the existing test suite plus `dotnet build` and `dotnet format`.

--- a/artifacts/feat-3634/brief.md
+++ b/artifacts/feat-3634/brief.md
@@ -1,0 +1,41 @@
+## Module
+BackgroundJobs
+
+## Finding
+`RecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync` (line 53–58 of `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs`) executes one `GetByJobNameAsync` database call per job inside a `foreach` loop, then a final `SaveChangesAsync`:
+
+```csharp
+foreach (var config in defaultConfigurations)
+{
+    var existing = await GetByJobNameAsync(config.JobName, cancellationToken); // N separate queries
+    if (existing == null)
+    {
+        await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+    }
+}
+await _context.SaveChangesAsync(cancellationToken);
+```
+
+For N registered jobs this issues N + 1 DB round-trips at every application startup.
+
+## Why it matters
+N+1 is a well-known anti-pattern. While the current job count is small, the pattern grows proportionally with new jobs and is avoidable at zero cost. Startup time and connection pool pressure increase unnecessarily.
+
+## Suggested fix
+Load all existing `JobName` values in a single query and filter in-memory before inserting:
+
+```csharp
+var existingNames = await _context.RecurringJobConfigurations
+    .Select(c => c.JobName)
+    .ToHashSetAsync(cancellationToken);
+
+foreach (var config in defaultConfigurations.Where(c => !existingNames.Contains(c.JobName)))
+{
+    await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+}
+
+await _context.SaveChangesAsync(cancellationToken);
+```
+
+---
+_Filed by daily arch-review routine on 2026-07-14._

--- a/artifacts/feat-3634/code-review.r1.md
+++ b/artifacts/feat-3634/code-review.r1.md
@@ -1,0 +1,29 @@
+## Review Result: CLEAN
+
+### Blocking
+- None
+
+### Advisory
+- None
+
+### Notes
+
+Verified independently (not just re-stated from the task description):
+
+- `git diff origin/main --stat` confirms the entire code change is the one file, `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs` (plus pipeline artifact/metadata files, which carry no runtime behavior). Diff content matches exactly what was quoted in the spec.
+- Public surface unchanged: `IRecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob>, CancellationToken)` signature is untouched, and `GetByJobNameAsync` is still present and still used by its other four call sites (`UpdateRecurringJobCronHandler`, `GetRecurringJobHandler`, `UpdateRecurringJobStatusHandler`, `RecurringJobStatusChecker`) — it was correctly left alone rather than removed as dead code.
+- The seeding call site (`ServiceCollectionExtensions.cs:463`) is unchanged, consistent with the interface staying stable.
+- EF Core 8.0.8 compatibility constraint respected: uses `.Select(c => c.JobName).ToListAsync(cancellationToken)` wrapped in `new HashSet<string>(...)`, not the unavailable `ToHashSetAsync`.
+- Query reduction confirmed by inspection: one `SELECT JobName` query replaces the N per-config `GetByJobNameAsync` round-trips inside the loop; one `SaveChangesAsync` at the end, as before.
+- `cancellationToken` is threaded through `ToListAsync`, `AddAsync`, and `SaveChangesAsync` — matches the pre-existing threading pattern.
+- Insert-only-when-missing semantics preserved: `defaultConfigurations.Where(c => !existingNames.Contains(c.JobName))` is equivalent to the old per-item null check, and LINQ `Where` over an array is lazily streamed, so mutating `existingNames` inside the loop (`existingNames.Add(config.JobName)`) is evaluated correctly on each iteration rather than against a stale snapshot.
+- The `existingNames.Add(config.JobName)` line is a defensive addition not explicitly required by the spec, but it is a strict improvement, not a deviation with downside: the original code was not actually safe against duplicate `JobName`s appearing within a single `defaultConfigurations` batch (a `FirstOrDefaultAsync` query does not see entities in the `Added`-but-unsaved change-tracker state under EF Core's InMemory or relational providers), so the new code is more correct here, not less. Given `defaultConfigurations` is built from discovered `IRecurringJob` implementations (expected to have unique names), this is inert in practice but harmless and correctly commented.
+
+Independent verification results (re-ran rather than trusting the stated numbers):
+- `dotnet build` on the full solution: 0 errors (pre-existing warnings in unrelated files only).
+- `dotnet format Anela.Heblo.sln --verify-no-changes --no-restore`: clean, no output.
+- `dotnet test --filter FullyQualifiedName~RecurringJobConfigurationRepositoryTests --no-build`: **Passed! Failed: 0, Passed: 8, Skipped: 0, Total: 8** — matches the claimed 8/8, including both behavior-pinning tests `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` and `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`.
+
+No architecture, DTO, or module-boundary concerns apply here — this is an internal, single-file persistence-layer change with no contract impact. Nothing to flag against `docs/architecture/development_guidelines.md` (no DTO involved; `RecurringJobConfiguration` is an internal domain entity, unaffected by the DTO-must-be-a-class rule).
+
+This is a clean, well-scoped, correctly verified performance fix. Ready to merge.

--- a/artifacts/feat-3634/design.r1.md
+++ b/artifacts/feat-3634/design.r1.md
@@ -1,0 +1,15 @@
+# Design: Eliminate N+1 Queries in RecurringJobConfiguration Seeding
+
+## Component Design
+
+`RecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync` (the only component touched) changes its internal query strategy but keeps its existing responsibility and public contract unchanged: given a set of discovered `IRecurringJob` instances, insert a default `RecurringJobConfiguration` row for any job that does not already have one.
+
+- Load all existing `JobName` values with a single projection query (`Select(c => c.JobName)`), materialized via `ToListAsync` + `new HashSet<string>(...)` (EF Core 8.0.8 does not have `ToHashSetAsync`, per the architecture review).
+- Filter the default configurations in-memory against that set, inserting only the missing ones and adding each newly queued name back into the set (guards against duplicate `JobName`s within the same discovered-job batch).
+- Persist with a single `SaveChangesAsync` call, as today.
+
+No new components, no new interfaces, no new files.
+
+## Data Schemas
+
+No schema changes. `RecurringJobConfiguration` entity and the `RecurringJobConfigurations` table are unchanged; only the read pattern used to seed them changes.

--- a/artifacts/feat-3634/impl/fix-recurring-job-seeding-n-plus-one.r1.md
+++ b/artifacts/feat-3634/impl/fix-recurring-job-seeding-n-plus-one.r1.md
@@ -1,0 +1,36 @@
+# Implementation: fix-recurring-job-seeding-n-plus-one
+
+## What was implemented
+Replaced the per-job `GetByJobNameAsync` lookup inside `SeedDefaultConfigurationsAsync`'s `foreach` loop with a single query that loads all existing `JobName` values into a `HashSet<string>`, then filters the default configurations in-memory before inserting only the missing ones. `SaveChangesAsync` is still called exactly once at the end.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs` — `SeedDefaultConfigurationsAsync` now issues one `SELECT JobName` query instead of N `GetByJobNameAsync` calls; a `HashSet<string>` guard also prevents inserting duplicate `JobName`s if the discovered-job batch itself contains duplicates.
+
+## Tests
+`backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationRepositoryTests.cs` — no changes needed. These existing tests already pin the required behavior and passed unchanged:
+- `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations`
+- `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`
+
+## How to verify
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecurringJobConfigurationRepositoryTests"
+# Passed! - Failed: 0, Passed: 8, Skipped: 0, Total: 8
+
+dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+# Build succeeded. 0 Warning(s), 0 Error(s)
+
+dotnet format backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj --verify-no-changes
+# Exit 0, no formatting changes needed
+```
+
+## Notes
+Per the architecture review (Decision 1), used `.Select(c => c.JobName).ToListAsync(cancellationToken)` wrapped in `new HashSet<string>(...)` rather than `ToHashSetAsync`, since EF Core 8.0.8 (this project's pinned version) does not provide `ToHashSetAsync` (added in EF Core 9.0). No interface, call-site, entity, or schema changes were needed.
+
+## PR Summary
+Fixed an N+1 query anti-pattern in `RecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync`, which ran one `GetByJobNameAsync` database round-trip per discovered recurring job at every application startup. Replaced it with a single query that loads all existing job names into a `HashSet<string>`, then filters the default configurations in-memory before a single `SaveChangesAsync`. Behavior is unchanged — only configurations for genuinely missing jobs are inserted — and the existing repository tests pass without modification.
+
+### Changes
+- `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs` — single-query + in-memory-filter seeding instead of per-job lookups
+
+## Status
+DONE

--- a/artifacts/feat-3634/review/fix-recurring-job-seeding-n-plus-one.r1.md
+++ b/artifacts/feat-3634/review/fix-recurring-job-seeding-n-plus-one.r1.md
@@ -1,0 +1,49 @@
+# Code Review: Eliminate N+1 Queries in RecurringJobConfiguration Seeding
+
+## Summary
+The implementation correctly eliminates N+1 queries in `SeedDefaultConfigurationsAsync` by loading all existing job names in a single query, then filtering in-memory. The change preserves insert-only-when-missing semantics, threads the cancellation token correctly, and guards against duplicate JobNames within the batch. All tests pass and code builds cleanly.
+
+## Review Result: PASS
+
+### task: fix-recurring-job-seeding-n-plus-one
+**Status:** PASS
+
+**Verification:**
+
+1. **EF Core 8.0.8 compatibility** ✓  
+   Uses `.Select(c => c.JobName).ToListAsync(cancellationToken)` wrapped in `new HashSet<string>(...)` as required; no attempt to use unavailable `ToHashSetAsync`.
+
+2. **Query reduction** ✓  
+   Loads all existing JobNames in one query before the loop, eliminating the N per-config `GetByJobNameAsync` calls. Reduces from N+1 queries to 1 query.
+
+3. **In-memory filtering** ✓  
+   The `defaultConfigurations.Where(c => !existingNames.Contains(c.JobName))` filter executes in-memory after data is loaded.
+
+4. **Single SaveChangesAsync** ✓  
+   One `SaveChangesAsync` call after all adds, as required.
+
+5. **Duplicate guard within batch** ✓  
+   `existingNames.Add(config.JobName)` inside the loop prevents duplicate JobNames within the same `defaultConfigurations` batch from being inserted twice.
+
+6. **Semantics preserved** ✓  
+   Before: insert if not already present (via `GetByJobNameAsync` check).  
+   After: insert if not in `existingNames` HashSet.  
+   Behavior is equivalent and idempotent.
+
+7. **Cancellation token threading** ✓  
+   `cancellationToken` is passed to `ToListAsync(cancellationToken)`.
+
+8. **No API surface changes** ✓  
+   Method signature unchanged; internal refactoring only.
+
+9. **Tests passing** ✓  
+   All 8 tests in RecurringJobConfigurationRepositoryTests pass, including the critical ones:
+   - `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations`
+   - `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`
+
+10. **Build/format compliance** ✓  
+    `dotnet build` succeeds with 0 errors/warnings.  
+    `dotnet format --verify-no-changes` passes (Exit 0).
+
+## Overall Notes
+The implementation is well-commented, explaining the EF Core 8.0.8 limitation that necessitated the manual HashSet construction. The code is clear, correct, and achieves the N+1 elimination goal without architectural compromise. Ready to merge.

--- a/artifacts/feat-3634/spec.r1.md
+++ b/artifacts/feat-3634/spec.r1.md
@@ -1,0 +1,121 @@
+# Specification: Eliminate N+1 Queries in RecurringJobConfiguration Seeding
+
+## Summary
+`RecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync` currently issues one `SELECT` per discovered recurring job (an N+1 query pattern) to check for existing configurations before inserting missing ones. This spec defines replacing that per-job lookup with a single query that loads all existing job names once, then filters in-memory. The change is a behavior-preserving performance fix executed at every application startup; there is no user-facing surface and no schema change.
+
+## Background
+On application startup, `SeedRecurringJobConfigurationsAsync` (in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`, line ~451) resolves all discovered `IRecurringJob` implementations from DI and calls `SeedDefaultConfigurationsAsync(discoveredJobs)`. The repository (`backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs`, lines 40–62) builds default `RecurringJobConfiguration` records from each job's metadata, then loops over them, calling `GetByJobNameAsync` (a `FirstOrDefaultAsync` against `RecurringJobConfigurations`) once per job to decide whether the configuration already exists. For N registered jobs this produces N `SELECT` round-trips plus one final `SaveChangesAsync`, i.e. N+1 database round-trips at every startup.
+
+There are currently 9 registered jobs (confirmed by `RecurringJobConfigurationRepositoryTests`), so the present cost is modest, but it grows linearly with each new job and adds avoidable startup latency and connection-pool pressure. The architecture review flagged this as a well-known anti-pattern that is fixable at effectively zero cost while preserving the existing "insert only jobs that do not already exist" semantics.
+
+The fix is to load the set of existing `JobName` values in a single query, then filter the default configurations in-memory before adding the missing ones and saving once.
+
+## Functional Requirements
+
+### FR-1: Single query to load existing job names
+`SeedDefaultConfigurationsAsync` must load all existing `JobName` values from `RecurringJobConfigurations` in exactly one database query instead of one query per job.
+
+**Acceptance criteria:**
+- The method issues exactly one read query against `RecurringJobConfigurations` regardless of the number of discovered jobs (verifiable by inspection; the per-job `GetByJobNameAsync` call inside the loop is removed).
+- The existing names are materialized into a set keyed by `JobName` (e.g. `HashSet<string>`) for O(1) membership checks.
+- The query projects only `JobName` (`Select(c => c.JobName)`), not full entities.
+
+### FR-2: Preserve insert-only-when-missing semantics
+The method must insert a configuration if and only if no configuration with the same `JobName` already exists, exactly as today.
+
+**Acceptance criteria:**
+- Given an empty table and N discovered jobs, all N configurations are inserted (existing test `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` passes unchanged, expecting 9 rows).
+- Given a table that already contains a configuration for one of the discovered job names, that configuration is not duplicated and only the missing ones are inserted (existing test `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate` passes unchanged, expecting 9 rows total and a single `purchase-price-recalculation` row).
+- Existing configurations are never updated, deleted, or otherwise mutated by this method; the "seed on first run only" behavior documented in the design docs is retained.
+
+### FR-3: Single save
+All inserts continue to be persisted with a single `SaveChangesAsync` call after the loop.
+
+**Acceptance criteria:**
+- `SaveChangesAsync` is invoked exactly once per call to `SeedDefaultConfigurationsAsync`.
+- When there are no missing configurations, the method still completes successfully (a `SaveChangesAsync` with no tracked changes is a no-op and acceptable).
+
+### FR-4: Deduplicate within the incoming job set (edge case)
+If the discovered job collection contains two jobs with the same `JobName` and that name is not yet in the database, the method must not attempt to insert two rows with the same key in a single save.
+
+**Acceptance criteria:**
+- The in-memory filter guards against inserting a name that has already been queued for insertion during the same call, in addition to names already present in the database. (Assumption: duplicate `JobName`s in the discovered set are not expected in practice; see Open Questions. This criterion may be satisfied by tracking newly added names in the same set used for the existing-name check.)
+
+### FR-5: Signature and behavioral contract unchanged
+The public signature of `SeedDefaultConfigurationsAsync` and the `IRecurringJobConfigurationRepository` interface are unchanged. `cancellationToken` continues to be threaded through the query and save.
+
+**Acceptance criteria:**
+- No change to `IRecurringJobConfigurationRepository` (`backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobConfigurationRepository.cs`).
+- No change to the call site in `ServiceCollectionExtensions.SeedRecurringJobConfigurationsAsync`.
+- `cancellationToken` is passed to both the read query and `SaveChangesAsync`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Database round-trips for seeding drop from N+1 to 2 (one read, one write), independent of the number of registered jobs. This must measurably reduce startup query count; the improvement is O(N) → O(1) in read round-trips. No regression in overall startup time is acceptable.
+
+### NFR-2: Security
+No change to authentication, authorization, or data exposure. The method runs only at application startup within a DI scope and touches only the `RecurringJobConfigurations` table. No new data is logged; job names are non-sensitive configuration identifiers.
+
+### NFR-3: Correctness under concurrency
+Seeding runs once during single-instance startup and is not expected to race with other writers. The fix does not introduce a transaction boundary weaker than today's (today's per-job reads are already non-transactional relative to the final save). If two application instances start simultaneously against a shared database, a duplicate-key insert is theoretically possible under both the old and new code; this is pre-existing behavior and out of scope (see Open Questions).
+
+### NFR-4: Maintainability
+The resulting code should be shorter and clearer than the current loop, with no new dependencies. Must satisfy `dotnet build` and `dotnet format`.
+
+## Data Model
+No schema changes.
+
+Entity `RecurringJobConfiguration` (`backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`), persisted to table `RecurringJobConfigurations`. Relevant field for this change:
+- `JobName` (string) — unique business key used to determine whether a configuration already exists. Other fields (`DisplayName`, `Description`, `CronExpression`, `IsEnabled`/`DefaultIsEnabled`, `LastModifiedBy`, etc.) are populated from `IRecurringJob.Metadata` and are unaffected.
+
+## API / Interface Design
+No public API, endpoint, or event changes. This is an internal repository implementation change only.
+
+Target method (proposed shape, per the review's suggested fix):
+
+```csharp
+public async Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+{
+    var defaultConfigurations = jobs.Select(job => new RecurringJobConfiguration(
+        job.Metadata.JobName,
+        job.Metadata.DisplayName,
+        job.Metadata.Description,
+        job.Metadata.CronExpression,
+        job.Metadata.DefaultIsEnabled,
+        "System"
+    )).ToArray();
+
+    var existingNames = await _context.RecurringJobConfigurations
+        .Select(c => c.JobName)
+        .ToHashSetAsync(cancellationToken);
+
+    foreach (var config in defaultConfigurations.Where(c => !existingNames.Contains(c.JobName)))
+    {
+        await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+        existingNames.Add(config.JobName); // guards FR-4 in-set duplicates
+    }
+
+    await _context.SaveChangesAsync(cancellationToken);
+}
+```
+
+Note: `ToHashSetAsync` requires `Microsoft.EntityFrameworkCore` (already imported in the file). Verify the installed EF Core version exposes `ToHashSetAsync`; if not, use `.ToListAsync(cancellationToken)` followed by `new HashSet<string>(...)`.
+
+## Dependencies
+- Entity Framework Core (`Microsoft.EntityFrameworkCore`) — already referenced; provides `ToHashSetAsync`/`ToListAsync`.
+- `ApplicationDbContext` and the `RecurringJobConfigurations` `DbSet` — unchanged.
+- Existing test project `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationRepositoryTests.cs`, which uses an in-memory/EF context and must continue to pass without modification.
+
+## Out of Scope
+- Any change to the discovery, registration, or scheduling of recurring jobs (`HangfireRecurringJobScheduler`, `RecurringJobDiscoveryService`).
+- Adding a unique database constraint/index on `JobName` (would be a separate hardening task).
+- Making seeding safe against concurrent multi-instance startup (distributed lock, upsert, retry on duplicate key).
+- Batching/bulk-insert optimization of the `AddAsync`/`SaveChangesAsync` write path beyond the existing single save.
+- Updating existing configurations when job metadata changes (seeding remains first-run-only, as designed).
+- Any frontend, API surface, or documentation changes beyond incidental code comments.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3634",
+  "issue_number": 3634,
+  "created_at": "2026-07-14T08:15:05.142657Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-recurring-job-seeding-n-plus-one",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-14T08:20:25.150286Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T08:20:46.778642Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-14T08:23:03.193649Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-14T08:23:30.477524Z"
     }
   },
   "tasks": [
     {
       "name": "fix-recurring-job-seeding-n-plus-one",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-14T08:23:30.654353Z"
     }
   ]
 }

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-14T08:23:03.193649Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-14T08:23:30.477524Z"
+      "status": "completed",
+      "updated_at": "2026-07-14T08:50:02.108647Z"
     }
   },
   "tasks": [
     {
       "name": "fix-recurring-job-seeding-n-plus-one",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-14T08:23:30.654353Z"
+      "updated_at": "2026-07-14T08:50:01.925007Z"
     }
   ]
 }

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-14T08:50:02.108647Z"
+    },
+    "code-review": {
+      "status": "completed",
+      "updated_at": "2026-07-14T09:05:47.169624Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-14T08:18:08.943500Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T08:20:25.150286Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T08:18:08.943500Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3634/state.json
+++ b/artifacts/feat-3634/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-14T08:20:46.778642Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T08:23:03.193649Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3634/task-context/fix-recurring-job-seeding-n-plus-one.md
+++ b/artifacts/feat-3634/task-context/fix-recurring-job-seeding-n-plus-one.md
@@ -1,0 +1,78 @@
+### task: fix-recurring-job-seeding-n-plus-one
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs:52-59` (the `foreach` loop inside `SeedDefaultConfigurationsAsync`)
+- Test (existing, no change expected): `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationRepositoryTests.cs`
+
+**Context:**
+- The `Microsoft.EntityFrameworkCore` using directive is already present at line 2 of the repository file — no new imports needed.
+- EF Core 8.0.8 does **not** provide `ToHashSetAsync` (added in EF Core 9.0). The spec's proposed snippet uses `ToHashSetAsync` and would fail `dotnet build`. Per the architecture review's Decision 1, materialize with `.Select(c => c.JobName).ToListAsync(cancellationToken)` wrapped in `new HashSet<string>(...)`. Do **not** upgrade the EF Core package.
+- Do not add a `StringComparer` to the `HashSet` — job names are lowercase-hyphenated constants; ordinal comparison matches both the DB and the EF InMemory test provider (arch review Risk table).
+
+- [ ] **Step 1: Confirm the existing tests currently pass (red/green baseline).** Establish that the test suite is green before changing anything, so any post-change failure is attributable to the edit. Run:
+  ```bash
+  dotnet test /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecurringJobConfigurationRepositoryTests"
+  ```
+  Expected: all tests pass, including `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` and `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`. No test edits are needed — these two tests already pin the required behavior (FR-2) and serve as the acceptance gate unchanged.
+
+- [ ] **Step 2: Replace the N+1 loop with a single-query + in-memory filter.** Edit `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs`. Replace exactly this block (lines 52-59):
+  ```csharp
+        foreach (var config in defaultConfigurations)
+        {
+            var existing = await GetByJobNameAsync(config.JobName, cancellationToken);
+            if (existing == null)
+            {
+                await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+            }
+        }
+  ```
+  with:
+  ```csharp
+        // Load all existing job names in a single query (EF Core 8.0.8 has no ToHashSetAsync)
+        var existingNames = new HashSet<string>(
+            await _context.RecurringJobConfigurations
+                .Select(c => c.JobName)
+                .ToListAsync(cancellationToken));
+
+        foreach (var config in defaultConfigurations.Where(c => !existingNames.Contains(c.JobName)))
+        {
+            await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+            existingNames.Add(config.JobName); // guard against duplicate JobNames within the same batch (FR-4)
+        }
+  ```
+  The `defaultConfigurations` projection above the block (lines 43-50) and the final `await _context.SaveChangesAsync(cancellationToken);` (line 61) remain unchanged. Result: one read query, in-memory filter, single save.
+
+- [ ] **Step 3: Run the targeted test suite for this file.** Verify the change preserves behavior:
+  ```bash
+  dotnet test /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecurringJobConfigurationRepositoryTests"
+  ```
+  Expected: all `RecurringJobConfigurationRepositoryTests` pass, unchanged. In particular `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` (9 rows) and `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate` (9 rows, single `purchase-price-recalculation`) must be green.
+
+- [ ] **Step 4: Build the solution.** Confirm compilation (catches any accidental `ToHashSetAsync` usage or type error):
+  ```bash
+  dotnet build /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  ```
+  Expected: build succeeds with no errors.
+
+- [ ] **Step 5: Apply code formatting.** Run:
+  ```bash
+  dotnet format /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  ```
+  Expected: no formatting violations remain (command exits 0). If it rewrote whitespace, that is fine — re-run Step 4 to confirm the build still passes.
+
+- [ ] **Step 6: Commit.** Stage only the changed repository file and commit:
+  ```bash
+  cd /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa && \
+  git add backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs && \
+  git commit -m "perf(background-jobs): eliminate N+1 queries in RecurringJobConfiguration seeding
+
+Replace per-job GetByJobNameAsync lookup in SeedDefaultConfigurationsAsync
+with a single projection query loading all existing JobName values into a
+HashSet, then filter in-memory. Read round-trips drop from N to 1; insert-
+only-when-missing semantics and single SaveChangesAsync are preserved.
+Uses ToListAsync + new HashSet<string> (EF Core 8.0.8 has no ToHashSetAsync).
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01McG68FR6PiDSFhPExiX2Xo"
+  ```
+  Expected: a single commit containing only `RecurringJobConfigurationRepository.cs`.

--- a/artifacts/feat-3634/task-plan.r1.md
+++ b/artifacts/feat-3634/task-plan.r1.md
@@ -1,0 +1,88 @@
+# Eliminate N+1 Queries in RecurringJobConfiguration Seeding - Implementation Plan
+
+**Goal:** Replace the per-job `GetByJobNameAsync` lookup inside `SeedDefaultConfigurationsAsync` (an N+1 query pattern executed at every application startup) with a single projection query that loads all existing `JobName` values once, then filters the default configurations in-memory before a single `SaveChangesAsync`. Behavior is preserved exactly (insert only missing jobs); read round-trips drop from N to 1.
+
+**Architecture:** Backend-only performance fix. The change is confined to one method body in the persistence-layer repository (`RecurringJobConfigurationRepository`). No interface, call-site, entity, DbContext, DI, or schema changes. The existing `RecurringJobConfigurationRepositoryTests` already pin the two behaviors that must be preserved (9 rows from empty; 9 rows with no duplicate when one pre-exists) and are the acceptance gate.
+
+**Tech Stack:** .NET 8, EF Core 8.0.8, xUnit
+
+---
+
+### task: fix-recurring-job-seeding-n-plus-one
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs:52-59` (the `foreach` loop inside `SeedDefaultConfigurationsAsync`)
+- Test (existing, no change expected): `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationRepositoryTests.cs`
+
+**Context:**
+- The `Microsoft.EntityFrameworkCore` using directive is already present at line 2 of the repository file — no new imports needed.
+- EF Core 8.0.8 does **not** provide `ToHashSetAsync` (added in EF Core 9.0). The spec's proposed snippet uses `ToHashSetAsync` and would fail `dotnet build`. Per the architecture review's Decision 1, materialize with `.Select(c => c.JobName).ToListAsync(cancellationToken)` wrapped in `new HashSet<string>(...)`. Do **not** upgrade the EF Core package.
+- Do not add a `StringComparer` to the `HashSet` — job names are lowercase-hyphenated constants; ordinal comparison matches both the DB and the EF InMemory test provider (arch review Risk table).
+
+- [ ] **Step 1: Confirm the existing tests currently pass (red/green baseline).** Establish that the test suite is green before changing anything, so any post-change failure is attributable to the edit. Run:
+  ```bash
+  dotnet test /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecurringJobConfigurationRepositoryTests"
+  ```
+  Expected: all tests pass, including `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` and `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`. No test edits are needed — these two tests already pin the required behavior (FR-2) and serve as the acceptance gate unchanged.
+
+- [ ] **Step 2: Replace the N+1 loop with a single-query + in-memory filter.** Edit `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs`. Replace exactly this block (lines 52-59):
+  ```csharp
+        foreach (var config in defaultConfigurations)
+        {
+            var existing = await GetByJobNameAsync(config.JobName, cancellationToken);
+            if (existing == null)
+            {
+                await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+            }
+        }
+  ```
+  with:
+  ```csharp
+        // Load all existing job names in a single query (EF Core 8.0.8 has no ToHashSetAsync)
+        var existingNames = new HashSet<string>(
+            await _context.RecurringJobConfigurations
+                .Select(c => c.JobName)
+                .ToListAsync(cancellationToken));
+
+        foreach (var config in defaultConfigurations.Where(c => !existingNames.Contains(c.JobName)))
+        {
+            await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+            existingNames.Add(config.JobName); // guard against duplicate JobNames within the same batch (FR-4)
+        }
+  ```
+  The `defaultConfigurations` projection above the block (lines 43-50) and the final `await _context.SaveChangesAsync(cancellationToken);` (line 61) remain unchanged. Result: one read query, in-memory filter, single save.
+
+- [ ] **Step 3: Run the targeted test suite for this file.** Verify the change preserves behavior:
+  ```bash
+  dotnet test /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecurringJobConfigurationRepositoryTests"
+  ```
+  Expected: all `RecurringJobConfigurationRepositoryTests` pass, unchanged. In particular `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` (9 rows) and `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate` (9 rows, single `purchase-price-recalculation`) must be green.
+
+- [ ] **Step 4: Build the solution.** Confirm compilation (catches any accidental `ToHashSetAsync` usage or type error):
+  ```bash
+  dotnet build /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  ```
+  Expected: build succeeds with no errors.
+
+- [ ] **Step 5: Apply code formatting.** Run:
+  ```bash
+  dotnet format /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa/backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+  ```
+  Expected: no formatting violations remain (command exits 0). If it rewrote whitespace, that is fine — re-run Step 4 to confirm the build still passes.
+
+- [ ] **Step 6: Commit.** Stage only the changed repository file and commit:
+  ```bash
+  cd /home/user/worktrees/feature-3634-Arch-Review-Backgroundjobs-N-1-Queries-In-Seeddefa && \
+  git add backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs && \
+  git commit -m "perf(background-jobs): eliminate N+1 queries in RecurringJobConfiguration seeding
+
+Replace per-job GetByJobNameAsync lookup in SeedDefaultConfigurationsAsync
+with a single projection query loading all existing JobName values into a
+HashSet, then filter in-memory. Read round-trips drop from N to 1; insert-
+only-when-missing semantics and single SaveChangesAsync are preserved.
+Uses ToListAsync + new HashSet<string> (EF Core 8.0.8 has no ToHashSetAsync).
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01McG68FR6PiDSFhPExiX2Xo"
+  ```
+  Expected: a single commit containing only `RecurringJobConfigurationRepository.cs`.

--- a/backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs
@@ -49,13 +49,16 @@ public class RecurringJobConfigurationRepository : IRecurringJobConfigurationRep
             "System"
         )).ToArray();
 
-        foreach (var config in defaultConfigurations)
+        // Load all existing job names in a single query (EF Core 8.0.8 has no ToHashSetAsync)
+        var existingNames = new HashSet<string>(
+            await _context.RecurringJobConfigurations
+                .Select(c => c.JobName)
+                .ToListAsync(cancellationToken));
+
+        foreach (var config in defaultConfigurations.Where(c => !existingNames.Contains(c.JobName)))
         {
-            var existing = await GetByJobNameAsync(config.JobName, cancellationToken);
-            if (existing == null)
-            {
-                await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
-            }
+            await _context.RecurringJobConfigurations.AddAsync(config, cancellationToken);
+            existingNames.Add(config.JobName); // guard against duplicate JobNames within the same batch
         }
 
         await _context.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
Closes #3634

## What the issue was

`RecurringJobConfigurationRepository.SeedDefaultConfigurationsAsync` (`backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs`) executed one `GetByJobNameAsync` database call per discovered recurring job inside a `foreach` loop, then a final `SaveChangesAsync`. For N registered jobs this issued N + 1 database round-trips at every application startup — a classic N+1 query anti-pattern flagged by the daily arch-review routine.

## How it was fixed / handled

Replaced the per-job lookup with a single query that loads all existing `JobName` values into a `HashSet<string>`, then filters the discovered configurations in-memory before inserting only the missing ones and saving once. Read round-trips drop from N to 1 (total round-trips: N+1 → 2).

Since this project pins EF Core 8.0.8, which does not provide `ToHashSetAsync` (added in EF Core 9.0), the fix uses `.Select(c => c.JobName).ToListAsync(cancellationToken)` wrapped in `new HashSet<string>(...)` instead. A defensive guard (`existingNames.Add(config.JobName)` inside the loop) also prevents inserting duplicate `JobName`s if the discovered-job batch itself ever contained duplicates.

No interface, call-site, entity, or schema changes were needed — `IRecurringJobConfigurationRepository` and the startup call site in `ServiceCollectionExtensions` are untouched, and insert-only-when-missing semantics are preserved exactly. The existing tests (`SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations`, `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`) pass unchanged (8/8).

## Validation

- `dotnet build` — 0 errors, 0 warnings on the affected project (full solution build also clean of new warnings)
- `dotnet format --verify-no-changes` — clean
- `dotnet test --filter FullyQualifiedName~RecurringJobConfigurationRepositoryTests` — 8/8 passed

## Artifacts

Brief, spec, architecture review, design, task plan, impl, and review markdown for this fix are committed under `artifacts/feat-3634/` on this branch.

## Code review

Whole-branch code review ran in-pipeline and came back **CLEAN** (no blocking or advisory findings), with independent re-verification of the diff, build, format, and targeted test run. Full review: `artifacts/feat-3634/code-review.r1.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01McG68FR6PiDSFhPExiX2Xo)_