### PR TITLE
feat: add expiration column and range filter to material inventory

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogMappingProfile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogMappingProfile.cs
@@ -17,6 +17,7 @@ public class CatalogMappingProfile : Profile
         CreateMap<CatalogAggregate, CatalogItemDto>()
             .ForMember(dest => dest.Price, opt => opt.MapFrom(src => src))
             .ForMember(dest => dest.LastStockTaking, opt => opt.MapFrom(src => src.LastStockTaking))
+            .ForMember(dest => dest.MinimalExpiration, opt => opt.MapFrom(src => src.MinimalExpiration))
             .ForMember(dest => dest.HasLots, opt => opt.MapFrom(src => src.HasLots))
             .ForMember(dest => dest.Lots, opt => opt.Ignore()); // Set manually in handler
 

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/CatalogItemDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/CatalogItemDto.cs
@@ -20,6 +20,7 @@ public class CatalogItemDto
     public string? Note { get; set; }
     public string? Image { get; set; }
     public DateTime? LastStockTaking { get; set; }
+    public DateOnly? MinimalExpiration { get; set; }
     public bool HasLots { get; set; }
     public List<LotDto> Lots { get; set; } = new();
 }

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/GetCatalogListRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/GetCatalogListRequest.cs
@@ -17,4 +17,15 @@ public class GetCatalogListRequest : IRequest<GetCatalogListResponse>
     /// Search term for autocomplete - searches in both ProductName and ProductCode with OR logic
     /// </summary>
     public string? SearchTerm { get; set; }
+
+    /// <summary>
+    /// Inclusive lower bound (ISO "yyyy-MM-dd") for a material's nearest lot expiration.
+    /// When either expiration bound is set, only items that have an expiration are returned.
+    /// </summary>
+    public string? ExpirationFrom { get; set; }
+
+    /// <summary>
+    /// Inclusive upper bound (ISO "yyyy-MM-dd") for a material's nearest lot expiration.
+    /// </summary>
+    public string? ExpirationTo { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTile.cs
@@ -70,7 +70,7 @@ public class MaterialExpirationSummaryTile : ITile
                 },
                 drillDown = new
                 {
-                    filters = new { type = "Material" },
+                    filters = new { type = "Material", sortBy = "expiration", sortDescending = false },
                     enabled = true,
                     tooltip = "Zobrazit suroviny"
                 }

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/GetCatalogList/GetCatalogListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/GetCatalogList/GetCatalogListHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq.Expressions;
 using Anela.Heblo.Application.Features.Catalog.Contracts;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -52,6 +53,18 @@ public class GetCatalogListHandler : IRequestHandler<GetCatalogListRequest, GetC
             filter = filter.And(x => x.ProductCode.ToLowerInvariant().Contains(productCode.ToLowerInvariant()));
         }
 
+        // Filter by nearest lot expiration range. When set, only items that actually have
+        // an expiration (available lots with an expiration date) are returned.
+        if (TryParseExpirationBound(request.ExpirationFrom, out var expirationFrom))
+        {
+            filter = filter.And(x => x.MinimalExpiration.HasValue && x.MinimalExpiration.Value >= expirationFrom);
+        }
+
+        if (TryParseExpirationBound(request.ExpirationTo, out var expirationTo))
+        {
+            filter = filter.And(x => x.MinimalExpiration.HasValue && x.MinimalExpiration.Value <= expirationTo);
+        }
+
         // Get all filtered items (repository doesn't support paging directly)
         var allItems = await _catalogRepository.FindAsync(filter, cancellationToken);
 
@@ -69,6 +82,9 @@ public class GetCatalogListHandler : IRequestHandler<GetCatalogListRequest, GetC
             "erp" => request.SortDescending ? query.OrderByDescending(x => x.Stock.Erp) : query.OrderBy(x => x.Stock.Erp),
             "eshop" => request.SortDescending ? query.OrderByDescending(x => x.Stock.Eshop) : query.OrderBy(x => x.Stock.Eshop),
             "lastinventorydays" => ApplyLastInventoryDaysSorting(query, request.SortDescending),
+            "expiration" => request.SortDescending
+                ? query.OrderBy(x => !x.MinimalExpiration.HasValue).ThenByDescending(x => x.MinimalExpiration)
+                : query.OrderBy(x => !x.MinimalExpiration.HasValue).ThenBy(x => x.MinimalExpiration),
             _ => query.OrderBy(x => x.ProductCode) // Default sort by ProductCode
         };
 
@@ -92,6 +108,9 @@ public class GetCatalogListHandler : IRequestHandler<GetCatalogListRequest, GetC
             PageSize = request.PageSize
         };
     }
+
+    private static bool TryParseExpirationBound(string? value, out DateOnly date)
+        => DateOnly.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out date);
 
     private static IQueryable<CatalogAggregate> ApplyLastInventoryDaysSorting(IQueryable<CatalogAggregate> query, bool sortDescending)
     {

--- a/backend/src/Anela.Heblo.Domain/Features/Catalog/CatalogAggregate.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Catalog/CatalogAggregate.cs
@@ -156,6 +156,22 @@ public class CatalogAggregate : Entity<string>
     public bool IsMinStockConfigured => Properties.StockMinSetup > 0;
     public bool IsOptimalStockConfigured => Properties.OptimalStockDaysSetup > 0;
     public DateTime? LastStockTaking => StockTakingHistory.OrderByDescending(o => o.Date).FirstOrDefault()?.Date;
+
+    // Earliest expiration across available lots (in-stock lots with an expiration date).
+    // Null when the product has no expiring available lot.
+    public DateOnly? MinimalExpiration
+    {
+        get
+        {
+            var availableExpirations = Stock.Lots
+                .Where(l => l.Amount > 0 && l.Expiration.HasValue)
+                .Select(l => l.Expiration!.Value)
+                .ToList();
+
+            return availableExpirations.Count > 0 ? availableExpirations.Min() : null;
+        }
+    }
+
     public bool HasExpiration { get; set; }
     public bool HasLots { get; set; }
     public double Volume { get; set; }

--- a/backend/test/Anela.Heblo.Tests/Domain/Catalog/CatalogAggregateTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Catalog/CatalogAggregateTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.ConsumedMaterials;
+using Anela.Heblo.Domain.Features.Catalog.Lots;
 using Anela.Heblo.Domain.Features.Catalog.Price;
 using Anela.Heblo.Domain.Features.Catalog.PurchaseHistory;
 using Anela.Heblo.Domain.Features.Catalog.Sales;
@@ -426,5 +427,66 @@ public class CatalogAggregateTests
         aggregate.CurrentPurchasePrice.Should().BeNull();
         aggregate.SellingPriceWithVat.Should().BeNull();
         aggregate.PurchasePriceWithVat.Should().BeNull();
+    }
+
+    [Fact]
+    public void MinimalExpiration_ReturnsEarliestExpiration_AcrossAvailableLots()
+    {
+        // Arrange
+        var aggregate = new CatalogAggregate();
+        aggregate.Stock.Lots = new List<CatalogLot>
+        {
+            new() { ProductCode = "M1", Amount = 5, Expiration = new DateOnly(2026, 5, 1) },
+            new() { ProductCode = "M1", Amount = 3, Expiration = new DateOnly(2026, 2, 15) },
+            new() { ProductCode = "M1", Amount = 1, Expiration = new DateOnly(2026, 8, 20) }
+        };
+
+        // Assert
+        aggregate.MinimalExpiration.Should().Be(new DateOnly(2026, 2, 15));
+    }
+
+    [Fact]
+    public void MinimalExpiration_IgnoresLotsWithoutAvailableAmount()
+    {
+        // Arrange
+        var aggregate = new CatalogAggregate();
+        aggregate.Stock.Lots = new List<CatalogLot>
+        {
+            new() { ProductCode = "M1", Amount = 0, Expiration = new DateOnly(2025, 1, 1) }, // earliest but not available
+            new() { ProductCode = "M1", Amount = 4, Expiration = new DateOnly(2026, 3, 10) }
+        };
+
+        // Assert
+        aggregate.MinimalExpiration.Should().Be(new DateOnly(2026, 3, 10));
+    }
+
+    [Fact]
+    public void MinimalExpiration_IgnoresLotsWithoutExpiration()
+    {
+        // Arrange
+        var aggregate = new CatalogAggregate();
+        aggregate.Stock.Lots = new List<CatalogLot>
+        {
+            new() { ProductCode = "M1", Amount = 4, Expiration = null },
+            new() { ProductCode = "M1", Amount = 2, Expiration = new DateOnly(2026, 6, 1) }
+        };
+
+        // Assert
+        aggregate.MinimalExpiration.Should().Be(new DateOnly(2026, 6, 1));
+    }
+
+    [Fact]
+    public void MinimalExpiration_ReturnsNull_WhenNoAvailableExpiringLots()
+    {
+        // Arrange
+        var aggregate = new CatalogAggregate();
+        aggregate.Stock.Lots = new List<CatalogLot>
+        {
+            new() { ProductCode = "M1", Amount = 0, Expiration = new DateOnly(2025, 1, 1) },
+            new() { ProductCode = "M1", Amount = 5, Expiration = null }
+        };
+
+        // Assert
+        aggregate.MinimalExpiration.Should().BeNull();
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTileTests.cs
@@ -235,6 +235,23 @@ public class MaterialExpirationSummaryTileTests
         doc.RootElement.GetProperty("error").GetString().Should().Be("boom");
     }
 
+    [Fact]
+    public async Task LoadDataAsync_DrillDown_TargetsMaterialsSortedByEarliestExpiration()
+    {
+        // Arrange
+        SetupCatalog();
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert - clicking the tile should land on the material inventory sorted by soonest expiration
+        var doc = Serialize(result);
+        var filters = doc.RootElement.GetProperty("drillDown").GetProperty("filters");
+        filters.GetProperty("type").GetString().Should().Be("Material");
+        filters.GetProperty("sortBy").GetString().Should().Be("expiration");
+        filters.GetProperty("sortDescending").GetBoolean().Should().BeFalse();
+    }
+
     private async Task<JsonElement> LoadDataSection()
     {
         var result = await _tile.LoadDataAsync();

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/GetCatalogListHandlerExpirationFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/GetCatalogListHandlerExpirationFilterTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Application.Features.Catalog.UseCases.GetCatalogList;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Lots;
+using AutoMapper;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+/// <summary>
+/// Tests for the ExpirationFrom / ExpirationTo range filtering in GetCatalogListHandler.
+/// </summary>
+public class GetCatalogListHandlerExpirationFilterTests
+{
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly GetCatalogListHandler _handler;
+
+    public GetCatalogListHandlerExpirationFilterTests()
+    {
+        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _mapperMock = new Mock<IMapper>();
+        _handler = new GetCatalogListHandler(_catalogRepositoryMock.Object, _mapperMock.Object);
+
+        // Project by input so the applied filter is genuinely asserted
+        _mapperMock.Setup(m => m.Map<List<CatalogItemDto>>(It.IsAny<List<CatalogAggregate>>()))
+            .Returns((List<CatalogAggregate> src) => src.Select(x => new CatalogItemDto { ProductCode = x.ProductCode }).ToList());
+    }
+
+    [Fact]
+    public async Task Handle_ExpirationRange_ReturnsOnlyItemsWithExpirationInRange()
+    {
+        // Arrange
+        var items = new List<CatalogAggregate>
+        {
+            CreateItemWithLot("BEFORE", new DateOnly(2026, 1, 1)),   // before range
+            CreateItemWithLot("IN1", new DateOnly(2026, 3, 15)),     // in range
+            CreateItemWithLot("IN2", new DateOnly(2026, 4, 30)),     // in range (inclusive upper)
+            CreateItemWithLot("AFTER", new DateOnly(2026, 6, 1)),    // after range
+            CreateItemWithLot("NONE")                                // no expiration -> excluded
+        };
+
+        var request = new GetCatalogListRequest
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            ExpirationFrom = "2026-03-01",
+            ExpirationTo = "2026-04-30"
+        };
+
+        _catalogRepositoryMock.Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Expression<Func<CatalogAggregate, bool>> predicate, CancellationToken _) => items.Where(predicate.Compile()).ToList());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(new[] { "IN1", "IN2" }, result.Items.Select(i => i.ProductCode).OrderBy(c => c).ToArray());
+    }
+
+    [Fact]
+    public async Task Handle_ExpirationToOnly_ReturnsExpiredItems_ExcludingNulls()
+    {
+        // Arrange - "Po expiraci" preset: only an upper bound
+        var items = new List<CatalogAggregate>
+        {
+            CreateItemWithLot("EXPIRED", new DateOnly(2000, 12, 31)),
+            CreateItemWithLot("FUTURE", new DateOnly(2030, 1, 1)),
+            CreateItemWithLot("NONE")
+        };
+
+        var request = new GetCatalogListRequest
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            ExpirationTo = "2026-07-13"
+        };
+
+        _catalogRepositoryMock.Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Expression<Func<CatalogAggregate, bool>> predicate, CancellationToken _) => items.Where(predicate.Compile()).ToList());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(new[] { "EXPIRED" }, result.Items.Select(i => i.ProductCode).ToArray());
+    }
+
+    [Fact]
+    public async Task Handle_NoExpirationFilter_ReturnsAllItemsIncludingNulls()
+    {
+        // Arrange
+        var items = new List<CatalogAggregate>
+        {
+            CreateItemWithLot("WITH", new DateOnly(2026, 5, 1)),
+            CreateItemWithLot("NONE")
+        };
+
+        var request = new GetCatalogListRequest { PageNumber = 1, PageSize = 10 };
+
+        _catalogRepositoryMock.Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Expression<Func<CatalogAggregate, bool>> predicate, CancellationToken _) => items.Where(predicate.Compile()).ToList());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    private static CatalogAggregate CreateItemWithLot(string productCode, DateOnly? expiration = null)
+    {
+        var item = new CatalogAggregate
+        {
+            Id = productCode,
+            ProductName = productCode,
+            Type = ProductType.Material
+        };
+
+        if (expiration.HasValue)
+        {
+            item.Stock.Lots = new List<CatalogLot>
+            {
+                new() { ProductCode = productCode, Amount = 5, Expiration = expiration }
+            };
+        }
+
+        return item;
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/GetCatalogListHandlerSortingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/GetCatalogListHandlerSortingTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Anela.Heblo.Application.Features.Catalog.Contracts;
 using Anela.Heblo.Application.Features.Catalog.UseCases.GetCatalogList;
 using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Lots;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using AutoMapper;
 using Moq;
@@ -320,6 +321,91 @@ public class GetCatalogListHandlerSortingTests
         Assert.Equal("ITEM-A", result.Items[0].ProductCode);
         Assert.Equal("ITEM-B", result.Items[1].ProductCode);
         Assert.Equal("ITEM-C", result.Items[2].ProductCode);
+    }
+
+    [Fact]
+    public async Task Handle_ExpirationAscending_SortsByEarliestAvailableLot_NullsLast()
+    {
+        // Arrange - min expiration is the earliest expiration across available (Amount > 0) lots.
+        // Items with no expiring available lot should sort last, preserving original order.
+        var items = new List<CatalogAggregate>
+        {
+            CreateCatalogItemWithLots("ITEM1", (5m, new DateOnly(2026, 3, 1)), (2m, new DateOnly(2026, 1, 15))), // min = 2026-01-15
+            CreateCatalogItemWithLots("ITEM2"),                                                                  // no lots -> null
+            CreateCatalogItemWithLots("ITEM3", (3m, new DateOnly(2026, 2, 10))),                                 // min = 2026-02-10
+            CreateCatalogItemWithLots("ITEM4", (0m, new DateOnly(2025, 1, 1)))                                   // only zero-amount lot -> null
+        };
+
+        var request = new GetCatalogListRequest
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            SortBy = "expiration",
+            SortDescending = false
+        };
+
+        _catalogRepositoryMock.Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        // Project by input so the handler's ordering is genuinely asserted
+        _mapperMock.Setup(m => m.Map<List<CatalogItemDto>>(It.IsAny<List<CatalogAggregate>>()))
+            .Returns((List<CatalogAggregate> src) => src.Select(x => new CatalogItemDto { ProductCode = x.ProductCode }).ToList());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - earliest expiration first, null-expiration items last (stable original order)
+        Assert.True(result.Success);
+        Assert.Equal(new[] { "ITEM1", "ITEM3", "ITEM2", "ITEM4" }, result.Items.Select(i => i.ProductCode).ToArray());
+    }
+
+    [Fact]
+    public async Task Handle_ExpirationDescending_SortsByLatestAvailableLot_NullsLast()
+    {
+        // Arrange
+        var items = new List<CatalogAggregate>
+        {
+            CreateCatalogItemWithLots("ITEM1", (2m, new DateOnly(2026, 1, 15))), // min = 2026-01-15
+            CreateCatalogItemWithLots("ITEM2"),                                  // null
+            CreateCatalogItemWithLots("ITEM3", (3m, new DateOnly(2026, 2, 10)))  // min = 2026-02-10
+        };
+
+        var request = new GetCatalogListRequest
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            SortBy = "expiration",
+            SortDescending = true
+        };
+
+        _catalogRepositoryMock.Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        _mapperMock.Setup(m => m.Map<List<CatalogItemDto>>(It.IsAny<List<CatalogAggregate>>()))
+            .Returns((List<CatalogAggregate> src) => src.Select(x => new CatalogItemDto { ProductCode = x.ProductCode }).ToList());
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - latest expiration first, null-expiration items last
+        Assert.True(result.Success);
+        Assert.Equal(new[] { "ITEM3", "ITEM1", "ITEM2" }, result.Items.Select(i => i.ProductCode).ToArray());
+    }
+
+    private static CatalogAggregate CreateCatalogItemWithLots(string productCode, params (decimal Amount, DateOnly? Expiration)[] lots)
+    {
+        var item = new CatalogAggregate
+        {
+            Id = productCode,
+            ProductName = productCode,
+            Type = ProductType.Material
+        };
+
+        item.Stock.Lots = lots
+            .Select(l => new CatalogLot { ProductCode = productCode, Amount = l.Amount, Expiration = l.Expiration })
+            .ToList();
+
+        return item;
     }
 
     private static CatalogAggregate CreateCatalogItem(string productCode, string productName, string location, DateTime? lastStockTaking)

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -1797,7 +1797,7 @@ export class ApiClient {
         return Promise.resolve<SetCarrierCoolingResponse>(null as any);
     }
 
-    catalog_GetCatalogList(productTypes: ProductType[] | null | undefined, pageNumber: number | undefined, pageSize: number | undefined, sortBy: string | null | undefined, sortDescending: boolean | undefined, productName: string | null | undefined, productCode: string | null | undefined, searchTerm: string | null | undefined): Promise<GetCatalogListResponse> {
+    catalog_GetCatalogList(productTypes: ProductType[] | null | undefined, pageNumber: number | undefined, pageSize: number | undefined, sortBy: string | null | undefined, sortDescending: boolean | undefined, productName: string | null | undefined, productCode: string | null | undefined, searchTerm: string | null | undefined, expirationFrom: string | null | undefined, expirationTo: string | null | undefined): Promise<GetCatalogListResponse> {
         let url_ = this.baseUrl + "/api/Catalog?";
         if (productTypes !== undefined && productTypes !== null)
             productTypes && productTypes.forEach(item => { url_ += "ProductTypes=" + encodeURIComponent("" + item) + "&"; });
@@ -1821,6 +1821,10 @@ export class ApiClient {
             url_ += "ProductCode=" + encodeURIComponent("" + productCode) + "&";
         if (searchTerm !== undefined && searchTerm !== null)
             url_ += "SearchTerm=" + encodeURIComponent("" + searchTerm) + "&";
+        if (expirationFrom !== undefined && expirationFrom !== null)
+            url_ += "ExpirationFrom=" + encodeURIComponent("" + expirationFrom) + "&";
+        if (expirationTo !== undefined && expirationTo !== null)
+            url_ += "ExpirationTo=" + encodeURIComponent("" + expirationTo) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
@@ -11752,6 +11756,112 @@ export class ApiClient {
         return Promise.resolve<SendMessageResponse>(null as any);
     }
 
+    smartsupp_SubmitDraftReplyFeedback(request: SubmitDraftReplyFeedbackRequest): Promise<SubmitDraftReplyFeedbackResponse> {
+        let url_ = this.baseUrl + "/api/smartsupp/draft-reply/feedback";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSmartsupp_SubmitDraftReplyFeedback(_response);
+        });
+    }
+
+    protected processSmartsupp_SubmitDraftReplyFeedback(response: Response): Promise<SubmitDraftReplyFeedbackResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = SubmitDraftReplyFeedbackResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            let resultData409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result409 = ProblemDetails.fromJS(resultData409);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result409);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<SubmitDraftReplyFeedbackResponse>(null as any);
+    }
+
+    smartsupp_GetDraftReplyFeedbackList(pageNumber: number | undefined, pageSize: number | undefined, sortBy: string | undefined, sortDescending: boolean | undefined, hasFeedback: boolean | null | undefined, userId: string | null | undefined): Promise<GetDraftReplyFeedbackListResponse> {
+        let url_ = this.baseUrl + "/api/smartsupp/draft-reply/feedback/list?";
+        if (pageNumber === null)
+            throw new Error("The parameter 'pageNumber' cannot be null.");
+        else if (pageNumber !== undefined)
+            url_ += "pageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === null)
+            throw new Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (sortBy === null)
+            throw new Error("The parameter 'sortBy' cannot be null.");
+        else if (sortBy !== undefined)
+            url_ += "sortBy=" + encodeURIComponent("" + sortBy) + "&";
+        if (sortDescending === null)
+            throw new Error("The parameter 'sortDescending' cannot be null.");
+        else if (sortDescending !== undefined)
+            url_ += "sortDescending=" + encodeURIComponent("" + sortDescending) + "&";
+        if (hasFeedback !== undefined && hasFeedback !== null)
+            url_ += "hasFeedback=" + encodeURIComponent("" + hasFeedback) + "&";
+        if (userId !== undefined && userId !== null)
+            url_ += "userId=" + encodeURIComponent("" + userId) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSmartsupp_GetDraftReplyFeedbackList(_response);
+        });
+    }
+
+    protected processSmartsupp_GetDraftReplyFeedbackList(response: Response): Promise<GetDraftReplyFeedbackListResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetDraftReplyFeedbackListResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetDraftReplyFeedbackListResponse>(null as any);
+    }
+
     smartsupp_CloseConversation(id: string): Promise<CloseConversationResponse> {
         let url_ = this.baseUrl + "/api/smartsupp/conversations/{id}/close";
         if (id === undefined || id === null)
@@ -11798,6 +11908,80 @@ export class ApiClient {
             });
         }
         return Promise.resolve<CloseConversationResponse>(null as any);
+    }
+
+    smartsupp_RecordPresence(id: string): Promise<RecordPresenceResponse> {
+        let url_ = this.baseUrl + "/api/smartsupp/conversations/{id}/presence";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "POST",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSmartsupp_RecordPresence(_response);
+        });
+    }
+
+    protected processSmartsupp_RecordPresence(response: Response): Promise<RecordPresenceResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordPresenceResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordPresenceResponse>(null as any);
+    }
+
+    smartsupp_RemovePresence(id: string): Promise<RemovePresenceResponse> {
+        let url_ = this.baseUrl + "/api/smartsupp/conversations/{id}/presence";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSmartsupp_RemovePresence(_response);
+        });
+    }
+
+    protected processSmartsupp_RemovePresence(response: Response): Promise<RemovePresenceResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RemovePresenceResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RemovePresenceResponse>(null as any);
     }
 
     smartsupp_RefreshOrphanContacts(): Promise<RefreshOrphanContactsResponse> {
@@ -13311,6 +13495,8 @@ export enum ErrorCodes {
     SmartsuppSendMessageUnavailable = "SmartsuppSendMessageUnavailable",
     SmartsuppAgentMappingNotFound = "SmartsuppAgentMappingNotFound",
     SmartsuppCloseConversationUnavailable = "SmartsuppCloseConversationUnavailable",
+    SmartsuppDraftReplyFeedbackLogNotFound = "SmartsuppDraftReplyFeedbackLogNotFound",
+    SmartsuppDraftReplyFeedbackAlreadySubmitted = "SmartsuppDraftReplyFeedbackAlreadySubmitted",
     LotNotFound = "LotNotFound",
     MaterialContainerNotFound = "MaterialContainerNotFound",
     LotAlreadyExists = "LotAlreadyExists",
@@ -16947,6 +17133,7 @@ export class CatalogItemDto implements ICatalogItemDto {
     note?: string | undefined;
     image?: string | undefined;
     lastStockTaking?: Date | undefined;
+    minimalExpiration?: Date | undefined;
     hasLots?: boolean;
     lots?: LotDto[];
 
@@ -16977,6 +17164,7 @@ export class CatalogItemDto implements ICatalogItemDto {
             this.note = _data["note"];
             this.image = _data["image"];
             this.lastStockTaking = _data["lastStockTaking"] ? new Date(_data["lastStockTaking"].toString()) : <any>undefined;
+            this.minimalExpiration = _data["minimalExpiration"] ? new Date(_data["minimalExpiration"].toString()) : <any>undefined;
             this.hasLots = _data["hasLots"];
             if (Array.isArray(_data["lots"])) {
                 this.lots = [] as any;
@@ -17011,6 +17199,7 @@ export class CatalogItemDto implements ICatalogItemDto {
         data["note"] = this.note;
         data["image"] = this.image;
         data["lastStockTaking"] = this.lastStockTaking ? this.lastStockTaking.toISOString() : <any>undefined;
+        data["minimalExpiration"] = this.minimalExpiration ? formatDate(this.minimalExpiration) : <any>undefined;
         data["hasLots"] = this.hasLots;
         if (Array.isArray(this.lots)) {
             data["lots"] = [];
@@ -17038,6 +17227,7 @@ export interface ICatalogItemDto {
     note?: string | undefined;
     image?: string | undefined;
     lastStockTaking?: Date | undefined;
+    minimalExpiration?: Date | undefined;
     hasLots?: boolean;
     lots?: LotDto[];
 }
@@ -24007,12 +24197,12 @@ export interface IDeleteDocumentResponse extends IBaseResponse {
 }
 
 export class GetFeedbackListResponse extends BaseResponse implements IGetFeedbackListResponse {
-    logs?: FeedbackLogSummary[];
+    logs?: RagFeedbackLogSummary[];
     totalCount?: number;
     pageNumber?: number;
     pageSize?: number;
     totalPages?: number;
-    stats?: FeedbackStatsDto;
+    stats?: RagFeedbackStatsDto;
 
     constructor(data?: IGetFeedbackListResponse) {
         super(data);
@@ -24024,13 +24214,13 @@ export class GetFeedbackListResponse extends BaseResponse implements IGetFeedbac
             if (Array.isArray(_data["logs"])) {
                 this.logs = [] as any;
                 for (let item of _data["logs"])
-                    this.logs!.push(FeedbackLogSummary.fromJS(item));
+                    this.logs!.push(RagFeedbackLogSummary.fromJS(item));
             }
             this.totalCount = _data["totalCount"];
             this.pageNumber = _data["pageNumber"];
             this.pageSize = _data["pageSize"];
             this.totalPages = _data["totalPages"];
-            this.stats = _data["stats"] ? FeedbackStatsDto.fromJS(_data["stats"]) : <any>undefined;
+            this.stats = _data["stats"] ? RagFeedbackStatsDto.fromJS(_data["stats"]) : <any>undefined;
         }
     }
 
@@ -24059,30 +24249,39 @@ export class GetFeedbackListResponse extends BaseResponse implements IGetFeedbac
 }
 
 export interface IGetFeedbackListResponse extends IBaseResponse {
-    logs?: FeedbackLogSummary[];
+    logs?: RagFeedbackLogSummary[];
     totalCount?: number;
     pageNumber?: number;
     pageSize?: number;
     totalPages?: number;
-    stats?: FeedbackStatsDto;
+    stats?: RagFeedbackStatsDto;
 }
 
-export class FeedbackLogSummary implements IFeedbackLogSummary {
+export class RagFeedbackLogSummary implements IRagFeedbackLogSummary {
     id?: string;
+    feature?: RagFeature;
     question?: string;
     answer?: string;
+    expandedQuery?: string | undefined;
+    systemPrompt?: string;
+    retrievedChunks?: RagFeedbackChunkDto[];
     topK?: number;
     sourceCount?: number;
     durationMs?: number;
     createdAt?: Date;
     userId?: string | undefined;
     userName?: string | undefined;
+    conversationId?: string | undefined;
+    topic?: string | undefined;
+    sentAnswer?: string | undefined;
+    wasEdited?: boolean | undefined;
+    sentAt?: Date | undefined;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
     feedbackComment?: string | undefined;
     hasFeedback?: boolean;
 
-    constructor(data?: IFeedbackLogSummary) {
+    constructor(data?: IRagFeedbackLogSummary) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -24094,14 +24293,27 @@ export class FeedbackLogSummary implements IFeedbackLogSummary {
     init(_data?: any) {
         if (_data) {
             this.id = _data["id"];
+            this.feature = _data["feature"];
             this.question = _data["question"];
             this.answer = _data["answer"];
+            this.expandedQuery = _data["expandedQuery"];
+            this.systemPrompt = _data["systemPrompt"];
+            if (Array.isArray(_data["retrievedChunks"])) {
+                this.retrievedChunks = [] as any;
+                for (let item of _data["retrievedChunks"])
+                    this.retrievedChunks!.push(RagFeedbackChunkDto.fromJS(item));
+            }
             this.topK = _data["topK"];
             this.sourceCount = _data["sourceCount"];
             this.durationMs = _data["durationMs"];
             this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
             this.userId = _data["userId"];
             this.userName = _data["userName"];
+            this.conversationId = _data["conversationId"];
+            this.topic = _data["topic"];
+            this.sentAnswer = _data["sentAnswer"];
+            this.wasEdited = _data["wasEdited"];
+            this.sentAt = _data["sentAt"] ? new Date(_data["sentAt"].toString()) : <any>undefined;
             this.precisionScore = _data["precisionScore"];
             this.styleScore = _data["styleScore"];
             this.feedbackComment = _data["feedbackComment"];
@@ -24109,9 +24321,9 @@ export class FeedbackLogSummary implements IFeedbackLogSummary {
         }
     }
 
-    static fromJS(data: any): FeedbackLogSummary {
+    static fromJS(data: any): RagFeedbackLogSummary {
         data = typeof data === 'object' ? data : {};
-        let result = new FeedbackLogSummary();
+        let result = new RagFeedbackLogSummary();
         result.init(data);
         return result;
     }
@@ -24119,14 +24331,27 @@ export class FeedbackLogSummary implements IFeedbackLogSummary {
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
         data["id"] = this.id;
+        data["feature"] = this.feature;
         data["question"] = this.question;
         data["answer"] = this.answer;
+        data["expandedQuery"] = this.expandedQuery;
+        data["systemPrompt"] = this.systemPrompt;
+        if (Array.isArray(this.retrievedChunks)) {
+            data["retrievedChunks"] = [];
+            for (let item of this.retrievedChunks)
+                data["retrievedChunks"].push(item.toJSON());
+        }
         data["topK"] = this.topK;
         data["sourceCount"] = this.sourceCount;
         data["durationMs"] = this.durationMs;
         data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
         data["userId"] = this.userId;
         data["userName"] = this.userName;
+        data["conversationId"] = this.conversationId;
+        data["topic"] = this.topic;
+        data["sentAnswer"] = this.sentAnswer;
+        data["wasEdited"] = this.wasEdited;
+        data["sentAt"] = this.sentAt ? this.sentAt.toISOString() : <any>undefined;
         data["precisionScore"] = this.precisionScore;
         data["styleScore"] = this.styleScore;
         data["feedbackComment"] = this.feedbackComment;
@@ -24135,29 +24360,95 @@ export class FeedbackLogSummary implements IFeedbackLogSummary {
     }
 }
 
-export interface IFeedbackLogSummary {
+export interface IRagFeedbackLogSummary {
     id?: string;
+    feature?: RagFeature;
     question?: string;
     answer?: string;
+    expandedQuery?: string | undefined;
+    systemPrompt?: string;
+    retrievedChunks?: RagFeedbackChunkDto[];
     topK?: number;
     sourceCount?: number;
     durationMs?: number;
     createdAt?: Date;
     userId?: string | undefined;
     userName?: string | undefined;
+    conversationId?: string | undefined;
+    topic?: string | undefined;
+    sentAnswer?: string | undefined;
+    wasEdited?: boolean | undefined;
+    sentAt?: Date | undefined;
     precisionScore?: number | undefined;
     styleScore?: number | undefined;
     feedbackComment?: string | undefined;
     hasFeedback?: boolean;
 }
 
-export class FeedbackStatsDto implements IFeedbackStatsDto {
+export enum RagFeature {
+    KnowledgeBase = "KnowledgeBase",
+    SmartsuppDraftReply = "SmartsuppDraftReply",
+}
+
+export class RagFeedbackChunkDto implements IRagFeedbackChunkDto {
+    chunkId?: string;
+    documentId?: string;
+    filename?: string;
+    score?: number;
+    content?: string;
+
+    constructor(data?: IRagFeedbackChunkDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.chunkId = _data["chunkId"];
+            this.documentId = _data["documentId"];
+            this.filename = _data["filename"];
+            this.score = _data["score"];
+            this.content = _data["content"];
+        }
+    }
+
+    static fromJS(data: any): RagFeedbackChunkDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new RagFeedbackChunkDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["chunkId"] = this.chunkId;
+        data["documentId"] = this.documentId;
+        data["filename"] = this.filename;
+        data["score"] = this.score;
+        data["content"] = this.content;
+        return data;
+    }
+}
+
+export interface IRagFeedbackChunkDto {
+    chunkId?: string;
+    documentId?: string;
+    filename?: string;
+    score?: number;
+    content?: string;
+}
+
+export class RagFeedbackStatsDto implements IRagFeedbackStatsDto {
     totalQuestions?: number;
     totalWithFeedback?: number;
     avgPrecisionScore?: number | undefined;
     avgStyleScore?: number | undefined;
 
-    constructor(data?: IFeedbackStatsDto) {
+    constructor(data?: IRagFeedbackStatsDto) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -24175,9 +24466,9 @@ export class FeedbackStatsDto implements IFeedbackStatsDto {
         }
     }
 
-    static fromJS(data: any): FeedbackStatsDto {
+    static fromJS(data: any): RagFeedbackStatsDto {
         data = typeof data === 'object' ? data : {};
-        let result = new FeedbackStatsDto();
+        let result = new RagFeedbackStatsDto();
         result.init(data);
         return result;
     }
@@ -24192,7 +24483,7 @@ export class FeedbackStatsDto implements IFeedbackStatsDto {
     }
 }
 
-export interface IFeedbackStatsDto {
+export interface IRagFeedbackStatsDto {
     totalQuestions?: number;
     totalWithFeedback?: number;
     avgPrecisionScore?: number | undefined;
@@ -38842,6 +39133,7 @@ export class ConversationDto implements IConversationDto {
     locationIp?: string | undefined;
     variables?: { [key: string]: string; };
     otherConversations?: ConversationSummaryDto[];
+    activeViewers?: ConversationPresenceDto[];
 
     constructor(data?: IConversationDto) {
         if (data) {
@@ -38913,6 +39205,11 @@ export class ConversationDto implements IConversationDto {
                 this.otherConversations = [] as any;
                 for (let item of _data["otherConversations"])
                     this.otherConversations!.push(ConversationSummaryDto.fromJS(item));
+            }
+            if (Array.isArray(_data["activeViewers"])) {
+                this.activeViewers = [] as any;
+                for (let item of _data["activeViewers"])
+                    this.activeViewers!.push(ConversationPresenceDto.fromJS(item));
             }
         }
     }
@@ -38986,6 +39283,11 @@ export class ConversationDto implements IConversationDto {
             for (let item of this.otherConversations)
                 data["otherConversations"].push(item.toJSON());
         }
+        if (Array.isArray(this.activeViewers)) {
+            data["activeViewers"] = [];
+            for (let item of this.activeViewers)
+                data["activeViewers"].push(item.toJSON());
+        }
         return data;
     }
 }
@@ -39023,6 +39325,7 @@ export interface IConversationDto {
     locationIp?: string | undefined;
     variables?: { [key: string]: string; };
     otherConversations?: ConversationSummaryDto[];
+    activeViewers?: ConversationPresenceDto[];
 }
 
 export class ConversationSummaryDto implements IConversationSummaryDto {
@@ -39075,6 +39378,58 @@ export interface IConversationSummaryDto {
     lastMessageAt?: Date | undefined;
     lastMessagePreview?: string | undefined;
     isUnread?: boolean;
+}
+
+export class ConversationPresenceDto implements IConversationPresenceDto {
+    agentId?: string;
+    displayName?: string;
+    source?: string;
+    isCurrentUser?: boolean;
+    enteredAt?: Date;
+
+    constructor(data?: IConversationPresenceDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.agentId = _data["agentId"];
+            this.displayName = _data["displayName"];
+            this.source = _data["source"];
+            this.isCurrentUser = _data["isCurrentUser"];
+            this.enteredAt = _data["enteredAt"] ? new Date(_data["enteredAt"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): ConversationPresenceDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new ConversationPresenceDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["agentId"] = this.agentId;
+        data["displayName"] = this.displayName;
+        data["source"] = this.source;
+        data["isCurrentUser"] = this.isCurrentUser;
+        data["enteredAt"] = this.enteredAt ? this.enteredAt.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IConversationPresenceDto {
+    agentId?: string;
+    displayName?: string;
+    source?: string;
+    isCurrentUser?: boolean;
+    enteredAt?: Date;
 }
 
 export class GetConversationResponse extends BaseResponse implements IGetConversationResponse {
@@ -39219,6 +39574,7 @@ export interface IMessageDto {
 }
 
 export class GenerateDraftReplyResponse extends BaseResponse implements IGenerateDraftReplyResponse {
+    id?: string | undefined;
     answer?: string;
     sources?: DraftReplySource[];
 
@@ -39229,6 +39585,7 @@ export class GenerateDraftReplyResponse extends BaseResponse implements IGenerat
     override init(_data?: any) {
         super.init(_data);
         if (_data) {
+            this.id = _data["id"];
             this.answer = _data["answer"];
             if (Array.isArray(_data["sources"])) {
                 this.sources = [] as any;
@@ -39247,6 +39604,7 @@ export class GenerateDraftReplyResponse extends BaseResponse implements IGenerat
 
     override toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
         data["answer"] = this.answer;
         if (Array.isArray(this.sources)) {
             data["sources"] = [];
@@ -39259,6 +39617,7 @@ export class GenerateDraftReplyResponse extends BaseResponse implements IGenerat
 }
 
 export interface IGenerateDraftReplyResponse extends IBaseResponse {
+    id?: string | undefined;
     answer?: string;
     sources?: DraftReplySource[];
 }
@@ -39720,6 +40079,7 @@ export interface ISendMessageResponse extends IBaseResponse {
 
 export class SendMessageBody implements ISendMessageBody {
     content?: string;
+    draftLogId?: string | undefined;
 
     constructor(data?: ISendMessageBody) {
         if (data) {
@@ -39733,6 +40093,7 @@ export class SendMessageBody implements ISendMessageBody {
     init(_data?: any) {
         if (_data) {
             this.content = _data["content"];
+            this.draftLogId = _data["draftLogId"];
         }
     }
 
@@ -39746,12 +40107,150 @@ export class SendMessageBody implements ISendMessageBody {
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
         data["content"] = this.content;
+        data["draftLogId"] = this.draftLogId;
         return data;
     }
 }
 
 export interface ISendMessageBody {
     content?: string;
+    draftLogId?: string | undefined;
+}
+
+export class SubmitDraftReplyFeedbackResponse extends BaseResponse implements ISubmitDraftReplyFeedbackResponse {
+
+    constructor(data?: ISubmitDraftReplyFeedbackResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): SubmitDraftReplyFeedbackResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new SubmitDraftReplyFeedbackResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface ISubmitDraftReplyFeedbackResponse extends IBaseResponse {
+}
+
+export class SubmitDraftReplyFeedbackRequest implements ISubmitDraftReplyFeedbackRequest {
+    logId?: string;
+    precisionScore?: number;
+    styleScore?: number;
+    comment?: string | undefined;
+
+    constructor(data?: ISubmitDraftReplyFeedbackRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.logId = _data["logId"];
+            this.precisionScore = _data["precisionScore"];
+            this.styleScore = _data["styleScore"];
+            this.comment = _data["comment"];
+        }
+    }
+
+    static fromJS(data: any): SubmitDraftReplyFeedbackRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new SubmitDraftReplyFeedbackRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["logId"] = this.logId;
+        data["precisionScore"] = this.precisionScore;
+        data["styleScore"] = this.styleScore;
+        data["comment"] = this.comment;
+        return data;
+    }
+}
+
+export interface ISubmitDraftReplyFeedbackRequest {
+    logId?: string;
+    precisionScore?: number;
+    styleScore?: number;
+    comment?: string | undefined;
+}
+
+export class GetDraftReplyFeedbackListResponse extends BaseResponse implements IGetDraftReplyFeedbackListResponse {
+    logs?: RagFeedbackLogSummary[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+    stats?: RagFeedbackStatsDto;
+
+    constructor(data?: IGetDraftReplyFeedbackListResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["logs"])) {
+                this.logs = [] as any;
+                for (let item of _data["logs"])
+                    this.logs!.push(RagFeedbackLogSummary.fromJS(item));
+            }
+            this.totalCount = _data["totalCount"];
+            this.pageNumber = _data["pageNumber"];
+            this.pageSize = _data["pageSize"];
+            this.totalPages = _data["totalPages"];
+            this.stats = _data["stats"] ? RagFeedbackStatsDto.fromJS(_data["stats"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): GetDraftReplyFeedbackListResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetDraftReplyFeedbackListResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.logs)) {
+            data["logs"] = [];
+            for (let item of this.logs)
+                data["logs"].push(item.toJSON());
+        }
+        data["totalCount"] = this.totalCount;
+        data["pageNumber"] = this.pageNumber;
+        data["pageSize"] = this.pageSize;
+        data["totalPages"] = this.totalPages;
+        data["stats"] = this.stats ? this.stats.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetDraftReplyFeedbackListResponse extends IBaseResponse {
+    logs?: RagFeedbackLogSummary[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+    stats?: RagFeedbackStatsDto;
 }
 
 export class CloseConversationResponse extends BaseResponse implements ICloseConversationResponse {
@@ -39779,6 +40278,60 @@ export class CloseConversationResponse extends BaseResponse implements ICloseCon
 }
 
 export interface ICloseConversationResponse extends IBaseResponse {
+}
+
+export class RecordPresenceResponse extends BaseResponse implements IRecordPresenceResponse {
+
+    constructor(data?: IRecordPresenceResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): RecordPresenceResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new RecordPresenceResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IRecordPresenceResponse extends IBaseResponse {
+}
+
+export class RemovePresenceResponse extends BaseResponse implements IRemovePresenceResponse {
+
+    constructor(data?: IRemovePresenceResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): RemovePresenceResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new RemovePresenceResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IRemovePresenceResponse extends IBaseResponse {
 }
 
 export class RefreshOrphanContactsResponse extends BaseResponse implements IRefreshOrphanContactsResponse {

--- a/frontend/src/api/hooks/__tests__/useInventory.test.tsx
+++ b/frontend/src/api/hooks/__tests__/useInventory.test.tsx
@@ -394,7 +394,9 @@ describe('useInventory - Complex Sorting Logic', () => {
         true, // sortDescending
         undefined, // productName
         undefined, // productCode
-        undefined // searchTerm
+        undefined, // searchTerm
+        undefined, // expirationFrom
+        undefined // expirationTo
       );
 
       const items = result.current.data?.items || [];

--- a/frontend/src/api/hooks/useInventory.ts
+++ b/frontend/src/api/hooks/useInventory.ts
@@ -48,9 +48,11 @@ const fetchInventoryList = async (
         params.sortDescending,
         params.productName || undefined,
         params.productCode || undefined,
-        undefined // searchTerm
+        undefined, // searchTerm
+        undefined, // expirationFrom
+        undefined // expirationTo
       );
-      
+
       if (result.items) {
         allResults.push(...result.items);
       }
@@ -132,7 +134,9 @@ const fetchInventoryList = async (
       params.sortDescending,
       params.productName || undefined,
       params.productCode || undefined,
-      undefined // searchTerm
+      undefined, // searchTerm
+      undefined, // expirationFrom
+      undefined // expirationTo
     );
 
     return {

--- a/frontend/src/api/hooks/useManufactureInventory.ts
+++ b/frontend/src/api/hooks/useManufactureInventory.ts
@@ -15,6 +15,8 @@ export interface GetManufactureInventoryListRequest {
   sortDescending?: boolean;
   productName?: string;
   productCode?: string;
+  expirationFrom?: string;
+  expirationTo?: string;
 }
 
 export interface GetManufactureInventoryListResponse {
@@ -56,6 +58,8 @@ const fetchManufactureInventoryList = async (
     params.productName || undefined,
     params.productCode || undefined,
     undefined, // searchTerm
+    params.expirationFrom || undefined,
+    params.expirationTo || undefined,
   );
 
   return {
@@ -76,6 +80,8 @@ export const useManufactureInventoryQuery = (
   pageSize: number = 20,
   sortBy?: string,
   sortDescending: boolean = false,
+  expirationFromFilter?: string,
+  expirationToFilter?: string,
 ) => {
   const params: GetManufactureInventoryListRequest = {
     pageNumber,
@@ -85,6 +91,8 @@ export const useManufactureInventoryQuery = (
     sortDescending,
     productName: productNameFilter || undefined,
     productCode: productCodeFilter || undefined,
+    expirationFrom: expirationFromFilter || undefined,
+    expirationTo: expirationToFilter || undefined,
   };
 
   return useQuery({
@@ -99,6 +107,8 @@ export const useManufactureInventoryQuery = (
         pageSize,
         sortBy,
         sortDescending,
+        expirationFromFilter,
+        expirationToFilter,
       },
     ],
     queryFn: () => fetchManufactureInventoryList(params),

--- a/frontend/src/components/pages/ManufactureInventoryList.tsx
+++ b/frontend/src/components/pages/ManufactureInventoryList.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   Search,
   Filter,
@@ -34,6 +35,28 @@ const productTypeLabels: Record<ProductType, string> = {
   [ProductType.UNDEFINED]: "Nedefinováno",
 };
 
+// Expiration bucket boundaries - keep in sync with the "Expirace surovin" dashboard tile
+// (MaterialExpirationSummaryTile: SoonDays = 30, HorizonDays = 90).
+const EXPIRATION_SOON_DAYS = 30;
+const EXPIRATION_HORIZON_DAYS = 90;
+
+const startOfToday = (): Date => {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+};
+
+const addDays = (date: Date, days: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+// Format a Date to a local "yyyy-MM-dd" string (matches <input type="date"> values)
+const toIsoDate = (date: Date): string => {
+  const pad = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+};
+
 const ManufactureInventoryList: React.FC = () => {
   useScreenView('Manufacturing', 'ManufactureInventory');
 
@@ -47,6 +70,12 @@ const ManufactureInventoryList: React.FC = () => {
     ProductType.Material,
   );
 
+  // Expiration range filter - ISO "yyyy-MM-dd" strings (as produced by <input type="date">)
+  const [expirationFromInput, setExpirationFromInput] = useState("");
+  const [expirationToInput, setExpirationToInput] = useState("");
+  const [expirationFromFilter, setExpirationFromFilter] = useState("");
+  const [expirationToFilter, setExpirationToFilter] = useState("");
+
   // Pagination states
   const [pageNumber, setPageNumber] = useState(1);
   const [pageSize, setPageSize] = useState(20);
@@ -54,6 +83,9 @@ const ManufactureInventoryList: React.FC = () => {
   // Sorting states - default sort by lastInventoryDays descending
   const [sortBy, setSortBy] = useState<string>("lastInventoryDays");
   const [sortDescending, setSortDescending] = useState(true);
+
+  // Read initial sort from URL (e.g. when navigating from the material expiration dashboard tile)
+  const [searchParams] = useSearchParams();
 
   // Modal states
   const [selectedItem, setSelectedItem] = useState<CatalogItemDto | null>(null);
@@ -75,6 +107,8 @@ const ManufactureInventoryList: React.FC = () => {
     pageSize,
     sortBy,
     sortDescending,
+    expirationFromFilter,
+    expirationToFilter,
   );
 
   // Items are already filtered by the manufacture inventory hook
@@ -87,6 +121,8 @@ const ManufactureInventoryList: React.FC = () => {
   const handleApplyFilters = async () => {
     setProductNameFilter(productNameInput);
     setProductCodeFilter(productCodeInput);
+    setExpirationFromFilter(expirationFromInput);
+    setExpirationToFilter(expirationToInput);
     setPageNumber(1);
 
     await refetch();
@@ -106,9 +142,41 @@ const ManufactureInventoryList: React.FC = () => {
     setProductNameFilter("");
     setProductCodeFilter("");
     setProductTypeFilter(ProductType.Material);
+    setExpirationFromInput("");
+    setExpirationToInput("");
+    setExpirationFromFilter("");
+    setExpirationToFilter("");
     setPageNumber(1);
 
     await refetch();
+  };
+
+  // Prefill and apply an expiration range preset (dates as ISO "yyyy-MM-dd")
+  const applyExpirationPreset = (from: string, to: string) => {
+    setExpirationFromInput(from);
+    setExpirationToInput(to);
+    setExpirationFromFilter(from);
+    setExpirationToFilter(to);
+    setPageNumber(1);
+  };
+
+  // Expiration bucket presets - mirror the "Expirace surovin" dashboard tile boundaries
+  const handleExpiredPreset = () => {
+    // Everything up to and including yesterday = expired (expiration < today)
+    applyExpirationPreset("", toIsoDate(addDays(startOfToday(), -1)));
+  };
+
+  const handleWithin30Preset = () => {
+    const today = startOfToday();
+    applyExpirationPreset(toIsoDate(today), toIsoDate(addDays(today, EXPIRATION_SOON_DAYS)));
+  };
+
+  const handleWithin90Preset = () => {
+    const today = startOfToday();
+    applyExpirationPreset(
+      toIsoDate(addDays(today, EXPIRATION_SOON_DAYS + 1)),
+      toIsoDate(addDays(today, EXPIRATION_HORIZON_DAYS)),
+    );
   };
 
   // Sorting handler
@@ -137,6 +205,18 @@ const ManufactureInventoryList: React.FC = () => {
   React.useEffect(() => {
     setPageNumber(1);
   }, [productTypeFilter]);
+
+  // Seed sort state from URL query params (e.g. from the expiration dashboard tile)
+  React.useEffect(() => {
+    const sortByParam = searchParams.get("sortBy");
+    const sortDescParam = searchParams.get("sortDescending");
+    if (sortByParam) {
+      setSortBy(sortByParam);
+    }
+    if (sortDescParam !== null) {
+      setSortDescending(sortDescParam === "true");
+    }
+  }, [searchParams]);
 
   // Modal handlers
   const handleItemClick = (event: React.MouseEvent, item: CatalogItemDto) => {
@@ -312,6 +392,60 @@ const ManufactureInventoryList: React.FC = () => {
             </button>
           </div>
         </div>
+
+        {/* Expiration range filter */}
+        <div className="flex items-center flex-wrap gap-3 mt-3 pt-3 border-t border-gray-100 dark:border-graphite-border">
+          <span className="text-sm font-medium text-gray-900 dark:text-graphite-text">Expirace:</span>
+
+          <div className="flex items-center gap-2">
+            <label htmlFor="expirationFrom" className="text-sm text-gray-600 dark:text-graphite-muted whitespace-nowrap">
+              Od
+            </label>
+            <input
+              type="date"
+              id="expirationFrom"
+              value={expirationFromInput}
+              onChange={(e) => setExpirationFromInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="py-2 px-3 sm:text-sm border-gray-300 dark:border-graphite-border dark:bg-graphite-surface-2 dark:text-graphite-text rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label htmlFor="expirationTo" className="text-sm text-gray-600 dark:text-graphite-muted whitespace-nowrap">
+              Do
+            </label>
+            <input
+              type="date"
+              id="expirationTo"
+              value={expirationToInput}
+              onChange={(e) => setExpirationToInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="py-2 px-3 sm:text-sm border-gray-300 dark:border-graphite-border dark:bg-graphite-surface-2 dark:text-graphite-text rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleExpiredPreset}
+              className="px-3 py-2 text-sm font-medium rounded-md border border-red-300 text-red-700 hover:bg-red-50 dark:border-red-500/40 dark:text-red-300 dark:hover:bg-red-500/10 transition-colors"
+            >
+              Po expiraci
+            </button>
+            <button
+              onClick={handleWithin30Preset}
+              className="px-3 py-2 text-sm font-medium rounded-md border border-orange-300 text-orange-700 hover:bg-orange-50 dark:border-orange-500/40 dark:text-orange-300 dark:hover:bg-orange-500/10 transition-colors"
+            >
+              ≤ 30 dní
+            </button>
+            <button
+              onClick={handleWithin90Preset}
+              className="px-3 py-2 text-sm font-medium rounded-md border border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-500/40 dark:text-amber-300 dark:hover:bg-amber-500/10 transition-colors"
+            >
+              31–90 dní
+            </button>
+          </div>
+        </div>
       </div>
 
       {/* Data Grid - Scrollable */}
@@ -327,6 +461,7 @@ const ManufactureInventoryList: React.FC = () => {
                   Název materiálu
                 </SortableHeader>
                 <SortableHeader column="lastInventoryDays" align="center">Posl. Inventura</SortableHeader>
+                <SortableHeader column="expiration" align="center">Expirace</SortableHeader>
                 <SortableHeader column="available" align="center">Skladem</SortableHeader>
 
               </tr>
@@ -372,8 +507,21 @@ const ManufactureInventoryList: React.FC = () => {
                         <span className="text-gray-400 dark:text-graphite-faint text-sm">-</span>
                       )}
                     </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-center">
+                      {item.minimalExpiration ? (
+                        <span className="text-sm text-gray-700 dark:text-graphite-muted">
+                          {new Date(item.minimalExpiration).toLocaleDateString('cs-CZ', {
+                            day: '2-digit',
+                            month: '2-digit',
+                            year: 'numeric',
+                          })}
+                        </span>
+                      ) : (
+                        <span className="text-gray-400 dark:text-graphite-faint text-sm">-</span>
+                      )}
+                    </td>
                     <td className="px-6 py-5 whitespace-nowrap text-center">
-                      <span 
+                      <span
                         className="inline-flex items-center px-4 py-2 rounded-full text-base font-semibold bg-green-100 dark:bg-emerald-900/30 text-green-800 dark:text-emerald-300 justify-center inventory-badge hover:bg-green-200 dark:hover:bg-emerald-900/50 hover:text-green-900 dark:hover:text-emerald-200 cursor-pointer"
                       >
                         {available}


### PR DESCRIPTION
Adds a sortable **Expirace** column to *Zásoby materiálů* showing the earliest expiration across each material's available lots (`min` over in-stock lots), computed as a real `DateOnly` so both sorting and filtering are date-based, not string-based. Adds an **Expirace Od/Do** range filter with three preset buttons — *Po expiraci*, *≤ 30 dní*, *31–90 dní* — that mirror the "Expirace surovin" dashboard tile buckets; when a range is set, only materials that actually have an expiration are returned. The dashboard tile now drills down into this list pre-sorted by earliest expiration. Backend adds `MinimalExpiration` on the catalog aggregate/DTO plus `expiration` sort and `ExpirationFrom`/`ExpirationTo` filters on the catalog list endpoint (dates passed as ISO strings to avoid timezone drift); the TS client and its callers are updated accordingly. Covered by new backend tests (aggregate min-expiration, expiration sort ordering, range filtering, tile drill-down) with backend and frontend builds/tests green.