### PR TITLE
#3661: Retry Azure blob container creation after transient failure

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
@@ -272,9 +272,10 @@ public sealed class AzureBlobStorageService : IBlobStorageService
     private async Task<BlobContainerClient> GetOrCreateContainerAsync(string containerName, CancellationToken cancellationToken = default)
     {
         var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
-        if (_containerExists.TryAdd(containerName, true))
+        if (!_containerExists.ContainsKey(containerName))
         {
             await containerClient.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+            _containerExists.TryAdd(containerName, true);
         }
 
         return containerClient;

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
@@ -759,6 +759,45 @@ public class AzureBlobStorageServiceTests
     }
 
     [Fact]
+    public async Task UploadAsync_CreateIfNotExistsFailsThenRetried_ShouldRetryCreation()
+    {
+        // Arrange — fresh instance so _containerExists cache is empty
+        var mockBlobServiceClient = new Mock<BlobServiceClient>();
+        var mockLogger = new Mock<ILogger<AzureBlobStorageService>>();
+        var factory = new Mock<IHttpClientFactory>();
+        var service = new AzureBlobStorageService(
+            mockBlobServiceClient.Object,
+            factory.Object,
+            mockLogger.Object);
+
+        var containerName = "documents";
+        var mockContainerClient = new Mock<BlobContainerClient>();
+        var mockBlobClient = new Mock<BlobClient>();
+
+        mockBlobClient.Setup(x => x.Uri).Returns(new Uri($"https://test.blob.core.windows.net/{containerName}/file.txt"));
+        mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContentInfo>>()));
+        mockContainerClient.Setup(x => x.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
+        mockContainerClient.SetupSequence(x => x.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RequestFailedException("transient failure"))
+            .ReturnsAsync(Mock.Of<Azure.Response<BlobContainerInfo>>());
+        mockBlobServiceClient.Setup(x => x.GetBlobContainerClient(containerName)).Returns(mockContainerClient.Object);
+
+        // Act — first upload fails during container creation
+        await Assert.ThrowsAsync<RequestFailedException>(
+            () => service.UploadAsync(new MemoryStream(new byte[] { 1 }), containerName, "file1.txt", "text/plain"));
+
+        // A retry of the outer call must re-attempt container creation rather than
+        // silently skipping it because the failed attempt already cached the name.
+        await service.UploadAsync(new MemoryStream(new byte[] { 2 }), containerName, "file2.txt", "text/plain");
+
+        // Assert — CreateIfNotExistsAsync retried after the first failure
+        mockContainerClient.Verify(
+            x => x.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task UploadAsync_BlobStorageException_ShouldThrow()
     {
         // Arrange


### PR DESCRIPTION
Closes #3661

## What the issue was
`AzureBlobStorageService.GetOrCreateContainerAsync` cached the container name in `_containerExists` via `TryAdd` **before** calling `CreateIfNotExistsAsync`. If creation threw (e.g. a transient Azure failure), the name was already cached. `DownloadResilienceService`'s retries then called `GetOrCreateContainerAsync` again, but `TryAdd` returned `false` for the now-cached name, so creation was silently skipped on every retry — the service could not recover from a failed container creation until process restart flushed the in-memory dictionary.

## How it was fixed
Moved the cache write to *after* `CreateIfNotExistsAsync` succeeds, in `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`:

```csharp
private async Task<BlobContainerClient> GetOrCreateContainerAsync(string containerName, CancellationToken cancellationToken = default)
{
    var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
    if (!_containerExists.ContainsKey(containerName))
    {
        await containerClient.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
        _containerExists.TryAdd(containerName, true);
    }

    return containerClient;
}
```

This accepts a harmless race on concurrent first calls (both call the idempotent `CreateIfNotExistsAsync`) in exchange for correct retry behavior after a transient failure.

Added a regression test (`UploadAsync_CreateIfNotExistsFailsThenRetried_ShouldRetryCreation`) in `AzureBlobStorageServiceTests.cs` that simulates a failed `CreateIfNotExistsAsync` followed by a retried upload, asserting creation is re-attempted rather than silently skipped. All 46 tests in the file pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AQh2xFmCQADGqbCncJ4ShZ)_