### PR TITLE
#3637: implementation

### DIFF
--- a/artifacts/feat-3637/arch-review.r1.md
+++ b/artifacts/feat-3637/arch-review.r1.md
@@ -1,0 +1,89 @@
+# Architecture Review: Targeted per-job lookup for `GetJobStartedAt` in Hangfire background worker
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a localized correctness/performance fix inside a single private method of `HangfireBackgroundWorker` (`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs`), the sole implementation of `IBackgroundWorker`. It does not touch the public interface, DTOs, controllers, or any cross-module boundary.
+
+Verified against the actual file (not just the spec's description):
+- `GetJobById` (lines 126–152) already does two other targeted, O(1) lookups on the same `IStorageConnection`: `connection.GetJobData(jobId)` (line 131) and, via `GetJobState` (lines 154–158), `connection.GetStateData(jobId)`. `GetJobStartedAt` (lines 160–177) is the outlier — it re-derives `JobStorage.Current.GetMonitoringApi()` and pages `ProcessingJobs(0, int.MaxValue)` just to filter down to one key. The fix brings this method in line with the pattern its siblings already use.
+- `GetPendingJobs` and `GetRunningJobs` (lines 52–124) use the monitoring API too, but bounded by `_options.MaxPendingJobsPageSize` — correctly out of scope per the spec, and I confirm no unbounded scans exist elsewhere in the class.
+- The class holds no injected `IStorageConnection`/`JobStorage` — it reads the ambient static `JobStorage.Current` on every call. This is an existing convention in this class (not introduced by this fix) and matters for testability (see Prerequisites/Risks).
+- `Anela.Heblo.API.csproj` references `Hangfire.PostgreSql` (not SQL Server as the spec's Background section speculates) and, importantly, already references `Hangfire.MemoryStorage` in the production project. This means an in-memory `JobStorage` provider is already on the dependency graph and available to tests without adding a new package reference — see Specification Amendments.
+- The existing test file `backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` only covers constructor/options wiring via reflection; it has zero coverage of `GetJobById`/`GetJobStartedAt` today, confirming FR-3's premise.
+
+This is a drop-in, mechanical replacement. No architectural decision is required beyond "use the same primitive the sibling method already uses" — which the spec itself proposes and which I confirm is correct and idiomatic for this codebase.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. Single method body replaced within an existing class:
+
+```
+IBackgroundWorker (interface, unchanged)
+        |
+HangfireBackgroundWorker (unchanged public surface)
+        |
+        +-- GetJobById(jobId)                 [unchanged]
+              +-- connection.GetJobData(jobId)         [unchanged, O(1)]
+              +-- GetJobState(connection, jobId)        [unchanged, O(1)]
+              |     +-- connection.GetStateData(jobId)
+              +-- GetJobStartedAt(connection, jobId)   [REWRITTEN, now O(1)]
+                    +-- connection.GetStateData(jobId)  <-- same primitive, no new call site
+```
+
+### Key Design Decisions
+
+#### Decision 1: Read `StartedAt` from `GetStateData` instead of scanning `ProcessingJobs`
+**Options considered:**
+1. Keep `ProcessingJobs` but cap the page size (mirrors `GetRunningJobs`'s bounded pattern) — still O(N), just a smaller constant; doesn't fix the fundamental mismatch (per-job lookup implemented as a collection scan).
+2. Call `connection.GetJobData(jobId)` for `CreatedAt`-adjacent data — `GetJobData` does not carry `StartedAt`; that value lives in the "Processing" state's `Data` dictionary, not the job data record. Ruled out.
+3. **Call `connection.GetStateData(jobId)` and read `Data["StartedAt"]` via `JobHelper.DeserializeNullableDateTime` when `Name == "Processing"`.** This mirrors `GetJobState`, which already calls the identical primitive for the identical `jobId` in the identical call path.
+
+**Chosen approach:** Option 3, exactly as specified in `spec.r1.md` FR-1.
+
+**Rationale:** O(1), zero new dependencies, consistent with the class's existing patterns, and it's the documented, supported way Hangfire itself stores/retrieves `ProcessingState` metadata (`Hangfire.States.ProcessingState` writes `StartedAt` into the state `Data` dictionary; `Hangfire.Common.JobHelper.DeserializeNullableDateTime` is the matching reader Hangfire uses internally).
+
+#### Decision 2: Do not consolidate `GetJobState` + `GetJobStartedAt` into one `GetStateData` call
+**Options considered:** Since both methods now call `connection.GetStateData(jobId)` with the same `jobId`, `GetJobById` could fetch `StateData` once and pass it to both, avoiding two storage round-trips per status check.
+
+**Chosen approach:** Do not do this now; leave `GetJobState` and `GetJobStartedAt` as independent methods, each performing its own `GetStateData` call.
+
+**Rationale:** The spec explicitly marks this consolidation "Out of Scope" (spec.r1.md, line 73) as a reasonable follow-on, not part of this fix. Keeping the two calls separate is a two-line-diff change with an obvious, narrow blast radius; conflating it with a bigger refactor increases review surface for zero required benefit. Flag it as a fast-follow ticket, not part of this PR — don't opportunistically do it here per this repo's "surgical changes" convention.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files or directories. Single edit:
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` — replace the body of `GetJobStartedAt` (lines 160–177) per FR-1. Signature (`private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)`) stays identical — no caller changes needed.
+
+Test addition (new test methods, existing file — do not relocate):
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` — add the FR-3 coverage here. The spec's "Open Questions" note about possibly relocating is unnecessary churn; this file already houses `HangfireBackgroundWorkerTests`, and moving it is out of scope for a targeted perf fix.
+
+### Interfaces and Contracts
+No interface or contract changes. `IBackgroundWorker`, `BackgroundJobInfo`, and all public signatures are untouched. The only "contract" that matters here is Hangfire's own storage contract:
+- `IStorageConnection.GetStateData(string jobId) : StateData?` — `StateData.Name` (string, e.g. `"Processing"`), `StateData.Data` (`IReadOnlyDictionary<string, string>` / `Dictionary<string,string>` depending on Hangfire version — verify against the installed `Hangfire.Core` version's signature before writing the code; do not assume it matches a different Hangfire major version's API).
+- `Hangfire.Common.JobHelper.DeserializeNullableDateTime(string)` — Hangfire's own helper for parsing `StartedAt`/`EnqueuedAt`-style stored timestamps. Use it rather than `DateTime.Parse` to stay consistent with how Hangfire serialized the value in the first place (culture/format safety).
+
+### Data Flow
+1. Caller invokes `IBackgroundWorker.GetJobById(jobId)`.
+2. `GetJobById` opens a connection, fetches `JobData` (unchanged), computes `state` via `GetJobState` (unchanged), then computes `StartedAt` via the rewritten `GetJobStartedAt`.
+3. `GetJobStartedAt` calls `connection.GetStateData(jobId)` once (a single keyed storage read, not a page scan).
+4. If `stateData?.Name == "Processing"` and `stateData.Data["StartedAt"]` deserializes successfully, return the `DateTime`. In every other case (null stateData, non-Processing state, missing/invalid key, or any exception) return `null`, preserving today's fail-safe `try/catch { return null; }` behavior.
+5. `GetJobById` assembles and returns `BackgroundJobInfo` exactly as before — no shape change.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Hangfire's `StateData.Data` key name/casing for `"StartedAt"` could differ across `Hangfire.Core` versions or storage providers (Postgres vs. the in-memory test provider) | Medium | Before finalizing, grep the installed `Hangfire.Core` source/NuGet package (or `Hangfire.States.ProcessingState`) for the literal key it writes, and assert the exact key/format in the new unit test rather than assuming `"StartedAt"` a priori. The FR-3 tests are the safety net for this. |
+| Testing requires swapping the ambient static `JobStorage.Current`, since `HangfireBackgroundWorker` is not constructed with an injected storage/connection | Medium | Use the already-referenced `Hangfire.MemoryStorage` package: in test setup, set `JobStorage.Current = new Hangfire.MemoryStorage.MemoryStorage()` (or the project's existing pattern if one exists elsewhere in the test suite — grep first), seed a job into the desired state via `BackgroundJob.Enqueue`/`BackgroundJob.Schedule` plus a manual state transition, then call `GetJobById`. Restore/reset `JobStorage.Current` after each test (or use a fixture) to avoid cross-test pollution, since it's a process-wide static. |
+| Silent behavior drift if `Data["StartedAt"]` is present under a non-`"Processing"` state name in some Hangfire version (e.g., custom states) | Low | Spec FR-1 already pins the check to `stateData?.Name == "Processing"` exactly — implement it as an exact string match, not a "key exists" check, to avoid returning stale/incorrect timestamps for jobs in other states. |
+| None of the above are new risks introduced by this change — the removed code path (`ProcessingJobs(0, int.MaxValue)`) was strictly worse on every axis (perf, memory, and no better correctness) | N/A | No mitigation needed; this is a strict improvement with no behavior-preserving downside once FR-1's acceptance criteria are met. |
+
+## Specification Amendments
+1. **Storage provider correction:** spec.r1.md's Background section states "SQL Server, per the Hangfire.SqlServer provider convention used by Hangfire." The actual project (`Anela.Heblo.API.csproj`) references `Hangfire.PostgreSql`, not `Hangfire.SqlServer`. This doesn't change the fix (the `IStorageConnection`/`GetStateData` API is provider-agnostic), but implementers should not go looking for SQL Server-specific behavior or assume T-SQL semantics anywhere near this code.
+2. **Test infrastructure clarification:** spec.r1.md's Dependencies section is unsure which fake/in-memory `IStorageConnection` provider to use. Resolved: `Hangfire.MemoryStorage` (v1.8.1.2) is already a package reference in `Anela.Heblo.API.csproj` (the production project, likely used for local dev/demo mode) and is therefore available transitively to the test project. Use `Hangfire.MemoryStorage.MemoryStorage` as the `JobStorage.Current` test double rather than introducing a new mocking dependency or hand-rolled fake of `IStorageConnection` (which is a large interface — not worth hand-mocking when a real in-memory provider already ships with the solution).
+3. **Test location confirmed, no relocation needed:** spec.r1.md hedges on whether `HangfireBackgroundWorkerTests.cs` (under `backend/test/Anela.Heblo.Tests/Features/Invoices/`) is the right home. Confirmed: this is the existing, sole test file for this class today. Add the new tests here; do not create a new test file or namespace for this fix.
+
+## Prerequisites
+None. No migrations, no config, no new package references (Hangfire.MemoryStorage is already present), no infrastructure changes. This can be implemented and merged standalone.

--- a/artifacts/feat-3637/brief.md
+++ b/artifacts/feat-3637/brief.md
@@ -1,0 +1,52 @@
+## Module
+BackgroundJobs
+
+## Finding
+`HangfireBackgroundWorker.GetJobStartedAt` (`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs`, lines 160–177) retrieves every processing job from the Hangfire storage — using `int.MaxValue` as the page size — just to find the start time of a single job by its ID:
+
+```csharp
+private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)
+{
+    try
+    {
+        var monitoring = JobStorage.Current.GetMonitoringApi();
+        var processingJobs = monitoring.ProcessingJobs(0, int.MaxValue);  // ← full table scan
+
+        var processingJob = processingJobs.FirstOrDefault(j => j.Key == jobId);
+        if (processingJob.Value != null)
+            return processingJob.Value.StartedAt;
+
+        return null;
+    }
+    catch { return null; }
+}
+```
+
+`GetJobStartedAt` is called from `GetJobById` (line 141), which is a per-job-ID lookup. Under normal production load with many concurrent or queued jobs this issues a full-table-equivalent scan through all currently-processing jobs for every single-job status call.
+
+## Why it matters
+O(N) memory allocation and DB load for an O(1) lookup. The Hangfire `IStorageConnection` already exposes per-job data via `GetJobData(jobId)` and `GetStateData(jobId)` — both of which are used elsewhere in the same class. The `StartedAt` value can be obtained from the state data or by a targeted per-job query rather than scanning the entire processing queue.
+
+## Suggested fix
+Remove the `ProcessingJobs` scan. Read `StartedAt` from the state data that `GetJobState` already fetches, or from `connection.GetJobData`:
+
+```csharp
+private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)
+{
+    // GetStateData is already called by GetJobState for the same jobId;
+    // the "Processing" state stores StartedAt in its Data dictionary.
+    var stateData = connection.GetStateData(jobId);
+    if (stateData?.Name == "Processing" &&
+        stateData.Data.TryGetValue("StartedAt", out var raw) &&
+        JobHelper.DeserializeNullableDateTime(raw) is { } startedAt)
+    {
+        return startedAt;
+    }
+    return null;
+}
+```
+
+This eliminates the `int.MaxValue` scan entirely.
+
+---
+_Filed by daily arch-review routine on 2026-07-14._

--- a/artifacts/feat-3637/code-review.r1.md
+++ b/artifacts/feat-3637/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs:136` and `:164` — `GetJobById` now calls `connection.GetStateData(jobId)` twice in the same request: once inside `GetJobState` (line 156) and once inside `GetJobStartedAt` (line 164). Both calls happen within the same `GetJobById` invocation, so this is two storage round-trips where one `StateData` fetch would do. The spec explicitly calls this out as an acceptable, out-of-scope follow-on (consolidating the two lookups), so this is advisory only, not a blocker.

--- a/artifacts/feat-3637/design.r1.md
+++ b/artifacts/feat-3637/design.r1.md
@@ -1,0 +1,50 @@
+# Design: Targeted per-job lookup for `GetJobStartedAt` in Hangfire background worker
+
+## Component Design
+
+### `HangfireBackgroundWorker` (`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs`)
+No new components are introduced. The change is scoped to the internals of one existing method.
+
+- **`GetJobById(string jobId) : BackgroundJobInfo?`** (public, unchanged signature and behavior)
+  - Opens a storage connection.
+  - Fetches job data via `connection.GetJobData(jobId)` (unchanged, O(1)).
+  - Resolves current state via `GetJobState(connection, jobId)` (unchanged, O(1) — calls `connection.GetStateData(jobId)`).
+  - Resolves `StartedAt` via `GetJobStartedAt(connection, jobId)` (**rewritten** below).
+  - Assembles and returns `BackgroundJobInfo` exactly as today; no shape change.
+
+- **`GetJobStartedAt(IStorageConnection connection, string jobId) : DateTime?`** (private static, signature unchanged)
+  - Responsibility narrows to: given a job ID, return its `StartedAt` timestamp *if and only if* the job's current Hangfire state is `"Processing"`, else `null`.
+  - New implementation:
+    1. Call `connection.GetStateData(jobId)` — a single keyed storage read (same primitive `GetJobState` already uses for the same `jobId`).
+    2. If the result is `null`, return `null`.
+    3. If `stateData.Name != "Processing"` (exact string match, not a key-existence check), return `null`.
+    4. Otherwise, look up `stateData.Data["StartedAt"]`; if the key is missing, return `null`.
+    5. Deserialize the value via `Hangfire.Common.JobHelper.DeserializeNullableDateTime(string)`; return the resulting `DateTime?` (which itself may be `null` if deserialization fails per that helper's contract).
+  - Wrap the entire body in the existing `try/catch { return null; }` fail-safe (preserving current behavior for any unexpected exception, e.g. storage errors).
+  - Removed: the call to `JobStorage.Current.GetMonitoringApi().ProcessingJobs(0, int.MaxValue)` and the subsequent `FirstOrDefault(j => j.Key == jobId)` linear scan.
+
+- **No changes** to `IBackgroundWorker`, `BackgroundJobInfo`, `GetPendingJobs`, `GetRunningJobs`, `GetJobState`, `GetJobDisplayName`, or any other public member of the class.
+
+### Interfaces and Contracts consumed (external, unchanged)
+- `Hangfire.Storage.IStorageConnection.GetStateData(string jobId) : StateData?` — already used by `GetJobState`; now also used directly by `GetJobStartedAt` instead of the monitoring API.
+- `Hangfire.Common.JobHelper.DeserializeNullableDateTime(string) : DateTime?` — Hangfire's own helper for parsing stored `StartedAt`-style timestamps; used instead of `DateTime.Parse` to match Hangfire's own serialization format/culture handling.
+- Verify the installed `Hangfire.Core` version's exact `StateData.Data` type (`Dictionary<string,string>` vs `IReadOnlyDictionary<string,string>`) before writing the key lookup, per the architecture review's note — do not assume a specific major-version shape.
+
+### Test component (`backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs`)
+No new test file/namespace. Add test methods to the existing file covering:
+- Job in `"Processing"` state with a valid, parseable `StartedAt` entry in state `Data` → `GetJobById(...).StartedAt` (or equivalent) is non-null and matches the seeded value.
+- Job in a non-`"Processing"` state (e.g. `"Succeeded"`, `"Enqueued"`, `"Failed"`, `"Scheduled"`) → `StartedAt == null`.
+- Nonexistent job ID (`GetStateData` returns `null`) → `StartedAt == null` (or `GetJobById` returns `null`, matching existing unknown-job behavior).
+- Test setup uses `Hangfire.MemoryStorage.MemoryStorage` assigned to `JobStorage.Current` (already a package reference in the production project) as the `IStorageConnection` test double, seeding jobs into the desired state; reset/restore `JobStorage.Current` between tests since it is a process-wide static.
+
+## Data Schemas
+
+No new or changed schemas, DTOs, database entities, API request/response shapes, or event payloads. This fix reads exclusively from Hangfire's existing internal storage model:
+
+- `StateData` (Hangfire-defined, read-only from this codebase's perspective):
+  - `Name: string` — current state name (e.g. `"Processing"`, `"Succeeded"`, `"Enqueued"`, `"Failed"`, `"Scheduled"`).
+  - `Data: IDictionary<string, string>` (exact type per installed Hangfire version) — state-specific fields; for `"Processing"` this includes a `"StartedAt"` entry written by `Hangfire.States.ProcessingState` and serialized in Hangfire's own datetime string format.
+
+- `BackgroundJobInfo` — unchanged; no new fields. Its `StartedAt` field's *value* is now sourced from `GetStateData` instead of `ProcessingJobs`, but its type and the field's meaning are identical.
+
+No migrations, no new tables/columns, no new API contracts.

--- a/artifacts/feat-3637/impl/fix-hangfire-getjobstartedat-full-scan.r1.md
+++ b/artifacts/feat-3637/impl/fix-hangfire-getjobstartedat-full-scan.r1.md
@@ -1,0 +1,31 @@
+# Implementation: fix-hangfire-getjobstartedat-full-scan
+
+## What was implemented
+Replaced the body of `HangfireBackgroundWorker.GetJobStartedAt` so it no longer pages through every "Processing" job via `monitoring.ProcessingJobs(0, int.MaxValue)` and linear-scans for a match. It now reads the job's own state data directly via `connection.GetStateData(jobId)` — the same call `GetJobState` already makes for the same `jobId` — and returns `StartedAt` only when the state is `"Processing"` and the key is present and parseable. The method's private static signature and its only caller (`GetJobById`) are unchanged.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` — rewrote `GetJobStartedAt` (lines 160–177) to use `connection.GetStateData(jobId)` + `JobHelper.DeserializeNullableDateTime` instead of the full `ProcessingJobs` scan.
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` — added regression coverage for `GetJobById`/`GetJobStartedAt` (previously untested): a job in `"Processing"` state with a valid `StartedAt` returns it; a non-`"Processing"` state returns `null`; a `"Processing"` state missing the `StartedAt` key returns `null`; a nonexistent job ID returns `null`. Seeds job state directly via `IWriteOnlyTransaction.SetJobState` with a minimal `FakeState : IState` (since `Hangfire.States.ProcessingState`'s constructor is internal). Reuses the existing `HangfireTestFixture`/`[Collection("Hangfire")]` in-memory-storage fixture; no new test infrastructure was added.
+
+## Tests
+`backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` — 6 tests total (2 pre-existing constructor tests unchanged, 4 new): `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime`, `GetJobById_NonProcessingState_ReturnsNullStartedAt`, `GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt`, `GetJobById_NonexistentJobId_ReturnsNull`.
+
+## How to verify
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~HangfireBackgroundWorkerTests"
+```
+Confirmed red before the fix (the `ValidStartedAt` case failed with `StartedAt` `null` instead of the seeded value) and green after (6/6 passed). `dotnet format Anela.Heblo.sln --verify-no-changes` reports no violations for the two changed files.
+
+## Notes
+Ran the full `dotnet test Anela.Heblo.sln` suite: 5706 passed, 4 skipped, 76 failed. All 76 failures are pre-existing `Testcontainers`/PostgreSQL integration tests failing with "Docker is either not running or misconfigured" — this sandbox has no Docker daemon. None of the failures reference Hangfire or this change; they are an environment limitation, not a regression.
+
+## PR Summary
+Fixed a performance issue flagged by the automated architecture-review routine: `HangfireBackgroundWorker.GetJobStartedAt` was calling `monitoring.ProcessingJobs(0, int.MaxValue)` — a full scan of every currently-processing Hangfire job — just to find one job's start time by ID. It now uses the already-available `connection.GetStateData(jobId)` targeted lookup instead, the same call the class's `GetJobState` method already makes for the same job ID.
+
+### Changes
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` — `GetJobStartedAt` now reads `StartedAt` from state data instead of scanning all processing jobs.
+- `backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` — added regression tests covering `GetJobById`'s `StartedAt` resolution across processing/non-processing/missing-key/nonexistent-job scenarios.
+
+## Status
+DONE

--- a/artifacts/feat-3637/review/fix-hangfire-getjobstartedat-full-scan.r1.md
+++ b/artifacts/feat-3637/review/fix-hangfire-getjobstartedat-full-scan.r1.md
@@ -1,0 +1,27 @@
+# Code Review: fix-hangfire-getjobstartedat-full-scan
+
+## Summary
+The implementation rewrites `HangfireBackgroundWorker.GetJobStartedAt` exactly as specified: it replaces the `monitoring.ProcessingJobs(0, int.MaxValue)` linear scan with a targeted `connection.GetStateData(jobId)` lookup, checks the state name against `ProcessingState.StateName`, and reads `StartedAt` via `JobHelper.DeserializeNullableDateTime`. The method's private static signature and its only caller (`GetJobById`) are untouched, and four new regression tests plus the two pre-existing constructor tests cover the acceptance criteria using the existing shared `HangfireTestFixture`.
+
+## Review Result: PASS
+
+### task: fix-hangfire-getjobstartedat-full-scan
+**Status:** PASS
+
+Verification performed:
+- Read the actual diff (`git show HEAD`) and the current file content of `HangfireBackgroundWorker.cs`: `GetJobStartedAt` (lines 160-176) now matches the spec's Step 3 replacement verbatim — no `ProcessingJobs` call, no `int.MaxValue` paging. `grep -n "ProcessingJobs"` against the file shows only one remaining match, at line 99 inside `GetRunningJobs` (bounded by `_options.MaxPendingJobsPageSize`), confirming the acceptance criterion "no call to `ProcessingJobs` ... in `GetJobStartedAt`."
+- `GetJobById` (lines 126-152) is byte-for-byte unchanged from what the spec described as the "untouched" caller; it still calls `GetJobStartedAt(connection, jobId)` at line 144.
+- `IBackgroundWorker`, `BackgroundJobInfo`, `GetPendingJobs`, `GetRunningJobs`, `GetJobState`, `GetJobDisplayName` are all unchanged in the diff — only `GetJobStartedAt`'s body was touched, matching the "surgical change" requirement.
+- The test file `HangfireBackgroundWorkerTests.cs` matches the spec's Step 1 content exactly: `[Collection("Hangfire")]` wiring against `HangfireTestFixture`, the two original constructor tests preserved unchanged, and four new tests (`ProcessingStateWithValidStartedAt`, `NonProcessingState`, `ProcessingStateWithMissingStartedAtKey`, `NonexistentJobId`) plus the `CreateEnqueuedJob`/`SeedJobState`/`FakeState` helpers, reusing the existing fixture without introducing new test infrastructure.
+- Confirmed `HangfireTestFixture.cs` (referenced, unmodified) provides the in-memory `MemoryStorage`-backed `JobStorage.Current` and `[CollectionDefinition("Hangfire", DisableParallelization = true)]` exactly as the task described, so the new tests' assumptions about shared state hold.
+- `TargetFramework net8.0` with `ImplicitUsings enable` in the test project confirms `System` (Console, DateTime, Action) is implicitly available, so the test file's explicit usings (`System.Collections.Generic`, `System.Linq.Expressions`, `Hangfire`, `Hangfire.Common`, `Hangfire.States`, etc.) are sufficient for the code to compile as written.
+- All acceptance criteria from the task context are traceable to concrete code: state-name check against `ProcessingState.StateName`, `TryGetValue("StartedAt", ...)` handling for the missing-key case, `try/catch` returning `null` on any storage exception (covering the nonexistent-job path via `GetJobData` returning null upstream in `GetJobById`), and the exact preserved method signature `private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)`.
+- The implementation summary reports a full-suite `dotnet test` run with 5706 passed, 4 skipped, 76 failed, and states the 76 failures are pre-existing Testcontainers/PostgreSQL integration tests failing due to no Docker daemon in the sandbox, unrelated to this change. This is a plausible, well-documented environment limitation rather than a regression; nothing in the diff touches database/container integration code.
+
+No functional requirement, architecture guidance, or explicitly-required test is unmet based on static review of the diff, task spec, and test file.
+
+## Docs to Update
+None. This is an internal performance fix with no public contract, feature-flag, or architecture-doc surface affected.
+
+## Overall Notes
+This review is based on static inspection of the diff, the full `HangfireBackgroundWorker.cs` source, the full test file, and the `HangfireTestFixture.cs` fixture — a live `dotnet test` run of `HangfireBackgroundWorkerTests` was not completed within this review session due to environment build/restore latency, so the "all 6 tests pass" claim rests on the implementation summary's report plus code-level correctness (the logic is straightforward and directly traceable: `GetStateData` → name check → dictionary lookup → `JobHelper.DeserializeNullableDateTime`, all APIs used elsewhere in the same file in the same way). No logic defects were found on inspection.

--- a/artifacts/feat-3637/spec.r1.md
+++ b/artifacts/feat-3637/spec.r1.md
@@ -1,0 +1,79 @@
+# Specification: Targeted per-job lookup for `GetJobStartedAt` in Hangfire background worker
+
+## Summary
+`HangfireBackgroundWorker.GetJobStartedAt` currently retrieves the entire Hangfire "processing" job set (`monitoring.ProcessingJobs(0, int.MaxValue)`) to find the start time of a single, known job ID. This is replaced with a targeted, O(1) lookup via `IStorageConnection.GetStateData(jobId)`, reading `StartedAt` directly out of the "Processing" state's data dictionary. This is a pure internal performance fix with no change to the public contract of `IBackgroundWorker` or `BackgroundJobInfo`.
+
+## Background
+`HangfireBackgroundWorker` (`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs`) implements `IBackgroundWorker`, wrapping Hangfire's static `BackgroundJob` / `JobStorage` APIs so the rest of the codebase can enqueue, schedule, and query background jobs through an interface.
+
+`GetJobById(string jobId)` (line 126) is the single-job status endpoint used by callers that need the state of one specific job (e.g. a status-polling UI or API endpoint). It already does a targeted lookup for the job's core data (`connection.GetJobData(jobId)`, O(1)) and its current state (`GetJobState`, which calls `connection.GetStateData(jobId)`, also O(1)). However, for the job's `StartedAt` timestamp, it delegates to `GetJobStartedAt` (line 160), which pages through **every** currently-processing job (`monitoring.ProcessingJobs(0, int.MaxValue)`) and does an in-memory linear scan (`FirstOrDefault(j => j.Key == jobId)`) to find the one matching entry.
+
+This means a single-job status check — which should be O(1) — degrades to O(N) in both Hangfire storage query cost and application memory allocation, where N is the number of jobs currently in the "Processing" state. Under production load with many concurrent/queued jobs, this is unnecessary load on the job storage backend (SQL Server, per the Hangfire.SqlServer provider convention used by Hangfire) and repeated full materialization of processing-job data for every status poll.
+
+Hangfire already stores `StartedAt` as part of the "Processing" state's `Data` dictionary (set by `Hangfire.States.ProcessingState`), and this value is retrievable directly via `connection.GetStateData(jobId)` — the same primitive already used by the sibling method `GetJobState`. No monitoring-API table scan is needed.
+
+This was flagged by the automated daily architecture-review routine (2026-07-14) as a performance finding in the BackgroundJobs module. The fix is small, self-contained, and low-risk: it changes only the internal implementation of one private method, preserving its signature and public-facing behavior.
+
+## Functional Requirements
+
+### FR-1: Replace the full-scan lookup with a targeted per-job state read
+`GetJobStartedAt(IStorageConnection connection, string jobId)` must no longer call `JobStorage.Current.GetMonitoringApi().ProcessingJobs(0, int.MaxValue)`. Instead, it must call `connection.GetStateData(jobId)` and, when the job's current state is `"Processing"`, read the `StartedAt` value out of that state's `Data` dictionary using `Hangfire.Common.JobHelper.DeserializeNullableDateTime`.
+
+**Acceptance criteria:**
+- The method contains no call to `ProcessingJobs` (or any other `int.MaxValue`-paged monitoring API call).
+- For a job whose current Hangfire state is `"Processing"` and whose state `Data` dictionary contains a parseable `"StartedAt"` entry, the method returns that value as a `DateTime`.
+- For a job that is not in the `"Processing"` state (e.g. `"Succeeded"`, `"Enqueued"`, `"Failed"`, `"Scheduled"`), the method returns `null`.
+- For a job ID that does not exist in storage (`GetStateData` returns `null`), the method returns `null`.
+- If the `"StartedAt"` key is missing from the state data, or its value cannot be deserialized by `JobHelper.DeserializeNullableDateTime`, the method returns `null` rather than throwing.
+- Any unexpected exception raised while reading state data is caught and results in a `null` return (preserving today's `try/catch { return null; }` fail-safe behavior), consistent with `GetJobById`'s existing overall exception handling.
+
+### FR-2: Preserve existing method signature and call sites
+`GetJobStartedAt` keeps its current signature — `private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)` — and its only caller, `GetJobById` (line 144), requires no changes. `IBackgroundWorker`, `BackgroundJobInfo`, and all other public types are unaffected.
+
+**Acceptance criteria:**
+- `GetJobById`'s behavior (the shape and field values of the returned `BackgroundJobInfo`, and the `null` return for unknown job IDs) is unchanged for all existing test cases and manual verification scenarios, except that the `StartedAt` field is now computed via a direct state lookup instead of a full scan.
+- No changes to `IBackgroundWorker`, `BackgroundJobInfo`, `GetPendingJobs`, `GetRunningJobs`, `GetJobState`, or `GetJobDisplayName`.
+
+### FR-3: Regression test coverage for the fixed method
+Add unit test coverage exercising `GetJobStartedAt`'s (or `GetJobById`'s) behavior across the state variations described in FR-1, since no such coverage currently exists (the existing `HangfireBackgroundWorkerTests.cs` only covers constructor/options wiring).
+
+**Acceptance criteria:**
+- A test confirms that a job whose state data reports `"Processing"` with a valid `StartedAt` payload yields the expected non-null `DateTime` (via `GetJobById`, using an in-memory/fake `IStorageConnection` or Hangfire's `InMemoryStorage` test provider — whichever fits the existing test setup conventions for this class/project).
+- A test confirms that a job in a non-`"Processing"` state yields `StartedAt == null`.
+- A test confirms that a nonexistent job ID yields `StartedAt == null` (or `GetJobById` returns `null`, per existing behavior for unknown jobs).
+- Tests do not depend on real SQL Server-backed Hangfire storage; they use whatever in-memory/test-double approach is already established in the test project (see Dependencies).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- The fixed lookup must be O(1) with respect to the number of currently-processing jobs — a single indexed/keyed storage read per call, not a paged scan.
+- No new N+1 or repeated-query patterns may be introduced elsewhere in the class as a side effect of this change.
+- No functional regression in response time for `GetJobById` overall; the change should only improve or maintain latency, never worsen it.
+
+### NFR-2: Security
+No change. This method reads job metadata already accessible to authorized callers of `IBackgroundWorker`; no new data exposure, authentication, or authorization concerns are introduced.
+
+## Data Model
+No schema or entity changes. This fix operates entirely on Hangfire's existing internal storage model, specifically:
+- `IStorageConnection.GetStateData(jobId)` → `StateData` with `Name` (state name, e.g. `"Processing"`) and `Data` (a `Dictionary<string, string>` of state-specific fields, including `"StartedAt"` for the Processing state, serialized via Hangfire's `JobHelper`).
+
+No new fields are added to `BackgroundJobInfo`.
+
+## API / Interface Design
+No public API, controller, or route changes. This is an internal implementation change within `HangfireBackgroundWorker`, a private helper method used only by `GetJobById`. The `IBackgroundWorker` interface contract (`GetJobById(string jobId) : BackgroundJobInfo?`) is unchanged.
+
+## Dependencies
+- `Hangfire.Storage.IStorageConnection.GetStateData(string jobId)` — already in use elsewhere in this class (`GetJobState`).
+- `Hangfire.Common.JobHelper.DeserializeNullableDateTime(string)` — standard Hangfire helper for deserializing stored date/time values; used by Hangfire internally for the same `"StartedAt"` field.
+- Existing test project conventions in `backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` (or a more suitable test location/namespace if the reviewer/architect prefers relocating Hangfire-worker tests — see Open Questions/assumption below) and whatever fake/in-memory `IStorageConnection` or Hangfire test-storage provider is already available in the solution.
+
+## Out of Scope
+- Changing `GetPendingJobs` or `GetRunningJobs`, which also call monitoring APIs with a bounded page size (`_options.MaxPendingJobsPageSize`) — these are not full-scan (`int.MaxValue`) queries and are not part of this finding.
+- Any change to Hangfire storage provider configuration, retention policy, or dashboard behavior.
+- Broader refactors of `HangfireBackgroundWorker` (e.g. consolidating `GetJobState` and `GetJobStartedAt` into a single `GetStateData` call to avoid two separate lookups within `GetJobById`) — this would be a reasonable follow-on optimization but is not required to resolve the specific finding, which targets only the `int.MaxValue` scan.
+- Adding new public API endpoints or UI surfaces for job status.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3637",
+  "issue_number": 3637,
+  "created_at": "2026-07-14T11:15:11.635542Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-14T11:20:34.149150Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T11:30:52.508784Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-hangfire-getjobstartedat-full-scan",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-14T11:17:14.307460Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T11:19:33.130320Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-14T11:30:52.508784Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-14T11:31:23.486633Z"
+      "status": "completed",
+      "updated_at": "2026-07-14T12:05:56.513963Z"
     }
   },
   "tasks": [
     {
       "name": "fix-hangfire-getjobstartedat-full-scan",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-14T11:31:23.693718Z"
+      "updated_at": "2026-07-14T12:05:50.543848Z"
     }
   ]
 }

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-14T11:19:33.130320Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T11:20:34.149150Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-14T11:17:14.307460Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-14T11:30:52.508784Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-14T11:31:23.486633Z"
     }
   },
   "tasks": [
     {
       "name": "fix-hangfire-getjobstartedat-full-scan",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-14T11:31:23.693718Z"
     }
   ]
 }

--- a/artifacts/feat-3637/state.json
+++ b/artifacts/feat-3637/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-14T12:05:56.513963Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-14T12:05:56.911009Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3637/task-context/fix-hangfire-getjobstartedat-full-scan.md
+++ b/artifacts/feat-3637/task-context/fix-hangfire-getjobstartedat-full-scan.md
@@ -1,0 +1,292 @@
+### task: fix-hangfire-getjobstartedat-full-scan
+
+**Context — what's being fixed and why:**
+`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` implements `IBackgroundWorker`. Its `GetJobById(string jobId)` method (lines 126–152) does two O(1) lookups on an `IStorageConnection` — `connection.GetJobData(jobId)` and, via `GetJobState`, `connection.GetStateData(jobId)` — but delegates `StartedAt` resolution to `GetJobStartedAt` (lines 160–177), which instead pages through **every** job in the Hangfire "Processing" state via the monitoring API (`monitoring.ProcessingJobs(0, int.MaxValue)`) and does a linear `FirstOrDefault` scan to find the one entry matching `jobId`. This is unnecessary O(N) storage/memory cost for what should be a single keyed lookup — the exact same `StartedAt` value is already present in the "Processing" state's own `Data` dictionary, retrievable via `connection.GetStateData(jobId)` (the same call `GetJobState` already makes for the same `jobId`).
+
+This task rewrites only the body of `GetJobStartedAt`, preserving its private static signature and its only caller (`GetJobById`) untouched, and adds regression tests for the class (which today has zero coverage of `GetJobById`/`GetJobStartedAt` — only constructor/options wiring is tested).
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` (rewrite `GetJobStartedAt`, lines 160–177)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` (add regression tests; wire into the shared `[Collection("Hangfire")]` fixture)
+- Reference (read-only, no changes): `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/Infrastructure/HangfireTestFixture.cs` — existing `HangfireTestFixture` / `[CollectionDefinition("Hangfire", DisableParallelization = true)]` that configures `JobStorage.Current` to `Hangfire.MemoryStorage.MemoryStorage()` once per test run. Reuse this; do not create a new fixture.
+
+---
+
+- [ ] **Step 1: Write the failing tests in `HangfireBackgroundWorkerTests.cs`**
+
+Replace the entire current file content with the following (it keeps the two existing constructor tests unchanged and adds the new state-based coverage plus the test-seeding helpers):
+
+```csharp
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Anela.Heblo.Xcc;
+using FluentAssertions;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Invoices;
+
+[Collection("Hangfire")]
+public class HangfireBackgroundWorkerTests
+{
+    private readonly HangfireBackgroundWorker _worker;
+
+    public HangfireBackgroundWorkerTests(HangfireTestFixture fixture)
+    {
+        // HangfireTestFixture (shared via the "Hangfire" collection) configures
+        // JobStorage.Current to an in-memory Hangfire.MemoryStorage instance once
+        // for the whole test run — see HangfireTestFixture.cs.
+        _worker = new HangfireBackgroundWorker(Options.Create(new HangfireOptions()));
+    }
+
+    [Fact]
+    public void Constructor_StoresHangfireOptions()
+    {
+        // Arrange
+        var options = Options.Create(new HangfireOptions { MaxPendingJobsPageSize = 200 });
+
+        // Act
+        var worker = new HangfireBackgroundWorker(options);
+
+        // Assert — the worker must hold the options so its monitoring calls use the cap.
+        var stored = typeof(HangfireBackgroundWorker)
+            .GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(worker) as HangfireOptions;
+
+        stored.Should().NotBeNull();
+        stored!.MaxPendingJobsPageSize.Should().Be(200);
+    }
+
+    [Fact]
+    public void Constructor_AcceptsCustomPageSize()
+    {
+        // Arrange
+        var options = Options.Create(new HangfireOptions { MaxPendingJobsPageSize = 50 });
+
+        // Act
+        var worker = new HangfireBackgroundWorker(options);
+
+        // Assert
+        var stored = typeof(HangfireBackgroundWorker)
+            .GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(worker) as HangfireOptions;
+
+        stored!.MaxPendingJobsPageSize.Should().Be(50);
+    }
+
+    #region GetJobById / GetJobStartedAt state coverage (targeted GetStateData lookup)
+
+    [Fact]
+    public void GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime()
+    {
+        // Arrange: a job whose current Hangfire state is "Processing" and whose
+        // state Data dictionary carries a valid, parseable "StartedAt" entry.
+        var jobId = CreateEnqueuedJob();
+        var expectedStartedAt = new DateTime(2026, 7, 14, 10, 0, 0, DateTimeKind.Utc);
+        SeedJobState(jobId, ProcessingState.StateName, new Dictionary<string, string>
+        {
+            ["StartedAt"] = JobHelper.SerializeDateTime(expectedStartedAt)
+        });
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Processing");
+        result.StartedAt.Should().Be(expectedStartedAt);
+    }
+
+    [Fact]
+    public void GetJobById_NonProcessingState_ReturnsNullStartedAt()
+    {
+        // Arrange: job is created directly into the "Enqueued" state and never
+        // transitioned to "Processing".
+        var jobId = CreateEnqueuedJob();
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Enqueued");
+        result.StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt()
+    {
+        // Arrange: state name is "Processing" but the state Data dictionary has
+        // no "StartedAt" entry at all.
+        var jobId = CreateEnqueuedJob();
+        SeedJobState(jobId, ProcessingState.StateName, new Dictionary<string, string>());
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Processing");
+        result.StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetJobById_NonexistentJobId_ReturnsNull()
+    {
+        // Act
+        var result = _worker.GetJobById("nonexistent-job-id-does-not-exist");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private static string CreateEnqueuedJob()
+    {
+        var client = new BackgroundJobClient(JobStorage.Current);
+        Expression<Action> methodCall = () => Console.WriteLine("test job");
+        var job = Job.FromExpression(methodCall);
+        return client.Create(job, new EnqueuedState());
+    }
+
+    /// <summary>
+    /// Seeds the given job directly into the given state/data via a write transaction,
+    /// bypassing Hangfire's normal state-transition pipeline. This is necessary because
+    /// Hangfire.States.ProcessingState's constructor is internal and cannot be
+    /// instantiated from test code; FakeState below stands in for it, carrying only
+    /// the (Name, Data) pair that HangfireBackgroundWorker.GetJobStartedAt reads.
+    /// </summary>
+    private static void SeedJobState(string jobId, string stateName, Dictionary<string, string> data)
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        using var transaction = connection.CreateWriteTransaction();
+        transaction.SetJobState(jobId, new FakeState(stateName, data));
+        transaction.Commit();
+    }
+
+    private sealed class FakeState : IState
+    {
+        private readonly Dictionary<string, string> _data;
+
+        public FakeState(string name, Dictionary<string, string> data)
+        {
+            Name = name;
+            _data = data;
+        }
+
+        public string Name { get; }
+        public string? Reason => null;
+        public bool IsFinal => false;
+        public bool IgnoreJobLoadException => false;
+        public Dictionary<string, string> SerializeData() => _data;
+    }
+
+    #endregion
+}
+```
+
+Notes on this test design (verified against the actual installed `Hangfire.Core 1.8.21` package via a throwaway reflection probe before writing this plan — do not deviate from these facts):
+- `Hangfire.Storage.StateData.Data` is `IDictionary<string, string>`, and `Hangfire.Common.JobHelper.DeserializeNullableDateTime(string) : DateTime?` is the correct reader for the `"StartedAt"` value serialized via `JobHelper.SerializeDateTime`.
+- `Hangfire.States.ProcessingState` has only an **internal** `(string serverId, string workerId)` constructor — it cannot be `new`'d from test code. `IWriteOnlyTransaction.SetJobState(string jobId, IState state)` accepts any `IState`, so the minimal `FakeState` above (implementing `Name`/`Reason`/`IsFinal`/`IgnoreJobLoadException`/`SerializeData()`) is the correct, dependency-free way to seed a job into an arbitrary named state with arbitrary state data, without needing Hangfire's real state-transition/filter pipeline (which `HangfireBackgroundWorker.GetJobStartedAt` doesn't depend on either — it only reads `connection.GetStateData(jobId)`).
+- Confirmed via an end-to-end run against the *actual* `HangfireBackgroundWorker.GetJobById`: with today's (unfixed) `GetJobStartedAt` implementation, `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime` and `GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt`'s "Processing" scenarios do **not** find the seeded value (the old `ProcessingJobs()` monitoring-API scan only sees jobs added to storage's "processing" set by the real state-transition pipeline, which `SetJobState` alone does not populate) — so the first of these two tests is expected to fail before Step 3's fix and pass after it. This is the intended TDD red/green signal.
+
+- [ ] **Step 2: Run tests to verify the new ones fail for the expected reason**
+
+Run:
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~HangfireBackgroundWorkerTests"
+```
+Expected: `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime` FAILS (`result.StartedAt` is `null`, not the expected `DateTime`). The other three new tests (`NonProcessingState`, `MissingStartedAtKey`, `NonexistentJobId`) and the two pre-existing constructor tests PASS already, since they don't depend on the buggy scan path returning a value.
+
+- [ ] **Step 3: Replace `GetJobStartedAt`'s body in `HangfireBackgroundWorker.cs`**
+
+Current code (lines 160–177 of `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs`):
+
+```csharp
+    private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)
+    {
+        try
+        {
+            var monitoring = JobStorage.Current.GetMonitoringApi();
+            var processingJobs = monitoring.ProcessingJobs(0, int.MaxValue);
+
+            var processingJob = processingJobs.FirstOrDefault(j => j.Key == jobId);
+            if (processingJob.Value != null)
+                return processingJob.Value.StartedAt;
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+```
+
+Replace it with:
+
+```csharp
+    private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)
+    {
+        try
+        {
+            var stateData = connection.GetStateData(jobId);
+            if (stateData?.Name != ProcessingState.StateName)
+                return null;
+
+            return stateData.Data.TryGetValue("StartedAt", out var startedAt)
+                ? JobHelper.DeserializeNullableDateTime(startedAt)
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+```
+
+No `using` changes are needed: the file already has `using Hangfire.Common;` (for `JobHelper`) and `using Hangfire.States;` (for `ProcessingState`) at the top (lines 5–6), and `IStorageConnection`/`JobStorage` are already imported via `using Hangfire.Storage;` / `using Hangfire;` (lines 7, 4). No other method in the class changes; `GetJobById` (lines 126–152) calls `GetJobStartedAt(connection, jobId)` exactly as before (line 144) and requires no edit.
+
+- [ ] **Step 4: Run tests to verify everything passes**
+
+Run:
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~HangfireBackgroundWorkerTests"
+```
+Expected: all 6 tests PASS (`Constructor_StoresHangfireOptions`, `Constructor_AcceptsCustomPageSize`, `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime`, `GetJobById_NonProcessingState_ReturnsNullStartedAt`, `GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt`, `GetJobById_NonexistentJobId_ReturnsNull`).
+
+- [ ] **Step 5: Full backend validation**
+
+Run, from the repo root:
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A/backend
+dotnet build Anela.Heblo.sln
+dotnet format Anela.Heblo.sln --verify-no-changes
+dotnet test Anela.Heblo.sln
+```
+Expected: build succeeds with no new warnings/errors introduced by this change; `dotnet format --verify-no-changes` reports no formatting violations (if it reports violations caused by this change's new code, run `dotnet format Anela.Heblo.sln` to fix and re-verify); the full test suite passes, including the 6 tests in `HangfireBackgroundWorkerTests`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A
+git add backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs
+git commit -m "perf: replace full ProcessingJobs scan in GetJobStartedAt with targeted GetStateData lookup"
+```
+
+**Acceptance criteria for this task (traced to spec.r1.md FR-1/FR-2/FR-3):**
+- [ ] `HangfireBackgroundWorker.GetJobStartedAt` contains no call to `ProcessingJobs` or any other `int.MaxValue`-paged monitoring API call (grep confirms: `grep -n "ProcessingJobs" backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` should only match the bounded call inside `GetRunningJobs`, not `GetJobStartedAt`).
+- [ ] A job in `"Processing"` state with a parseable `"StartedAt"` entry yields that exact `DateTime` via `GetJobById`.
+- [ ] A job in a non-`"Processing"` state yields `StartedAt == null` via `GetJobById`.
+- [ ] A job in `"Processing"` state missing the `"StartedAt"` key yields `StartedAt == null`.
+- [ ] A nonexistent job ID yields `GetJobById(...) == null`.
+- [ ] `GetJobStartedAt`'s signature (`private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)`) and its only caller (`GetJobById`) are unchanged.
+- [ ] `IBackgroundWorker`, `BackgroundJobInfo`, `GetPendingJobs`, `GetRunningJobs`, `GetJobState`, `GetJobDisplayName` are unchanged.
+- [ ] `dotnet build`, `dotnet format --verify-no-changes`, and the full `dotnet test` suite all pass.

--- a/artifacts/feat-3637/task-plan.r1.md
+++ b/artifacts/feat-3637/task-plan.r1.md
@@ -1,0 +1,304 @@
+# Targeted per-job lookup for `GetJobStartedAt` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the O(N) full-table `ProcessingJobs(0, int.MaxValue)` scan in `HangfireBackgroundWorker.GetJobStartedAt` with an O(1) targeted `IStorageConnection.GetStateData(jobId)` read, with regression test coverage, and no change to any public contract.
+
+**Architecture:** Single-method rewrite inside `HangfireBackgroundWorker` (the sole `IBackgroundWorker` implementation). `GetJobStartedAt` currently re-derives `JobStorage.Current.GetMonitoringApi()` and pages through every processing job to find one by key; the fix instead calls `connection.GetStateData(jobId)` — the exact same primitive the sibling method `GetJobState` already uses on the same connection — and reads `StartedAt` out of the state's `Data` dictionary via `Hangfire.Common.JobHelper.DeserializeNullableDateTime` when the state name is `"Processing"` (`Hangfire.States.ProcessingState.StateName`). No new files, no interface changes, no caller changes (`GetJobById` is unaffected). Test coverage is added to the existing `HangfireBackgroundWorkerTests.cs`, using the project's already-established `[Collection("Hangfire")]` / `HangfireTestFixture` pattern (backed by `Hangfire.MemoryStorage`, already a package reference) plus a minimal test-only `IState` implementation to seed a job directly into a given state/data via `IWriteOnlyTransaction.SetJobState`, since `Hangfire.States.ProcessingState`'s constructor is internal and cannot be called from test code.
+
+**Tech Stack:** .NET 8, Hangfire.Core 1.8.21 (`Hangfire.Storage.IStorageConnection`, `Hangfire.Storage.IWriteOnlyTransaction`, `Hangfire.States.IState` / `ProcessingState`, `Hangfire.Common.JobHelper`), Hangfire.MemoryStorage 1.8.1.2 (test double for `JobStorage.Current`), xUnit, FluentAssertions.
+
+---
+
+### task: fix-hangfire-getjobstartedat-full-scan
+
+**Context — what's being fixed and why:**
+`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` implements `IBackgroundWorker`. Its `GetJobById(string jobId)` method (lines 126–152) does two O(1) lookups on an `IStorageConnection` — `connection.GetJobData(jobId)` and, via `GetJobState`, `connection.GetStateData(jobId)` — but delegates `StartedAt` resolution to `GetJobStartedAt` (lines 160–177), which instead pages through **every** job in the Hangfire "Processing" state via the monitoring API (`monitoring.ProcessingJobs(0, int.MaxValue)`) and does a linear `FirstOrDefault` scan to find the one entry matching `jobId`. This is unnecessary O(N) storage/memory cost for what should be a single keyed lookup — the exact same `StartedAt` value is already present in the "Processing" state's own `Data` dictionary, retrievable via `connection.GetStateData(jobId)` (the same call `GetJobState` already makes for the same `jobId`).
+
+This task rewrites only the body of `GetJobStartedAt`, preserving its private static signature and its only caller (`GetJobById`) untouched, and adds regression tests for the class (which today has zero coverage of `GetJobById`/`GetJobStartedAt` — only constructor/options wiring is tested).
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` (rewrite `GetJobStartedAt`, lines 160–177)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs` (add regression tests; wire into the shared `[Collection("Hangfire")]` fixture)
+- Reference (read-only, no changes): `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/Infrastructure/HangfireTestFixture.cs` — existing `HangfireTestFixture` / `[CollectionDefinition("Hangfire", DisableParallelization = true)]` that configures `JobStorage.Current` to `Hangfire.MemoryStorage.MemoryStorage()` once per test run. Reuse this; do not create a new fixture.
+
+---
+
+- [ ] **Step 1: Write the failing tests in `HangfireBackgroundWorkerTests.cs`**
+
+Replace the entire current file content with the following (it keeps the two existing constructor tests unchanged and adds the new state-based coverage plus the test-seeding helpers):
+
+```csharp
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Anela.Heblo.Xcc;
+using FluentAssertions;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Invoices;
+
+[Collection("Hangfire")]
+public class HangfireBackgroundWorkerTests
+{
+    private readonly HangfireBackgroundWorker _worker;
+
+    public HangfireBackgroundWorkerTests(HangfireTestFixture fixture)
+    {
+        // HangfireTestFixture (shared via the "Hangfire" collection) configures
+        // JobStorage.Current to an in-memory Hangfire.MemoryStorage instance once
+        // for the whole test run — see HangfireTestFixture.cs.
+        _worker = new HangfireBackgroundWorker(Options.Create(new HangfireOptions()));
+    }
+
+    [Fact]
+    public void Constructor_StoresHangfireOptions()
+    {
+        // Arrange
+        var options = Options.Create(new HangfireOptions { MaxPendingJobsPageSize = 200 });
+
+        // Act
+        var worker = new HangfireBackgroundWorker(options);
+
+        // Assert — the worker must hold the options so its monitoring calls use the cap.
+        var stored = typeof(HangfireBackgroundWorker)
+            .GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(worker) as HangfireOptions;
+
+        stored.Should().NotBeNull();
+        stored!.MaxPendingJobsPageSize.Should().Be(200);
+    }
+
+    [Fact]
+    public void Constructor_AcceptsCustomPageSize()
+    {
+        // Arrange
+        var options = Options.Create(new HangfireOptions { MaxPendingJobsPageSize = 50 });
+
+        // Act
+        var worker = new HangfireBackgroundWorker(options);
+
+        // Assert
+        var stored = typeof(HangfireBackgroundWorker)
+            .GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(worker) as HangfireOptions;
+
+        stored!.MaxPendingJobsPageSize.Should().Be(50);
+    }
+
+    #region GetJobById / GetJobStartedAt state coverage (targeted GetStateData lookup)
+
+    [Fact]
+    public void GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime()
+    {
+        // Arrange: a job whose current Hangfire state is "Processing" and whose
+        // state Data dictionary carries a valid, parseable "StartedAt" entry.
+        var jobId = CreateEnqueuedJob();
+        var expectedStartedAt = new DateTime(2026, 7, 14, 10, 0, 0, DateTimeKind.Utc);
+        SeedJobState(jobId, ProcessingState.StateName, new Dictionary<string, string>
+        {
+            ["StartedAt"] = JobHelper.SerializeDateTime(expectedStartedAt)
+        });
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Processing");
+        result.StartedAt.Should().Be(expectedStartedAt);
+    }
+
+    [Fact]
+    public void GetJobById_NonProcessingState_ReturnsNullStartedAt()
+    {
+        // Arrange: job is created directly into the "Enqueued" state and never
+        // transitioned to "Processing".
+        var jobId = CreateEnqueuedJob();
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Enqueued");
+        result.StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt()
+    {
+        // Arrange: state name is "Processing" but the state Data dictionary has
+        // no "StartedAt" entry at all.
+        var jobId = CreateEnqueuedJob();
+        SeedJobState(jobId, ProcessingState.StateName, new Dictionary<string, string>());
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Processing");
+        result.StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetJobById_NonexistentJobId_ReturnsNull()
+    {
+        // Act
+        var result = _worker.GetJobById("nonexistent-job-id-does-not-exist");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private static string CreateEnqueuedJob()
+    {
+        var client = new BackgroundJobClient(JobStorage.Current);
+        Expression<Action> methodCall = () => Console.WriteLine("test job");
+        var job = Job.FromExpression(methodCall);
+        return client.Create(job, new EnqueuedState());
+    }
+
+    /// <summary>
+    /// Seeds the given job directly into the given state/data via a write transaction,
+    /// bypassing Hangfire's normal state-transition pipeline. This is necessary because
+    /// Hangfire.States.ProcessingState's constructor is internal and cannot be
+    /// instantiated from test code; FakeState below stands in for it, carrying only
+    /// the (Name, Data) pair that HangfireBackgroundWorker.GetJobStartedAt reads.
+    /// </summary>
+    private static void SeedJobState(string jobId, string stateName, Dictionary<string, string> data)
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        using var transaction = connection.CreateWriteTransaction();
+        transaction.SetJobState(jobId, new FakeState(stateName, data));
+        transaction.Commit();
+    }
+
+    private sealed class FakeState : IState
+    {
+        private readonly Dictionary<string, string> _data;
+
+        public FakeState(string name, Dictionary<string, string> data)
+        {
+            Name = name;
+            _data = data;
+        }
+
+        public string Name { get; }
+        public string? Reason => null;
+        public bool IsFinal => false;
+        public bool IgnoreJobLoadException => false;
+        public Dictionary<string, string> SerializeData() => _data;
+    }
+
+    #endregion
+}
+```
+
+Notes on this test design (verified against the actual installed `Hangfire.Core 1.8.21` package via a throwaway reflection probe before writing this plan — do not deviate from these facts):
+- `Hangfire.Storage.StateData.Data` is `IDictionary<string, string>`, and `Hangfire.Common.JobHelper.DeserializeNullableDateTime(string) : DateTime?` is the correct reader for the `"StartedAt"` value serialized via `JobHelper.SerializeDateTime`.
+- `Hangfire.States.ProcessingState` has only an **internal** `(string serverId, string workerId)` constructor — it cannot be `new`'d from test code. `IWriteOnlyTransaction.SetJobState(string jobId, IState state)` accepts any `IState`, so the minimal `FakeState` above (implementing `Name`/`Reason`/`IsFinal`/`IgnoreJobLoadException`/`SerializeData()`) is the correct, dependency-free way to seed a job into an arbitrary named state with arbitrary state data, without needing Hangfire's real state-transition/filter pipeline (which `HangfireBackgroundWorker.GetJobStartedAt` doesn't depend on either — it only reads `connection.GetStateData(jobId)`).
+- Confirmed via an end-to-end run against the *actual* `HangfireBackgroundWorker.GetJobById`: with today's (unfixed) `GetJobStartedAt` implementation, `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime` and `GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt`'s "Processing" scenarios do **not** find the seeded value (the old `ProcessingJobs()` monitoring-API scan only sees jobs added to storage's "processing" set by the real state-transition pipeline, which `SetJobState` alone does not populate) — so the first of these two tests is expected to fail before Step 3's fix and pass after it. This is the intended TDD red/green signal.
+
+- [ ] **Step 2: Run tests to verify the new ones fail for the expected reason**
+
+Run:
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~HangfireBackgroundWorkerTests"
+```
+Expected: `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime` FAILS (`result.StartedAt` is `null`, not the expected `DateTime`). The other three new tests (`NonProcessingState`, `MissingStartedAtKey`, `NonexistentJobId`) and the two pre-existing constructor tests PASS already, since they don't depend on the buggy scan path returning a value.
+
+- [ ] **Step 3: Replace `GetJobStartedAt`'s body in `HangfireBackgroundWorker.cs`**
+
+Current code (lines 160–177 of `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs`):
+
+```csharp
+    private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)
+    {
+        try
+        {
+            var monitoring = JobStorage.Current.GetMonitoringApi();
+            var processingJobs = monitoring.ProcessingJobs(0, int.MaxValue);
+
+            var processingJob = processingJobs.FirstOrDefault(j => j.Key == jobId);
+            if (processingJob.Value != null)
+                return processingJob.Value.StartedAt;
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+```
+
+Replace it with:
+
+```csharp
+    private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)
+    {
+        try
+        {
+            var stateData = connection.GetStateData(jobId);
+            if (stateData?.Name != ProcessingState.StateName)
+                return null;
+
+            return stateData.Data.TryGetValue("StartedAt", out var startedAt)
+                ? JobHelper.DeserializeNullableDateTime(startedAt)
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+```
+
+No `using` changes are needed: the file already has `using Hangfire.Common;` (for `JobHelper`) and `using Hangfire.States;` (for `ProcessingState`) at the top (lines 5–6), and `IStorageConnection`/`JobStorage` are already imported via `using Hangfire.Storage;` / `using Hangfire;` (lines 7, 4). No other method in the class changes; `GetJobById` (lines 126–152) calls `GetJobStartedAt(connection, jobId)` exactly as before (line 144) and requires no edit.
+
+- [ ] **Step 4: Run tests to verify everything passes**
+
+Run:
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~HangfireBackgroundWorkerTests"
+```
+Expected: all 6 tests PASS (`Constructor_StoresHangfireOptions`, `Constructor_AcceptsCustomPageSize`, `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime`, `GetJobById_NonProcessingState_ReturnsNullStartedAt`, `GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt`, `GetJobById_NonexistentJobId_ReturnsNull`).
+
+- [ ] **Step 5: Full backend validation**
+
+Run, from the repo root:
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A/backend
+dotnet build Anela.Heblo.sln
+dotnet format Anela.Heblo.sln --verify-no-changes
+dotnet test Anela.Heblo.sln
+```
+Expected: build succeeds with no new warnings/errors introduced by this change; `dotnet format --verify-no-changes` reports no formatting violations (if it reports violations caused by this change's new code, run `dotnet format Anela.Heblo.sln` to fix and re-verify); the full test suite passes, including the 6 tests in `HangfireBackgroundWorkerTests`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/user/worktrees/feature-3637-Arch-Review-Backgroundjobs-Getjobstartedat-Scans-A
+git add backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs
+git commit -m "perf: replace full ProcessingJobs scan in GetJobStartedAt with targeted GetStateData lookup"
+```
+
+**Acceptance criteria for this task (traced to spec.r1.md FR-1/FR-2/FR-3):**
+- [ ] `HangfireBackgroundWorker.GetJobStartedAt` contains no call to `ProcessingJobs` or any other `int.MaxValue`-paged monitoring API call (grep confirms: `grep -n "ProcessingJobs" backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs` should only match the bounded call inside `GetRunningJobs`, not `GetJobStartedAt`).
+- [ ] A job in `"Processing"` state with a parseable `"StartedAt"` entry yields that exact `DateTime` via `GetJobById`.
+- [ ] A job in a non-`"Processing"` state yields `StartedAt == null` via `GetJobById`.
+- [ ] A job in `"Processing"` state missing the `"StartedAt"` key yields `StartedAt == null`.
+- [ ] A nonexistent job ID yields `GetJobById(...) == null`.
+- [ ] `GetJobStartedAt`'s signature (`private static DateTime? GetJobStartedAt(IStorageConnection connection, string jobId)`) and its only caller (`GetJobById`) are unchanged.
+- [ ] `IBackgroundWorker`, `BackgroundJobInfo`, `GetPendingJobs`, `GetRunningJobs`, `GetJobState`, `GetJobDisplayName` are unchanged.
+- [ ] `dotnet build`, `dotnet format --verify-no-changes`, and the full `dotnet test` suite all pass.

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs
@@ -161,14 +161,13 @@ public class HangfireBackgroundWorker : IBackgroundWorker
     {
         try
         {
-            var monitoring = JobStorage.Current.GetMonitoringApi();
-            var processingJobs = monitoring.ProcessingJobs(0, int.MaxValue);
+            var stateData = connection.GetStateData(jobId);
+            if (stateData?.Name != ProcessingState.StateName)
+                return null;
 
-            var processingJob = processingJobs.FirstOrDefault(j => j.Key == jobId);
-            if (processingJob.Value != null)
-                return processingJob.Value.StartedAt;
-
-            return null;
+            return stateData.Data.TryGetValue("StartedAt", out var startedAt)
+                ? JobHelper.DeserializeNullableDateTime(startedAt)
+                : null;
         }
         catch
         {

--- a/backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Invoices/HangfireBackgroundWorkerTests.cs
@@ -1,14 +1,31 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Reflection;
-using Anela.Heblo.Xcc;
 using Anela.Heblo.API.Infrastructure.Hangfire;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Anela.Heblo.Xcc;
 using FluentAssertions;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Invoices;
 
+[Collection("Hangfire")]
 public class HangfireBackgroundWorkerTests
 {
+    private readonly HangfireBackgroundWorker _worker;
+
+    public HangfireBackgroundWorkerTests(HangfireTestFixture fixture)
+    {
+        // HangfireTestFixture (shared via the "Hangfire" collection) configures
+        // JobStorage.Current to an in-memory Hangfire.MemoryStorage instance once
+        // for the whole test run — see HangfireTestFixture.cs.
+        _worker = new HangfireBackgroundWorker(Options.Create(new HangfireOptions()));
+    }
+
     [Fact]
     public void Constructor_StoresHangfireOptions()
     {
@@ -43,4 +60,112 @@ public class HangfireBackgroundWorkerTests
 
         stored!.MaxPendingJobsPageSize.Should().Be(50);
     }
+
+    #region GetJobById / GetJobStartedAt state coverage (targeted GetStateData lookup)
+
+    [Fact]
+    public void GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime()
+    {
+        // Arrange: a job whose current Hangfire state is "Processing" and whose
+        // state Data dictionary carries a valid, parseable "StartedAt" entry.
+        var jobId = CreateEnqueuedJob();
+        var expectedStartedAt = new DateTime(2026, 7, 14, 10, 0, 0, DateTimeKind.Utc);
+        SeedJobState(jobId, ProcessingState.StateName, new Dictionary<string, string>
+        {
+            ["StartedAt"] = JobHelper.SerializeDateTime(expectedStartedAt)
+        });
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Processing");
+        result.StartedAt.Should().Be(expectedStartedAt);
+    }
+
+    [Fact]
+    public void GetJobById_NonProcessingState_ReturnsNullStartedAt()
+    {
+        // Arrange: job is created directly into the "Enqueued" state and never
+        // transitioned to "Processing".
+        var jobId = CreateEnqueuedJob();
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Enqueued");
+        result.StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetJobById_ProcessingStateWithMissingStartedAtKey_ReturnsNullStartedAt()
+    {
+        // Arrange: state name is "Processing" but the state Data dictionary has
+        // no "StartedAt" entry at all.
+        var jobId = CreateEnqueuedJob();
+        SeedJobState(jobId, ProcessingState.StateName, new Dictionary<string, string>());
+
+        // Act
+        var result = _worker.GetJobById(jobId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.State.Should().Be("Processing");
+        result.StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetJobById_NonexistentJobId_ReturnsNull()
+    {
+        // Act
+        var result = _worker.GetJobById("nonexistent-job-id-does-not-exist");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    private static string CreateEnqueuedJob()
+    {
+        var client = new BackgroundJobClient(JobStorage.Current);
+        Expression<Action> methodCall = () => Console.WriteLine("test job");
+        var job = Job.FromExpression(methodCall);
+        return client.Create(job, new EnqueuedState());
+    }
+
+    /// <summary>
+    /// Seeds the given job directly into the given state/data via a write transaction,
+    /// bypassing Hangfire's normal state-transition pipeline. This is necessary because
+    /// Hangfire.States.ProcessingState's constructor is internal and cannot be
+    /// instantiated from test code; FakeState below stands in for it, carrying only
+    /// the (Name, Data) pair that HangfireBackgroundWorker.GetJobStartedAt reads.
+    /// </summary>
+    private static void SeedJobState(string jobId, string stateName, Dictionary<string, string> data)
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        using var transaction = connection.CreateWriteTransaction();
+        transaction.SetJobState(jobId, new FakeState(stateName, data));
+        transaction.Commit();
+    }
+
+    private sealed class FakeState : IState
+    {
+        private readonly Dictionary<string, string> _data;
+
+        public FakeState(string name, Dictionary<string, string> data)
+        {
+            Name = name;
+            _data = data;
+        }
+
+        public string Name { get; }
+        public string? Reason => null;
+        public bool IsFinal => false;
+        public bool IgnoreJobLoadException => false;
+        public Dictionary<string, string> SerializeData() => _data;
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #3637

## What the issue was
`HangfireBackgroundWorker.GetJobStartedAt` did a full scan of every currently-processing Hangfire job (`monitoring.ProcessingJobs(0, int.MaxValue)`) just to find the start time of a single job by ID — O(N) storage/memory cost for what should be an O(1) keyed lookup, flagged by the automated daily arch-review routine.

## How it was fixed / handled
Rewrote `GetJobStartedAt` to read `StartedAt` directly from `connection.GetStateData(jobId)` — the same call the class's `GetJobState` method already makes for the same job ID — instead of paging through the monitoring API. The method's private static signature and its only caller (`GetJobById`) are unchanged. Added 4 regression tests covering the processing/non-processing/missing-key/nonexistent-job scenarios, reusing the existing `HangfireTestFixture`/`Hangfire.MemoryStorage`-backed test collection (previously the class had zero coverage of `GetJobById`/`GetJobStartedAt`).

Verified: the previously-untested `GetJobById_ProcessingStateWithValidStartedAt_ReturnsMatchingDateTime` case is red before the fix and green after; all 6 tests in the file pass; `dotnet build` and `dotnet format --verify-no-changes` are clean. A full-solution `dotnet test` run shows only pre-existing Testcontainers/PostgreSQL integration failures caused by this sandbox having no Docker daemon — unrelated to this change.

## Artifacts
Brief, spec, architecture review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3637/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs:136` and `:164` — `GetJobById` now calls `connection.GetStateData(jobId)` twice in the same request: once inside `GetJobState` (line 156) and once inside `GetJobStartedAt` (line 164). Both calls happen within the same `GetJobById` invocation, so this is two storage round-trips where one `StateData` fetch would do. The spec explicitly calls this out as an acceptable, out-of-scope follow-on (consolidating the two lookups), so this is advisory only, not a blocker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuwuAeiD6uVFHxhBq4exNt)_