### PR TITLE
#3672: Remove unused IConfiguration parameter from AddOrgChartAdapter

### DIFF
--- a/artifacts/feat-3672/arch-review.r1.md
+++ b/artifacts/feat-3672/arch-review.r1.md
@@ -1,0 +1,74 @@
+# Architecture Review: Remove unused `IConfiguration` parameter from `AddOrgChartAdapter`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+Trivial, in-pattern cleanup — not a feature. `AddOrgChartAdapter` is a private-assembly DI extension method with exactly one call site (`Program.cs:128`). Verified directly against the code:
+
+- `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs:9-15` — the `IConfiguration configuration` parameter is accepted but never referenced in the method body, which only calls `services.AddHttpClient<IOrgChartService, OrgChartService>()`.
+- `backend/src/Anela.Heblo.API/Program.cs:126-128` — three sibling adapter registrations (`AddPlaudAdapter`, `AddMicrosoft365Adapter`, `AddOrgChartAdapter`) all currently take `builder.Configuration`, but the spec scopes this change to `AddOrgChartAdapter` only.
+
+No architectural pattern is introduced or broken. This is a signature simplification within a single vertical slice's adapter registration, with no cross-module, persistence, API contract, or UI surface.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. Existing shape is unchanged:
+
+```
+Program.cs ──calls──> AddOrgChartAdapter(services) ──registers──> HttpClient<IOrgChartService, OrgChartService>
+```
+
+The only change is removal of the unused `IConfiguration` edge into `AddOrgChartAdapter`.
+
+### Key Design Decisions
+
+#### Decision 1: Remove the parameter now vs. leave it "reserved"
+**Options considered:**
+1. Leave as-is ("reserved for future base-URL configuration").
+2. Remove the parameter and re-add it later if/when OrgChart actually needs configuration.
+
+**Chosen approach:** Option 2, per the spec.
+
+**Rationale:** YAGNI. The parameter currently has zero readers and misleads maintainers into thinking configuration is wired up. Re-adding a single parameter later, when a real base-URL requirement exists, is a one-line change with no migration cost. There is no cost to removing it now beyond touching two lines.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files, no structural changes. Edit in place:
+
+1. `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`
+   - Line 9-11: change signature from
+     ```csharp
+     public static IServiceCollection AddOrgChartAdapter(
+         this IServiceCollection services,
+         IConfiguration configuration) // reserved for future base-URL configuration
+     ```
+     to
+     ```csharp
+     public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
+     ```
+   - Line 2: remove `using Microsoft.Extensions.Configuration;` — confirmed nothing else in the file uses it (the file has no other references to `IConfiguration` or that namespace).
+   - Line body (line 13, `services.AddHttpClient<IOrgChartService, OrgChartService>();`) stays untouched.
+
+2. `backend/src/Anela.Heblo.API/Program.cs`
+   - Line 128: change `builder.Services.AddOrgChartAdapter(builder.Configuration);` to `builder.Services.AddOrgChartAdapter();`
+   - Lines 126-127 and 130 (sibling `AddPlaudAdapter`, `AddMicrosoft365Adapter`, and the following `AddSingleton` call) are explicitly out of scope — do not touch them, even though they share the same call pattern.
+
+### Interfaces and Contracts
+Internal DI extension method only; not part of any public API surface, OpenAPI contract, or DTO. No client regeneration needed. No test doubles or mocks reference this signature (confirmed no other call sites exist in the repo besides `Program.cs:128`).
+
+### Data Flow
+Unchanged. `AddOrgChartAdapter` registers a typed `HttpClient<IOrgChartService, OrgChartService>` at startup; no runtime data flow is affected by removing an unused parameter.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missed call site elsewhere in repo | Low | Confirmed via grep: `Program.cs:128` is the only caller. `dotnet build` will fail loudly if any other call site exists. |
+| Someone later needs OrgChart base-URL config and re-adds this exact "reserved" anti-pattern | Low | Out-of-scope note in spec already flags this — future config need should be its own deliberate change, not a speculative parameter. |
+
+## Specification Amendments
+None. The spec's FR-1/FR-2 already name the exact two files and line ranges verified above; no discrepancy found between spec and actual code.
+
+## Prerequisites
+None. No migrations, config, or infrastructure changes needed — pure compile-time signature edit. Standard validation applies: `dotnet build` + `dotnet format` on the backend after the change.

--- a/artifacts/feat-3672/brief.md
+++ b/artifacts/feat-3672/brief.md
@@ -1,0 +1,40 @@
+## Module
+OrgChart
+
+## Finding
+`OrgChartAdapterServiceCollectionExtensions.AddOrgChartAdapter` declares an `IConfiguration configuration` parameter (line 10) that is never read inside the method body. The inline comment `// reserved for future base-URL configuration` makes the YAGNI violation explicit.
+
+File: `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`
+
+```csharp
+public static IServiceCollection AddOrgChartAdapter(
+    this IServiceCollection services,
+    IConfiguration configuration) // reserved for future base-URL configuration  ← never used
+{
+    services.AddHttpClient();
+    return services;
+}
+```
+
+The call site in `Program.cs:128` passes `builder.Configuration`, which is also thrown away.
+
+## Why it matters
+The parameter signals to readers that it does something — they spend time looking for the configuration it supposedly affects. "Reserved for future use" in production code is speculative design; when the need arises, adding a parameter is a one-line change. Until then, the dead parameter is misleading noise.
+
+## Suggested fix
+Remove the parameter from the method signature and update the single call site in `Program.cs`:
+
+```csharp
+// OrgChartAdapterServiceCollectionExtensions.cs
+public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
+{
+    services.AddHttpClient();
+    return services;
+}
+
+// Program.cs
+builder.Services.AddOrgChartAdapter();
+```
+
+---
+_Filed by daily arch-review routine on 2026-07-16._

--- a/artifacts/feat-3672/code-review.r1.md
+++ b/artifacts/feat-3672/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3672/design.r1.md
+++ b/artifacts/feat-3672/design.r1.md
@@ -1,0 +1,7 @@
+# Design: Remove unused `IConfiguration` parameter from `AddOrgChartAdapter`
+
+## Component Design
+`OrgChartAdapterServiceCollectionExtensions.AddOrgChartAdapter` (in `Anela.Heblo.Adapters.OrgChart`) drops its unused `IConfiguration configuration` parameter, becoming `AddOrgChartAdapter(this IServiceCollection services)`. Its sole responsibility — registering `HttpClient<IOrgChartService, OrgChartService>()` — is unchanged. The unused `using Microsoft.Extensions.Configuration;` directive is removed. The single call site, `Program.cs:128`, is updated from `AddOrgChartAdapter(builder.Configuration)` to `AddOrgChartAdapter()`. No other component, interface, or module boundary is affected.
+
+## Data Schemas
+Not applicable — no database, API, or event payload is involved; this is a compile-time DI method signature change only.

--- a/artifacts/feat-3672/impl/remove-unused-orgchart-config-param.r1.md
+++ b/artifacts/feat-3672/impl/remove-unused-orgchart-config-param.r1.md
@@ -1,0 +1,33 @@
+# Implementation: remove-unused-orgchart-config-param
+
+## What was implemented
+Removed the unused `IConfiguration configuration` parameter from `AddOrgChartAdapter` (a DI-registration extension method that never read the parameter) and removed the now-unnecessary `using Microsoft.Extensions.Configuration;` directive. Updated the single call site in `Program.cs` to drop the now-obsolete `builder.Configuration` argument.
+
+## Files created/modified
+- `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs` — dropped the unused `IConfiguration configuration` parameter and its stray `using` directive; signature simplified to `AddOrgChartAdapter(this IServiceCollection services)`.
+- `backend/src/Anela.Heblo.API/Program.cs` — line 128 changed from `builder.Services.AddOrgChartAdapter(builder.Configuration);` to `builder.Services.AddOrgChartAdapter();`.
+
+## Tests
+- `dotnet build Anela.Heblo.sln` — succeeded, 0 errors (1 pre-existing unrelated warning from an access-matrix code-gen post-build step that predates this change).
+- `dotnet format Anela.Heblo.sln --include <the two changed files>` — no changes needed.
+- `dotnet test Anela.Heblo.sln` — 76-161 failures depending on run, all pre-existing and environmental: Testcontainers/Docker-backed integration tests (`PostgresSharedContainerFixture`, `*SqlShapeTests`, `*RealDatabase*`) fail because no Docker daemon is available in this sandbox, and `*IntegrationTests` under `Flexi`/`Shoptet` adapters fail because they require live external API access. `grep -rn "AddOrgChartAdapter" backend/ --include="*.cs"` confirms exactly two matches (definition + call site) and no OrgChart-related test references either symbol. No failure is related to `AddOrgChartAdapter` or `OrgChartAdapterServiceCollectionExtensions`.
+
+## How to verify
+```bash
+grep -rn "AddOrgChartAdapter" backend/ --include="*.cs"
+git diff backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs backend/src/Anela.Heblo.API/Program.cs
+cd backend && dotnet build ../Anela.Heblo.sln
+```
+
+## Notes
+The task plan's suggested `cd backend && dotnet build`/`dotnet format`/`dotnet test` commands don't work as written because the `.sln` file lives at the repo root, not under `backend/`; ran them against `Anela.Heblo.sln` from the repo root instead. No other deviations — the diff matches the plan's exact target code.
+
+## PR Summary
+Removed a dead `IConfiguration configuration` parameter from `AddOrgChartAdapter`, a DI-registration extension method that never read it (the inline comment called it "reserved for future base-URL configuration" — pure YAGNI speculation). Updated the method's one call site in `Program.cs` to match the simplified signature. No behavior change; this is a signature-only cleanup.
+
+### Changes
+- `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs` — removed unused parameter and its `using` directive
+- `backend/src/Anela.Heblo.API/Program.cs` — updated call site to drop the removed argument
+
+## Status
+DONE

--- a/artifacts/feat-3672/review/remove-unused-orgchart-config-param.r1.md
+++ b/artifacts/feat-3672/review/remove-unused-orgchart-config-param.r1.md
@@ -1,0 +1,17 @@
+# Code Review: Remove unused orgchart config parameter
+
+## Summary
+The implementation is a clean, mechanical removal of the unused `IConfiguration configuration` parameter from `AddOrgChartAdapter`, updating the single call site in `Program.cs` accordingly. Verified independently against the actual git diff (commit `1aaf391`): both files match the exact target contents specified in the task, the `using Microsoft.Extensions.Configuration;` directive was removed, the method body is untouched, and the build succeeds with 0 errors.
+
+## Review Result: PASS
+
+### task: remove-unused-orgchart-config-param
+**Status:** PASS
+
+## Overall Notes
+- Verified `git show 1aaf391` (the actual code commit, distinct from the later `6816e1f` artifact-bookkeeping commit) shows exactly two files changed, matching the spec's exact target diff byte-for-byte: the `using Microsoft.Extensions.Configuration;` line removed, the signature collapsed to `AddOrgChartAdapter(this IServiceCollection services)`, and `Program.cs` line 128 changed to `builder.Services.AddOrgChartAdapter();` with adjacent lines (127, 130) untouched.
+- `grep -rn "AddOrgChartAdapter" backend/ --include="*.cs"` returns exactly 2 matches (definition + call site), confirming no missed call sites, including test projects.
+- Re-ran `dotnet build Anela.Heblo.sln` independently — succeeded with 0 errors (only pre-existing nullable-reference warnings in unrelated test files).
+- The developer's note that `dotnet build`/`format`/`test` must be run against `Anela.Heblo.sln` from the repo root rather than `cd backend && dotnet build` (since the `.sln` lives at repo root, not under `backend/`) is a reasonable, correctly-explained deviation from the task's literal commands — the intent (build succeeds, tests pass) was still satisfied.
+- The reported `dotnet test` failures (Testcontainers/Docker-backed integration tests, live-API-dependent `*IntegrationTests`) are consistent with a sandboxed environment lacking Docker/network access, and the developer confirmed via grep that no failure references `AddOrgChartAdapter` or `OrgChartAdapterServiceCollectionExtensions`. This is a pre-existing environment limitation, not a defect introduced by this change.
+- Commit message matches the spec's suggested wording and rationale.

--- a/artifacts/feat-3672/spec.r1.md
+++ b/artifacts/feat-3672/spec.r1.md
@@ -1,0 +1,69 @@
+# Specification: Remove unused `IConfiguration` parameter from `AddOrgChartAdapter`
+
+## Summary
+`OrgChartAdapterServiceCollectionExtensions.AddOrgChartAdapter` accepts an `IConfiguration configuration` parameter that is never used in the method body — it exists only for a speculative future need, per the inline comment `// reserved for future base-URL configuration`. This is a mechanical YAGNI cleanup: drop the unused parameter and update its single call site.
+
+## Background
+This finding was raised by the daily architecture-review routine (2026-07-16) against `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`. Dead parameters marked "reserved for future use" mislead readers into thinking configuration is being consumed when it isn't, and add no value until that future need actually materializes — at which point re-adding the parameter is trivial. No behavior of `AddOrgChartAdapter` depends on the `configuration` value today; it registers a typed `HttpClient<IOrgChartService, OrgChartService>()` and nothing else.
+
+## Functional Requirements
+
+### FR-1: Remove the unused parameter from `AddOrgChartAdapter`
+In `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`, change the method signature from:
+```csharp
+public static IServiceCollection AddOrgChartAdapter(
+    this IServiceCollection services,
+    IConfiguration configuration) // reserved for future base-URL configuration
+```
+to:
+```csharp
+public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
+```
+The method body (`services.AddHttpClient<IOrgChartService, OrgChartService>(); return services;`) is unchanged. Remove the now-unused `using Microsoft.Extensions.Configuration;` directive if nothing else in the file requires it.
+
+**Acceptance criteria:**
+- `AddOrgChartAdapter` has a single parameter: `this IServiceCollection services`.
+- The `// reserved for future base-URL configuration` comment is removed.
+- No other line in the method body changes.
+- The file compiles without the `Microsoft.Extensions.Configuration` using directive if it is otherwise unused.
+
+### FR-2: Update the call site in `Program.cs`
+In `backend/src/Anela.Heblo.API/Program.cs` (line 128), change:
+```csharp
+builder.Services.AddOrgChartAdapter(builder.Configuration);
+```
+to:
+```csharp
+builder.Services.AddOrgChartAdapter();
+```
+
+**Acceptance criteria:**
+- The call site no longer passes `builder.Configuration`.
+- No other lines in `Program.cs` are touched (lines 126–127 and 130, the adjacent `AddPlaudAdapter`/`AddMicrosoft365Adapter`/`AddSingleton` calls, remain exactly as-is).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Not applicable — no runtime behavior changes; this is a compile-time signature change only.
+
+### NFR-2: Security
+Not applicable — no configuration, secrets, or auth handling is affected. `AddOrgChartAdapter` never read `IConfiguration` before, so no code path is losing access to configuration it actually relied on.
+
+## Data Model
+Not applicable — no entities or persistence involved.
+
+## API / Interface Design
+Internal DI extension method signature change only, scoped to a single assembly (`Anela.Heblo.Adapters.OrgChart`) and its single consumer (`Anela.Heblo.API`). No public HTTP API, contract, or DTO is affected.
+
+## Dependencies
+None beyond the two files already identified. No other file in the repository calls `AddOrgChartAdapter` (confirmed: `Program.cs:128` is the only call site).
+
+## Out of Scope
+- Any change to `OrgChartService`, `IOrgChartService`, or the `AddHttpClient<IOrgChartService, OrgChartService>()` registration itself.
+- Introducing actual base-URL configuration for the OrgChart adapter. If/when that need arises, it should be a separate, deliberate change with its own spec — not reintroduced speculatively here.
+- Changes to `AddPlaudAdapter`, `AddMicrosoft365Adapter`, or any other adapter registration in `Program.cs`, even though they follow a similar `(builder.Configuration)` pattern.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-17T05:17:51.572658Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T05:18:25.219314Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-17T05:20:02.779294Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-17T05:20:30.600193Z"
+      "status": "completed",
+      "updated_at": "2026-07-17T06:00:55.957924Z"
     }
   },
   "tasks": [
     {
       "name": "remove-unused-orgchart-config-param",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-17T05:20:30.795620Z"
+      "updated_at": "2026-07-17T06:00:50.341529Z"
     }
   ]
 }

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T05:16:55.587187Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-17T05:20:02.779294Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-17T05:20:30.600193Z"
     }
   },
   "tasks": [
     {
       "name": "remove-unused-orgchart-config-param",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-17T05:20:30.795620Z"
     }
   ]
 }

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-17T06:00:55.957924Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-17T06:01:03.228145Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "remove-unused-orgchart-config-param",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-17T05:16:55.587187Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T05:17:51.572658Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3672",
+  "issue_number": 3672,
+  "created_at": "2026-07-17T05:15:35.349170Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3672/state.json
+++ b/artifacts/feat-3672/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-17T05:18:25.219314Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T05:20:02.779294Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3672/task-context/remove-unused-orgchart-config-param.md
+++ b/artifacts/feat-3672/task-context/remove-unused-orgchart-config-param.md
@@ -1,0 +1,183 @@
+### task: remove-unused-orgchart-config-param
+
+You are working in a .NET 8 backend repository. Your job is a small, mechanical cleanup across exactly two files. Follow the steps below in order.
+
+#### Step 1: Confirm the current state of the target file
+
+Read `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`. Its current full contents are exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.OrgChart;
+
+public static class OrgChartAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddOrgChartAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration) // reserved for future base-URL configuration
+    {
+        services.AddHttpClient<IOrgChartService, OrgChartService>();
+        return services;
+    }
+}
+```
+
+If the file does not match this exactly, stop and report the discrepancy instead of proceeding — do not guess at edits.
+
+#### Step 2: Edit the target file
+
+Make two changes to `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`:
+
+1. Remove the now-unused using directive. Change:
+   ```csharp
+   using Anela.Heblo.Application.Features.OrgChart.Services;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   ```
+   to:
+   ```csharp
+   using Anela.Heblo.Application.Features.OrgChart.Services;
+   using Microsoft.Extensions.DependencyInjection;
+   ```
+
+2. Simplify the method signature. Change:
+   ```csharp
+   public static IServiceCollection AddOrgChartAdapter(
+       this IServiceCollection services,
+       IConfiguration configuration) // reserved for future base-URL configuration
+   {
+   ```
+   to:
+   ```csharp
+   public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
+   {
+   ```
+
+The method body (`services.AddHttpClient<IOrgChartService, OrgChartService>(); return services;`) must remain exactly unchanged.
+
+The resulting file must be exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.OrgChart;
+
+public static class OrgChartAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
+    {
+        services.AddHttpClient<IOrgChartService, OrgChartService>();
+        return services;
+    }
+}
+```
+
+#### Step 3: Update the call site in Program.cs
+
+Read `backend/src/Anela.Heblo.API/Program.cs` around line 128. The current line is:
+
+```csharp
+        builder.Services.AddOrgChartAdapter(builder.Configuration);
+```
+
+It sits between these two unchanged lines (do not touch them — they are shown only so you can locate the correct line uniquely):
+
+```csharp
+        builder.Services.AddPlaudAdapter(builder.Configuration);
+        builder.Services.AddMicrosoft365Adapter(builder.Configuration);
+        builder.Services.AddOrgChartAdapter(builder.Configuration);
+
+        builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+```
+
+Change only the `AddOrgChartAdapter` line from:
+```csharp
+        builder.Services.AddOrgChartAdapter(builder.Configuration);
+```
+to:
+```csharp
+        builder.Services.AddOrgChartAdapter();
+```
+
+Do not modify the `AddPlaudAdapter`, `AddMicrosoft365Adapter`, or `AddSingleton<IIssuedInvoiceSource>` lines, or any other line in `Program.cs`.
+
+#### Step 4: Search for any other call sites
+
+Run a repository-wide search to confirm there are no other callers of `AddOrgChartAdapter` that would break:
+
+```bash
+grep -rn "AddOrgChartAdapter" backend/ --include="*.cs"
+```
+
+Expected output: exactly two matches — the method definition in `OrgChartAdapterServiceCollectionExtensions.cs` and the call site in `Program.cs`. If any additional call site appears (e.g. in a test project), update it the same way: remove the `builder.Configuration` (or equivalent `IConfiguration` variable) argument from the call.
+
+#### Step 5: Build the backend
+
+From the repository root, run:
+
+```bash
+cd backend && dotnet build
+```
+
+The build must succeed with no errors. If it fails, read the compiler error carefully — a failure here almost always means either the signature edit or the call-site edit was not applied exactly as specified above, or an additional call site was missed in Step 4.
+
+#### Step 6: Format the backend
+
+From the repository root, run:
+
+```bash
+cd backend && dotnet format
+```
+
+This should complete without needing further manual changes (the edit already follows the existing file's style). If `dotnet format` modifies any file beyond the two touched above, review the diff to ensure it only applies whitespace/style normalization, not unrelated logic changes.
+
+#### Step 7: Run the affected backend tests
+
+There are no tests specific to `AddOrgChartAdapter` (it is a DI registration extension method with no dedicated unit test). Run the full backend test suite to make sure nothing else references the old signature:
+
+```bash
+cd backend && dotnet test
+```
+
+All tests must pass. A failure referencing `AddOrgChartAdapter` or `OrgChartAdapterServiceCollectionExtensions` indicates a missed call site — go back to Step 4.
+
+#### Step 8: Verify the final diff
+
+Run:
+
+```bash
+git diff backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs backend/src/Anela.Heblo.API/Program.cs
+```
+
+Confirm the diff shows exactly:
+- In `OrgChartAdapterServiceCollectionExtensions.cs`: removal of the `using Microsoft.Extensions.Configuration;` line, and the method signature collapsed to a single-line `public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)` with the `// reserved for future base-URL configuration` comment gone.
+- In `Program.cs`: the single line `builder.Services.AddOrgChartAdapter(builder.Configuration);` changed to `builder.Services.AddOrgChartAdapter();`, with no other line changed.
+
+If the diff contains any other changes (e.g. from `dotnet format` touching unrelated files), revert those unrelated changes and keep only the two files listed in the spec.
+
+#### Step 9: Commit
+
+Stage exactly the two files and commit:
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs backend/src/Anela.Heblo.API/Program.cs
+git commit -m "Remove unused IConfiguration parameter from AddOrgChartAdapter
+
+YAGNI cleanup: the parameter was never read in the method body and was
+marked 'reserved for future base-URL configuration'. Removed it and
+updated the single call site in Program.cs."
+```
+
+**Verification checklist for this task:**
+- [ ] `OrgChartAdapterServiceCollectionExtensions.cs` matches the exact target contents in Step 2.
+- [ ] `Program.cs` line (formerly 128) reads `builder.Services.AddOrgChartAdapter();` and no adjacent line changed.
+- [ ] `grep -rn "AddOrgChartAdapter" backend/ --include="*.cs"` returns exactly 2 matches (definition + call site).
+- [ ] `cd backend && dotnet build` succeeds with zero errors.
+- [ ] `cd backend && dotnet format` completes cleanly.
+- [ ] `cd backend && dotnet test` — all tests pass.
+- [ ] `git diff` touches only the two named files, with only the described changes.
+- [ ] Changes committed.

--- a/artifacts/feat-3672/task-plan.r1.md
+++ b/artifacts/feat-3672/task-plan.r1.md
@@ -1,0 +1,190 @@
+# Implementation Plan: Remove unused `IConfiguration` parameter from `AddOrgChartAdapter`
+
+## Overview
+`OrgChartAdapterServiceCollectionExtensions.AddOrgChartAdapter` in the backend takes an `IConfiguration configuration` parameter that is never read inside the method body. This is a pure YAGNI cleanup: remove the unused parameter, remove the now-unused `using Microsoft.Extensions.Configuration;` directive, and update the single call site in `Program.cs`. No behavior changes — this is a compile-time signature simplification only.
+
+---
+
+### task: remove-unused-orgchart-config-param
+
+You are working in a .NET 8 backend repository. Your job is a small, mechanical cleanup across exactly two files. Follow the steps below in order.
+
+#### Step 1: Confirm the current state of the target file
+
+Read `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`. Its current full contents are exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.OrgChart;
+
+public static class OrgChartAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddOrgChartAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration) // reserved for future base-URL configuration
+    {
+        services.AddHttpClient<IOrgChartService, OrgChartService>();
+        return services;
+    }
+}
+```
+
+If the file does not match this exactly, stop and report the discrepancy instead of proceeding — do not guess at edits.
+
+#### Step 2: Edit the target file
+
+Make two changes to `backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs`:
+
+1. Remove the now-unused using directive. Change:
+   ```csharp
+   using Anela.Heblo.Application.Features.OrgChart.Services;
+   using Microsoft.Extensions.Configuration;
+   using Microsoft.Extensions.DependencyInjection;
+   ```
+   to:
+   ```csharp
+   using Anela.Heblo.Application.Features.OrgChart.Services;
+   using Microsoft.Extensions.DependencyInjection;
+   ```
+
+2. Simplify the method signature. Change:
+   ```csharp
+   public static IServiceCollection AddOrgChartAdapter(
+       this IServiceCollection services,
+       IConfiguration configuration) // reserved for future base-URL configuration
+   {
+   ```
+   to:
+   ```csharp
+   public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
+   {
+   ```
+
+The method body (`services.AddHttpClient<IOrgChartService, OrgChartService>(); return services;`) must remain exactly unchanged.
+
+The resulting file must be exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.OrgChart;
+
+public static class OrgChartAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
+    {
+        services.AddHttpClient<IOrgChartService, OrgChartService>();
+        return services;
+    }
+}
+```
+
+#### Step 3: Update the call site in Program.cs
+
+Read `backend/src/Anela.Heblo.API/Program.cs` around line 128. The current line is:
+
+```csharp
+        builder.Services.AddOrgChartAdapter(builder.Configuration);
+```
+
+It sits between these two unchanged lines (do not touch them — they are shown only so you can locate the correct line uniquely):
+
+```csharp
+        builder.Services.AddPlaudAdapter(builder.Configuration);
+        builder.Services.AddMicrosoft365Adapter(builder.Configuration);
+        builder.Services.AddOrgChartAdapter(builder.Configuration);
+
+        builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+```
+
+Change only the `AddOrgChartAdapter` line from:
+```csharp
+        builder.Services.AddOrgChartAdapter(builder.Configuration);
+```
+to:
+```csharp
+        builder.Services.AddOrgChartAdapter();
+```
+
+Do not modify the `AddPlaudAdapter`, `AddMicrosoft365Adapter`, or `AddSingleton<IIssuedInvoiceSource>` lines, or any other line in `Program.cs`.
+
+#### Step 4: Search for any other call sites
+
+Run a repository-wide search to confirm there are no other callers of `AddOrgChartAdapter` that would break:
+
+```bash
+grep -rn "AddOrgChartAdapter" backend/ --include="*.cs"
+```
+
+Expected output: exactly two matches — the method definition in `OrgChartAdapterServiceCollectionExtensions.cs` and the call site in `Program.cs`. If any additional call site appears (e.g. in a test project), update it the same way: remove the `builder.Configuration` (or equivalent `IConfiguration` variable) argument from the call.
+
+#### Step 5: Build the backend
+
+From the repository root, run:
+
+```bash
+cd backend && dotnet build
+```
+
+The build must succeed with no errors. If it fails, read the compiler error carefully — a failure here almost always means either the signature edit or the call-site edit was not applied exactly as specified above, or an additional call site was missed in Step 4.
+
+#### Step 6: Format the backend
+
+From the repository root, run:
+
+```bash
+cd backend && dotnet format
+```
+
+This should complete without needing further manual changes (the edit already follows the existing file's style). If `dotnet format` modifies any file beyond the two touched above, review the diff to ensure it only applies whitespace/style normalization, not unrelated logic changes.
+
+#### Step 7: Run the affected backend tests
+
+There are no tests specific to `AddOrgChartAdapter` (it is a DI registration extension method with no dedicated unit test). Run the full backend test suite to make sure nothing else references the old signature:
+
+```bash
+cd backend && dotnet test
+```
+
+All tests must pass. A failure referencing `AddOrgChartAdapter` or `OrgChartAdapterServiceCollectionExtensions` indicates a missed call site — go back to Step 4.
+
+#### Step 8: Verify the final diff
+
+Run:
+
+```bash
+git diff backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs backend/src/Anela.Heblo.API/Program.cs
+```
+
+Confirm the diff shows exactly:
+- In `OrgChartAdapterServiceCollectionExtensions.cs`: removal of the `using Microsoft.Extensions.Configuration;` line, and the method signature collapsed to a single-line `public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)` with the `// reserved for future base-URL configuration` comment gone.
+- In `Program.cs`: the single line `builder.Services.AddOrgChartAdapter(builder.Configuration);` changed to `builder.Services.AddOrgChartAdapter();`, with no other line changed.
+
+If the diff contains any other changes (e.g. from `dotnet format` touching unrelated files), revert those unrelated changes and keep only the two files listed in the spec.
+
+#### Step 9: Commit
+
+Stage exactly the two files and commit:
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs backend/src/Anela.Heblo.API/Program.cs
+git commit -m "Remove unused IConfiguration parameter from AddOrgChartAdapter
+
+YAGNI cleanup: the parameter was never read in the method body and was
+marked 'reserved for future base-URL configuration'. Removed it and
+updated the single call site in Program.cs."
+```
+
+**Verification checklist for this task:**
+- [ ] `OrgChartAdapterServiceCollectionExtensions.cs` matches the exact target contents in Step 2.
+- [ ] `Program.cs` line (formerly 128) reads `builder.Services.AddOrgChartAdapter();` and no adjacent line changed.
+- [ ] `grep -rn "AddOrgChartAdapter" backend/ --include="*.cs"` returns exactly 2 matches (definition + call site).
+- [ ] `cd backend && dotnet build` succeeds with zero errors.
+- [ ] `cd backend && dotnet format` completes cleanly.
+- [ ] `cd backend && dotnet test` — all tests pass.
+- [ ] `git diff` touches only the two named files, with only the described changes.
+- [ ] Changes committed.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.OrgChart/OrgChartAdapterServiceCollectionExtensions.cs
@@ -1,14 +1,11 @@
 using Anela.Heblo.Application.Features.OrgChart.Services;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Anela.Heblo.Adapters.OrgChart;
 
 public static class OrgChartAdapterServiceCollectionExtensions
 {
-    public static IServiceCollection AddOrgChartAdapter(
-        this IServiceCollection services,
-        IConfiguration configuration) // reserved for future base-URL configuration
+    public static IServiceCollection AddOrgChartAdapter(this IServiceCollection services)
     {
         services.AddHttpClient<IOrgChartService, OrgChartService>();
         return services;

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -125,7 +125,7 @@ public partial class Program
         builder.Services.AddOpenMeteoAdapter(builder.Configuration);
         builder.Services.AddPlaudAdapter(builder.Configuration);
         builder.Services.AddMicrosoft365Adapter(builder.Configuration);
-        builder.Services.AddOrgChartAdapter(builder.Configuration);
+        builder.Services.AddOrgChartAdapter();
 
         builder.Services.AddSingleton<IIssuedInvoiceSource>(sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
 


### PR DESCRIPTION
Closes #3672

## What the issue was
`OrgChartAdapterServiceCollectionExtensions.AddOrgChartAdapter` declared an `IConfiguration configuration` parameter that was never read inside the method body — marked with a `// reserved for future base-URL configuration` comment. This is speculative, unused code (YAGNI violation) that misleads readers into thinking the parameter does something.

## How it was fixed / handled
Removed the unused parameter and the now-unnecessary `using Microsoft.Extensions.Configuration;` directive from `OrgChartAdapterServiceCollectionExtensions.cs`, and updated the single call site in `Program.cs:128` to drop the now-obsolete `builder.Configuration` argument. Pure signature simplification — no behavior change. Confirmed via `grep` that no other call sites exist.

## Artifacts
- Brief, spec, arch-review, design, task plan, impl, and review markdown are committed in this branch under `artifacts/feat-3672/`.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7mPHNN7qeqtngJZGkRagf)_