### PR TITLE
#3674: Remove FileStorage Azure adapter's compile-time dependency on the Application layer

### DIFF
--- a/artifacts/feat-3674/arch-review.r1.md
+++ b/artifacts/feat-3674/arch-review.r1.md
@@ -1,0 +1,101 @@
+# Architecture Review: Remove Azure Adapter's Compile-Time Dependency on the Application Layer (FileStorage)
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The finding is real and the spec's fix is correctly scoped. I verified every claim against the actual source:
+
+- `AzureBlobStorageService.cs:39` does call `_httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName)`, and line 4 imports `Anela.Heblo.Application.Features.FileStorage` for no other reason — nothing else in the file touches the Application layer. This is a genuine violation of the Domain ← Application ← Adapters dependency direction that `docs/architecture/filesystem.md` and `memory/decisions/clean-architecture-vertical-slice.md` establish (API/Adapters depend inward on Application/Domain, never the reverse — and an outer-ring project reaching into Application for a bare string constant is exactly the kind of coupling that rule exists to prevent).
+- `FileStorageModule.cs:14` does declare `public const string FileDownloadClientName = "FileDownload";` inside `AddFileStorageModule`'s static class, alongside DI wiring — confirming the constant is genuinely stranded in a composition-root file, not a natural Application-owned concept.
+- `AzureBlobStorageServiceTests.cs` imports `Anela.Heblo.Application.Features.FileStorage` and references `FileStorageModule.FileDownloadClientName` in exactly the pattern described (11 occurrences, not "~10" but close enough not to matter).
+- `PurchaseOrderConstants.cs` is a solid, directly-comparable precedent: a plain `public static class` of `const` fields sitting in `Anela.Heblo.Domain.Features.Purchase`, used across layers. `FileStorageConstants` in `Anela.Heblo.Domain.Features.FileStorage` follows the identical shape and sits next to the existing `IBlobStorageService.cs` / `BlobItemInfo` in that same namespace.
+- `DownloadFromUrlHandler.cs` (Application layer) uses `FileStorageModule.FileDownloadClientName` twice (lines 95, 144) and is correctly left untouched by the spec — it already legitimately lives in Application, so referencing an Application-layer module constant is not a boundary violation for it.
+- `AzureAdapterModule.cs` legitimately references `Anela.Heblo.Application.Features.FileStorage` (for `FileStorageOptions`) and `Anela.Heblo.Application.Shared.Printing` (for `PrintPickingListOptions`) purely for DI composition-root wiring. I checked all 20 adapter `.csproj` files under `backend/src/Adapters/`: 15 of them reference `Anela.Heblo.Application`, and only 4 (HomeAssistant, OpenMeteo, Smartsupp, SendGrid-via-Xcc-only) reference Domain exclusively. So "Adapter → Application ProjectReference for options binding" is the dominant, accepted pattern in this codebase, not an outlier — the spec is right to leave `AzureAdapterModule.cs` and the `.csproj` alone and scope this fix narrowly to the one runtime-logic reference (`AzureBlobStorageService.cs`) that has no DI-wiring justification.
+- No `NetArchTest`/architecture-fitness-function project exists in the repo today. `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` exists but its allowlist mechanism polices **intra-Application cross-module** namespace boundaries (e.g. `Catalog -> Logistics`), not the **Adapters → Application layering rule** this spec addresses. There is nothing to update there, and the spec correctly avoids inventing new tooling in this change (explicitly out of scope).
+
+Net: this is a minimal, low-risk, single-purpose refactor that removes a genuine architectural smell without touching runtime behavior, DI wiring, or the project's dependency graph. It's exactly the kind of "surgical fix" this codebase's own conventions call for. I endorse the spec as written, with one clarifying amendment below (constant type, not visibility or placement).
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. One new static holder class in Domain, one one-line change in the Adapter, one const-forwarding edit in the existing Application module, and a mechanical test update. No DI graph changes, no new interfaces, no new abstractions.
+
+```
+Anela.Heblo.Domain.Features.FileStorage
+  ├── IBlobStorageService.cs        (existing)
+  └── FileStorageConstants.cs       (NEW — const string FileDownloadClientName)
+
+Anela.Heblo.Application.Features.FileStorage
+  └── FileStorageModule.cs          (EDIT — FileDownloadClientName becomes a forwarding const)
+
+Anela.Heblo.Adapters.Azure.Features.FileStorage
+  └── AzureBlobStorageService.cs    (EDIT — drop Application using, reference Domain constant)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Where the constant lives
+**Options considered:**
+1. Move to Domain as a `const string` on a new `FileStorageConstants` static class (spec's proposal).
+2. Move to Domain as an `IOptions<T>`-style options class (brief's alternative suggestion).
+3. Leave as-is and add a NetArchTest allowlist exception instead of fixing the code.
+
+**Chosen approach:** Option 1 — a Domain-layer `static class FileStorageConstants` with a `const string`.
+
+**Rationale:** `FileDownloadClientName` is not configuration — it's a fixed, compile-time-known key that names an `IHttpClientFactory` registration. It never varies by environment or deployment, so wrapping it in `IOptions<T>` (which implies runtime-bindable, environment-specific config) would be over-engineering and would require DI resolution at a callsite (`AzureBlobStorageService.DownloadFromUrlAsync`) that has no other reason to depend on `IOptions<T>`. `PurchaseOrderConstants` is the established precedent in this exact codebase for "small, stable, cross-layer string/int constants belong in a Domain-layer `static class`." Option 3 (allowlisting instead of fixing) papers over a real violation instead of removing it, and there's no existing architecture-test infrastructure that even covers this class of violation — introducing one is explicitly out of scope for this change, so there's nothing to allowlist against yet.
+
+#### Decision 2: Keep `FileStorageModule.FileDownloadClientName` as a forwarding const
+**Options considered:**
+1. Delete `FileStorageModule.FileDownloadClientName` entirely and repoint all Application-layer consumers (`DownloadFromUrlHandler.cs`, `FileStorageModuleTests.cs`) at `FileStorageConstants` directly.
+2. Keep it as `public const string FileDownloadClientName = FileStorageConstants.FileDownloadClientName;` (spec's proposal).
+
+**Chosen approach:** Option 2.
+
+**Rationale:** This keeps the diff surgical — `DownloadFromUrlHandler.cs` is explicitly out of scope per the spec, and touching it (plus its tests) to satisfy a rename would violate "surgical changes" for no architectural benefit; both names now resolve to the same compile-time literal, so there is no drift risk. This is a short-lived compatibility shim, not a long-term dual-source-of-truth: once a future, separately-scoped cleanup touches `DownloadFromUrlHandler.cs` anyway, it should switch to `FileStorageConstants` directly and the forwarding const can be deleted. Flagging this now so it isn't forgotten (see Specification Amendments).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New file: `backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs` — same directory as the existing `IBlobStorageService.cs`, matching the `PurchaseOrderConstants.cs` precedent (`Domain/Features/Purchase/PurchaseOrderConstants.cs`) exactly. No new folders.
+
+### Interfaces and Contracts
+
+No interface changes. This is a pure constant-relocation; `IBlobStorageService` and its single implementation `AzureBlobStorageService` keep identical signatures and behavior.
+
+### Data Flow
+
+Unchanged at runtime. Compile-time reference graph changes from:
+
+```
+Adapters.Azure --(compile-time)--> Application.Features.FileStorage.FileStorageModule.FileDownloadClientName
+```
+to:
+```
+Adapters.Azure --(compile-time)--> Domain.Features.FileStorage.FileStorageConstants.FileDownloadClientName
+Application.Features.FileStorage.FileStorageModule.FileDownloadClientName --(compile-time)--> Domain.Features.FileStorage.FileStorageConstants.FileDownloadClientName  (forwarding const, both resolve to the same literal at compile time)
+```
+
+The Adapters.Azure → Application `ProjectReference` in the `.csproj` is retained (per spec, out of scope to remove) but is no longer exercised by `AzureBlobStorageService.cs` specifically — it remains justified solely by `AzureAdapterModule.cs`'s legitimate options-binding usage.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Two `FileDownloadClientName` consts (Domain source + Application forwarder) drift if someone edits one without the other | Low | Both are `const`, so any value mismatch is impossible without deliberately editing both lines; `FileStorageModuleTests.cs::AddFileStorageModule_NamedClient_ConstantIsExported` already asserts the value is `"FileDownload"` and will catch any divergence. No new test needed. |
+| Forwarding const becomes permanent clutter instead of a stepping stone | Low | Call it out explicitly in the PR description / a follow-up note (see Specification Amendments) so a future FileStorage-touching change removes it when `DownloadFromUrlHandler.cs` is next modified for unrelated reasons. Not worth a dedicated task on its own. |
+| Reviewer expects this PR to also fix `AzureAdapterModule.cs`'s Application references, since it's the same file family | Low | Spec's FR-5 already states this is intentionally out of scope and explains why (legitimate DI-wiring pattern, consistent with 15/19 other adapters). Worth restating in the PR description to preempt review churn. |
+
+Both risks are low because the change is compile-time-only, mechanically verifiable by `dotnet build`, and covered by an existing test that pins the constant's value.
+
+## Specification Amendments
+
+None required to FR-1 through FR-5 — they are accurate and correctly scoped as verified above. One non-blocking note for the implementer:
+
+- **Optional follow-up (not part of this task):** once any future change legitimately touches `DownloadFromUrlHandler.cs` or `FileStorageModuleTests.cs`, prefer switching those two consumers to reference `Anela.Heblo.Domain.Features.FileStorage.FileStorageConstants.FileDownloadClientName` directly and deleting the `FileStorageModule.FileDownloadClientName` forwarding const at that point. Do not do this now — it would violate the "surgical changes" rule and expand the diff beyond what this task requires.
+
+## Prerequisites
+
+None. No schema changes, no feature flags, no other in-flight branches touch these files (confirmed via the file contents read directly from the worktree). Implementation can proceed straight from this review.

--- a/artifacts/feat-3674/brief.md
+++ b/artifacts/feat-3674/brief.md
@@ -1,0 +1,22 @@
+## Module
+FileStorage
+
+## Finding
+`AzureBlobStorageService` (in `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`, line 39) imports and uses `FileStorageModule.FileDownloadClientName` from `Anela.Heblo.Application.Features.FileStorage`:
+
+```csharp
+using Anela.Heblo.Application.Features.FileStorage;
+// ...
+var httpClient = _httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName);
+```
+
+`FileStorageModule` is an Application-layer class. This means the Azure adapter (infrastructure/outer ring) has a compile-time dependency on the Application layer.
+
+## Why it matters
+Clean Architecture's dependency rule requires outer rings to depend inward only — adapters depend on Domain, not Application. Here the adapter crosses that boundary just to access a string constant (`"FileDownload"`). This introduces an unwanted coupling: changing or splitting `FileStorageModule` can now break the Azure adapter. It also makes the adapter harder to test in isolation (the Application project must be referenced).
+
+## Suggested fix
+Move the constant to the Domain layer (e.g. as a `public const` on `IBlobStorageService` or a new `FileStorageConstants` class in `Anela.Heblo.Domain.Features.FileStorage`), or introduce an options class (e.g. `BlobStorageAdapterOptions`) injected into the adapter that carries the client name. Either approach removes the adapter's dependency on the Application project.
+
+---
+_Filed by daily arch-review routine on 2026-07-17._

--- a/artifacts/feat-3674/code-review.r1.md
+++ b/artifacts/feat-3674/code-review.r1.md
@@ -1,0 +1,10 @@
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+## Notes
+The diff is a minimal, mechanical constant relocation: adds `backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs`, repoints `AzureBlobStorageService.cs` at it (dropping its `using Anela.Heblo.Application.Features.FileStorage;`), turns `FileStorageModule.FileDownloadClientName` into a forwarding const, and updates `AzureBlobStorageServiceTests.cs` to reference the new Domain constant. The string value (`"FileDownload"`), `HttpClient` registration, and all runtime behavior are unchanged — verified by 116 passing FileStorage-scoped tests, a clean `dotnet build`, and a no-diff `dotnet format`. No scope creep: `AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, and all `.csproj` files are untouched, matching the spec's explicit out-of-scope list.

--- a/artifacts/feat-3674/design.r1.md
+++ b/artifacts/feat-3674/design.r1.md
@@ -1,0 +1,13 @@
+# Design: Remove Azure Adapter's Compile-Time Dependency on the Application Layer (FileStorage)
+
+## Component Design
+
+- **New: `FileStorageConstants`** (`Anela.Heblo.Domain.Features.FileStorage`) — a `public static class` holding `public const string FileDownloadClientName = "FileDownload"`. Sole responsibility: own the logical `HttpClient` name as a Domain-layer compile-time constant, following the `PurchaseOrderConstants` precedent.
+- **Changed: `AzureBlobStorageService`** (`Anela.Heblo.Adapters.Azure`) — drops its `using Anela.Heblo.Application.Features.FileStorage;` import and resolves the named `HttpClient` via `FileStorageConstants.FileDownloadClientName` instead of `FileStorageModule.FileDownloadClientName`. No other behavior changes.
+- **Changed: `FileStorageModule`** (`Anela.Heblo.Application.Features.FileStorage`) — `FileDownloadClientName` becomes a forwarding const (`= FileStorageConstants.FileDownloadClientName`), preserving the existing public member for `DownloadFromUrlHandler.cs` and tests with zero call-site changes.
+- **Changed: `AzureBlobStorageServiceTests`** — swaps its `FileStorageModule.FileDownloadClientName` references (~11 sites) for `FileStorageConstants.FileDownloadClientName` and updates the `using` directive accordingly.
+- **Unchanged:** `AzureAdapterModule.cs`, `IBlobStorageService`, `DownloadFromUrlHandler.cs`, `.csproj` references, DI registration, and all HttpClient behavior (pooling, timeout, decompression).
+
+## Data Schemas
+
+Not applicable — no persisted data, API contract, or event payload changes. This is a compile-time constant relocation with an identical runtime string value (`"FileDownload"`).

--- a/artifacts/feat-3674/impl/fix-filestorage-adapter-application-dependency.r1.md
+++ b/artifacts/feat-3674/impl/fix-filestorage-adapter-application-dependency.r1.md
@@ -1,0 +1,35 @@
+# Implementation: fix-filestorage-adapter-application-dependency
+
+## What was implemented
+Removed `AzureBlobStorageService`'s compile-time dependency on the Application-layer `FileStorageModule` by introducing a Domain-layer `FileStorageConstants` class holding the `FileDownloadClientName` string. `FileStorageModule.FileDownloadClientName` now forwards to the Domain constant so existing Application-layer consumers (`DownloadFromUrlHandler.cs`, `FileStorageModuleTests.cs`) need no changes.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs` — new file, `public static class` with `public const string FileDownloadClientName = "FileDownload"`.
+- `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` — removed `using Anela.Heblo.Application.Features.FileStorage;`, switched to `FileStorageConstants.FileDownloadClientName`.
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs` — `FileDownloadClientName` is now a forwarding const referencing `FileStorageConstants.FileDownloadClientName`.
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs` — swapped `using Anela.Heblo.Application.Features.FileStorage;` for `using Anela.Heblo.Domain.Features.FileStorage;`; replaced all `FileStorageModule.FileDownloadClientName` references with `FileStorageConstants.FileDownloadClientName`.
+
+## Tests
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~FileStorage"` — 116 passed, 0 failed (covers `AzureBlobStorageServiceTests`, `FileStorageModuleTests`, `DownloadFromUrlHandlerTests`, `SimpleFileStorageTest`).
+
+## How to verify
+1. `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` → no matches.
+2. `dotnet build Anela.Heblo.sln` → succeeds, 0 errors.
+3. `dotnet format Anela.Heblo.sln --verify-no-changes` → no diff.
+4. `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~FileStorage"` → all pass.
+
+## Notes
+- `dotnet build` emits a pre-existing warning (MSB3073, exit code 134) from the `Anela.Heblo.AccessMatrixGen` post-build tool failing to parse a JSON file — this is unrelated to this change (reproduces on a clean checkout of the same commit before this diff) and does not fail the build.
+- No diff in `AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, or any `.csproj`, matching the spec's scope constraints.
+
+## PR Summary
+`AzureBlobStorageService` (an infrastructure adapter) imported the Application-layer `FileStorageModule` purely to read a string constant naming its `HttpClient`, violating Clean Architecture's dependency rule. This change adds a `FileStorageConstants` class in the Domain layer holding that constant, points the adapter at it instead, and turns `FileStorageModule.FileDownloadClientName` into a forwarding const so every existing Application-layer caller and test keeps compiling unchanged. Pure compile-time refactor — the `HttpClient` name, its registration, and all runtime behavior are unchanged.
+
+### Changes
+- `backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs` — new Domain-layer constant holder
+- `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` — drop Application dependency, use Domain constant
+- `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs` — forwarding const
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs` — updated to reference the Domain constant
+
+## Status
+DONE

--- a/artifacts/feat-3674/review/fix-filestorage-adapter-application-dependency.r1.md
+++ b/artifacts/feat-3674/review/fix-filestorage-adapter-application-dependency.r1.md
@@ -1,0 +1,20 @@
+# Code Review: Remove Azure Adapter's Compile-Time Dependency on the Application Layer (FileStorage)
+
+## Summary
+The implementation matches the task plan exactly: a new `FileStorageConstants` class in Domain, the adapter switched to it, a forwarding const left in `FileStorageModule` for backward compatibility, and the adapter's tests updated to the Domain constant. Independently verified against commit `c39db03`.
+
+## Review Result: PASS
+
+### task: fix-filestorage-adapter-application-dependency
+**Status:** PASS
+
+Verification performed:
+- `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` returns no matches (exit code 1).
+- `git show c39db03 --stat` shows only the 4 expected code files changed plus the impl artifact — no diff in `AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, `FileStorageModuleTests.cs`, or any `.csproj`.
+- `dotnet build Anela.Heblo.sln` succeeds with 0 errors (one pre-existing, unrelated AccessMatrixGen tool warning reproduces independent of this change).
+- `dotnet format Anela.Heblo.sln --verify-no-changes` reports no diff.
+- `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~FileStorage"` — 116/116 passed, covering `AzureBlobStorageServiceTests`, `FileStorageModuleTests`, `DownloadFromUrlHandlerTests`, `SimpleFileStorageTest`.
+- `FileStorageModule.FileDownloadClientName` is now `= FileStorageConstants.FileDownloadClientName;` — still a compile-time const, still equals `"FileDownload"`, and `FileStorageModuleTests.cs`'s assertion against it is unchanged and passing.
+
+## Overall Notes
+Clean, surgical, in-scope refactor. No further action needed.

--- a/artifacts/feat-3674/spec.r1.md
+++ b/artifacts/feat-3674/spec.r1.md
@@ -1,0 +1,138 @@
+# Specification: Remove Azure Adapter's Compile-Time Dependency on the Application Layer (FileStorage)
+
+## Summary
+`AzureBlobStorageService` — the Azure Blob Storage implementation of `IBlobStorageService` living in the Adapters (infrastructure) ring — currently imports `Anela.Heblo.Application.Features.FileStorage.FileStorageModule` solely to read the constant string `FileDownloadClientName` ("FileDownload") used to resolve a named `HttpClient`. This violates the Clean Architecture dependency rule (adapters must depend inward on Domain, never on Application) and creates an avoidable coupling: any refactor of `FileStorageModule` can break the adapter for reasons unrelated to blob storage. This spec moves the constant to the Domain layer so the adapter depends only on Domain types, while leaving the adapter's existing (and separately justified) `ProjectReference` to the Application project and `AzureAdapterModule.cs`'s use of Application-layer Options classes untouched.
+
+## Background
+`AzureBlobStorageService.cs` (`backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`) implements `IBlobStorageService`, which is correctly defined in the Domain layer (`Anela.Heblo.Domain.Features.FileStorage.IBlobStorageService`). Inside `DownloadFromUrlAsync` (line 39), the adapter calls:
+
+```csharp
+var httpClient = _httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName);
+```
+
+`FileStorageModule` (`backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`) is an `IServiceCollection` extension class in the Application layer. It both defines `public const string FileDownloadClientName = "FileDownload";` and registers the matching named `HttpClient` via `services.AddHttpClient(FileDownloadClientName)...`. The Application-layer `DownloadFromUrlHandler` also references the same constant (both to pass it through to a resilience helper and to issue a HEAD probe).
+
+This is a narrowly-scoped fix, not a wholesale re-architecture of the Azure adapter project:
+- `Anela.Heblo.Adapters.Azure.csproj` has exactly one `ProjectReference`, to `Anela.Heblo.Application.csproj`. It does **not** have a direct reference to `Anela.Heblo.Domain.csproj` today — `IBlobStorageService` and other Domain types are visible to the adapter only *transitively*, because `Anela.Heblo.Application.csproj` itself references `Anela.Heblo.Domain.csproj`.
+- `AzureAdapterModule.cs` (the adapter's composition-root/DI-wiring class, in the same project) legitimately reads Application-layer Options classes today (`FileStorageOptions`, `PrintPickingListOptions`) to construct `BlobServiceClient` and `BlobContainerClient` instances. This composition-root pattern — where an adapter's own `IServiceCollection` extension method reaches into Application for strongly-typed configuration — is an established, accepted pattern elsewhere in this codebase (see e.g. `Anela.Heblo.Adapters.WebSearch`, `Anela.Heblo.Adapters.Microsoft365`, `Anela.Heblo.Adapters.Plaud`, all of which import `Anela.Heblo.Application.*` in their own `*AdapterServiceCollectionExtensions.cs`/module files). **This spec does not change that pattern and does not remove the adapter project's `ProjectReference` to Application.**
+- What is out of line with the rest of the codebase is a concrete *service implementation* (`AzureBlobStorageService`, not a DI-wiring/module class) reaching into Application for a plain string constant used in ordinary business logic. That is the specific defect this spec fixes.
+
+The codebase already has precedent for Domain-layer constant classes, e.g. `Anela.Heblo.Domain.Features.Purchase.PurchaseOrderConstants`, which holds `public const string` validation-message constants. This spec follows that established pattern rather than introducing a new options-injection mechanism, because the value in question is a fixed logical `HttpClient` name (not environment-specific configuration) shared as a compile-time identifier between the Application-layer registration (`services.AddHttpClient(name)`) and the Domain-typed adapter that resolves it (`IHttpClientFactory.CreateClient(name)`).
+
+## Functional Requirements
+
+### FR-1: Add a Domain-layer constant for the file-download `HttpClient` name
+Add a new type `FileStorageConstants` in namespace `Anela.Heblo.Domain.Features.FileStorage` (new file `backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs`, alongside the existing `IBlobStorageService.cs` in that folder), exposing:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.FileStorage;
+
+public static class FileStorageConstants
+{
+    /// <summary>
+    /// Logical name of the HttpClient (registered via IHttpClientFactory) used for
+    /// downloading files from external URLs before uploading them to blob storage.
+    /// </summary>
+    public const string FileDownloadClientName = "FileDownload";
+}
+```
+
+**Acceptance criteria:**
+- `Anela.Heblo.Domain.Features.FileStorage.FileStorageConstants.FileDownloadClientName` exists, is `public const string`, and equals `"FileDownload"` (unchanged value — no behavioral/runtime change).
+- The new file lives under `backend/src/Anela.Heblo.Domain/Features/FileStorage/`, matching the existing placement of `IBlobStorageService.cs`.
+- No new `ProjectReference` is required for `Anela.Heblo.Domain.csproj` itself (it has none today for this feature and needs none).
+
+### FR-2: Adapter consumes the Domain constant instead of the Application module
+Update `AzureBlobStorageService.cs` so it no longer references `Anela.Heblo.Application.Features.FileStorage.FileStorageModule` anywhere:
+- Remove `using Anela.Heblo.Application.Features.FileStorage;`.
+- Change line 39 to `var httpClient = _httpClientFactory.CreateClient(FileStorageConstants.FileDownloadClientName);`, relying on the existing `using Anela.Heblo.Domain.Features.FileStorage;` already present in the file.
+
+**Acceptance criteria:**
+- `AzureBlobStorageService.cs` contains no `using` directive and no fully-qualified reference to any `Anela.Heblo.Application.*` namespace or type.
+- `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` returns no matches.
+- The named `HttpClient` resolved by the adapter (`"FileDownload"`) is unchanged, so it still matches the client registered by `FileStorageModule.AddFileStorageModule` at startup — no behavioral regression.
+
+### FR-3: Preserve backward compatibility for existing Application-layer consumers
+`FileStorageModule.FileDownloadClientName` is also referenced today by `DownloadFromUrlHandler.cs` (Application layer, two call sites) and by several existing unit tests. These are Application-layer-to-Application-layer references and are architecturally fine as-is; they are not required to change. To avoid a duplicated magic string (one source of truth) while keeping every existing call site compiling unchanged, `FileStorageModule` keeps a `FileDownloadClientName` member but its value is sourced from the new Domain constant:
+
+```csharp
+public const string FileDownloadClientName = FileStorageConstants.FileDownloadClientName;
+```
+
+(A `const` may reference another `const` at compile time in C#, so this remains a compile-time constant — no behavioral change to `services.AddHttpClient(FileDownloadClientName)` in the same file.)
+
+**Acceptance criteria:**
+- `FileStorageModule.FileDownloadClientName` still exists, is still `public const string`, and still equals `"FileDownload"`.
+- `DownloadFromUrlHandler.cs` requires no code change and continues to compile and behave identically.
+- Existing test `FileStorageModuleTests.cs` line 102 (`Assert.Equal("FileDownload", FileStorageModule.FileDownloadClientName);`) continues to pass unmodified.
+
+### FR-4: Align the adapter's unit tests with its corrected dependency direction
+`AzureBlobStorageServiceTests.cs` (`backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`) currently imports `Anela.Heblo.Application.Features.FileStorage` and uses `FileStorageModule.FileDownloadClientName` in ten `Mock<IHttpClientFactory>` setup/verify calls (lines 31, 75, 87, 146, 171, 424, 453, 481, 507, 547, 574). Since the test project already has project references to every layer, this is not a compile-time architecture violation — but leaving it as-is would mean the test for an "adapter now depends only on Domain" fix still visibly depends on Application, which is confusing and undercuts the intent of the change. Update these references to `Anela.Heblo.Domain.Features.FileStorage.FileStorageConstants.FileDownloadClientName`, replacing the `using Anela.Heblo.Application.Features.FileStorage;` import with `using Anela.Heblo.Domain.Features.FileStorage;` (the latter is likely already needed/present given the test constructs `AzureBlobStorageService`).
+
+**Acceptance criteria:**
+- `AzureBlobStorageServiceTests.cs` contains no reference to `Anela.Heblo.Application.Features.FileStorage.FileStorageModule`.
+- All existing tests in `AzureBlobStorageServiceTests.cs` continue to pass unmodified in behavior (only the constant's source changes, not its value).
+
+### FR-5: No changes to DI registration, HttpClient behavior, or public contracts
+This is a pure internal refactor of where a constant is declared. No changes are required or permitted to:
+- `AzureAdapterModule.cs` (DI wiring stays as-is; its existing references to `Anela.Heblo.Application.Features.FileStorage` for `FileStorageOptions` are out of scope — see Background).
+- `FileStorageModule.AddFileStorageModule`'s `services.AddHttpClient(FileDownloadClientName)...` registration logic (socket pooling, timeout, decompression settings) — unchanged.
+- `IBlobStorageService`'s public interface — unchanged.
+- `Anela.Heblo.Adapters.Azure.csproj`'s `ProjectReference` to `Anela.Heblo.Application.csproj` — stays, because `AzureAdapterModule.cs` still needs it (see Background).
+
+**Acceptance criteria:**
+- `AzureAdapterModule.cs` diff is empty.
+- `FileStorageModule.AddFileStorageModule` method body is unchanged except for FR-3's one-line constant declaration.
+- `Anela.Heblo.Adapters.Azure.csproj` retains its `ProjectReference` to `Anela.Heblo.Application.csproj` (removing it would break `AzureAdapterModule.cs`'s existing, in-scope-elsewhere use of `FileStorageOptions`/`PrintPickingListOptions`).
+
+## Non-Functional Requirements
+
+### NFR-1: Build correctness
+`dotnet build` (full solution) and `dotnet format` must succeed with zero new errors or warnings after the change, per this repository's standard validation gate.
+
+### NFR-2: No runtime/behavioral change
+This is a compile-time-only refactor. The named `HttpClient` string value (`"FileDownload"`), its registration (pooled sockets, infinite `HttpClient.Timeout`, automatic decompression), and every consumer's runtime behavior must be byte-for-byte identical before and after. No new configuration keys, no new appsettings entries, no Key Vault changes.
+
+### NFR-3: Test coverage preserved
+All existing tests touching this area must pass unmodified in assertions (only import/reference changes per FR-4):
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/DownloadFromUrlHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/FileStorage/SimpleFileStorageTest.cs`
+
+### NFR-4: Architectural boundary verification
+Add (or run manually and record in the PR) a repo-wide grep to prove the fix:
+```bash
+git grep -n "Anela.Heblo.Application" -- backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+```
+Expected: empty output. This should be recorded as evidence in the PR description; a permanent architecture test (e.g. NetArchTest/dependency-graph assertion) is explicitly out of scope for this change (see Out of Scope).
+
+## Data Model
+Not applicable — this change introduces no new persisted or transmitted data structures. `FileStorageConstants` is a compile-time constant holder, not a domain entity.
+
+## API / Interface Design
+Not applicable — no public API surface (HTTP endpoints, MediatR requests, DTOs) changes. The only "interface" affected is the internal C# namespace/type from which `AzureBlobStorageService` sources one string constant:
+
+| Before | After |
+|---|---|
+| `Anela.Heblo.Application.Features.FileStorage.FileStorageModule.FileDownloadClientName` | `Anela.Heblo.Domain.Features.FileStorage.FileStorageConstants.FileDownloadClientName` |
+
+`Anela.Heblo.Application.Features.FileStorage.FileStorageModule.FileDownloadClientName` continues to exist (FR-3) as a forwarding const for existing Application-layer consumers.
+
+## Dependencies
+- No new NuGet packages.
+- No new `ProjectReference` entries required (Domain has no dependents to add; Adapter already sees Domain types transitively via its existing Application reference and already has a `using Anela.Heblo.Domain.Features.FileStorage;` directive in the target file for `IBlobStorageService`/`BlobItemInfo`).
+- Depends on the existing `PurchaseOrderConstants` precedent in `Anela.Heblo.Domain.Features.Purchase` only as a style reference, not a code dependency.
+
+## Out of Scope
+- Removing `Anela.Heblo.Adapters.Azure.csproj`'s `ProjectReference` to `Anela.Heblo.Application.csproj` entirely. `AzureAdapterModule.cs` still legitimately needs `FileStorageOptions` and `PrintPickingListOptions` from Application for its `IServiceCollection` wiring — a pattern used consistently by other adapters in this codebase (WebSearch, Microsoft365, Plaud, OrgChart, etc.). Changing that broader pattern is a separate, much larger architectural discussion and not part of this fix.
+- Adding a permanent automated architecture/dependency test (e.g., NetArchTest) that fails the build if any Adapter service implementation imports `Anela.Heblo.Application.*`. This spec only fixes the one known violation; introducing enforcement tooling is a separate initiative the team may pursue later.
+- Moving `FileStorageOptions`, `FileDownloadOptions`, or any other Application-layer FileStorage configuration classes to Domain. Only the single `FileDownloadClientName` string constant moves.
+- Renaming the `"FileDownload"` HttpClient logical name itself.
+- Any change to `DownloadFromUrlHandler.cs` — it stays on `FileStorageModule.FileDownloadClientName` (Application-to-Application reference, architecturally valid).
+- Auditing or fixing the other ~39 files across the codebase found to `using Anela.Heblo.Application.*` from Adapter projects (per repository grep during investigation) — most of those are legitimate DI-wiring/module files (`*AdapterServiceCollectionExtensions.cs`), not service implementations reaching into Application for business-logic constants. A broader audit is future work, not part of this fix.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-17T07:21:29.807411Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T07:21:52.270448Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3674",
+  "issue_number": 3674,
+  "created_at": "2026-07-17T07:14:41.581619Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T07:18:11.780619Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-filestorage-adapter-application-dependency",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-17T07:21:07.949655Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T07:21:29.807411Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-17T07:21:52.270448Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-17T07:22:12.242968Z"
     }
   },
   "tasks": [
     {
       "name": "fix-filestorage-adapter-application-dependency",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-17T07:22:12.450732Z"
     }
   ]
 }

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-17T08:01:04.705913Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-17T08:01:08.891134Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-17T07:18:11.780619Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-17T07:21:07.949655Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3674/state.json
+++ b/artifacts/feat-3674/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-17T07:21:52.270448Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-17T07:22:12.242968Z"
+      "status": "completed",
+      "updated_at": "2026-07-17T08:01:04.705913Z"
     }
   },
   "tasks": [
     {
       "name": "fix-filestorage-adapter-application-dependency",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-17T07:22:12.450732Z"
+      "updated_at": "2026-07-17T08:01:00.211868Z"
     }
   ]
 }

--- a/artifacts/feat-3674/task-context/fix-filestorage-adapter-application-dependency.md
+++ b/artifacts/feat-3674/task-context/fix-filestorage-adapter-application-dependency.md
@@ -1,0 +1,46 @@
+
+## Goal
+Remove `AzureBlobStorageService`'s compile-time dependency on the Application-layer `FileStorageModule` by introducing a Domain-layer constant, while preserving full backward compatibility for existing Application-layer consumers and tests.
+
+## Steps
+
+1. **Add the Domain constant.** Create `backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs`:
+   ```csharp
+   namespace Anela.Heblo.Domain.Features.FileStorage;
+
+   public static class FileStorageConstants
+   {
+       public const string FileDownloadClientName = "FileDownload";
+   }
+   ```
+
+2. **Update the adapter.** In `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`:
+   - Remove `using Anela.Heblo.Application.Features.FileStorage;`.
+   - Change the `_httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName)` call to `_httpClientFactory.CreateClient(FileStorageConstants.FileDownloadClientName)`, relying on the file's existing `using Anela.Heblo.Domain.Features.FileStorage;`.
+   - Verify with `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` — must return no matches.
+
+3. **Make `FileStorageModule.FileDownloadClientName` a forwarding const.** In `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`, change:
+   ```csharp
+   public const string FileDownloadClientName = "FileDownload";
+   ```
+   to:
+   ```csharp
+   public const string FileDownloadClientName = FileStorageConstants.FileDownloadClientName;
+   ```
+   (Add `using Anela.Heblo.Domain.Features.FileStorage;` if not already present in this file.) `services.AddHttpClient(FileDownloadClientName)...` registration body stays unchanged.
+
+4. **Update the adapter's unit tests.** In `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`:
+   - Replace `using Anela.Heblo.Application.Features.FileStorage;` with `using Anela.Heblo.Domain.Features.FileStorage;` (if not already present).
+   - Replace all ~11 occurrences of `FileStorageModule.FileDownloadClientName` with `FileStorageConstants.FileDownloadClientName`.
+
+5. **Leave untouched:** `AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, `FileStorageModuleTests.cs`, `DownloadFromUrlHandlerTests.cs`, `SimpleFileStorageTest.cs`, and all `.csproj` files.
+
+## Acceptance criteria
+- `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` returns empty.
+- `dotnet build` succeeds with zero new errors/warnings.
+- `dotnet format` produces no diff.
+- All tests in `backend/test/Anela.Heblo.Tests/Features/FileStorage/` pass (`AzureBlobStorageServiceTests.cs`, `FileStorageModuleTests.cs`, `DownloadFromUrlHandlerTests.cs`, `SimpleFileStorageTest.cs`), assertions unchanged.
+- `FileStorageModuleTests.cs` line asserting `Assert.Equal("FileDownload", FileStorageModule.FileDownloadClientName)` passes unmodified.
+- No diff in `AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, or any `.csproj`.
+
+## Status: COMPLETE

--- a/artifacts/feat-3674/task-plan.r1.md
+++ b/artifacts/feat-3674/task-plan.r1.md
@@ -1,0 +1,51 @@
+# Task Plan: Remove Azure Adapter's Compile-Time Dependency on the Application Layer (FileStorage)
+
+Single cohesive task — the change touches four tightly-related files and cannot be usefully split without leaving the build broken between tasks.
+
+### task: fix-filestorage-adapter-application-dependency
+
+## Goal
+Remove `AzureBlobStorageService`'s compile-time dependency on the Application-layer `FileStorageModule` by introducing a Domain-layer constant, while preserving full backward compatibility for existing Application-layer consumers and tests.
+
+## Steps
+
+1. **Add the Domain constant.** Create `backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs`:
+   ```csharp
+   namespace Anela.Heblo.Domain.Features.FileStorage;
+
+   public static class FileStorageConstants
+   {
+       public const string FileDownloadClientName = "FileDownload";
+   }
+   ```
+
+2. **Update the adapter.** In `backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs`:
+   - Remove `using Anela.Heblo.Application.Features.FileStorage;`.
+   - Change the `_httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName)` call to `_httpClientFactory.CreateClient(FileStorageConstants.FileDownloadClientName)`, relying on the file's existing `using Anela.Heblo.Domain.Features.FileStorage;`.
+   - Verify with `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` — must return no matches.
+
+3. **Make `FileStorageModule.FileDownloadClientName` a forwarding const.** In `backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs`, change:
+   ```csharp
+   public const string FileDownloadClientName = "FileDownload";
+   ```
+   to:
+   ```csharp
+   public const string FileDownloadClientName = FileStorageConstants.FileDownloadClientName;
+   ```
+   (Add `using Anela.Heblo.Domain.Features.FileStorage;` if not already present in this file.) `services.AddHttpClient(FileDownloadClientName)...` registration body stays unchanged.
+
+4. **Update the adapter's unit tests.** In `backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs`:
+   - Replace `using Anela.Heblo.Application.Features.FileStorage;` with `using Anela.Heblo.Domain.Features.FileStorage;` (if not already present).
+   - Replace all ~11 occurrences of `FileStorageModule.FileDownloadClientName` with `FileStorageConstants.FileDownloadClientName`.
+
+5. **Leave untouched:** `AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, `FileStorageModuleTests.cs`, `DownloadFromUrlHandlerTests.cs`, `SimpleFileStorageTest.cs`, and all `.csproj` files.
+
+## Acceptance criteria
+- `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` returns empty.
+- `dotnet build` succeeds with zero new errors/warnings.
+- `dotnet format` produces no diff.
+- All tests in `backend/test/Anela.Heblo.Tests/Features/FileStorage/` pass (`AzureBlobStorageServiceTests.cs`, `FileStorageModuleTests.cs`, `DownloadFromUrlHandlerTests.cs`, `SimpleFileStorageTest.cs`), assertions unchanged.
+- `FileStorageModuleTests.cs` line asserting `Assert.Equal("FileDownload", FileStorageModule.FileDownloadClientName)` passes unmodified.
+- No diff in `AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, or any `.csproj`.
+
+## Status: COMPLETE

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Anela.Heblo.Application.Features.FileStorage;
 using Anela.Heblo.Domain.Features.FileStorage;
 using Microsoft.Extensions.Logging;
 
@@ -36,7 +35,7 @@ public sealed class AzureBlobStorageService : IBlobStorageService
 
             // Download file from URL — resolve the named client per call so socket pooling
             // is managed by IHttpClientFactory (SocketsHttpHandler with PooledConnectionLifetime).
-            var httpClient = _httpClientFactory.CreateClient(FileStorageModule.FileDownloadClientName);
+            var httpClient = _httpClientFactory.CreateClient(FileStorageConstants.FileDownloadClientName);
             using var response = await httpClient.GetAsync(fileUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();
 

--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
@@ -11,7 +11,7 @@ namespace Anela.Heblo.Application.Features.FileStorage;
 
 public static class FileStorageModule
 {
-    public const string FileDownloadClientName = "FileDownload";
+    public const string FileDownloadClientName = FileStorageConstants.FileDownloadClientName;
 
     public static IServiceCollection AddFileStorageModule(
         this IServiceCollection services,

--- a/backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Domain.Features.FileStorage;
+
+public static class FileStorageConstants
+{
+    public const string FileDownloadClientName = "FileDownload";
+}

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
@@ -1,5 +1,5 @@
 using Anela.Heblo.Adapters.Azure.Features.FileStorage;
-using Anela.Heblo.Application.Features.FileStorage;
+using Anela.Heblo.Domain.Features.FileStorage;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -28,7 +28,7 @@ public class AzureBlobStorageServiceTests
         var httpClient = new HttpClient(_stubHandler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory = new Mock<IHttpClientFactory>();
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
             .Returns(httpClient);
 
         _service = new AzureBlobStorageService(
@@ -72,7 +72,7 @@ public class AzureBlobStorageServiceTests
 
         // Assert — factory must have been asked for the named client exactly once
         _mockHttpClientFactory.Verify(
-            f => f.CreateClient(FileStorageModule.FileDownloadClientName),
+            f => f.CreateClient(FileStorageConstants.FileDownloadClientName),
             Times.Once);
     }
 
@@ -84,7 +84,7 @@ public class AzureBlobStorageServiceTests
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
 
         var factory = new Mock<IHttpClientFactory>();
-        factory.Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+        factory.Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
                .Returns(client);
 
         var service = new AzureBlobStorageService(
@@ -143,7 +143,7 @@ public class AzureBlobStorageServiceTests
         var handler = BuildNoContentTypeHandler();
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
             .Returns(client);
 
         SetupContainerAndBlobClient(containerName, out _, out var blobMock, out _);
@@ -168,7 +168,7 @@ public class AzureBlobStorageServiceTests
         var handler = BuildNoContentTypeHandler();
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
             .Returns(client);
 
         SetupContainerAndBlobClient(containerName, out _, out var blobMock, out _);
@@ -421,7 +421,7 @@ public class AzureBlobStorageServiceTests
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
 
         var factory = new Mock<IHttpClientFactory>();
-        factory.Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+        factory.Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
                .Returns(client);
 
         var service = new AzureBlobStorageService(
@@ -450,7 +450,7 @@ public class AzureBlobStorageServiceTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, "test content");
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
             .Returns(client);
 
         SetupContainerAndBlobClient(containerName, out _, out _, out var capturedBlobNames);
@@ -478,7 +478,7 @@ public class AzureBlobStorageServiceTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, overrideContent: responseContent);
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
             .Returns(client);
 
         SetupContainerAndBlobClient(containerName, out _, out _, out var capturedBlobNames);
@@ -504,7 +504,7 @@ public class AzureBlobStorageServiceTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, overrideContent: responseContent);
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
             .Returns(client);
 
         SetupContainerAndBlobClient(containerName, out _, out _, out var capturedBlobNames);
@@ -544,7 +544,7 @@ public class AzureBlobStorageServiceTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, overrideContent: responseContent);
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         _mockHttpClientFactory
-            .Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName))
+            .Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName))
             .Returns(client);
 
         SetupContainerAndBlobClient(containerName, out _, out _, out var capturedBlobNames);
@@ -571,7 +571,7 @@ public class AzureBlobStorageServiceTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, "test content");
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://test/") };
         var factory = new Mock<IHttpClientFactory>();
-        factory.Setup(f => f.CreateClient(FileStorageModule.FileDownloadClientName)).Returns(client);
+        factory.Setup(f => f.CreateClient(FileStorageConstants.FileDownloadClientName)).Returns(client);
 
         var service = new AzureBlobStorageService(
             mockBlobServiceClient.Object,


### PR DESCRIPTION
Closes #3674

## What the issue was
`AzureBlobStorageService` (an infrastructure/adapter-layer service implementing `IBlobStorageService`) imported `Anela.Heblo.Application.Features.FileStorage.FileStorageModule` solely to read the string constant `FileDownloadClientName` ("FileDownload") used to resolve a named `HttpClient`. This violated Clean Architecture's dependency rule — adapters must depend inward on Domain, never on Application — creating an avoidable coupling where an unrelated refactor of `FileStorageModule` could break the Azure adapter.

## How it was fixed / handled
- Added a new `FileStorageConstants` class in the Domain layer (`backend/src/Anela.Heblo.Domain/Features/FileStorage/FileStorageConstants.cs`) holding `FileDownloadClientName`, following the existing `PurchaseOrderConstants` precedent for Domain-layer constant classes.
- `AzureBlobStorageService.cs` now resolves the named `HttpClient` via `FileStorageConstants.FileDownloadClientName` and no longer references the Application layer at all.
- `FileStorageModule.FileDownloadClientName` is kept as a forwarding const (`= FileStorageConstants.FileDownloadClientName`) so existing Application-layer consumers (`DownloadFromUrlHandler.cs`, `FileStorageModuleTests.cs`) need zero changes — this is a pure compile-time relocation, no runtime/behavioral change.
- `AzureBlobStorageServiceTests.cs` updated to reference the Domain constant instead of the Application one.

Verification: `git grep -n "Anela.Heblo.Application" backend/src/Adapters/Anela.Heblo.Adapters.Azure/Features/FileStorage/AzureBlobStorageService.cs` returns no matches. `dotnet build` succeeds, `dotnet format --verify-no-changes` is clean, and all 116 FileStorage-scoped tests pass.

`AzureAdapterModule.cs`, `IBlobStorageService.cs`, `DownloadFromUrlHandler.cs`, and all `.csproj` files are untouched — out of scope per the spec (the adapter project's `ProjectReference` to Application is still legitimately needed by `AzureAdapterModule.cs`'s DI wiring, an established pattern used by other adapters in this codebase).

## Artifacts
Brief, spec, arch review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3674/` in this branch.

## Code review

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

The diff is a minimal, mechanical constant relocation with no scope creep. No blocking findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Zy9Tn4JZaZcEuebRXi5d)_