### PR TITLE
#3686: Fix RecurringJobSeeder to update developer-owned metadata on existing job configs

### DIFF
--- a/artifacts/feat-3686/arch-review.r1.md
+++ b/artifacts/feat-3686/arch-review.r1.md
@@ -1,0 +1,102 @@
+# Architecture Review: Propagate Developer-Owned Metadata Updates in RecurringJobSeeder
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a one-method behavioral fix inside an existing, well-isolated application service (`RecurringJobSeeder`, in `Anela.Heblo.Application.Features.BackgroundJobs.Services`). It touches no module boundary, no contract, no persistence schema, and no UI. The fix stays entirely within the vertical slice that already owns this concern (`BackgroundJobs`), and reuses machinery that already exists for exactly this purpose:
+
+- `RecurringJobConfiguration.UpdateConfiguration(displayName, description, cronExpression, modifiedBy)` — the domain entity already models "developer-owned fields get overwritten, cron is passed through" as its update contract. It is already exercised by `UpdateRecurringJobCronHandler` conceptually (admin path) and unit-tested in `RecurringJobConfigurationTests.UpdateConfiguration_ShouldUpdateProperties`.
+- `IRecurringJobConfigurationRepository.UpdateAsync` — already implemented in `RecurringJobConfigurationRepository` (`backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs`) as a straightforward `Update` + `SaveChangesAsync`, and already used elsewhere (e.g. `UpdateRecurringJobCronHandler`, `UpdateRecurringJobStatusHandler`) for admin-driven writes.
+
+No new interface, no new repository method, no new domain method, and no schema change is needed — confirming the spec's stated scope. This aligns with the project's Vertical Slice rules in `docs/architecture/development_guidelines.md` (repository binding lives in `BackgroundJobsModule.cs`, already registered; no changes needed there either).
+
+The `RecurringJobConfiguration()` domain constructor path (used for the insert branch) is untouched. The only change is what happens in the branch of `SeedDefaultConfigurationsAsync` where `existing != null` — today a no-op, going forward an update call.
+
+## Proposed Architecture
+
+### Component Overview
+No new components. Existing flow, one branch changed:
+
+```
+API startup (ServiceCollectionExtensions.cs ~line 463)
+        │
+        ▼
+IRecurringJobSeeder.SeedDefaultConfigurationsAsync(discoveredJobs)
+        │
+        ▼
+RecurringJobSeeder  (Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs)
+        │  for each job.Metadata → build in-memory RecurringJobConfiguration
+        │
+        ├─ existing == null ─────────────► repository.AddAsync(config)          [unchanged]
+        │
+        └─ existing != null ─────────────► existing.UpdateConfiguration(        [NEW]
+                                                config.DisplayName,
+                                                config.Description,
+                                                existing.CronExpression,  ◄─ preserve admin value
+                                                "System")
+                                            repository.UpdateAsync(existing)
+                │
+                ▼
+        IRecurringJobConfigurationRepository (Domain interface)
+                │
+                ▼
+        RecurringJobConfigurationRepository (Persistence, EF Core, ApplicationDbContext)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Where the split happens
+**Options considered:**
+1. Change `RecurringJobSeeder.SeedDefaultConfigurationsAsync` directly (as spec proposes).
+2. Push the merge logic into the domain entity as a new method, e.g. `ReconcileWithCode(...)`.
+3. Push it into the repository as an `UpsertAsync` method.
+
+**Chosen approach:** Option 1 — modify only the seeder's loop body.
+
+**Rationale:** The seeder is the only place that knows about the "code wins for X, admin wins for Y" policy — it's an application-layer concern, not a domain invariant or a persistence concern. `UpdateConfiguration` already expresses the right domain contract (it takes `cronExpression` as a parameter rather than assuming it, which is precisely what lets the seeder pass through the *existing* value instead of the *incoming* one). Adding a new domain or repository method would duplicate logic that the seeder can express in three lines, and would expand the change surface beyond what the bug requires. This matches the project rule to make surgical, traceable changes — every new line here maps directly to the brief.
+
+#### Decision 2: Unconditional update vs. diff-and-skip
+**Options considered:**
+1. Always call `UpdateAsync` for existing rows, even when `DisplayName`/`Description` are unchanged.
+2. Compare incoming vs. stored values first and only call `UpdateAsync` when something actually differs.
+
+**Chosen approach:** Option 1, per spec NFR-1.
+
+**Rationale:** Startup-time seeding runs once, against a low tens of rows; the cost of an always-write is negligible and the code stays simpler (no extra branching, no equality-comparison bugs to get wrong). This is explicitly called out as acceptable and preferred in the spec — no deviation proposed.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Single file changes to:
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs` — replace the `if (existing == null) { AddAsync }` body with the if/else from the spec (and update the method's XML doc comment, which currently says "Only creates configurations for jobs that don't already exist" — that line is now incorrect and must be revised as part of this change, since it directly describes the behavior being fixed).
+
+Existing tests to revisit (not necessarily rewrite, but verify against the new behavior) in `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs`:
+- `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate` currently only asserts row count stays at 9. It will still pass unchanged, but it no longer exercises the interesting new behavior (metadata propagation) — the acceptance criteria in the spec (FR-1, FR-2) imply new test cases are expected here: metadata-drift-is-corrected, cron-is-preserved, isEnabled-is-preserved. Per the spec's "Out of Scope" section, exact test authorship is left to the implementer, but the existing test file is clearly the right home for them — no new test file/module needed.
+
+### Interfaces and Contracts
+No interface changes. Confirmed by reading the actual signatures in this checkout:
+- `RecurringJobConfiguration.UpdateConfiguration(string displayName, string description, string cronExpression, string modifiedBy)` — `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs:71-91`. Validates all four args are non-blank (throws `ValidationException` otherwise); since `job.Metadata` values are code-defined string literals, these guards will not trip in practice.
+- `IRecurringJobConfigurationRepository.UpdateAsync(RecurringJobConfiguration, CancellationToken)` — `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobConfigurationRepository.cs:8`, implemented via EF Core `Update()` + `SaveChangesAsync()` in `RecurringJobConfigurationRepository`.
+
+One implementation nuance worth flagging explicitly for the developer: `existing` is fetched via `GetByJobNameAsync` on the *same* `ApplicationDbContext`/scope the seeder runs in (both seeder and repository are registered `Scoped`, and seeding runs once per scope at startup — see `ServiceCollectionExtensions.cs` around line 463). That means `existing` is already a change-tracked entity by the time `UpdateAsync` calls `_context.RecurringJobConfigurations.Update(existing)` — this is harmless (EF allows re-marking an already-tracked entity as `Modified`) but means the explicit `UpdateAsync` call is technically redundant with EF's own change tracking. Do not "optimize" this away by removing the `UpdateAsync` call — keep calling it explicitly, both for symmetry with the insert branch and because it keeps the seeder decoupled from assumptions about EF tracking/scope lifetimes.
+
+### Data Flow
+1. At startup, `ServiceCollectionExtensions` resolves discovered `IRecurringJob` implementations and calls `IRecurringJobSeeder.SeedDefaultConfigurationsAsync`.
+2. For each job, the seeder builds an in-memory `RecurringJobConfiguration` from `job.Metadata` (used only as a values carrier for the insert path and as the source of `DisplayName`/`Description` for the update path — it is never persisted directly in the update path).
+3. `GetByJobNameAsync` checks for an existing row.
+   - Missing → `AddAsync(config)` inserts the freshly-built entity as today.
+   - Present → call `existing.UpdateConfiguration(config.DisplayName, config.Description, existing.CronExpression, "System")`, then `UpdateAsync(existing)`. Note `existing.CronExpression` (not `config.CronExpression`) is passed — this is the crux of the fix: it makes `UpdateConfiguration` a no-op on the field it must not touch, while the entity's own current `IsEnabled` is left alone entirely because `UpdateConfiguration` does not accept it as a parameter.
+4. `LastModifiedAt`/`LastModifiedBy` are stamped by `UpdateConfiguration` itself (`"System"`), giving auditors a way to distinguish seeder-driven writes from admin-driven writes (which use different `modifiedBy` values via `UpdateRecurringJobCronHandler`/`UpdateRecurringJobStatusHandler`).
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Every app restart now issues an `UPDATE` per existing job row, increasing write volume vs. today's read-only steady state | Low | Accepted per spec NFR-1; volume is low tens of rows, startup-only, well within EF/SQLite-or-SQL-Server write budget |
+| A future developer adds a genuinely admin-editable field to `RecurringJobMetadata`/`RecurringJobConfiguration` and wires it through `UpdateConfiguration` without realizing the seeder would then silently overwrite it | Low-Medium | Keep the doc-comment on `SeedDefaultConfigurationsAsync` accurate and explicit about "code-owned vs. admin-owned" so the next change respects the same split; this review calls out updating that comment as part of this change |
+| XML doc comment on `SeedDefaultConfigurationsAsync` becomes stale/misleading if not updated alongside the code | Low | Update the comment as part of this change (see Directory/Module Structure section) |
+
+## Specification Amendments
+None to the functional scope. One clarifying addition: the spec's "Out of Scope" section defers test authorship to the implementer; this review recommends (not requires, since the brief is architecture-only) that the implementer add test cases to the existing `RecurringJobSeederTests.cs` file directly covering FR-1's three acceptance criteria (metadata updated, cron/isEnabled preserved, insert path unchanged) rather than creating a new test file — this keeps all seeder behavior tests co-located as they are today.
+
+## Prerequisites
+None. No migrations, no config, no new infrastructure — this is a pure in-place code change to `RecurringJobSeeder.SeedDefaultConfigurationsAsync`, ready to implement directly against `main`/the current worktree.

--- a/artifacts/feat-3686/brief.md
+++ b/artifacts/feat-3686/brief.md
@@ -1,0 +1,50 @@
+## Module
+BackgroundJobs
+
+## Finding
+`RecurringJobSeeder.SeedDefaultConfigurationsAsync` only inserts rows for jobs that have no existing database record. If a row already exists, the method skips it silently:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs  lines 28–37
+foreach (var config in defaultConfigurations)
+{
+    var existing = await _repository.GetByJobNameAsync(config.JobName, cancellationToken);
+    if (existing == null)
+    {
+        await _repository.AddAsync(config, cancellationToken);
+    }
+    // Nothing happens when existing != null
+}
+```
+
+This means that if a developer changes a job's `DisplayName` or `Description` in `RecurringJobMetadata`, the change is never propagated to the database, and the UI permanently shows the old values.
+
+## Why it matters
+`DisplayName` and `Description` are developer-owned fields — they describe the job's purpose and are not editable by administrators. Leaving them permanently frozen at the values from the first seeding run causes configuration drift between the codebase and the database. The displayed names in the admin panel become stale and potentially misleading.
+
+This is distinct from `CronExpression` and `IsEnabled`, which are intentionally preserved in the database because administrators may override them at runtime.
+
+## Suggested fix
+Split the upsert logic: always apply code-owned fields, never overwrite runtime-admin fields.
+
+```csharp
+if (existing == null)
+{
+    await _repository.AddAsync(config, cancellationToken);
+}
+else
+{
+    // Update developer-owned display metadata only
+    existing.UpdateConfiguration(
+        config.DisplayName,
+        config.Description,
+        existing.CronExpression,   // preserve admin override
+        "System");
+    await _repository.UpdateAsync(existing, cancellationToken);
+}
+```
+
+`RecurringJobConfiguration.UpdateConfiguration` (domain entity method) already accepts `displayName`, `description`, and `cronExpression`, so no domain changes are needed.
+
+---
+_Filed by daily arch-review routine on 2026-07-18._

--- a/artifacts/feat-3686/code-review.r1.md
+++ b/artifacts/feat-3686/code-review.r1.md
@@ -1,0 +1,17 @@
+# Code Review: Propagate Developer-Owned Metadata Updates in RecurringJobSeeder (#3686)
+
+## Review Result: CLEAN
+
+### Blocking (correctness)
+- None
+
+### Advisory (cleanup)
+- None
+
+## Notes
+Reviewed the full branch diff against `origin/main` merge-base (`2c28fc9`), scoped to `backend/`. The change is exactly the surgical fix described in the brief and spec:
+
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs:42-49` — adds an `else` branch to the existing seeding loop. When a `RecurringJobConfiguration` row already exists, it calls `existing.UpdateConfiguration(config.DisplayName, config.Description, existing.CronExpression, "System")` — correctly passing the *existing* row's `CronExpression` (not the code-default `config.CronExpression`), so an administrator's runtime cron override survives reseeding — followed by `_repository.UpdateAsync(existing, cancellationToken)`. Verified `RecurringJobConfigurationRepository.UpdateAsync` (`backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs:34-38`) does a plain `Update` + `SaveChangesAsync`, no surprises. `IsEnabled` is never touched by this path (`UpdateConfiguration` has no such parameter), so admin-toggled enable/disable state is preserved as intended. The insert branch (`existing == null`) is untouched.
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs:82-161` — three new tests cover exactly the three behaviors: stale `DisplayName`/`Description` get corrected, an admin-customized `CronExpression`/`IsEnabled` survive seeding, and `LastModifiedBy` becomes `"System"` after the seeder updates a row. Ran `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"`: `Passed! - Failed: 0, Passed: 5, Skipped: 0, Total: 5`.
+
+No correctness issues found. No reuse/simplification/efficiency concerns — the change reuses existing domain (`UpdateConfiguration`) and repository (`UpdateAsync`) methods exactly as they already exist, introduces no new abstractions, and is confined to the single loop branch called out in the brief. Scope matches the spec/arch-review/task-plan with no drift.

--- a/artifacts/feat-3686/design.r1.md
+++ b/artifacts/feat-3686/design.r1.md
@@ -1,0 +1,59 @@
+# Design: Propagate Developer-Owned Metadata Updates in RecurringJobSeeder
+
+## Component Design
+
+### `RecurringJobSeeder.SeedDefaultConfigurationsAsync` (modified)
+`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+
+Responsibility: at application startup, ensure every discovered `IRecurringJob` has a corresponding `RecurringJobConfiguration` row, and keep that row's developer-owned fields (`DisplayName`, `Description`) in sync with the job's current `Metadata`, while never touching the admin-owned fields (`CronExpression`, `IsEnabled`).
+
+Change is confined to the branch of the existing seeding loop where a row is found for a job (`existing != null`). No new methods, no new class members, no signature change to `SeedDefaultConfigurationsAsync` itself.
+
+Loop body (per discovered job, `config` = in-memory `RecurringJobConfiguration` built from `job.Metadata`):
+
+```csharp
+foreach (var config in defaultConfigurations)
+{
+    var existing = await _repository.GetByJobNameAsync(config.JobName, cancellationToken);
+    if (existing == null)
+    {
+        await _repository.AddAsync(config, cancellationToken);          // unchanged
+    }
+    else
+    {
+        existing.UpdateConfiguration(
+            config.DisplayName,
+            config.Description,
+            existing.CronExpression,   // pass through the existing value: preserves admin override
+            "System");
+        await _repository.UpdateAsync(existing, cancellationToken);     // new: was previously a no-op branch
+    }
+}
+```
+
+- `IsEnabled` is never referenced in the update branch: `UpdateConfiguration` has no `isEnabled` parameter, so the entity's current value is left untouched by construction.
+- `UpdateAsync` is called unconditionally for every pre-existing job on every run (no diff-and-skip), per NFR-1.
+- The method's XML doc comment must be revised: it currently states the seeder "Only creates configurations for jobs that don't already exist," which is no longer accurate once the update branch is added.
+
+### Reused, unmodified components
+- **`RecurringJobConfiguration.UpdateConfiguration(string displayName, string description, string cronExpression, string modifiedBy)`** (`backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs:71-91`) — existing domain method, already validates non-blank args and stamps `LastModifiedAt`/`LastModifiedBy`. Called with the job's `DisplayName`/`Description` and the entity's own current `CronExpression` (not the code-defined one), plus `modifiedBy = "System"`.
+- **`IRecurringJobConfigurationRepository.UpdateAsync(RecurringJobConfiguration, CancellationToken)`** (`backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJobConfigurationRepository.cs:8`) — existing repository method, implemented via EF Core `Update()` + `SaveChangesAsync()` in `RecurringJobConfigurationRepository`. Already used by admin-driven paths (`UpdateRecurringJobCronHandler`, `UpdateRecurringJobStatusHandler`); no changes to its implementation.
+- **`IRecurringJobConfigurationRepository.GetByJobNameAsync`** and **`AddAsync`** — unchanged, used exactly as today for the insert path.
+
+No new interfaces, no new repository methods, no new domain methods, no DI registration changes (`BackgroundJobsModule.cs` already wires up the repository).
+
+## Data Schemas
+
+No schema changes. `RecurringJobConfiguration` entity fields, unchanged shape, with ownership semantics now enforced by the seeder's update branch:
+
+| Field | Ownership | Seeder behavior on existing row |
+|---|---|---|
+| `JobName` | Match key | Read-only (used to look up `existing`) |
+| `DisplayName` | Developer-owned | Overwritten from `job.Metadata.DisplayName` via `UpdateConfiguration` |
+| `Description` | Developer-owned | Overwritten from `job.Metadata.Description` via `UpdateConfiguration` |
+| `CronExpression` | Admin-owned | Preserved: `existing.CronExpression` passed back into `UpdateConfiguration`, making it a no-op on this field |
+| `IsEnabled` | Admin-owned | Preserved: not a parameter of `UpdateConfiguration`, left untouched |
+| `LastModifiedAt` | Audit | Updated by `UpdateConfiguration` to current timestamp |
+| `LastModifiedBy` | Audit | Updated by `UpdateConfiguration` to `"System"` |
+
+No changes to request/response DTOs, controllers, or event payloads — this is an internal startup-seeding code path with no external API surface.

--- a/artifacts/feat-3686/impl/fix-recurring-job-seeder-upsert.r1.md
+++ b/artifacts/feat-3686/impl/fix-recurring-job-seeder-upsert.r1.md
@@ -1,0 +1,31 @@
+# Implementation: fix-recurring-job-seeder-upsert
+
+## What was implemented
+`RecurringJobSeeder.SeedDefaultConfigurationsAsync` now upserts instead of insert-only-if-missing. When a `RecurringJobConfiguration` row already exists for a discovered job, the seeder calls the existing domain method `existing.UpdateConfiguration(config.DisplayName, config.Description, existing.CronExpression, "System")` — passing the *existing* row's `CronExpression` back in so the admin's runtime override is preserved — and then persists the change via the existing `_repository.UpdateAsync(existing, cancellationToken)`. The insert branch (`existing == null`) is untouched. The XML doc comment above the method was updated to describe the new upsert behavior. No new abstractions, interfaces, or repository/domain methods were introduced.
+
+Three new unit tests were added to the existing test class to cover the three acceptance criteria from the spec/task-plan:
+1. Stale `DisplayName`/`Description` on an existing row get corrected to match `job.Metadata`.
+2. An admin-customized `CronExpression` and `IsEnabled` survive seeding unchanged.
+3. `LastModifiedBy` becomes `"System"` after the seeder updates a row (even if it was previously `"Admin"`).
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs` — added the `else` branch in the seeding loop calling `UpdateConfiguration` + `UpdateAsync`; updated the method's XML doc comment.
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs` — added `SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled`, and `SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem`.
+
+## Tests
+Ran the filtered test command from the task plan:
+```
+dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"
+```
+Result: `Passed! - Failed: 0, Passed: 5, Skipped: 0, Total: 5` — all 5 tests in `RecurringJobSeederTests` pass, including the 2 pre-existing tests (`..._WhenEmpty_CreatesAllDefaultConfigurations`, `..._WhenConfigurationsExist_DoesNotDuplicate`) and the 3 new ones.
+
+## How to verify
+1. `cd backend && dotnet build Anela.Heblo.sln` — should build with no errors.
+2. `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"` — should report 5/5 passed.
+3. Inspect `RecurringJobSeeder.cs` — confirm the `else` branch calls `UpdateConfiguration` with `existing.CronExpression` (not `config.CronExpression`) so admin cron overrides are preserved, and that `IsEnabled` is never touched.
+
+## Notes
+No deviations from the task plan. The plan's exact code for both the test additions and the fixed seeder file matched the actual current source (verified field values against the existing `CreateMockJobs()` fixture before applying). `dotnet format --verify-no-changes` and the full solution test suite run are being executed as part of the pipeline's finishing/validation step, per the orchestrator flow, rather than repeated here.
+
+## Status
+DONE

--- a/artifacts/feat-3686/review/fix-recurring-job-seeder-upsert.r1.md
+++ b/artifacts/feat-3686/review/fix-recurring-job-seeder-upsert.r1.md
@@ -1,0 +1,23 @@
+# Code Review: Propagate Developer-Owned Metadata Updates in RecurringJobSeeder
+
+## Summary
+The implementation matches the spec, arch-review, and task-plan exactly: the seeder's loop now upserts, calling the existing `UpdateConfiguration(displayName, description, cronExpression, modifiedBy)` domain method with the row's own `CronExpression` passed through (preserving admin overrides) and `"System"` as `modifiedBy`, then persists via the existing `UpdateAsync`. No new abstractions were introduced. Verified directly against the real source file (not just the impl summary) — the code matches what was claimed.
+
+## Review Result: PASS
+
+### task: fix-recurring-job-seeder-upsert
+**Status:** PASS
+
+Verification performed:
+- Read `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs` directly: the `else` branch calls `existing.UpdateConfiguration(config.DisplayName, config.Description, existing.CronExpression, "System")` (note: `existing.CronExpression`, not `config.CronExpression` — correctly preserves the admin override per FR-1) followed by `_repository.UpdateAsync(existing, cancellationToken)`. The `existing == null` insert branch is byte-for-byte unchanged, satisfying FR-1's "insert path unchanged" acceptance criterion.
+- `IsEnabled` is never referenced in the update path — `UpdateConfiguration` has no `isEnabled` parameter — satisfying FR-2.
+- Read `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs`: the three new tests (`..._UpdatesDisplayNameAndDescription`, `..._PreservesCronExpressionAndIsEnabled`, `..._SetsLastModifiedByToSystem`) exist and exercise exactly the three acceptance-criteria scenarios from the task-plan, using the pre-existing `CreateMockJobs()`/`MockRecurringJob` fixtures with correct real fixture values (`"purchase-price-recalculation"`, `"Purchase Price Recalculation"`, `"0 2 * * *"`, `DefaultIsEnabled: true`). The two pre-existing tests are untouched.
+- Ran `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"` directly: `Passed! - Failed: 0, Passed: 5, Skipped: 0, Total: 5`. All 5 tests pass, confirming the acceptance criteria are actually met at runtime, not just claimed.
+- Architecture adherence: matches arch-review.r1.md's Decision 1 exactly — no new repository method, no new domain method, change confined to the single loop branch. `Skip Design: true` was correct (no UI/contract changes touched).
+- No obvious correctness bugs, no missing error handling gaps introduced (validation already lives in `UpdateConfiguration` itself, unchanged), no security concerns (this is startup-only seeding code, `modifiedBy` hardcoded to `"System"` exactly as the insert path already did).
+
+## Docs to Update
+(None — this is an internal bug fix with no public API, CLI, or operational behavior change; no README/CLAUDE.md/agent-doc updates are implicated.)
+
+## Overall Notes
+Clean, surgical fix exactly matching the brief's suggested diff. No scope creep. The XML doc comment above `SeedDefaultConfigurationsAsync` was appropriately updated to describe the new upsert behavior (flagged as stale in the arch-review) — this is a doc-comment correction directly tied to the behavior change, not unrelated cleanup.

--- a/artifacts/feat-3686/spec.r1.md
+++ b/artifacts/feat-3686/spec.r1.md
@@ -1,0 +1,82 @@
+# Specification: Propagate Developer-Owned Metadata Updates in RecurringJobSeeder
+
+## Summary
+`RecurringJobSeeder.SeedDefaultConfigurationsAsync` currently inserts a `RecurringJobConfiguration` row only when no record exists for a job, silently skipping any job that already has a row. This means changes to code-owned fields (`DisplayName`, `Description`) made by developers in `RecurringJobMetadata` never reach the database, and the admin UI keeps showing stale values indefinitely. This spec covers changing the seeder to upsert: keep inserting new jobs as before, but for existing jobs, update `DisplayName` and `Description` from code while preserving the admin-editable `CronExpression` and `IsEnabled` fields untouched.
+
+## Background
+`RecurringJobConfiguration` rows are seeded once per job at startup from `IRecurringJob.Metadata`. Two of the fields on that entity are developer-owned and should always reflect the current code (`DisplayName`, `Description`); two are admin-owned and must survive across deployments because administrators may have changed them at runtime (`CronExpression`, `IsEnabled`). Today, the seeder's "insert if missing" logic means that once a row is created, it is never revisited — so developer-owned fields silently drift out of sync with the code whenever they're edited in `RecurringJobMetadata`, while admin-owned fields (which the seeder never had a chance to overwrite anyway) are not the problem. This is an internal architecture-review finding, not a user-facing bug report; there is no reported production incident, but the drift is real and will worsen as more jobs are added or renamed.
+
+## Functional Requirements
+
+### FR-1: Upsert developer-owned metadata on seeding
+When `SeedDefaultConfigurationsAsync` runs and finds an existing `RecurringJobConfiguration` row for a job (matched by `JobName`), it must update that row's `DisplayName` and `Description` to match the current values from `job.Metadata`, using the existing `RecurringJobConfiguration.UpdateConfiguration(displayName, description, cronExpression, modifiedBy)` domain method. The `cronExpression` argument passed to `UpdateConfiguration` must be the **existing** row's current `CronExpression` (not the value from `job.Metadata`), so that the admin's runtime override is preserved. The `modifiedBy` argument must be `"System"`, consistent with the value already used for inserts.
+
+**Acceptance criteria:**
+- Given a job whose `RecurringJobConfiguration` row already exists in the database, when `SeedDefaultConfigurationsAsync` runs and `job.Metadata.DisplayName` or `job.Metadata.Description` differs from the stored values, the stored `DisplayName`/`Description` are updated to match `job.Metadata` after seeding completes.
+- Given a job whose `RecurringJobConfiguration` row already exists and an administrator has set a custom `CronExpression` and/or `IsEnabled` value that differs from `job.Metadata.CronExpression` / `job.Metadata.DefaultIsEnabled`, when `SeedDefaultConfigurationsAsync` runs, the stored `CronExpression` and `IsEnabled` values are unchanged after seeding completes.
+- Given a job whose `RecurringJobConfiguration` row does not yet exist, when `SeedDefaultConfigurationsAsync` runs, a new row is inserted with all fields taken from `job.Metadata`, exactly as today (no behavior change for the insert path).
+- The updated row's `LastModifiedAt` and `LastModifiedBy` reflect the seeder's update (set by `UpdateConfiguration`), i.e. `LastModifiedBy == "System"`.
+- `IRecurringJobConfigurationRepository.UpdateAsync` is called exactly once per pre-existing job on each seeding run, regardless of whether the metadata actually changed (idempotent no-op update is acceptable; see NFR-1).
+
+### FR-2: No change to IsEnabled handling
+`IsEnabled` is not passed to `UpdateConfiguration` (that method does not accept it) and is not touched by the update path at all. The existing row's `IsEnabled` value is left exactly as-is when updating an existing configuration.
+
+**Acceptance criteria:**
+- After seeding a pre-existing job whose `IsEnabled` differs from `job.Metadata.DefaultIsEnabled`, the stored `IsEnabled` value still differs from `job.Metadata.DefaultIsEnabled` in the same direction (i.e., unchanged).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Seeding runs once at application startup against a small, fixed set of recurring jobs (expected: low tens of rows). Calling `UpdateAsync` unconditionally for every pre-existing job (rather than diffing first and skipping unchanged rows) is acceptable and preferred for simplicity; no batching or conditional-skip optimization is required. This must not introduce a measurable startup delay (sub-second for the full seeding pass under normal job counts).
+
+### NFR-2: Security
+No new authentication, authorization, or data-sensitivity concerns are introduced. The seeder already runs as part of trusted startup code with direct repository access; `modifiedBy` continues to be hardcoded to `"System"` for both insert and update paths, distinguishing seeder-driven changes from admin-driven changes (which presumably use a different `modifiedBy` value in the admin UI's own update path).
+
+## Data Model
+No schema or entity changes. Existing entity: `RecurringJobConfiguration` (backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs), with the pre-existing `UpdateConfiguration(displayName, description, cronExpression, modifiedBy)` method reused as-is. Fields involved:
+- Developer-owned (always overwritten by seeder): `DisplayName`, `Description`
+- Admin-owned (preserved by seeder, never overwritten): `CronExpression`, `IsEnabled`
+- Audit fields updated by `UpdateConfiguration`: `LastModifiedAt`, `LastModifiedBy`
+
+## API / Interface Design
+No public API or UI changes. This is an internal change to `RecurringJobSeeder.SeedDefaultConfigurationsAsync` in `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`:
+
+```csharp
+foreach (var config in defaultConfigurations)
+{
+    var existing = await _repository.GetByJobNameAsync(config.JobName, cancellationToken);
+    if (existing == null)
+    {
+        await _repository.AddAsync(config, cancellationToken);
+    }
+    else
+    {
+        existing.UpdateConfiguration(
+            config.DisplayName,
+            config.Description,
+            existing.CronExpression,   // preserve admin override
+            "System");
+        await _repository.UpdateAsync(existing, cancellationToken);
+    }
+}
+```
+
+No changes to `IRecurringJobConfigurationRepository`, `IRecurringJob`, `RecurringJobMetadata`, or any controller/DTO.
+
+## Dependencies
+- `RecurringJobConfiguration.UpdateConfiguration` (already exists, no domain changes needed).
+- `IRecurringJobConfigurationRepository.UpdateAsync` (already exists; used elsewhere for admin-driven updates, so no new repository method is needed).
+- No external services or new libraries.
+
+## Out of Scope
+- Any change to how `CronExpression` or `IsEnabled` are seeded or reconciled (they remain admin-owned and are never overwritten by the seeder).
+- Any change to the admin UI, controllers, or endpoints that expose `RecurringJobConfiguration`.
+- Adding change-detection/diffing to skip no-op `UpdateAsync` calls (see NFR-1 — unconditional update on every run is accepted).
+- Handling jobs that are removed from code but still have a database row (orphaned configurations) — not mentioned in the brief and not addressed here.
+- Any validation changes to `UpdateConfiguration` itself (its existing null/whitespace checks are assumed sufficient, since `job.Metadata` values are code-defined and expected to always be valid).
+- Unit/integration test additions beyond what's implied by the acceptance criteria above (test implementation is a development-team concern, not specified further here).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -23,6 +23,10 @@
     "developing": {
       "status": "completed",
       "updated_at": "2026-07-18T07:14:43.058271Z"
+    },
+    "code-review": {
+      "status": "in_progress",
+      "updated_at": "2026-07-18T07:14:49.149189Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -25,5 +25,12 @@
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "fix-recurring-job-seeder-upsert",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3686",
+  "issue_number": 3686,
+  "created_at": "2026-07-18T06:15:59.483975Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "completed",
+      "updated_at": "2026-07-18T06:18:53.473683Z"
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-18T06:24:21.002311Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-18T06:24:45.837361Z"
     }
   },
   "tasks": [
     {
       "name": "fix-recurring-job-seeder-upsert",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-18T06:24:46.192215Z"
     }
   ]
 }

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -9,8 +9,8 @@
       "updated_at": "2026-07-18T06:18:53.473683Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-18T06:20:58.985723Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -13,8 +13,8 @@
       "updated_at": "2026-07-18T06:20:58.985723Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-18T06:21:46.517533Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-18T06:24:21.002311Z"
     },
     "developing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-18T06:24:45.837361Z"
+      "status": "completed",
+      "updated_at": "2026-07-18T07:14:43.058271Z"
     }
   },
   "tasks": [
     {
       "name": "fix-recurring-job-seeder-upsert",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-18T06:24:46.192215Z"
+      "updated_at": "2026-07-18T07:14:34.842815Z"
     }
   ]
 }

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -17,8 +17,8 @@
       "updated_at": "2026-07-18T06:21:46.517533Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "completed",
+      "updated_at": "2026-07-18T06:24:21.002311Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3686/state.json
+++ b/artifacts/feat-3686/state.json
@@ -25,8 +25,8 @@
       "updated_at": "2026-07-18T07:14:43.058271Z"
     },
     "code-review": {
-      "status": "in_progress",
-      "updated_at": "2026-07-18T07:14:49.149189Z"
+      "status": "completed",
+      "updated_at": "2026-07-18T07:16:17.096887Z"
     }
   },
   "tasks": [

--- a/artifacts/feat-3686/task-context/fix-recurring-job-seeder-upsert.md
+++ b/artifacts/feat-3686/task-context/fix-recurring-job-seeder-upsert.md
@@ -1,0 +1,206 @@
+### task: fix-recurring-job-seeder-upsert
+
+**Goal:** Change `RecurringJobSeeder.SeedDefaultConfigurationsAsync` so that when a `RecurringJobConfiguration` row already exists for a discovered job, the seeder updates the row's developer-owned fields (`DisplayName`, `Description`) from `job.Metadata` via `UpdateConfiguration`, while preserving the admin-owned fields (`CronExpression`, `IsEnabled`) exactly as stored. The insert path for missing rows is unchanged. Add test coverage in the existing test file proving: (1) stale `DisplayName`/`Description` get corrected, (2) an admin-customized `CronExpression` and `IsEnabled` survive seeding, (3) `LastModifiedBy` becomes `"System"` after the update.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs`
+
+- [ ] Step 1: Add three new failing tests to `RecurringJobSeederTests.cs`. Open `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs` and locate the existing test `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate` (ends just before the `public void Dispose()` method). Insert the following three test methods immediately after that test's closing brace and before `public void Dispose()`:
+
+  ```csharp
+      [Fact]
+      public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription()
+      {
+          // Arrange - add an existing configuration with stale DisplayName/Description
+          var existingConfig = new RecurringJobConfiguration(
+              "purchase-price-recalculation",
+              "Old Display Name",
+              "Old description that no longer matches the code",
+              "0 2 * * *",
+              true,
+              "System");
+
+          await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+          await _context.SaveChangesAsync();
+
+          var mockJobs = CreateMockJobs();
+
+          // Act
+          await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+          // Assert
+          var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+          Assert.NotNull(updated);
+          Assert.Equal("Purchase Price Recalculation", updated!.DisplayName);
+          Assert.Equal("Recalculates purchase prices for all materials and products", updated.Description);
+      }
+
+      [Fact]
+      public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled()
+      {
+          // Arrange - add an existing configuration with an admin-customized CronExpression and IsEnabled
+          var existingConfig = new RecurringJobConfiguration(
+              "purchase-price-recalculation",
+              "Purchase Price Recalculation",
+              "Recalculates purchase prices for all materials and products",
+              "0 0 * * *", // admin-customized cron, differs from mock job's "0 2 * * *"
+              false,       // admin-disabled, differs from mock job's DefaultIsEnabled: true
+              "System");
+
+          await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+          await _context.SaveChangesAsync();
+
+          var mockJobs = CreateMockJobs();
+
+          // Act
+          await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+          // Assert
+          var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+          Assert.NotNull(updated);
+          Assert.Equal("0 0 * * *", updated!.CronExpression);
+          Assert.False(updated.IsEnabled);
+      }
+
+      [Fact]
+      public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem()
+      {
+          // Arrange - add an existing configuration whose last modification was made by an admin
+          var existingConfig = new RecurringJobConfiguration(
+              "purchase-price-recalculation",
+              "Purchase Price Recalculation",
+              "Recalculates purchase prices for all materials and products",
+              "0 2 * * *",
+              true,
+              "Admin");
+
+          await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+          await _context.SaveChangesAsync();
+
+          var mockJobs = CreateMockJobs();
+
+          // Act
+          await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+          // Assert
+          var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+          Assert.NotNull(updated);
+          Assert.Equal("System", updated!.LastModifiedBy);
+      }
+
+  ```
+
+  Do not modify anything else in the file at this step.
+
+- [ ] Step 2: Run the new tests and confirm they fail against the current (unfixed) seeder. From the repository root run:
+
+  ```
+  dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"
+  ```
+
+  Expected: the three new tests (`SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem`) FAIL. The first fails because `DisplayName`/`Description` remain `"Old Display Name"` / `"Old description that no longer matches the code"` (seeder currently no-ops on existing rows). The third fails because `LastModifiedBy` remains `"Admin"`. The second test (`PreservesCronExpressionAndIsEnabled`) is expected to PASS even before the fix, since the current seeder never touches an existing row at all — that's fine; it will continue to pass after the fix too, and it exists to lock in the preservation behavior going forward. The two pre-existing tests (`SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations`, `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`) continue to PASS.
+
+- [ ] Step 3: Implement the fix in `RecurringJobSeeder.cs`. Open `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`. Replace the entire file contents with:
+
+  ```csharp
+  using Anela.Heblo.Domain.Features.BackgroundJobs;
+
+  namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+  public class RecurringJobSeeder : IRecurringJobSeeder
+  {
+      private readonly IRecurringJobConfigurationRepository _repository;
+
+      public RecurringJobSeeder(IRecurringJobConfigurationRepository repository)
+      {
+          _repository = repository;
+      }
+
+      /// <summary>
+      /// Seeds database with configurations from discovered IRecurringJob implementations.
+      /// Creates configurations for jobs that don't already exist in the database. For jobs
+      /// that already have a configuration row, updates the developer-owned fields
+      /// (DisplayName, Description) to match the current code, while preserving the
+      /// admin-owned fields (CronExpression, IsEnabled) exactly as stored.
+      /// </summary>
+      /// <param name="jobs">Collection of discovered recurring jobs</param>
+      /// <param name="cancellationToken">Cancellation token</param>
+      public async Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+      {
+          // Create configurations from discovered job metadata
+          var defaultConfigurations = jobs.Select(job => new RecurringJobConfiguration(
+              job.Metadata.JobName,
+              job.Metadata.DisplayName,
+              job.Metadata.Description,
+              job.Metadata.CronExpression,
+              job.Metadata.DefaultIsEnabled,
+              "System"
+          )).ToArray();
+
+          foreach (var config in defaultConfigurations)
+          {
+              var existing = await _repository.GetByJobNameAsync(config.JobName, cancellationToken);
+              if (existing == null)
+              {
+                  await _repository.AddAsync(config, cancellationToken);
+              }
+              else
+              {
+                  existing.UpdateConfiguration(
+                      config.DisplayName,
+                      config.Description,
+                      existing.CronExpression,   // preserve admin override
+                      "System");
+                  await _repository.UpdateAsync(existing, cancellationToken);
+              }
+          }
+      }
+  }
+  ```
+
+  This changes only the `foreach` loop body (adding the `else` branch) and the XML doc comment above `SeedDefaultConfigurationsAsync`; everything else in the file is unchanged from its current state.
+
+- [ ] Step 4: Run the full seeder test file again and confirm all tests pass:
+
+  ```
+  dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"
+  ```
+
+  Expected: all 5 tests pass — `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations`, `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem`.
+
+- [ ] Step 5: Run the full backend build and formatting check to make sure nothing else broke:
+
+  ```
+  dotnet build backend/Anela.Heblo.sln
+  dotnet format backend/Anela.Heblo.sln --verify-no-changes
+  ```
+
+  Expected: build succeeds with no errors; `dotnet format --verify-no-changes` reports no formatting violations. If `dotnet format` reports violations introduced by this change, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`) to apply fixes, then re-run the test command from Step 4 to confirm tests still pass.
+
+- [ ] Step 6: Run the full test project (not just the filtered subset) to confirm no regressions elsewhere in the solution:
+
+  ```
+  dotnet test backend/Anela.Heblo.sln
+  ```
+
+  Expected: all tests in the solution pass, with no failures introduced outside `RecurringJobSeederTests`.
+
+- [ ] Step 7: Commit the change. Stage exactly the two touched files and commit:
+
+  ```
+  git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs
+  git commit -m "Fix RecurringJobSeeder to upsert developer-owned metadata on existing job configs"
+  ```
+
+## Self-Review
+
+- FR-1 (upsert developer-owned metadata, preserve existing `CronExpression` argument, `modifiedBy = "System"`): covered by Step 3 implementation and verified by the `UpdatesDisplayNameAndDescription` and `PreservesCronExpressionAndIsEnabled` tests in Step 1.
+- FR-1's `LastModifiedBy == "System"` acceptance criterion: covered by the `SetsLastModifiedByToSystem` test.
+- FR-1's "insert path unchanged" acceptance criterion: covered by the pre-existing, untouched `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` test, which continues to pass since the `existing == null` branch is byte-for-byte unchanged.
+- FR-2 (`IsEnabled` never touched by the update path): covered by `PreservesCronExpressionAndIsEnabled`, and structurally guaranteed since `UpdateConfiguration` has no `isEnabled` parameter (unchanged domain method, not modified by this plan).
+- NFR-1 (unconditional update, no diff-and-skip, no measurable startup delay): satisfied by construction — the `else` branch always calls `UpdateConfiguration` + `UpdateAsync` with no equality check; no batching/optimization added, matching the spec's explicit preference for simplicity.
+- NFR-2 (no new auth/security surface, `modifiedBy` hardcoded to `"System"` for both paths): satisfied — `"System"` literal reused unchanged from the insert path.
+- No new interfaces, repository methods, or domain methods were introduced; `UpdateConfiguration` and `UpdateAsync` are reused exactly as they exist today, matching the architecture review's Decision 1 and the design document.
+- No placeholders: every step contains complete, literal code (full replacement file for the seeder, complete test method bodies) and exact runnable commands with stated expected outcomes.
+- Out-of-scope items from the spec (orphaned configuration cleanup, admin UI/controller changes, `UpdateConfiguration` validation changes, diff-and-skip optimization) are not touched by any step, consistent with the spec's "Out of Scope" section.

--- a/artifacts/feat-3686/task-plan.r1.md
+++ b/artifacts/feat-3686/task-plan.r1.md
@@ -1,0 +1,212 @@
+# Implementation Plan: Propagate Developer-Owned Metadata Updates in RecurringJobSeeder
+
+Source artifacts: `spec.r1.md`, `arch-review.r1.md`, `design.r1.md` (feature 3686).
+
+This is a single-file, single-branch behavioral fix confined to `RecurringJobSeeder.SeedDefaultConfigurationsAsync`. Per the architecture review and design, no new abstractions, interfaces, repository methods, or domain methods are introduced — the existing `RecurringJobConfiguration.UpdateConfiguration(displayName, description, cronExpression, modifiedBy)` and `IRecurringJobConfigurationRepository.UpdateAsync` are reused as-is. Scope is intentionally one task.
+
+### task: fix-recurring-job-seeder-upsert
+
+**Goal:** Change `RecurringJobSeeder.SeedDefaultConfigurationsAsync` so that when a `RecurringJobConfiguration` row already exists for a discovered job, the seeder updates the row's developer-owned fields (`DisplayName`, `Description`) from `job.Metadata` via `UpdateConfiguration`, while preserving the admin-owned fields (`CronExpression`, `IsEnabled`) exactly as stored. The insert path for missing rows is unchanged. Add test coverage in the existing test file proving: (1) stale `DisplayName`/`Description` get corrected, (2) an admin-customized `CronExpression` and `IsEnabled` survive seeding, (3) `LastModifiedBy` becomes `"System"` after the update.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs`
+
+- [ ] Step 1: Add three new failing tests to `RecurringJobSeederTests.cs`. Open `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs` and locate the existing test `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate` (ends just before the `public void Dispose()` method). Insert the following three test methods immediately after that test's closing brace and before `public void Dispose()`:
+
+  ```csharp
+      [Fact]
+      public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription()
+      {
+          // Arrange - add an existing configuration with stale DisplayName/Description
+          var existingConfig = new RecurringJobConfiguration(
+              "purchase-price-recalculation",
+              "Old Display Name",
+              "Old description that no longer matches the code",
+              "0 2 * * *",
+              true,
+              "System");
+
+          await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+          await _context.SaveChangesAsync();
+
+          var mockJobs = CreateMockJobs();
+
+          // Act
+          await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+          // Assert
+          var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+          Assert.NotNull(updated);
+          Assert.Equal("Purchase Price Recalculation", updated!.DisplayName);
+          Assert.Equal("Recalculates purchase prices for all materials and products", updated.Description);
+      }
+
+      [Fact]
+      public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled()
+      {
+          // Arrange - add an existing configuration with an admin-customized CronExpression and IsEnabled
+          var existingConfig = new RecurringJobConfiguration(
+              "purchase-price-recalculation",
+              "Purchase Price Recalculation",
+              "Recalculates purchase prices for all materials and products",
+              "0 0 * * *", // admin-customized cron, differs from mock job's "0 2 * * *"
+              false,       // admin-disabled, differs from mock job's DefaultIsEnabled: true
+              "System");
+
+          await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+          await _context.SaveChangesAsync();
+
+          var mockJobs = CreateMockJobs();
+
+          // Act
+          await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+          // Assert
+          var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+          Assert.NotNull(updated);
+          Assert.Equal("0 0 * * *", updated!.CronExpression);
+          Assert.False(updated.IsEnabled);
+      }
+
+      [Fact]
+      public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem()
+      {
+          // Arrange - add an existing configuration whose last modification was made by an admin
+          var existingConfig = new RecurringJobConfiguration(
+              "purchase-price-recalculation",
+              "Purchase Price Recalculation",
+              "Recalculates purchase prices for all materials and products",
+              "0 2 * * *",
+              true,
+              "Admin");
+
+          await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+          await _context.SaveChangesAsync();
+
+          var mockJobs = CreateMockJobs();
+
+          // Act
+          await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+          // Assert
+          var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+          Assert.NotNull(updated);
+          Assert.Equal("System", updated!.LastModifiedBy);
+      }
+
+  ```
+
+  Do not modify anything else in the file at this step.
+
+- [ ] Step 2: Run the new tests and confirm they fail against the current (unfixed) seeder. From the repository root run:
+
+  ```
+  dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"
+  ```
+
+  Expected: the three new tests (`SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem`) FAIL. The first fails because `DisplayName`/`Description` remain `"Old Display Name"` / `"Old description that no longer matches the code"` (seeder currently no-ops on existing rows). The third fails because `LastModifiedBy` remains `"Admin"`. The second test (`PreservesCronExpressionAndIsEnabled`) is expected to PASS even before the fix, since the current seeder never touches an existing row at all — that's fine; it will continue to pass after the fix too, and it exists to lock in the preservation behavior going forward. The two pre-existing tests (`SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations`, `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`) continue to PASS.
+
+- [ ] Step 3: Implement the fix in `RecurringJobSeeder.cs`. Open `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`. Replace the entire file contents with:
+
+  ```csharp
+  using Anela.Heblo.Domain.Features.BackgroundJobs;
+
+  namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+  public class RecurringJobSeeder : IRecurringJobSeeder
+  {
+      private readonly IRecurringJobConfigurationRepository _repository;
+
+      public RecurringJobSeeder(IRecurringJobConfigurationRepository repository)
+      {
+          _repository = repository;
+      }
+
+      /// <summary>
+      /// Seeds database with configurations from discovered IRecurringJob implementations.
+      /// Creates configurations for jobs that don't already exist in the database. For jobs
+      /// that already have a configuration row, updates the developer-owned fields
+      /// (DisplayName, Description) to match the current code, while preserving the
+      /// admin-owned fields (CronExpression, IsEnabled) exactly as stored.
+      /// </summary>
+      /// <param name="jobs">Collection of discovered recurring jobs</param>
+      /// <param name="cancellationToken">Cancellation token</param>
+      public async Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+      {
+          // Create configurations from discovered job metadata
+          var defaultConfigurations = jobs.Select(job => new RecurringJobConfiguration(
+              job.Metadata.JobName,
+              job.Metadata.DisplayName,
+              job.Metadata.Description,
+              job.Metadata.CronExpression,
+              job.Metadata.DefaultIsEnabled,
+              "System"
+          )).ToArray();
+
+          foreach (var config in defaultConfigurations)
+          {
+              var existing = await _repository.GetByJobNameAsync(config.JobName, cancellationToken);
+              if (existing == null)
+              {
+                  await _repository.AddAsync(config, cancellationToken);
+              }
+              else
+              {
+                  existing.UpdateConfiguration(
+                      config.DisplayName,
+                      config.Description,
+                      existing.CronExpression,   // preserve admin override
+                      "System");
+                  await _repository.UpdateAsync(existing, cancellationToken);
+              }
+          }
+      }
+  }
+  ```
+
+  This changes only the `foreach` loop body (adding the `else` branch) and the XML doc comment above `SeedDefaultConfigurationsAsync`; everything else in the file is unchanged from its current state.
+
+- [ ] Step 4: Run the full seeder test file again and confirm all tests pass:
+
+  ```
+  dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"
+  ```
+
+  Expected: all 5 tests pass — `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations`, `SeedDefaultConfigurationsAsync_WhenConfigurationsExist_DoesNotDuplicate`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled`, `SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem`.
+
+- [ ] Step 5: Run the full backend build and formatting check to make sure nothing else broke:
+
+  ```
+  dotnet build backend/Anela.Heblo.sln
+  dotnet format backend/Anela.Heblo.sln --verify-no-changes
+  ```
+
+  Expected: build succeeds with no errors; `dotnet format --verify-no-changes` reports no formatting violations. If `dotnet format` reports violations introduced by this change, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`) to apply fixes, then re-run the test command from Step 4 to confirm tests still pass.
+
+- [ ] Step 6: Run the full test project (not just the filtered subset) to confirm no regressions elsewhere in the solution:
+
+  ```
+  dotnet test backend/Anela.Heblo.sln
+  ```
+
+  Expected: all tests in the solution pass, with no failures introduced outside `RecurringJobSeederTests`.
+
+- [ ] Step 7: Commit the change. Stage exactly the two touched files and commit:
+
+  ```
+  git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs
+  git commit -m "Fix RecurringJobSeeder to upsert developer-owned metadata on existing job configs"
+  ```
+
+## Self-Review
+
+- FR-1 (upsert developer-owned metadata, preserve existing `CronExpression` argument, `modifiedBy = "System"`): covered by Step 3 implementation and verified by the `UpdatesDisplayNameAndDescription` and `PreservesCronExpressionAndIsEnabled` tests in Step 1.
+- FR-1's `LastModifiedBy == "System"` acceptance criterion: covered by the `SetsLastModifiedByToSystem` test.
+- FR-1's "insert path unchanged" acceptance criterion: covered by the pre-existing, untouched `SeedDefaultConfigurationsAsync_WhenEmpty_CreatesAllDefaultConfigurations` test, which continues to pass since the `existing == null` branch is byte-for-byte unchanged.
+- FR-2 (`IsEnabled` never touched by the update path): covered by `PreservesCronExpressionAndIsEnabled`, and structurally guaranteed since `UpdateConfiguration` has no `isEnabled` parameter (unchanged domain method, not modified by this plan).
+- NFR-1 (unconditional update, no diff-and-skip, no measurable startup delay): satisfied by construction — the `else` branch always calls `UpdateConfiguration` + `UpdateAsync` with no equality check; no batching/optimization added, matching the spec's explicit preference for simplicity.
+- NFR-2 (no new auth/security surface, `modifiedBy` hardcoded to `"System"` for both paths): satisfied — `"System"` literal reused unchanged from the insert path.
+- No new interfaces, repository methods, or domain methods were introduced; `UpdateConfiguration` and `UpdateAsync` are reused exactly as they exist today, matching the architecture review's Decision 1 and the design document.
+- No placeholders: every step contains complete, literal code (full replacement file for the seeder, complete test method bodies) and exact runnable commands with stated expected outcomes.
+- Out-of-scope items from the spec (orphaned configuration cleanup, admin UI/controller changes, `UpdateConfiguration` validation changes, diff-and-skip optimization) are not touched by any step, consistent with the spec's "Out of Scope" section.

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs
@@ -13,7 +13,10 @@ public class RecurringJobSeeder : IRecurringJobSeeder
 
     /// <summary>
     /// Seeds database with configurations from discovered IRecurringJob implementations.
-    /// Only creates configurations for jobs that don't already exist in the database.
+    /// Creates configurations for jobs that don't already exist in the database. For jobs
+    /// that already have a configuration row, updates the developer-owned fields
+    /// (DisplayName, Description) to match the current code, while preserving the
+    /// admin-owned fields (CronExpression, IsEnabled) exactly as stored.
     /// </summary>
     /// <param name="jobs">Collection of discovered recurring jobs</param>
     /// <param name="cancellationToken">Cancellation token</param>
@@ -35,6 +38,15 @@ public class RecurringJobSeeder : IRecurringJobSeeder
             if (existing == null)
             {
                 await _repository.AddAsync(config, cancellationToken);
+            }
+            else
+            {
+                existing.UpdateConfiguration(
+                    config.DisplayName,
+                    config.Description,
+                    existing.CronExpression,   // preserve admin override
+                    "System");
+                await _repository.UpdateAsync(existing, cancellationToken);
             }
         }
     }

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs
@@ -79,6 +79,86 @@ public class RecurringJobSeederTests : IDisposable
         Assert.Single(purchasePriceConfigs);
     }
 
+    [Fact]
+    public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_UpdatesDisplayNameAndDescription()
+    {
+        // Arrange - add an existing configuration with stale DisplayName/Description
+        var existingConfig = new RecurringJobConfiguration(
+            "purchase-price-recalculation",
+            "Old Display Name",
+            "Old description that no longer matches the code",
+            "0 2 * * *",
+            true,
+            "System");
+
+        await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+        await _context.SaveChangesAsync();
+
+        var mockJobs = CreateMockJobs();
+
+        // Act
+        await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+        // Assert
+        var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+        Assert.NotNull(updated);
+        Assert.Equal("Purchase Price Recalculation", updated!.DisplayName);
+        Assert.Equal("Recalculates purchase prices for all materials and products", updated.Description);
+    }
+
+    [Fact]
+    public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_PreservesCronExpressionAndIsEnabled()
+    {
+        // Arrange - add an existing configuration with an admin-customized CronExpression and IsEnabled
+        var existingConfig = new RecurringJobConfiguration(
+            "purchase-price-recalculation",
+            "Purchase Price Recalculation",
+            "Recalculates purchase prices for all materials and products",
+            "0 0 * * *", // admin-customized cron, differs from mock job's "0 2 * * *"
+            false,       // admin-disabled, differs from mock job's DefaultIsEnabled: true
+            "System");
+
+        await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+        await _context.SaveChangesAsync();
+
+        var mockJobs = CreateMockJobs();
+
+        // Act
+        await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+        // Assert
+        var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+        Assert.NotNull(updated);
+        Assert.Equal("0 0 * * *", updated!.CronExpression);
+        Assert.False(updated.IsEnabled);
+    }
+
+    [Fact]
+    public async Task SeedDefaultConfigurationsAsync_WhenConfigurationExists_SetsLastModifiedByToSystem()
+    {
+        // Arrange - add an existing configuration whose last modification was made by an admin
+        var existingConfig = new RecurringJobConfiguration(
+            "purchase-price-recalculation",
+            "Purchase Price Recalculation",
+            "Recalculates purchase prices for all materials and products",
+            "0 2 * * *",
+            true,
+            "Admin");
+
+        await _context.RecurringJobConfigurations.AddAsync(existingConfig);
+        await _context.SaveChangesAsync();
+
+        var mockJobs = CreateMockJobs();
+
+        // Act
+        await _seeder.SeedDefaultConfigurationsAsync(mockJobs);
+
+        // Assert
+        var updated = await _repository.GetByJobNameAsync("purchase-price-recalculation");
+        Assert.NotNull(updated);
+        Assert.Equal("System", updated!.LastModifiedBy);
+    }
+
     public void Dispose()
     {
         _context.Dispose();


### PR DESCRIPTION
Closes #3686

## What the issue was
`RecurringJobSeeder.SeedDefaultConfigurationsAsync` only inserted a `RecurringJobConfiguration` row for jobs that had no existing database record. If a row already existed, the seeder silently skipped it. This meant that whenever a developer changed a job's `DisplayName` or `Description` in `RecurringJobMetadata`, the change never propagated to the database, and the admin UI kept showing stale, potentially misleading names/descriptions indefinitely — configuration drift between code and database that would only worsen over time.

`CronExpression` and `IsEnabled` are intentionally different: they're admin-owned and must survive across deployments if an administrator has customized them at runtime, so they were correctly never touched by the seeder — but that same "never touch existing rows" logic incorrectly applied to the developer-owned fields too.

## How it was fixed / handled
Split the seeder's upsert logic:
- **Insert path** (`existing == null`): unchanged — new jobs still get a full row created from `job.Metadata`.
- **Update path** (`existing != null`, new): calls the existing domain method `existing.UpdateConfiguration(config.DisplayName, config.Description, existing.CronExpression, "System")` — passing the **existing** row's `CronExpression` back in so any admin override survives — then persists via the existing `IRecurringJobConfigurationRepository.UpdateAsync`. `IsEnabled` is never touched (the method has no such parameter), preserving admin-toggled enable/disable state.

No new abstractions were introduced — this reuses `RecurringJobConfiguration.UpdateConfiguration` and `IRecurringJobConfigurationRepository.UpdateAsync` exactly as they already existed, per the brief's suggested fix.

Added three new unit tests to `RecurringJobSeederTests.cs` covering: (1) stale `DisplayName`/`Description` get corrected on reseed, (2) an admin-customized `CronExpression`/`IsEnabled` survive reseeding unchanged, (3) `LastModifiedBy` becomes `"System"` after the seeder updates a row.

**Validation performed:**
- `dotnet build` — 0 errors (pre-existing warnings unrelated to this change).
- `dotnet format --verify-no-changes` on the touched files — clean, no formatting violations.
- `dotnet test --filter "FullyQualifiedName~BackgroundJobs"` — 93/93 passed, 0 failed (includes the 3 new tests plus all existing BackgroundJobs-module tests).

## Artifacts
The full pipeline trail — brief, spec, architecture review, design, task plan, implementation summary, task-level review, and whole-branch code review — is committed under `artifacts/feat-3686/` in this branch.

## Code review
# Code Review: Propagate Developer-Owned Metadata Updates in RecurringJobSeeder (#3686)

## Review Result: CLEAN

### Blocking (correctness)
- None

### Advisory (cleanup)
- None

## Notes
Reviewed the full branch diff against `origin/main` merge-base (`2c28fc9`), scoped to `backend/`. The change is exactly the surgical fix described in the brief and spec:

- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs:42-49` — adds an `else` branch to the existing seeding loop. When a `RecurringJobConfiguration` row already exists, it calls `existing.UpdateConfiguration(config.DisplayName, config.Description, existing.CronExpression, "System")` — correctly passing the *existing* row's `CronExpression` (not the code-default `config.CronExpression`), so an administrator's runtime cron override survives reseeding — followed by `_repository.UpdateAsync(existing, cancellationToken)`. Verified `RecurringJobConfigurationRepository.UpdateAsync` (`backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationRepository.cs:34-38`) does a plain `Update` + `SaveChangesAsync`, no surprises. `IsEnabled` is never touched by this path (`UpdateConfiguration` has no such parameter), so admin-toggled enable/disable state is preserved as intended. The insert branch (`existing == null`) is untouched.
- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs:82-161` — three new tests cover exactly the three behaviors: stale `DisplayName`/`Description` get corrected, an admin-customized `CronExpression`/`IsEnabled` survive seeding, and `LastModifiedBy` becomes `"System"` after the seeder updates a row. Ran `dotnet test Anela.Heblo.sln --filter "FullyQualifiedName~RecurringJobSeederTests"`: `Passed! - Failed: 0, Passed: 5, Skipped: 0, Total: 5`.

No correctness issues found. No reuse/simplification/efficiency concerns — the change reuses existing domain (`UpdateConfiguration`) and repository (`UpdateAsync`) methods exactly as they already exist, introduces no new abstractions, and is confined to the single loop branch called out in the brief. Scope matches the spec/arch-review/task-plan with no drift.


---
_Generated by [Claude Code](https://claude.ai/code/session_011rXRmk4Jfd6CEXY4dyJEBk)_