### PR TITLE
feat: add test-source feature flag to delivered-order completion job

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -3,7 +3,8 @@
     "is-transport-box-tracking-enabled": false,
     "is-stock-taking-enabled": false,
     "is-background-refresh-enabled": true,
-    "is-delivered-order-completion-enabled": false
+    "is-delivered-order-completion-enabled": false,
+    "is-delivered-order-completion-test-source-enabled": false
   },
   "MarketingCalendar": {
     "GroupId": "GROUP-ID-FOR-MARKETING-CALENDAR-ACCESS",

--- a/backend/src/Anela.Heblo.Application/Features/FeatureFlags/FeatureFlagKeys.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FeatureFlags/FeatureFlagKeys.cs
@@ -12,4 +12,11 @@ public static class FeatureFlagKeys
     /// remark). When off, the job runs in dry-run mode and only logs what it would do.
     /// </summary>
     public const string DeliveredOrderCompletion = "is-delivered-order-completion-enabled";
+
+    /// <summary>
+    /// When on, the delivered-orders job polls the test source states (73 "Oprava-robot")
+    /// instead of the production "handed to carrier" states — lets the whole pipeline be
+    /// exercised on a controlled set of orders. When off, the production states are used.
+    /// </summary>
+    public const string DeliveredOrderCompletionTestSource = "is-delivered-order-completion-test-source-enabled";
 }

--- a/backend/src/Anela.Heblo.Application/Features/FeatureFlags/FeatureFlagRegistry.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FeatureFlags/FeatureFlagRegistry.cs
@@ -13,6 +13,9 @@ public static class FeatureFlagRegistry
         new(FeatureFlagKeys.DeliveredOrderCompletion,
             Description: "When on, the delivered-orders job changes order state to 'vyřízena' and writes the remark; when off it only logs what it would do (dry run).",
             DefaultValue: false),
+        new(FeatureFlagKeys.DeliveredOrderCompletionTestSource,
+            Description: "When on, the delivered-orders job polls test state 73 (Oprava-robot) instead of the production 'handed to carrier' states 70/82.",
+            DefaultValue: false),
     ];
 
     public static readonly IReadOnlyDictionary<string, FeatureFlagDefinition> ByKey =

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/Infrastructure/Jobs/CompleteDeliveredOrdersJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/Infrastructure/Jobs/CompleteDeliveredOrdersJob.cs
@@ -59,12 +59,24 @@ public sealed class CompleteDeliveredOrdersJob : IRecurringJob
                 FeatureFlagKeys.DeliveredOrderCompletion);
         }
 
+        var useTestSource = await _featureFlags.IsEnabledAsync(
+            FeatureFlagKeys.DeliveredOrderCompletionTestSource, cancellationToken);
+        var sourceStateIds = useTestSource
+            ? _settings.DeliveredCompletionTestSourceStateIds
+            : _settings.DeliveredCompletionSourceStateIds;
+        if (useTestSource)
+        {
+            _logger.LogInformation(
+                "CompleteDeliveredOrders: using TEST source states [{TestStates}] (feature flag '{Flag}' enabled) instead of the production states.",
+                string.Join(", ", sourceStateIds), FeatureFlagKeys.DeliveredOrderCompletionTestSource);
+        }
+
         var targetState = _settings.CompletedStatusId;
         var scanned = 0;
         var delivered = 0;
         var completed = 0;
 
-        foreach (var stateId in _settings.DeliveredCompletionSourceStateIds)
+        foreach (var stateId in sourceStateIds)
         {
             List<EshopOrderSummary> orders;
             try

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/ShoptetOrdersSettings.cs
@@ -46,6 +46,14 @@ public class ShoptetOrdersSettings
     public int[] DeliveredCompletionSourceStateIds { get; set; } = [70, 82];
 
     /// <summary>
+    /// Shoptet order status IDs polled by the auto-completion job when the
+    /// "is-delivered-order-completion-test-source-enabled" feature flag is on —
+    /// replaces <see cref="DeliveredCompletionSourceStateIds"/> entirely so the pipeline
+    /// can be exercised on a controlled set of orders. Defaults to 73 ("Oprava-robot").
+    /// </summary>
+    public int[] DeliveredCompletionTestSourceStateIds { get; set; } = [73];
+
+    /// <summary>
     /// Shoptet order status ID assigned when a delivered order is auto-completed.
     /// Defaults to -3 ("Vyřízena").
     /// </summary>

--- a/backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/CompleteDeliveredOrdersJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/CompleteDeliveredOrdersJobTests.cs
@@ -17,7 +17,7 @@ public class CompleteDeliveredOrdersJobTests
         Mock<IEshopOrderClient> Orders,
         Mock<IShipmentClient> Shipments,
         Mock<IRecurringJobStatusChecker> StatusChecker)
-        MakeSut(bool jobEnabled = true, bool applyChanges = true)
+        MakeSut(bool jobEnabled = true, bool applyChanges = true, bool useTestSource = false)
     {
         var orders = new Mock<IEshopOrderClient>();
         var shipments = new Mock<IShipmentClient>();
@@ -30,10 +30,14 @@ public class CompleteDeliveredOrdersJobTests
         featureFlags
             .Setup(f => f.IsEnabledAsync(FeatureFlagKeys.DeliveredOrderCompletion, It.IsAny<CancellationToken>()))
             .ReturnsAsync(applyChanges);
+        featureFlags
+            .Setup(f => f.IsEnabledAsync(FeatureFlagKeys.DeliveredOrderCompletionTestSource, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(useTestSource);
 
         var settings = Options.Create(new ShoptetOrdersSettings
         {
             DeliveredCompletionSourceStateIds = [70, 82],
+            DeliveredCompletionTestSourceStateIds = [73],
             CompletedStatusId = -3,
         });
 
@@ -147,6 +151,42 @@ public class CompleteDeliveredOrdersJobTests
         // Delivered orders are still detected (so the dry-run log reflects reality)...
         shipments.Verify(s => s.HasDeliveredShipmentAsync("ORD-1", It.IsAny<CancellationToken>()), Times.Once);
         // ...but no state change or remark is written while the flag is off.
+        orders.Verify(o => o.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        orders.Verify(o => o.UpdateEshopRemarkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UsesTestSourceState_WhenTestSourceFlagEnabled()
+    {
+        var (sut, orders, shipments, _) = MakeSut(useTestSource: true);
+        orders.Setup(o => o.ListOrdersByStatusAsync(73, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Order("ORD-TEST", 73)]);
+        shipments.Setup(s => s.HasDeliveredShipmentAsync("ORD-TEST", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        orders.Setup(o => o.GetEshopRemarkAsync("ORD-TEST", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(string.Empty);
+
+        await sut.ExecuteAsync();
+
+        // Test state 73 replaces the production source states entirely.
+        orders.Verify(o => o.ListOrdersByStatusAsync(73, It.IsAny<CancellationToken>()), Times.Once);
+        orders.Verify(o => o.ListOrdersByStatusAsync(70, It.IsAny<CancellationToken>()), Times.Never);
+        orders.Verify(o => o.ListOrdersByStatusAsync(82, It.IsAny<CancellationToken>()), Times.Never);
+        orders.Verify(o => o.UpdateStatusAsync("ORD-TEST", -3, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TestSourceRespectsDryRun_WhenCompletionFlagDisabled()
+    {
+        var (sut, orders, shipments, _) = MakeSut(applyChanges: false, useTestSource: true);
+        orders.Setup(o => o.ListOrdersByStatusAsync(73, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Order("ORD-TEST", 73)]);
+        shipments.Setup(s => s.HasDeliveredShipmentAsync("ORD-TEST", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await sut.ExecuteAsync();
+
+        orders.Verify(o => o.ListOrdersByStatusAsync(73, It.IsAny<CancellationToken>()), Times.Once);
         orders.Verify(o => o.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
         orders.Verify(o => o.UpdateEshopRemarkAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/FeatureFlags/HebloFeatureProviderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FeatureFlags/HebloFeatureProviderTests.cs
@@ -1,0 +1,115 @@
+using Anela.Heblo.Application.Features.FeatureFlags;
+using Anela.Heblo.Application.Features.FeatureFlags.Infrastructure;
+using Anela.Heblo.Domain.Features.FeatureFlags;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OpenFeature.Constant;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.FeatureFlags;
+
+/// <summary>
+/// Covers the three-layer flag resolution (DB override → appsettings → default) and the
+/// fail-open behavior the delivered-order dry-run gate depends on: any resolution failure
+/// must yield the supplied default (false), never an exception.
+/// </summary>
+public class HebloFeatureProviderTests
+{
+    private const string FlagKey = FeatureFlagKeys.DeliveredOrderCompletion;
+
+    private static HebloFeatureProvider MakeProvider(
+        Dictionary<string, bool>? dbOverrides = null,
+        Dictionary<string, string?>? configValues = null,
+        bool repoThrows = false)
+    {
+        var repo = new Mock<IFeatureFlagOverrideRepository>();
+        if (repoThrows)
+        {
+            repo.Setup(r => r.GetAllAsDictionaryAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("DB unavailable"));
+        }
+        else
+        {
+            repo.Setup(r => r.GetAllAsDictionaryAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbOverrides ?? []);
+        }
+
+        var services = new ServiceCollection();
+        services.AddSingleton(repo.Object);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues ?? [])
+            .Build();
+
+        return new HebloFeatureProvider(
+            scopeFactory,
+            new MemoryCache(new MemoryCacheOptions()),
+            configuration,
+            NullLogger<HebloFeatureProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task ResolveBooleanValueAsync_DbOverrideWins_OverConfigAndDefault()
+    {
+        var provider = MakeProvider(
+            dbOverrides: new Dictionary<string, bool> { [FlagKey] = true },
+            configValues: new Dictionary<string, string?> { [$"FeatureManagement:{FlagKey}"] = "false" });
+
+        var result = await provider.ResolveBooleanValueAsync(FlagKey, defaultValue: false);
+
+        result.Value.Should().BeTrue();
+        result.Reason.Should().Be(Reason.TargetingMatch);
+    }
+
+    [Fact]
+    public async Task ResolveBooleanValueAsync_FallsBackToConfig_WhenNoDbOverride()
+    {
+        var provider = MakeProvider(
+            configValues: new Dictionary<string, string?> { [$"FeatureManagement:{FlagKey}"] = "true" });
+
+        var result = await provider.ResolveBooleanValueAsync(FlagKey, defaultValue: false);
+
+        result.Value.Should().BeTrue();
+        result.Reason.Should().Be(Reason.Static);
+    }
+
+    [Fact]
+    public async Task ResolveBooleanValueAsync_FallsBackToDefault_WhenNoOverrideOrConfig()
+    {
+        var provider = MakeProvider();
+
+        var result = await provider.ResolveBooleanValueAsync(FlagKey, defaultValue: false);
+
+        result.Value.Should().BeFalse();
+        result.Reason.Should().Be(Reason.Default);
+    }
+
+    [Fact]
+    public async Task ResolveBooleanValueAsync_FailsOpenToDefault_WhenDbThrows()
+    {
+        var provider = MakeProvider(repoThrows: true);
+
+        var result = await provider.ResolveBooleanValueAsync(FlagKey, defaultValue: false);
+
+        result.Value.Should().BeFalse();
+        result.Reason.Should().Be(Reason.Error);
+    }
+
+    [Fact]
+    public async Task ResolveBooleanValueAsync_DbOverrideCanDisable_WhenConfigEnables()
+    {
+        var provider = MakeProvider(
+            dbOverrides: new Dictionary<string, bool> { [FlagKey] = false },
+            configValues: new Dictionary<string, string?> { [$"FeatureManagement:{FlagKey}"] = "true" });
+
+        var result = await provider.ResolveBooleanValueAsync(FlagKey, defaultValue: true);
+
+        result.Value.Should().BeFalse();
+        result.Reason.Should().Be(Reason.TargetingMatch);
+    }
+}

--- a/docs/integrations/shoptet-api.md
+++ b/docs/integrations/shoptet-api.md
@@ -1235,7 +1235,7 @@ After a successful `201` response, the shipment is in `requested` status. The la
 | `closed` | Closed |
 | `deleted` | Deleted |
 
-**Anela consumption:** `CompleteDeliveredOrdersJob` polls orders in states 70/82 hourly and, when any of their shipments reports `delivered`, moves the order to `-3` ("vyřízena").
+**Anela consumption:** `CompleteDeliveredOrdersJob` polls orders in states 70/82 hourly and, when any of their shipments reports `delivered`, moves the order to `-3` ("vyřízena"). With the `is-delivered-order-completion-test-source-enabled` feature flag on, it polls test state 73 ("Oprava-robot") instead — a controlled pool for end-to-end testing.
 
 **Webhook alternative:** `shipment:create` webhook fires when carrier confirms the shipment (tracking number assigned, label ready). Register via Shoptet webhooks if polling is undesirable.
 


### PR DESCRIPTION
Adds a second runtime feature flag, `is-delivered-order-completion-test-source-enabled` (default off): when on, `CompleteDeliveredOrdersJob` polls test state 73 ("Oprava-robot", configurable via `ShoptetOrdersSettings.DeliveredCompletionTestSourceStateIds`) instead of the production carrier states 70/82, giving a controlled order pool for end-to-end testing — place a delivered test order into state 73, flip both flags, trigger the job, and observe the full pipeline including real writes. The test source composes with the existing dry-run gate (`is-delivered-order-completion-enabled`), so it can also be exercised read-only. Also cherry-picks the `HebloFeatureProviderTests` (5 tests for the DB-override → appsettings → default resolution and fail-open behavior) that were pushed to the previous feature branch after its PR had merged and never landed on main. Verified with 9 job unit tests (2 new: test-source routing, test-source + dry-run) — 213 tests green across the touched scope.