### PR TITLE
#3660: Move IMarketingTransactionSource/MarketingTransaction to Application/Contracts

### DIFF
--- a/artifacts/feat-3660/arch-review.r1.md
+++ b/artifacts/feat-3660/arch-review.r1.md
@@ -1,0 +1,154 @@
+# Architecture Review: Relocate `IMarketingTransactionSource` / `MarketingTransaction` from Domain to Application/Contracts
+
+## Skip Design: true
+
+This is a pure backend namespace/project-placement refactor with no HTTP surface, MediatR contract, or UI impact. No design work applies.
+
+## Architectural Fit Assessment
+
+The finding is correct and the fix is the standard, already-precedented pattern in this codebase. `IMarketingTransactionSource` is an outbound port for external ad-platform adapters (`MetaAdsTransactionSource`, `GoogleAdsTransactionSource`), and `MarketingTransaction` is its transient DTO (carries `RawData`, raw third-party JSON — never persisted, no invariants). Both currently sit in `Anela.Heblo.Domain.Features.MarketingInvoices`, alongside the two types that *do* belong there: `ImportedMarketingTransaction` (EF entity) and `IImportedMarketingTransactionRepository` (repository contract).
+
+This is exactly the shape `docs/architecture/development_guidelines.md` calls "Contracts" and `docs/architecture/filesystem.md` places at `Application/Features/{Feature}/Contracts/`. The codebase already has a direct precedent for an outbound-port interface living there: `Anela.Heblo.Application.Features.Catalog.Contracts.ICatalogTransportSource` — "Catalog-owned read abstraction over Logistics transport-box state. Implemented by the Logistics module via an adapter." `IMarketingTransactionSource` is structurally identical: an Application-owned port implemented by adapter projects.
+
+Confirmed from source:
+- `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj` **already** carry `<ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />` and **no** reference to `Anela.Heblo.Domain`. Today they only compile because project references are transitive (Application → Domain), so the adapters can see `Anela.Heblo.Domain.Features.MarketingInvoices` through Application without declaring it directly. After the move, the adapters resolve the types directly from Application — no `.csproj` change is needed, confirming FR-4's expectation.
+- `MarketingInvoicesModule.cs` (`Application/Features/MarketingInvoices/MarketingInvoicesModule.cs`) only touches `IImportedMarketingTransactionRepository` / `IMarketingInvoiceImportService` — it does not reference `IMarketingTransactionSource` or `MarketingTransaction` and needs no change. (The two adapter DI extension methods — `MetaAdsAdapterServiceCollectionExtensions.cs`, `GoogleAdsAdapterServiceCollectionExtensions.cs` — register `IMarketingTransactionSource` themselves and are in the FR-3 file list.)
+- The `using Anela.Heblo.Domain.Features.MarketingInvoices;` in `ImportMarketingInvoicesHandler.cs`, `MarketingInvoiceImportService.cs`, and `IMarketingInvoiceImportService.cs` is used *only* for the two moved types in the first two files, and *only* for `IImportedMarketingTransactionRepository` in `MarketingInvoiceImportService.cs` (which also needs `IMarketingTransactionSource` as a method parameter type) — so that file keeps a Domain using but changes its meaning (only `IImportedMarketingTransactionRepository` remains from Domain), while gaining a new Application.Contracts using.
+
+No open design questions, no new dependencies, no data model change. This is a mechanical two-file move plus reference fix-ups.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before:
+  Anela.Heblo.Adapters.MetaAds  ──┐
+  Anela.Heblo.Adapters.GoogleAds ─┼──► Anela.Heblo.Domain.Features.MarketingInvoices
+                                  │      • IMarketingTransactionSource   (adapter port — wrong layer)
+                                  │      • MarketingTransaction          (DTO — wrong layer)
+                                  │      • ImportedMarketingTransaction  (entity — correct)
+                                  │      • IImportedMarketingTransactionRepository (correct)
+  Application (Handler, Service) ─┘
+
+After:
+  Anela.Heblo.Adapters.MetaAds  ──┐
+  Anela.Heblo.Adapters.GoogleAds ─┼──► Anela.Heblo.Application.Features.MarketingInvoices.Contracts
+                                  │      • IMarketingTransactionSource   (moved here)
+                                  │      • MarketingTransaction          (moved here)
+  Application (Handler, Service) ─┘
+                                       Anela.Heblo.Domain.Features.MarketingInvoices
+                                         • ImportedMarketingTransaction  (unchanged)
+                                         • IImportedMarketingTransactionRepository (unchanged)
+```
+
+Dependency direction after the change: `Adapters.MetaAds/GoogleAds → Application → Domain`, and separately `Application → Domain` for the entity/repository contract. Domain no longer has any awareness of ad-platform integration semantics or raw external payloads. This mirrors the `ICatalogTransportSource` precedent exactly.
+
+### Key Design Decisions
+
+#### Decision 1: Target namespace and folder for the two moved types
+
+**Options considered:**
+- (a) `Application/Features/MarketingInvoices/Contracts/` — flat contracts folder, matching `ICatalogTransportSource`'s placement in `Catalog/Contracts/`.
+- (b) `Application/Features/MarketingInvoices/Services/` alongside `IMarketingInvoiceImportService` — keeps port near its only consumer.
+- (c) A new `Adapters/Shared` project — avoids touching Application at all.
+
+**Chosen approach:** (a), exactly as the spec and issue specify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` and `.../Contracts/MarketingTransaction.cs`, namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`.
+
+**Rationale:** `Contracts/` is the documented, precedented location for "Shared DTOs across use cases" and outbound port interfaces (`filesystem.md` §Application Layer; `ICatalogTransportSource`, `IArticleKnowledgeSource`, `ICatalogPurchaseSource` all live in feature `Contracts/` folders). Option (b) would bury an adapter-facing port inside a folder documented for concrete services. Option (c) invents a new project for a problem the existing layering already solves — Domain was only ever a workaround for the adapters' visibility, and that workaround is exactly what this refactor removes.
+
+#### Decision 2: Namespace suffix — add `.Contracts` or keep `.MarketingInvoices`
+
+**Options considered:**
+- (a) `Anela.Heblo.Application.Features.MarketingInvoices.Contracts` (namespace matches folder path, C# convention in this repo).
+- (b) `Anela.Heblo.Application.Features.MarketingInvoices` (flat, matching `MarketingImportResult.cs`'s existing namespace at the feature root, avoiding one extra `using` in consumers).
+
+**Chosen approach:** (a) — matches folder-to-namespace convention used everywhere else in `Application/Features/*/Contracts/` (e.g. `Anela.Heblo.Application.Features.Catalog.Contracts`). This is also what the spec's acceptance criteria mandate verbatim.
+
+**Rationale:** Consistency with the rest of the codebase's `Contracts/` folders outweighs saving one `using` line. Every consumer file already needs a `using` edit regardless (they're currently pointed at `Domain.Features.MarketingInvoices`), so there's no marginal cost to using the fully-qualified `.Contracts` namespace.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create:
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs`
+
+Delete:
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IMarketingTransactionSource.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`
+
+Do not touch (stay in Domain, unchanged):
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs`
+
+No new `.csproj` edits are expected (verified above — both adapter projects already reference `Anela.Heblo.Application` and not `Anela.Heblo.Domain`).
+
+### Interfaces and Contracts
+
+`IMarketingTransactionSource` — member signatures unchanged, only namespace changes:
+```csharp
+namespace Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
+
+public interface IMarketingTransactionSource
+{
+    string Platform { get; }
+    Task<List<MarketingTransaction>> GetTransactionsAsync(DateTime from, DateTime to, CancellationToken ct);
+}
+```
+
+`MarketingTransaction` — all six properties unchanged, remains a plain class (not a record, per this repo's DTO convention):
+```csharp
+namespace Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
+
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+### Files requiring `using`/namespace edits (verified against current source)
+
+| File | Change |
+|---|---|
+| `Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs` | Replace `using Anela.Heblo.Domain.Features.MarketingInvoices;` → `using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;` (sole reason for the using) |
+| `Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs` | Same `using` swap. Keep `using Anela.Heblo.Domain.Features.BackgroundJobs;` (unrelated, for `IRecurringJob`) |
+| `Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs` | Same `using` swap |
+| `Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs` | Same `using` swap; keep `BackgroundJobs` using |
+| `Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs` | Replace the Domain using with the Contracts using (sole reason for the using — file only references `IMarketingTransactionSource`) |
+| `Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs` | Replace the Domain using with the Contracts using (sole reference) |
+| `Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` | **Add** `using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;` (for `IMarketingTransactionSource` parameter) while **keeping** `using Anela.Heblo.Domain.Features.MarketingInvoices;` (still needed for `IImportedMarketingTransactionRepository` and `ImportedMarketingTransaction`) |
+| `test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` | Add the Contracts using; the existing `using Anela.Heblo.Domain.Features.MarketingInvoices;` becomes dead (file only uses `IMarketingTransactionSource` from that namespace) and should be removed |
+| `test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | **Add** the Contracts using (for `IMarketingTransactionSource`); **keep** the Domain using (still needed for `IImportedMarketingTransactionRepository`) |
+
+`MarketingInvoicesModule.cs` requires **no change** — verified it only references `IImportedMarketingTransactionRepository` / `IMarketingInvoiceImportService`, neither of which moves.
+
+A repo-wide `git grep` for `IMarketingTransactionSource` and `MarketingTransaction\b` (excluding `ImportedMarketingTransaction`) should be re-run at implementation time to catch anything missed — the search performed for this review found exactly the file set enumerated in the spec plus `MarketingInvoicesModule.cs` (which needs no edit) and the EF migration snapshot/designer files (which reference `ImportedMarketingTransaction` only, out of scope).
+
+### Data Flow
+
+Unchanged. `ImportMarketingInvoicesHandler` selects the matching `IMarketingTransactionSource` by `Platform`, delegates to `MarketingInvoiceImportService.ImportAsync`, which calls `source.GetTransactionsAsync(...)`, maps each `MarketingTransaction` to an `ImportedMarketingTransaction` entity, and persists via `IImportedMarketingTransactionRepository`. Only the compile-time namespace of two types in that flow changes; no method signature, call order, or runtime behavior changes.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missing a reference not enumerated in the spec's file list, causing a build break | Low | Re-run `git grep -n "IMarketingTransactionSource\|MarketingTransaction\b"` (excluding `ImportedMarketingTransaction`) after the move, before considering the task done; `dotnet build` will also surface any miss immediately |
+| Accidentally removing the `Anela.Heblo.Domain.Features.MarketingInvoices` using from a file where it's still needed (e.g. `MarketingInvoiceImportService.cs`, `MarketingInvoiceImportServiceTests.cs` still need `IImportedMarketingTransactionRepository`) | Low | Per-file check noted in the table above; `dotnet build` fails loudly (CS0246) if a using is wrongly dropped |
+| Test project or adapter `.csproj` turns out to need a reference change after all (contradicting FR-4's expectation) | Very low | Verified in this review: both adapter `.csproj` files already reference only `Anela.Heblo.Application`, not `Anela.Heblo.Domain`; no change expected. Confirm with `dotnet build` regardless |
+
+No risk warrants a mitigation beyond "build and run the existing test suite" — this is as low-risk as a C# refactor gets.
+
+## Specification Amendments
+
+None required. The spec (`spec.r1.md`) is accurate and complete against the actual source: FR-1 through FR-5's acceptance criteria match what was found in the code. One clarification worth calling out for the implementer (not a spec change, just explicit confirmation): `MarketingInvoiceImportService.cs` and its test `MarketingInvoiceImportServiceTests.cs` must **retain** their `using Anela.Heblo.Domain.Features.MarketingInvoices;` (for `IImportedMarketingTransactionRepository`/`ImportedMarketingTransaction`) while **adding** the new Contracts using — these are the two files in the touched set that end up with *both* usings, not a simple swap. `MarketingInvoicesModule.cs` was checked and requires no change at all (not in the spec's list, and this review confirms that's correct — it doesn't reference either moved type).
+
+## Prerequisites
+
+None. No migrations, no config, no infrastructure changes — this is a self-contained code move gated only on `dotnet build` and the existing unit test suite (`ImportMarketingInvoicesHandlerTests`, `MarketingInvoiceImportServiceTests`) passing unmodified in behavior.

--- a/artifacts/feat-3660/brief.md
+++ b/artifacts/feat-3660/brief.md
@@ -1,0 +1,32 @@
+# Issue #3660: [arch-review] MarketingInvoices: IMarketingTransactionSource and MarketingTransaction belong in Application/Contracts, not Domain
+
+## Module
+MarketingInvoices
+
+## Finding
+`IMarketingTransactionSource` (`backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IMarketingTransactionSource.cs`) and `MarketingTransaction` (`backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`) live in the Domain layer, but neither is a domain concept:
+
+- **`IMarketingTransactionSource`** is an outbound port for external ad-platform adapters (Meta, Google). It abstracts HTTP/SDK calls to third-party APIs. Domain interfaces should represent repository contracts or domain services — not adapter ports for external integrations.
+- **`MarketingTransaction`** is a data carrier returned by that interface. It contains `RawData` (raw JSON from an external API), has no invariants, no validation, and no behavior. It is a DTO, not a domain type.
+
+The Domain layer currently contains four things: `ImportedMarketingTransaction` (the persisted entity — correct), `IImportedMarketingTransactionRepository` (repository interface — correct), and the two items above which don't belong there.
+
+The only reason they appear to be in Domain is that `MarketingTransaction` needs a location that both the adapter projects and the Application layer can see without a circular reference. Domain is the lowest-common denominator. That constraint disappears if both types are moved together to Application.
+
+## Why it matters
+Per `docs/architecture/development_guidelines.md`, Domain should contain only entities, value objects, domain service interfaces, and repository contracts. Per `docs/architecture/filesystem.md`, the canonical home for feature-level contracts consumed by Application services is `Application/Features/{Feature}/Contracts/`.
+
+Placing an adapter port in Domain means the project's cleanest, most stable layer now knows about "ad-platform source" semantics and raw API payloads. Domain is supposed to be the innermost ring; it should have zero knowledge of external integrations.
+
+The adapters (Meta, Google) currently depend on Domain for `IMarketingTransactionSource`. After the move the dependency direction becomes `Adapters → Application → Domain`, which is still correct Clean Architecture and more accurately reflects that this is an application-level integration concern.
+
+## Suggested fix
+1. Move `IMarketingTransactionSource` → `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs`
+2. Move `MarketingTransaction` → `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs`
+3. Update adapter `.csproj` files (`Anela.Heblo.Adapters.MetaAds`, `Anela.Heblo.Adapters.GoogleAds`) to reference `Anela.Heblo.Application` for these two types (they may already reference it for `ImportMarketingInvoicesRequest`/`ImportMarketingInvoicesResponse` — check first)
+4. Fix `namespace` declarations and `using` directives in all affected files (adapters, `ImportMarketingInvoicesHandler.cs`, `MarketingInvoiceImportService.cs`, `IMarketingInvoiceImportService.cs`)
+
+No behavioral change — this is a namespace/project placement correction only.
+
+---
+_Filed by daily arch-review routine on 2026-07-15._

--- a/artifacts/feat-3660/code-review.r1.md
+++ b/artifacts/feat-3660/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3660/design.r1.md
+++ b/artifacts/feat-3660/design.r1.md
@@ -1,0 +1,77 @@
+# Design: Move `IMarketingTransactionSource` and `MarketingTransaction` from Domain to Application/Contracts
+
+## Component Design
+
+This is a pure code-relocation refactor. No new components, no behavioral change — two existing types move to a new namespace/folder, and their consumers update `using` statements accordingly.
+
+### `IMarketingTransactionSource` (moved)
+- **New location:** `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs`
+- **New namespace:** `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`
+- **Responsibility:** unchanged — outbound port abstracting a single ad platform's transaction feed (Meta, Google). Selected by `Platform` and invoked via `GetTransactionsAsync(DateTime from, DateTime to, CancellationToken ct)`.
+- **Implementors** (unchanged, only their `using` changes): `MetaAdsTransactionSource`, `GoogleAdsTransactionSource`.
+- **Consumers** (unchanged, only their `using` changes): `ImportMarketingInvoicesHandler`, `MarketingInvoiceImportService`.
+- Precedent: structurally identical to `Anela.Heblo.Application.Features.Catalog.Contracts.ICatalogTransportSource` (Application-owned port, adapter-implemented).
+
+### `MarketingTransaction` (moved)
+- **New location:** `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs`
+- **New namespace:** `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`
+- **Responsibility:** unchanged — transient, non-persisted DTO carrying one raw transaction from an ad platform, including its raw JSON payload. Never mapped by EF; never exposed via HTTP/MediatR.
+- Remains a plain class (not a record), per this repo's DTO convention.
+
+### Unaffected components (explicitly out of scope, listed to make the boundary clear)
+- `ImportedMarketingTransaction` (EF entity) — stays in `Anela.Heblo.Domain.Features.MarketingInvoices`.
+- `IImportedMarketingTransactionRepository` — stays in `Anela.Heblo.Domain.Features.MarketingInvoices`.
+- `MarketingInvoicesModule.cs` — no change; it never referenced either moved type.
+- `ImportMarketingInvoicesRequest` / `ImportMarketingInvoicesResponse` (MediatR contracts) — no change.
+
+### Reference/using updates required (mechanical, no logic change)
+Files that need only a `using` swap (Domain → Application.Contracts):
+- `Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs`
+- `Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs` (keep unrelated `BackgroundJobs` using)
+- `Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs`
+- `Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs` (keep unrelated `BackgroundJobs` using)
+- `Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs`
+- `Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs`
+- `test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` (drop the now-dead Domain using)
+
+Files that need **both** usings (Domain using retained for `IImportedMarketingTransactionRepository`/`ImportedMarketingTransaction`, Contracts using added for `IMarketingTransactionSource`/`MarketingTransaction`):
+- `Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+- `test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+No `.csproj` changes expected: both `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj` already reference `Anela.Heblo.Application` (not `Anela.Heblo.Domain`) — verify, don't assume, during implementation.
+
+A repo-wide `git grep` for `IMarketingTransactionSource` and `MarketingTransaction\b` (excluding `ImportedMarketingTransaction`) must be re-run at implementation time to catch any reference not listed above.
+
+## Data Schemas
+
+No persisted schema changes. No API/MediatR/HTTP shape changes.
+
+`MarketingTransaction` shape (unchanged, only namespace moves):
+
+```csharp
+namespace Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
+
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+`IMarketingTransactionSource` shape (unchanged, only namespace moves):
+
+```csharp
+namespace Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
+
+public interface IMarketingTransactionSource
+{
+    string Platform { get; }
+    Task<List<MarketingTransaction>> GetTransactionsAsync(DateTime from, DateTime to, CancellationToken ct);
+}
+```
+
+`ImportedMarketingTransaction` (EF entity) and `IImportedMarketingTransactionRepository` are unchanged and remain in `Anela.Heblo.Domain.Features.MarketingInvoices` — not part of this move.

--- a/artifacts/feat-3660/impl/move-marketing-transaction-source-to-application-contracts.r1.md
+++ b/artifacts/feat-3660/impl/move-marketing-transaction-source-to-application-contracts.r1.md
@@ -1,0 +1,57 @@
+# Implementation: move-marketing-transaction-source-to-application-contracts
+
+## What was implemented
+Moved `IMarketingTransactionSource` and `MarketingTransaction` from the Domain
+layer (`Anela.Heblo.Domain.Features.MarketingInvoices`) to the Application
+layer (`Anela.Heblo.Application.Features.MarketingInvoices.Contracts`), and
+updated every consumer's `using` statements accordingly. No `.csproj` changes
+were needed — both adapter projects already referenced
+`Anela.Heblo.Application`. `ImportedMarketingTransaction` and
+`IImportedMarketingTransactionRepository` were left untouched in Domain.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` — moved from Domain (git rename), namespace updated
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs` — moved from Domain (git rename), namespace updated
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs` — using updated
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs` — using updated
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs` — using updated
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs` — using updated
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs` — using updated
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — using updated (kept Domain using for `ImportedMarketingTransaction`/repository)
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs` — using updated
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` — using updated
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — using updated (kept Domain using for entity/repository types)
+
+`MarketingInvoicesModule.cs` and `ApplicationDbContext.cs` needed no change —
+their `Anela.Heblo.Domain.Features.MarketingInvoices` using statements are for
+`ImportedMarketingTransaction`, which correctly stays in Domain.
+
+## Tests
+Ran `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingInvoices"`: **14/14 passed**.
+
+## How to verify
+1. `dotnet build Anela.Heblo.sln` from the repo root — builds clean (0 errors).
+2. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingInvoices"` — all pass.
+3. `grep -rn "Anela.Heblo.Domain.Features.MarketingInvoices" backend/ --include="*.cs"` — every remaining hit references `ImportedMarketingTransaction` or `IImportedMarketingTransactionRepository` (the entity/repository that correctly stays in Domain); no stray references to the moved types remain.
+
+## Notes
+No deviations from the plan. No csproj edits were required, as anticipated by
+the architecture review.
+
+## PR Summary
+Moved `IMarketingTransactionSource` (an outbound port for external ad-platform
+adapters) and its `MarketingTransaction` DTO out of the Domain layer into
+`Application/Features/MarketingInvoices/Contracts`, since neither is a domain
+concept — the interface is an adapter port and the DTO is a raw external-API
+data carrier with no domain behavior. This restores Domain as the innermost,
+integration-agnostic layer while keeping the dependency direction correct
+(`Adapters → Application → Domain`). Purely a namespace/project placement
+change — no behavior was altered.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` (new location)
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs` (new location)
+- Updated `using` statements in the Meta/Google Ads adapters, the marketing invoice import service/handler, and their unit tests
+
+## Status
+DONE

--- a/artifacts/feat-3660/review/move-marketing-transaction-source-to-application-contracts.r1.md
+++ b/artifacts/feat-3660/review/move-marketing-transaction-source-to-application-contracts.r1.md
@@ -1,0 +1,26 @@
+# Code Review: Move IMarketingTransactionSource/MarketingTransaction to Application/Contracts
+
+## Summary
+The implementation is a clean, mechanical namespace relocation that matches the spec and arch-review exactly. Verified directly against the actual diff (commit `4afdc73`): both types moved byte-for-byte (aside from namespace) into `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, every consumer's `using` was updated per the file list, `ImportedMarketingTransaction`/`IImportedMarketingTransactionRepository` are untouched, and no `.csproj` changes were needed (confirmed correct).
+
+## Review Result: PASS
+
+### task: move-marketing-transaction-source-to-application-contracts
+**Status:** PASS
+
+Verification performed independently of the impl summary:
+- `git show 4afdc73` confirms `IMarketingTransactionSource.cs` and `MarketingTransaction.cs` were created at the new path with the exact namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, interface members and all six `MarketingTransaction` properties unchanged, and `MarketingTransaction` remains a plain class (not a record).
+- The two old files no longer exist under `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/`; only `ImportedMarketingTransaction.cs` and `IImportedMarketingTransactionRepository.cs` remain there, unmodified.
+- Diffed all nine "swap"/"add using" files individually — each matches the spec's prescribed edit exactly: pure `using` swaps in the adapters, handler, and `IMarketingInvoiceImportService.cs`; additive Contracts `using` (Domain using retained) in `MarketingInvoiceImportService.cs` and `MarketingInvoiceImportServiceTests.cs`; unrelated `BackgroundJobs` using preserved in both adapter DI extension files.
+- Repo-wide `grep -rn "Anela.Heblo.Domain.Features.MarketingInvoices"` shows all remaining hits are for `ImportedMarketingTransaction`/`IImportedMarketingTransactionRepository` (in Domain itself, Persistence, and EF migrations) — no stray references to the moved types anywhere.
+- `grep` for `IMarketingTransactionSource`/`MarketingTransaction` under `Anela.Heblo.Domain` returns nothing — confirms clean removal.
+- `dotnet build Anela.Heblo.sln` succeeds with 0 errors (249 pre-existing nullable warnings unrelated to this change, present across many files not touched here).
+- `dotnet test ... --filter "FullyQualifiedName~MarketingInvoices"` — 14/14 pass.
+- `dotnet format Anela.Heblo.sln --verify-no-changes --include <all changed files>` — no formatting issues reported.
+- `MarketingInvoicesModule.cs` and `ApplicationDbContext.cs` are unchanged, correctly retaining their Domain using for `ImportedMarketingTransaction`, as required by the acceptance criteria.
+- No controller, MediatR request/response, or HTTP-exposed DTO was touched.
+
+All functional requirements (FR-1 through FR-5) and acceptance criteria from `spec.r1.md` are satisfied. The implementation follows the arch-review's guidance precisely (target namespace/folder, Contracts convention, no `.csproj` edits needed).
+
+## Overall Notes
+No cross-cutting concerns. This is as clean an execution of a scoped refactor as the arch-review anticipated — every file diff matches the plan with no scope creep, no behavioral changes, and no missed references.

--- a/artifacts/feat-3660/spec.r1.md
+++ b/artifacts/feat-3660/spec.r1.md
@@ -1,0 +1,97 @@
+# Specification: Move `IMarketingTransactionSource` and `MarketingTransaction` from Domain to Application/Contracts
+
+## Summary
+`IMarketingTransactionSource` and `MarketingTransaction` currently live in the Domain layer (`Anela.Heblo.Domain.Features.MarketingInvoices`) even though they are an adapter port and its DTO, not domain concepts. This change relocates both types to `Anela.Heblo.Application/Features/MarketingInvoices/Contracts/`, updates all namespace/using references across the adapters, Application services, and tests, and removes the now-unnecessary Domain dependency for these two types. This is a pure structural/namespace refactor with no behavioral change.
+
+## Background
+Per `docs/architecture/development_guidelines.md`, the Domain layer should contain only entities, value objects, domain service interfaces, and repository contracts. Per `docs/architecture/filesystem.md`, feature-level contracts consumed by Application services belong in `Application/Features/{Feature}/Contracts/`.
+
+`IMarketingTransactionSource` is an outbound port abstracting HTTP/SDK calls to third-party ad platforms (Meta, Google), and `MarketingTransaction` is the raw-payload-carrying DTO it returns. Neither has domain invariants or behavior. They were placed in Domain only as a lowest-common-denominator location visible to both the adapter projects and the Application layer, avoiding a circular reference. Moving both types together to Application removes that constraint, since the adapter projects (`Anela.Heblo.Adapters.MetaAds`, `Anela.Heblo.Adapters.GoogleAds`) already reference `Anela.Heblo.Application`.
+
+This was identified by the daily arch-review routine (issue #3660) as a Clean Architecture layering violation in the MarketingInvoices module.
+
+## Functional Requirements
+
+### FR-1: Relocate `IMarketingTransactionSource`
+Move the interface from `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IMarketingTransactionSource.cs` to `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs`, changing its namespace from `Anela.Heblo.Domain.Features.MarketingInvoices` to `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`. The interface body (members, signatures, XML docs if any) is otherwise unchanged.
+
+**Acceptance criteria:**
+- The file no longer exists under `Anela.Heblo.Domain`.
+- The file exists at `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`.
+- The interface's member signatures (`Platform`, `GetTransactionsAsync(DateTime from, DateTime to, CancellationToken ct)`) are byte-for-byte identical to before, aside from the namespace line.
+
+### FR-2: Relocate `MarketingTransaction`
+Move the class from `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs` to `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs`, changing its namespace from `Anela.Heblo.Domain.Features.MarketingInvoices` to `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`. All properties (`TransactionId`, `Amount`, `TransactionDate`, `Description`, `Currency`, `RawData`) remain unchanged.
+
+**Acceptance criteria:**
+- The file no longer exists under `Anela.Heblo.Domain`.
+- The file exists at `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs` with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`.
+- `MarketingTransaction` remains a plain C# class (not a record), consistent with the project's DTO convention.
+
+### FR-3: Update all references to the moved types
+Update `namespace`/`using` declarations in every file that references either type so the solution builds cleanly with the new locations. Based on the current codebase, the following files reference these types and must be updated:
+
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+A repo-wide search for `IMarketingTransactionSource` and `MarketingTransaction` (excluding `ImportedMarketingTransaction`, which is a distinct, correctly-placed Domain entity and must not be touched) must be performed as part of implementation to catch any reference not enumerated above.
+
+**Acceptance criteria:**
+- No file outside `Anela.Heblo.Application` contains a `using Anela.Heblo.Domain.Features.MarketingInvoices;` that was only needed for these two types (remove the using if it becomes unused; keep it if `ImportedMarketingTransaction`/`IImportedMarketingTransactionRepository` from the same namespace are still used in that file).
+- All files listed above compile against the new `Anela.Heblo.Application.Features.MarketingInvoices.Contracts` namespace.
+- `git grep -n "Domain.Features.MarketingInvoices.*MarketingTransaction\b"` (or equivalent) returns no hits referencing the moved types.
+
+### FR-4: Verify and, if needed, update project references
+Confirm whether `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj` need any changes. As of this spec, both already carry a `<ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />` (added previously for `ImportMarketingInvoicesRequest`/`ImportMarketingInvoicesResponse`), so no `.csproj` edits are expected to be necessary for this move. Confirm during implementation that no adapter project still requires a reference to `Anela.Heblo.Domain` solely for these two types, and remove such a reference only if it is otherwise unused by that project.
+
+**Acceptance criteria:**
+- `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj` reference `Anela.Heblo.Application` (already true; verify, don't assume).
+- Neither adapter project's compile step depends on a `Anela.Heblo.Domain` reference for `IMarketingTransactionSource`/`MarketingTransaction` (either that reference is removed if now dead, or it is retained because still needed for something else — implementer confirms which, and does not remove a still-needed reference).
+
+### FR-5: No behavioral change
+This is strictly a code-organization refactor. No public API contracts, MediatR request/response shapes, HTTP endpoints, database schema, or runtime behavior may change.
+
+**Acceptance criteria:**
+- No changes to any controller, MediatR request/response class, or DTO exposed to the frontend.
+- No changes to `ImportedMarketingTransaction` or `IImportedMarketingTransactionRepository` (these remain correctly in Domain and are out of scope).
+- Existing unit tests in `ImportMarketingInvoicesHandlerTests.cs` and `MarketingInvoiceImportServiceTests.cs` pass unmodified in behavior (only namespace/using updates permitted).
+- The generated OpenAPI/TypeScript client is unaffected (these types are not exposed through the API surface).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+N/A — no runtime code paths change; this is a compile-time namespace relocation.
+
+### NFR-2: Security
+N/A — no change to authentication, authorization, secrets handling, or data exposure. `RawData` (raw third-party JSON) continues to flow through the same code paths as before.
+
+## Data Model
+No persisted data model changes. `ImportedMarketingTransaction` (the EF-mapped entity) and its repository interface are untouched and remain in `Anela.Heblo.Domain.Features.MarketingInvoices`. `MarketingTransaction` is an in-memory transient DTO (never persisted) whose shape is unchanged — only its namespace/assembly location moves.
+
+## API / Interface Design
+No public HTTP API, MediatR contract, or frontend-facing interface changes. The only "interface" affected is the internal C# port `IMarketingTransactionSource`, whose member signatures are preserved exactly; only its namespace and assembly (Domain → Application) change.
+
+## Dependencies
+- `Anela.Heblo.Adapters.MetaAds` and `Anela.Heblo.Adapters.GoogleAds` projects (implement `IMarketingTransactionSource`).
+- `Anela.Heblo.Application` project (new home for both types; must build with the new files added under `Features/MarketingInvoices/Contracts/`).
+- `Anela.Heblo.Tests` project (unit tests referencing these types).
+- Depends on the existing `ProjectReference` from both adapter `.csproj` files to `Anela.Heblo.Application` (already present, per FR-4).
+
+## Out of Scope
+- Any change to `ImportedMarketingTransaction` (entity) or `IImportedMarketingTransactionRepository` (repository interface) — these correctly remain in Domain.
+- Any change to the shape, semantics, or validation of `MarketingTransaction`'s properties.
+- Any change to MediatR requests/responses (`ImportMarketingInvoicesRequest`/`ImportMarketingInvoicesResponse`) beyond incidental `using` updates if they happen to reference the moved types indirectly.
+- Any broader architectural cleanup of the MarketingInvoices module beyond this specific relocation.
+- Adding new tests; existing test coverage is preserved as-is (moved/updated only for compilation, not expanded).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-16T05:19:21.706002Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T05:20:37.587270Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T05:14:47.735044Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T05:16:25.778585Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-16T05:20:37.587270Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-16T05:20:49.082064Z"
+      "status": "completed",
+      "updated_at": "2026-07-16T05:59:48.959529Z"
     }
   },
   "tasks": [
     {
       "name": "move-marketing-transaction-source-to-application-contracts",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-16T05:20:49.292362Z"
+      "updated_at": "2026-07-16T05:59:43.827319Z"
     }
   ]
 }

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-16T05:20:37.587270Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-16T05:20:49.082064Z"
     }
   },
   "tasks": [
     {
       "name": "move-marketing-transaction-source-to-application-contracts",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-16T05:20:49.292362Z"
     }
   ]
 }

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-16T05:18:32.309020Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T05:19:21.706002Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "move-marketing-transaction-source-to-application-contracts",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3660",
+  "issue_number": 3660,
+  "created_at": "2026-07-16T05:14:43.660352Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "in_progress",
+      "updated_at": "2026-07-16T05:14:47.735044Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-16T05:16:25.778585Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-16T05:18:32.309020Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3660/state.json
+++ b/artifacts/feat-3660/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-16T05:59:48.959529Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-16T05:59:54.567721Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3660/task-context/move-marketing-transaction-source-to-application-contracts.md
+++ b/artifacts/feat-3660/task-context/move-marketing-transaction-source-to-application-contracts.md
@@ -1,0 +1,62 @@
+### task: move-marketing-transaction-source-to-application-contracts
+## Goal
+Move `IMarketingTransactionSource` and `MarketingTransaction` from `Anela.Heblo.Domain.Features.MarketingInvoices` to `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, and fix every consumer's namespace/using so the solution builds cleanly with no behavioral change. `ImportedMarketingTransaction` and `IImportedMarketingTransactionRepository` must remain untouched in Domain.
+
+## Files to change
+
+**Create (new location, namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`):**
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs`
+
+**Delete (old location):**
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IMarketingTransactionSource.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`
+
+**Do not touch (stay in Domain, unchanged):**
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs`
+
+**Edit — swap Domain using for Contracts using (sole reason for the using in these files):**
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs` (keep unrelated `using Anela.Heblo.Domain.Features.BackgroundJobs;`)
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs` (keep unrelated `using Anela.Heblo.Domain.Features.BackgroundJobs;`)
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs`
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` (drop the now-dead Domain using)
+
+**Edit — add Contracts using while keeping Domain using (still needed for `IImportedMarketingTransactionRepository`/`ImportedMarketingTransaction`):**
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+**Verify only, no change expected:**
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj` — confirm it references `Anela.Heblo.Application` and not `Anela.Heblo.Domain`
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj` — same check
+- `Application/Features/MarketingInvoices/MarketingInvoicesModule.cs` — confirmed by arch review to reference neither moved type; leave as-is
+
+## Steps
+1. Run a repo-wide `git grep -n "IMarketingTransactionSource"` and `git grep -n "MarketingTransaction\b"` (excluding `ImportedMarketingTransaction`) to confirm the file list above is complete before making changes; add any additional hits to scope.
+2. Create `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts` and the interface body unchanged (`Platform` property, `GetTransactionsAsync(DateTime from, DateTime to, CancellationToken ct)`).
+3. Create `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs` with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, as a plain class (not a record) with all six properties unchanged (`TransactionId`, `Amount`, `TransactionDate`, `Description`, `Currency`, `RawData`).
+4. Delete the two old files from `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/`: `IMarketingTransactionSource.cs` and `MarketingTransaction.cs`.
+5. Update each of the "swap" files (adapters' `*TransactionSource.cs`, adapters' `*AdapterServiceCollectionExtensions.cs`, `ImportMarketingInvoicesHandler.cs`, `IMarketingInvoiceImportService.cs`, `ImportMarketingInvoicesHandlerTests.cs`): replace `using Anela.Heblo.Domain.Features.MarketingInvoices;` with `using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;`, preserving any other unrelated usings already present (e.g. `BackgroundJobs`).
+6. Update `MarketingInvoiceImportService.cs` and `MarketingInvoiceImportServiceTests.cs`: add `using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;` while keeping the existing `using Anela.Heblo.Domain.Features.MarketingInvoices;` (still required for `IImportedMarketingTransactionRepository`/`ImportedMarketingTransaction`).
+7. Check `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj`: confirm each already has `<ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />` and no direct `Anela.Heblo.Domain` reference. No edit expected; only change if build reveals otherwise.
+8. Run `dotnet build` on the solution; fix any remaining CS0246/using errors surfaced by files not in the enumerated list.
+9. Run the full backend test suite, focusing on `ImportMarketingInvoicesHandlerTests` and `MarketingInvoiceImportServiceTests`, and confirm they pass unmodified in behavior (only using/namespace edits permitted in test files).
+10. Run `dotnet format` to ensure formatting compliance.
+11. Re-run `git grep -n "Domain.Features.MarketingInvoices"` repo-wide to confirm the only remaining hits are for `ImportedMarketingTransaction` / `IImportedMarketingTransactionRepository`, and `git grep -n "IMarketingTransactionSource\|MarketingTransaction\b"` to confirm no stray references to the old namespace remain.
+
+## Acceptance criteria
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IMarketingTransactionSource.cs` and `MarketingTransaction.cs` no longer exist.
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` and `MarketingTransaction.cs` exist with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, member signatures/properties byte-for-byte unchanged aside from namespace.
+- `MarketingTransaction` remains a plain class, not a record.
+- `dotnet build` succeeds for the whole solution with no errors.
+- `dotnet format` reports no changes needed (or has been applied).
+- All existing tests pass, including `ImportMarketingInvoicesHandlerTests` and `MarketingInvoiceImportServiceTests`, with no behavioral changes (diffs limited to using/namespace lines).
+- `ImportedMarketingTransaction` and `IImportedMarketingTransactionRepository` are unchanged and remain in `Anela.Heblo.Domain.Features.MarketingInvoices`.
+- No file outside `Anela.Heblo.Application` retains a `using Anela.Heblo.Domain.Features.MarketingInvoices;` unless it still needs `ImportedMarketingTransaction`/`IImportedMarketingTransactionRepository` from that namespace.
+- `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj` reference `Anela.Heblo.Application`; no unnecessary `Anela.Heblo.Domain` reference added or left dangling for these types.
+- `MarketingInvoicesModule.cs` is unchanged.
+- No changes to any controller, MediatR request/response class, HTTP-exposed DTO, or the generated OpenAPI/TypeScript client.
+- A repo-wide search confirms no remaining reference to `IMarketingTransactionSource` or `MarketingTransaction` under the old `Anela.Heblo.Domain.Features.MarketingInvoices` namespace.

--- a/artifacts/feat-3660/task-plan.r1.md
+++ b/artifacts/feat-3660/task-plan.r1.md
@@ -1,0 +1,67 @@
+# Task Plan: Move `IMarketingTransactionSource` and `MarketingTransaction` from Domain to Application/Contracts
+
+## Overview
+Relocate two Domain types (`IMarketingTransactionSource`, `MarketingTransaction`) that are actually an adapter port and its DTO into `Anela.Heblo.Application/Features/MarketingInvoices/Contracts/`, updating namespace/using declarations across all adapter, Application, and test consumers. Pure structural refactor, no behavior change, no `.csproj` edits expected.
+
+### task: move-marketing-transaction-source-to-application-contracts
+## Goal
+Move `IMarketingTransactionSource` and `MarketingTransaction` from `Anela.Heblo.Domain.Features.MarketingInvoices` to `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, and fix every consumer's namespace/using so the solution builds cleanly with no behavioral change. `ImportedMarketingTransaction` and `IImportedMarketingTransactionRepository` must remain untouched in Domain.
+
+## Files to change
+
+**Create (new location, namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`):**
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs`
+
+**Delete (old location):**
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IMarketingTransactionSource.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`
+
+**Do not touch (stay in Domain, unchanged):**
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs`
+
+**Edit — swap Domain using for Contracts using (sole reason for the using in these files):**
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs` (keep unrelated `using Anela.Heblo.Domain.Features.BackgroundJobs;`)
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs` (keep unrelated `using Anela.Heblo.Domain.Features.BackgroundJobs;`)
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs`
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` (drop the now-dead Domain using)
+
+**Edit — add Contracts using while keeping Domain using (still needed for `IImportedMarketingTransactionRepository`/`ImportedMarketingTransaction`):**
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+**Verify only, no change expected:**
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj` — confirm it references `Anela.Heblo.Application` and not `Anela.Heblo.Domain`
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj` — same check
+- `Application/Features/MarketingInvoices/MarketingInvoicesModule.cs` — confirmed by arch review to reference neither moved type; leave as-is
+
+## Steps
+1. Run a repo-wide `git grep -n "IMarketingTransactionSource"` and `git grep -n "MarketingTransaction\b"` (excluding `ImportedMarketingTransaction`) to confirm the file list above is complete before making changes; add any additional hits to scope.
+2. Create `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts` and the interface body unchanged (`Platform` property, `GetTransactionsAsync(DateTime from, DateTime to, CancellationToken ct)`).
+3. Create `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs` with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, as a plain class (not a record) with all six properties unchanged (`TransactionId`, `Amount`, `TransactionDate`, `Description`, `Currency`, `RawData`).
+4. Delete the two old files from `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/`: `IMarketingTransactionSource.cs` and `MarketingTransaction.cs`.
+5. Update each of the "swap" files (adapters' `*TransactionSource.cs`, adapters' `*AdapterServiceCollectionExtensions.cs`, `ImportMarketingInvoicesHandler.cs`, `IMarketingInvoiceImportService.cs`, `ImportMarketingInvoicesHandlerTests.cs`): replace `using Anela.Heblo.Domain.Features.MarketingInvoices;` with `using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;`, preserving any other unrelated usings already present (e.g. `BackgroundJobs`).
+6. Update `MarketingInvoiceImportService.cs` and `MarketingInvoiceImportServiceTests.cs`: add `using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;` while keeping the existing `using Anela.Heblo.Domain.Features.MarketingInvoices;` (still required for `IImportedMarketingTransactionRepository`/`ImportedMarketingTransaction`).
+7. Check `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj`: confirm each already has `<ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />` and no direct `Anela.Heblo.Domain` reference. No edit expected; only change if build reveals otherwise.
+8. Run `dotnet build` on the solution; fix any remaining CS0246/using errors surfaced by files not in the enumerated list.
+9. Run the full backend test suite, focusing on `ImportMarketingInvoicesHandlerTests` and `MarketingInvoiceImportServiceTests`, and confirm they pass unmodified in behavior (only using/namespace edits permitted in test files).
+10. Run `dotnet format` to ensure formatting compliance.
+11. Re-run `git grep -n "Domain.Features.MarketingInvoices"` repo-wide to confirm the only remaining hits are for `ImportedMarketingTransaction` / `IImportedMarketingTransactionRepository`, and `git grep -n "IMarketingTransactionSource\|MarketingTransaction\b"` to confirm no stray references to the old namespace remain.
+
+## Acceptance criteria
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IMarketingTransactionSource.cs` and `MarketingTransaction.cs` no longer exist.
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs` and `MarketingTransaction.cs` exist with namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`, member signatures/properties byte-for-byte unchanged aside from namespace.
+- `MarketingTransaction` remains a plain class, not a record.
+- `dotnet build` succeeds for the whole solution with no errors.
+- `dotnet format` reports no changes needed (or has been applied).
+- All existing tests pass, including `ImportMarketingInvoicesHandlerTests` and `MarketingInvoiceImportServiceTests`, with no behavioral changes (diffs limited to using/namespace lines).
+- `ImportedMarketingTransaction` and `IImportedMarketingTransactionRepository` are unchanged and remain in `Anela.Heblo.Domain.Features.MarketingInvoices`.
+- No file outside `Anela.Heblo.Application` retains a `using Anela.Heblo.Domain.Features.MarketingInvoices;` unless it still needs `ImportedMarketingTransaction`/`IImportedMarketingTransactionRepository` from that namespace.
+- `Anela.Heblo.Adapters.MetaAds.csproj` and `Anela.Heblo.Adapters.GoogleAds.csproj` reference `Anela.Heblo.Application`; no unnecessary `Anela.Heblo.Domain` reference added or left dangling for these types.
+- `MarketingInvoicesModule.cs` is unchanged.
+- No changes to any controller, MediatR request/response class, HTTP-exposed DTO, or the generated OpenAPI/TypeScript client.
+- A repo-wide search confirms no remaining reference to `IMarketingTransactionSource` or `MarketingTransaction` under the old `Anela.Heblo.Domain.Features.MarketingInvoices` namespace.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Adapters.GoogleAds;

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/IMarketingTransactionSource.cs
@@ -1,4 +1,4 @@
-namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+namespace Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 
 public interface IMarketingTransactionSource
 {

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/MarketingTransaction.cs
@@ -1,4 +1,4 @@
-namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+namespace Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 
 public class MarketingTransaction
 {

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/IMarketingInvoiceImportService.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 
 namespace Anela.Heblo.Application.Features.MarketingInvoices.Services;
 

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Microsoft.Extensions.Logging;
 

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/UseCases/ImportMarketingInvoices/ImportMarketingInvoicesHandler.cs
@@ -1,5 +1,5 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Anela.Heblo.Application.Features.MarketingInvoices.Services;
-using Anela.Heblo.Domain.Features.MarketingInvoices;
 using MediatR;
 using Microsoft.Extensions.Logging;
 

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Application.Features.MarketingInvoices;
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Anela.Heblo.Application.Features.MarketingInvoices.Services;
 using Anela.Heblo.Application.Features.MarketingInvoices.UseCases.ImportMarketingInvoices;
-using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Contracts;
 using Anela.Heblo.Application.Features.MarketingInvoices.Services;
 using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
Closes #3660

## What the issue was
`IMarketingTransactionSource` (an outbound port for external ad-platform adapters — Meta, Google) and its `MarketingTransaction` DTO (a raw-data carrier with no domain behavior) lived in the Domain layer, even though neither is a domain concept. Per `docs/architecture/development_guidelines.md` and `docs/architecture/filesystem.md`, Domain should contain only entities, value objects, domain service interfaces, and repository contracts — adapter ports and their DTOs belong in `Application/Features/{Feature}/Contracts/`.

## How it was fixed / handled
Moved both types to `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Contracts/` (namespace `Anela.Heblo.Application.Features.MarketingInvoices.Contracts`), and updated `using` statements in every consumer: the Meta Ads and Google Ads adapters, `MarketingInvoiceImportService`/`IMarketingInvoiceImportService`, `ImportMarketingInvoicesHandler`, and their unit tests. `ImportedMarketingTransaction` (the persisted entity) and `IImportedMarketingTransactionRepository` remain untouched in Domain, since those are correctly-placed domain concepts. No `.csproj` changes were needed — both adapter projects already referenced `Anela.Heblo.Application`. This is a namespace/project placement correction only — no behavioral change.

Verified: `dotnet build` succeeds with 0 errors, all 14 MarketingInvoices unit tests pass, `dotnet format --verify-no-changes` is clean, and a repo-wide grep confirms no stray references to the moved types remain outside the new location.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, review, and whole-branch code-review markdown are committed under `artifacts/feat-3660/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01UAY4Hz8G8k4EfiWxUXpSQy)_