### PR TITLE
#3662: Remove duplicate INFO log in FileStorageController

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/FileStorageController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/FileStorageController.cs
@@ -31,9 +31,6 @@ public class FileStorageController : BaseApiController
         [FromBody] DownloadFromUrlRequest request,
         CancellationToken cancellationToken = default)
     {
-        Logger.LogInformation("Processing file download and upload request from URL: {FileUrl} to container: {ContainerName}",
-            request.FileUrl, request.ContainerName);
-
         var response = await _mediator.Send(request, cancellationToken);
 
         return HandleResponse(response);


### PR DESCRIPTION
Closes #3662

## What the issue was
`FileStorageController.DownloadFromUrl` logged an INFO message with the request's `FileUrl`/`ContainerName` before dispatching to MediatR. `DownloadFromUrlHandler.Handle` already logs the identical message, so every request produced two duplicate log entries. This also violates the project rule that controllers only orchestrate MediatR requests — diagnostics that inspect the request payload belong in the handler — and added an extra log site exposing `FileUrl` (which can be a signed URL with embedded credentials).

## How it was fixed
Removed the redundant `Logger.LogInformation(...)` call (and the blank line after it) from `FileStorageController.DownloadFromUrl` in `backend/src/Anela.Heblo.API/Controllers/FileStorageController.cs`. The handler's existing log call is unchanged and remains the single source of truth for this diagnostic.

Verified with `dotnet build` (0 errors) and `dotnet format --verify-no-changes` on the changed file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr44jAsjnEQBUjgnMQ5PN9)_