### PR TITLE
fix: count materials not lots in expiration tile, add healthy segment

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTile.cs
@@ -4,10 +4,12 @@ using Anela.Heblo.Xcc.Services.Dashboard;
 namespace Anela.Heblo.Application.Features.Catalog.DashboardTiles;
 
 /// <summary>
-/// Dashboard tile showing material lots by proximity to their expiration date.
-/// Counts lots (with stock on hand) that are: already expired, expiring within 30 days,
-/// or expiring within 90 days. Lots expiring beyond the 90-day horizon are ignored.
-/// Scope: materials only (ProductType.Material with HasExpiration).
+/// Dashboard tile showing materials by proximity to their nearest lot expiration date.
+/// Counts each material once (by its earliest in-stock expiring lot) as: already expired,
+/// expiring within 30 days, expiring within 90 days, or healthy (more than 90 days out).
+/// This mirrors the drill-down list, which buckets materials by CatalogAggregate.MinimalExpiration.
+/// Scope: materials only (ProductType.Material with HasExpiration); materials without an
+/// in-stock expiring lot are excluded from every bucket.
 /// </summary>
 [TileId("materialexpirationsummary")]
 public class MaterialExpirationSummaryTile : ITile
@@ -41,16 +43,19 @@ public class MaterialExpirationSummaryTile : ITile
 
             var catalogItems = await _catalogRepository.GetAllAsync(cancellationToken);
 
+            // Bucket each material by its earliest in-stock expiring lot (MinimalExpiration).
+            // Materials without such a lot have a null MinimalExpiration and are excluded.
             var expirations = catalogItems
                 .Where(item => item.Type == ProductType.Material && item.HasExpiration)
-                .SelectMany(item => item.Stock.Lots)
-                .Where(lot => lot.Amount > 0 && lot.Expiration.HasValue)
-                .Select(lot => lot.Expiration!.Value)
+                .Select(item => item.MinimalExpiration)
+                .Where(exp => exp.HasValue)
+                .Select(exp => exp!.Value)
                 .ToList();
 
             var expired = expirations.Count(exp => exp < today);
             var within30 = expirations.Count(exp => exp >= today && exp <= soonThreshold);
             var within90 = expirations.Count(exp => exp > soonThreshold && exp <= horizonThreshold);
+            var ok = expirations.Count(exp => exp > horizonThreshold);
 
             return new
             {
@@ -60,6 +65,7 @@ public class MaterialExpirationSummaryTile : ITile
                     expired,     // already past expiration
                     within30,    // expiring within 30 days
                     within90,    // expiring within 31-90 days
+                    ok,          // healthy: expiring beyond the 90-day horizon
                     total = expired + within30 + within90,
                     date = now
                 },

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/DashboardTiles/MaterialExpirationSummaryTileTests.cs
@@ -95,7 +95,7 @@ public class MaterialExpirationSummaryTileTests
     }
 
     [Fact]
-    public async Task LoadDataAsync_LotBeyondHorizon_IsExcluded()
+    public async Task LoadDataAsync_LotBeyondHorizon_CountsAsOk()
     {
         // Arrange
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
@@ -104,7 +104,8 @@ public class MaterialExpirationSummaryTileTests
         // Act
         var data = await LoadDataSection();
 
-        // Assert
+        // Assert - healthy material: excluded from the "needs attention" total, counted as ok
+        data.GetProperty("ok").GetInt32().Should().Be(1);
         data.GetProperty("total").GetInt32().Should().Be(0);
     }
 
@@ -118,8 +119,9 @@ public class MaterialExpirationSummaryTileTests
         // Act
         var data = await LoadDataSection();
 
-        // Assert
+        // Assert - no in-stock lot: excluded from every bucket, including ok
         data.GetProperty("total").GetInt32().Should().Be(0);
+        data.GetProperty("ok").GetInt32().Should().Be(0);
     }
 
     [Fact]
@@ -131,8 +133,9 @@ public class MaterialExpirationSummaryTileTests
         // Act
         var data = await LoadDataSection();
 
-        // Assert
+        // Assert - no expiration date: excluded from every bucket, including ok
         data.GetProperty("total").GetInt32().Should().Be(0);
+        data.GetProperty("ok").GetInt32().Should().Be(0);
     }
 
     [Fact]
@@ -168,12 +171,12 @@ public class MaterialExpirationSummaryTileTests
     }
 
     [Fact]
-    public async Task LoadDataAsync_MaterialWithLotsSpanningBuckets_CountsEachLotInItsBucket()
+    public async Task LoadDataAsync_MaterialWithLotsSpanningBuckets_CountsMaterialOnceByEarliestExpiration()
     {
         // Arrange
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         SetupCatalog(CreateMaterial("MAT001",
-            CreateLot(today.AddDays(-5), amount: 5),   // expired
+            CreateLot(today.AddDays(-5), amount: 5),   // expired (earliest)
             CreateLot(today.AddDays(10), amount: 5),   // within30
             CreateLot(today.AddDays(60), amount: 5),   // within90
             CreateLot(today.AddDays(200), amount: 5))); // beyond horizon
@@ -181,11 +184,29 @@ public class MaterialExpirationSummaryTileTests
         // Act
         var data = await LoadDataSection();
 
-        // Assert
+        // Assert - one material counted once, in its most-urgent bucket (earliest expiration)
         data.GetProperty("expired").GetInt32().Should().Be(1);
-        data.GetProperty("within30").GetInt32().Should().Be(1);
-        data.GetProperty("within90").GetInt32().Should().Be(1);
-        data.GetProperty("total").GetInt32().Should().Be(3);
+        data.GetProperty("within30").GetInt32().Should().Be(0);
+        data.GetProperty("within90").GetInt32().Should().Be(0);
+        data.GetProperty("ok").GetInt32().Should().Be(0);
+        data.GetProperty("total").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_MaterialWithAllLotsBeyondHorizon_CountsAsOk()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        SetupCatalog(CreateMaterial("MAT001",
+            CreateLot(today.AddDays(120), amount: 5),
+            CreateLot(today.AddDays(200), amount: 5)));
+
+        // Act
+        var data = await LoadDataSection();
+
+        // Assert - earliest lot is beyond the horizon, so the material is healthy
+        data.GetProperty("ok").GetInt32().Should().Be(1);
+        data.GetProperty("total").GetInt32().Should().Be(0);
     }
 
     [Fact]
@@ -201,6 +222,7 @@ public class MaterialExpirationSummaryTileTests
         data.GetProperty("expired").GetInt32().Should().Be(0);
         data.GetProperty("within30").GetInt32().Should().Be(0);
         data.GetProperty("within90").GetInt32().Should().Be(0);
+        data.GetProperty("ok").GetInt32().Should().Be(0);
         data.GetProperty("total").GetInt32().Should().Be(0);
     }
 

--- a/frontend/src/components/dashboard/tiles/MaterialExpirationSummaryTile.tsx
+++ b/frontend/src/components/dashboard/tiles/MaterialExpirationSummaryTile.tsx
@@ -14,6 +14,7 @@ interface MaterialExpirationSummaryTileProps {
       expired?: number;    // already past expiration
       within30?: number;   // expiring within 30 days
       within90?: number;   // expiring within 31-90 days
+      ok?: number;         // healthy: expiring beyond the 90-day horizon
       total?: number;
       date?: string;
     };
@@ -51,14 +52,17 @@ export const MaterialExpirationSummaryTile: React.FC<MaterialExpirationSummaryTi
   const expired = data.data?.expired ?? 0;
   const within30 = data.data?.within30 ?? 0;
   const within90 = data.data?.within90 ?? 0;
+  const ok = data.data?.ok ?? 0;
 
-  const total = expired + within30 + within90;
+  // Include healthy materials so the pie shows a real proportion, not just problem buckets
+  const total = expired + within30 + within90 + ok;
 
   // Calculate percentages for pie chart
   const getPercentage = (value: number) => total > 0 ? (value / total) * 100 : 0;
   const expiredPercent = getPercentage(expired);
   const within30Percent = getPercentage(within30);
   const within90Percent = getPercentage(within90);
+  const okPercent = getPercentage(ok);
 
   // Create pie chart segments
   const createPieSegment = (startPercent: number, endPercent: number) => {
@@ -87,6 +91,10 @@ export const MaterialExpirationSummaryTile: React.FC<MaterialExpirationSummaryTi
   }
   if (within90Percent > 0) {
     segments.push({ path: createPieSegment(currentPercent, currentPercent + within90Percent), color: '#f59e0b' });
+    currentPercent += within90Percent;
+  }
+  if (okPercent > 0) {
+    segments.push({ path: createPieSegment(currentPercent, currentPercent + okPercent), color: '#22c55e' });
   }
 
   return (
@@ -139,6 +147,15 @@ export const MaterialExpirationSummaryTile: React.FC<MaterialExpirationSummaryTi
             <span className="text-base md:text-sm text-gray-700 dark:text-graphite-muted">31–90 dní</span>
           </div>
           <span className="text-2xl md:text-xl font-bold text-gray-900 dark:text-graphite-text">{within90}</span>
+        </div>
+
+        {/* Green: healthy (more than 90 days) */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <div className="w-4 h-4 rounded-sm bg-green-500"></div>
+            <span className="text-base md:text-sm text-gray-700 dark:text-graphite-muted">V pořádku</span>
+          </div>
+          <span className="text-2xl md:text-xl font-bold text-gray-900 dark:text-graphite-text">{ok}</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/dashboard/tiles/__tests__/MaterialExpirationSummaryTile.test.tsx
+++ b/frontend/src/components/dashboard/tiles/__tests__/MaterialExpirationSummaryTile.test.tsx
@@ -18,24 +18,26 @@ describe('MaterialExpirationSummaryTile', () => {
     mockNavigate.mockClear();
   });
 
-  it('renders the three bucket labels', () => {
-    const data = { status: 'success', data: { expired: 0, within30: 0, within90: 0 } };
+  it('renders the four bucket labels', () => {
+    const data = { status: 'success', data: { expired: 0, within30: 0, within90: 0, ok: 0 } };
 
     renderWithRouter(<MaterialExpirationSummaryTile data={data} />);
 
     expect(screen.getByText('Po expiraci')).toBeInTheDocument();
     expect(screen.getByText('≤ 30 dní')).toBeInTheDocument();
     expect(screen.getByText('31–90 dní')).toBeInTheDocument();
+    expect(screen.getByText('V pořádku')).toBeInTheDocument();
   });
 
   it('renders the counts for each bucket', () => {
-    const data = { status: 'success', data: { expired: 4, within30: 2, within90: 7 } };
+    const data = { status: 'success', data: { expired: 4, within30: 2, within90: 7, ok: 9 } };
 
     renderWithRouter(<MaterialExpirationSummaryTile data={data} />);
 
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('9')).toBeInTheDocument();
   });
 
   it('defaults missing bucket values to zero', () => {
@@ -43,7 +45,7 @@ describe('MaterialExpirationSummaryTile', () => {
 
     renderWithRouter(<MaterialExpirationSummaryTile data={data} />);
 
-    expect(screen.getAllByText('0')).toHaveLength(3);
+    expect(screen.getAllByText('0')).toHaveLength(4);
   });
 
   it('renders error state when status is error', () => {

--- a/frontend/src/components/pages/ManufactureInventoryList.tsx
+++ b/frontend/src/components/pages/ManufactureInventoryList.tsx
@@ -179,6 +179,14 @@ const ManufactureInventoryList: React.FC = () => {
     );
   };
 
+  const handleHealthyPreset = () => {
+    // Everything beyond the 90-day horizon = healthy (open-ended upper bound)
+    applyExpirationPreset(
+      toIsoDate(addDays(startOfToday(), EXPIRATION_HORIZON_DAYS + 1)),
+      "",
+    );
+  };
+
   // Sorting handler
   const handleSort = (column: string) => {
     if (sortBy === column) {
@@ -443,6 +451,12 @@ const ManufactureInventoryList: React.FC = () => {
               className="px-3 py-2 text-sm font-medium rounded-md border border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-500/40 dark:text-amber-300 dark:hover:bg-amber-500/10 transition-colors"
             >
               31–90 dní
+            </button>
+            <button
+              onClick={handleHealthyPreset}
+              className="px-3 py-2 text-sm font-medium rounded-md border border-green-300 text-green-700 hover:bg-green-50 dark:border-green-500/40 dark:text-green-300 dark:hover:bg-green-500/10 transition-colors"
+            >
+              &gt; 90 dní
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
The "Expirace surovin" dashboard tile counted individual lots, so a material with several expired lots was counted multiple times — inflating the tile's numbers (e.g. 80) versus the material-based drill-down list (e.g. 40). This now buckets each material once by its earliest in-stock expiring lot (`MinimalExpiration`), exactly matching the drill-down, and excludes materials that have no in-stock expiring lot from every bucket. A green "V pořádku" (>90 days) segment is added so the pie shows a real proportion instead of always summing the problem buckets to 100%, along with a matching ">90 dní" preset button on the material inventory list. Backend and frontend tests were updated to the new material-counting semantics.

## Test plan
- Backend: `dotnet build` + tile tests (16/16 pass)
- Frontend: `npm run build` + tile tests (6/6 pass)
- Manual: tile "Po expiraci" count now equals the drill-down "Po expiraci" preset; green OK slice renders; ">90 dní" preset lists healthy materials