### PR TITLE
feat(meetings): meeting participants and review-state management

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/MeetingTasksController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/MeetingTasksController.cs
@@ -8,6 +8,7 @@ using Anela.Heblo.Application.Features.MeetingTasks.UseCases.SubmitToTodo;
 using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateMeetingAccess;
 using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
 using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateTranscriptStatus;
 using Anela.Heblo.Domain.Features.Authorization;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -75,6 +76,18 @@ public sealed class MeetingTasksController : BaseApiController
     {
         request.TranscriptId = transcriptId;
         request.TaskId = taskId;
+        var result = await _mediator.Send(request, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpPut("{transcriptId:guid}/status")]
+    [FeatureAuthorize(Feature.Anela_Meetings, AccessLevel.Write)]
+    public async Task<ActionResult<UpdateTranscriptStatusResponse>> UpdateStatus(
+        Guid transcriptId,
+        [FromBody] UpdateTranscriptStatusRequest request,
+        CancellationToken ct = default)
+    {
+        request.TranscriptId = transcriptId;
         var result = await _mediator.Send(request, ct);
         return HandleResponse(result);
     }

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Contracts/MeetingTranscriptDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Contracts/MeetingTranscriptDto.cs
@@ -16,6 +16,7 @@ public class MeetingTranscriptDto
     public int ApprovedTaskCount { get; set; }
     public int RejectedTaskCount { get; set; }
     public List<ProposedTaskDto> Tasks { get; set; } = new();
+    public List<string> Participants { get; set; } = new();
     public string AccessLevel { get; set; } = "Private";
     public List<MeetingAccessGrantDto> AccessGrants { get; set; } = new();
 }

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/ClaudeMeetingTaskExtractor.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/ClaudeMeetingTaskExtractor.cs
@@ -8,16 +8,18 @@ namespace Anela.Heblo.Application.Features.MeetingTasks.Services;
 public sealed class ClaudeMeetingTaskExtractor : IMeetingTaskExtractor
 {
     private const string BasePrompt = """
-        Jsi asistent, který z transkriptu schůzky extrahuje akční položky.
-        Z dodaného souhrnu a transkriptu schůzky extrahuj všechny akční položky.
-        Vrať POUZE JSON pole (bez dalšího textu) obsahující objekty s těmito poli:
-        - title: stručný název úkolu
-        - description: podrobný popis úkolu
-        - assignee: jméno osoby odpovědné za splnění (nebo prázdný řetězec)
-        - assigneeEmail: e-mail osoby ze seznamu známých uživatelů níže, pokud
-          jméno nebo přezdívku v transkriptu dokážeš spolehlivě přiřadit ke
-          konkrétnímu uživateli; jinak null
-        - dueDate: datum splnění ve formátu ISO 8601 (nebo null)
+        Jsi asistent, který z transkriptu schůzky extrahuje účastníky a akční položky.
+        Vrať POUZE JSON objekt (bez dalšího textu) s těmito poli:
+        - participants: pole jmen všech osob, které se schůzky zúčastnily (odvoď z
+          transkriptu; každé jméno uveď jen jednou, bez duplicit)
+        - tasks: pole akčních položek, kde každá položka má tato pole:
+          - title: stručný název úkolu
+          - description: podrobný popis úkolu
+          - assignee: jméno osoby odpovědné za splnění (nebo prázdný řetězec)
+          - assigneeEmail: e-mail osoby ze seznamu známých uživatelů níže, pokud
+            jméno nebo přezdívku v transkriptu dokážeš spolehlivě přiřadit ke
+            konkrétnímu uživateli; jinak null
+          - dueDate: datum splnění ve formátu ISO 8601 (nebo null)
         """;
 
     private const string NoUsersNote =
@@ -40,7 +42,7 @@ public sealed class ClaudeMeetingTaskExtractor : IMeetingTaskExtractor
         _logger = logger;
     }
 
-    public async Task<List<ExtractedTask>> ExtractAsync(
+    public async Task<MeetingExtractionResult> ExtractAsync(
         string summary,
         string transcript,
         CancellationToken ct = default)
@@ -60,27 +62,44 @@ public sealed class ClaudeMeetingTaskExtractor : IMeetingTaskExtractor
 
             try
             {
-                var result = JsonSerializer.Deserialize<List<ExtractedTask>>(text, JsonOptions) ?? [];
+                var payload = JsonSerializer.Deserialize<ExtractionPayload>(text, JsonOptions);
+                var tasks = payload?.Tasks ?? [];
+                var participants = NormalizeParticipants(payload?.Participants);
 
-                if (result.Count == 0)
+                if (tasks.Count == 0)
                 {
                     _logger.LogWarning("Meeting task extraction completed with no tasks — Claude returned an empty array");
                 }
 
-                return result;
+                return new MeetingExtractionResult(tasks, participants);
             }
             catch (JsonException ex)
             {
                 _logger.LogError(ex, "Meeting task extraction returned malformed JSON — transcript will be imported without tasks");
-                return [];
+                return new MeetingExtractionResult([], []);
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Meeting task extraction failed — transcript will be imported without tasks");
-            return [];
+            return new MeetingExtractionResult([], []);
         }
     }
+
+    private static List<string> NormalizeParticipants(List<string>? participants)
+    {
+        if (participants is null || participants.Count == 0)
+            return [];
+
+        return participants
+            .Select(p => p?.Trim())
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Select(p => p!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private sealed record ExtractionPayload(List<string>? Participants, List<ExtractedTask>? Tasks);
 
     private string BuildSystemPrompt()
     {

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/IMeetingTaskExtractor.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/IMeetingTaskExtractor.cs
@@ -7,7 +7,9 @@ public record ExtractedTask(
     DateTime? DueDate,
     string? AssigneeEmail = null);
 
+public record MeetingExtractionResult(List<ExtractedTask> Tasks, List<string> Participants);
+
 public interface IMeetingTaskExtractor
 {
-    Task<List<ExtractedTask>> ExtractAsync(string summary, string transcript, CancellationToken ct = default);
+    Task<MeetingExtractionResult> ExtractAsync(string summary, string transcript, CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/GetTranscriptDetail/GetTranscriptDetailHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/GetTranscriptDetail/GetTranscriptDetailHandler.cs
@@ -68,6 +68,7 @@ public class GetTranscriptDetailHandler : IRequestHandler<GetTranscriptDetailReq
                 ExternalTaskId = t.ExternalTaskId,
                 IsManuallyAdded = t.IsManuallyAdded
             }).ToList(),
+            Participants = transcript.Participants,
             AccessLevel = transcript.AccessLevel.ToString(),
             AccessGrants = transcript.AccessGrants.Select(g => new MeetingAccessGrantDto
             {

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/IngestPlaudRecording/IngestPlaudRecordingHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/IngestPlaudRecording/IngestPlaudRecordingHandler.cs
@@ -51,8 +51,8 @@ public sealed class IngestPlaudRecordingHandler : IRequestHandler<IngestPlaudRec
         var transcript = await _plaudClient.GetTranscriptAsync(request.PlaudRecordingId, cancellationToken);
         var summaryResult = await _plaudClient.GetSummaryAsync(request.PlaudRecordingId, cancellationToken);
 
-        // Extract tasks using the meeting task extractor
-        var extractedTasks = await _extractor.ExtractAsync(summaryResult.MarkdownContent, transcript, cancellationToken);
+        // Extract tasks and participants using the meeting task extractor
+        var extraction = await _extractor.ExtractAsync(summaryResult.MarkdownContent, transcript, cancellationToken);
 
         // Prefer the human-set recording name; fall back to the summary headline
         var subject = !string.IsNullOrWhiteSpace(request.Name)
@@ -71,7 +71,8 @@ public sealed class IngestPlaudRecordingHandler : IRequestHandler<IngestPlaudRec
             RawTranscript = transcript,
             Status = MeetingTranscriptStatus.PendingReview,
             ReceivedAt = DateTime.UtcNow,
-            Tasks = extractedTasks
+            Participants = extraction.Participants,
+            Tasks = extraction.Tasks
                 .Select(t => new ProposedTask
                 {
                     Id = Guid.NewGuid(),

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/ReimportMeetingTranscript/ReimportMeetingTranscriptHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/ReimportMeetingTranscript/ReimportMeetingTranscriptHandler.cs
@@ -88,8 +88,9 @@ public sealed class ReimportMeetingTranscriptHandler
             transcript.Subject = summaryResult.Headline;
         // else: leave transcript.Subject unchanged
 
-        var extractedTasks = await _extractor.ExtractAsync(summaryResult.MarkdownContent, rawTranscript, cancellationToken);
-        var newTasks = extractedTasks
+        var extraction = await _extractor.ExtractAsync(summaryResult.MarkdownContent, rawTranscript, cancellationToken);
+        transcript.Participants = extraction.Participants;
+        var newTasks = extraction.Tasks
             .Select(t => new ProposedTask
             {
                 Id = Guid.NewGuid(),

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateTranscriptStatus/UpdateTranscriptStatusHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateTranscriptStatus/UpdateTranscriptStatusHandler.cs
@@ -1,0 +1,84 @@
+using Anela.Heblo.Application.Features.MeetingTasks.Services;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateTranscriptStatus;
+
+public class UpdateTranscriptStatusHandler : IRequestHandler<UpdateTranscriptStatusRequest, UpdateTranscriptStatusResponse>
+{
+    // The manual review toggle only moves between these two states. PartiallyApproved is a
+    // derived outcome of the submit-to-todo flow and cannot be set directly by the user.
+    private static readonly MeetingTranscriptStatus[] ManualStatuses =
+    {
+        MeetingTranscriptStatus.PendingReview,
+        MeetingTranscriptStatus.Approved,
+    };
+
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly IMeetingAccessGuard _accessGuard;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<UpdateTranscriptStatusHandler> _logger;
+
+    public UpdateTranscriptStatusHandler(
+        IMeetingTranscriptRepository repository,
+        IMeetingAccessGuard accessGuard,
+        ICurrentUserService currentUserService,
+        ILogger<UpdateTranscriptStatusHandler> logger)
+    {
+        _repository = repository;
+        _accessGuard = accessGuard;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<UpdateTranscriptStatusResponse> Handle(UpdateTranscriptStatusRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Updating meeting transcript status — TranscriptId: {TranscriptId}, Status: {Status}",
+            request.TranscriptId, request.Status);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new UpdateTranscriptStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        if (!_accessGuard.CanAccess(transcript))
+        {
+            _logger.LogWarning("Access denied to meeting transcript {TranscriptId} for current user", request.TranscriptId);
+            return new UpdateTranscriptStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        if (!Enum.TryParse<MeetingTranscriptStatus>(request.Status, ignoreCase: true, out var status)
+            || !ManualStatuses.Contains(status))
+        {
+            _logger.LogWarning("Invalid meeting transcript status value: {Status}", request.Status);
+            return new UpdateTranscriptStatusResponse(ErrorCodes.ValidationError,
+                new Dictionary<string, string> { ["status"] = $"Unknown or non-toggleable status: {request.Status}" });
+        }
+
+        transcript.Status = status;
+        if (status == MeetingTranscriptStatus.Approved)
+        {
+            transcript.ReviewedAt = DateTime.UtcNow;
+            transcript.ReviewedByUser = _currentUserService.GetCurrentUser().Email ?? string.Empty;
+        }
+        else
+        {
+            transcript.ReviewedAt = null;
+            transcript.ReviewedByUser = null;
+        }
+
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Meeting transcript status updated — TranscriptId: {TranscriptId}, Status: {Status}",
+            request.TranscriptId, status);
+
+        return new UpdateTranscriptStatusResponse { Status = status.ToString() };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateTranscriptStatus/UpdateTranscriptStatusRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateTranscriptStatus/UpdateTranscriptStatusRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateTranscriptStatus;
+
+public class UpdateTranscriptStatusRequest : IRequest<UpdateTranscriptStatusResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public string Status { get; set; } = null!;
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateTranscriptStatus/UpdateTranscriptStatusResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateTranscriptStatus/UpdateTranscriptStatusResponse.cs
@@ -1,0 +1,13 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateTranscriptStatus;
+
+public class UpdateTranscriptStatusResponse : BaseResponse
+{
+    public string? Status { get; set; }
+
+    public UpdateTranscriptStatusResponse() { }
+    public UpdateTranscriptStatusResponse(ErrorCodes errorCode) : base(errorCode) { }
+    public UpdateTranscriptStatusResponse(ErrorCodes errorCode, Dictionary<string, string> parameters)
+        : base(errorCode, parameters) { }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscript.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscript.cs
@@ -13,6 +13,7 @@ public class MeetingTranscript
     public DateTime? ReviewedAt { get; set; }
     public string? ReviewedByUser { get; set; }
     public List<ProposedTask> Tasks { get; set; } = new();
+    public List<string> Participants { get; set; } = new();
     public MeetingAccessLevel AccessLevel { get; set; } = MeetingAccessLevel.Private;
     public List<MeetingAccessGrant> AccessGrants { get; set; } = new();
 }

--- a/backend/src/Anela.Heblo.Persistence/MeetingTasks/MeetingTranscriptConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/MeetingTasks/MeetingTranscriptConfiguration.cs
@@ -1,12 +1,19 @@
+using System.Text.Json;
 using Anela.Heblo.Domain.Features.MeetingTasks;
 using Anela.Heblo.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Anela.Heblo.Persistence.MeetingTasks;
 
 public class MeetingTranscriptConfiguration : IEntityTypeConfiguration<MeetingTranscript>
 {
+    private static readonly ValueComparer<List<string>> ParticipantsComparer = new(
+        (a, b) => (a ?? new List<string>()).SequenceEqual(b ?? new List<string>()),
+        v => v == null ? 0 : v.Aggregate(0, (hash, item) => HashCode.Combine(hash, item.GetHashCode())),
+        v => v == null ? new List<string>() : v.ToList());
+
     public void Configure(EntityTypeBuilder<MeetingTranscript> builder)
     {
         builder.ToTable("MeetingTranscripts", "public");
@@ -52,6 +59,13 @@ public class MeetingTranscriptConfiguration : IEntityTypeConfiguration<MeetingTr
             .WithOne(x => x.MeetingTranscript)
             .HasForeignKey(x => x.MeetingTranscriptId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property(x => x.Participants)
+            .HasColumnType("jsonb")
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+                v => JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>())
+            .Metadata.SetValueComparer(ParticipantsComparer);
 
         builder.Property(x => x.AccessLevel)
             .IsRequired()

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260714103910_AddMeetingParticipants.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260714103910_AddMeetingParticipants.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714103910_AddMeetingParticipants")]
+    partial class AddMeetingParticipants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260714103910_AddMeetingParticipants.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260714103910_AddMeetingParticipants.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMeetingParticipants : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Participants",
+                schema: "public",
+                table: "MeetingTranscripts",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "[]");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Participants",
+                schema: "public",
+                table: "MeetingTranscripts");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/ClaudeMeetingTaskExtractorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/ClaudeMeetingTaskExtractorTests.cs
@@ -37,33 +37,55 @@ public sealed class ClaudeMeetingTaskExtractorTests
             .ReturnsAsync(chatResponse);
     }
 
+    private static string EmptyPayload => """{"participants":[],"tasks":[]}""";
+
     [Fact]
     public async Task ExtractAsync_WithValidJsonResponse_ReturnsParsedTasks()
     {
-        SetupResponse("""[{"title":"Meeting Action","description":"Follow up","assignee":"John","assigneeEmail":null,"dueDate":"2026-06-01"}]""");
+        SetupResponse("""{"participants":["John","Jane"],"tasks":[{"title":"Meeting Action","description":"Follow up","assignee":"John","assigneeEmail":null,"dueDate":"2026-06-01"}]}""");
 
         var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
-        result.Should().HaveCount(1);
-        result[0].Title.Should().Be("Meeting Action");
-        result[0].Assignee.Should().Be("John");
-        result[0].AssigneeEmail.Should().BeNull();
+        result.Tasks.Should().HaveCount(1);
+        result.Tasks[0].Title.Should().Be("Meeting Action");
+        result.Tasks[0].Assignee.Should().Be("John");
+        result.Tasks[0].AssigneeEmail.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ParsesParticipants()
+    {
+        SetupResponse("""{"participants":["John","Jane"],"tasks":[]}""");
+
+        var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
+
+        result.Participants.Should().Equal("John", "Jane");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NormalizesParticipants_TrimsBlanksAndDeduplicates()
+    {
+        SetupResponse("""{"participants":["John"," John ","","Jane"],"tasks":[]}""");
+
+        var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
+
+        result.Participants.Should().Equal("John", "Jane");
     }
 
     [Fact]
     public async Task ExtractAsync_ParsesAssigneeEmailWhenLlmMatchesUser()
     {
-        SetupResponse("""[{"title":"T","description":"D","assignee":"Andrea Nováková","assigneeEmail":"andrea@anela.cz","dueDate":null}]""");
+        SetupResponse("""{"participants":["Andrea Nováková"],"tasks":[{"title":"T","description":"D","assignee":"Andrea Nováková","assigneeEmail":"andrea@anela.cz","dueDate":null}]}""");
 
         var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
-        result[0].AssigneeEmail.Should().Be("andrea@anela.cz");
+        result.Tasks[0].AssigneeEmail.Should().Be("andrea@anela.cz");
     }
 
     [Fact]
     public async Task ExtractAsync_IncludesDirectoryUsersInPrompt()
     {
-        SetupResponse("[]");
+        SetupResponse(EmptyPayload);
 
         await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
@@ -75,7 +97,7 @@ public sealed class ClaudeMeetingTaskExtractorTests
     }
 
     [Fact]
-    public async Task ExtractAsync_WhenChatClientThrows_ReturnsEmptyList()
+    public async Task ExtractAsync_WhenChatClientThrows_ReturnsEmptyResult()
     {
         _mockChatClient
             .Setup(x => x.GetResponseAsync(
@@ -86,18 +108,20 @@ public sealed class ClaudeMeetingTaskExtractorTests
 
         var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
-        result.Should().BeEmpty();
+        result.Tasks.Should().BeEmpty();
+        result.Participants.Should().BeEmpty();
     }
 
     [Fact]
     public async Task ExtractAsync_WithMarkdownWrappedJson_StripsFenceAndParses()
     {
-        SetupResponse("```json\n[{\"title\":\"Action\",\"description\":\"Do it\",\"assignee\":\"Bob\",\"assigneeEmail\":null,\"dueDate\":null}]\n```");
+        SetupResponse("```json\n{\"participants\":[\"Bob\"],\"tasks\":[{\"title\":\"Action\",\"description\":\"Do it\",\"assignee\":\"Bob\",\"assigneeEmail\":null,\"dueDate\":null}]}\n```");
 
         var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
-        result.Should().HaveCount(1);
-        result[0].Title.Should().Be("Action");
+        result.Tasks.Should().HaveCount(1);
+        result.Tasks[0].Title.Should().Be("Action");
+        result.Participants.Should().Equal("Bob");
     }
 
     [Fact]
@@ -110,7 +134,7 @@ public sealed class ClaudeMeetingTaskExtractorTests
                 It.IsAny<ChatOptions?>(),
                 It.IsAny<CancellationToken>()))
             .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>((_, opts, _) => capturedOptions = opts)
-            .ReturnsAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, "[]")]));
+            .ReturnsAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, EmptyPayload)]));
 
         await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
@@ -130,7 +154,8 @@ public sealed class ClaudeMeetingTaskExtractorTests
 
         var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
-        result.Should().BeEmpty();
+        result.Tasks.Should().BeEmpty();
+        result.Participants.Should().BeEmpty();
         _mockLogger.Verify(
             x => x.Log(
                 LogLevel.Error,
@@ -142,13 +167,13 @@ public sealed class ClaudeMeetingTaskExtractorTests
     }
 
     [Fact]
-    public async Task ExtractAsync_WhenResponseIsEmptyArray_LogsWarningAndReturnsEmpty()
+    public async Task ExtractAsync_WhenResponseHasNoTasks_LogsWarningAndReturnsEmptyTasks()
     {
-        SetupResponse("[]");
+        SetupResponse(EmptyPayload);
 
         var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
-        result.Should().BeEmpty();
+        result.Tasks.Should().BeEmpty();
         _mockLogger.Verify(
             x => x.Log(
                 LogLevel.Warning,
@@ -171,7 +196,7 @@ public sealed class ClaudeMeetingTaskExtractorTests
 
         var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
 
-        result.Should().BeEmpty();
+        result.Tasks.Should().BeEmpty();
         _mockLogger.Verify(
             x => x.Log(
                 LogLevel.Error,

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/IngestPlaudRecordingHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/IngestPlaudRecordingHandlerTests.cs
@@ -74,7 +74,7 @@ public sealed class IngestPlaudRecordingHandlerTests
 
         _mockExtractor
             .Setup(e => e.ExtractAsync(summary, transcript, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(extractedTasks);
+            .ReturnsAsync(new MeetingExtractionResult(extractedTasks, new List<string> { "Alice", "Bob" }));
 
         _mockRepository
             .Setup(r => r.AddAsync(It.IsAny<MeetingTranscript>(), It.IsAny<CancellationToken>()))
@@ -98,6 +98,7 @@ public sealed class IngestPlaudRecordingHandlerTests
                     t.PlaudRecordingId == recordingId &&
                     t.Status == MeetingTranscriptStatus.PendingReview &&
                     t.Tasks.Count == 2 &&
+                    t.Participants.SequenceEqual(new[] { "Alice", "Bob" }) &&
                     t.Tasks.All(task => task.MeetingTranscriptId == t.Id && task.Status == ProposedTaskStatus.Pending && !task.IsManuallyAdded)),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -178,7 +179,7 @@ public sealed class IngestPlaudRecordingHandlerTests
 
         _mockExtractor
             .Setup(e => e.ExtractAsync(summary, transcript, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
 
         _mockRepository
             .Setup(r => r.AddAsync(It.IsAny<MeetingTranscript>(), It.IsAny<CancellationToken>()))
@@ -226,10 +227,12 @@ public sealed class IngestPlaudRecordingHandlerTests
             .ReturnsAsync(new PlaudSummaryResult("Headline", "summary"));
         _mockExtractor
             .Setup(e => e.ExtractAsync("summary", "transcript", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>
-            {
-                new("Task", "Desc", "Andy", null, AssigneeEmail: null)
-            });
+            .ReturnsAsync(new MeetingExtractionResult(
+                new List<ExtractedTask>
+                {
+                    new("Task", "Desc", "Andy", null, AssigneeEmail: null)
+                },
+                new List<string>()));
         _mockDirectory
             .Setup(d => d.Resolve("Andy"))
             .Returns(new MeetingUser("andrea@anela.cz", "Andrea Nováková", new[] { "Andy" }));
@@ -309,7 +312,7 @@ public sealed class IngestPlaudRecordingHandlerTests
             .ReturnsAsync(new PlaudSummaryResult("2026-05-18 10:25:12", "summary"));
         _mockExtractor
             .Setup(e => e.ExtractAsync("summary", "transcript", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
 
         MeetingTranscript? saved = null;
         _mockRepository
@@ -353,7 +356,7 @@ public sealed class IngestPlaudRecordingHandlerTests
             .ReturnsAsync(new PlaudSummaryResult("Generated Meeting Title", "summary"));
         _mockExtractor
             .Setup(e => e.ExtractAsync("summary", "transcript", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
 
         MeetingTranscript? saved = null;
         _mockRepository
@@ -397,7 +400,7 @@ public sealed class IngestPlaudRecordingHandlerTests
             .ReturnsAsync(new PlaudSummaryResult("Generated Meeting Title", "summary"));
         _mockExtractor
             .Setup(e => e.ExtractAsync("summary", "transcript", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
 
         MeetingTranscript? saved = null;
         _mockRepository

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/ReimportMeetingTranscriptHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/ReimportMeetingTranscriptHandlerTests.cs
@@ -136,7 +136,7 @@ public sealed class ReimportMeetingTranscriptHandlerTests
 
         _mockExtractor
             .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
 
         _mockRepository
             .Setup(r => r.ReplacePendingTasksAsync(It.IsAny<MeetingTranscript>(), It.IsAny<IReadOnlyList<ProposedTask>>(), It.IsAny<CancellationToken>()))
@@ -192,7 +192,7 @@ public sealed class ReimportMeetingTranscriptHandlerTests
 
         _mockExtractor
             .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
 
         _mockRepository
             .Setup(r => r.ReplacePendingTasksAsync(It.IsAny<MeetingTranscript>(), It.IsAny<IReadOnlyList<ProposedTask>>(), It.IsAny<CancellationToken>()))
@@ -277,10 +277,12 @@ public sealed class ReimportMeetingTranscriptHandlerTests
 
         _mockExtractor
             .Setup(e => e.ExtractAsync("New summary", "New transcript", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>
-            {
-                new("New Task 1", "Description 1", "Ondra", null, "ondra@anela.cz")
-            });
+            .ReturnsAsync(new MeetingExtractionResult(
+                new List<ExtractedTask>
+                {
+                    new("New Task 1", "Description 1", "Ondra", null, "ondra@anela.cz")
+                },
+                new List<string> { "Ondra", "Petra" }));
 
         IReadOnlyList<ProposedTask>? capturedNewTasks = null;
         _mockRepository
@@ -302,6 +304,7 @@ public sealed class ReimportMeetingTranscriptHandlerTests
         capturedNewTasks.Single().Status.Should().Be(ProposedTaskStatus.Pending);
         capturedNewTasks.Single().IsManuallyAdded.Should().BeFalse();
         capturedNewTasks.Should().NotContain(t => t.Id == approvedTask.Id);
+        entity.Participants.Should().Equal("Ondra", "Petra");
     }
 
     [Fact]
@@ -333,7 +336,7 @@ public sealed class ReimportMeetingTranscriptHandlerTests
             .ReturnsAsync(new PlaudSummaryResult("Headline", "Summary"));
         _mockExtractor
             .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
 
         IReadOnlyList<ProposedTask>? capturedNewTasks = null;
         _mockRepository
@@ -381,10 +384,12 @@ public sealed class ReimportMeetingTranscriptHandlerTests
             .ReturnsAsync(new PlaudSummaryResult("Headline", "Summary"));
         _mockExtractor
             .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>
-            {
-                new("Task", "Desc", "Andy", null, AssigneeEmail: null)
-            });
+            .ReturnsAsync(new MeetingExtractionResult(
+                new List<ExtractedTask>
+                {
+                    new("Task", "Desc", "Andy", null, AssigneeEmail: null)
+                },
+                new List<string>()));
         _mockDirectory
             .Setup(d => d.Resolve("Andy"))
             .Returns(new MeetingUser("andrea@anela.cz", "Andrea Pajgrt Bartošová", new[] { "Andy" }));
@@ -441,7 +446,7 @@ public sealed class ReimportMeetingTranscriptHandlerTests
             });
         _mockExtractor
             .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
         _mockRepository
             .Setup(r => r.ReplacePendingTasksAsync(It.IsAny<MeetingTranscript>(), It.IsAny<IReadOnlyList<ProposedTask>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -494,7 +499,7 @@ public sealed class ReimportMeetingTranscriptHandlerTests
             });
         _mockExtractor
             .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
         _mockRepository
             .Setup(r => r.ReplacePendingTasksAsync(It.IsAny<MeetingTranscript>(), It.IsAny<IReadOnlyList<ProposedTask>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -543,7 +548,7 @@ public sealed class ReimportMeetingTranscriptHandlerTests
             .ThrowsAsync(new HttpRequestException("Plaud API unavailable"));
         _mockExtractor
             .Setup(e => e.ExtractAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ExtractedTask>());
+            .ReturnsAsync(new MeetingExtractionResult(new List<ExtractedTask>(), new List<string>()));
         _mockRepository
             .Setup(r => r.ReplacePendingTasksAsync(It.IsAny<MeetingTranscript>(), It.IsAny<IReadOnlyList<ProposedTask>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateTranscriptStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateTranscriptStatusHandlerTests.cs
@@ -1,0 +1,174 @@
+using Anela.Heblo.Application.Features.MeetingTasks.Services;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateTranscriptStatus;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.MeetingTasks;
+
+public sealed class UpdateTranscriptStatusHandlerTests
+{
+    private readonly Mock<IMeetingTranscriptRepository> _mockRepository;
+    private readonly Mock<IMeetingAccessGuard> _mockAccessGuard;
+    private readonly Mock<ICurrentUserService> _mockCurrentUser;
+    private readonly Mock<ILogger<UpdateTranscriptStatusHandler>> _mockLogger;
+    private readonly UpdateTranscriptStatusHandler _handler;
+
+    public UpdateTranscriptStatusHandlerTests()
+    {
+        _mockRepository = new Mock<IMeetingTranscriptRepository>();
+        _mockAccessGuard = new Mock<IMeetingAccessGuard>();
+        _mockCurrentUser = new Mock<ICurrentUserService>();
+        _mockLogger = new Mock<ILogger<UpdateTranscriptStatusHandler>>();
+
+        _mockAccessGuard.Setup(g => g.CanAccess(It.IsAny<MeetingTranscript>())).Returns(true);
+        _mockCurrentUser
+            .Setup(c => c.GetCurrentUser())
+            .Returns(new CurrentUser("id-1", "Ondra", "ondra@anela.cz", true));
+
+        _handler = new UpdateTranscriptStatusHandler(
+            _mockRepository.Object,
+            _mockAccessGuard.Object,
+            _mockCurrentUser.Object,
+            _mockLogger.Object);
+    }
+
+    private MeetingTranscript SetupTranscript(MeetingTranscriptStatus status, out Guid id)
+    {
+        id = Guid.NewGuid();
+        var entity = new MeetingTranscript
+        {
+            Id = id,
+            PlaudRecordingId = "rec_1",
+            Subject = "Subject",
+            Summary = "Summary",
+            RawTranscript = "Transcript",
+            Status = status,
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(entity.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+        _mockRepository
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        return entity;
+    }
+
+    [Fact]
+    public async Task Handle_WhenMovingToApproved_SetsStatusAndReviewMetadata()
+    {
+        // Arrange
+        var entity = SetupTranscript(MeetingTranscriptStatus.PendingReview, out var id);
+
+        // Act
+        var response = await _handler.Handle(
+            new UpdateTranscriptStatusRequest { TranscriptId = id, Status = "Approved" },
+            CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.Status.Should().Be("Approved");
+        entity.Status.Should().Be(MeetingTranscriptStatus.Approved);
+        entity.ReviewedAt.Should().NotBeNull();
+        entity.ReviewedByUser.Should().Be("ondra@anela.cz");
+        _mockRepository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenMovingBackToPendingReview_ClearsReviewMetadata()
+    {
+        // Arrange
+        var entity = SetupTranscript(MeetingTranscriptStatus.Approved, out var id);
+        entity.ReviewedAt = DateTime.UtcNow;
+        entity.ReviewedByUser = "ondra@anela.cz";
+
+        // Act
+        var response = await _handler.Handle(
+            new UpdateTranscriptStatusRequest { TranscriptId = id, Status = "PendingReview" },
+            CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.Status.Should().Be("PendingReview");
+        entity.Status.Should().Be(MeetingTranscriptStatus.PendingReview);
+        entity.ReviewedAt.Should().BeNull();
+        entity.ReviewedByUser.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenStatusIsPartiallyApproved_ReturnsValidationError()
+    {
+        // Arrange
+        var entity = SetupTranscript(MeetingTranscriptStatus.PendingReview, out var id);
+
+        // Act
+        var response = await _handler.Handle(
+            new UpdateTranscriptStatusRequest { TranscriptId = id, Status = "PartiallyApproved" },
+            CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        entity.Status.Should().Be(MeetingTranscriptStatus.PendingReview);
+        _mockRepository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenStatusIsUnknown_ReturnsValidationError()
+    {
+        // Arrange
+        SetupTranscript(MeetingTranscriptStatus.PendingReview, out var id);
+
+        // Act
+        var response = await _handler.Handle(
+            new UpdateTranscriptStatusRequest { TranscriptId = id, Status = "Nonsense" },
+            CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        _mockRepository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenMeetingNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MeetingTranscript?)null);
+
+        // Act
+        var response = await _handler.Handle(
+            new UpdateTranscriptStatusRequest { TranscriptId = id, Status = "Approved" },
+            CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAccessDenied_ReturnsNotFound()
+    {
+        // Arrange
+        var entity = SetupTranscript(MeetingTranscriptStatus.PendingReview, out var id);
+        _mockAccessGuard.Setup(g => g.CanAccess(entity)).Returns(false);
+
+        // Act
+        var response = await _handler.Handle(
+            new UpdateTranscriptStatusRequest { TranscriptId = id, Status = "Approved" },
+            CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        _mockRepository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/frontend/src/api/hooks/useMeetingTasks.ts
+++ b/frontend/src/api/hooks/useMeetingTasks.ts
@@ -40,6 +40,7 @@ export interface MeetingTranscriptDto {
   approvedTaskCount: number;
   rejectedTaskCount: number;
   tasks: ProposedTaskDto[];
+  participants: string[];
   accessLevel: 'Private' | 'Public' | 'Restricted';
   accessGrants: MeetingAccessGrantDto[];
 }
@@ -226,6 +227,30 @@ export function useUpdateProposedTaskStatus() {
     mutationFn: async (input: UpdateProposedTaskStatusInput) =>
       fetchJson<{ success: boolean }>(
         `/api/meeting-tasks/${encodeURIComponent(input.transcriptId)}/tasks/${encodeURIComponent(input.taskId)}/status`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ status: input.status }),
+        },
+      ),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: MEETING_TASKS_KEYS.detail(vars.transcriptId) });
+      qc.invalidateQueries({ queryKey: MEETING_TASKS_KEYS.list });
+    },
+  });
+}
+
+export interface UpdateTranscriptStatusInput {
+  transcriptId: string;
+  status: TranscriptStatus;
+}
+
+export function useUpdateTranscriptStatus() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: UpdateTranscriptStatusInput) =>
+      fetchJson<{ success: boolean }>(
+        `/api/meeting-tasks/${encodeURIComponent(input.transcriptId)}/status`,
         {
           method: "PUT",
           headers: { "Content-Type": "application/json", Accept: "application/json" },

--- a/frontend/src/components/pages/automation/MeetingReviewLeaveDialog.tsx
+++ b/frontend/src/components/pages/automation/MeetingReviewLeaveDialog.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { AlertTriangle, X } from "lucide-react";
+
+interface MeetingReviewLeaveDialogProps {
+  isOpen: boolean;
+  isSaving: boolean;
+  /** Mark the meeting as reviewed ("Schváleno") and then leave. */
+  onSave: () => void;
+  /** Leave without changing the status — it stays "Ke kontrole". */
+  onDiscard: () => void;
+  /** Stay on the detail page. */
+  onKeepEditing: () => void;
+}
+
+/**
+ * Shown when the user tries to leave a meeting detail that is still "Ke kontrole".
+ * Offers to mark it reviewed, leave it as-is, or stay. Mirrors the shape of the
+ * shared UnsavedChangesDialog so it can be driven by `useUnsavedChangesDialog`.
+ */
+const MeetingReviewLeaveDialog: React.FC<MeetingReviewLeaveDialogProps> = ({
+  isOpen,
+  isSaving,
+  onSave,
+  onDiscard,
+  onKeepEditing,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        onClick={isSaving ? undefined : onKeepEditing}
+      />
+
+      {/* Dialog */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div className="relative bg-white dark:bg-graphite-surface rounded-lg shadow-xl dark:shadow-soft-dark max-w-md w-full p-6">
+          {/* Close button */}
+          <button
+            onClick={onKeepEditing}
+            className="absolute top-4 right-4 text-gray-400 dark:text-graphite-faint hover:text-gray-600 dark:hover:text-graphite-muted"
+            aria-label="Zavřít"
+          >
+            <X className="h-5 w-5" />
+          </button>
+
+          {/* Icon */}
+          <div className="flex items-center justify-center w-12 h-12 mx-auto bg-yellow-100 dark:bg-amber-900/30 rounded-full mb-4">
+            <AlertTriangle className="h-6 w-6 text-yellow-600 dark:text-amber-400" />
+          </div>
+
+          {/* Title */}
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-graphite-text text-center mb-2">
+            Porada je stále ke kontrole
+          </h3>
+
+          {/* Message */}
+          <div className="text-sm text-gray-600 dark:text-graphite-muted text-center mb-6">
+            <p>Chcete ji před odchodem označit jako schválenou?</p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-col gap-3">
+            <button
+              onClick={onSave}
+              disabled={isSaving}
+              className="w-full px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors disabled:opacity-50"
+            >
+              {isSaving ? "Ukládání…" : "Označit jako schváleno a odejít"}
+            </button>
+            <button
+              onClick={onDiscard}
+              disabled={isSaving}
+              className="w-full px-4 py-2 text-sm font-medium text-gray-700 dark:text-graphite-muted bg-white dark:bg-graphite-surface-2 border border-gray-300 dark:border-graphite-border rounded-md hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-50"
+            >
+              Nechat ke kontrole a odejít
+            </button>
+            <button
+              onClick={onKeepEditing}
+              disabled={isSaving}
+              className="w-full px-4 py-2 text-sm font-medium text-gray-700 dark:text-graphite-muted bg-white dark:bg-graphite-surface-2 border border-gray-300 dark:border-graphite-border rounded-md hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-50"
+            >
+              Zůstat
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MeetingReviewLeaveDialog;

--- a/frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx
+++ b/frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import {
   ArrowLeft, Check, X, Plus, Send, CheckCheck, Clock, CheckCircle, CheckCircle2,
-  ChevronDown, ChevronRight, AlertTriangle, RefreshCw, Download,
+  ChevronDown, ChevronRight, AlertTriangle, RefreshCw, Download, Undo2,
 } from "lucide-react";
 import {
   MeetingUserDto,
@@ -20,8 +20,12 @@ import {
   useSubmitToTodo,
   useUpdateProposedTask,
   useUpdateProposedTaskStatus,
+  useUpdateTranscriptStatus,
 } from "../../../api/hooks/useMeetingTasks";
+import { useUnsavedChangesDialog } from "../../../hooks/useUnsavedChangesDialog";
+import MeetingReviewLeaveDialog from "./MeetingReviewLeaveDialog";
 import { usePermissionsContext } from '../../../auth/PermissionsContext';
+import { useAuth } from '../../../auth/useAuth';
 import { useExplainSelection } from './explain/useExplainSelection';
 import { ExplainTooltip } from './explain/ExplainTooltip';
 import { ExplainModal } from './explain/ExplainModal';
@@ -90,8 +94,22 @@ const MeetingTaskDetailPage: React.FC = () => {
   const detail = useMeetingTaskDetail(id);
   const updateTask = useUpdateProposedTask();
   const updateStatus = useUpdateProposedTaskStatus();
+  const updateTranscriptStatus = useUpdateTranscriptStatus();
   const addTask = useAddProposedTask();
   const submitToTodo = useSubmitToTodo();
+
+  // Review-state leave guard: while a meeting is still "Ke kontrole" (PendingReview),
+  // leaving the detail prompts the user to mark it reviewed, leave it as-is, or stay.
+  const isPendingReview = detail.data?.transcript?.status === "PendingReview";
+  const markReviewed = async (): Promise<boolean> => {
+    try {
+      await updateTranscriptStatus.mutateAsync({ transcriptId: id, status: "Approved" });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const { dialogProps, requestNavigation } = useUnsavedChangesDialog(!!isPendingReview, markReviewed);
 
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<TaskFormData>(EMPTY_FORM);
@@ -106,6 +124,9 @@ const MeetingTaskDetailPage: React.FC = () => {
   const [reimportError, setReimportError] = useState<string | null>(null);
   const { hasPermission } = usePermissionsContext();
   const isMeetingManager = hasPermission('anela.meetings.write');
+  const { account } = useAuth();
+  const currentUserEmail = (account?.username ?? "").toLowerCase();
+  const [assigneeFilter, setAssigneeFilter] = useState<string | null>(null);
 
   const explainSelection = useExplainSelection();
   const explainMutation = useExplainMeetingSummary();
@@ -145,6 +166,22 @@ const MeetingTaskDetailPage: React.FC = () => {
   const tasks: ProposedTaskDto[] = transcript.tasks;
   const pendingTasks = tasks.filter((t) => t.status === "Pending");
   const approvedCount = tasks.filter((t) => t.status === "Approved").length;
+
+  // Distinct assignees present on the tasks, used to populate the person filter.
+  const assigneeFilterKey = (t: ProposedTaskDto) => (t.assigneeEmail ?? t.assignee ?? "").trim();
+  const assigneeOptions = Array.from(
+    tasks.reduce((map, t) => {
+      const key = assigneeFilterKey(t);
+      if (key && !map.has(key)) map.set(key, t.assignee || key);
+      return map;
+    }, new Map<string, string>()),
+    ([value, label]) => ({ value, label }),
+  );
+  const isMineActive =
+    currentUserEmail !== "" && assigneeFilter?.toLowerCase() === currentUserEmail;
+  const visibleTasks = assigneeFilter
+    ? tasks.filter((t) => assigneeFilterKey(t).toLowerCase() === assigneeFilter.toLowerCase())
+    : tasks;
 
   const beginEdit = (t: ProposedTaskDto) => {
     setEditingTaskId(t.id);
@@ -215,9 +252,13 @@ const MeetingTaskDetailPage: React.FC = () => {
   return (
     <div className="flex flex-col w-full overflow-auto" style={{ height: PAGE_CONTAINER_HEIGHT }}>
       <div className="px-4 sm:px-6 lg:px-8 py-3">
-        <Link to="/automation/meeting-tasks" className="inline-flex items-center text-sm text-indigo-700 dark:text-graphite-accent hover:underline">
+        <button
+          type="button"
+          onClick={() => requestNavigation("/automation/meeting-tasks")}
+          className="inline-flex items-center text-sm text-indigo-700 dark:text-graphite-accent hover:underline"
+        >
           <ArrowLeft className="w-4 h-4 mr-1" /> Zpet na seznam
-        </Link>
+        </button>
       </div>
 
       <div className="px-4 sm:px-6 lg:px-8 flex items-start justify-between gap-4">
@@ -226,9 +267,35 @@ const MeetingTaskDetailPage: React.FC = () => {
           <p className="mt-1 text-sm text-gray-600 dark:text-graphite-muted">
             {new Date(transcript.plaudCreatedAt).toLocaleString("cs-CZ")} · {transcript.plaudRecordingId}
           </p>
+          <p className="mt-1 text-sm text-gray-600 dark:text-graphite-muted">
+            <span className="font-medium">Účastníci:</span>{" "}
+            {transcript.participants.length > 0 ? transcript.participants.join(", ") : "—"}
+          </p>
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <TranscriptStatusBadge status={transcript.status} />
+          {isMeetingManager && transcript.status === "PendingReview" && (
+            <button
+              type="button"
+              onClick={() => updateTranscriptStatus.mutate({ transcriptId: id, status: "Approved" })}
+              disabled={updateTranscriptStatus.isPending}
+              className="inline-flex items-center px-3 py-1 text-sm rounded-lg border border-gray-300 dark:border-graphite-border hover:bg-gray-50 dark:hover:bg-white/5 dark:text-graphite-muted disabled:opacity-50"
+            >
+              <Check className="w-4 h-4 mr-1" aria-hidden="true" />
+              Označit jako schváleno
+            </button>
+          )}
+          {isMeetingManager && transcript.status === "Approved" && (
+            <button
+              type="button"
+              onClick={() => updateTranscriptStatus.mutate({ transcriptId: id, status: "PendingReview" })}
+              disabled={updateTranscriptStatus.isPending}
+              className="inline-flex items-center px-3 py-1 text-sm rounded-lg border border-gray-300 dark:border-graphite-border hover:bg-gray-50 dark:hover:bg-white/5 dark:text-graphite-muted disabled:opacity-50"
+            >
+              <Undo2 className="w-4 h-4 mr-1" aria-hidden="true" />
+              Vrátit ke kontrole
+            </button>
+          )}
           {transcript.accessLevel && (
             <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
               transcript.accessLevel === 'Public'
@@ -332,9 +399,36 @@ const MeetingTaskDetailPage: React.FC = () => {
 
       <div className="px-4 sm:px-6 lg:px-8 mt-6 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-graphite-text">
-          Navrhovane ulohy ({tasks.length})
+          Navrhovane ulohy ({assigneeFilter ? `${visibleTasks.length}/${tasks.length}` : tasks.length})
         </h2>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
+          <select
+            aria-label="Filtrovat podle osoby"
+            value={assigneeFilter ?? ""}
+            onChange={(e) => setAssigneeFilter(e.target.value || null)}
+            className="border border-gray-300 rounded-md px-2 py-1.5 text-sm dark:bg-graphite-surface-2 dark:border-graphite-border dark:text-graphite-text"
+          >
+            <option value="">Vsichni resitele</option>
+            {assigneeOptions.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          {currentUserEmail !== "" && (
+            <button
+              type="button"
+              aria-pressed={isMineActive}
+              onClick={() => setAssigneeFilter(isMineActive ? null : currentUserEmail)}
+              className={`inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium border ${
+                isMineActive
+                  ? "bg-indigo-600 text-white border-indigo-600 hover:bg-indigo-700"
+                  : "bg-white dark:bg-graphite-surface text-gray-700 dark:text-graphite-muted border-gray-300 dark:border-graphite-border hover:bg-gray-50 dark:hover:bg-white/5"
+              }`}
+            >
+              Ja
+            </button>
+          )}
           {pendingTasks.length > 0 && (
             <button
               type="button"
@@ -413,7 +507,12 @@ const MeetingTaskDetailPage: React.FC = () => {
       )}
 
       <div data-explainable="true" className="px-4 sm:px-6 lg:px-8 mt-3 space-y-2">
-        {tasks.map((t) => {
+        {assigneeFilter && visibleTasks.length === 0 && (
+          <p className="text-sm text-gray-500 dark:text-graphite-muted">
+            Zadnemu z vybranych resitelu nejsou prirazeny zadne ulohy.
+          </p>
+        )}
+        {visibleTasks.map((t) => {
           const isEditing = editingTaskId === t.id;
           const cardClass = t.status === "Approved"
             ? "bg-green-50 border-green-200 dark:bg-emerald-900/20 dark:border-emerald-900/40"
@@ -616,6 +715,8 @@ const MeetingTaskDetailPage: React.FC = () => {
           users={users.data ?? []}
         />
       )}
+
+      <MeetingReviewLeaveDialog {...dialogProps} />
     </div>
   );
 };

--- a/frontend/src/components/pages/automation/__tests__/MeetingTaskDetailPage.filter.test.tsx
+++ b/frontend/src/components/pages/automation/__tests__/MeetingTaskDetailPage.filter.test.tsx
@@ -7,6 +7,7 @@ import {
   useMeetingTaskDetail,
   useUpdateProposedTask,
   useUpdateProposedTaskStatus,
+  useUpdateTranscriptStatus,
   useAddProposedTask,
   useSubmitToTodo,
   useMeetingUsers,
@@ -99,6 +100,7 @@ function setupHooks(transcriptOverrides: Record<string, unknown> = {}) {
   (useMeetingTaskDetail as jest.Mock).mockReturnValue({ isLoading: false, data: { transcript: buildTranscript(transcriptOverrides) } });
   (useUpdateProposedTask as jest.Mock).mockReturnValue(noopMutation);
   (useUpdateProposedTaskStatus as jest.Mock).mockReturnValue(noopMutation);
+  (useUpdateTranscriptStatus as jest.Mock).mockReturnValue(noopMutation);
   (useAddProposedTask as jest.Mock).mockReturnValue(noopMutation);
   (useSubmitToTodo as jest.Mock).mockReturnValue(noopMutation);
   (useMeetingUsers as jest.Mock).mockReturnValue({ data: [] });

--- a/frontend/src/components/pages/automation/__tests__/MeetingTaskDetailPage.filter.test.tsx
+++ b/frontend/src/components/pages/automation/__tests__/MeetingTaskDetailPage.filter.test.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import * as downloadUtils from '../../../../utils/downloadTextFile';
 
 import {
   useMeetingTaskDetail,
   useUpdateProposedTask,
   useUpdateProposedTaskStatus,
-  useUpdateTranscriptStatus,
   useAddProposedTask,
   useSubmitToTodo,
   useMeetingUsers,
@@ -24,38 +22,49 @@ jest.mock('react-markdown', () => ({ __esModule: true, default: ({ children }: {
 jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
 
 jest.mock('../../../../api/hooks/useMeetingTasks');
-let mockHasPermission: (perm: string) => boolean = () => false;
 jest.mock('../../../../auth/PermissionsContext', () => ({
   usePermissionsContext: () => ({
     permissions: [],
     isSuperUser: false,
     groups: [],
     isLoading: false,
-    hasPermission: (p: string) => mockHasPermission(p),
+    hasPermission: () => false,
   }),
 }));
+let mockUsername: string | undefined = 'me@anela.cz';
 jest.mock('../../../../auth/useAuth', () => ({
-  useAuth: () => ({ account: { username: 'me@anela.cz' } }),
+  useAuth: () => ({ account: mockUsername ? { username: mockUsername } : null }),
 }));
 jest.mock('../explain/useExplainSelection');
 jest.mock('../explain/ExplainTooltip', () => ({ ExplainTooltip: () => null }));
 jest.mock('../explain/ExplainModal', () => ({ ExplainModal: () => null }));
 jest.mock('../access/ManageAccessModal', () => ({ ManageAccessModal: () => null }));
-jest.mock('../../../../utils/downloadTextFile', () => ({
-  ...jest.requireActual('../../../../utils/downloadTextFile'),
-  downloadTextFile: jest.fn(),
-}));
 
 // ---- Helpers ----
 
 const noopMutation = { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false, isError: false, error: null, reset: jest.fn() };
 
-function buildTranscript(overrides: Partial<{ summary: string; rawTranscript: string }> = {}) {
+function buildTask(overrides: Record<string, unknown>) {
+  return {
+    id: 'task-x',
+    title: 'Task',
+    description: '',
+    assignee: '',
+    assigneeEmail: null,
+    dueDate: null,
+    status: 'Approved',
+    externalTaskId: null,
+    isManuallyAdded: false,
+    ...overrides,
+  };
+}
+
+function buildTranscript(overrides: Record<string, unknown> = {}) {
   return {
     id: 'abc',
-    subject: 'Schůzka s týmem',
+    subject: 'Schůzka',
     summary: 'AI summary text',
-    rawTranscript: 'Speaker: Hello world',
+    rawTranscript: 'Speaker: Hello',
     plaudRecordingId: 'plaud-1',
     plaudCreatedAt: '2026-05-19T10:00:00Z',
     status: 'PendingReview',
@@ -86,11 +95,10 @@ function renderPage() {
   );
 }
 
-function setupHooks(transcriptOverrides: Parameters<typeof buildTranscript>[0] = {}) {
+function setupHooks(transcriptOverrides: Record<string, unknown> = {}) {
   (useMeetingTaskDetail as jest.Mock).mockReturnValue({ isLoading: false, data: { transcript: buildTranscript(transcriptOverrides) } });
   (useUpdateProposedTask as jest.Mock).mockReturnValue(noopMutation);
   (useUpdateProposedTaskStatus as jest.Mock).mockReturnValue(noopMutation);
-  (useUpdateTranscriptStatus as jest.Mock).mockReturnValue(noopMutation);
   (useAddProposedTask as jest.Mock).mockReturnValue(noopMutation);
   (useSubmitToTodo as jest.Mock).mockReturnValue(noopMutation);
   (useMeetingUsers as jest.Mock).mockReturnValue({ data: [] });
@@ -99,75 +107,68 @@ function setupHooks(transcriptOverrides: Parameters<typeof buildTranscript>[0] =
   (useExplainSelection as jest.Mock).mockReturnValue({ selectedText: null, clearSelection: jest.fn() });
 }
 
-// ---- Tests ----
-
 beforeEach(() => {
   jest.clearAllMocks();
-  mockHasPermission = () => false;
+  mockUsername = 'me@anela.cz';
 });
 
-describe('download summary button', () => {
-  it('is visible when summary is non-empty', () => {
-    setupHooks({ summary: 'Some summary' });
+describe('participants line', () => {
+  it('lists the meeting participants', () => {
+    setupHooks({ participants: ['Alice', 'Bob'] });
     renderPage();
-    expect(screen.getByRole('button', { name: /stáhnout souhrn/i })).toBeInTheDocument();
+    expect(screen.getByText('Účastníci:')).toBeInTheDocument();
+    expect(screen.getByText('Alice, Bob')).toBeInTheDocument();
   });
 
-  it('is hidden when summary is empty', () => {
-    setupHooks({ summary: '' });
+  it('renders a dash when there are no participants', () => {
+    setupHooks({ participants: [] });
     renderPage();
-    expect(screen.queryByRole('button', { name: /stáhnout souhrn/i })).not.toBeInTheDocument();
-  });
-
-  it('calls downloadTextFile with .md filename and text/markdown MIME type on click', () => {
-    setupHooks({ summary: '# AI Summary\nContent here' });
-    renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /stáhnout souhrn/i }));
-    expect(downloadUtils.downloadTextFile).toHaveBeenCalledWith(
-      '# AI Summary\nContent here',
-      'schůzka-s-týmem-summary.md',
-      'text/markdown',
-    );
+    expect(
+      screen.getByText((_, element) => element?.tagName === 'P' && element.textContent === 'Účastníci: —'),
+    ).toBeInTheDocument();
   });
 });
 
-describe('download transcript button', () => {
-  it('is visible when rawTranscript is non-empty', () => {
-    setupHooks({ rawTranscript: 'Speaker: Hello' });
+describe('suggested tasks filter', () => {
+  const tasks = [
+    buildTask({ id: 't1', title: 'My Task', assignee: 'Já', assigneeEmail: 'me@anela.cz' }),
+    buildTask({ id: 't2', title: 'Bob Task', assignee: 'Bob', assigneeEmail: 'bob@anela.cz' }),
+  ];
+
+  it('shows all tasks initially', () => {
+    setupHooks({ tasks });
     renderPage();
-    expect(screen.getByRole('button', { name: /stáhnout přepis/i })).toBeInTheDocument();
+    expect(screen.getByText('My Task')).toBeInTheDocument();
+    expect(screen.getByText('Bob Task')).toBeInTheDocument();
   });
 
-  it('is hidden when rawTranscript is empty', () => {
-    setupHooks({ rawTranscript: '' });
+  it('filters to the selected person via the dropdown', () => {
+    setupHooks({ tasks });
     renderPage();
-    expect(screen.queryByRole('button', { name: /stáhnout přepis/i })).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Filtrovat podle osoby'), { target: { value: 'bob@anela.cz' } });
+    expect(screen.getByText('Bob Task')).toBeInTheDocument();
+    expect(screen.queryByText('My Task')).not.toBeInTheDocument();
   });
 
-  it('calls downloadTextFile with .txt filename and text/plain MIME type on click', () => {
-    setupHooks({ rawTranscript: 'Speaker A: Hello\nSpeaker B: World' });
+  it('filters to my tasks when the Ja toggle is pressed', () => {
+    setupHooks({ tasks });
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /stáhnout přepis/i }));
-    expect(downloadUtils.downloadTextFile).toHaveBeenCalledWith(
-      'Speaker A: Hello\nSpeaker B: World',
-      'schůzka-s-týmem-transcript.txt',
-      'text/plain',
-    );
-  });
-});
-
-describe('manage access button', () => {
-  it('is hidden when user lacks anela.meetings.write', () => {
-    mockHasPermission = () => false;
-    setupHooks();
-    renderPage();
-    expect(screen.queryByRole('button', { name: /spravovat přístup/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Ja' }));
+    expect(screen.getByText('My Task')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Task')).not.toBeInTheDocument();
   });
 
-  it('is visible when user has anela.meetings.write', () => {
-    mockHasPermission = (p) => p === 'anela.meetings.write';
-    setupHooks();
+  it('hides the Ja toggle when there is no signed-in user', () => {
+    mockUsername = undefined;
+    setupHooks({ tasks });
     renderPage();
-    expect(screen.getByRole('button', { name: /spravovat přístup/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Ja' })).not.toBeInTheDocument();
+  });
+
+  it('shows an empty-state message when the filter matches no tasks', () => {
+    setupHooks({ tasks: [buildTask({ id: 't2', title: 'Bob Task', assignee: 'Bob', assigneeEmail: 'bob@anela.cz' })] });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Ja' }));
+    expect(screen.getByText(/nejsou prirazeny zadne ulohy/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/pages/automation/__tests__/MeetingTaskDetailPage.reviewState.test.tsx
+++ b/frontend/src/components/pages/automation/__tests__/MeetingTaskDetailPage.reviewState.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import {
+  useMeetingTaskDetail,
+  useUpdateProposedTask,
+  useUpdateProposedTaskStatus,
+  useUpdateTranscriptStatus,
+  useAddProposedTask,
+  useSubmitToTodo,
+  useMeetingUsers,
+  useReimportMeeting,
+  useExplainMeetingSummary,
+} from '../../../../api/hooks/useMeetingTasks';
+import { useExplainSelection } from '../explain/useExplainSelection';
+import MeetingTaskDetailPage from '../MeetingTaskDetailPage';
+
+// ---- Module mocks ----
+
+jest.mock('react-markdown', () => ({ __esModule: true, default: ({ children }: { children: React.ReactNode }) => <>{children}</> }));
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
+
+jest.mock('../../../../api/hooks/useMeetingTasks');
+jest.mock('../../../../auth/PermissionsContext', () => ({
+  usePermissionsContext: () => ({
+    permissions: [],
+    isSuperUser: true,
+    groups: [],
+    isLoading: false,
+    hasPermission: () => true,
+  }),
+}));
+jest.mock('../../../../auth/useAuth', () => ({
+  useAuth: () => ({ account: { username: 'me@anela.cz' } }),
+}));
+jest.mock('../explain/useExplainSelection');
+jest.mock('../explain/ExplainTooltip', () => ({ ExplainTooltip: () => null }));
+jest.mock('../explain/ExplainModal', () => ({ ExplainModal: () => null }));
+jest.mock('../access/ManageAccessModal', () => ({ ManageAccessModal: () => null }));
+
+// ---- Helpers ----
+
+const noopMutation = { mutate: jest.fn(), mutateAsync: jest.fn(), isPending: false, isError: false, error: null, reset: jest.fn() };
+
+let transcriptStatusMutation: {
+  mutate: jest.Mock;
+  mutateAsync: jest.Mock;
+  isPending: boolean;
+  isError: boolean;
+  error: null;
+  reset: jest.Mock;
+};
+
+function buildTranscript(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'abc',
+    subject: 'Schůzka',
+    summary: 'AI summary text',
+    rawTranscript: 'Speaker: Hello',
+    plaudRecordingId: 'plaud-1',
+    plaudCreatedAt: '2026-05-19T10:00:00Z',
+    status: 'PendingReview',
+    receivedAt: '2026-05-19T10:00:00Z',
+    reviewedAt: null,
+    reviewedByUser: null,
+    taskCount: 0,
+    approvedTaskCount: 0,
+    rejectedTaskCount: 0,
+    tasks: [],
+    participants: [],
+    accessLevel: 'Private' as const,
+    accessGrants: [],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/automation/meeting-tasks/abc']}>
+        <Routes>
+          <Route path="/automation/meeting-tasks/:id" element={<MeetingTaskDetailPage />} />
+          <Route path="/automation/meeting-tasks" element={<div>SEZNAM PORAD</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function setupHooks(transcriptOverrides: Record<string, unknown> = {}) {
+  (useMeetingTaskDetail as jest.Mock).mockReturnValue({ isLoading: false, data: { transcript: buildTranscript(transcriptOverrides) } });
+  (useUpdateProposedTask as jest.Mock).mockReturnValue(noopMutation);
+  (useUpdateProposedTaskStatus as jest.Mock).mockReturnValue(noopMutation);
+  (useUpdateTranscriptStatus as jest.Mock).mockReturnValue(transcriptStatusMutation);
+  (useAddProposedTask as jest.Mock).mockReturnValue(noopMutation);
+  (useSubmitToTodo as jest.Mock).mockReturnValue(noopMutation);
+  (useMeetingUsers as jest.Mock).mockReturnValue({ data: [] });
+  (useReimportMeeting as jest.Mock).mockReturnValue(noopMutation);
+  (useExplainMeetingSummary as jest.Mock).mockReturnValue(noopMutation);
+  (useExplainSelection as jest.Mock).mockReturnValue({ selectedText: null, clearSelection: jest.fn() });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  transcriptStatusMutation = {
+    mutate: jest.fn(),
+    mutateAsync: jest.fn().mockResolvedValue({ success: true }),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: jest.fn(),
+  };
+});
+
+describe('review-state toggle', () => {
+  it('marks a pending meeting as approved', () => {
+    setupHooks({ status: 'PendingReview' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Označit jako schváleno/i }));
+    expect(transcriptStatusMutation.mutate).toHaveBeenCalledWith({ transcriptId: 'abc', status: 'Approved' });
+  });
+
+  it('reverts an approved meeting back to pending review', () => {
+    setupHooks({ status: 'Approved' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Vrátit ke kontrole/i }));
+    expect(transcriptStatusMutation.mutate).toHaveBeenCalledWith({ transcriptId: 'abc', status: 'PendingReview' });
+  });
+});
+
+describe('leave-detail review prompt', () => {
+  it('prompts when leaving a meeting that is still pending review', () => {
+    setupHooks({ status: 'PendingReview' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Zpet na seznam/i }));
+    expect(screen.getByText('Porada je stále ke kontrole')).toBeInTheDocument();
+    expect(screen.queryByText('SEZNAM PORAD')).not.toBeInTheDocument();
+  });
+
+  it('marks reviewed and leaves when choosing the approve option', async () => {
+    setupHooks({ status: 'PendingReview' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Zpet na seznam/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Označit jako schváleno a odejít' }));
+    await waitFor(() => expect(transcriptStatusMutation.mutateAsync).toHaveBeenCalledWith({ transcriptId: 'abc', status: 'Approved' }));
+    expect(await screen.findByText('SEZNAM PORAD')).toBeInTheDocument();
+  });
+
+  it('leaves without changing status when choosing keep pending', async () => {
+    setupHooks({ status: 'PendingReview' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Zpet na seznam/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Nechat ke kontrole a odejít' }));
+    expect(await screen.findByText('SEZNAM PORAD')).toBeInTheDocument();
+    expect(transcriptStatusMutation.mutate).not.toHaveBeenCalled();
+    expect(transcriptStatusMutation.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('stays on the page when choosing to stay', () => {
+    setupHooks({ status: 'PendingReview' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Zpet na seznam/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Zůstat' }));
+    expect(screen.queryByText('Porada je stále ke kontrole')).not.toBeInTheDocument();
+    expect(screen.queryByText('SEZNAM PORAD')).not.toBeInTheDocument();
+  });
+
+  it('does not prompt when the meeting is already approved', async () => {
+    setupHooks({ status: 'Approved' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Zpet na seznam/i }));
+    expect(await screen.findByText('SEZNAM PORAD')).toBeInTheDocument();
+    expect(screen.queryByText('Porada je stále ke kontrole')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Extracts and persists meeting participants (new jsonb column via the `AddMeetingParticipants` migration), shows them on the meeting detail page, and adds a per-person filter over proposed tasks. Introduces user-driven review state: newly imported meetings stay "Ke kontrole" (PendingReview), a manager can toggle a meeting to "Schváleno" (Approved) and back from the detail header, and leaving a still-pending detail prompts to mark it reviewed, leave it as-is, or stay. This is backed by a new `UpdateTranscriptStatus` use case and a `PUT /api/meeting-tasks/{id}/status` endpoint. All backend (`UpdateTranscriptStatusHandlerTests`) and frontend (detail-page review-state, filter, download) tests pass, along with `dotnet build`/`format` and the frontend build/lint.