### PR TITLE
feat: post GOODYDO0001 gift lines to account 325002 on Abra Flexi export

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiInvoiceMappingProfile.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiInvoiceMappingProfile.cs
@@ -8,6 +8,9 @@ namespace Anela.Heblo.Adapters.Flexi.Invoices;
 
 public class FlexiInvoiceMappingProfile : BaseFlexiProfile
 {
+    private const string GiftGoodyProductCode = "GOODYDO0001";
+    private const string GiftBaseCreditAccount = "code:325002"; // zklDalUcet for GOODYDO0001 gifts
+
     public FlexiInvoiceMappingProfile()
     {
 
@@ -65,6 +68,7 @@ public class FlexiInvoiceMappingProfile : BaseFlexiProfile
             .ForMember(dest => dest.PriceList, opt => opt.MapFrom(src => string.IsNullOrEmpty(src.Code) || src.Code.StartsWith("SHIPPING") || src.Code.StartsWith("BILLING") ? null : $"code:{src.Code}"))
             .ForMember(dest => dest.Store, opt => opt.MapFrom(src => src.IsNonStock || string.IsNullOrEmpty(src.Code) || src.Code.StartsWith("SHIPPING") || src.Code.StartsWith("BILLING") ? null : "code:ZBOZI"))
             .ForMember(dest => dest.VatRateType, opt => opt.MapFrom(src => MapVatRateType(src.ItemPrice.VatRate)))
+            .ForMember(dest => dest.AccountBaseDal, opt => opt.MapFrom(src => src.Code == GiftGoodyProductCode ? GiftBaseCreditAccount : null))
             .ForMember(dest => dest.PriceVatType, opt => opt.MapFrom(src => "typCeny.bezDph"))
             .ForMember(dest => dest.CopyCategoryVatReport, opt => opt.MapFrom(src => true))
             .ForMember(dest => dest.CopyCategoryVat, opt => opt.MapFrom(src => true));

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Invoices/FlexiInvoiceMappingProfileGiftAccountTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Invoices/FlexiInvoiceMappingProfileGiftAccountTests.cs
@@ -1,0 +1,85 @@
+using Anela.Heblo.Adapters.Flexi.Invoices;
+using Anela.Heblo.Domain.Features.Invoices;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Rem.FlexiBeeSDK.Model.Invoices;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Invoices;
+
+public class FlexiInvoiceMappingProfileGiftAccountTests
+{
+    private const string GiftProductCode = "GOODYDO0001";
+
+    private static IssuedInvoiceDetailFlexiDto MapSingleItem(string itemCode)
+    {
+        var config = new MapperConfiguration(
+            c => c.AddProfile<FlexiInvoiceMappingProfile>(),
+            NullLoggerFactory.Instance);
+        var mapper = config.CreateMapper();
+
+        var domain = new IssuedInvoiceDetail
+        {
+            Code = "INV1",
+            OrderCode = "ORD1",
+            Customer = new InvoiceCustomer { Name = "Test" },
+            BillingAddress = new InvoiceAddress { Street = "S", City = "C", CountryCode = "CZ" },
+            DeliveryAddress = new InvoiceAddress { Street = "S", City = "C", CountryCode = "CZ" },
+            Price = new InvoicePrice { CurrencyCode = "CZK", WithoutVat = 100m, WithVat = 112m, Vat = 12m },
+            Items = new List<IssuedInvoiceDetailItem>
+            {
+                new()
+                {
+                    Code = itemCode,
+                    Name = "Item",
+                    Amount = 1m,
+                    ItemPrice = new InvoicePrice
+                    {
+                        CurrencyCode = "CZK",
+                        WithoutVat = 100m,
+                        WithVat = 112m,
+                        Vat = 12m,
+                        TotalWithoutVat = 100m,
+                        TotalWithVat = 112m,
+                        VatRate = "high",
+                    },
+                }
+            },
+        };
+
+        return mapper.Map<IssuedInvoiceDetailFlexiDto>(domain);
+    }
+
+    [Fact]
+    public void Map_SetsBaseCreditAccount_ForGiftProduct()
+    {
+        // Act
+        var flexi = MapSingleItem(GiftProductCode);
+
+        // Assert
+        flexi.Items.Should().HaveCount(1);
+        flexi.Items[0].AccountBaseDal.Should().Be("code:325002");
+    }
+
+    [Fact]
+    public void Map_LeavesDphToAbra_ForGiftProduct()
+    {
+        // Act
+        var flexi = MapSingleItem(GiftProductCode);
+
+        // Assert — DPH classification stays owned by the Abra product config
+        flexi.Items[0].CopyCategoryVat.Should().BeTrue();
+        flexi.Items[0].CategoryVat.Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_DoesNotSetBaseCreditAccount_ForNonGiftProduct()
+    {
+        // Act
+        var flexi = MapSingleItem("P1");
+
+        // Assert
+        flexi.Items[0].AccountBaseDal.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## What

Gift product **GOODYDO0001** on issued invoices must post its base amount to account **325002** (`zklDalUcet`) with DPH kód **000U**. Since this DAL account cannot be configured on the ceník item in Abra Flexi, the invoice-export mapper (`FlexiInvoiceMappingProfile`) now forces `AccountBaseDal = code:325002` for that single product code, leaving every other line untouched. DPH kód 000U stays owned by the Abra product config via the existing `CopyCategoryVat = true`, so no VAT logic changes here. Added `FlexiInvoiceMappingProfileGiftAccountTests` covering the gift line (325002 set), a non-gift line (unset), and the DPH-still-copied regression.

## Notes

Affects **future** imports only; already-imported July 2026 doklady need a bulk přeúčtování in Abra. Verify against staging after deploy that the doklad posts base → 325002 (DAL) + DPH 000U — this also confirms the `code:325002` account-reference format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)