### PR TITLE
#3673: Move getLevelColor from OrgChartPage into PositionCard

### DIFF
--- a/artifacts/feat-3673/arch-review.r1.md
+++ b/artifacts/feat-3673/arch-review.r1.md
@@ -1,0 +1,88 @@
+# Architecture Review: Move `getLevelColor` from `OrgChartPage` into `PositionCard`
+
+## Skip Design: true
+
+No new or changed UI/UX. Verified against the actual source: the border-color classes returned by `getLevelColor` (`frontend/src/pages/OrgChartPage.tsx:168-181`) are moved verbatim into `frontend/src/components/OrgChart/PositionCard.tsx`; rendered DOM and Tailwind classes are byte-for-byte identical before and after. `docs/design/ui_design_document.md` and `docs/design/layout_definition.md` govern visual design decisions and component styling choices — neither applies here since no styling, layout, or visual behavior changes. This is an internal code-organization change only.
+
+## Architectural Fit Assessment
+
+This aligns cleanly with existing frontend conventions in `docs/architecture/filesystem.md`: components live under `frontend/src/components/` with co-located `__tests__/`, and are expected to own their own presentation logic. `PositionCard` (`frontend/src/components/OrgChart/PositionCard.tsx`) is a self-contained recursive tree-node component; `OrgChartPage` (`frontend/src/pages/OrgChartPage.tsx`) owns data fetching, filtering, zoom, and connection-line layout. `getLevelColor` is a pure `number => string` mapping with no dependency on page state (filters, zoom, positions list) — it belongs with the component that renders the border it styles, not with the page that merely passes `level` down. The only integration point is the `PositionCardProps` contract and the two call sites (`OrgChartPage.tsx:333-338` and `PositionCard.tsx`'s own recursive self-render at lines 119-124), both already identified correctly in the spec.
+
+There is no framework, module-boundary, or contract-generation concern here (no OpenAPI/DTO involvement — `PositionDto.level` already exists and is untouched).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before:
+  OrgChartPage (owns getLevelColor) --getLevelColor prop--> PositionCard (consumes, recurses prop to self)
+
+After:
+  OrgChartPage (owns data/layout only) --position, getChildren--> PositionCard (owns getLevelColor internally, no self-prop-drilling of it)
+```
+
+No new components, files, or module boundaries are introduced.
+
+### Key Design Decisions
+
+#### Decision 1: Co-locate vs. extract to shared module
+**Options considered:**
+1. Move `getLevelColor` as an internal, non-exported helper inside `PositionCard.tsx`.
+2. Extract to a new co-located file, e.g. `frontend/src/components/OrgChart/levelColors.ts`.
+
+**Chosen approach:** Option 1 — internal, non-exported module-level function in `PositionCard.tsx`, matching the spec (FR-1).
+
+**Rationale:** `PositionCard` is the sole consumer and the mapping is a small, unvarying switch statement (4 branches + default). A separate file adds an indirection with no current benefit — YAGNI. The spec already flags a `levelColors.ts` extraction as Out of Scope, correctly deferring it until an actual second consumer or theming requirement appears (`getInitials` in the same file is a precedent for this pattern: small pure helpers live inline in the component file, not extracted).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Changes confined to the three files the spec identifies, plus the auto-regenerated snapshot:
+- `frontend/src/components/OrgChart/PositionCard.tsx` — add internal `getLevelColor`, remove it from `PositionCardProps` (currently `position.tsx:4-8`) and from the destructured params (line 19) and the recursive self-render props (lines 119-124).
+- `frontend/src/pages/OrgChartPage.tsx` — delete the function (lines 168-181) and the `getLevelColor={getLevelColor}` prop at the `<PositionCard>` call site (lines 333-338).
+- `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx` — remove `stubLevelColor` (line 21) and the `getLevelColor={stubLevelColor}` prop at both call sites (lines 40, 76).
+- `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap` — regenerate via test runner (`npm test -- -u` or equivalent), not hand-edited, per NFR/spec Out of Scope.
+
+### Interfaces and Contracts
+
+`PositionCardProps` narrows from three fields to two:
+
+```typescript
+// Before
+export interface PositionCardProps {
+  position: PositionDto;
+  getChildren: (parentId: string) => PositionDto[];
+  getLevelColor: (level: number) => string;
+}
+
+// After
+export interface PositionCardProps {
+  position: PositionDto;
+  getChildren: (parentId: string) => PositionDto[];
+}
+```
+
+`getLevelColor` becomes a private, non-exported `const` in `PositionCard.tsx`, called as `getLevelColor(position.level ?? 1)` in place of the current prop invocation — preserving the existing `?? 1` fallback exactly (do not change default-level semantics as part of this move).
+
+No other public interface changes. `OrgChartPage` is not exported/consumed elsewhere with a different shape, per spec's Dependencies section (confirmed no other file references `getLevelColor`).
+
+### Data Flow
+
+Unchanged except for where the color decision is computed: `position.level` still flows from `OrgChartPage`'s fetched/filtered position data into `PositionCard` via the `position` prop (unchanged); `PositionCard` now derives its own border class from `position.level` internally instead of receiving a pre-selected class-producing function. No data crosses a new boundary; this is a pure locality-of-behavior fix.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Snapshot regeneration silently masks a real behavioral drift (not just the stub→real-class diff) | Low | Diff the regenerated `.snap` file by hand before committing; confirm only the border-color class strings change and no other markup shifts. |
+| Recursive self-render (`PositionCard.tsx:119-124`) missed, leaving a stale `getLevelColor` prop passed to self | Low | TypeScript will fail to compile once `getLevelColor` is removed from `PositionCardProps` — the recursive call site becomes a type error, making this self-catching. Run `npm run build` to confirm. |
+
+## Specification Amendments
+
+None. The spec's line-number references were verified against current source and are accurate (interface at 4-8, destructure at 19, recursive render at 119-124, page definition at 168-181, page call site at 333-338, test stub/props at 21/40/76). No functional or scope changes needed.
+
+## Prerequisites
+
+None. No migrations, config, or infrastructure changes required. This can be implemented immediately as a standalone, self-verifying change (TypeScript compilation + existing test suite with regenerated snapshot are sufficient verification — no new tests required per spec's Out of Scope).

--- a/artifacts/feat-3673/brief.md
+++ b/artifacts/feat-3673/brief.md
@@ -1,0 +1,57 @@
+# [arch-review] OrgChart: `getLevelColor` belongs in `PositionCard`, not prop-drilled from the page
+
+## Module
+OrgChart
+
+## Finding
+`getLevelColor` is a pure presentation function that maps a hierarchy level to a Tailwind border-color class. It is defined in `OrgChartPage.tsx` (lines 168–181) and injected into `PositionCard` as a required prop:
+
+```typescript
+// OrgChartPage.tsx:168-181
+const getLevelColor = (level: number) => {
+  switch (level) {
+    case 1: return 'border-l-4 border-red-500';
+    case 2: return 'border-l-4 border-orange-500';
+    case 3: return 'border-l-4 border-yellow-500';
+    case 4: return 'border-l-4 border-green-500';
+    default: return 'border-l-4 border-gray-500';
+  }
+};
+```
+
+```typescript
+// PositionCard.tsx:6-7 — accepts it as a prop
+export interface PositionCardProps {
+  position: PositionDto;
+  getChildren: (parentId: string) => PositionDto[];
+  getLevelColor: (level: number) => string;   // ← leaks page internals into the card's contract
+}
+```
+
+`PositionCard` is the **only consumer** of `getLevelColor`. The function is never overridden or varied — the page always passes the same implementation.
+
+## Why it matters
+- **Single Responsibility**: `OrgChartPage` is responsible for fetching and laying out the chart; the color scheme of an individual card is `PositionCard`'s concern.
+- **Cohesion**: A reader of `PositionCard` must jump to the page to understand how level colors are determined.
+- **Unnecessary prop surface**: The extra prop widens `PositionCardProps`, makes tests for `PositionCard` harder to write (they must supply a stub), and adds a call-site argument that carries zero information.
+
+## Suggested fix
+Move `getLevelColor` inside `PositionCard.tsx` (or a co-located `levelColors.ts` if you later want to theme it), remove it from `PositionCardProps`, and delete it from `OrgChartPage`:
+
+```typescript
+// PositionCard.tsx — add internally
+const getLevelColor = (level: number): string => {
+  switch (level) {
+    case 1: return 'border-l-4 border-red-500';
+    case 2: return 'border-l-4 border-orange-500';
+    case 3: return 'border-l-4 border-yellow-500';
+    case 4: return 'border-l-4 border-green-500';
+    default: return 'border-l-4 border-gray-500';
+  }
+};
+
+// Remove from PositionCardProps; remove prop from OrgChartPage's JSX
+```
+
+---
+_Filed by daily arch-review routine on 2026-07-16._

--- a/artifacts/feat-3673/code-review.r1.md
+++ b/artifacts/feat-3673/code-review.r1.md
@@ -1,0 +1,7 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None

--- a/artifacts/feat-3673/design.r1.md
+++ b/artifacts/feat-3673/design.r1.md
@@ -1,0 +1,27 @@
+# Design: Move `getLevelColor` from `OrgChartPage` into `PositionCard`
+
+## Component Design
+
+No new components. `PositionCard.tsx` gains one private, non-exported helper:
+
+```typescript
+const getLevelColor = (level: number): string => {
+  switch (level) {
+    case 1: return 'border-l-4 border-red-500';
+    case 2: return 'border-l-4 border-orange-500';
+    case 3: return 'border-l-4 border-yellow-500';
+    case 4: return 'border-l-4 border-green-500';
+    default: return 'border-l-4 border-gray-500';
+  }
+};
+```
+
+`PositionCardProps` narrows from `{ position, getChildren, getLevelColor }` to `{ position, getChildren }`. `OrgChartPage.tsx` loses its `getLevelColor` definition and the corresponding prop at the `<PositionCard>` call site. No other component's contract changes.
+
+## Data Schemas
+
+Not applicable — no data model, API, or DTO changes. `position.level: number` (already part of `PositionDto`) is the only input, consumed identically before and after.
+
+---
+
+`Skip Design: true` per `arch-review.r1.md` — this is a pure code-organization refactor with no UI/UX change (rendered DOM and Tailwind classes are byte-for-byte identical before and after), so no UX/UI section is included per the designer agent's output rules.

--- a/artifacts/feat-3673/impl/move-getlevelcolor-to-positioncard.r1.md
+++ b/artifacts/feat-3673/impl/move-getlevelcolor-to-positioncard.r1.md
@@ -1,0 +1,34 @@
+# Implementation: move-getlevelcolor-to-positioncard
+
+## What was implemented
+
+Moved the pure `getLevelColor` helper (level number → Tailwind border-color class) out of `OrgChartPage.tsx`, where it was defined and prop-drilled into `PositionCard`, and into `PositionCard.tsx` as a private, non-exported module-level function. `PositionCard` now computes its own border color instead of receiving it as a prop, including in its recursive self-render. `PositionCardProps` no longer declares `getLevelColor`. The one test file for `PositionCard` was updated to drop the `stubLevelColor` stub and the prop from both render calls, and its Jest snapshot was regenerated to reflect the real color classes.
+
+## Files created/modified
+
+- `frontend/src/components/OrgChart/PositionCard.tsx` — removed `getLevelColor` from `PositionCardProps`; added a private module-level `getLevelColor` function (identical switch/case logic: levels 1-4 → red/orange/yellow/green, default → gray, all with `border-l-4` prefix); dropped `getLevelColor` from the destructured props and from the recursive `<PositionCard>` self-render call.
+- `frontend/src/pages/OrgChartPage.tsx` — deleted the local `getLevelColor` definition; removed the `getLevelColor={getLevelColor}` prop from the `<PositionCard>` call site. No other logic in this file (data fetching, filters, zoom, connection lines) was touched.
+- `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx` — removed the `stubLevelColor` helper and the `getLevelColor={stubLevelColor}` prop from both test render calls. No other assertions or test structure changed.
+- `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap` — regenerated via `-u` test run (not hand-edited).
+
+## Tests
+
+- `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx` — both existing tests (`renders a leaf position...`, `renders a recursive position with one child`) pass. Snapshot regenerated and diffed: the only changes are the border-color class strings (`border-l-4 level-1` → `border-l-4 border-red-500`, `level-2` → `border-orange-500`, `level-3` → `border-yellow-500`), confirming no unintended markup/structure change.
+
+## How to verify
+
+From `frontend/`:
+1. `npm run build` — succeeds with zero TypeScript errors.
+2. `npm run lint` — pre-existing repo-wide failures unrelated to this change (see Notes); the three touched files introduce zero new lint errors.
+3. `CI=true npx react-scripts test src/components/OrgChart/__tests__/PositionCard.test.tsx -u --watchAll=false` then re-run without `-u` — both pass cleanly (2/2 tests, 2/2 snapshots).
+4. `git diff frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap` — confirms only the three class-string changes described above.
+5. `grep -rn getLevelColor frontend/src` — only two occurrences remain, both in `PositionCard.tsx`: the module-level function definition and its single call site in the card's `className` computation. Zero references in `OrgChartPage.tsx` or `PositionCard.test.tsx`.
+
+## Notes
+
+- `npm run lint` fails with 160 pre-existing problems (147 errors, 13 warnings) across ~25 files unrelated to this task (mostly `testing-library/no-node-access`, `no-wait-for-multiple-assertions`, etc. in unrelated test files). I confirmed this is pre-existing: `git stash` + re-running eslint on just the three touched files before my change showed the identical 14 `testing-library` errors in `PositionCard.test.tsx` (same rule, same count, only line numbers shifted from the stub-line removal). My change introduces zero new lint errors. This appears to be pre-existing lint debt in the repository, not something introduced or in-scope for this refactor.
+- `node_modules` did not exist in the worktree (fresh checkout) and `npm ci`/`npm install` failed with an ERESOLVE peer-dependency conflict (react-i18next requires TypeScript 5, project pins 4.9.5). Copied `node_modules` from the main repo checkout (`/home/user/Anela.Heblo/frontend/node_modules`, which was already installed and working) into the worktree to run verification. This is a local environment workaround only, not a source change.
+- Committed with `git add -A` per the strict commit instructions, which also picked up `artifacts/feat-3673/state.json` (pipeline-managed bookkeeping file already transitioned to `in_progress` by the orchestrator before this task started).
+
+## Status
+DONE

--- a/artifacts/feat-3673/review/move-getlevelcolor-to-positioncard.r1.md
+++ b/artifacts/feat-3673/review/move-getlevelcolor-to-positioncard.r1.md
@@ -1,0 +1,19 @@
+# Code Review: Move getLevelColor from OrgChartPage into PositionCard
+
+## Summary
+The diff matches the task context exactly: `getLevelColor` was removed from `PositionCardProps` and from `OrgChartPage.tsx`, and re-added inside `PositionCard.tsx` as a private, non-exported module-level function with byte-identical switch/case logic. The recursive self-render and the `OrgChartPage` call site both drop the `getLevelColor` prop, tests drop the `stubLevelColor` stub, and the snapshot diff shows only the expected class-string changes (`level-N` → real Tailwind color classes). I independently re-ran `PositionCard.test.tsx` and confirmed both tests pass cleanly against the regenerated snapshot.
+
+## Review Result: PASS
+
+### task: move-getlevelcolor-to-positioncard
+**Status:** PASS
+
+## Docs to Update
+(None — this is an internal-only refactor with no public-facing surface change.)
+
+## Overall Notes
+- Repo-wide grep for `getLevelColor` in `frontend/src` returns exactly two hits, both in `PositionCard.tsx`: the module-level definition and its single call site in the `className` template — no leftover references in `OrgChartPage.tsx` or the test file.
+- Verified independently: `CI=true npx react-scripts test src/components/OrgChart/__tests__/PositionCard.test.tsx --watchAll=false` → 2/2 tests pass, 2/2 snapshots pass.
+- `npx tsc --noEmit` in this worktree fails, but only inside `node_modules/react-i18next/*.d.ts` (TS5-only syntax against the project's pinned TypeScript 4.9.5), and `git diff` confirms `package.json`/`package-lock.json` are untouched by this change — this is a pre-existing environment/dependency issue, not something introduced by the diff, consistent with the implementer's own disclosure about the worktree's `node_modules` state.
+- Lint pre-existing-debt claim in the implementation summary was not independently re-verified line-by-line, but the diff itself is small and mechanical enough (prop/const relocation, no new logic) that it's very unlikely to introduce new lint violations; not a blocker.
+- Diff is scoped exactly to the four files named in the task context, with no stray edits to `OrgChartPage.tsx` data fetching, filtering, zoom, or connection-line logic.

--- a/artifacts/feat-3673/spec.r1.md
+++ b/artifacts/feat-3673/spec.r1.md
@@ -1,0 +1,88 @@
+# Specification: Move `getLevelColor` from `OrgChartPage` into `PositionCard`
+
+## Summary
+`getLevelColor` is a pure, unvarying presentation helper that maps a hierarchy level to a Tailwind border-color class. It currently lives in `OrgChartPage.tsx` and is prop-drilled into `PositionCard`, its only consumer. This change relocates the function into `PositionCard.tsx`, removes it from `PositionCardProps`, and removes the now-unused prop and definition from `OrgChartPage.tsx`.
+
+## Background
+This is an architecture-review finding (module: OrgChart, filed 2026-07-16) flagging a Single-Responsibility / cohesion violation: `OrgChartPage` should own data fetching and layout, while an individual card's color scheme is `PositionCard`'s own concern. The function is never overridden or parameterized differently by any caller, so the prop only adds surface area — it widens `PositionCardProps`, forces `PositionCard`'s tests to supply a stub, and requires readers of `PositionCard` to jump to the page to understand how its own border color is determined.
+
+## Functional Requirements
+
+### FR-1: Relocate `getLevelColor` into `PositionCard.tsx`
+Move the function currently defined at `frontend/src/pages/OrgChartPage.tsx:168-181` into `frontend/src/components/OrgChart/PositionCard.tsx` as a module-level (non-exported) helper, with an explicit `number => string` signature and identical switch/case behavior (levels 1-4 map to red/orange/yellow/green respectively, any other level falls back to gray):
+
+```typescript
+const getLevelColor = (level: number): string => {
+  switch (level) {
+    case 1: return 'border-l-4 border-red-500';
+    case 2: return 'border-l-4 border-orange-500';
+    case 3: return 'border-l-4 border-yellow-500';
+    case 4: return 'border-l-4 border-green-500';
+    default: return 'border-l-4 border-gray-500';
+  }
+};
+```
+
+**Acceptance criteria:**
+- `getLevelColor` is defined inside `PositionCard.tsx` and is not exported.
+- For inputs 1, 2, 3, 4, and any other number (e.g. 0, 5, undefined-defaulted), the returned class string is byte-for-byte identical to the pre-change implementation.
+- The component body calls the local `getLevelColor(position.level ?? 1)` in place of the current prop invocation (`PositionCard.tsx:27-29`), preserving the `?? 1` default-level fallback.
+
+### FR-2: Remove `getLevelColor` from `PositionCardProps` and the component signature
+`PositionCardProps` (`PositionCard.tsx:4-8`) no longer declares `getLevelColor`, and the destructured function parameter (`PositionCard.tsx:19`) no longer includes it.
+
+**Acceptance criteria:**
+- `PositionCardProps` contains only `position` and `getChildren`.
+- The recursive self-render of `PositionCard` (`PositionCard.tsx:119-124`) no longer passes a `getLevelColor` prop.
+- No `getLevelColor` prop appears anywhere in `PositionCard.tsx`'s public interface or JSX.
+
+### FR-3: Remove `getLevelColor` and its call-site argument from `OrgChartPage.tsx`
+Delete the function definition at `OrgChartPage.tsx:168-181` and remove the `getLevelColor={getLevelColor}` prop from the `<PositionCard>` invocation at `OrgChartPage.tsx:333-338`.
+
+**Acceptance criteria:**
+- `OrgChartPage.tsx` no longer defines or references `getLevelColor` anywhere.
+- The `<PositionCard>` JSX call site passes only `position` and `getChildren`.
+- No other behavior of `OrgChartPage` changes (data fetching, filtering, zoom, connection-line rendering are untouched).
+
+### FR-4: Update existing `PositionCard` unit tests
+`frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx` currently defines a `stubLevelColor` helper and passes it as a `getLevelColor` prop in both test cases (lines 21, 40, 76). Since the prop no longer exists, the stub and both prop usages must be removed, and the tests must exercise the component's real (now-internal) color logic.
+
+**Acceptance criteria:**
+- `stubLevelColor` and all `getLevelColor={...}` props are removed from the test file.
+- Existing snapshots in `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap` are regenerated to reflect the real border classes (e.g. `border-red-500` for level 1, `border-l-4 border-orange-500`... for level 2 in the child-rendering test) instead of the stub's `level-${level}` classes.
+- Both existing test cases (`renders a leaf position...`, `renders a recursive position with one child`) pass unmodified in structure, only with the stub/prop removed.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavioral equivalence
+This is a pure refactor: rendered DOM output, CSS classes, and component behavior for all existing call sites must be identical before and after the change (aside from the test snapshot update required by FR-4, which reflects the tests now using real logic instead of a stub).
+
+### NFR-2: No new dependencies or public API changes
+No new npm packages, no changes to `PositionDto` or other API-generated types, and no changes to how `OrgChartPage` is consumed by any other module.
+
+## Data Model
+Not applicable — no data model changes. `getLevelColor` operates only on the `level: number` field already present on `PositionDto`/`Position`.
+
+## API / Interface Design
+- **Before:** `PositionCardProps = { position, getChildren, getLevelColor }`
+- **After:** `PositionCardProps = { position, getChildren }`
+
+No backend, HTTP, or MediatR changes. This is a frontend-only, intra-module refactor confined to:
+- `frontend/src/components/OrgChart/PositionCard.tsx`
+- `frontend/src/pages/OrgChartPage.tsx`
+- `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx`
+- `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap` (regenerated, not hand-edited)
+
+## Dependencies
+None. No other file references `getLevelColor` (confirmed via repo-wide search — the only occurrences are in `PositionCard.tsx`, `OrgChartPage.tsx`, and `PositionCard.test.tsx`).
+
+## Out of Scope
+- Extracting `getLevelColor` into a separate co-located `levelColors.ts` file (mentioned in the brief as a future option if theming is later needed) — not part of this change.
+- Any change to the actual color mapping, level thresholds, or visual design of position cards.
+- Any change to `OrgChartPage`'s other responsibilities (filtering, zoom, connection-line rendering, data fetching).
+- Broader test coverage additions beyond adjusting the two existing tests and their snapshot for the prop removal.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-17T06:16:24.052915Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-17T06:16:24.242184Z"
+      "status": "completed",
+      "updated_at": "2026-07-17T06:17:43.381620Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-17T06:28:27.190017Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-17T06:28:27.468776Z"
+      "status": "completed",
+      "updated_at": "2026-07-17T06:29:16.938813Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-17T06:19:24.956558Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-17T06:19:36.629147Z"
+      "status": "completed",
+      "updated_at": "2026-07-17T06:28:27.190017Z"
     }
   },
   "tasks": [
     {
       "name": "move-getlevelcolor-to-positioncard",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-17T06:19:36.822453Z"
+      "updated_at": "2026-07-17T06:28:16.082885Z"
     }
   ]
 }

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-17T06:28:27.190017Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-17T06:28:27.468776Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-17T06:19:24.956558Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-17T06:19:36.629147Z"
     }
   },
   "tasks": [
     {
       "name": "move-getlevelcolor-to-positioncard",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-17T06:19:36.822453Z"
     }
   ]
 }

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -6,11 +6,11 @@
   "phases": {
     "analyzing": {
       "status": "completed",
-      "updated_at": "2026-07-17T06:16:15.917104Z"
+      "updated_at": "2026-07-17T06:16:24.052915Z"
     },
     "architecting": {
       "status": "in_progress",
-      "updated_at": "2026-07-17T06:16:16.159020Z"
+      "updated_at": "2026-07-17T06:16:24.242184Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-17T06:17:43.381620Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T06:18:06.675345Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-17T06:18:06.848323Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3673",
+  "issue_number": 3673,
+  "created_at": "2026-07-17T06:14:43.791725Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-17T06:16:15.917104Z"
+    },
+    "architecting": {
+      "status": "in_progress",
+      "updated_at": "2026-07-17T06:16:16.159020Z"
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3673/state.json
+++ b/artifacts/feat-3673/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-17T06:18:06.675345Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-17T06:18:06.848323Z"
+      "status": "completed",
+      "updated_at": "2026-07-17T06:19:24.956558Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "move-getlevelcolor-to-positioncard",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3673/task-context/move-getlevelcolor-to-positioncard.md
+++ b/artifacts/feat-3673/task-context/move-getlevelcolor-to-positioncard.md
@@ -1,0 +1,218 @@
+### task: move-getlevelcolor-to-positioncard
+
+## Context
+
+This is a small, purely mechanical frontend refactor confirmed by an architecture review (`arch-review.r1.md`, Skip Design: true — no visual/UX change). `getLevelColor` is a pure `number => string` function that maps a hierarchy level to a Tailwind border-color class. It currently lives in `OrgChartPage.tsx` and is prop-drilled into `PositionCard.tsx`, its only consumer (including its own recursive self-render). It must move to live inside `PositionCard.tsx` as a private, non-exported helper, since the component that renders the border should own the logic that computes it. This is a single cohesive change — do not split it into multiple tasks.
+
+All file/line references below were verified directly against current source (as of this plan) and match the spec and arch-review exactly.
+
+## Files to touch
+
+1. `frontend/src/components/OrgChart/PositionCard.tsx`
+2. `frontend/src/pages/OrgChartPage.tsx`
+3. `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx`
+4. `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap` (regenerate via test runner — do not hand-edit)
+
+## Exact changes
+
+### 1. `frontend/src/components/OrgChart/PositionCard.tsx`
+
+Current relevant content:
+
+```typescript
+export interface PositionCardProps {
+  position: PositionDto;
+  getChildren: (parentId: string) => PositionDto[];
+  getLevelColor: (level: number) => string;
+}
+
+const getInitials = (name: string | undefined): string => {
+  if (!name) return '?';
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase();
+};
+
+function PositionCard({ position, getChildren, getLevelColor }: PositionCardProps): JSX.Element {
+```
+
+Change to:
+
+- Remove `getLevelColor: (level: number) => string;` from `PositionCardProps` so it becomes:
+
+  ```typescript
+  export interface PositionCardProps {
+    position: PositionDto;
+    getChildren: (parentId: string) => PositionDto[];
+  }
+  ```
+
+- Add a new private, non-exported module-level function immediately after the `PositionCardProps` interface (before or after `getInitials` is fine; place it directly above or below `getInitials` for consistency with that existing inline-helper pattern):
+
+  ```typescript
+  const getLevelColor = (level: number): string => {
+    switch (level) {
+      case 1:
+        return 'border-l-4 border-red-500';
+      case 2:
+        return 'border-l-4 border-orange-500';
+      case 3:
+        return 'border-l-4 border-yellow-500';
+      case 4:
+        return 'border-l-4 border-green-500';
+      default:
+        return 'border-l-4 border-gray-500';
+    }
+  };
+  ```
+
+  This must be byte-for-byte identical in output to the version currently in `OrgChartPage.tsx` (same switch/case branches, same class strings). Do not change the color mapping or add an explicit return type deviation beyond what's shown (an explicit `(level: number): string =>` signature is fine and matches the spec).
+
+- Update the component signature to drop `getLevelColor` from the destructured props:
+
+  ```typescript
+  function PositionCard({ position, getChildren }: PositionCardProps): JSX.Element {
+  ```
+
+- In the JSX (currently around line 27-29), the call site:
+
+  ```typescript
+  className={`bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 ${getLevelColor(
+    position.level ?? 1
+  )} relative mb-20`}
+  ```
+
+  stays exactly as-is — it already calls `getLevelColor(position.level ?? 1)`; only the resolution of `getLevelColor` changes from a prop to the local module-level const. Preserve the `?? 1` fallback exactly.
+
+- In the recursive self-render (currently around line 119-124):
+
+  ```typescript
+  <PositionCard
+    key={child.id}
+    position={child}
+    getChildren={getChildren}
+    getLevelColor={getLevelColor}
+  />
+  ```
+
+  remove the `getLevelColor={getLevelColor}` line so it becomes:
+
+  ```typescript
+  <PositionCard
+    key={child.id}
+    position={child}
+    getChildren={getChildren}
+  />
+  ```
+
+### 2. `frontend/src/pages/OrgChartPage.tsx`
+
+- Delete the function definition currently at (approximately) lines 168-181:
+
+  ```typescript
+  const getLevelColor = (level: number) => {
+    switch (level) {
+      case 1:
+        return 'border-l-4 border-red-500';
+      case 2:
+        return 'border-l-4 border-orange-500';
+      case 3:
+        return 'border-l-4 border-yellow-500';
+      case 4:
+        return 'border-l-4 border-green-500';
+      default:
+        return 'border-l-4 border-gray-500';
+    }
+  };
+  ```
+
+  Remove this block entirely (it sits between the `totalEmployees` calculation and the `getChildren` const definition — leave both of those untouched).
+
+- At the `<PositionCard>` JSX call site (approximately lines 333-338):
+
+  ```typescript
+  <PositionCard
+    key={root.id}
+    position={root}
+    getChildren={getChildren}
+    getLevelColor={getLevelColor}
+  />
+  ```
+
+  remove the `getLevelColor={getLevelColor}` line so it becomes:
+
+  ```typescript
+  <PositionCard
+    key={root.id}
+    position={root}
+    getChildren={getChildren}
+  />
+  ```
+
+- Do not touch anything else in this file: data fetching (`useOrgChart`), filtering logic, zoom state/handlers, connection-line rendering (`renderConnections`), and all other JSX must remain exactly as they are.
+
+### 3. `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx`
+
+- Remove the stub helper (currently line 21):
+
+  ```typescript
+  const stubLevelColor = (level: number): string => `border-l-4 level-${level}`;
+  ```
+
+- Remove the `getLevelColor={stubLevelColor}` prop from both `<PositionCard ... />` invocations (currently lines 40 and 76 — one in `'renders a leaf position with data-position-id on the outer card'`, one in `'renders a recursive position with one child'`). E.g.:
+
+  ```typescript
+  const { container } = render(
+    <PositionCard
+      position={position}
+      getChildren={noChildren}
+    />,
+  );
+  ```
+
+  and similarly for the second test's `parent`/`getChildren` render call. Do not change any other part of either test (assertions, `data-position-id` queries, `toMatchSnapshot()` calls, test structure/names all stay identical).
+
+### 4. Snapshot file
+
+- Do not hand-edit `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap`. After making the changes above, regenerate it by running the test suite with the update flag (from the `frontend/` directory):
+
+  ```
+  CI=true npx react-scripts test src/components/OrgChart/__tests__/PositionCard.test.tsx -u --watchAll=false
+  ```
+
+  (or equivalent `npm test -- -u` invocation that runs non-interactively and updates snapshots).
+
+- After regeneration, manually diff the snapshot file (`git diff` on the `.snap` file) and confirm the **only** changes are the border-color class strings — e.g. class fragments like `border-l-4 level-1` / `border-l-4 level-2` / `border-l-4 level-3` (from the stub) become the real classes: `border-l-4 border-red-500` (level 1), `border-l-4 border-orange-500` (level 2), `border-l-4 border-yellow-500` (level 3), respectively, matching the two existing tests' `level: 1`, `level: 2`, `level: 3` fixture values. No other markup, structure, or text content in the snapshot should change. If anything else differs, stop and investigate before proceeding — that would indicate an unintended behavioral change, not just the expected stub-to-real-class diff.
+
+## Out of scope (do not do)
+
+- Do not extract `getLevelColor` into a new shared file (e.g. `levelColors.ts`).
+- Do not change the color mapping, level thresholds, or any visual/design behavior.
+- Do not modify any other `OrgChartPage` responsibility (data fetching, filters, zoom, connection lines).
+- Do not add new tests beyond what's needed to keep the two existing tests passing with the prop removed.
+
+## Acceptance criteria
+
+- `PositionCardProps` in `PositionCard.tsx` contains only `position` and `getChildren` — no `getLevelColor` field.
+- `PositionCard.tsx` defines a private, non-exported `getLevelColor` module-level function with identical switch/case behavior and class strings as the original (levels 1-4 → red/orange/yellow/green, all others → gray, `border-l-4` prefix on every branch).
+- The `PositionCard` component body calls `getLevelColor(position.level ?? 1)` for its own border class, and no longer accepts `getLevelColor` as a prop anywhere, including its recursive self-render.
+- `OrgChartPage.tsx` no longer defines or references `getLevelColor` anywhere, and its `<PositionCard>` call site passes only `position` and `getChildren`. No other `OrgChartPage` behavior changes.
+- `PositionCard.test.tsx` no longer defines `stubLevelColor` and no longer passes a `getLevelColor` prop in either test; both existing test cases pass with only the stub/prop removed (no other structural changes).
+- The Jest snapshot file is regenerated (not hand-edited) and, when diffed, shows only border-color class-string changes (stub `level-N` classes replaced by the real `border-{color}-500` classes) — no other markup differences.
+- `npm run build` succeeds with no TypeScript errors (this will also catch any stale `getLevelColor` prop reference via a compile error, since `PositionCardProps` no longer declares it).
+- `npm run lint` passes.
+- The full existing test suite for `PositionCard.test.tsx` (and ideally the broader `npm test` run, or at minimum any test touching `OrgChartPage`/`PositionCard`) passes.
+- A repo-wide search for `getLevelColor` confirms it now appears only inside `PositionCard.tsx` (definition + two call sites: JSX class computation and recursive self-render no longer needed) — zero references remain in `OrgChartPage.tsx` or `PositionCard.test.tsx`.
+
+## Verification steps (run from `frontend/` directory)
+
+1. `npm run build` — must succeed with zero TypeScript errors.
+2. `npm run lint` — must pass.
+3. Run the updated test with snapshot regeneration as described above, then re-run without `-u` to confirm it now passes cleanly against the regenerated snapshot:
+   ```
+   CI=true npx react-scripts test src/components/OrgChart/__tests__/PositionCard.test.tsx --watchAll=false
+   ```
+4. `git diff` the `.snap` file and confirm only the described class-string changes are present.
+5. Grep the `frontend/src` tree for `getLevelColor` and confirm the only remaining occurrences are within `PositionCard.tsx`.

--- a/artifacts/feat-3673/task-plan.r1.md
+++ b/artifacts/feat-3673/task-plan.r1.md
@@ -1,0 +1,220 @@
+# Task Plan: Move `getLevelColor` from `OrgChartPage` into `PositionCard`
+
+### task: move-getlevelcolor-to-positioncard
+
+## Context
+
+This is a small, purely mechanical frontend refactor confirmed by an architecture review (`arch-review.r1.md`, Skip Design: true — no visual/UX change). `getLevelColor` is a pure `number => string` function that maps a hierarchy level to a Tailwind border-color class. It currently lives in `OrgChartPage.tsx` and is prop-drilled into `PositionCard.tsx`, its only consumer (including its own recursive self-render). It must move to live inside `PositionCard.tsx` as a private, non-exported helper, since the component that renders the border should own the logic that computes it. This is a single cohesive change — do not split it into multiple tasks.
+
+All file/line references below were verified directly against current source (as of this plan) and match the spec and arch-review exactly.
+
+## Files to touch
+
+1. `frontend/src/components/OrgChart/PositionCard.tsx`
+2. `frontend/src/pages/OrgChartPage.tsx`
+3. `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx`
+4. `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap` (regenerate via test runner — do not hand-edit)
+
+## Exact changes
+
+### 1. `frontend/src/components/OrgChart/PositionCard.tsx`
+
+Current relevant content:
+
+```typescript
+export interface PositionCardProps {
+  position: PositionDto;
+  getChildren: (parentId: string) => PositionDto[];
+  getLevelColor: (level: number) => string;
+}
+
+const getInitials = (name: string | undefined): string => {
+  if (!name) return '?';
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase();
+};
+
+function PositionCard({ position, getChildren, getLevelColor }: PositionCardProps): JSX.Element {
+```
+
+Change to:
+
+- Remove `getLevelColor: (level: number) => string;` from `PositionCardProps` so it becomes:
+
+  ```typescript
+  export interface PositionCardProps {
+    position: PositionDto;
+    getChildren: (parentId: string) => PositionDto[];
+  }
+  ```
+
+- Add a new private, non-exported module-level function immediately after the `PositionCardProps` interface (before or after `getInitials` is fine; place it directly above or below `getInitials` for consistency with that existing inline-helper pattern):
+
+  ```typescript
+  const getLevelColor = (level: number): string => {
+    switch (level) {
+      case 1:
+        return 'border-l-4 border-red-500';
+      case 2:
+        return 'border-l-4 border-orange-500';
+      case 3:
+        return 'border-l-4 border-yellow-500';
+      case 4:
+        return 'border-l-4 border-green-500';
+      default:
+        return 'border-l-4 border-gray-500';
+    }
+  };
+  ```
+
+  This must be byte-for-byte identical in output to the version currently in `OrgChartPage.tsx` (same switch/case branches, same class strings). Do not change the color mapping or add an explicit return type deviation beyond what's shown (an explicit `(level: number): string =>` signature is fine and matches the spec).
+
+- Update the component signature to drop `getLevelColor` from the destructured props:
+
+  ```typescript
+  function PositionCard({ position, getChildren }: PositionCardProps): JSX.Element {
+  ```
+
+- In the JSX (currently around line 27-29), the call site:
+
+  ```typescript
+  className={`bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 ${getLevelColor(
+    position.level ?? 1
+  )} relative mb-20`}
+  ```
+
+  stays exactly as-is — it already calls `getLevelColor(position.level ?? 1)`; only the resolution of `getLevelColor` changes from a prop to the local module-level const. Preserve the `?? 1` fallback exactly.
+
+- In the recursive self-render (currently around line 119-124):
+
+  ```typescript
+  <PositionCard
+    key={child.id}
+    position={child}
+    getChildren={getChildren}
+    getLevelColor={getLevelColor}
+  />
+  ```
+
+  remove the `getLevelColor={getLevelColor}` line so it becomes:
+
+  ```typescript
+  <PositionCard
+    key={child.id}
+    position={child}
+    getChildren={getChildren}
+  />
+  ```
+
+### 2. `frontend/src/pages/OrgChartPage.tsx`
+
+- Delete the function definition currently at (approximately) lines 168-181:
+
+  ```typescript
+  const getLevelColor = (level: number) => {
+    switch (level) {
+      case 1:
+        return 'border-l-4 border-red-500';
+      case 2:
+        return 'border-l-4 border-orange-500';
+      case 3:
+        return 'border-l-4 border-yellow-500';
+      case 4:
+        return 'border-l-4 border-green-500';
+      default:
+        return 'border-l-4 border-gray-500';
+    }
+  };
+  ```
+
+  Remove this block entirely (it sits between the `totalEmployees` calculation and the `getChildren` const definition — leave both of those untouched).
+
+- At the `<PositionCard>` JSX call site (approximately lines 333-338):
+
+  ```typescript
+  <PositionCard
+    key={root.id}
+    position={root}
+    getChildren={getChildren}
+    getLevelColor={getLevelColor}
+  />
+  ```
+
+  remove the `getLevelColor={getLevelColor}` line so it becomes:
+
+  ```typescript
+  <PositionCard
+    key={root.id}
+    position={root}
+    getChildren={getChildren}
+  />
+  ```
+
+- Do not touch anything else in this file: data fetching (`useOrgChart`), filtering logic, zoom state/handlers, connection-line rendering (`renderConnections`), and all other JSX must remain exactly as they are.
+
+### 3. `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx`
+
+- Remove the stub helper (currently line 21):
+
+  ```typescript
+  const stubLevelColor = (level: number): string => `border-l-4 level-${level}`;
+  ```
+
+- Remove the `getLevelColor={stubLevelColor}` prop from both `<PositionCard ... />` invocations (currently lines 40 and 76 — one in `'renders a leaf position with data-position-id on the outer card'`, one in `'renders a recursive position with one child'`). E.g.:
+
+  ```typescript
+  const { container } = render(
+    <PositionCard
+      position={position}
+      getChildren={noChildren}
+    />,
+  );
+  ```
+
+  and similarly for the second test's `parent`/`getChildren` render call. Do not change any other part of either test (assertions, `data-position-id` queries, `toMatchSnapshot()` calls, test structure/names all stay identical).
+
+### 4. Snapshot file
+
+- Do not hand-edit `frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap`. After making the changes above, regenerate it by running the test suite with the update flag (from the `frontend/` directory):
+
+  ```
+  CI=true npx react-scripts test src/components/OrgChart/__tests__/PositionCard.test.tsx -u --watchAll=false
+  ```
+
+  (or equivalent `npm test -- -u` invocation that runs non-interactively and updates snapshots).
+
+- After regeneration, manually diff the snapshot file (`git diff` on the `.snap` file) and confirm the **only** changes are the border-color class strings — e.g. class fragments like `border-l-4 level-1` / `border-l-4 level-2` / `border-l-4 level-3` (from the stub) become the real classes: `border-l-4 border-red-500` (level 1), `border-l-4 border-orange-500` (level 2), `border-l-4 border-yellow-500` (level 3), respectively, matching the two existing tests' `level: 1`, `level: 2`, `level: 3` fixture values. No other markup, structure, or text content in the snapshot should change. If anything else differs, stop and investigate before proceeding — that would indicate an unintended behavioral change, not just the expected stub-to-real-class diff.
+
+## Out of scope (do not do)
+
+- Do not extract `getLevelColor` into a new shared file (e.g. `levelColors.ts`).
+- Do not change the color mapping, level thresholds, or any visual/design behavior.
+- Do not modify any other `OrgChartPage` responsibility (data fetching, filters, zoom, connection lines).
+- Do not add new tests beyond what's needed to keep the two existing tests passing with the prop removed.
+
+## Acceptance criteria
+
+- `PositionCardProps` in `PositionCard.tsx` contains only `position` and `getChildren` — no `getLevelColor` field.
+- `PositionCard.tsx` defines a private, non-exported `getLevelColor` module-level function with identical switch/case behavior and class strings as the original (levels 1-4 → red/orange/yellow/green, all others → gray, `border-l-4` prefix on every branch).
+- The `PositionCard` component body calls `getLevelColor(position.level ?? 1)` for its own border class, and no longer accepts `getLevelColor` as a prop anywhere, including its recursive self-render.
+- `OrgChartPage.tsx` no longer defines or references `getLevelColor` anywhere, and its `<PositionCard>` call site passes only `position` and `getChildren`. No other `OrgChartPage` behavior changes.
+- `PositionCard.test.tsx` no longer defines `stubLevelColor` and no longer passes a `getLevelColor` prop in either test; both existing test cases pass with only the stub/prop removed (no other structural changes).
+- The Jest snapshot file is regenerated (not hand-edited) and, when diffed, shows only border-color class-string changes (stub `level-N` classes replaced by the real `border-{color}-500` classes) — no other markup differences.
+- `npm run build` succeeds with no TypeScript errors (this will also catch any stale `getLevelColor` prop reference via a compile error, since `PositionCardProps` no longer declares it).
+- `npm run lint` passes.
+- The full existing test suite for `PositionCard.test.tsx` (and ideally the broader `npm test` run, or at minimum any test touching `OrgChartPage`/`PositionCard`) passes.
+- A repo-wide search for `getLevelColor` confirms it now appears only inside `PositionCard.tsx` (definition + two call sites: JSX class computation and recursive self-render no longer needed) — zero references remain in `OrgChartPage.tsx` or `PositionCard.test.tsx`.
+
+## Verification steps (run from `frontend/` directory)
+
+1. `npm run build` — must succeed with zero TypeScript errors.
+2. `npm run lint` — must pass.
+3. Run the updated test with snapshot regeneration as described above, then re-run without `-u` to confirm it now passes cleanly against the regenerated snapshot:
+   ```
+   CI=true npx react-scripts test src/components/OrgChart/__tests__/PositionCard.test.tsx --watchAll=false
+   ```
+4. `git diff` the `.snap` file and confirm only the described class-string changes are present.
+5. Grep the `frontend/src` tree for `getLevelColor` and confirm the only remaining occurrences are within `PositionCard.tsx`.

--- a/frontend/src/components/OrgChart/PositionCard.tsx
+++ b/frontend/src/components/OrgChart/PositionCard.tsx
@@ -4,7 +4,6 @@ import { PositionDto } from '../../api/generated/api-client';
 export interface PositionCardProps {
   position: PositionDto;
   getChildren: (parentId: string) => PositionDto[];
-  getLevelColor: (level: number) => string;
 }
 
 const getInitials = (name: string | undefined): string => {
@@ -16,7 +15,22 @@ const getInitials = (name: string | undefined): string => {
     .toUpperCase();
 };
 
-function PositionCard({ position, getChildren, getLevelColor }: PositionCardProps): JSX.Element {
+const getLevelColor = (level: number): string => {
+  switch (level) {
+    case 1:
+      return 'border-l-4 border-red-500';
+    case 2:
+      return 'border-l-4 border-orange-500';
+    case 3:
+      return 'border-l-4 border-yellow-500';
+    case 4:
+      return 'border-l-4 border-green-500';
+    default:
+      return 'border-l-4 border-gray-500';
+  }
+};
+
+function PositionCard({ position, getChildren }: PositionCardProps): JSX.Element {
   const children = getChildren(position.id!);
 
   return (
@@ -120,7 +134,6 @@ function PositionCard({ position, getChildren, getLevelColor }: PositionCardProp
               key={child.id}
               position={child}
               getChildren={getChildren}
-              getLevelColor={getLevelColor}
             />
           ))}
         </div>

--- a/frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx
+++ b/frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx
@@ -18,8 +18,6 @@ const makeEmployee = (overrides: Partial<EmployeeDto>): EmployeeDto => {
 
 const noChildren = (_parentId: string): PositionDto[] => [];
 
-const stubLevelColor = (level: number): string => `border-l-4 level-${level}`;
-
 describe('PositionCard', () => {
   it('renders a leaf position with data-position-id on the outer card', () => {
     // Arrange
@@ -37,7 +35,6 @@ describe('PositionCard', () => {
       <PositionCard
         position={position}
         getChildren={noChildren}
-        getLevelColor={stubLevelColor}
       />,
     );
 
@@ -73,7 +70,6 @@ describe('PositionCard', () => {
       <PositionCard
         position={parent}
         getChildren={getChildren}
-        getLevelColor={stubLevelColor}
       />,
     );
 

--- a/frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap
+++ b/frontend/src/components/OrgChart/__tests__/__snapshots__/PositionCard.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PositionCard renders a leaf position with data-position-id on the outer
     class="flex flex-col items-center"
   >
     <div
-      class="bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 border-l-4 level-1 relative mb-20"
+      class="bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 border-l-4 border-red-500 relative mb-20"
       data-position-id="pos-1"
     >
       <div
@@ -62,7 +62,7 @@ exports[`PositionCard renders a recursive position with one child 1`] = `
     class="flex flex-col items-center"
   >
     <div
-      class="bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 border-l-4 level-2 relative mb-20"
+      class="bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 border-l-4 border-orange-500 relative mb-20"
       data-position-id="parent"
     >
       <div
@@ -91,7 +91,7 @@ exports[`PositionCard renders a recursive position with one child 1`] = `
         class="flex flex-col items-center"
       >
         <div
-          class="bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 border-l-4 level-3 relative mb-20"
+          class="bg-white dark:bg-graphite-surface rounded-xl shadow-lg dark:shadow-soft-dark p-6 w-80 transition-all hover:shadow-2xl hover:-translate-y-1 border-l-4 border-yellow-500 relative mb-20"
           data-position-id="child"
         >
           <div

--- a/frontend/src/pages/OrgChartPage.tsx
+++ b/frontend/src/pages/OrgChartPage.tsx
@@ -165,21 +165,6 @@ const OrgChartPage: React.FC = () => {
 
   const totalEmployees = filteredPositions.reduce((sum, pos) => sum + (pos.employees?.length || 0), 0);
 
-  const getLevelColor = (level: number) => {
-    switch (level) {
-      case 1:
-        return 'border-l-4 border-red-500';
-      case 2:
-        return 'border-l-4 border-orange-500';
-      case 3:
-        return 'border-l-4 border-yellow-500';
-      case 4:
-        return 'border-l-4 border-green-500';
-      default:
-        return 'border-l-4 border-gray-500';
-    }
-  };
-
   const getChildren = (parentId: string): Position[] =>
     orgChartGetChildren(parentId, filteredPositions);
 
@@ -334,7 +319,6 @@ const OrgChartPage: React.FC = () => {
                   key={root.id}
                   position={root}
                   getChildren={getChildren}
-                  getLevelColor={getLevelColor}
                 />
               ))}
             </div>


### PR DESCRIPTION
Closes #3673

## What the issue was
`getLevelColor`, a pure presentation function mapping a hierarchy level to a Tailwind border-color class, lived in `OrgChartPage.tsx` and was prop-drilled into `PositionCard`, its only consumer. This widened `PositionCardProps` with a prop that never varied, made `PositionCard` harder to test in isolation, and forced readers of `PositionCard` to jump to the page to understand its own border-color logic — a Single Responsibility / cohesion violation flagged by the daily arch-review routine.

## How it was fixed / handled
- Moved `getLevelColor` into `frontend/src/components/OrgChart/PositionCard.tsx` as a private, non-exported module-level function with byte-for-byte identical switch/case behavior.
- Removed `getLevelColor` from `PositionCardProps` and from the component's destructured parameters, including the recursive self-render call site.
- Deleted the now-unused `getLevelColor` definition and its prop pass-through from `frontend/src/pages/OrgChartPage.tsx` — no other `OrgChartPage` behavior (data fetching, filtering, zoom, connection-line rendering) was touched.
- Updated `frontend/src/components/OrgChart/__tests__/PositionCard.test.tsx` to drop the `stubLevelColor` helper and its prop usage, and regenerated the Jest snapshot — the diff shows only the expected class-string swap (stub `level-N` classes → real Tailwind classes), no other markup changes.

Verified: `npm run build` compiles cleanly, the `PositionCard` test suite passes (2/2 tests, 2/2 snapshots), and a repo-wide grep confirms `getLevelColor` now only appears in `PositionCard.tsx`.

## Artifacts
Brief, spec, arch-review, design, task plan, impl, review, and whole-branch code-review markdown are committed under `artifacts/feat-3673/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None


---
_Generated by [Claude Code](https://claude.ai/code/session_016RW9VcvaE2TkFZ6jczWCUJ)_