### PR TITLE
#3618: implementation

### DIFF
--- a/artifacts/feat-3618/arch-review.r1.md
+++ b/artifacts/feat-3618/arch-review.r1.md
@@ -1,0 +1,76 @@
+# Architecture Review: CalculateBatchByIngredientRequestValidator unit tests
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a pure test-addition task with zero production-code footprint. It fits directly into an already-established convention: FluentValidation validators under `backend/src/Anela.Heblo.Application/Features/<Module>/Validators/` are unit-tested 1:1 with `FluentValidation.TestHelper` in `backend/test/Anela.Heblo.Tests/Features/<Module>/`. The target validator, `CalculateBatchByIngredientRequestValidator`, is a trivial three-rule `AbstractValidator<CalculateBatchByIngredientRequest>` (verified by reading the source directly) with no dependencies, no custom validators, and no async rules — there is nothing here that deviates from the pattern already implemented in the sibling file `CalculateBatchPlanRequestValidatorTests.cs` in the same directory, and mirrored again in `GetManufactureOutputRequestValidatorTests.cs` and `GetManufacturingStockAnalysisRequestValidatorTests.cs` in the same `Features/Manufacture` test folder. No new architecture is being introduced; this review exists mainly to confirm there's nothing to design.
+
+Confirmed via source inspection:
+- `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` references `xunit`/`xunit.runner.visualstudio` only — no direct `FluentValidation.TestHelper` package entry. This is fine: `FluentValidation.TestHelper` (namespace) ships inside the main `FluentValidation` package (v11.9.0, referenced transitively via `Anela.Heblo.Application.csproj`), which the sibling test already consumes successfully (`using FluentValidation.TestHelper;`). No csproj changes needed.
+- The validator's three rules (`ProductCode`: NotEmpty + MaxLength(50); `IngredientCode`: NotEmpty + MaxLength(50); `DesiredIngredientAmount`: GreaterThan(0) + LessThanOrEqualTo(999999.99)) exactly match the brief/spec description — no drift between spec and current code to flag.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. One new leaf test file joins an existing flat collection of validator test files:
+
+```
+backend/test/Anela.Heblo.Tests/Features/Manufacture/
+├── CalculateBatchPlanRequestValidatorTests.cs        (existing, pattern source)
+├── CalculateBatchByIngredientHandlerTests.cs         (existing, handler-level, untouched)
+└── CalculateBatchByIngredientRequestValidatorTests.cs (NEW — this task)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Test style — mirror `CalculateBatchPlanRequestValidatorTests` exactly
+**Options considered:** (a) Copy the sibling's structure/conventions verbatim; (b) invent a leaner style (e.g. a single parameterized `[Theory]` covering all fields via reflection or a data-driven table).
+**Chosen approach:** (a). One `[Fact]` for the happy path, `[Theory]`/`[InlineData]` per rule/boundary, field-init `_validator` in the constructor, AAA comments (`// Arrange` / `// Act` / `// Assert`).
+**Rationale:** This is a solo-maintainer codebase with an established, repeated pattern across multiple validator test files in the same folder. Deviating (option b) would save a handful of lines but break scanability for the next validator test someone copies from. Consistency wins outright for a task this small.
+
+#### Decision 2: One test class, not split by field
+**Options considered:** Separate test classes per property (`ProductCode`, `IngredientCode`, `DesiredIngredientAmount`); single class covering all rules of the validator.
+**Chosen approach:** Single class `CalculateBatchByIngredientRequestValidatorTests`, matching 1 validator ↔ 1 test class convention used throughout the module.
+**Rationale:** The validator itself is a single cohesive unit (3 rules, no sub-validators). Splitting would be over-engineering for ~10-12 test methods total.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+Create exactly one file:
+`backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs`
+
+- Namespace: `Anela.Heblo.Tests.Features.Manufacture`
+- Class: `CalculateBatchByIngredientRequestValidatorTests`
+- Usings required: `Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchByIngredient` (for `CalculateBatchByIngredientRequest`), `Anela.Heblo.Application.Features.Manufacture.Validators` (for the validator), `FluentValidation.TestHelper`, `Xunit`.
+- No changes to any `.csproj`, no new NuGet packages, no changes to production source.
+
+### Interfaces and Contracts
+No new interfaces. Tests exercise the existing public contract only:
+
+```csharp
+public class CalculateBatchByIngredientRequest : IRequest<CalculateBatchByIngredientResponse>
+{
+    public string ProductCode { get; set; } = null!;
+    public string IngredientCode { get; set; } = null!;
+    public double DesiredIngredientAmount { get; set; }
+}
+```
+and `CalculateBatchByIngredientRequestValidator : AbstractValidator<CalculateBatchByIngredientRequest>` (constructor-only, no injected dependencies — safe to `new` up once per test class instance, matching the sibling's field-init-in-constructor pattern).
+
+Note for the implementer: `ProductCode`/`IngredientCode` are non-nullable (`= null!`) at the C# type level but the spec (FR-5/FR-7) requires a `[InlineData(null)]` case. This is legal and necessary here — `TestValidate` builds the object via property assignment at runtime, and FluentValidation's `NotEmpty()` rule correctly flags a runtime-assigned `null`, exactly as the sibling test already does for `CalculateBatchPlanRequest.ProductCode` (also `null!`-typed). No special handling needed; follow the sibling's precedent verbatim.
+
+### Data Flow
+Not applicable in the runtime sense — this is a pure unit test: instantiate `CalculateBatchByIngredientRequest`, call `_validator.TestValidate(request)`, assert on the `TestValidationResult<T>`. No handler, no service, no persistence layer is touched or mocked.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Boundary test for `999999.99` fails due to floating-point comparison inside FluentValidation's `LessThanOrEqualTo` on a `double` | Low | Use the exact literal `999999.99` as specified — FluentValidation's comparison validator uses `CompareTo` on `IComparable`, which is exact for identical literals; the sibling pattern already relies on plain `double` comparisons without issue. No epsilon/tolerance logic needed. |
+| Test file name/namespace collision with existing `CalculateBatchByIngredientHandlerTests.cs` in the same folder | Very Low | Confirmed no existing `CalculateBatchByIngredientRequestValidatorTests.cs` file exists yet (directory listing checked) — no collision. |
+| Someone later "improves" the validator (e.g. changes the cap or drops `MaximumLength`) without noticing these tests | Low | Out of scope to prevent via architecture — the entire point of this task is that these tests will now catch that regression going forward. |
+
+## Specification Amendments
+None. The spec (`spec.r1.md`) is accurate, verified against the actual validator and DTO source, and directly implementable as written — FR-1 through FR-8 map one-to-one onto the validator's three rules with no gaps or conflicts found.
+
+## Prerequisites
+None. No migrations, no config, no infrastructure changes. The test project already builds and already has every dependency (`xunit`, transitively-available `FluentValidation.TestHelper`) needed. Implementation can start immediately.

--- a/artifacts/feat-3618/brief.md
+++ b/artifacts/feat-3618/brief.md
@@ -1,0 +1,33 @@
+## Module / File
+`backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchByIngredientRequestValidator.cs`
+
+## Coverage
+Line coverage: 0.0% (filter threshold: 60%)
+
+## What's not tested
+The validator has no tests. The key gap is the `DesiredIngredientAmount` bounds check:
+
+- Must be `> 0` — a zero or negative amount should be rejected
+- Must be `<= 999999.99` — the upper cap prevents batch calculations from running against unreasonably large ingredient quantities
+
+If either bound is silently broken (e.g., by a refactor of the validator base class or an accidental rule removal), invalid amounts would flow into the batch calculation service, potentially causing silent incorrect results or overflow.
+
+Also untested: `ProductCode` and `IngredientCode` required + max 50 chars each.
+
+## Why it matters
+Batch calculations feed directly into manufacture planning (batch sizes, material consumption). An uncaught zero or negative ingredient amount could produce a division-by-zero or negative batch size downstream.
+
+## Suggested approach
+Unit tests on `CalculateBatchByIngredientRequestValidator`:
+- `DesiredIngredientAmount = 0` → validation error
+- `DesiredIngredientAmount = -1` → validation error
+- `DesiredIngredientAmount = 999999.99` → no error (boundary)
+- `DesiredIngredientAmount = 1000000` → validation error (over cap)
+- `DesiredIngredientAmount = 100` → no error (happy path)
+- `ProductCode = ""` → required error
+- `IngredientCode = ""` → required error
+
+~1 hour effort.
+
+---
+_Filed by weekly coverage-gap routine on 2026-07-13. Based on CI run #28968007617 (06d109fe5edcb456730222410f64385606100b1b)._

--- a/artifacts/feat-3618/code-review.r1.md
+++ b/artifacts/feat-3618/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3618/design.r1.md
+++ b/artifacts/feat-3618/design.r1.md
@@ -1,0 +1,30 @@
+# Design: Unit tests for CalculateBatchByIngredientRequestValidator
+
+## Component Design
+
+One new xUnit test class, no production code:
+
+- **`CalculateBatchByIngredientRequestValidatorTests`** — `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs`, namespace `Anela.Heblo.Tests.Features.Manufacture`. Field-inits `CalculateBatchByIngredientRequestValidator` once and exercises it via `FluentValidation.TestHelper.TestValidate(...)`, mirroring the sibling `CalculateBatchPlanRequestValidatorTests` in the same folder. Test methods:
+  - `Validate_ValidRequest_PassesValidation` (`[Fact]`)
+  - `Validate_DesiredIngredientAmount_BelowOrEqualZero_FailsValidation` (`[Theory]`: `0`, `-1`, `-0.01`)
+  - `Validate_DesiredIngredientAmount_ValidPositiveValue_PassesValidation` (`[Theory]`: `0.01`, `100`, `999999.99`)
+  - `Validate_DesiredIngredientAmount_AboveUpperBound_FailsValidation` (`[Theory]`: `1000000`, `999999.991`)
+  - `Validate_ProductCode_Empty_FailsValidation` (`[Theory]`: `""`, `" "`, `null`)
+  - `Validate_ProductCode_MaxLength_Boundary` (50 chars passes, 51 chars fails)
+  - `Validate_IngredientCode_Empty_FailsValidation` (`[Theory]`: `""`, `" "`, `null`)
+  - `Validate_IngredientCode_MaxLength_Boundary` (50 chars passes, 51 chars fails)
+
+No other components are introduced or modified. `CalculateBatchByIngredientRequestValidator` and `CalculateBatchByIngredientRequest` are consumed as-is, unchanged.
+
+## Data Schemas
+
+None. Tests exercise the existing DTO only — no schema, API, or event payload changes:
+
+```csharp
+public class CalculateBatchByIngredientRequest : IRequest<CalculateBatchByIngredientResponse>
+{
+    public string ProductCode { get; set; } = null!;
+    public string IngredientCode { get; set; } = null!;
+    public double DesiredIngredientAmount { get; set; }
+}
+```

--- a/artifacts/feat-3618/impl/add-validator-tests.r1.md
+++ b/artifacts/feat-3618/impl/add-validator-tests.r1.md
@@ -1,0 +1,38 @@
+# Implementation: add-validator-tests
+
+## What was implemented
+Added a new xUnit test class `CalculateBatchByIngredientRequestValidatorTests` covering all three FluentValidation rules on `CalculateBatchByIngredientRequestValidator`: the `DesiredIngredientAmount` lower bound (`> 0`) and upper bound (`<= 999999.99`), and the `ProductCode`/`IngredientCode` required + max-length(50) rules. No production code was modified.
+
+## Files created/modified
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs` — 8 test methods (1 happy-path `[Fact]`, 4 `[Theory]` bound checks, 2 `[Fact]` max-length boundary checks, 1 more `[Theory]`), mirroring the conventions of the sibling `CalculateBatchPlanRequestValidatorTests.cs`.
+
+## Tests
+- `Validate_ValidRequest_PassesValidation` — happy path, no errors.
+- `Validate_DesiredIngredientAmount_BelowOrEqualZero_FailsValidation` — `0`, `-1`, `-0.01`.
+- `Validate_DesiredIngredientAmount_ValidPositiveValue_PassesValidation` — `0.01`, `100`, `999999.99` (upper boundary pass).
+- `Validate_DesiredIngredientAmount_AboveUpperBound_FailsValidation` — `1000000`, `999999.991`.
+- `Validate_ProductCode_Empty_FailsValidation` — `""`, `" "`, `null`.
+- `Validate_ProductCode_MaxLength_Boundary` — 50 chars passes, 51 chars fails.
+- `Validate_IngredientCode_Empty_FailsValidation` — `""`, `" "`, `null`.
+- `Validate_IngredientCode_MaxLength_Boundary` — 50 chars passes, 51 chars fails.
+
+## How to verify
+```bash
+dotnet build Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CalculateBatchByIngredientRequestValidatorTests" --no-build
+```
+Result: 17/17 passed (8 test methods, several `[Theory]`-expanded).
+
+Full `Anela.Heblo.Tests` suite was also run for regressions: 5851 passed, 76 failed, 4 skipped. All 76 failures are pre-existing Docker/Testcontainers-dependent integration tests (Postgres containers) that cannot run in this sandbox (no Docker daemon) — unrelated to this change. None reference `CalculateBatchByIngredient` or the `Manufacture.Validators` namespace.
+
+## Notes
+No deviations from the task plan. No production code, csproj, or any other file was touched — `git status` shows exactly one new file.
+
+## PR Summary
+Closes the 0% test-coverage gap on `CalculateBatchByIngredientRequestValidator` by adding a focused unit test suite covering its `DesiredIngredientAmount` bounds and the `ProductCode`/`IngredientCode` required + max-length rules. Test-only change, no production code modified.
+
+### Changes
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs` — new test file, 8 test methods covering all validator rules
+
+## Status
+DONE

--- a/artifacts/feat-3618/review/add-validator-tests.r1.md
+++ b/artifacts/feat-3618/review/add-validator-tests.r1.md
@@ -1,0 +1,31 @@
+# Code Review: add-validator-tests
+
+## Summary
+The new test class `CalculateBatchByIngredientRequestValidatorTests` implements all 8 required test cases from the spec, correctly asserting against the right properties for each of the three validation rules (`ProductCode`, `IngredientCode`, `DesiredIngredientAmount`). It mirrors the sibling `CalculateBatchPlanRequestValidatorTests.cs` structure precisely, and no production code was touched.
+
+## Review Result: PASS
+
+### task: add-validator-tests
+**Status:** PASS
+
+## Overall Notes
+Verification performed:
+
+- **Spec compliance**: All 8 test cases from the task spec are present with matching names and behavior:
+  1. `Validate_ValidRequest_PassesValidation` — happy path, `ShouldNotHaveAnyValidationErrors()`.
+  2. `Validate_DesiredIngredientAmount_BelowOrEqualZero_FailsValidation` — `[InlineData(0, -1, -0.01)]`.
+  3. `Validate_DesiredIngredientAmount_ValidPositiveValue_PassesValidation` — `[InlineData(0.01, 100, 999999.99)]`.
+  4. `Validate_DesiredIngredientAmount_AboveUpperBound_FailsValidation` — `[InlineData(1000000, 999999.991)]`.
+  5. `Validate_ProductCode_Empty_FailsValidation` — `[InlineData("", " ", null)]`, `string?` param.
+  6. `Validate_ProductCode_MaxLength_Boundary` — 50 chars passes, 51 chars fails, using `new string('A', 50/51)`.
+  7. `Validate_IngredientCode_Empty_FailsValidation` — same pattern as #5.
+  8. `Validate_IngredientCode_MaxLength_Boundary` — same pattern as #6.
+  Each test that targets one field keeps the other fields set to valid values, per the spec's isolation requirement.
+
+- **Architecture/convention adherence**: Namespace `Anela.Heblo.Tests.Features.Manufacture`, validator field instantiated in the constructor (not per-test `new`), `// Arrange` / `// Act` / `// Assert` blocks present in every test, `TestValidate` + `ShouldHaveValidationErrorFor`/`ShouldNotHaveValidationErrorFor`/`ShouldNotHaveAnyValidationErrors` used exclusively (no message-text assertions), required usings present — all matching the sibling file's conventions exactly.
+
+- **No production code changes**: `git diff --stat HEAD~1 HEAD -- . ':!artifacts'` shows exactly one file changed: the new test file (190 insertions, 0 deletions). `git show --stat HEAD` confirms the only non-artifact file touched is `CalculateBatchByIngredientRequestValidatorTests.cs`; the validator, request DTO, and all `.csproj` files are untouched.
+
+- **Build and tests pass**: Ran `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CalculateBatchByIngredientRequestValidatorTests"` from the repo root. Build succeeded (only pre-existing nullable-reference warnings in unrelated files, plus two expected `CS8601` warnings in the new file itself from assigning `null` to `string?`-typed local variables in the `[Theory]` boundary tests — consistent with the identical pattern already present in the sibling file). Result: `Passed! - Failed: 0, Passed: 17, Skipped: 0, Total: 17, Duration: 29 ms`, matching the developer's reported outcome.
+
+No issues found. No documentation updates are required for this test-only change.

--- a/artifacts/feat-3618/spec.r1.md
+++ b/artifacts/feat-3618/spec.r1.md
@@ -1,0 +1,109 @@
+# Specification: Unit tests for CalculateBatchByIngredientRequestValidator
+
+## Summary
+Add a focused xUnit + FluentValidation.TestHelper test suite for `CalculateBatchByIngredientRequestValidator`, covering the `DesiredIngredientAmount` numeric bounds and the `ProductCode`/`IngredientCode` required + max-length(50) rules. This closes a 0% coverage gap on a validator that guards inputs feeding directly into manufacture batch planning.
+
+## Background
+`CalculateBatchByIngredientRequestValidator` (`backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchByIngredientRequestValidator.cs`) validates `CalculateBatchByIngredientRequest` before it reaches the batch calculation service. It currently has no tests (0.0% line coverage, filter threshold 60%), flagged by the weekly coverage-gap routine on 2026-07-13 (CI run #28968007617). The validator enforces three rules:
+
+- `ProductCode`: `NotEmpty()`, `MaximumLength(50)`
+- `IngredientCode`: `NotEmpty()`, `MaximumLength(50)`
+- `DesiredIngredientAmount` (double): `GreaterThan(0)`, `LessThanOrEqualTo(999999.99)`
+
+If a refactor silently drops or weakens the `DesiredIngredientAmount` bounds, an invalid amount (zero, negative, or unreasonably large) could flow into batch calculations, risking division-by-zero or negative/overflowing batch sizes downstream. This task adds regression tests only — no production code changes.
+
+A sibling test in the same module, `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanRequestValidatorTests.cs`, establishes the local convention: xUnit `[Fact]`/`[Theory]`, `FluentValidation.TestHelper`'s `TestValidate(request)`, and assertions via `ShouldHaveValidationErrorFor(x => ...)` / `ShouldNotHaveValidationErrorFor(x => ...)` / `ShouldNotHaveAnyValidationErrors()`. The new test class follows this same pattern.
+
+## Functional Requirements
+
+### FR-1: New test file `CalculateBatchByIngredientRequestValidatorTests.cs`
+Create `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs`, namespace `Anela.Heblo.Tests.Features.Manufacture`, class `CalculateBatchByIngredientRequestValidatorTests`, instantiating `CalculateBatchByIngredientRequestValidator` once (constructor or field init), matching the style of the existing `CalculateBatchPlanRequestValidatorTests` in the same directory.
+
+**Acceptance criteria:**
+- File exists at the path above and compiles as part of `Anela.Heblo.Tests`.
+- Uses `FluentValidation.TestHelper` (`TestValidate`) and `Xunit`, no new test dependencies introduced.
+- No production/source files are modified.
+
+### FR-2: Happy-path validation
+A fully valid request (non-empty `ProductCode` and `IngredientCode` within 50 chars, `DesiredIngredientAmount` a positive value at or below 999999.99) produces no validation errors.
+
+**Acceptance criteria:**
+- `[Fact] Validate_ValidRequest_PassesValidation` builds a valid request (e.g. `ProductCode = "PROD001"`, `IngredientCode = "ING001"`, `DesiredIngredientAmount = 100`) and asserts `result.ShouldNotHaveAnyValidationErrors()`.
+
+### FR-3: `DesiredIngredientAmount` lower bound (`> 0`)
+Zero and negative amounts must fail validation on `DesiredIngredientAmount`; small positive amounts must pass.
+
+**Acceptance criteria:**
+- `[Theory]` with `[InlineData(0)]` and `[InlineData(-1)]` (plus a representative fractional negative, e.g. `-0.01`, is optional but recommended) asserts `result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+- A passing case for a small positive value (e.g. `0.01` or `100`) asserts `result.ShouldNotHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+### FR-4: `DesiredIngredientAmount` upper bound (`<= 999999.99`)
+The boundary value `999999.99` must pass; any value strictly greater than it must fail.
+
+**Acceptance criteria:**
+- `[Fact]` or `[Theory]` case with `DesiredIngredientAmount = 999999.99` asserts `result.ShouldNotHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+- `[Theory]` covering values over the cap (at minimum `1000000`; `999999.991` is a good tight-boundary addition) asserts `result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+### FR-5: `ProductCode` required
+An empty, whitespace-only, or `null` `ProductCode` must fail validation on `ProductCode`; other fields in the request stay valid so the failure is attributable to this rule.
+
+**Acceptance criteria:**
+- `[Theory]` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]` asserts `result.ShouldHaveValidationErrorFor(x => x.ProductCode)`, mirroring the `CalculateBatchPlanRequestValidatorTests.Validate_InvalidSemiproductCode_FailsValidation` pattern.
+
+### FR-6: `ProductCode` max length 50
+A `ProductCode` of exactly 50 characters must pass; 51+ characters must fail.
+
+**Acceptance criteria:**
+- A case with a 50-character `ProductCode` asserts `result.ShouldNotHaveValidationErrorFor(x => x.ProductCode)`.
+- A case with a 51-character `ProductCode` asserts `result.ShouldHaveValidationErrorFor(x => x.ProductCode)`.
+
+### FR-7: `IngredientCode` required
+An empty, whitespace-only, or `null` `IngredientCode` must fail validation on `IngredientCode`.
+
+**Acceptance criteria:**
+- `[Theory]` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]` asserts `result.ShouldHaveValidationErrorFor(x => x.IngredientCode)`.
+
+### FR-8: `IngredientCode` max length 50
+A `IngredientCode` of exactly 50 characters must pass; 51+ characters must fail.
+
+**Acceptance criteria:**
+- A case with a 50-character `IngredientCode` asserts `result.ShouldNotHaveValidationErrorFor(x => x.IngredientCode)`.
+- A case with a 51-character `IngredientCode` asserts `result.ShouldHaveValidationErrorFor(x => x.IngredientCode)`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — these are in-memory unit tests with no I/O; the full suite should run in well under 1 second.
+
+### NFR-2: Security
+Not applicable — no auth, no data sensitivity; validator operates on plain request DTOs.
+
+## Data Model
+No new or changed data model. Tests exercise the existing `CalculateBatchByIngredientRequest` DTO (`backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientRequest.cs`):
+
+```csharp
+public class CalculateBatchByIngredientRequest : IRequest<CalculateBatchByIngredientResponse>
+{
+    public string ProductCode { get; set; } = null!;
+    public string IngredientCode { get; set; } = null!;
+    public double DesiredIngredientAmount { get; set; }
+}
+```
+
+## API / Interface Design
+Not applicable — no API or UI surface changes. This is a backend unit-test-only addition targeting `CalculateBatchByIngredientRequestValidator`.
+
+## Dependencies
+- Existing test project `backend/test/Anela.Heblo.Tests` (xUnit, `FluentValidation.TestHelper`) — already referenced by sibling validator tests in the same project, no new package references required.
+- No dependency on other in-flight features or external services.
+
+## Out of Scope
+- Any change to `CalculateBatchByIngredientRequestValidator.cs` or `CalculateBatchByIngredientRequest.cs` itself.
+- Testing the `CalculateBatchByIngredient` handler/use case or `CalculateBatchCalculationService` logic — this task is validator-only.
+- Integration/E2E tests — this is a pure unit-test task.
+- Broader coverage improvements elsewhere in the `Manufacture` module.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-16T03:17:39.036292Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T03:17:39.198092Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T03:18:34.962789Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-validator-tests",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-16T03:15:36.792211Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T03:15:43.897743Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T03:17:03.063363Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-16T03:17:12.934833Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-16T03:18:34.962789Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-16T03:18:59.816462Z"
     }
   },
   "tasks": [
     {
       "name": "add-validator-tests",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-16T03:19:00.054008Z"
     }
   ]
 }

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T03:15:36.792211Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-16T03:15:43.897743Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-16T03:18:34.962789Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T03:18:59.816462Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T03:49:22.736240Z"
     }
   },
   "tasks": [
     {
       "name": "add-validator-tests",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-16T03:19:00.054008Z"
+      "updated_at": "2026-07-16T03:49:17.151567Z"
     }
   ]
 }

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3618",
+  "issue_number": 3618,
+  "created_at": "2026-07-16T03:14:05.884380Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-16T03:49:22.736240Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-16T03:49:23.036081Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-16T03:17:03.063363Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T03:17:12.934833Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T03:17:39.036292Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-16T03:17:39.198092Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3618/state.json
+++ b/artifacts/feat-3618/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-16T03:49:22.736240Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T03:49:23.036081Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T03:54:31.549005Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3618/task-context/add-validator-tests.md
+++ b/artifacts/feat-3618/task-context/add-validator-tests.md
@@ -1,0 +1,97 @@
+### task: add-validator-tests
+
+**Goal**
+Add a new xUnit test class `CalculateBatchByIngredientRequestValidatorTests` that closes the 0% coverage gap on `CalculateBatchByIngredientRequestValidator`, covering all three validation rules (`ProductCode`, `IngredientCode`, `DesiredIngredientAmount`) per FR-1 through FR-8 of `artifacts/feat-3618/spec.r1.md`.
+
+**File to create**
+`backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs`
+
+Do not modify any other file. In particular:
+- Do NOT modify `backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchByIngredientRequestValidator.cs`
+- Do NOT modify `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientRequest.cs`
+- Do NOT modify any `.csproj` (no new package references are needed — `FluentValidation.TestHelper` is already available transitively, exactly as consumed by the sibling test file below)
+
+**System under test (read-only reference — do not change)**
+
+`backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchByIngredientRequestValidator.cs`:
+```csharp
+public class CalculateBatchByIngredientRequestValidator : AbstractValidator<CalculateBatchByIngredientRequest>
+{
+    public CalculateBatchByIngredientRequestValidator()
+    {
+        RuleFor(x => x.ProductCode)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.IngredientCode)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.DesiredIngredientAmount)
+            .GreaterThan(0)
+            .LessThanOrEqualTo(999999.99);
+    }
+}
+```
+(`.WithMessage(...)` calls omitted above for brevity — actual file has them; tests must not assert on message text, only on which property has an error.)
+
+`CalculateBatchByIngredientRequest` (in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientRequest.cs`):
+```csharp
+public class CalculateBatchByIngredientRequest : IRequest<CalculateBatchByIngredientResponse>
+{
+    public string ProductCode { get; set; } = null!;
+    public string IngredientCode { get; set; } = null!;
+    public double DesiredIngredientAmount { get; set; }
+}
+```
+
+**Convention to follow (mirror exactly)**
+
+Sibling file: `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanRequestValidatorTests.cs`. Match its structure precisely:
+- Namespace `Anela.Heblo.Tests.Features.Manufacture`, one public test class, no base class.
+- Validator instantiated once via a `private readonly` field, assigned in the constructor (not `[Fact]`-local `new`):
+  ```csharp
+  private readonly CalculateBatchByIngredientRequestValidator _validator;
+
+  public CalculateBatchByIngredientRequestValidatorTests()
+  {
+      _validator = new CalculateBatchByIngredientRequestValidator();
+  }
+  ```
+- Every test method has `// Arrange`, `// Act`, `// Assert` comment blocks, in that order.
+- Use `_validator.TestValidate(request)` for the Act step, and `ShouldNotHaveAnyValidationErrors()` / `ShouldHaveValidationErrorFor(x => x.Prop)` / `ShouldNotHaveValidationErrorFor(x => x.Prop)` for assertions (from `FluentValidation.TestHelper`).
+- `[Theory]`/`[InlineData]` for parameterized cases (e.g. the sibling's `Validate_InvalidSemiproductCode_FailsValidation(string? semiproductCode)` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]`).
+- Required usings:
+  ```csharp
+  using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchByIngredient;
+  using Anela.Heblo.Application.Features.Manufacture.Validators;
+  using FluentValidation.TestHelper;
+  using Xunit;
+  ```
+- When a test targets one field, keep the other fields set to valid values so a failure is unambiguously attributable to the rule under test (e.g. when testing `ProductCode` invalidity, still set a valid `IngredientCode` and a valid `DesiredIngredientAmount`).
+
+**Test cases to implement** (from spec FR-2 through FR-8; method names are suggestions from `design.r1.md` — keep them or use equivalents that clearly convey the same scenario)
+
+1. `Validate_ValidRequest_PassesValidation` — `[Fact]`. Valid request, e.g. `ProductCode = "PROD001"`, `IngredientCode = "ING001"`, `DesiredIngredientAmount = 100`. Assert `result.ShouldNotHaveAnyValidationErrors()`.
+
+2. `Validate_DesiredIngredientAmount_BelowOrEqualZero_FailsValidation` — `[Theory]` with `[InlineData(0)]`, `[InlineData(-1)]`, `[InlineData(-0.01)]`. Other fields valid. Assert `result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+3. `Validate_DesiredIngredientAmount_ValidPositiveValue_PassesValidation` — `[Theory]` with `[InlineData(0.01)]`, `[InlineData(100)]`, `[InlineData(999999.99)]` (covers FR-3 passing case and the FR-4 upper boundary-passes case). Assert `result.ShouldNotHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+4. `Validate_DesiredIngredientAmount_AboveUpperBound_FailsValidation` — `[Theory]` with `[InlineData(1000000)]`, `[InlineData(999999.991)]`. Assert `result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+5. `Validate_ProductCode_Empty_FailsValidation` — `[Theory]` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]`, parameter typed `string?`. Other fields valid (valid `IngredientCode`, valid `DesiredIngredientAmount`). Assert `result.ShouldHaveValidationErrorFor(x => x.ProductCode)`.
+
+6. `Validate_ProductCode_MaxLength_Boundary` — one case with a 50-character `ProductCode` asserting `result.ShouldNotHaveValidationErrorFor(x => x.ProductCode)`, and one case with a 51-character `ProductCode` asserting `result.ShouldHaveValidationErrorFor(x => x.ProductCode)`. Implement as two `[Fact]`s or a `[Theory]` with a length/expected-outcome pair — either is acceptable; generate the strings with `new string('A', 50)` / `new string('A', 51)` rather than hardcoding literal 50/51-char strings.
+
+7. `Validate_IngredientCode_Empty_FailsValidation` — `[Theory]` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]`, parameter typed `string?`. Other fields valid. Assert `result.ShouldHaveValidationErrorFor(x => x.IngredientCode)`.
+
+8. `Validate_IngredientCode_MaxLength_Boundary` — same pattern as case 6 but for `IngredientCode`: 50 chars passes, 51 chars fails.
+
+**Definition of done**
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs` exists with the 8 test cases above (or a superset that still satisfies every FR), following the sibling file's structure and naming style.
+- No file other than this new test file is created or modified — verify with `git status` / `git diff --stat` showing only this one new file.
+- `dotnet build` succeeds for the solution.
+- `dotnet test --filter "FullyQualifiedName~CalculateBatchByIngredientRequestValidatorTests"` passes (all new tests green).
+- Full `dotnet test` run for `Anela.Heblo.Tests` shows no regressions (all previously-passing tests still pass).
+- `dotnet format` produces no changes to the new file (or is run and any formatting diffs are accepted before finishing).

--- a/artifacts/feat-3618/task-plan.r1.md
+++ b/artifacts/feat-3618/task-plan.r1.md
@@ -1,0 +1,104 @@
+# Task Plan: Unit tests for CalculateBatchByIngredientRequestValidator
+
+## Scope note
+This is a single-file, test-only addition (0 production code changes). Per the spec and architecture review, it is implemented as exactly one task.
+
+---
+
+### task: add-validator-tests
+
+**Goal**
+Add a new xUnit test class `CalculateBatchByIngredientRequestValidatorTests` that closes the 0% coverage gap on `CalculateBatchByIngredientRequestValidator`, covering all three validation rules (`ProductCode`, `IngredientCode`, `DesiredIngredientAmount`) per FR-1 through FR-8 of `artifacts/feat-3618/spec.r1.md`.
+
+**File to create**
+`backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs`
+
+Do not modify any other file. In particular:
+- Do NOT modify `backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchByIngredientRequestValidator.cs`
+- Do NOT modify `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientRequest.cs`
+- Do NOT modify any `.csproj` (no new package references are needed — `FluentValidation.TestHelper` is already available transitively, exactly as consumed by the sibling test file below)
+
+**System under test (read-only reference — do not change)**
+
+`backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchByIngredientRequestValidator.cs`:
+```csharp
+public class CalculateBatchByIngredientRequestValidator : AbstractValidator<CalculateBatchByIngredientRequest>
+{
+    public CalculateBatchByIngredientRequestValidator()
+    {
+        RuleFor(x => x.ProductCode)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.IngredientCode)
+            .NotEmpty()
+            .MaximumLength(50);
+
+        RuleFor(x => x.DesiredIngredientAmount)
+            .GreaterThan(0)
+            .LessThanOrEqualTo(999999.99);
+    }
+}
+```
+(`.WithMessage(...)` calls omitted above for brevity — actual file has them; tests must not assert on message text, only on which property has an error.)
+
+`CalculateBatchByIngredientRequest` (in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientRequest.cs`):
+```csharp
+public class CalculateBatchByIngredientRequest : IRequest<CalculateBatchByIngredientResponse>
+{
+    public string ProductCode { get; set; } = null!;
+    public string IngredientCode { get; set; } = null!;
+    public double DesiredIngredientAmount { get; set; }
+}
+```
+
+**Convention to follow (mirror exactly)**
+
+Sibling file: `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanRequestValidatorTests.cs`. Match its structure precisely:
+- Namespace `Anela.Heblo.Tests.Features.Manufacture`, one public test class, no base class.
+- Validator instantiated once via a `private readonly` field, assigned in the constructor (not `[Fact]`-local `new`):
+  ```csharp
+  private readonly CalculateBatchByIngredientRequestValidator _validator;
+
+  public CalculateBatchByIngredientRequestValidatorTests()
+  {
+      _validator = new CalculateBatchByIngredientRequestValidator();
+  }
+  ```
+- Every test method has `// Arrange`, `// Act`, `// Assert` comment blocks, in that order.
+- Use `_validator.TestValidate(request)` for the Act step, and `ShouldNotHaveAnyValidationErrors()` / `ShouldHaveValidationErrorFor(x => x.Prop)` / `ShouldNotHaveValidationErrorFor(x => x.Prop)` for assertions (from `FluentValidation.TestHelper`).
+- `[Theory]`/`[InlineData]` for parameterized cases (e.g. the sibling's `Validate_InvalidSemiproductCode_FailsValidation(string? semiproductCode)` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]`).
+- Required usings:
+  ```csharp
+  using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchByIngredient;
+  using Anela.Heblo.Application.Features.Manufacture.Validators;
+  using FluentValidation.TestHelper;
+  using Xunit;
+  ```
+- When a test targets one field, keep the other fields set to valid values so a failure is unambiguously attributable to the rule under test (e.g. when testing `ProductCode` invalidity, still set a valid `IngredientCode` and a valid `DesiredIngredientAmount`).
+
+**Test cases to implement** (from spec FR-2 through FR-8; method names are suggestions from `design.r1.md` — keep them or use equivalents that clearly convey the same scenario)
+
+1. `Validate_ValidRequest_PassesValidation` — `[Fact]`. Valid request, e.g. `ProductCode = "PROD001"`, `IngredientCode = "ING001"`, `DesiredIngredientAmount = 100`. Assert `result.ShouldNotHaveAnyValidationErrors()`.
+
+2. `Validate_DesiredIngredientAmount_BelowOrEqualZero_FailsValidation` — `[Theory]` with `[InlineData(0)]`, `[InlineData(-1)]`, `[InlineData(-0.01)]`. Other fields valid. Assert `result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+3. `Validate_DesiredIngredientAmount_ValidPositiveValue_PassesValidation` — `[Theory]` with `[InlineData(0.01)]`, `[InlineData(100)]`, `[InlineData(999999.99)]` (covers FR-3 passing case and the FR-4 upper boundary-passes case). Assert `result.ShouldNotHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+4. `Validate_DesiredIngredientAmount_AboveUpperBound_FailsValidation` — `[Theory]` with `[InlineData(1000000)]`, `[InlineData(999999.991)]`. Assert `result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount)`.
+
+5. `Validate_ProductCode_Empty_FailsValidation` — `[Theory]` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]`, parameter typed `string?`. Other fields valid (valid `IngredientCode`, valid `DesiredIngredientAmount`). Assert `result.ShouldHaveValidationErrorFor(x => x.ProductCode)`.
+
+6. `Validate_ProductCode_MaxLength_Boundary` — one case with a 50-character `ProductCode` asserting `result.ShouldNotHaveValidationErrorFor(x => x.ProductCode)`, and one case with a 51-character `ProductCode` asserting `result.ShouldHaveValidationErrorFor(x => x.ProductCode)`. Implement as two `[Fact]`s or a `[Theory]` with a length/expected-outcome pair — either is acceptable; generate the strings with `new string('A', 50)` / `new string('A', 51)` rather than hardcoding literal 50/51-char strings.
+
+7. `Validate_IngredientCode_Empty_FailsValidation` — `[Theory]` with `[InlineData("")]`, `[InlineData(" ")]`, `[InlineData(null)]`, parameter typed `string?`. Other fields valid. Assert `result.ShouldHaveValidationErrorFor(x => x.IngredientCode)`.
+
+8. `Validate_IngredientCode_MaxLength_Boundary` — same pattern as case 6 but for `IngredientCode`: 50 chars passes, 51 chars fails.
+
+**Definition of done**
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs` exists with the 8 test cases above (or a superset that still satisfies every FR), following the sibling file's structure and naming style.
+- No file other than this new test file is created or modified — verify with `git status` / `git diff --stat` showing only this one new file.
+- `dotnet build` succeeds for the solution.
+- `dotnet test --filter "FullyQualifiedName~CalculateBatchByIngredientRequestValidatorTests"` passes (all new tests green).
+- Full `dotnet test` run for `Anela.Heblo.Tests` shows no regressions (all previously-passing tests still pass).
+- `dotnet format` produces no changes to the new file (or is run and any formatting diffs are accepted before finishing).

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientRequestValidatorTests.cs
@@ -1,0 +1,190 @@
+using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchByIngredient;
+using Anela.Heblo.Application.Features.Manufacture.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture;
+
+public class CalculateBatchByIngredientRequestValidatorTests
+{
+    private readonly CalculateBatchByIngredientRequestValidator _validator;
+
+    public CalculateBatchByIngredientRequestValidatorTests()
+    {
+        _validator = new CalculateBatchByIngredientRequestValidator();
+    }
+
+    [Fact]
+    public void Validate_ValidRequest_PassesValidation()
+    {
+        // Arrange
+        var request = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = "PROD001",
+            IngredientCode = "ING001",
+            DesiredIngredientAmount = 100
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-0.01)]
+    public void Validate_DesiredIngredientAmount_BelowOrEqualZero_FailsValidation(double amount)
+    {
+        // Arrange
+        var request = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = "PROD001",
+            IngredientCode = "ING001",
+            DesiredIngredientAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount);
+    }
+
+    [Theory]
+    [InlineData(0.01)]
+    [InlineData(100)]
+    [InlineData(999999.99)]
+    public void Validate_DesiredIngredientAmount_ValidPositiveValue_PassesValidation(double amount)
+    {
+        // Arrange
+        var request = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = "PROD001",
+            IngredientCode = "ING001",
+            DesiredIngredientAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.DesiredIngredientAmount);
+    }
+
+    [Theory]
+    [InlineData(1000000)]
+    [InlineData(999999.991)]
+    public void Validate_DesiredIngredientAmount_AboveUpperBound_FailsValidation(double amount)
+    {
+        // Arrange
+        var request = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = "PROD001",
+            IngredientCode = "ING001",
+            DesiredIngredientAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.DesiredIngredientAmount);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void Validate_ProductCode_Empty_FailsValidation(string? productCode)
+    {
+        // Arrange
+        var request = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = productCode,
+            IngredientCode = "ING001",
+            DesiredIngredientAmount = 100
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.ProductCode);
+    }
+
+    [Fact]
+    public void Validate_ProductCode_MaxLength_Boundary()
+    {
+        // Arrange
+        var validRequest = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = new string('A', 50),
+            IngredientCode = "ING001",
+            DesiredIngredientAmount = 100
+        };
+        var invalidRequest = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = new string('A', 51),
+            IngredientCode = "ING001",
+            DesiredIngredientAmount = 100
+        };
+
+        // Act
+        var validResult = _validator.TestValidate(validRequest);
+        var invalidResult = _validator.TestValidate(invalidRequest);
+
+        // Assert
+        validResult.ShouldNotHaveValidationErrorFor(x => x.ProductCode);
+        invalidResult.ShouldHaveValidationErrorFor(x => x.ProductCode);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void Validate_IngredientCode_Empty_FailsValidation(string? ingredientCode)
+    {
+        // Arrange
+        var request = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = "PROD001",
+            IngredientCode = ingredientCode,
+            DesiredIngredientAmount = 100
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.IngredientCode);
+    }
+
+    [Fact]
+    public void Validate_IngredientCode_MaxLength_Boundary()
+    {
+        // Arrange
+        var validRequest = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = "PROD001",
+            IngredientCode = new string('A', 50),
+            DesiredIngredientAmount = 100
+        };
+        var invalidRequest = new CalculateBatchByIngredientRequest
+        {
+            ProductCode = "PROD001",
+            IngredientCode = new string('A', 51),
+            DesiredIngredientAmount = 100
+        };
+
+        // Act
+        var validResult = _validator.TestValidate(validRequest);
+        var invalidResult = _validator.TestValidate(invalidRequest);
+
+        // Assert
+        validResult.ShouldNotHaveValidationErrorFor(x => x.IngredientCode);
+        invalidResult.ShouldHaveValidationErrorFor(x => x.IngredientCode);
+    }
+}


### PR DESCRIPTION
Closes #3618

## What the issue was
`CalculateBatchByIngredientRequestValidator` (`backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchByIngredientRequestValidator.cs`) had 0% test coverage. The validator guards `DesiredIngredientAmount` bounds (`> 0`, `<= 999999.99`) and the required + max-length(50) rules on `ProductCode`/`IngredientCode` before requests reach manufacture batch planning. An uncaught regression to these rules could silently let invalid amounts (zero, negative, or unreasonably large) flow into batch calculations.

## How it was fixed / handled
Added a focused xUnit + `FluentValidation.TestHelper` test suite, `CalculateBatchByIngredientRequestValidatorTests`, mirroring the conventions of the sibling `CalculateBatchPlanRequestValidatorTests.cs` in the same module. 8 test methods cover:
- Happy path (valid request, no errors)
- `DesiredIngredientAmount` lower bound (`0`, `-1`, `-0.01` fail; small positive values pass)
- `DesiredIngredientAmount` upper bound (`999999.99` passes; `1000000`, `999999.991` fail)
- `ProductCode` / `IngredientCode` required (empty, whitespace, null all fail)
- `ProductCode` / `IngredientCode` max-length boundary (50 chars passes, 51 fails)

This is a test-only change — no production code was modified. Full new-test run: 17/17 passing. Full `Anela.Heblo.Tests` suite run for regressions: 5851 passed, 76 failed (all pre-existing Docker/Testcontainers-dependent integration tests that cannot run without a Docker daemon in this sandbox — unrelated to this change), 4 skipped.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3618/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_016EFp1jbWPvhNxwZh3ggQh8)_