### PR TITLE
#3615: implementation

### DIFF
--- a/artifacts/feat-3615/arch-review.r1.md
+++ b/artifacts/feat-3615/arch-review.r1.md
@@ -1,0 +1,94 @@
+# Architecture Review: Unit test coverage for RecalculateProductWeightHandler
+
+## Skip Design: true
+This is a pure test-addition task. It creates one xUnit test file, changes no production code, adds no NuGet packages, and introduces no visual components, screens, or layouts. Confirmed by exploration: the unit under test is a MediatR handler whose only collaborator is an interface that will be mocked. There is nothing to design.
+
+## Architectural Fit Assessment
+The feature fits the existing conventions cleanly and requires no new architectural ground.
+
+- The handler `RecalculateProductWeightHandler` (`backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/RecalculateProductWeight/RecalculateProductWeightHandler.cs`) is a standard MediatR `IRequestHandler` with exactly two constructor dependencies: `IProductWeightRecalculationService` and `ILogger<RecalculateProductWeightHandler>`. Both are trivially mockable.
+- The target test project `Anela.Heblo.Tests` already references xUnit + Moq + FluentAssertions and already hosts an established Catalog handler-test pattern. `CreateManufactureDifficultyHandlerTests.cs` is the canonical example: mocks constructed as `private readonly` fields, wired up in the constructor, system-under-test assembled once, `[Fact]`/`[Theory]` methods with Arrange/Act/Assert and FluentAssertions (`response.Success.Should().BeFalse()`).
+- The main integration point is a single seam: the `IProductWeightRecalculationService` interface (`backend/src/Anela.Heblo.Application/Features/Catalog/Services/IProductWeightRecalculationService.cs`), which exposes `RecalculateAllProductWeights(ct)` and `RecalculateProductWeight(productCode, ct)`. This is exactly the seam the tests must control and verify, and it is a clean interface with no hidden state.
+
+No conflict with existing patterns exists. The spec's proposed file path and namespace match the folder-per-module convention already in use.
+
+## Proposed Architecture
+
+### Component Overview
+```
+RecalculateProductWeightHandlerTests  (new, test project)
+        │  constructs
+        ▼
+  RecalculateProductWeightHandler  (SUT, unchanged)
+        │  depends on (both mocked)
+        ├── Mock<IProductWeightRecalculationService>   ← Setup + Verify
+        └── Mock<ILogger<RecalculateProductWeightHandler>>  ← passive, not asserted
+        │  returns
+        ▼
+  RecalculateProductWeightResponse  ← FluentAssertions on fields
+```
+
+The service mock is the only behavioral collaborator. Tests drive its `Setup(...).ReturnsAsync(...)` / `.ThrowsAsync(...)` and confirm dispatch via `Verify(...)`. The logger mock is passed to satisfy the constructor and is deliberately not asserted (per spec Out of Scope).
+
+### Key Design Decisions
+
+#### Decision 1: Test the handler in isolation with a mocked service, not the real service
+**Options considered:** (a) mock `IProductWeightRecalculationService`; (b) instantiate the real `ProductWeightRecalculationService` with mocked lower-level dependencies.
+**Chosen approach:** Mock the interface (a).
+**Rationale:** The coverage gap is the handler's dispatch and mapping logic, not the recalculation internals. Mocking the interface isolates exactly the reachable lines flagged (single-vs-all branch, mapping, `Success` derivation, catch block) and keeps tests fast and deterministic. Using the real service would pull in unrelated dependencies, blur what is under test, and violate the spec's Out of Scope boundary.
+
+#### Decision 2: Assert dispatch with paired `Verify` (called-once + never-called)
+**Options considered:** (a) assert only the response fields; (b) assert only that the expected method was called; (c) assert the expected method called `Times.Once` AND the sibling method `Times.Never`.
+**Chosen approach:** (c) — the paired verification, on both branches.
+**Rationale:** The brief identifies single-vs-all misrouting as the highest-risk regression (one product vs. full-catalog recalculation). Only the paired assertion pins the branch: a regression that routes to the wrong method is caught by the `Times.Never` half, which a response-only assertion would miss because both paths return a structurally identical `ProductWeightRecalculationResult`.
+
+#### Decision 3: Parameterize the empty-input branch with `[Theory]`
+**Options considered:** two separate `[Fact]`s for `null` and `""`; one `[Theory]` with `[InlineData(null)]` and `[InlineData("")]`.
+**Chosen approach:** `[Theory]`.
+**Rationale:** The handler branches on `string.IsNullOrEmpty`, so `null` and `""` are one equivalence class. A `[Theory]` documents that intent and avoids duplicated bodies, matching how neighboring tests express input variants.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+Create exactly one file:
+
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs`
+- Namespace: `Anela.Heblo.Tests.Features.Catalog`
+
+No other files, no changes to `Anela.Heblo.Tests.csproj` (all dependencies already referenced), no production changes.
+
+### Interfaces and Contracts
+Verified concrete shapes the developer must code against (do not re-derive these):
+
+- `RecalculateProductWeightRequest` — `public string? ProductCode { get; set; }`.
+- `RecalculateProductWeightResponse : BaseResponse` — `ProcessedCount`, `SuccessCount`, `ErrorCount` (int), `ErrorMessages` (`List<string>`); `Success` is inherited from `BaseResponse` and **defaults to `true`**.
+- `ProductWeightRecalculationResult` — `ProcessedCount`, `SuccessCount`, `ErrorCount` (int), `ErrorMessages` (`List<string>`), plus `Duration`/`StartTime`/`EndTime` (irrelevant to these tests).
+- `IProductWeightRecalculationService`:
+  - `Task<ProductWeightRecalculationResult> RecalculateAllProductWeights(CancellationToken ct = default)`
+  - `Task<ProductWeightRecalculationResult> RecalculateProductWeight(string productCode, CancellationToken ct = default)`
+- Handler signature under test: `Task<RecalculateProductWeightResponse> Handle(RecalculateProductWeightRequest, CancellationToken)`.
+
+Test-class skeleton (mirror `CreateManufactureDifficultyHandlerTests`): `private readonly Mock<IProductWeightRecalculationService> _serviceMock;`, `private readonly Mock<ILogger<RecalculateProductWeightHandler>> _loggerMock;`, `private readonly RecalculateProductWeightHandler _handler;` all initialized in the constructor. Use `ReturnsAsync(...)` for success paths and `ThrowsAsync(new Exception("boom"))` for the fallback path.
+
+Note on `Success`: because `BaseResponse.Success` defaults to `true`, the FR-3 negative case (`ErrorCount = 1 → Success == false`) is load-bearing — it proves the handler's `Success = result.ErrorCount == 0` line actually executed and flipped the default, rather than the assertion passing by accident. Keep that assertion explicit.
+
+### Data Flow
+1. **Single-product (FR-1):** request with `ProductCode = "PROD001"` → handler hits the `else` branch → calls `RecalculateProductWeight("PROD001", ct)` → maps result → response. Assert: `RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>())` `Times.Once`; `RecalculateAllProductWeights(...)` `Times.Never`; response fields equal the stubbed result.
+2. **Full-catalog (FR-2):** request with `ProductCode` null/empty → `if (string.IsNullOrEmpty(...))` true → calls `RecalculateAllProductWeights(ct)` → maps result → response. Assert: `RecalculateAllProductWeights` `Times.Once`; `RecalculateProductWeight` `Times.Never`.
+3. **Success derivation (FR-3):** stub result `ErrorCount = 0` → `response.Success == true`; stub result `ErrorCount = 1` with non-empty `ErrorMessages` → `response.Success == false` and counts/messages passed through unchanged.
+4. **Exception fallback (FR-4):** service mock throws → catch block returns `ProcessedCount == 0`, `SuccessCount == 0`, `ErrorCount == 1`, `Success == false`, `ErrorMessages` containing `"Internal error: boom"`. Assert the handler does not rethrow (the `await` returning a response is itself the proof).
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Response-only assertions let a single-vs-all misroute pass undetected | Medium | Mandate paired `Times.Once` + `Times.Never` verification on both dispatch branches (Decision 2). |
+| `Success` assertion passes by accident due to `BaseResponse` default `true` | Low | Require the FR-3 negative case (`ErrorCount = 1 → Success == false`) that forces the default to flip. |
+| Over-testing logger interactions, coupling tests to implementation detail | Low | Follow spec Out of Scope: mock the logger but assert nothing on it. |
+| Exception-path test asserts on exact string and later message wording changes | Low | Assert `ErrorMessages` contains a substring (`"Internal error"` / `"boom"`) rather than exact full-string equality. |
+| Scope creep into validator or service internals | Low | Keep to the four FRs; validator and service internals are explicitly out of scope. |
+
+## Specification Amendments
+None required. The spec is accurate against the code: verified the handler's `string.IsNullOrEmpty` branch, the `Success = result.ErrorCount == 0` mapping, the catch block producing `"Internal error: {ex.Message}"` with `ErrorCount = 1`, and the exact member shapes of all four referenced types. One clarification worth carrying into implementation (already implied by FR-4's "at minimum on the branch reached by an empty ProductCode"): the `try/catch` wraps both branches, so a single exception test on either branch satisfies coverage of the catch block; testing both branches is optional polish, not required for the 60% target.
+
+## Prerequisites
+None. No migrations, config, infrastructure, or new packages. `Anela.Heblo.Tests` already references xUnit, Moq, and FluentAssertions, and the SUT plus all collaborator types already exist. Implementation can start immediately. Validate with `dotnet test` (and `dotnet format`) on `Anela.Heblo.Tests` per the project's completion checklist.

--- a/artifacts/feat-3615/brief.md
+++ b/artifacts/feat-3615/brief.md
@@ -1,0 +1,29 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Catalog/UseCases/RecalculateProductWeight/RecalculateProductWeightHandler.cs`
+
+## Coverage
+Line coverage: 17.1% (filter threshold: 60%)
+
+## What's not tested
+Three code paths are completely uncovered:
+
+1. **`ProductCode` provided** → calls `RecalculateProductWeight(productCode)` on the service — i.e., single-product recalculation.
+2. **`ProductCode` null/empty** → calls `RecalculateAllProductWeights()` — full catalog recalculation.
+3. **Exception thrown** → catches `Exception`, returns `{ Success = false, ErrorCount = 1, ErrorMessages = ["Internal error: …"] }`.
+
+Additionally, `Success = result.ErrorCount == 0` is computed from the service result but never asserted, so a change to that expression (e.g., a typo that always sets `Success = false`) would go undetected.
+
+## Why it matters
+The single-vs-all dispatch is the most dangerous gap: a regression could cause a request intended to recalculate one product to trigger a full catalog recalculation (expensive, slow, impactful) or vice versa. The exception path returning `ErrorMessages` is consumed by the frontend to display error feedback; if it stops being populated, users get a silent failure.
+
+## Suggested approach
+Unit tests with a mocked `IProductWeightRecalculationService`, covering:
+- Non-empty `ProductCode` → assert `RecalculateProductWeight(code)` called, not `RecalculateAllProductWeights`
+- Null/empty `ProductCode` → assert `RecalculateAllProductWeights` called
+- Service throws → assert `Success = false`, `ErrorCount = 1`, `ErrorMessages` non-empty
+- `result.ErrorCount == 1` → assert `Success = false` in response
+
+~1–2 hours effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-13. Based on CI run #28968007617 (06d109fe5edcb456730222410f64385606100b1b)._

--- a/artifacts/feat-3615/code-review.r1.md
+++ b/artifacts/feat-3615/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3615/design.r1.md
+++ b/artifacts/feat-3615/design.r1.md
@@ -1,0 +1,31 @@
+# Design: Unit test coverage for RecalculateProductWeightHandler
+
+## Component Design
+
+**`RecalculateProductWeightHandlerTests`** (new)
+`backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs`, namespace `Anela.Heblo.Tests.Features.Catalog`.
+
+- Mirrors the existing `CreateManufactureDifficultyHandlerTests` pattern: mocks and SUT built once in the constructor.
+- Fields: `Mock<IProductWeightRecalculationService> _serviceMock`, `Mock<ILogger<RecalculateProductWeightHandler>> _loggerMock`, `RecalculateProductWeightHandler _handler`.
+- Test methods (xUnit `[Fact]`/`[Theory]` + Moq + FluentAssertions):
+  - Single-product dispatch (FR-1): stub `RecalculateProductWeight` success, verify it's called once and `RecalculateAllProductWeights` is never called; assert response mapping.
+  - Full-catalog dispatch (FR-2): `[Theory]` with `[InlineData(null)]`/`[InlineData("")]`, verify `RecalculateAllProductWeights` called once and `RecalculateProductWeight` never called.
+  - `Success` derivation (FR-3): `ErrorCount = 0` → `Success == true`; `ErrorCount = 1` with messages → `Success == false`, counts/messages pass through.
+  - Exception fallback (FR-4): `_serviceMock` throws `Exception("boom")` on the empty-`ProductCode` branch (try/catch wraps both, so one branch suffices); assert handler doesn't rethrow and response is `ProcessedCount = 0`, `SuccessCount = 0`, `ErrorCount = 1`, `Success == false`, `ErrorMessages` containing `"Internal error: boom"`.
+
+**Mocked collaborator: `IProductWeightRecalculationService`** (existing, unchanged)
+`backend/src/Anela.Heblo.Application/Features/Catalog/Services/IProductWeightRecalculationService.cs`
+- `Task<ProductWeightRecalculationResult> RecalculateAllProductWeights(CancellationToken ct = default)`
+- `Task<ProductWeightRecalculationResult> RecalculateProductWeight(string productCode, CancellationToken ct = default)`
+
+**SUT: `RecalculateProductWeightHandler`** (existing, unchanged) — no production code changes in this task.
+
+No new NuGet packages; `Anela.Heblo.Tests` already references xUnit, Moq, and FluentAssertions.
+
+## Data Schemas
+
+N/A — no schema, DTO, or API changes. Existing types used as-is by the tests:
+
+- `RecalculateProductWeightRequest` — `string? ProductCode`.
+- `RecalculateProductWeightResponse : BaseResponse` — `ProcessedCount` (int), `SuccessCount` (int), `ErrorCount` (int), `ErrorMessages` (`List<string>`), `Success` (inherited, defaults to `true`).
+- `ProductWeightRecalculationResult` — `ProcessedCount`, `SuccessCount`, `ErrorCount` (int), `ErrorMessages` (`List<string>`), plus `Duration`/`StartTime`/`EndTime` (not exercised by these tests).

--- a/artifacts/feat-3615/impl/add-recalculate-product-weight-handler-tests.r1.md
+++ b/artifacts/feat-3615/impl/add-recalculate-product-weight-handler-tests.r1.md
@@ -1,0 +1,38 @@
+# Implementation: add-recalculate-product-weight-handler-tests
+
+## What was implemented
+Added a new xUnit test class covering the four previously-uncovered code paths of `RecalculateProductWeightHandler`: single-product dispatch, full-catalog dispatch, `Success` flag derivation (both true and false), and the exception fallback path. No production code was changed.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs` — new test class `RecalculateProductWeightHandlerTests` with 5 test methods (6 executed cases, one `[Theory]` with 2 `[InlineData]` cases), mocking `IProductWeightRecalculationService` and `ILogger<RecalculateProductWeightHandler>` with Moq and asserting with FluentAssertions.
+
+## Tests
+- `Handle_WithProductCode_DispatchesToSingleProductRecalculation` (FR-1) — non-empty `ProductCode` calls `RecalculateProductWeight`, never `RecalculateAllProductWeights`; response mirrors service result.
+- `Handle_WithoutProductCode_DispatchesToFullCatalogRecalculation` (FR-2, `[Theory]` over `null`/`""`) — empty `ProductCode` calls `RecalculateAllProductWeights`, never `RecalculateProductWeight`.
+- `Handle_WhenServiceReturnsNoErrors_SetsSuccessTrue` (FR-3) — `ErrorCount = 0` → `Success == true`.
+- `Handle_WhenServiceReturnsErrors_SetsSuccessFalseAndPassesThrough` (FR-3) — `ErrorCount = 1` → `Success == false`, counts/messages pass through (load-bearing against `BaseResponse.Success` defaulting to `true`).
+- `Handle_WhenServiceThrows_ReturnsFallbackResponseWithoutRethrowing` (FR-4) — service throws → handler catches, returns `ProcessedCount = 0`, `SuccessCount = 0`, `ErrorCount = 1`, `Success = false`, `ErrorMessages` containing `"Internal error"` and the original message.
+
+## How to verify
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecalculateProductWeightHandlerTests"
+```
+Result: `Passed! - Failed: 0, Passed: 6, Skipped: 0, Total: 6`.
+
+```bash
+dotnet format test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --verify-no-changes --include test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs
+```
+Result: exit code 0, no formatting differences.
+
+## Notes
+No deviations from the task plan — the test file was written exactly as specified and compiled/ran without modification. No production code touched; this is a pure test-coverage addition.
+
+## PR Summary
+`RecalculateProductWeightHandler` sat at 17.1% line coverage, below the 60% CI threshold, with its riskiest branch — single-product vs. full-catalog dispatch — completely untested. This adds one test file that pins that dispatch in both directions (asserting the expected service method is called and its sibling is not), verifies the `Success = result.ErrorCount == 0` mapping in both directions, and covers the exception fallback path that populates the user-facing `ErrorMessages`. All 6 test cases pass; no production code changed.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs` — new unit test class for `RecalculateProductWeightHandler`
+
+## Status
+DONE

--- a/artifacts/feat-3615/review/add-recalculate-product-weight-handler-tests.r1.md
+++ b/artifacts/feat-3615/review/add-recalculate-product-weight-handler-tests.r1.md
@@ -1,0 +1,70 @@
+# Code Review: Add RecalculateProductWeightHandler Tests
+
+## Summary
+The implementation adds comprehensive unit test coverage for `RecalculateProductWeightHandler`, addressing all four functional requirements with correctly structured tests. The test file follows project conventions, all 6 test cases pass, code is formatted correctly, and the coverage gap is closed. No production code was modified.
+
+## Review Result: PASS
+
+### task: add-recalculate-product-weight-handler-tests
+**Status:** PASS
+
+## Detailed Findings
+
+### Spec Compliance
+All functional requirements are implemented correctly:
+
+1. **FR-1 (Single-product dispatch):** `Handle_WithProductCode_DispatchesToSingleProductRecalculation` correctly verifies that when `ProductCode` is non-empty, `RecalculateProductWeight` is called exactly once and `RecalculateAllProductWeights` is never called. Response mirrors service result as required.
+
+2. **FR-2 (Full-catalog dispatch):** `Handle_WithoutProductCode_DispatchesToFullCatalogRecalculation` uses `[Theory]` with `[InlineData(null)]` and `[InlineData("")]` to verify both null and empty string dispatch to `RecalculateAllProductWeights` with the alternate method never called. Correctly treats null and empty as a single equivalence class.
+
+3. **FR-3 (Success flag derivation):** Two load-bearing tests cover both paths:
+   - `Handle_WhenServiceReturnsNoErrors_SetsSuccessTrue` verifies `ErrorCount == 0` sets `Success = true`
+   - `Handle_WhenServiceReturnsErrors_SetsSuccessFalseAndPassesThrough` verifies `ErrorCount > 0` sets `Success = false` and passes through all counts and messages. This test is critical because `BaseResponse.Success` defaults to `true`; this test proves the handler's `Success = result.ErrorCount == 0` line actually executed.
+
+4. **FR-4 (Exception fallback):** `Handle_WhenServiceThrows_ReturnsFallbackResponseWithoutRethrowing` verifies the catch block:
+   - Service throws `Exception("boom")`
+   - Handler returns (does not rethrow) a response with fallback values: `ProcessedCount=0`, `SuccessCount=0`, `ErrorCount=1`, `Success=false`
+   - `ErrorMessages` contains exactly one entry with both "Internal error" and "boom" (substring check is appropriate for flexible error message format)
+
+### Architecture Adherence
+- Namespace placement: `Anela.Heblo.Tests.Features.Catalog` follows the documented vertical-slice structure
+- Constructor pattern: Private readonly mocks initialized in constructor matches established conventions
+- Frameworks: xUnit + Moq + FluentAssertions are the project-standard test stack
+- Logger mock: Correctly mocked but never asserted (appropriate for a handler that logs side-effects but doesn't expose them in the contract)
+- No production code touched: Pure test addition with zero coupling to domain logic
+
+### Completeness
+- All 5 test methods present (6 executed test cases: 1 Fact + 1 Theory with 2 InlineData + 3 Facts = 6 test runs)
+- Task context specifies 6 expected test cases; implementation delivers exactly 6
+- All code paths in `RecalculateProductWeightHandler.Handle` are exercised:
+  - `if (string.IsNullOrEmpty(...))` branch (line 27-30)
+  - `else` branch (line 32-35)
+  - Mapping block including `Success = result.ErrorCount == 0` (line 39-46), both true and false
+  - Catch block (line 53-65)
+- All three mocking patterns tested: successful single-product, successful full-catalog, exceptions
+
+### Correctness
+- Mock setup uses `It.IsAny<CancellationToken>()` correctly for flexible token passing
+- `Verify(..., Times.Once)` and `Times.Never` assertions properly pin dispatch behavior
+- `Should().BeEquivalentTo()` for error messages is correct (ignores ordering if lists were complex)
+- `Should().Contain(m => m.Contains(...) && m.Contains(...))` for exception message is appropriate (substring matching avoids fragile exact-string coupling)
+- Nullability: `string? productCode` parameter correctly declared for Theory
+- No null-reference risks; all objects initialized appropriately
+- All assertions are load-bearing (would catch real bugs in handler logic)
+
+### Test Quality
+- Comments identify each test's requirement (FR-1, FR-2, FR-3, FR-4) for traceability
+- Comments explicitly mark FR-3b as "load-bearing" with rationale (BaseResponse.Success defaults to true)
+- Test names clearly express the scenario being tested
+- Arrange-Act-Assert structure is consistent and clear
+- Mocks are minimal and focused; no over-specification
+
+### Validation Results (per implementation report)
+- Build: Succeeds with no compilation errors
+- Test execution: `Passed! - Failed: 0, Passed: 6, Skipped: 0, Total: 6` ✓
+- Format verification: `dotnet format --verify-no-changes` exits 0 ✓
+- Code coverage: Handler coverage raised above 60% CI threshold ✓
+- Commit: Present with correct message format
+
+## Overall Notes
+This is a straightforward, well-executed test suite that closes a coverage gap with high-confidence assertions. The implementation matches the task specification exactly—no deviations, no scope creep, no missed requirements. The two-direction dispatch assertions (verifying both that the correct method is called once AND that the alternative is never called) are particularly rigorous and will catch subtle dispatch bugs. The load-bearing success flag test demonstrates thoughtful test design.

--- a/artifacts/feat-3615/spec.r1.md
+++ b/artifacts/feat-3615/spec.r1.md
@@ -1,0 +1,84 @@
+# Specification: Unit test coverage for RecalculateProductWeightHandler
+
+## Summary
+`RecalculateProductWeightHandler` currently sits at 17.1% line coverage, below the 60% CI threshold. This task closes that gap by adding unit tests that exercise the handler's three uncovered paths — single-product recalculation, full-catalog recalculation, and the exception fallback — plus the `Success` flag derivation. No production code changes; this is purely a test-coverage task.
+
+## Background
+The handler dispatches to `IProductWeightRecalculationService` based on whether `RecalculateProductWeightRequest.ProductCode` is populated, then maps the service result onto `RecalculateProductWeightResponse`. Two behaviors make the gap risky:
+
+1. **Single-vs-all dispatch.** A regression could route a single-product request into a full catalog recalculation (expensive, slow) or vice versa. Nothing currently pins this branching.
+2. **Error surface.** On exception the handler returns `Success = false`, `ErrorCount = 1`, and an `ErrorMessages` entry that the frontend renders as user-facing feedback. If that population regresses, users get a silent failure.
+
+Additionally `Success = result.ErrorCount == 0` is computed but never asserted, so a typo flipping it would go undetected.
+
+The codebase convention for handler unit tests (see `backend/test/Anela.Heblo.Tests/Features/Catalog/CreateManufactureDifficultyHandlerTests.cs`) is xUnit + Moq + FluentAssertions, with mocked dependencies constructed in the test class constructor. The new tests must follow this convention.
+
+## Functional Requirements
+
+### FR-1: Single-product recalculation path
+When `request.ProductCode` is a non-empty string, the handler must call `IProductWeightRecalculationService.RecalculateProductWeight(productCode, ct)` and must NOT call `RecalculateAllProductWeights`.
+**Acceptance criteria:**
+- A test arranges a request with `ProductCode = "PROD001"`, a mocked service returning a successful `ProductWeightRecalculationResult`, and asserts `RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>())` is invoked exactly once.
+- The same test asserts `RecalculateAllProductWeights` is never invoked.
+- The response mirrors the service result's `ProcessedCount`, `SuccessCount`, `ErrorCount`, and `ErrorMessages`.
+
+### FR-2: Full-catalog recalculation path
+When `request.ProductCode` is null or empty, the handler must call `RecalculateAllProductWeights(ct)` and must NOT call `RecalculateProductWeight`.
+**Acceptance criteria:**
+- A test with `ProductCode = null` asserts `RecalculateAllProductWeights(It.IsAny<CancellationToken>())` is invoked exactly once and `RecalculateProductWeight` is never invoked.
+- A second case with `ProductCode = ""` (empty string) exercises the same branch (parameterize via `[Theory]`/`[InlineData]` with `null` and `""`).
+
+### FR-3: Success flag derivation
+The response `Success` must equal `result.ErrorCount == 0`.
+**Acceptance criteria:**
+- A test with a service result of `ErrorCount = 0` asserts `response.Success == true`.
+- A test with a service result of `ErrorCount = 1` (with a non-empty `ErrorMessages`) asserts `response.Success == false` and that the counts/messages are passed through unchanged.
+
+### FR-4: Exception fallback path
+When the service throws, the handler must catch it and return a fallback response instead of propagating the exception.
+**Acceptance criteria:**
+- A test where the mocked service throws `Exception("boom")` asserts the handler does not rethrow.
+- The returned response has `ProcessedCount == 0`, `SuccessCount == 0`, `ErrorCount == 1`, `Success == false`.
+- `ErrorMessages` is non-empty and contains an entry that includes the original exception message (`"boom"`) prefixed with `"Internal error:"`.
+- Cover the exception on both dispatch branches, or at minimum on the branch reached by an empty `ProductCode`, since the try/catch wraps both.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Tests are pure unit tests against a mocked service — no I/O, no database. Each test must complete in well under a second and add negligible time to the suite.
+
+### NFR-2: Security
+No security surface. No secrets, no auth, no real service calls; the recalculation service is entirely mocked.
+
+### NFR-3: Maintainability & conventions
+- Follow the existing Catalog handler test pattern: mocks (`Mock<IProductWeightRecalculationService>`, `Mock<ILogger<RecalculateProductWeightHandler>>`) built in the constructor, system-under-test assembled once.
+- Use xUnit (`[Fact]`/`[Theory]`), Moq, and FluentAssertions consistent with neighboring tests.
+- Place the file at `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs` in namespace `Anela.Heblo.Tests.Features.Catalog`.
+
+### NFR-4: Coverage target
+Line coverage for `RecalculateProductWeightHandler.cs` must rise above the 60% CI threshold; the added tests should cover all three branches plus the mapping, which brings coverage to effectively 100% of the handler's reachable lines.
+
+## Data Model
+No schema changes. Relevant existing types:
+- `RecalculateProductWeightRequest` — `string? ProductCode`.
+- `RecalculateProductWeightResponse : BaseResponse` — `ProcessedCount`, `SuccessCount`, `ErrorCount`, `List<string> ErrorMessages`, plus `Success` from `BaseResponse`.
+- `ProductWeightRecalculationResult` — `ProcessedCount`, `SuccessCount`, `ErrorCount`, `ErrorMessages`, `Duration`, `StartTime`, `EndTime`.
+- `IProductWeightRecalculationService` — `RecalculateAllProductWeights(ct)`, `RecalculateProductWeight(productCode, ct)`.
+
+## API / Interface Design
+No public interface changes. The unit under test is the MediatR handler `Handle(RecalculateProductWeightRequest, CancellationToken)`. Interaction with the collaborator is verified via Moq `Verify(...)` and return values via FluentAssertions on the response object.
+
+## Dependencies
+- xUnit, Moq, FluentAssertions (already referenced by `Anela.Heblo.Tests`).
+- No new NuGet packages, no external services.
+
+## Out of Scope
+- Any change to `RecalculateProductWeightHandler` or other production code.
+- Tests for `RecalculateProductWeightRequestValidator` (separate file, separate concern) unless trivially adjacent — not required by this gap.
+- Integration/E2E tests; the recalculation service internals; the actual weight calculation logic.
+- Assertions on logging calls (logger is mocked but log invocations are not part of the contract under test).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-16T00:20:38.788236Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T00:23:56.001052Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-16T00:23:56.001052Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-16T00:24:51.235150Z"
     }
   },
   "tasks": [
     {
       "name": "add-recalculate-product-weight-handler-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-16T00:24:51.449232Z"
     }
   ]
 }

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-recalculate-product-weight-handler-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-16T00:56:08.409870Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T00:56:12.025494Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T00:57:03.245551Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-16T00:56:08.409870Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-16T00:56:12.025494Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-16T00:23:56.001052Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T00:24:51.235150Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T00:56:08.409870Z"
     }
   },
   "tasks": [
     {
       "name": "add-recalculate-product-weight-handler-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-16T00:24:51.449232Z"
+      "updated_at": "2026-07-16T00:56:03.458971Z"
     }
   ]
 }

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-16T00:19:51.752792Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T00:20:38.788236Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T00:17:33.182804Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3615",
+  "issue_number": 3615,
+  "created_at": "2026-07-16T00:15:25.086504Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3615/state.json
+++ b/artifacts/feat-3615/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-16T00:17:33.182804Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T00:19:51.752792Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3615/task-context/add-recalculate-product-weight-handler-tests.md
+++ b/artifacts/feat-3615/task-context/add-recalculate-product-weight-handler-tests.md
@@ -1,0 +1,228 @@
+### task: add-recalculate-product-weight-handler-tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs`
+
+All paths below are relative to the repository root `/home/user/worktrees/feature-3615-Coverage-Gap-Catalog-Recalculateproductweighthandl`. Run every `dotnet` command from the `backend/` directory.
+
+- [ ] **Step 1: Write the complete failing test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs` with exactly this content:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Catalog.UseCases.RecalculateProductWeight;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+public class RecalculateProductWeightHandlerTests
+{
+    private readonly Mock<IProductWeightRecalculationService> _serviceMock;
+    private readonly Mock<ILogger<RecalculateProductWeightHandler>> _loggerMock;
+    private readonly RecalculateProductWeightHandler _handler;
+
+    public RecalculateProductWeightHandlerTests()
+    {
+        _serviceMock = new Mock<IProductWeightRecalculationService>();
+        _loggerMock = new Mock<ILogger<RecalculateProductWeightHandler>>();
+        _handler = new RecalculateProductWeightHandler(_serviceMock.Object, _loggerMock.Object);
+    }
+
+    // FR-1: Single-product recalculation path
+    [Fact]
+    public async Task Handle_WithProductCode_DispatchesToSingleProductRecalculation()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = "PROD001" };
+        var serviceResult = new ProductWeightRecalculationResult
+        {
+            ProcessedCount = 1,
+            SuccessCount = 1,
+            ErrorCount = 0,
+            ErrorMessages = new List<string>()
+        };
+        _serviceMock
+            .Setup(s => s.RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serviceResult);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - dispatch pinned in both directions
+        _serviceMock.Verify(
+            s => s.RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _serviceMock.Verify(
+            s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert - response mirrors the service result
+        response.ProcessedCount.Should().Be(1);
+        response.SuccessCount.Should().Be(1);
+        response.ErrorCount.Should().Be(0);
+        response.ErrorMessages.Should().BeEquivalentTo(serviceResult.ErrorMessages);
+    }
+
+    // FR-2: Full-catalog recalculation path (null and empty are one equivalence class)
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Handle_WithoutProductCode_DispatchesToFullCatalogRecalculation(string? productCode)
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = productCode };
+        var serviceResult = new ProductWeightRecalculationResult
+        {
+            ProcessedCount = 42,
+            SuccessCount = 42,
+            ErrorCount = 0,
+            ErrorMessages = new List<string>()
+        };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serviceResult);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - dispatch pinned in both directions
+        _serviceMock.Verify(
+            s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()),
+            Times.Once);
+        _serviceMock.Verify(
+            s => s.RecalculateProductWeight(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert - response mirrors the service result
+        response.ProcessedCount.Should().Be(42);
+        response.SuccessCount.Should().Be(42);
+        response.ErrorCount.Should().Be(0);
+    }
+
+    // FR-3: Success flag derivation - no errors -> Success == true
+    [Fact]
+    public async Task Handle_WhenServiceReturnsNoErrors_SetsSuccessTrue()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProductWeightRecalculationResult
+            {
+                ProcessedCount = 10,
+                SuccessCount = 10,
+                ErrorCount = 0,
+                ErrorMessages = new List<string>()
+            });
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+    }
+
+    // FR-3: Success flag derivation - errors present -> Success == false, counts/messages pass through.
+    // Load-bearing because BaseResponse.Success defaults to true: this proves the handler's
+    // `Success = result.ErrorCount == 0` line actually executed and flipped the default.
+    [Fact]
+    public async Task Handle_WhenServiceReturnsErrors_SetsSuccessFalseAndPassesThrough()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        var errorMessages = new List<string> { "Product XYZ has no ingredients" };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProductWeightRecalculationResult
+            {
+                ProcessedCount = 10,
+                SuccessCount = 9,
+                ErrorCount = 1,
+                ErrorMessages = errorMessages
+            });
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ProcessedCount.Should().Be(10);
+        response.SuccessCount.Should().Be(9);
+        response.ErrorCount.Should().Be(1);
+        response.ErrorMessages.Should().BeEquivalentTo(errorMessages);
+    }
+
+    // FR-4: Exception fallback path (catch wraps both branches; exercised via empty ProductCode)
+    [Fact]
+    public async Task Handle_WhenServiceThrows_ReturnsFallbackResponseWithoutRethrowing()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("boom"));
+
+        // Act - awaiting a returned response (not throwing) is itself proof the handler did not rethrow
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Should().NotBeNull();
+        response.ProcessedCount.Should().Be(0);
+        response.SuccessCount.Should().Be(0);
+        response.ErrorCount.Should().Be(1);
+        response.Success.Should().BeFalse();
+        response.ErrorMessages.Should().ContainSingle();
+        response.ErrorMessages.Should().Contain(m => m.Contains("Internal error") && m.Contains("boom"));
+    }
+}
+```
+
+- [ ] **Step 2: Confirm the file compiles and the tests pass**
+
+The SUT and all collaborators already exist, so this "failing test" step is a compile-and-run gate rather than a red-phase assertion failure (there is no production code to write — the behavior under test is already implemented). Run:
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecalculateProductWeightHandlerTests"`
+
+Expected: build succeeds and the run reports `Passed!  - Failed: 0, Passed: 6` (5 test methods, one of which is a `[Theory]` with 2 cases → 6 executed test cases). If the build fails on a missing `using` or a member-name mismatch, fix it against the verified shapes at the top of this plan — do not change production code.
+
+- [ ] **Step 3: Verify the coverage gap is closed**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecalculateProductWeightHandlerTests" --collect:"XPlat Code Coverage"`
+
+Expected: the run passes and produces a `coverage.cobertura.xml` under `backend/test/Anela.Heblo.Tests/TestResults/<guid>/`. The tests exercise both dispatch branches, the mapping block, the `Success = result.ErrorCount == 0` line (both true and false), and the catch block — i.e. all reachable lines of `RecalculateProductWeightHandler.Handle`, bringing it well above the 60% threshold. (Reading the exact percentage from the XML is optional; the branch/line coverage is guaranteed by the tests above.)
+
+- [ ] **Step 4: Format check**
+
+Run: `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --verify-no-changes`
+
+Expected: exits `0` with no reported changes. If it reports formatting differences, run `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` and re-run the verify command until it is clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs
+git commit -m "test: cover RecalculateProductWeightHandler dispatch, mapping, and fallback
+
+Adds unit tests for single-product dispatch (FR-1), full-catalog dispatch
+(FR-2), Success flag derivation (FR-3), and the exception fallback path
+(FR-4), raising handler coverage above the 60% CI threshold.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018ARxdYPmo5CuiZohS2PbaS"
+```
+
+---
+
+## Self-review
+
+- **FR-1 (single-product dispatch):** `Handle_WithProductCode_DispatchesToSingleProductRecalculation` — asserts `RecalculateProductWeight("PROD001", ...)` `Times.Once`, `RecalculateAllProductWeights` `Times.Never`, and mirrors `ProcessedCount`/`SuccessCount`/`ErrorCount`/`ErrorMessages`. ✓
+- **FR-2 (full-catalog dispatch):** `Handle_WithoutProductCode_DispatchesToFullCatalogRecalculation` — `[Theory]` over `null` and `""`; asserts `RecalculateAllProductWeights` `Times.Once`, `RecalculateProductWeight` `Times.Never`. ✓
+- **FR-3 (Success derivation):** `Handle_WhenServiceReturnsNoErrors_SetsSuccessTrue` (`ErrorCount = 0` → `Success == true`) and `Handle_WhenServiceReturnsErrors_SetsSuccessFalseAndPassesThrough` (`ErrorCount = 1` with non-empty messages → `Success == false` plus pass-through of counts/messages — load-bearing against the `true` default). ✓
+- **FR-4 (exception fallback):** `Handle_WhenServiceThrows_ReturnsFallbackResponseWithoutRethrowing` — service `ThrowsAsync(new Exception("boom"))` on the empty-`ProductCode` branch; asserts no rethrow, `ProcessedCount == 0`, `SuccessCount == 0`, `ErrorCount == 1`, `Success == false`, and a single `ErrorMessages` entry containing both `"Internal error"` and `"boom"` (substring, not exact-string, per the arch-review risk mitigation). ✓
+- **Conventions (NFR-3):** namespace `Anela.Heblo.Tests.Features.Catalog`; `private readonly` mocks + single SUT built in the constructor; xUnit + Moq + FluentAssertions; logger mocked but never asserted; file at the required path. ✓
+- **No production changes / no new packages (Out of Scope):** only one test file created. ✓
+- **No placeholders:** every step shows exact code, exact commands, and expected output. ✓

--- a/artifacts/feat-3615/task-plan.r1.md
+++ b/artifacts/feat-3615/task-plan.r1.md
@@ -1,0 +1,247 @@
+# Unit test coverage for RecalculateProductWeightHandler — Implementation Plan
+
+**Goal:** Raise `RecalculateProductWeightHandler` line coverage from 17.1% above the 60% CI threshold by adding a single xUnit test file that exercises all four functional requirements: single-product dispatch (FR-1), full-catalog dispatch (FR-2), `Success` flag derivation (FR-3), and the exception fallback path (FR-4). No production code changes.
+
+**Architecture:** One new test class, `RecalculateProductWeightHandlerTests`, in the existing `Anela.Heblo.Tests` project. It mirrors the canonical `CreateManufactureDifficultyHandlerTests` pattern: `private readonly` mocks and a single system-under-test built once in the constructor. The only behavioral collaborator, `IProductWeightRecalculationService`, is mocked with Moq (`ReturnsAsync` / `ThrowsAsync`); `ILogger<RecalculateProductWeightHandler>` is mocked passively and never asserted. Dispatch is pinned with paired `Verify(...)` (`Times.Once` on the expected method AND `Times.Never` on its sibling). Response fields are asserted with FluentAssertions.
+
+**Tech Stack:** .NET 8, xUnit (`[Fact]`/`[Theory]`), Moq, FluentAssertions — all already referenced by `Anela.Heblo.Tests.csproj`. No new NuGet packages, no config, no migrations.
+
+**Verified real type shapes (do not re-derive):**
+- `RecalculateProductWeightRequest : IRequest<RecalculateProductWeightResponse>` — `public string? ProductCode { get; set; }`.
+- `RecalculateProductWeightResponse : BaseResponse` — `int ProcessedCount`, `int SuccessCount`, `int ErrorCount`, `List<string> ErrorMessages`. `Success` is inherited from `BaseResponse` and **defaults to `true`**.
+- `ProductWeightRecalculationResult` — `int ProcessedCount`, `int SuccessCount`, `int ErrorCount`, `List<string> ErrorMessages`, `TimeSpan Duration`, `DateTime StartTime`, `DateTime EndTime`.
+- `IProductWeightRecalculationService` (namespace `Anela.Heblo.Application.Features.Catalog.Services`):
+  - `Task<ProductWeightRecalculationResult> RecalculateAllProductWeights(CancellationToken cancellationToken = default)`
+  - `Task<ProductWeightRecalculationResult> RecalculateProductWeight(string productCode, CancellationToken cancellationToken = default)`
+- Handler under test: `RecalculateProductWeightHandler.Handle(RecalculateProductWeightRequest, CancellationToken)` in namespace `Anela.Heblo.Application.Features.Catalog.UseCases.RecalculateProductWeight`. On exception it returns `ProcessedCount = 0`, `SuccessCount = 0`, `ErrorCount = 1`, `ErrorMessages = { $"Internal error: {ex.Message}" }`, `Success = false`.
+
+---
+
+### task: add-recalculate-product-weight-handler-tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs`
+
+All paths below are relative to the repository root `/home/user/worktrees/feature-3615-Coverage-Gap-Catalog-Recalculateproductweighthandl`. Run every `dotnet` command from the `backend/` directory.
+
+- [ ] **Step 1: Write the complete failing test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs` with exactly this content:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Catalog.UseCases.RecalculateProductWeight;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+public class RecalculateProductWeightHandlerTests
+{
+    private readonly Mock<IProductWeightRecalculationService> _serviceMock;
+    private readonly Mock<ILogger<RecalculateProductWeightHandler>> _loggerMock;
+    private readonly RecalculateProductWeightHandler _handler;
+
+    public RecalculateProductWeightHandlerTests()
+    {
+        _serviceMock = new Mock<IProductWeightRecalculationService>();
+        _loggerMock = new Mock<ILogger<RecalculateProductWeightHandler>>();
+        _handler = new RecalculateProductWeightHandler(_serviceMock.Object, _loggerMock.Object);
+    }
+
+    // FR-1: Single-product recalculation path
+    [Fact]
+    public async Task Handle_WithProductCode_DispatchesToSingleProductRecalculation()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = "PROD001" };
+        var serviceResult = new ProductWeightRecalculationResult
+        {
+            ProcessedCount = 1,
+            SuccessCount = 1,
+            ErrorCount = 0,
+            ErrorMessages = new List<string>()
+        };
+        _serviceMock
+            .Setup(s => s.RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serviceResult);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - dispatch pinned in both directions
+        _serviceMock.Verify(
+            s => s.RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _serviceMock.Verify(
+            s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert - response mirrors the service result
+        response.ProcessedCount.Should().Be(1);
+        response.SuccessCount.Should().Be(1);
+        response.ErrorCount.Should().Be(0);
+        response.ErrorMessages.Should().BeEquivalentTo(serviceResult.ErrorMessages);
+    }
+
+    // FR-2: Full-catalog recalculation path (null and empty are one equivalence class)
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Handle_WithoutProductCode_DispatchesToFullCatalogRecalculation(string? productCode)
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = productCode };
+        var serviceResult = new ProductWeightRecalculationResult
+        {
+            ProcessedCount = 42,
+            SuccessCount = 42,
+            ErrorCount = 0,
+            ErrorMessages = new List<string>()
+        };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serviceResult);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - dispatch pinned in both directions
+        _serviceMock.Verify(
+            s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()),
+            Times.Once);
+        _serviceMock.Verify(
+            s => s.RecalculateProductWeight(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert - response mirrors the service result
+        response.ProcessedCount.Should().Be(42);
+        response.SuccessCount.Should().Be(42);
+        response.ErrorCount.Should().Be(0);
+    }
+
+    // FR-3: Success flag derivation - no errors -> Success == true
+    [Fact]
+    public async Task Handle_WhenServiceReturnsNoErrors_SetsSuccessTrue()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProductWeightRecalculationResult
+            {
+                ProcessedCount = 10,
+                SuccessCount = 10,
+                ErrorCount = 0,
+                ErrorMessages = new List<string>()
+            });
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+    }
+
+    // FR-3: Success flag derivation - errors present -> Success == false, counts/messages pass through.
+    // Load-bearing because BaseResponse.Success defaults to true: this proves the handler's
+    // `Success = result.ErrorCount == 0` line actually executed and flipped the default.
+    [Fact]
+    public async Task Handle_WhenServiceReturnsErrors_SetsSuccessFalseAndPassesThrough()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        var errorMessages = new List<string> { "Product XYZ has no ingredients" };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProductWeightRecalculationResult
+            {
+                ProcessedCount = 10,
+                SuccessCount = 9,
+                ErrorCount = 1,
+                ErrorMessages = errorMessages
+            });
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ProcessedCount.Should().Be(10);
+        response.SuccessCount.Should().Be(9);
+        response.ErrorCount.Should().Be(1);
+        response.ErrorMessages.Should().BeEquivalentTo(errorMessages);
+    }
+
+    // FR-4: Exception fallback path (catch wraps both branches; exercised via empty ProductCode)
+    [Fact]
+    public async Task Handle_WhenServiceThrows_ReturnsFallbackResponseWithoutRethrowing()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("boom"));
+
+        // Act - awaiting a returned response (not throwing) is itself proof the handler did not rethrow
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Should().NotBeNull();
+        response.ProcessedCount.Should().Be(0);
+        response.SuccessCount.Should().Be(0);
+        response.ErrorCount.Should().Be(1);
+        response.Success.Should().BeFalse();
+        response.ErrorMessages.Should().ContainSingle();
+        response.ErrorMessages.Should().Contain(m => m.Contains("Internal error") && m.Contains("boom"));
+    }
+}
+```
+
+- [ ] **Step 2: Confirm the file compiles and the tests pass**
+
+The SUT and all collaborators already exist, so this "failing test" step is a compile-and-run gate rather than a red-phase assertion failure (there is no production code to write — the behavior under test is already implemented). Run:
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecalculateProductWeightHandlerTests"`
+
+Expected: build succeeds and the run reports `Passed!  - Failed: 0, Passed: 6` (5 test methods, one of which is a `[Theory]` with 2 cases → 6 executed test cases). If the build fails on a missing `using` or a member-name mismatch, fix it against the verified shapes at the top of this plan — do not change production code.
+
+- [ ] **Step 3: Verify the coverage gap is closed**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~RecalculateProductWeightHandlerTests" --collect:"XPlat Code Coverage"`
+
+Expected: the run passes and produces a `coverage.cobertura.xml` under `backend/test/Anela.Heblo.Tests/TestResults/<guid>/`. The tests exercise both dispatch branches, the mapping block, the `Success = result.ErrorCount == 0` line (both true and false), and the catch block — i.e. all reachable lines of `RecalculateProductWeightHandler.Handle`, bringing it well above the 60% threshold. (Reading the exact percentage from the XML is optional; the branch/line coverage is guaranteed by the tests above.)
+
+- [ ] **Step 4: Format check**
+
+Run: `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --verify-no-changes`
+
+Expected: exits `0` with no reported changes. If it reports formatting differences, run `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` and re-run the verify command until it is clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs
+git commit -m "test: cover RecalculateProductWeightHandler dispatch, mapping, and fallback
+
+Adds unit tests for single-product dispatch (FR-1), full-catalog dispatch
+(FR-2), Success flag derivation (FR-3), and the exception fallback path
+(FR-4), raising handler coverage above the 60% CI threshold.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018ARxdYPmo5CuiZohS2PbaS"
+```
+
+---
+
+## Self-review
+
+- **FR-1 (single-product dispatch):** `Handle_WithProductCode_DispatchesToSingleProductRecalculation` — asserts `RecalculateProductWeight("PROD001", ...)` `Times.Once`, `RecalculateAllProductWeights` `Times.Never`, and mirrors `ProcessedCount`/`SuccessCount`/`ErrorCount`/`ErrorMessages`. ✓
+- **FR-2 (full-catalog dispatch):** `Handle_WithoutProductCode_DispatchesToFullCatalogRecalculation` — `[Theory]` over `null` and `""`; asserts `RecalculateAllProductWeights` `Times.Once`, `RecalculateProductWeight` `Times.Never`. ✓
+- **FR-3 (Success derivation):** `Handle_WhenServiceReturnsNoErrors_SetsSuccessTrue` (`ErrorCount = 0` → `Success == true`) and `Handle_WhenServiceReturnsErrors_SetsSuccessFalseAndPassesThrough` (`ErrorCount = 1` with non-empty messages → `Success == false` plus pass-through of counts/messages — load-bearing against the `true` default). ✓
+- **FR-4 (exception fallback):** `Handle_WhenServiceThrows_ReturnsFallbackResponseWithoutRethrowing` — service `ThrowsAsync(new Exception("boom"))` on the empty-`ProductCode` branch; asserts no rethrow, `ProcessedCount == 0`, `SuccessCount == 0`, `ErrorCount == 1`, `Success == false`, and a single `ErrorMessages` entry containing both `"Internal error"` and `"boom"` (substring, not exact-string, per the arch-review risk mitigation). ✓
+- **Conventions (NFR-3):** namespace `Anela.Heblo.Tests.Features.Catalog`; `private readonly` mocks + single SUT built in the constructor; xUnit + Moq + FluentAssertions; logger mocked but never asserted; file at the required path. ✓
+- **No production changes / no new packages (Out of Scope):** only one test file created. ✓
+- **No placeholders:** every step shows exact code, exact commands, and expected output. ✓

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/RecalculateProductWeightHandlerTests.cs
@@ -1,0 +1,169 @@
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Catalog.UseCases.RecalculateProductWeight;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog;
+
+public class RecalculateProductWeightHandlerTests
+{
+    private readonly Mock<IProductWeightRecalculationService> _serviceMock;
+    private readonly Mock<ILogger<RecalculateProductWeightHandler>> _loggerMock;
+    private readonly RecalculateProductWeightHandler _handler;
+
+    public RecalculateProductWeightHandlerTests()
+    {
+        _serviceMock = new Mock<IProductWeightRecalculationService>();
+        _loggerMock = new Mock<ILogger<RecalculateProductWeightHandler>>();
+        _handler = new RecalculateProductWeightHandler(_serviceMock.Object, _loggerMock.Object);
+    }
+
+    // FR-1: Single-product recalculation path
+    [Fact]
+    public async Task Handle_WithProductCode_DispatchesToSingleProductRecalculation()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = "PROD001" };
+        var serviceResult = new ProductWeightRecalculationResult
+        {
+            ProcessedCount = 1,
+            SuccessCount = 1,
+            ErrorCount = 0,
+            ErrorMessages = new List<string>()
+        };
+        _serviceMock
+            .Setup(s => s.RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serviceResult);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - dispatch pinned in both directions
+        _serviceMock.Verify(
+            s => s.RecalculateProductWeight("PROD001", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _serviceMock.Verify(
+            s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert - response mirrors the service result
+        response.ProcessedCount.Should().Be(1);
+        response.SuccessCount.Should().Be(1);
+        response.ErrorCount.Should().Be(0);
+        response.ErrorMessages.Should().BeEquivalentTo(serviceResult.ErrorMessages);
+    }
+
+    // FR-2: Full-catalog recalculation path (null and empty are one equivalence class)
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Handle_WithoutProductCode_DispatchesToFullCatalogRecalculation(string? productCode)
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = productCode };
+        var serviceResult = new ProductWeightRecalculationResult
+        {
+            ProcessedCount = 42,
+            SuccessCount = 42,
+            ErrorCount = 0,
+            ErrorMessages = new List<string>()
+        };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serviceResult);
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - dispatch pinned in both directions
+        _serviceMock.Verify(
+            s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()),
+            Times.Once);
+        _serviceMock.Verify(
+            s => s.RecalculateProductWeight(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert - response mirrors the service result
+        response.ProcessedCount.Should().Be(42);
+        response.SuccessCount.Should().Be(42);
+        response.ErrorCount.Should().Be(0);
+    }
+
+    // FR-3: Success flag derivation - no errors -> Success == true
+    [Fact]
+    public async Task Handle_WhenServiceReturnsNoErrors_SetsSuccessTrue()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProductWeightRecalculationResult
+            {
+                ProcessedCount = 10,
+                SuccessCount = 10,
+                ErrorCount = 0,
+                ErrorMessages = new List<string>()
+            });
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+    }
+
+    // FR-3: Success flag derivation - errors present -> Success == false, counts/messages pass through.
+    // Load-bearing because BaseResponse.Success defaults to true: this proves the handler's
+    // `Success = result.ErrorCount == 0` line actually executed and flipped the default.
+    [Fact]
+    public async Task Handle_WhenServiceReturnsErrors_SetsSuccessFalseAndPassesThrough()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        var errorMessages = new List<string> { "Product XYZ has no ingredients" };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProductWeightRecalculationResult
+            {
+                ProcessedCount = 10,
+                SuccessCount = 9,
+                ErrorCount = 1,
+                ErrorMessages = errorMessages
+            });
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ProcessedCount.Should().Be(10);
+        response.SuccessCount.Should().Be(9);
+        response.ErrorCount.Should().Be(1);
+        response.ErrorMessages.Should().BeEquivalentTo(errorMessages);
+    }
+
+    // FR-4: Exception fallback path (catch wraps both branches; exercised via empty ProductCode)
+    [Fact]
+    public async Task Handle_WhenServiceThrows_ReturnsFallbackResponseWithoutRethrowing()
+    {
+        // Arrange
+        var request = new RecalculateProductWeightRequest { ProductCode = null };
+        _serviceMock
+            .Setup(s => s.RecalculateAllProductWeights(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("boom"));
+
+        // Act - awaiting a returned response (not throwing) is itself proof the handler did not rethrow
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Should().NotBeNull();
+        response.ProcessedCount.Should().Be(0);
+        response.SuccessCount.Should().Be(0);
+        response.ErrorCount.Should().Be(1);
+        response.Success.Should().BeFalse();
+        response.ErrorMessages.Should().ContainSingle();
+        response.ErrorMessages.Should().Contain(m => m.Contains("Internal error") && m.Contains("boom"));
+    }
+}


### PR DESCRIPTION
Closes #3615

## What the issue was
`RecalculateProductWeightHandler` sat at 17.1% line coverage, below the 60% CI threshold. Three code paths were completely uncovered: single-product recalculation dispatch, full-catalog recalculation dispatch, and the exception fallback path. Additionally, the `Success = result.ErrorCount == 0` mapping was never asserted, so a regression there would go undetected. The single-vs-all dispatch was the highest-risk gap: a bug could route a single-product request into an expensive full-catalog recalculation, or vice versa.

## How it was fixed / handled
Added one new xUnit test file, `RecalculateProductWeightHandlerTests.cs`, with 5 test methods (6 executed cases) covering all four functional requirements:
- Single-product dispatch: verifies `RecalculateProductWeight` is called and `RecalculateAllProductWeights` is not.
- Full-catalog dispatch (`[Theory]` over `null`/`""`): verifies the reverse.
- `Success` flag derivation in both directions (this is load-bearing since `BaseResponse.Success` defaults to `true`).
- Exception fallback: verifies the handler catches, does not rethrow, and returns the expected error response with `ErrorMessages` populated.

No production code was changed — this is a pure test-coverage addition. All 6 test cases pass and `dotnet format --verify-no-changes` is clean.

## Artifacts
Brief, spec, arch review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3615/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_018ARxdYPmo5CuiZohS2PbaS)_