### PR TITLE
#3685: rename Hangfire-coupled interfaces to technology-agnostic names

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -356,9 +356,9 @@ public static class ServiceCollectionExtensions
         // Register Hangfire adapter implementations (interfaces live in Application,
         // concrete types live in API/Infrastructure/Hangfire — relocated to keep the
         // Application project free of Hangfire imports for these specific adapters).
-        services.AddScoped<IHangfireJobEnqueuer, HangfireJobEnqueuer>();
+        services.AddScoped<IJobEnqueuer, HangfireJobEnqueuer>();
         services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>();
-        services.AddSingleton<IHangfireRecurringJobScheduler, HangfireRecurringJobScheduler>();
+        services.AddSingleton<ICronScheduler, HangfireRecurringJobScheduler>();
 
         // Note: IRecurringJobStatusChecker is now registered in Application layer (BackgroundJobsModule)
 

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobEnqueuer.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobEnqueuer.cs
@@ -11,7 +11,7 @@ namespace Anela.Heblo.API.Infrastructure.Hangfire;
 /// Service responsible for enqueueing recurring jobs via Hangfire using reflection.
 /// Uses reflection to dynamically call IBackgroundJobClient.Enqueue with proper generic type resolution.
 /// </summary>
-public class HangfireJobEnqueuer : IHangfireJobEnqueuer
+public class HangfireJobEnqueuer : IJobEnqueuer
 {
     private readonly ILogger<HangfireJobEnqueuer> _logger;
     private readonly IBackgroundJobClient _backgroundJobClient;

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireRecurringJobScheduler.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireRecurringJobScheduler.cs
@@ -10,7 +10,7 @@ namespace Anela.Heblo.API.Infrastructure.Hangfire;
 /// <see cref="HangfireJobRegistrationHelper"/> so the runtime-update path uses
 /// the same registration code as startup discovery.
 /// </summary>
-public class HangfireRecurringJobScheduler : IHangfireRecurringJobScheduler
+public class HangfireRecurringJobScheduler : ICronScheduler
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<HangfireRecurringJobScheduler> _logger;

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/BackgroundJobsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/BackgroundJobsModule.cs
@@ -16,7 +16,7 @@ public static class BackgroundJobsModule
         services.AddScoped<IRecurringJobConfigurationRepository, RecurringJobConfigurationRepository>();
         // Startup-only seeding service (Application layer, wraps the repository)
         services.AddScoped<IRecurringJobSeeder, RecurringJobSeeder>();
-        // Hangfire adapter implementations (IHangfireJobEnqueuer, IHangfireRecurringJobScheduler)
+        // Hangfire adapter implementations (IJobEnqueuer, ICronScheduler)
         // are registered in Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices
         // because their implementations live in the API project (Clean Architecture dependency rule).
 

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/ICronScheduler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/ICronScheduler.cs
@@ -4,7 +4,7 @@ namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
 /// Applies a CRON expression update to a running Hangfire job schedule immediately,
 /// without requiring a restart.
 /// </summary>
-public interface IHangfireRecurringJobScheduler
+public interface ICronScheduler
 {
     void UpdateCronSchedule(string jobName, string cronExpression);
 }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IJobEnqueuer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IJobEnqueuer.cs
@@ -5,7 +5,7 @@ namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
 /// <summary>
 /// Service responsible for enqueueing recurring jobs via Hangfire using reflection.
 /// </summary>
-public interface IHangfireJobEnqueuer
+public interface IJobEnqueuer
 {
     /// <summary>
     /// Enqueues a recurring job for immediate execution using Hangfire's BackgroundJob.Enqueue.

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs
@@ -10,13 +10,13 @@ public class TriggerRecurringJobHandler : IRequestHandler<TriggerRecurringJobReq
 {
     private readonly IEnumerable<IRecurringJob> _jobs;
     private readonly IRecurringJobStatusChecker _statusChecker;
-    private readonly IHangfireJobEnqueuer _jobEnqueuer;
+    private readonly IJobEnqueuer _jobEnqueuer;
     private readonly ILogger<TriggerRecurringJobHandler> _logger;
 
     public TriggerRecurringJobHandler(
         IEnumerable<IRecurringJob> jobs,
         IRecurringJobStatusChecker statusChecker,
-        IHangfireJobEnqueuer jobEnqueuer,
+        IJobEnqueuer jobEnqueuer,
         ILogger<TriggerRecurringJobHandler> logger)
     {
         _jobs = jobs ?? throw new ArgumentNullException(nameof(jobs));

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/UpdateRecurringJobCron/UpdateRecurringJobCronHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/UpdateRecurringJobCron/UpdateRecurringJobCronHandler.cs
@@ -14,13 +14,13 @@ public class UpdateRecurringJobCronHandler : IRequestHandler<UpdateRecurringJobC
     private readonly ILogger<UpdateRecurringJobCronHandler> _logger;
     private readonly IRecurringJobConfigurationRepository _repository;
     private readonly ICurrentUserService _currentUserService;
-    private readonly IHangfireRecurringJobScheduler _scheduler;
+    private readonly ICronScheduler _scheduler;
 
     public UpdateRecurringJobCronHandler(
         ILogger<UpdateRecurringJobCronHandler> logger,
         IRecurringJobConfigurationRepository repository,
         ICurrentUserService currentUserService,
-        IHangfireRecurringJobScheduler scheduler)
+        ICronScheduler scheduler)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
@@ -20,12 +20,12 @@ public class TriggerRecurringJobHandlerTests
     private static TriggerRecurringJobHandler CreateHandler(
         IEnumerable<IRecurringJob>? jobs = null,
         Mock<IRecurringJobStatusChecker>? statusChecker = null,
-        Mock<IHangfireJobEnqueuer>? enqueuer = null)
+        Mock<IJobEnqueuer>? enqueuer = null)
     {
         return new TriggerRecurringJobHandler(
             jobs ?? Array.Empty<IRecurringJob>(),
             (statusChecker ?? new Mock<IRecurringJobStatusChecker>()).Object,
-            (enqueuer ?? new Mock<IHangfireJobEnqueuer>()).Object,
+            (enqueuer ?? new Mock<IJobEnqueuer>()).Object,
             new Mock<ILogger<TriggerRecurringJobHandler>>().Object);
     }
 
@@ -91,7 +91,7 @@ public class TriggerRecurringJobHandlerTests
             .Setup(x => x.IsJobEnabledAsync("enabled-job", It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(true);
 
-        var enqueuer = new Mock<IHangfireJobEnqueuer>();
+        var enqueuer = new Mock<IJobEnqueuer>();
         enqueuer
             .Setup(x => x.EnqueueJob(It.IsAny<IRecurringJob>(), It.IsAny<CancellationToken>()))
             .Returns((string?)null);

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/UpdateRecurringJobCronHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/UpdateRecurringJobCronHandlerTests.cs
@@ -13,14 +13,14 @@ public class UpdateRecurringJobCronHandlerTests
 {
     private readonly Mock<IRecurringJobConfigurationRepository> _repositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
-    private readonly Mock<IHangfireRecurringJobScheduler> _schedulerMock;
+    private readonly Mock<ICronScheduler> _schedulerMock;
     private readonly UpdateRecurringJobCronHandler _handler;
 
     public UpdateRecurringJobCronHandlerTests()
     {
         _repositoryMock = new Mock<IRecurringJobConfigurationRepository>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
-        _schedulerMock = new Mock<IHangfireRecurringJobScheduler>();
+        _schedulerMock = new Mock<ICronScheduler>();
 
         _currentUserServiceMock
             .Setup(x => x.GetCurrentUser())


### PR DESCRIPTION
Closes #3685

## What the issue was
Two Application-layer interfaces in the BackgroundJobs module embedded the concrete technology name "Hangfire" in their abstractions:
- `IHangfireJobEnqueuer`
- `IHangfireRecurringJobScheduler`

This violates the Dependency Inversion Principle — an inner-ring abstraction shouldn't be named after its only concrete implementation. It also contradicted the pattern already set by `IFailedJobCounter` in the same folder, which is named after behavior, not technology.

## How it was fixed
Renamed the two interfaces to technology-agnostic names and updated every reference:
- `IHangfireJobEnqueuer` → `IJobEnqueuer`
- `IHangfireRecurringJobScheduler` → `ICronScheduler`

Updated: the interface files themselves, the DI registration in `ServiceCollectionExtensions.cs`, a doc comment in `BackgroundJobsModule.cs`, the two consuming handlers (`TriggerRecurringJobHandler`, `UpdateRecurringJobCronHandler`), and their corresponding unit tests.

The concrete implementation classes (`HangfireJobEnqueuer`, `HangfireRecurringJobScheduler` in `API/Infrastructure/Hangfire/`) intentionally keep their "Hangfire" names — that's the correct layer for technology-specific naming.

This is a pure rename with no behavior change. `dotnet build` succeeds with 0 errors, and all 90 BackgroundJobs unit tests pass.

## Code review

A code-reviewer pass was run against the diff and confirmed: no remaining references to the old interface names anywhere in the codebase, the rename is fully consistent across every call site (declarations, DI registration, consumers, tests), and nothing beyond the scope of the rename was touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAvxKNw1txu2o52DQjeCA3)_