### PR TITLE
fix: grant E2E synthetic user super_user role to restore nightly E2E auth (#3680)

### DIFF
--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs
@@ -83,6 +83,14 @@ public class E2ESessionService : IE2ESessionService
             new Claim("oid", "e2e-test-object-id"),
             new Claim("tid", environmentName), // Use environment as tenant for testing
             new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
+            // E2E test user is a super_user: full access via the same wildcard path as mock
+            // auth (MockAuthenticationHandler) and production break-glass. This is what
+            // populates the frontend permission list from /api/auth/me (GetMeHandler returns
+            // the wildcard for super_user), which the sidebar/RequireMenuPath gate on. Without
+            // it the nav collapses to Dashboard and every role-gated E2E page times out (#3680).
+            // The per-module role claims below are now redundant under super_user but kept as
+            // harmless defense-in-depth.
+            new Claim(ClaimTypes.Role, AccessRoles.SuperUser),
             new Claim("scp", "access_as_user"),
             // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.
             // FeatureAuthorize checks the role claim (permission strings were renamed away from the

--- a/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs
@@ -83,13 +83,7 @@ public class E2ESessionService : IE2ESessionService
             new Claim("oid", "e2e-test-object-id"),
             new Claim("tid", environmentName), // Use environment as tenant for testing
             new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
-            // E2E test user is a super_user: full access via the same wildcard path as mock
-            // auth (MockAuthenticationHandler) and production break-glass. This is what
-            // populates the frontend permission list from /api/auth/me (GetMeHandler returns
-            // the wildcard for super_user), which the sidebar/RequireMenuPath gate on. Without
-            // it the nav collapses to Dashboard and every role-gated E2E page times out (#3680).
-            // The per-module role claims below are now redundant under super_user but kept as
-            // harmless defense-in-depth.
+            // super_user routes /api/auth/me through the wildcard, populating full permissions for E2E sidebar (#3680).
             new Claim(ClaimTypes.Role, AccessRoles.SuperUser),
             new Claim("scp", "access_as_user"),
             // Grant the finance overview read role so E2E tests can reach /api/FinancialOverview.

--- a/backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs
@@ -50,4 +50,17 @@ public class E2ESessionServiceTests
         claims.Should().Contain(c =>
             c.Type == ClaimTypes.Email && c.Value == "e2e-test@anela-heblo.com");
     }
+
+    [Fact]
+    public void CreateSyntheticUserClaims_IncludesSuperUserRole()
+    {
+        // E2E test user must be super_user so GET /api/auth/me returns the full
+        // permission wildcard and the frontend sidebar/nav renders (issue #3680).
+        var sut = CreateSut();
+
+        var claims = sut.CreateSyntheticUserClaims("Staging");
+
+        claims.Should().Contain(c =>
+            c.Type == ClaimTypes.Role && c.Value == AccessRoles.SuperUser);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs
@@ -54,8 +54,7 @@ public class E2ESessionServiceTests
     [Fact]
     public void CreateSyntheticUserClaims_IncludesSuperUserRole()
     {
-        // E2E test user must be super_user so GET /api/auth/me returns the full
-        // permission wildcard and the frontend sidebar/nav renders (issue #3680).
+        // super_user claim required so /api/auth/me returns full permissions (#3680).
         var sut = CreateSut();
 
         var claims = sut.CreateSyntheticUserClaims("Staging");

--- a/docs/superpowers/plans/2026-07-17-fix-nightly-e2e-unauthenticated.md
+++ b/docs/superpowers/plans/2026-07-17-fix-nightly-e2e-unauthenticated.md
@@ -1,0 +1,133 @@
+# Fix Nightly E2E Unauthenticated (issue #3680) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Grant the E2E test synthetic user the `super_user` role so `/api/auth/me` returns full permissions, restoring the sidebar/nav in E2E runs and clearing ~321 nightly failures.
+
+**Architecture:** The frontend nav is gated by the permission list returned from `GET /api/auth/me` (`GetMeHandler`), which returns all permissions only for `super_user`; otherwise it uses the DB permission resolver, which returns empty for the unknown E2E synthetic user. The E2E synthetic user (`E2ESessionService.CreateSyntheticUserClaims`) currently has `Base` + piecemeal per-module role claims but not `super_user`, so `/api/auth/me` returns empty permissions and the sidebar collapses to Dashboard. Adding a single `super_user` role claim routes the E2E user through the existing wildcard path (identical to how `MockAuthenticationHandler` treats mock users), populating the full permission list.
+
+**Tech Stack:** .NET 8, xUnit + FluentAssertions + Moq, MediatR. Backend-only change; no frontend or workflow changes.
+
+---
+
+## Root Cause (why this is the fix)
+
+- Failing run [#29553600888](https://github.com/onpaj/Anela.Heblo/actions/runs/29553600888) log shows backend E2E auth **succeeds**: `✅ E2E authentication successful on attempt 1` (cookie issued). Live staging confirms `env-info` → `Staging` and `POST /api/e2etest/auth` (no token) → `400` (endpoints enabled).
+- Reproduced live: browser to `https://heblo.stg.anela.cz/?e2e=true` → `isE2ETestMode()`=true, `useE2EAuth` authenticates client-side, yet `GET /api/auth/me` → 401/empty and sidebar shows only **Dashboard**.
+- `GetMeHandler` (`backend/src/Anela.Heblo.Application/Features/Authorization/UseCases/GetMe/GetMeHandler.cs`): returns `AccessMatrix.AllRoleValues().Append(Base)` only when `IsInRole(SuperUser)`; else calls `IPermissionResolver.ResolveAsync(...)` which "Returns empty for inactive/unknown users."
+- `E2ESessionService.CreateSyntheticUserClaims` has no `AccessRoles.SuperUser` claim → empty permissions → nav gone. `PermissionClaimsTransformation` (lines 58-66) grants `super_user` the wildcard regardless of DB. `MockAuthenticationHandler.cs:38-42` already does exactly this for mock users.
+- Workflow env/secrets are unchanged vs `b286a66^`; that commit only made result-counting honest, unmasking this pre-existing break.
+
+## File Structure
+
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs` — add one `super_user` role claim in `CreateSyntheticUserClaims`. One responsibility: build the E2E synthetic identity.
+- Modify (test): `backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs` — add a regression `[Fact]` asserting the `super_user` claim is present.
+- Reference only (no change): `GetMeHandler.cs` (already returns all permissions for super_user, proven by `GetMeHandlerTests.Handle_SuperUser_ReturnsAllPermissionsAndIsSuperUser`), `PermissionClaimsTransformation.cs`, `MockAuthenticationHandler.cs`, `frontend/src/auth/PermissionsContext.tsx`, `frontend/src/api/hooks/usePermissions.ts`.
+
+## Non-goals
+
+- Do **not** delete the existing per-module role claims (they become redundant under `super_user`, but removal is deferred to keep this surgical).
+- `baleni`'s 3 non-auth failures are a separate fixture issue — out of scope.
+- No frontend, workflow, or `appsettings` changes.
+
+---
+
+### Task 1: Grant the E2E synthetic user the `super_user` role
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs` (inside `CreateSyntheticUserClaims`, right after the `AccessRoles.Base` claim)
+- Test: `backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add this `[Fact]` to `backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs` (after the existing `CreateSyntheticUserClaims_StillIncludesExistingRoles_RegressionGuard` test, before the closing brace):
+
+```csharp
+    [Fact]
+    public void CreateSyntheticUserClaims_IncludesSuperUserRole()
+    {
+        // E2E test user must be super_user so GET /api/auth/me returns the full
+        // permission wildcard and the frontend sidebar/nav renders (issue #3680).
+        var sut = CreateSut();
+
+        var claims = sut.CreateSyntheticUserClaims("Staging");
+
+        claims.Should().Contain(c =>
+            c.Type == ClaimTypes.Role && c.Value == AccessRoles.SuperUser);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~E2ESessionServiceTests.CreateSyntheticUserClaims_IncludesSuperUserRole"
+```
+Expected: FAIL — assertion "Expected claims to contain ... super_user" (the claim is not yet present).
+
+- [ ] **Step 3: Add the `super_user` claim (minimal implementation)**
+
+In `backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs`, locate the existing line inside `CreateSyntheticUserClaims`:
+
+```csharp
+            new Claim(ClaimTypes.Role, AccessRoles.Base), // Base role for application access
+```
+
+Insert immediately **after** it:
+
+```csharp
+            // E2E test user is a super_user: full access via the same wildcard path as mock
+            // auth (MockAuthenticationHandler) and production break-glass. This is what
+            // populates the frontend permission list from /api/auth/me (GetMeHandler returns
+            // the wildcard for super_user), which the sidebar/RequireMenuPath gate on. Without
+            // it the nav collapses to Dashboard and every role-gated E2E page times out (#3680).
+            // The per-module role claims below are now redundant under super_user but kept as
+            // harmless defense-in-depth.
+            new Claim(ClaimTypes.Role, AccessRoles.SuperUser),
+```
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~E2ESessionServiceTests.CreateSyntheticUserClaims_IncludesSuperUserRole"
+```
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Run the full authorization test suite to confirm no regressions**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Authorization"
+```
+Expected: PASS — including the existing `E2ESessionServiceTests.*`, `GetMeHandlerTests.Handle_SuperUser_ReturnsAllPermissionsAndIsSuperUser` (which already proves super_user → full permissions), and `GetMeHandlerTests.Handle_RegularUser_*`. The existing E2E claim tests use `.Should().Contain(...)` (presence checks) and remain green.
+
+- [ ] **Step 6: Build and format**
+
+Run:
+```bash
+cd backend && dotnet build && dotnet format --verify-no-changes
+```
+Expected: Build succeeded, 0 warnings/errors; format reports no changes (run `dotnet format` without the flag first if it reports differences).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Authentication/E2ESessionService.cs \
+        backend/test/Anela.Heblo.Tests/Authorization/E2ESessionServiceTests.cs
+git commit -m "fix: grant E2E synthetic user super_user so /api/auth/me returns full permissions (#3680)"
+```
+
+---
+
+## Post-merge verification (requires staging deploy)
+
+The E2E cookie flow needs the deployed staging image, so full end-to-end confirmation happens after deploy:
+
+1. Trigger `e2e-nightly-regression.yml` via `workflow_dispatch` for a single module (e.g. `core` or `stock-operations`).
+2. Confirm the run's page snapshots show the full sidebar (Katalog, Sklad, Marketing, Administrace) and contain **no** "Click to authenticate".
+3. Manual smoke (once deployed): establish the E2E session (`POST /api/e2etest/auth` with a valid SP bearer token, set `sessionStorage['e2e-test-token']`), load `?e2e=true`, and confirm `GET /api/auth/me` returns `isSuperUser: true` with a non-empty `permissions` array and the sidebar renders all modules.
+4. **Definition of done (#3680):** nightly (or single-module) re-run shows the full sidebar, no "Click to authenticate" in snapshots, and the ~321 auth-symptom failures clear.

--- a/memory/gotchas/e2e-nav-gates-on-auth-me-permissions.md
+++ b/memory/gotchas/e2e-nav-gates-on-auth-me-permissions.md
@@ -1,0 +1,19 @@
+# E2E frontend nav gates on /api/auth/me permissions, not client-side roles
+
+## Symptom
+Nightly E2E renders the app "unauthenticated": sidebar shows only Dashboard, "Click to authenticate" everywhere, ~all role-gated module tests time out. Easy to misdiagnose as a workflow/secret regression (issue #3680 blamed the per-module matrix split). It is NOT: the workflow env/secrets were unchanged, and the backend E2E auth actually *succeeds* (`✅ E2E authentication successful`, SP token valid, `/api/e2etest/auth` issues the cookie, `env-info` → Staging).
+
+## Root cause
+The frontend sidebar/nav is gated by the **permission list from `GET /api/auth/me`** via `usePermissionsContext().hasPermission(...)` (`frontend/src/auth/PermissionsContext.tsx` → `usePermissions` → `client.auth_Me()`), **not** by the client-side `E2E_USER` roles in `frontend/src/auth/e2eAuth.ts`.
+
+`GetMeHandler` returns the full permission set **only for `super_user`**; otherwise it calls `IPermissionResolver.ResolveAsync(...)`, which "returns empty for inactive/unknown users." The E2E synthetic user (`E2ESessionService.CreateSyntheticUserClaims`, `oid=e2e-test-object-id`) is not a DB user and had `Base` + per-module role claims but **not `super_user`** → `/api/auth/me` returned empty permissions → nav collapsed.
+
+Per-module `ClaimTypes.Role` claims only satisfy API `[FeatureAuthorize]` endpoint gates (that's why Dashboard tiles loaded data) — they never populate the `/api/auth/me` permission list. Adding one role per module (commits #3540, #3542, #3670) was whack-a-mole at the wrong layer.
+
+## Fix
+Add `new Claim(ClaimTypes.Role, AccessRoles.SuperUser)` to `CreateSyntheticUserClaims` — same wildcard path `MockAuthenticationHandler` already uses for mock users. `PermissionClaimsTransformation` + `GetMeHandler` then grant the wildcard regardless of DB. (PR #3684)
+
+## Fast repro (no secrets needed)
+Browser to `https://heblo.stg.anela.cz/?e2e=true`: `isE2ETestMode()` is true and `useE2EAuth` authenticates client-side, but `GET /api/auth/me` → 401/empty and the sidebar is Dashboard-only. Pre-fix vs post-fix is visible here without the E2E cookie flow.
+
+Related: [[e2e-auth-navigatetoapp-vs-createe2eauthsession]].


### PR DESCRIPTION
## Summary

Fixes #3680, where ~321 of 357 nightly E2E tests failed because the app rendered unauthenticated (sidebar collapsed to Dashboard-only, "Click to authenticate" everywhere). Investigation ruled out the suspected workflow/secret regression — backend E2E auth actually succeeds — and traced the real cause to `/api/auth/me` returning empty permissions for the E2E synthetic user: the frontend nav gates on that permission list, and `GetMeHandler` only returns the full set for `super_user`, otherwise falling back to the DB resolver which is empty for the unknown synthetic user. This grants the E2E synthetic user the `super_user` role in `E2ESessionService.CreateSyntheticUserClaims` (mirroring how `MockAuthenticationHandler` already treats mock users), plus a TDD regression test asserting the claim; the existing per-module role claims are kept as harmless defense-in-depth. Verified live against staging (`?e2e=true` reproduced the empty-permission failure) and by the existing `GetMeHandlerTests` proving `super_user` → full permissions.

## Verification
- Backend: `dotnet build` + `dotnet format` clean; Authorization suite 129 passing (TDD RED→GREEN).
- Post-deploy: re-run one E2E module on staging and confirm the full sidebar renders with no "Click to authenticate".