### PR TITLE
feat: print centered material container barcode labels on Zebra @ 300 dpi

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,5 +1,17 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]
-run = "./scripts/conductor-run.sh"
 setup = "dotnet restore && npm --prefix frontend install --legacy-peer-deps"
+
+[scripts.run.RunAll]
+command = "./scripts/conductor-run.sh all"
+default = true
+icon = "play"
+
+[scripts.run.RunBackend]
+command = "./scripts/conductor-run.sh backend"
+icon = "server"
+
+[scripts.run.RunFrontend]
+command = "./scripts/conductor-run.sh frontend"
+icon = "globe"

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Cups/CupsLabelPrintingService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Cups/CupsLabelPrintingService.cs
@@ -28,7 +28,12 @@ public class CupsLabelPrintingService : ILabelPrintingService
         try
         {
             await File.WriteAllTextAsync(tempPath, zpl, cancellationToken);
-            await _cups.PrintAsync(tempPath, printer, "application/octet-stream", cancellationToken);
+            // Send as raw so CUPS passes the ZPL straight to the printer without invoking a
+            // driver/filter chain. With "application/octet-stream" CUPS auto-types the ASCII
+            // ZPL as text and a driver-based queue rasterizes the source as printed text
+            // instead of interpreting it. "application/vnd.cups-raw" forces passthrough and
+            // works with both raw and driver-based queues.
+            await _cups.PrintAsync(tempPath, printer, "application/vnd.cups-raw", cancellationToken);
             _logger.LogInformation("Sent ZPL label batch to printer {Printer}", printer);
         }
         finally

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -547,7 +547,7 @@
     //"ServerUrl": "https://10.0.0.4:631", // PROD and STG env
     "ServerUrl": "http://100.86.160.29:631", // Tailscale (localhost) env
     "PrinterName": "Brother-HL-L2442DW",
-    "LabelPrinterName": "Zebra-Raw",
+    "LabelPrinterName": "Zebra_ZD411",
     "Username": "xxxx",
     "Password": "xxxxx"
   },

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Inventory/Printing/MaterialContainerLabelZplBuilder.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Inventory/Printing/MaterialContainerLabelZplBuilder.cs
@@ -4,8 +4,10 @@ namespace Anela.Heblo.Application.Features.Catalog.Inventory.Printing;
 
 public static class MaterialContainerLabelZplBuilder
 {
-    private const int LabelWidthDots = 406;   // ~50 mm @ 203 dpi
-    private const int LabelHeightDots = 203;  // ~25 mm @ 203 dpi
+    private const int LabelWidthDots = 590;     // 50 mm @ 300 dpi
+    private const int LabelHeightDots = 236;    // 20 mm @ 300 dpi
+    private const int BarcodeHeightDots = 118;  // 10 mm @ 300 dpi
+    private const int BarcodeModuleWidth = 3;   // ^BY3
 
     public static string Build(IReadOnlyCollection<string> codes)
     {
@@ -18,10 +20,17 @@ public static class MaterialContainerLabelZplBuilder
             sb.Append("^XA");
             sb.Append($"^PW{LabelWidthDots}");
             sb.Append($"^LL{LabelHeightDots}");
-            sb.Append("^FO30,25^BY2");
-            sb.Append("^BCN,90,N,N,N");          // Code128, height 90, no embedded text
+            // Code128 @ 300 dpi, module width BY3, 10 mm tall. ^FB centers text but NOT a
+            // barcode field, so the barcode is centered with an explicit origin computed from
+            // its deterministic width: Subset B (mode N) encodes (chars + 2) symbols at 11
+            // modules each plus a 13-module stop.
+            var barcodeWidthDots = ((code.Length + 2) * 11 + 13) * BarcodeModuleWidth;
+            var barcodeLeftDots = Math.Max(0, (LabelWidthDots - barcodeWidthDots) / 2);
+            sb.Append($"^FO{barcodeLeftDots},20^BY{BarcodeModuleWidth}");
+            sb.Append($"^BCN,{BarcodeHeightDots},N,N,N");  // Code128, no embedded text
             sb.Append($"^FD{code}^FS");
-            sb.Append($"^FO30,135^A0N,30,30^FD{code}^FS");  // human-readable code
+            // Human-readable code, enlarged and centered under the barcode (~40 mm wide).
+            sb.Append($"^FO0,150^A0N,60,52^FB{LabelWidthDots},1,0,C,0^FD{code}^FS");
             sb.Append("^XZ");
         }
         return sb.ToString();

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CupsLabelPrintingServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CupsLabelPrintingServiceTests.cs
@@ -14,7 +14,7 @@ public class CupsLabelPrintingServiceTests
     {
         var cups = new Mock<ICupsPrintingService>();
         string? capturedPath = null;
-        cups.Setup(c => c.PrintAsync(It.IsAny<string>(), "Zebra-Raw", "application/octet-stream", It.IsAny<CancellationToken>()))
+        cups.Setup(c => c.PrintAsync(It.IsAny<string>(), "Zebra-Raw", "application/vnd.cups-raw", It.IsAny<CancellationToken>()))
             .Callback<string, string?, string, CancellationToken>((p, _, _, _) =>
             {
                 capturedPath = p;
@@ -36,7 +36,7 @@ public class CupsLabelPrintingServiceTests
     {
         var cups = new Mock<ICupsPrintingService>();
         string? capturedPath = null;
-        cups.Setup(c => c.PrintAsync(It.IsAny<string>(), "Zebra-Raw", "application/octet-stream", It.IsAny<CancellationToken>()))
+        cups.Setup(c => c.PrintAsync(It.IsAny<string>(), "Zebra-Raw", "application/vnd.cups-raw", It.IsAny<CancellationToken>()))
             .Callback<string, string?, string, CancellationToken>((p, _, _, _) =>
             {
                 capturedPath = p;

--- a/scripts/conductor-run.sh
+++ b/scripts/conductor-run.sh
@@ -2,10 +2,29 @@
 
 # Conductor run script — launches backend + frontend on dynamically picked free ports
 # so multiple Conductor workspaces of Heblo can run in parallel without colliding.
+#
+# Usage: conductor-run.sh [all|backend|frontend]
+#   all       (default) start both the backend and the frontend
+#   backend   start only the backend
+#   frontend  start only the frontend (expects a backend running elsewhere;
+#             override its URL with REACT_APP_API_URL)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+MODE="${1:-all}"
+RUN_BACKEND=false
+RUN_FRONTEND=false
+case "$MODE" in
+  all) RUN_BACKEND=true; RUN_FRONTEND=true ;;
+  backend) RUN_BACKEND=true ;;
+  frontend) RUN_FRONTEND=true ;;
+  *)
+    echo "❌ Unknown mode '$MODE'. Use: all | backend | frontend" >&2
+    exit 1
+    ;;
+esac
 
 # Find the first free TCP port at or above the given starting port.
 find_free_port() {
@@ -16,62 +35,77 @@ find_free_port() {
   echo "$port"
 }
 
-# Bases 5100/3100 keep Conductor instances clear of the manual 5000/3000 dev scripts.
-BACKEND_PORT="$(find_free_port 5100)"
-FRONTEND_PORT="$(find_free_port 3100)"
-
 BRANCH="$(git -C "$PROJECT_ROOT" branch --show-current)"
 if [ -z "$BRANCH" ]; then
   BRANCH="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
 fi
 
-echo "🚀 Starting Heblo (Conductor)"
+echo "🚀 Starting Heblo (Conductor) — mode: $MODE"
 echo "   Branch:   $BRANCH"
-echo "   Backend:  http://localhost:$BACKEND_PORT"
-echo "   Frontend: http://localhost:$FRONTEND_PORT"
+
+# Bases 5100/3100 keep Conductor instances clear of the manual 5000/3000 dev scripts.
+if [ "$RUN_BACKEND" = true ]; then
+  BACKEND_PORT="$(find_free_port 5100)"
+  echo "   Backend:  http://localhost:$BACKEND_PORT"
+fi
+if [ "$RUN_FRONTEND" = true ]; then
+  FRONTEND_PORT="$(find_free_port 3100)"
+  echo "   Frontend: http://localhost:$FRONTEND_PORT"
+fi
 echo ""
 
 # Stop both children when this script (and its process group) is stopped.
 trap 'kill 0' EXIT INT TERM
 
-# Backend — dynamic port via ASPNETCORE_URLS.
-# UseConductorOverrides=true layers appsettings.Conductor.json (disables all hydration /
-# background refresh) and makes CORS accept any loopback origin, so the dynamically
-# chosen frontend port is allowed without a fixed allow-list.
-(
-  cd "$PROJECT_ROOT"
-  ASPNETCORE_ENVIRONMENT=Development \
-  ASPNETCORE_URLS="http://localhost:$BACKEND_PORT" \
-  UseConductorOverrides=true \
-    dotnet run --project backend/src/Anela.Heblo.API --no-launch-profile
-) &
-BACKEND_PID=$!
+if [ "$RUN_BACKEND" = true ]; then
+  # Backend — dynamic port via ASPNETCORE_URLS.
+  # UseConductorOverrides=true layers appsettings.Conductor.json (disables all hydration /
+  # background refresh) and makes CORS accept any loopback origin, so the dynamically
+  # chosen frontend port is allowed without a fixed allow-list.
+  (
+    cd "$PROJECT_ROOT"
+    ASPNETCORE_ENVIRONMENT=Development \
+    ASPNETCORE_URLS="http://localhost:$BACKEND_PORT" \
+    UseConductorOverrides=true \
+      dotnet run --project backend/src/Anela.Heblo.API --no-launch-profile
+  ) &
+  BACKEND_PID=$!
 
-# Wait for the backend to actually listen — `dotnet run` builds first, so this can
-# take 30-60s. Bail out early with a clear message if the build/start failed.
-echo "⏳ Waiting for backend to build and listen on port $BACKEND_PORT ..."
-for _ in $(seq 1 150); do
-  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
-    echo "❌ Backend exited before becoming ready — check the build output above."
-    exit 1
-  fi
-  if curl -sf -o /dev/null "http://localhost:$BACKEND_PORT/health/live" 2>/dev/null; then
-    echo "✅ Backend is up on http://localhost:$BACKEND_PORT"
-    break
-  fi
-  sleep 2
-done
+  # Wait for the backend to actually listen — `dotnet run` builds first, so this can
+  # take 30-60s. Bail out early with a clear message if the build/start failed.
+  echo "⏳ Waiting for backend to build and listen on port $BACKEND_PORT ..."
+  for _ in $(seq 1 150); do
+    if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+      echo "❌ Backend exited before becoming ready — check the build output above."
+      exit 1
+    fi
+    if curl -sf -o /dev/null "http://localhost:$BACKEND_PORT/health/live" 2>/dev/null; then
+      echo "✅ Backend is up on http://localhost:$BACKEND_PORT"
+      break
+    fi
+    sleep 2
+  done
+fi
 
-# Frontend — start:conductor has no inline env, so these exported vars take effect.
-# REACT_APP_REDIRECT_URI is cleared so MSAL falls back to window.location.origin.
-(
-  cd "$PROJECT_ROOT"
-  PORT="$FRONTEND_PORT" \
-  REACT_APP_API_URL="http://localhost:$BACKEND_PORT" \
-  REACT_APP_USE_MOCK_AUTH=false \
-  REACT_APP_REDIRECT_URI= \
-  REACT_APP_BRANCH_NAME="$BRANCH" \
-    npm --prefix frontend run start:conductor
-) &
+if [ "$RUN_FRONTEND" = true ]; then
+  # Frontend — start:conductor has no inline env, so these exported vars take effect.
+  # REACT_APP_REDIRECT_URI is cleared so MSAL falls back to window.location.origin.
+  # When the backend runs here, point at it; otherwise honor a caller-supplied
+  # REACT_APP_API_URL (the backend is expected to be running elsewhere).
+  if [ "$RUN_BACKEND" = true ]; then
+    API_URL="http://localhost:$BACKEND_PORT"
+  else
+    API_URL="${REACT_APP_API_URL:-http://localhost:5000}"
+  fi
+  (
+    cd "$PROJECT_ROOT"
+    PORT="$FRONTEND_PORT" \
+    REACT_APP_API_URL="$API_URL" \
+    REACT_APP_USE_MOCK_AUTH=false \
+    REACT_APP_REDIRECT_URI= \
+    REACT_APP_BRANCH_NAME="$BRANCH" \
+      npm --prefix frontend run start:conductor
+  ) &
+fi
 
 wait


### PR DESCRIPTION
Generates ZPL for material container labels sized for a 50×20 mm Zebra label at 300 dpi: a centered Code128 barcode (~34×10 mm) with a centered human-readable code beneath it, with the barcode centered via an explicit width-derived origin because ZPL `^FB` centers text but not barcode fields. Labels are now sent to CUPS as `application/vnd.cups-raw` so the Zebra queue passes the ZPL through instead of rasterizing it as text, and the label printer target is updated to `Zebra_ZD411`. Also adds an `[all|backend|frontend]` mode parameter to the Conductor run script with matching RunAll/RunBackend/RunFrontend entries in `.conductor/settings.toml` so backend and/or frontend can be started independently. Tests: `MaterialContainerLabelZplBuilderTests` and `CupsLabelPrintingServiceTests` pass (5/5).