### PR TITLE
#3687: persist and use per-job TimeZoneId for next-run calculation

### DIFF
--- a/artifacts/feat-3687/arch-review.r1.md
+++ b/artifacts/feat-3687/arch-review.r1.md
@@ -1,0 +1,216 @@
+# Architecture Review: Persist and use per-job TimeZoneId in BackgroundJobs recurring job configuration
+
+## Skip Design: true
+
+Backend-only change: one entity property, one DTO field, one calculator parameter, one migration. No UI surfacing (explicitly out of scope in spec). No new endpoints, no new interaction pattern.
+
+## Architectural Fit Assessment
+
+The feature slots cleanly into the existing `BackgroundJobs` vertical slice — every file the spec touches already exists and already has a clear seam for this addition (`RecurringJobConfiguration`, `RecurringJobDto`, `RecurringJobNextRunCalculator`, the two GET handlers, the seeder). No new abstractions, no new module boundary, no cross-module coupling. This is a same-shape, same-pattern extension of fields that already exist one layer over (`RecurringJobMetadata.TimeZoneId`) — closing a gap rather than introducing a new concept.
+
+Verified against the codebase:
+- `RecurringJobConfiguration` (`backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`) is a plain `class` (`Entity<string>`), not a record — consistent with project rules, no conflict.
+- `RecurringJobDto` (`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs`) is already a plain class with `= string.Empty` defaults — the spec's proposed `TimeZoneId` field matches the existing style exactly.
+- `BackgroundJobsMappingProfile` uses `CreateMap<RecurringJobConfiguration, RecurringJobDto>()` with no explicit member mappings — AutoMapper's default same-name-property matching will pick up `TimeZoneId` automatically once it exists on both sides. Confirmed no change needed there, per spec.
+
+One factual correction to the spec, found during exploration (see Specification Amendments): the spec's "API / Interface Design" section states `UpdateRecurringJobCronHandler` calls `RecurringJobConfiguration.UpdateConfiguration(...)`. It does not — it calls a separate, narrower method, `UpdateCronExpression(cronExpression, modifiedBy)`. This changes the scope of caller updates slightly (fewer than the spec implies) and is corrected below.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. Five existing files change, one migration is added:
+
+```
+Domain:       RecurringJobConfiguration.cs          (+ TimeZoneId property, ctor param, UpdateConfiguration param)
+Application:  RecurringJobDto.cs                     (+ TimeZoneId field)
+Application:  RecurringJobNextRunCalculator.cs        (Calculate(...) gains timeZoneId param)
+Application:  GetRecurringJobHandler.cs                (pass dto.TimeZoneId)
+Application:  GetRecurringJobsListHandler.cs            (pass dto.TimeZoneId)
+Application:  RecurringJobSeeder.cs                     (pass job.Metadata.TimeZoneId)
+Persistence:  RecurringJobConfigurationConfiguration.cs (+ column config)
+Persistence:  Migrations/<ts>_AddTimeZoneIdToRecurringJobConfigurations.cs (new)
+Persistence:  Migrations/ApplicationDbContextModelSnapshot.cs (regenerated)
+```
+
+`BackgroundJobsMappingProfile.cs` — no change (confirmed).
+
+### Key Design Decisions
+
+#### Decision 1: Constructor parameter position for `timeZoneId`
+
+**Options considered:**
+- Append at the end of the constructor parameter list (minimizes textual diff per call site, but separates it from the cron-related fields it's conceptually paired with).
+- Insert immediately after `cronExpression` (groups the two schedule-related fields together; matches how `RecurringJobMetadata` documents them as a pair).
+
+**Chosen approach:** Insert after `cronExpression`, before `isEnabled`:
+```csharp
+public RecurringJobConfiguration(
+    string jobName,
+    string displayName,
+    string description,
+    string cronExpression,
+    string timeZoneId,
+    bool isEnabled,
+    string lastModifiedBy)
+```
+Same ordering for `UpdateConfiguration`:
+```csharp
+public void UpdateConfiguration(
+    string displayName,
+    string description,
+    string cronExpression,
+    string timeZoneId,
+    string modifiedBy)
+```
+
+**Rationale:** `cronExpression` and `timeZoneId` are read together everywhere they're consumed (`RecurringJobNextRunCalculator.Calculate`, `HangfireJobRegistrationHelper.RegisterOrUpdate`) — keeping them adjacent in the constructor signature makes future call sites self-documenting. This is a positional-parameter change either way (all ~30 existing call sites — see Risks — must be touched regardless of where the parameter lands), so there's no "cheaper" option; pick the more readable one.
+
+#### Decision 2: `UpdateRecurringJobCronHandler` / `UpdateCronExpression` — do NOT touch
+
+**Options considered:**
+- Follow the spec literally and modify `UpdateRecurringJobCronHandler` to pass a `timeZoneId` argument into `UpdateConfiguration` (as the spec's "API / Interface Design" section directs).
+- Leave `UpdateRecurringJobCronHandler` and `RecurringJobConfiguration.UpdateCronExpression` untouched, since they don't call `UpdateConfiguration` at all.
+
+**Chosen approach:** Leave both untouched. Verified in `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/UpdateRecurringJobCron/UpdateRecurringJobCronHandler.cs:67` — it calls `job.UpdateCronExpression(request.CronExpression, modifiedBy)`, a separate two-parameter method (`RecurringJobConfiguration.cs:113`) that only ever touched `CronExpression`, `LastModifiedAt`, `LastModifiedBy`. It does not call the four/five-parameter `UpdateConfiguration`. `UpdateCronExpression`'s signature is out of scope for this fix — it doesn't set `TimeZoneId` today and doesn't need to.
+
+**Rationale:** `UpdateConfiguration` currently has **no production caller at all** — grep confirms its only call sites are two unit tests (`RecurringJobConfigurationRepositoryTests.cs:130`, `RecurringJobConfigurationTests.cs:137`). It exists as a general-purpose update method on the aggregate but nothing in the current UseCases wires up to it. Adding `timeZoneId` to it is still correct per spec (keep the domain method's contract complete and consistent with the constructor), but no handler needs to change to accommodate it. See Specification Amendments.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No structural changes — every touched file already lives in its correct location per `docs/architecture/filesystem.md` (Domain entity in `Anela.Heblo.Domain/Features/BackgroundJobs/`, DTO in `Anela.Heblo.Application/Features/BackgroundJobs/Contracts/`, handlers under `UseCases/{UseCase}/`, EF config under `Anela.Heblo.Persistence/BackgroundJobs/`, migration under `Anela.Heblo.Persistence/Migrations/`).
+
+### Interfaces and Contracts
+
+**`RecurringJobConfiguration.cs`** — add property, private-ctor init, public-ctor param + validation, `UpdateConfiguration` param + validation:
+```csharp
+[Required]
+[MaxLength(100)]
+public string TimeZoneId { get; private set; }
+
+// private ctor
+TimeZoneId = string.Empty;
+
+// public ctor — validate like the other required strings:
+if (string.IsNullOrWhiteSpace(timeZoneId))
+    throw new ValidationException("TimeZoneId is required");
+...
+TimeZoneId = timeZoneId;
+
+// UpdateConfiguration — same validation pattern as cronExpression:
+if (string.IsNullOrWhiteSpace(timeZoneId))
+    throw new ValidationException("TimeZoneId is required");
+...
+TimeZoneId = timeZoneId;
+```
+`[MaxLength(100)]` matches the convention already used for `JobName`/`LastModifiedBy` (identifier-length strings) on this entity — confirmed by reading the file, not assumed.
+
+**`RecurringJobDto.cs`** — add, placed next to `CronExpression` to mirror the entity's field grouping:
+```csharp
+public string CronExpression { get; set; } = string.Empty;
+public string TimeZoneId { get; set; } = string.Empty;
+public bool IsEnabled { get; set; }
+```
+
+**`RecurringJobNextRunCalculator.cs`** — exact new signature:
+```csharp
+public static DateTime? Calculate(string cronExpression, bool isEnabled, string timeZoneId, DateTime utcNow, ILogger logger, string? jobName = null)
+{
+    ...
+    tz = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+    ...
+    catch (TimeZoneNotFoundException ex)
+    {
+        logger.LogWarning(ex, "Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'",
+            timeZoneId, jobName);
+        return null;
+    }
+```
+`RecurringJobMetadata.DefaultTimeZoneId` is no longer referenced inside this file at all after the change (verified it has exactly one other reference, in `RecurringJobConfigurationTests.cs`/seeder fallback context — not in the calculator).
+
+**Callers** — both are one-line diffs, confirmed exact current call shape:
+- `GetRecurringJobHandler.cs:47-48`: `RecurringJobNextRunCalculator.Calculate(dto.CronExpression, dto.IsEnabled, dto.TimeZoneId, utcNow, _logger, dto.JobName)`
+- `GetRecurringJobsListHandler.cs:41-42`: same change, inside the existing `foreach (var dto in jobDtos)` loop.
+
+**`RecurringJobSeeder.cs`** — add one line to the existing object-initializer-style constructor call at line 23-30:
+```csharp
+var defaultConfigurations = jobs.Select(job => new RecurringJobConfiguration(
+    job.Metadata.JobName,
+    job.Metadata.DisplayName,
+    job.Metadata.Description,
+    job.Metadata.CronExpression,
+    job.Metadata.TimeZoneId,
+    job.Metadata.DefaultIsEnabled,
+    "System"
+)).ToArray();
+```
+`RecurringJobMetadata.TimeZoneId` already defaults to `DefaultTimeZoneId = "Europe/Prague"` (`RecurringJobMetadata.cs:41`), so no explicit fallback logic is needed here — every `IRecurringJob` implementation either sets it explicitly (as `FlexiAnalyticsSyncJob` does, from `FlexiAnalyticsSyncOptions.TimeZone`) or inherits the default.
+
+**`UpdateRecurringJobCronHandler.cs` / `UpdateCronExpression`** — no change (Decision 2).
+
+### Data Flow
+
+Unchanged shape, one more field riding along: `IRecurringJob.Metadata.TimeZoneId` → `RecurringJobSeeder` → `RecurringJobConfiguration.TimeZoneId` (persisted) → `AutoMapper` → `RecurringJobDto.TimeZoneId` → `RecurringJobNextRunCalculator.Calculate(..., timeZoneId, ...)` → `RecurringJobDto.NextRunAt`. This now runs parallel to, and in agreement with, `RecurringJobDiscoveryService` → `HangfireJobRegistrationHelper.RegisterOrUpdate` → `RecurringJobOptions.TimeZone`, which already uses `job.Metadata.TimeZoneId` directly (`HangfireRecurringJobScheduler.cs:47`). Both paths now read from the same ultimate source per job; the persisted `RecurringJobConfiguration.TimeZoneId` is a cache of it for display purposes, not a competing source of truth (`RecurringJobMetadata` — sourced from code/config — remains authoritative; the DB column mirrors it at seed time, same pattern already used for `CronExpression`/`DisplayName`/`Description`).
+
+### Migration — exact approach for this repo
+
+**Mechanism confirmed:** `docs/development/setup.md` § "Database Migrations Runbook" (not just the CLAUDE.md one-liner) documents the actual split:
+- **Production**: migrations run automatically at app startup via `MigrateDatabaseAsync` (`Program.cs:165`) — no manual step.
+- **Development / Test / Staging**: migrations are **not** auto-applied. Deploying code that depends on a new migration before running `dotnet ef database update` against that environment produces `Npgsql.PostgresException: 42P01: relation "<table>" does not exist` (or, for a column addition, a missing-column error at query time). This exact hazard is already documented for `AddDataQualityTables` → `StandardizeTableNamingToPascalCase` and applies identically here.
+
+**Table/column naming — verified, not assumed:** the *live* physical name is `"RecurringJobConfigurations"` (PascalCase, schema `public`), with PascalCase columns (`JobName`, `CronExpression`, etc.) — confirmed via `ApplicationDbContextModelSnapshot.cs:333-380`. The original `20260105125530_AddRecurringJobConfigurations.cs` migration created the table with **snake_case** names (`recurring_job_configurations`, `job_name`, ...) — this was a one-off inconsistency at the time, since **no snake-case naming convention is registered anywhere in `ApplicationDbContext`/`PersistenceModule`** (verified — no `UseSnakeCaseNamingConvention` or equivalent). It was corrected by a later migration, `20260424142720_StandardizeTableNamingToPascalCase.cs`, which explicitly renamed the table and every column/index back to PascalCase to match EF's default (no-convention) naming. **Do not copy the naming style of the original 2026-01-05 migration file** — copy the style of any migration after 2026-04-24 (e.g. `20260715150507_AddLotLabelDriftCorrection.cs`).
+
+**Exact migration content** (mirrors `AddLotLabelDriftCorrection.cs`, the closest existing example — a single `NOT NULL` column with a C#-level default that both sets the DB default and backfills existing rows):
+```bash
+dotnet ef migrations add AddTimeZoneIdToRecurringJobConfigurations \
+  --project backend/src/Anela.Heblo.Persistence --startup-project backend/src/Anela.Heblo.API
+```
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.AddColumn<string>(
+        name: "TimeZoneId",
+        schema: "public",
+        table: "RecurringJobConfigurations",
+        type: "character varying(100)",
+        maxLength: 100,
+        nullable: false,
+        defaultValue: "Europe/Prague");
+}
+
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.DropColumn(
+        name: "TimeZoneId",
+        schema: "public",
+        table: "RecurringJobConfigurations");
+}
+```
+`ApplicationDbContextModelSnapshot.cs` is regenerated automatically by the `dotnet ef migrations add` command — do not hand-edit it; just verify the new `b.Property<string>("TimeZoneId")...` block appears in the `RecurringJobConfiguration` entity section (alongside `JobName` et al., ~line 357).
+
+`RecurringJobConfigurationConfiguration.cs` — add, in the same block as the other `[MaxLength]`-backed string properties:
+```csharp
+builder.Property(e => e.TimeZoneId)
+    .HasMaxLength(100)
+    .IsRequired();
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Staging/Test 500s if app code deploys before the migration is applied (documented "ordering hazard" pattern, same as `AddDataQualityTables`/`StandardizeTableNamingToPascalCase`) | Medium | Apply `dotnet ef database update` to Staging/Test **before** merging/deploying the dependent code; verify via `/health/ready` per the runbook. Production is unaffected (auto-migrates at startup). |
+| ~30 existing call sites of `new RecurringJobConfiguration(...)` across test files (`RecurringJobConfigurationRepositoryTests`, `RecurringJobConfigurationTests`, `GetRecurringJobsListHandlerTests`, `GetRecurringJobHandlerTests`, `RecurringJobStatusCheckerTests`, `RecurringJobDiscoveryServiceTests`, `RecurringJobSeederTests`, `UpdateRecurringJobStatusHandlerTests`) all break on the constructor signature change (positional args) | Low (mechanical, high count) | Add the constructor param as specified; the compiler will point at every failing call site — no risk of silently-wrong tests, just volume. Already called out in spec's acceptance criteria. |
+| Spec's claim that `UpdateRecurringJobCronHandler` calls `UpdateConfiguration` is incorrect, could lead an implementer to add an unnecessary/incorrect change to that handler | Low | Corrected in this review (Decision 2) and in Specification Amendments below — implementer should skip that handler entirely. |
+| `FlexiAnalyticsSyncJob` already reads `TimeZoneId` from `FlexiAnalyticsSyncOptions.TimeZone` (config-driven, defaults to `"Europe/Prague"` but is operator-overridable per environment) — this is not a purely hypothetical future scenario | Informational | No action needed beyond this fix; noted because it means the "latent" bug in the brief is one config change away from being live in any environment, which supports prioritizing this fix. |
+
+## Specification Amendments
+
+1. **§ "API / Interface Design", correct this sentence:** *"Any existing 'update job' command/handler (e.g. `UpdateRecurringJobCronHandler`) that calls `RecurringJobConfiguration.UpdateConfiguration(...)` must be updated to pass a `timeZoneId` argument, since that method's signature changes per FR-1.1."* — **This is factually incorrect.** `UpdateRecurringJobCronHandler` calls `RecurringJobConfiguration.UpdateCronExpression(cronExpression, modifiedBy)`, a different, narrower method that does not touch `TimeZoneId` and is not changing in this fix. `UpdateConfiguration` currently has zero production callers (only two unit tests call it directly). No handler-level change is required for this sentence's concern; remove it or replace with: "`UpdateConfiguration` gains a `timeZoneId` parameter per FR-1.1; it currently has no production caller, so no handler needs updating as a result."
+2. **FR-1.1, constructor/`UpdateConfiguration` parameter position** — spec doesn't pin down where `timeZoneId` goes in the parameter list. This review fixes it: immediately after `cronExpression`, before `isEnabled` (ctor) / before `modifiedBy` (`UpdateConfiguration`). See Decision 1.
+
+## Prerequisites
+
+None. All target files exist today with the exact shapes described above; no other in-flight work in `BackgroundJobs` was found that would conflict (no other open changes to `RecurringJobConfiguration`, `RecurringJobDto`, or the calculator in this worktree).

--- a/artifacts/feat-3687/brief.md
+++ b/artifacts/feat-3687/brief.md
@@ -1,0 +1,40 @@
+# [arch-review] BackgroundJobs: RecurringJobConfiguration doesn't persist TimeZoneId; NextRunCalculator silently uses default timezone for all jobs
+
+## Module
+BackgroundJobs
+
+## Finding
+`RecurringJobMetadata` supports a per-job timezone via `TimeZoneId` (defaulting to `"Europe/Prague"`), and `HangfireJobRegistrationHelper.RegisterOrUpdate` correctly passes it to Hangfire so jobs are scheduled in the right timezone:
+
+```csharp
+// backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs  line 83
+TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
+```
+
+However, `RecurringJobConfiguration` (the persisted entity) has no `TimeZoneId` column, and `RecurringJobDto` has no timezone field. As a result, `RecurringJobNextRunCalculator` always derives "next run" using the constant default:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs  line 24
+tz = TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId);
+```
+
+This means that if any job is ever implemented with a non-Prague timezone, Hangfire will correctly schedule it in that timezone, but the UI will display the wrong "next run" time because the calculator uses Prague unconditionally.
+
+The data model already acknowledges timezones as a first-class concern (the `TimeZoneId` property on `RecurringJobMetadata`, the timezone plumbing in `HangfireJobRegistrationHelper`), but the persistence model drops it — an inconsistency in the domain representation.
+
+## Why it matters
+This is a latent display bug. It's dormant right now only because all current jobs happen to use the default timezone. The moment a job with a different timezone is added, the "Next run" column in the admin UI will show a wrong time without any error or warning. It will also be hard to diagnose because both the Hangfire dashboard and the API endpoint return contradictory data.
+
+## Suggested fix
+Add `TimeZoneId` to `RecurringJobConfiguration` and `RecurringJobDto`, and pass it through to the calculator:
+
+1. **Domain entity** (`RecurringJobConfiguration.cs`): add `public string TimeZoneId { get; private set; }` — set in constructor, included in `UpdateConfiguration`.
+2. **DTO** (`RecurringJobDto.cs`): add `public string TimeZoneId { get; set; }`.
+3. **Mapping** (`BackgroundJobsMappingProfile.cs`): `CreateMap` already covers same-named properties; no explicit mapping needed if names match.
+4. **Calculator** (`RecurringJobNextRunCalculator.cs`): change the signature to `Calculate(string cronExpression, bool isEnabled, string timeZoneId, DateTime utcNow, ...)` and use the passed-in `timeZoneId` instead of the constant.
+5. **Callers** (`GetRecurringJobHandler`, `GetRecurringJobsListHandler`): pass `dto.TimeZoneId`.
+6. **Seeder** (`RecurringJobSeeder`): pass `job.Metadata.TimeZoneId` to the `RecurringJobConfiguration` constructor (add the parameter).
+7. **Migration**: add a `TimeZoneId` column with default `'Europe/Prague'` (no data loss, all existing rows are already using the default).
+
+---
+_Filed by daily arch-review routine on 2026-07-18._

--- a/artifacts/feat-3687/design.r1.md
+++ b/artifacts/feat-3687/design.r1.md
@@ -1,0 +1,189 @@
+# Design: Persist and use per-job TimeZoneId in BackgroundJobs recurring job configuration
+
+## Component Design
+
+No new components are introduced. This closes a gap in an existing data path by threading a `TimeZoneId` value through five existing components in the `BackgroundJobs` vertical slice, plus a new EF Core migration.
+
+### `RecurringJobConfiguration` (Domain entity)
+`Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`
+
+- Responsibility: the persisted aggregate representing one recurring job's admin-configurable state (cron expression, enabled flag, timezone, audit fields).
+- Interface change:
+  - New property: `public string TimeZoneId { get; private set; }` — initialized to `string.Empty` in the private (EF Core) constructor, matching the pattern of `JobName`, `CronExpression`, etc.
+  - Public constructor gains a required `timeZoneId` parameter, positioned immediately after `cronExpression` and before `isEnabled`:
+    ```
+    public RecurringJobConfiguration(string jobName, string displayName, string description,
+        string cronExpression, string timeZoneId, bool isEnabled, string lastModifiedBy)
+    ```
+    Validated with the same `ValidationException` pattern used for other required strings (throw when null/whitespace), then assigned to `TimeZoneId`.
+  - `UpdateConfiguration(...)` gains a `timeZoneId` parameter in the same relative position (after `cronExpression`, before `modifiedBy`), validated and assigned identically to how `cronExpression` is handled today. Note: `UpdateConfiguration` currently has no production caller (only two unit tests) — its contract is kept complete and consistent with the constructor, but no handler changes as a result.
+  - `[MaxLength(100)]` attribute on `TimeZoneId`, matching the identifier-length convention already used for `JobName`/`LastModifiedBy` on this entity.
+  - `UpdateCronExpression(cronExpression, modifiedBy)` is a separate, narrower method (used by `UpdateRecurringJobCronHandler`) and is **not** touched — it never set `TimeZoneId` and doesn't need to.
+
+### `RecurringJobDto` (Application contract)
+`Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs`
+
+- Responsibility: the API-facing shape returned by the "get job" / "get jobs list" use cases.
+- Interface change: new field `public string TimeZoneId { get; set; } = string.Empty;`, placed next to `CronExpression` to mirror the entity's field grouping. Remains a plain class (project rule: DTOs are never records).
+- No change to `BackgroundJobsMappingProfile.cs` — the existing `CreateMap<RecurringJobConfiguration, RecurringJobDto>()` maps same-named properties automatically once `TimeZoneId` exists on both sides.
+
+### `RecurringJobNextRunCalculator` (Application service)
+`Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs`
+
+- Responsibility: pure, static, in-memory computation of a job's next scheduled run time from its cron expression and timezone.
+- Interface change — new signature:
+  ```
+  public static DateTime? Calculate(string cronExpression, bool isEnabled, string timeZoneId,
+      DateTime utcNow, ILogger logger, string? jobName = null)
+  ```
+  - Resolves the timezone via `TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)` instead of `TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId)`.
+  - On `TimeZoneNotFoundException`, the warning log now reports the passed-in `timeZoneId` (not the default constant).
+  - Error-handling contract unchanged: still returns `null` for a disabled job, unresolvable timezone, or invalid cron expression.
+  - `RecurringJobMetadata.DefaultTimeZoneId` is no longer referenced inside this file; it remains the fallback used upstream when a job doesn't override its metadata timezone.
+
+### Callers of the calculator
+- `GetRecurringJobHandler.cs` (`UseCases/GetRecurringJob/`): `RecurringJobNextRunCalculator.Calculate(dto.CronExpression, dto.IsEnabled, dto.TimeZoneId, utcNow, _logger, dto.JobName)`.
+- `GetRecurringJobsListHandler.cs` (`UseCases/GetRecurringJobsList/`): same change, applied inside the existing `foreach (var dto in jobDtos)` loop.
+
+Both are single-argument insertions at an existing call site; no other logic in these handlers changes.
+
+### `RecurringJobSeeder` (Application service)
+`Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+
+- Responsibility: seeds `RecurringJobConfiguration` rows from discovered `IRecurringJob` metadata (`SeedDefaultConfigurationsAsync`).
+- Change: passes `job.Metadata.TimeZoneId` as the new constructor argument when building each `RecurringJobConfiguration`. No explicit fallback logic needed here — `RecurringJobMetadata.TimeZoneId` already defaults to `RecurringJobMetadata.DefaultTimeZoneId` (`"Europe/Prague"`) for any job that doesn't override it.
+
+### EF Core configuration
+`Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`
+
+- Adds:
+  ```
+  builder.Property(e => e.TimeZoneId)
+      .HasMaxLength(100)
+      .IsRequired();
+  ```
+  Placed alongside the other `[MaxLength]`-backed string property configurations on this entity.
+
+### Data flow (end-to-end)
+
+```
+IRecurringJob.Metadata.TimeZoneId
+    → RecurringJobSeeder.SeedDefaultConfigurationsAsync
+    → RecurringJobConfiguration.TimeZoneId (persisted, EF Core)
+    → AutoMapper (CreateMap<RecurringJobConfiguration, RecurringJobDto>)
+    → RecurringJobDto.TimeZoneId
+    → RecurringJobNextRunCalculator.Calculate(..., timeZoneId, ...)
+    → RecurringJobDto.NextRunAt
+```
+
+This runs parallel to, and now agrees with, the already-correct registration path:
+```
+IRecurringJob.Metadata.TimeZoneId → HangfireJobRegistrationHelper.RegisterOrUpdate → RecurringJobOptions.TimeZone
+```
+`RecurringJobMetadata` (code/config-sourced) remains the single authoritative source; the persisted `RecurringJobConfiguration.TimeZoneId` is a display-layer cache of it at seed time — the same pattern already used for `CronExpression`, `DisplayName`, and `Description`.
+
+### Out of scope for this change
+- `HangfireJobRegistrationHelper` / job registration and discovery flow — already correct, not modified.
+- `UpdateRecurringJobCronHandler` — calls `RecurringJobConfiguration.UpdateCronExpression(cronExpression, modifiedBy)`, a distinct method not touched by this change.
+- Any UI surfacing of `TimeZoneId` (admin frontend) — API-contract-only change; the generated TypeScript client will pick up the new field automatically on next build, but no frontend usage is added.
+- New validation that a `TimeZoneId` string is a resolvable timezone at write time — unresolvable timezones remain handled defensively downstream (`TimeZoneNotFoundException` → warning + `null NextRunAt`), unchanged.
+
+## Data Schemas
+
+### Database schema change
+
+Table `public.RecurringJobConfigurations` gains one column:
+
+| Column | Type | Nullable | Default | Notes |
+|---|---|---|---|---|
+| `TimeZoneId` | `character varying(100)` (Postgres) / `nvarchar(100)` provider-equivalent | No | `'Europe/Prague'` | IANA/Windows timezone id resolvable via `TimeZoneInfo.FindSystemTimeZoneById`; mirrors `RecurringJobMetadata.TimeZoneId` / `RecurringJobMetadata.DefaultTimeZoneId`. |
+
+No new tables, no relationship or index changes.
+
+**Migration** — new file under `Anela.Heblo.Persistence/Migrations/`, named `<timestamp>_AddTimeZoneIdToRecurringJobConfigurations.cs`, generated via:
+```bash
+dotnet ef migrations add AddTimeZoneIdToRecurringJobConfigurations \
+  --project backend/src/Anela.Heblo.Persistence --startup-project backend/src/Anela.Heblo.API
+```
+Content pattern (mirrors `AddLotLabelDriftCorrection.cs` — a single `NOT NULL` column with a database-level default so no manual backfill step is required):
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.AddColumn<string>(
+        name: "TimeZoneId",
+        schema: "public",
+        table: "RecurringJobConfigurations",
+        type: "character varying(100)",
+        maxLength: 100,
+        nullable: false,
+        defaultValue: "Europe/Prague");
+}
+
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.DropColumn(
+        name: "TimeZoneId",
+        schema: "public",
+        table: "RecurringJobConfigurations");
+}
+```
+`ApplicationDbContextModelSnapshot.cs` is regenerated automatically by `dotnet ef migrations add` — do not hand-edit; verify a `b.Property<string>("TimeZoneId")...` block appears in the `RecurringJobConfiguration` entity section.
+
+Naming convention note: follow the PascalCase table/column style used from `20260424142720_StandardizeTableNamingToPascalCase.cs` onward (e.g. `20260715150507_AddLotLabelDriftCorrection.cs`) — **not** the snake_case style of the original `20260105125530_AddRecurringJobConfigurations.cs`, which was a one-off inconsistency later corrected.
+
+Deployment note: per `docs/development/setup.md` § "Database Migrations Runbook", Production auto-migrates at app startup (`MigrateDatabaseAsync`); Development/Test/Staging do **not** auto-apply migrations — `dotnet ef database update` must be run against those environments before deploying dependent code, to avoid a missing-column error at query time.
+
+### API response shape (additive, backward-compatible)
+
+No new endpoints, no request contract changes. Existing responses gain one field on each `RecurringJobDto`:
+
+**`GetRecurringJobResponse` (single job)** and **`GetRecurringJobsListResponse` (list)** — each contained `RecurringJobDto` now includes:
+```json
+{
+  "jobName": "string",
+  "displayName": "string",
+  "description": "string",
+  "cronExpression": "string",
+  "timeZoneId": "string",
+  "isEnabled": true,
+  "nextRunAt": "2026-07-19T08:00:00Z",
+  "...": "existing fields unchanged"
+}
+```
+- `timeZoneId`: new field, non-nullable string (e.g. `"Europe/Prague"`, `"America/New_York"`).
+- `nextRunAt`: unchanged shape, but now computed by `RecurringJobNextRunCalculator.Calculate` using `timeZoneId` instead of the previously hardcoded `RecurringJobMetadata.DefaultTimeZoneId`, so it matches the timezone Hangfire actually schedules the job in.
+
+The OpenAPI TypeScript client is auto-generated on build and will pick up `timeZoneId` automatically; no manual frontend client changes are required.
+
+### Domain constructor / method signatures (contract summary)
+
+```csharp
+// RecurringJobConfiguration — public constructor
+public RecurringJobConfiguration(
+    string jobName,
+    string displayName,
+    string description,
+    string cronExpression,
+    string timeZoneId,   // new, required, non-null/whitespace
+    bool isEnabled,
+    string lastModifiedBy)
+
+// RecurringJobConfiguration.UpdateConfiguration
+public void UpdateConfiguration(
+    string displayName,
+    string description,
+    string cronExpression,
+    string timeZoneId,   // new, required, non-null/whitespace
+    string modifiedBy)
+
+// RecurringJobNextRunCalculator.Calculate
+public static DateTime? Calculate(
+    string cronExpression,
+    bool isEnabled,
+    string timeZoneId,   // new; replaces internal use of RecurringJobMetadata.DefaultTimeZoneId
+    DateTime utcNow,
+    ILogger logger,
+    string? jobName = null)
+```
+
+These are positional-parameter breaking changes at the C# level; every existing call site (production and the ~30 test call sites enumerated in the architecture review) must be updated to compile, but no external/API-facing contract is broken — the response payload change is purely additive.

--- a/artifacts/feat-3687/impl/add-recurring-job-timezone-id.r1.md
+++ b/artifacts/feat-3687/impl/add-recurring-job-timezone-id.r1.md
@@ -1,0 +1,54 @@
+# Implementation: add-recurring-job-timezone-id
+
+## What was implemented
+
+Added a persisted, per-job `TimeZoneId` to `RecurringJobConfiguration` and threaded it end-to-end so `RecurringJobNextRunCalculator` computes `NextRunAt` using each job's own configured timezone, instead of the hardcoded `RecurringJobMetadata.DefaultTimeZoneId` ("Europe/Prague"). This closes the latent display bug described in the issue: Hangfire already scheduled jobs correctly per-timezone via `HangfireJobRegistrationHelper`, but the API/UI "next run" calculation ignored it.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs` — added `TimeZoneId` property, threaded through the constructor and `UpdateConfiguration` (positioned right after `cronExpression`), with the same required/non-empty validation as `CronExpression`.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs` — added `TimeZoneId` field.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs` — `Calculate(...)` now takes a `timeZoneId` parameter and uses it instead of the constant default; removed the now-unused `Anela.Heblo.Domain.Features.BackgroundJobs` using.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs` — passes `job.Metadata.TimeZoneId` into the entity constructor.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJob/GetRecurringJobHandler.cs` and `.../GetRecurringJobsList/GetRecurringJobsListHandler.cs` — pass `dto.TimeZoneId` into the calculator call.
+- `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs` — EF Core column config: `nvarchar(100)`, required.
+- `backend/src/Anela.Heblo.Persistence/Migrations/20260718074122_AddTimeZoneIdToRecurringJobConfigurations.cs` (+ `.Designer.cs`, + updated `ApplicationDbContextModelSnapshot.cs`) — generated via `dotnet ef migrations add`; adds `TimeZoneId` column (`character varying(100)`, `NOT NULL DEFAULT 'Europe/Prague'`) to `RecurringJobConfigurations`, matching the PascalCase convention established by `20260424142720_StandardizeTableNamingToPascalCase.cs`.
+- Test files updated for the new constructor/method signatures: `GetRecurringJobHandlerTests.cs`, `GetRecurringJobsListHandlerTests.cs`, `RecurringJobConfigurationRepositoryTests.cs`, `RecurringJobConfigurationTests.cs`, `RecurringJobDiscoveryServiceTests.cs`, `RecurringJobSeederTests.cs`, `RecurringJobStatusCheckerTests.cs`, `UpdateRecurringJobCronHandlerTests.cs`, `UpdateRecurringJobStatusHandlerTests.cs`.
+
+`UpdateRecurringJobCronHandler` was confirmed (per the architect review) to call the separate, narrower `UpdateCronExpression(...)` method, not `UpdateConfiguration(...)` — it was left untouched apart from a one-line test-fixture update for the new constructor signature.
+
+## Tests
+
+- Existing ~95 `BackgroundJobs` unit tests updated for the new signatures and passing.
+- `RecurringJobConfigurationTests.cs` — added new cases asserting `TimeZoneId` round-trips through the constructor and `UpdateConfiguration`, and that a null/empty `TimeZoneId` throws `ValidationException`.
+- `RecurringJobNextRunCalculator` coverage (within the existing handler tests) now includes a case with a non-default `TimeZoneId` (e.g. `"America/New_York"`) asserting `NextRunAt` differs from the value computed under the default Prague timezone — proving the calculator now actually respects the passed-in timezone.
+
+## How to verify
+
+```
+cd backend
+dotnet build Anela.Heblo.sln
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~BackgroundJobs" --no-build
+dotnet format Anela.Heblo.sln --verify-no-changes
+```
+
+## Notes
+
+- Ran the full `Anela.Heblo.Tests` suite: 5900 passed, 76 failed, 4 skipped. All 76 failures are pre-existing `Testcontainers`/Docker-dependent integration tests (Leaflet, KnowledgeBase, Bank, Catalog, Invoices, MeetingTasks, Photobank, Purchase, Article repository/SQL-shape tests) that fail with `"Docker is either not running or misconfigured"` in this sandbox, which has no Docker daemon — none reference `BackgroundJobs` and none are affected by this change.
+- This change is behavior-preserving for all current data: every existing `RecurringJobConfiguration` row will get `TimeZoneId = 'Europe/Prague'` via the migration default, identical to today's hardcoded behavior. Behavior only changes once a job is configured with a non-default timezone.
+- Per CLAUDE.md, DB migrations are manual in this repo (not auto-applied outside Production) — the new migration must be applied with `dotnet ef database update` before/alongside deploying this code to Dev/Test/Staging.
+
+## PR Summary
+
+Fixes a latent display bug in the BackgroundJobs admin UI: `RecurringJobConfiguration` didn't persist a per-job timezone, so `RecurringJobNextRunCalculator` always assumed the default `Europe/Prague` timezone regardless of what a job's metadata actually specified — even though Hangfire itself already scheduled jobs correctly per-timezone. This PR adds a `TimeZoneId` column/property to the persisted entity and DTO and threads it through to the calculator and its two callers, so the "next run" display matches what Hangfire actually does. All existing jobs keep their current (correct) behavior via a `'Europe/Prague'` migration default; only a job configured with a non-default timezone would see a behavior change, and it would now be the *correct* one.
+
+### Changes
+- `RecurringJobConfiguration.cs` — new `TimeZoneId` property, constructor param, `UpdateConfiguration` param
+- `RecurringJobDto.cs` — new `TimeZoneId` field
+- `RecurringJobNextRunCalculator.cs` — `Calculate(...)` takes and uses `timeZoneId`
+- `RecurringJobSeeder.cs`, `GetRecurringJobHandler.cs`, `GetRecurringJobsListHandler.cs` — pass the timezone through
+- `RecurringJobConfigurationConfiguration.cs` + new EF Core migration — persist the column
+- Nine BackgroundJobs test files updated/extended for the new signatures and new timezone-respecting behavior
+
+## Status
+DONE

--- a/artifacts/feat-3687/review/add-recurring-job-timezone-id.r1.md
+++ b/artifacts/feat-3687/review/add-recurring-job-timezone-id.r1.md
@@ -1,0 +1,28 @@
+# Code Review: BackgroundJobs TimeZoneId persistence
+
+## Summary
+The implementation matches the task spec closely: `TimeZoneId` is added to `RecurringJobConfiguration` (constructor + `UpdateConfiguration`, both after `cronExpression`), threaded through `RecurringJobDto`, `RecurringJobNextRunCalculator.Calculate`, both handler call sites, the seeder, EF Core configuration, and a correctly-styled migration. Every call site of the changed signatures was updated, `dotnet build` is clean, `dotnet format --verify-no-changes` is clean, and all 95 BackgroundJobs tests plus the new required timezone-divergence test pass.
+
+## Review Result: PASS
+
+### task: add-recurring-job-timezone-id
+**Status:** PASS
+
+## Docs to Update
+(none — task explicitly scoped DB migration application as an out-of-scope operational step already covered by `docs/development/setup.md`)
+
+## Overall Notes
+
+Verification performed:
+
+- **`RecurringJobNextRunCalculator.Calculate`**: signature is now `(cronExpression, isEnabled, timeZoneId, utcNow, logger, jobName = null)`. `TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)` replaces the old `RecurringJobMetadata.DefaultTimeZoneId` reference in both the resolution call and the `TimeZoneNotFoundException` log format argument. Confirmed via `grep -n "DefaultTimeZoneId"` that the string no longer appears anywhere in the file (the unused `using Anela.Heblo.Domain.Features.BackgroundJobs;` was correctly removed too), satisfying the acceptance criterion verbatim.
+- **Call sites**: `grep -rn "RecurringJobNextRunCalculator.Calculate("` across `backend/` shows only the two production call sites (`GetRecurringJobHandler.cs`, `GetRecurringJobsListHandler.cs`), both updated to pass `dto.TimeZoneId`. `grep -rn "new RecurringJobConfiguration("` and `grep -rn "\.UpdateConfiguration("` show no remaining old-signature callers — every test file listed in the spec was updated with a `timeZoneId` argument in the correct position.
+- **Migration**: `20260718074122_AddTimeZoneIdToRecurringJobConfigurations.cs` adds `TimeZoneId` as `character varying(100)`, `maxLength: 100`, `nullable: false`, `defaultValue: "Europe/Prague"` on `RecurringJobConfigurations` in schema `public` — matches the entity's `[MaxLength(100)]`/`[Required]` and the EF Core `HasMaxLength(100).IsRequired()` config exactly, and follows the `AddLotLabelDriftCorrection.cs` PascalCase style rather than the deprecated snake_case one. `ApplicationDbContextModelSnapshot.cs` was correctly regenerated with the matching `b.Property<string>("TimeZoneId")` entry.
+- **`UpdateRecurringJobCronHandler.cs`** and **`BackgroundJobsMappingProfile.cs`**: confirmed via `git diff HEAD~1 HEAD` to be completely unmodified, as required.
+- **Build**: `dotnet build Anela.Heblo.sln` → 0 errors (251 pre-existing warnings, unrelated to this change).
+- **Format**: `dotnet format Anela.Heblo.sln --verify-no-changes` → no output, i.e. clean.
+- **BackgroundJobs tests**: `dotnet test ... --filter "FullyQualifiedName~BackgroundJobs" --no-build` → 95/95 passed, including the new required test proving `Calculate` respects a non-default timezone (`GetRecurringJobHandlerTests.Handle_WhenJobHasNonDefaultTimeZone_UsesJobTimeZoneForNextRunAt`, with hand-verified DST arithmetic: fixed `utcNow` 2026-03-30 12:00 UTC → 08:00 EDT in New York, next `13:00` cron occurrence same day → 17:00 UTC; independently confirmed this differs from the Prague-timezone result of 2026-03-31 11:00 UTC, since Prague was already at 14:00 CEST at that instant), plus new `RecurringJobConfigurationTests` constructor/`UpdateConfiguration` timezone validation tests, and a `RecurringJobSeederTests` assertion that seeded `TimeZoneId` differs per job metadata (`"America/New_York"` for `invoice-classification`).
+- **Full suite / Docker-failure claim spot check**: ran the entire `Anela.Heblo.Tests` suite (no filter): 5900 passed, 76 failed, 4 skipped — matching the impl summary's numbers exactly. Extracted all 76 failing test names and confirmed every one is a `*IntegrationTests`/`*SqlShapeTests` under `Bank`, `Catalog`, `Invoices`, `Leaflet`, `MeetingTasks`, `Photobank`, `Purchase`, `Persistence.GridLayouts`, `Persistence.Smartsupp`, `KnowledgeBase`, or `Article` namespace, and each failure's stack trace is the identical `System.ArgumentException: Docker is either not running or misconfigured` from `PostgreSqlBuilder.Build()` / Testcontainers. None reference `BackgroundJobs`. The claim is verified, not just plausible.
+- **Round-trip persistence**: `RecurringJobConfigurationRepositoryTests.cs` includes both a construct-then-load assertion (`TimeZoneId == "America/New_York"`) and an `UpdateConfiguration`-then-reload assertion, both against the EF Core-backed repository, confirming the new column mapping works end-to-end as the spec required.
+
+No issues found. The implementation is behavior-preserving for existing data (migration default `'Europe/Prague'`) and the fix is demonstrated to actually change behavior for non-default timezones, exactly as the task intended.

--- a/artifacts/feat-3687/spec.r1.md
+++ b/artifacts/feat-3687/spec.r1.md
@@ -1,0 +1,103 @@
+# Specification: Persist and use per-job TimeZoneId in BackgroundJobs recurring job configuration
+
+## Summary
+`RecurringJobConfiguration` (the persisted entity behind the BackgroundJobs admin UI) does not store a `TimeZoneId`, so `RecurringJobNextRunCalculator` always computes "next run" using the hardcoded default timezone (`Europe/Prague`), even though Hangfire itself is registered with the job's actual configured timezone via `HangfireJobRegistrationHelper`. This fix threads `TimeZoneId` through the domain entity, DTO, mapping, calculator, and seeder so the displayed "next run" time is always computed in the same timezone Hangfire actually uses.
+
+## Background
+`RecurringJobMetadata` already models `TimeZoneId` as a first-class, per-job concept (defaulting to `RecurringJobMetadata.DefaultTimeZoneId = "Europe/Prague"`), and `HangfireJobRegistrationHelper.RegisterOrUpdate` correctly passes it through to Hangfire's `RecurringJobOptions.TimeZone`. However, the persistence model (`RecurringJobConfiguration` entity, `RecurringJobDto`, and `RecurringJobSeeder`) drops this field entirely, and `RecurringJobNextRunCalculator` unconditionally uses the constant default when computing `NextRunAt`.
+
+This is currently a **latent** bug: all jobs today happen to use the default timezone, so the calculator's hardcoded assumption produces correct results by coincidence. The moment a job is registered with a non-default `TimeZoneId`, Hangfire will schedule and execute it correctly in that timezone, but the admin UI's "Next run" column will silently display a wrong time computed in `Europe/Prague` instead — with no error, warning, or visible inconsistency between the two data sources (Hangfire dashboard vs. the API/UI). This spec closes that gap by making `TimeZoneId` a persisted, first-class property of `RecurringJobConfiguration`, flowing end-to-end from job discovery through to the calculator.
+
+## Functional Requirements
+
+### FR-1: Persist and use the job's configured timezone for "next run" calculation
+The system must persist each recurring job's `TimeZoneId` alongside its other configuration (cron expression, enabled state, etc.), and `RecurringJobNextRunCalculator` must use that persisted, per-job value — not a hardcoded constant — when computing `NextRunAt`.
+
+Scope of change (grounded in the current codebase, all under `backend/src/`):
+
+1. **Domain entity** — `Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`
+   - Add `public string TimeZoneId { get; private set; }`.
+   - Initialize to `string.Empty` in the private (EF Core) constructor, consistent with the other string properties.
+   - Add a required `timeZoneId` parameter to the public constructor; validate it the same way other required string parameters are validated (`ValidationException` when null/whitespace); assign to `TimeZoneId`.
+   - Add a `timeZoneId` parameter to `UpdateConfiguration(...)`; validate and assign it the same way `cronExpression` is validated and assigned, so timezone changes go through the same update path as cron changes.
+
+2. **DTO** — `Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs`
+   - Add `public string TimeZoneId { get; set; } = string.Empty;`, following the existing pattern of non-nullable string properties defaulting to `string.Empty` in this DTO.
+   - Per project rule, this DTO **must remain a class** (not a C# record).
+
+3. **Mapping** — `Anela.Heblo.Application/Features/BackgroundJobs/BackgroundJobsMappingProfile.cs`
+   - No change needed. The existing `CreateMap<RecurringJobConfiguration, RecurringJobDto>();` maps same-named properties automatically; adding `TimeZoneId` to both sides is sufficient.
+
+4. **Calculator** — `Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs`
+   - Change `Calculate(string cronExpression, bool isEnabled, DateTime utcNow, ILogger logger, string? jobName = null)` to `Calculate(string cronExpression, bool isEnabled, string timeZoneId, DateTime utcNow, ILogger logger, string? jobName = null)`.
+   - Replace `TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId)` with `TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)`.
+   - Update the `TimeZoneNotFoundException` log message to report the passed-in `timeZoneId` (not the default constant) so the warning reflects what was actually looked up.
+   - Keep the existing null-return-on-failure behavior (disabled job, timezone not found, invalid cron) unchanged — this fix does not change the calculator's error-handling contract, only its timezone source.
+   - `RecurringJobMetadata.DefaultTimeZoneId` remains as the fallback default used when constructing new configurations (see FR-1.6); it is no longer referenced directly inside the calculator.
+
+5. **Callers** — update both call sites to pass the DTO's timezone:
+   - `Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJob/GetRecurringJobHandler.cs` (line ~47-48): `RecurringJobNextRunCalculator.Calculate(dto.CronExpression, dto.IsEnabled, dto.TimeZoneId, utcNow, _logger, dto.JobName)`.
+   - `Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs` (line ~41-42): same change, inside the `foreach (var dto in jobDtos)` loop.
+
+6. **Seeder** — `Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+   - In `SeedDefaultConfigurationsAsync`, pass `job.Metadata.TimeZoneId` as the new constructor argument when building each `RecurringJobConfiguration` from discovered `IRecurringJob` metadata, so newly-seeded rows start with the job's actual configured timezone (falling back to `RecurringJobMetadata.DefaultTimeZoneId` = `"Europe/Prague"` for any job that doesn't override it, since `RecurringJobMetadata.TimeZoneId` already defaults there).
+
+7. **EF Core configuration and migration**
+   - `Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`: add a `builder.Property(e => e.TimeZoneId).HasMaxLength(100).IsRequired();` entry, consistent with the `[MaxLength(100)]` attribute to be added on the entity property (matching the `JobName`/`Id` column length convention already used for identifier-like strings in this entity).
+   - New EF Core migration (naming convention observed from `20260105125530_AddRecurringJobConfigurations.cs`, e.g. `AddTimeZoneIdToRecurringJobConfigurations`): add a `TimeZoneId` column, `nvarchar(100)` (or provider equivalent) `NOT NULL DEFAULT 'Europe/Prague'`, to the `public.RecurringJobConfigurations` table. Using a database-level default ensures no data loss/backfill step is needed — all existing rows currently rely on the default timezone, so they receive `'Europe/Prague'` automatically. Update `ApplicationDbContextModelSnapshot.cs` accordingly (standard EF migration output).
+
+**Acceptance criteria:**
+- `RecurringJobConfiguration` has a persisted `TimeZoneId` property, set via both the public constructor and `UpdateConfiguration`.
+- `RecurringJobDto` exposes `TimeZoneId`.
+- `GetRecurringJobHandler` and `GetRecurringJobsListHandler` pass `dto.TimeZoneId` into `RecurringJobNextRunCalculator.Calculate`.
+- `RecurringJobNextRunCalculator.Calculate` resolves the timezone from its `timeZoneId` parameter, not from `RecurringJobMetadata.DefaultTimeZoneId`.
+- `RecurringJobSeeder` seeds new `RecurringJobConfiguration` rows with `job.Metadata.TimeZoneId`.
+- A new EF Core migration adds the `TimeZoneId` column with a `'Europe/Prague'` default and applies cleanly to an existing database with no data loss.
+- For a job configured with a non-default `TimeZoneId` (e.g. `"America/New_York"`), `GET` endpoints returning `RecurringJobDto.NextRunAt` compute that value using the job's own timezone, matching the timezone Hangfire uses via `HangfireJobRegistrationHelper.RegisterOrUpdate`.
+- All existing jobs (which use the default timezone) continue to report the same `NextRunAt` as before this change — i.e., this is a behavior-preserving change for current data, and only changes behavior once a non-default timezone is actually configured.
+- Existing unit/integration tests covering `RecurringJobConfiguration`, `RecurringJobDto`, `RecurringJobNextRunCalculator`, `RecurringJobSeeder`, `GetRecurringJobHandler`, and `GetRecurringJobsListHandler` are updated to construct/assert with the new `TimeZoneId` parameter/property, and continue to pass.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact expected. This adds one `string` column to an existing lookup table and one additional constructor/method parameter passed by reference; no new queries, joins, or I/O are introduced. `RecurringJobNextRunCalculator.Calculate` remains an in-memory, synchronous computation per job, unchanged in complexity.
+
+### NFR-2: Security
+No new security surface. `TimeZoneId` is server-controlled configuration data (sourced from `IRecurringJob` metadata at seed time, or admin-updated), not user input from an untrusted external source. It flows through the same validation and `ValidationException` pattern already used for `CronExpression` in `RecurringJobConfiguration`. No new authentication/authorization concerns — this reuses the existing endpoints and their existing access control.
+
+### NFR-3: Data integrity
+The new `TimeZoneId` column must be `NOT NULL` with a database-level default (`'Europe/Prague'`) so that:
+- The migration is safe to apply against the existing `RecurringJobConfigurations` table without a manual backfill step.
+- Any row inserted outside the seeder path (if one ever exists) cannot end up with a null/missing timezone, preserving the invariant that `RecurringJobNextRunCalculator` always receives a resolvable `timeZoneId`.
+
+## Data Model
+`RecurringJobConfiguration` (table `public.RecurringJobConfigurations`) gains one column:
+
+| Column | Type | Nullable | Default | Notes |
+|---|---|---|---|---|
+| `TimeZoneId` | `nvarchar(100)` / provider equivalent | No | `'Europe/Prague'` | IANA/Windows timezone id resolvable via `TimeZoneInfo.FindSystemTimeZoneById`; mirrors `RecurringJobMetadata.TimeZoneId` and `RecurringJobMetadata.DefaultTimeZoneId`. |
+
+No new tables, no relationship changes. `RecurringJobDto` gains a parallel `TimeZoneId` field with no independent validation beyond what `RecurringJobConfiguration` already enforces at write time.
+
+## API / Interface Design
+No new endpoints. Existing endpoints backed by `GetRecurringJobRequest`/`GetRecurringJobResponse` (single job) and `GetRecurringJobsListRequest`/`GetRecurringJobsListResponse` (list) now return a `TimeZoneId` field on each `RecurringJobDto` in their response payload, and their `NextRunAt` value is computed using that timezone instead of the previously hardcoded default. This is an additive, backward-compatible change to the response contract (new field only); no request contract changes. Since the OpenAPI TypeScript client is auto-generated on build, the frontend's generated types will pick up `timeZoneId` automatically — no manual frontend client changes are required by this spec (any UI surfacing of the new field, if desired, is out of scope — see below).
+
+Any existing "update job" command/handler (e.g. `UpdateRecurringJobCronHandler`) that calls `RecurringJobConfiguration.UpdateConfiguration(...)` must be updated to pass a `timeZoneId` argument, since that method's signature changes per FR-1.1. Where the job's timezone is not being changed by that specific command, pass through the entity's current `TimeZoneId` unchanged.
+
+## Dependencies
+- `NCrontab.Advanced` (already used by `RecurringJobNextRunCalculator` for cron parsing) — no version or usage change.
+- `TimeZoneInfo.FindSystemTimeZoneById` / host OS timezone database — unchanged; same resolution mechanism already used by `HangfireJobRegistrationHelper`, now shared consistently by the calculator.
+- EF Core migration tooling (existing `Anela.Heblo.Persistence` migrations pipeline) — this fix requires a new migration, applied manually per this repo's convention (database migrations are not automated in deployment).
+- No new external services or libraries.
+
+## Out of Scope
+- Adding UI in the admin frontend to display or edit `TimeZoneId` per job (this spec only makes the field available on the API contract; any frontend surfacing is a separate follow-up).
+- Adding validation that a `TimeZoneId` string is a resolvable timezone at the point of API/command input (beyond the existing null/whitespace check pattern already used for other required strings on the entity). `HangfireJobRegistrationHelper` and `RecurringJobNextRunCalculator` already handle unresolvable timezones defensively (`TimeZoneNotFoundException` / warning + null `NextRunAt`); this spec does not add new upfront validation.
+- Changing `HangfireJobRegistrationHelper` or the job registration/discovery flow — it already correctly handles per-job timezones and is not modified by this fix.
+- Backfilling or auditing historical `NextRunAt` values that were previously computed incorrectly for non-default-timezone jobs — not applicable today since no job currently uses a non-default timezone.
+- Any change to `RecurringJobMetadata` itself — it already exposes `TimeZoneId` correctly.
+
+## Open Questions
+None. The brief and current codebase are precise enough to implement this without further clarification; all decisions above (migration default value, seeder fallback, `UpdateConfiguration` signature change, no frontend UI change) are reasonable, low-risk assumptions consistent with the existing code patterns and explicitly noted inline above.
+
+## Status: COMPLETE

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -5,8 +5,8 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-18T07:16:51.152306Z"
     },
     "architecting": {
       "status": "pending",

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -1,0 +1,29 @@
+{
+  "feature_id": "feat-3687",
+  "issue_number": 3687,
+  "created_at": "2026-07-18T07:16:47.264845Z",
+  "max_revisions": 3,
+  "phases": {
+    "analyzing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "architecting": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "designing": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "planning": {
+      "status": "pending",
+      "updated_at": null
+    },
+    "developing": {
+      "status": "pending",
+      "updated_at": null
+    }
+  },
+  "tasks": []
+}

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -5,12 +5,12 @@
   "max_revisions": 3,
   "phases": {
     "analyzing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-18T07:16:51.152306Z"
+      "status": "completed",
+      "updated_at": "2026-07-18T07:19:06.753964Z"
     },
     "architecting": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-18T07:19:07.033049Z"
     },
     "designing": {
       "status": "pending",

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -28,9 +28,9 @@
   "tasks": [
     {
       "name": "add-recurring-job-timezone-id",
-      "status": "in_progress",
+      "status": "completed",
       "revision": 1,
-      "updated_at": "2026-07-18T07:27:50.680583Z"
+      "updated_at": "2026-07-18T08:15:11.920787Z"
     }
   ]
 }

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -13,12 +13,12 @@
       "updated_at": "2026-07-18T07:23:53.786463Z"
     },
     "designing": {
-      "status": "in_progress",
-      "updated_at": "2026-07-18T07:23:54.064495Z"
+      "status": "completed",
+      "updated_at": "2026-07-18T07:24:59.254019Z"
     },
     "planning": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-18T07:24:59.512240Z"
     },
     "developing": {
       "status": "pending",

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -21,16 +21,16 @@
       "updated_at": "2026-07-18T07:27:37.787176Z"
     },
     "developing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-18T07:27:50.499233Z"
     }
   },
   "tasks": [
     {
       "name": "add-recurring-job-timezone-id",
-      "status": "pending",
+      "status": "in_progress",
       "revision": 1,
-      "updated_at": null
+      "updated_at": "2026-07-18T07:27:50.680583Z"
     }
   ]
 }

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -17,13 +17,20 @@
       "updated_at": "2026-07-18T07:24:59.254019Z"
     },
     "planning": {
-      "status": "in_progress",
-      "updated_at": "2026-07-18T07:24:59.512240Z"
+      "status": "completed",
+      "updated_at": "2026-07-18T07:27:37.787176Z"
     },
     "developing": {
       "status": "pending",
       "updated_at": null
     }
   },
-  "tasks": []
+  "tasks": [
+    {
+      "name": "add-recurring-job-timezone-id",
+      "status": "pending",
+      "revision": 1,
+      "updated_at": null
+    }
+  ]
 }

--- a/artifacts/feat-3687/state.json
+++ b/artifacts/feat-3687/state.json
@@ -9,12 +9,12 @@
       "updated_at": "2026-07-18T07:19:06.753964Z"
     },
     "architecting": {
-      "status": "in_progress",
-      "updated_at": "2026-07-18T07:19:07.033049Z"
+      "status": "completed",
+      "updated_at": "2026-07-18T07:23:53.786463Z"
     },
     "designing": {
-      "status": "pending",
-      "updated_at": null
+      "status": "in_progress",
+      "updated_at": "2026-07-18T07:23:54.064495Z"
     },
     "planning": {
       "status": "pending",

--- a/artifacts/feat-3687/task-context/add-recurring-job-timezone-id.md
+++ b/artifacts/feat-3687/task-context/add-recurring-job-timezone-id.md
@@ -1,0 +1,359 @@
+### task: add-recurring-job-timezone-id
+
+## Goal
+
+Add a persisted, per-job `TimeZoneId` to `RecurringJobConfiguration` and thread it end-to-end so `RecurringJobNextRunCalculator` computes `NextRunAt` using each job's own configured timezone (as already used by Hangfire via `HangfireJobRegistrationHelper`) instead of the hardcoded `RecurringJobMetadata.DefaultTimeZoneId` ("Europe/Prague"). This closes a latent bug: today all jobs happen to use the default timezone so results are coincidentally correct, but any job configured with a non-default `TimeZoneId` would show a wrong "next run" time in the API/UI while Hangfire actually runs it correctly.
+
+## Context
+
+Background (from spec): `RecurringJobMetadata` already models `TimeZoneId` per job (default `"Europe/Prague"` via `RecurringJobMetadata.DefaultTimeZoneId`), and `HangfireJobRegistrationHelper.RegisterOrUpdate` already passes it to Hangfire correctly. The gap is entirely in the persistence/display path: `RecurringJobConfiguration` (entity), `RecurringJobDto`, `RecurringJobSeeder`, and `RecurringJobNextRunCalculator` all ignore per-job timezone today.
+
+This is a behavior-preserving change for all *current* data (every existing job uses the default timezone) — it only changes behavior once a non-default `TimeZoneId` is actually configured (e.g. `FlexiAnalyticsSyncJob`, whose timezone is config-driven via `FlexiAnalyticsSyncOptions.TimeZone` and could already differ from the default in some environment).
+
+Architecture review notes (authoritative — corrects the spec in two places):
+1. **`UpdateRecurringJobCronHandler` does NOT call `UpdateConfiguration`.** It calls a separate, narrower method `job.UpdateCronExpression(request.CronExpression, modifiedBy)` (verified at `UpdateRecurringJobCronHandler.cs:67`), which never touches `TimeZoneId` and is **not modified** by this change. `UpdateConfiguration` currently has **zero production callers** — only two unit tests call it directly (`RecurringJobConfigurationRepositoryTests.cs`, `RecurringJobConfigurationTests.cs`). Its contract is still extended for consistency, but no handler needs to change because of it.
+2. **Constructor/`UpdateConfiguration` parameter position:** insert `timeZoneId` immediately after `cronExpression`, before `isEnabled` (constructor) / before `modifiedBy` (`UpdateConfiguration`) — grouping the two schedule-related fields together, matching how `RecurringJobMetadata` treats them as a pair.
+
+Migration mechanism (from arch review, verified against `docs/development/setup.md` § "Database Migrations Runbook"): Production auto-migrates at app startup (`MigrateDatabaseAsync` in `Program.cs`). Development/Test/Staging do **not** auto-apply migrations — `dotnet ef database update` must be run manually against those environments before/along with deploying this code (same hazard as prior migrations `AddDataQualityTables` → `StandardizeTableNamingToPascalCase`). This is an operational step outside this task's scope (per CLAUDE.md, DB migrations are manual, not automated in deployment) — just generate the migration correctly.
+
+**Naming convention warning:** the live table is `"RecurringJobConfigurations"` (PascalCase, schema `public`), with PascalCase columns. The *original* migration `20260105125530_AddRecurringJobConfigurations.cs` used snake_case — that was a one-off inconsistency, later corrected by `20260424142720_StandardizeTableNamingToPascalCase.cs`. **Do not copy the snake_case style.** Copy the style of `20260715150507_AddLotLabelDriftCorrection.cs` (below), which is the current PascalCase convention.
+
+## Current code (verified by reading the files directly — use as the exact basis for diffs)
+
+### `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`
+```csharp
+public class RecurringJobConfiguration : Entity<string>
+{
+    [Required]
+    [MaxLength(100)]
+    public string JobName { get; private set; }
+    // ... DisplayName [MaxLength(200)], Description [MaxLength(500)] ...
+
+    [Required]
+    [MaxLength(50)]
+    public string CronExpression { get; private set; }
+
+    public bool IsEnabled { get; private set; }
+    public DateTime LastModifiedAt { get; private set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string LastModifiedBy { get; private set; }
+
+    // Private constructor for EF Core
+    private RecurringJobConfiguration()
+    {
+        JobName = string.Empty;
+        DisplayName = string.Empty;
+        Description = string.Empty;
+        CronExpression = string.Empty;
+        LastModifiedBy = string.Empty;
+    }
+
+    public RecurringJobConfiguration(
+        string jobName,
+        string displayName,
+        string description,
+        string cronExpression,
+        bool isEnabled,
+        string lastModifiedBy)
+    {
+        if (string.IsNullOrWhiteSpace(jobName))
+            throw new ValidationException("JobName is required");
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ValidationException("DisplayName is required");
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ValidationException("Description is required");
+        if (string.IsNullOrWhiteSpace(cronExpression))
+            throw new ValidationException("CronExpression is required");
+        if (string.IsNullOrWhiteSpace(lastModifiedBy))
+            throw new ValidationException("LastModifiedBy is required");
+
+        JobName = jobName;
+        Id = jobName; // JobName is the primary key
+        DisplayName = displayName;
+        Description = description;
+        CronExpression = cronExpression;
+        IsEnabled = isEnabled;
+        LastModifiedAt = DateTime.UtcNow;
+        LastModifiedBy = lastModifiedBy;
+    }
+
+    public void UpdateConfiguration(
+        string displayName,
+        string description,
+        string cronExpression,
+        string modifiedBy)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ValidationException("DisplayName is required");
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ValidationException("Description is required");
+        if (string.IsNullOrWhiteSpace(cronExpression))
+            throw new ValidationException("CronExpression is required");
+        if (string.IsNullOrWhiteSpace(modifiedBy))
+            throw new ValidationException("ModifiedBy is required");
+
+        DisplayName = displayName;
+        Description = description;
+        CronExpression = cronExpression;
+        LastModifiedAt = DateTime.UtcNow;
+        LastModifiedBy = modifiedBy;
+    }
+
+    public void Enable(string modifiedBy) { ... }
+    public void Disable(string modifiedBy) { ... }
+
+    public void UpdateCronExpression(string cronExpression, string modifiedBy)
+    {
+        // unchanged, unmodified by this task
+    }
+}
+```
+
+### `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs`
+```csharp
+public class RecurringJobDto
+{
+    public string JobName { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string CronExpression { get; set; } = string.Empty;
+    public bool IsEnabled { get; set; }
+    public DateTime LastModifiedAt { get; set; }
+    public string LastModifiedBy { get; set; } = string.Empty;
+    public DateTime? NextRunAt { get; set; }
+}
+```
+
+### `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs`
+```csharp
+public static class RecurringJobNextRunCalculator
+{
+    public static DateTime? Calculate(string cronExpression, bool isEnabled, DateTime utcNow, ILogger logger, string? jobName = null)
+    {
+        if (!isEnabled) return null;
+
+        TimeZoneInfo tz;
+        try
+        {
+            tz = TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId);
+        }
+        catch (TimeZoneNotFoundException ex)
+        {
+            logger.LogWarning(ex, "Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'",
+                RecurringJobMetadata.DefaultTimeZoneId, jobName);
+            return null;
+        }
+
+        try
+        {
+            var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(utcNow, tz);
+            var nextLocal = CrontabSchedule.Parse(cronExpression).GetNextOccurrence(nowLocal);
+            var nextUtc = TimeZoneInfo.ConvertTimeToUtc(
+                DateTime.SpecifyKind(nextLocal, DateTimeKind.Unspecified), tz);
+            return DateTime.SpecifyKind(nextUtc, DateTimeKind.Utc);
+        }
+        catch (CrontabException ex)
+        {
+            logger.LogWarning(ex, "Invalid CRON expression '{CronExpression}' for job '{JobName}', NextRunAt will be null",
+                cronExpression, jobName);
+            return null;
+        }
+    }
+}
+```
+`RecurringJobMetadata.DefaultTimeZoneId = "Europe/Prague"` (const) and `RecurringJobMetadata.TimeZoneId` (instance property, defaults to `DefaultTimeZoneId`) live in `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs` — **not modified** by this task.
+
+### `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+```csharp
+public async Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+{
+    var defaultConfigurations = jobs.Select(job => new RecurringJobConfiguration(
+        job.Metadata.JobName,
+        job.Metadata.DisplayName,
+        job.Metadata.Description,
+        job.Metadata.CronExpression,
+        job.Metadata.DefaultIsEnabled,
+        "System"
+    )).ToArray();
+    // ... existing add-if-not-exists loop, unchanged
+}
+```
+
+### `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`
+Configures `Id` (100), `JobName` (100), `DisplayName` (200), `Description` (500), `CronExpression` (50, note: **not** 100 — the entity's own `[MaxLength(50)]` on `CronExpression` differs from `TimeZoneId`'s planned 100), `IsEnabled`, `LastModifiedAt`, `LastModifiedBy` (100), plus two indexes (`JobName` unique, `IsEnabled`). No `TimeZoneId` entry today.
+
+### `GetRecurringJobHandler.cs` (line 47-48) and `GetRecurringJobsListHandler.cs` (line 41-42)
+Both currently call:
+```csharp
+RecurringJobNextRunCalculator.Calculate(dto.CronExpression, dto.IsEnabled, utcNow, _logger, dto.JobName)
+```
+(the list handler does this inside `foreach (var dto in jobDtos)`).
+
+### `UpdateRecurringJobCronHandler.cs`
+Calls `job.UpdateCronExpression(request.CronExpression, modifiedBy)` at line 67 — **confirmed this is NOT `UpdateConfiguration`**. Do not modify this file.
+
+### Migration style to copy — `backend/src/Anela.Heblo.Persistence/Migrations/20260715150507_AddLotLabelDriftCorrection.cs`
+```csharp
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLotLabelDriftCorrection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DriftEveryNLabels",
+                schema: "public",
+                table: "LotLabelCalibrations",
+                type: "integer",
+                nullable: false,
+                defaultValue: 3);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DriftEveryNLabels",
+                schema: "public",
+                table: "LotLabelCalibrations");
+        }
+    }
+}
+```
+This task's migration mirrors this shape but adds a `string` column with `maxLength: 100` and a string default instead of an `int` column.
+
+### Existing test call sites that will break on the constructor/`UpdateConfiguration`/`Calculate` signature changes (verified via grep, counts = number of matching lines, not necessarily distinct call sites — some are on multi-line invocations)
+All under `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/`:
+- `RecurringJobConfigurationRepositoryTests.cs` — constructs `RecurringJobConfiguration` directly (incl. one `UpdateConfiguration(...)` call around line 130 per arch review) — 7 matches
+- `RecurringJobConfigurationTests.cs` — direct entity unit tests, including one `UpdateConfiguration(...)` call around line 137 per arch review — 10 matches
+- `RecurringJobDiscoveryServiceTests.cs` — a test double's `GetAllAsync` builds a `RecurringJobConfiguration` (around line 205: `jobName: "test-async-job"`, ...) — 1 match
+- `RecurringJobSeederTests.cs` — 1 match
+- `RecurringJobStatusCheckerTests.cs` — 2 matches
+- `UpdateRecurringJobCronHandlerTests.cs` — 1 match (constructs a `RecurringJobConfiguration` as test fixture data; does not call `UpdateConfiguration` since the handler under test uses `UpdateCronExpression`)
+- `UpdateRecurringJobStatusHandlerTests.cs` — 6 matches
+- `GetRecurringJobHandlerTests.cs` — 2 matches (also likely asserts on `RecurringJobNextRunCalculator.Calculate` behavior / `dto.NextRunAt` — check for direct `Calculate(...)` calls too, not just the DTO/entity constructor)
+- `GetRecurringJobsListHandlerTests.cs` — 12 matches
+
+Also search these same test files (and any `RecurringJobNextRunCalculatorTests.cs` if it exists — check for it, it was not enumerated above but may exist) for direct calls to `RecurringJobNextRunCalculator.Calculate(...)`, which also need the new `timeZoneId` argument inserted.
+
+## Files to create/modify
+
+1. `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`
+2. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs`
+3. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs`
+4. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJob/GetRecurringJobHandler.cs`
+5. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs`
+6. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+7. `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`
+8. New file: `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_AddTimeZoneIdToRecurringJobConfigurations.cs` (+ matching `.Designer.cs`, generated by tooling)
+9. `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` (regenerated automatically — do not hand-edit)
+10. All test files listed above under `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/`: `RecurringJobConfigurationRepositoryTests.cs`, `RecurringJobConfigurationTests.cs`, `RecurringJobDiscoveryServiceTests.cs`, `RecurringJobSeederTests.cs`, `RecurringJobStatusCheckerTests.cs`, `UpdateRecurringJobCronHandlerTests.cs`, `UpdateRecurringJobStatusHandlerTests.cs`, `GetRecurringJobHandlerTests.cs`, `GetRecurringJobsListHandlerTests.cs`, plus any `RecurringJobNextRunCalculatorTests.cs` if present.
+
+**Explicitly NOT modified:** `BackgroundJobsMappingProfile.cs` (AutoMapper same-name matching handles it automatically), `UpdateRecurringJobCronHandler.cs` (`UpdateCronExpression` is untouched), `HangfireJobRegistrationHelper.cs` / `HangfireRecurringJobScheduler.cs` / `RecurringJobMetadata.cs` (already correct, out of scope).
+
+## Implementation steps
+
+1. **Domain entity** (`RecurringJobConfiguration.cs`):
+   - Add `[Required] [MaxLength(100)] public string TimeZoneId { get; private set; }` (place it after `CronExpression`, before `IsEnabled`, mirroring field grouping).
+   - In the private (EF Core) constructor, add `TimeZoneId = string.Empty;`.
+   - In the public constructor, insert `string timeZoneId` as a parameter immediately after `cronExpression`, before `isEnabled`. Add validation `if (string.IsNullOrWhiteSpace(timeZoneId)) throw new ValidationException("TimeZoneId is required");` alongside the other required-string checks, and assign `TimeZoneId = timeZoneId;` alongside the other assignments.
+   - In `UpdateConfiguration(...)`, insert `string timeZoneId` immediately after `cronExpression`, before `modifiedBy`. Add the same validation and assignment pattern used for `cronExpression`.
+   - Leave `Enable`, `Disable`, `UpdateCronExpression` untouched.
+
+2. **DTO** (`RecurringJobDto.cs`): add `public string TimeZoneId { get; set; } = string.Empty;` placed immediately after `CronExpression`. Keep as a class (never a record, per project rule).
+
+3. **Mapping**: no change needed to `BackgroundJobsMappingProfile.cs` — verify after step 1-2 that `CreateMap<RecurringJobConfiguration, RecurringJobDto>()` still compiles and picks up `TimeZoneId` (same-name auto-mapping).
+
+4. **Calculator** (`RecurringJobNextRunCalculator.cs`):
+   - Change signature to `public static DateTime? Calculate(string cronExpression, bool isEnabled, string timeZoneId, DateTime utcNow, ILogger logger, string? jobName = null)`.
+   - Replace `TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId)` with `TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)`.
+   - Update the `TimeZoneNotFoundException` catch block's log call to pass `timeZoneId` instead of `RecurringJobMetadata.DefaultTimeZoneId` as the format argument (message text can stay the same, e.g. `"Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'", timeZoneId, jobName`).
+   - Do not change the null-return-on-failure contract otherwise. Remove the now-unused `using` for `RecurringJobMetadata` if it becomes unreferenced in this file (check — it's in the same namespace `Anela.Heblo.Domain.Features.BackgroundJobs`, likely no explicit `using` needed to remove).
+
+5. **Callers**:
+   - `GetRecurringJobHandler.cs` line ~47-48: change to `RecurringJobNextRunCalculator.Calculate(dto.CronExpression, dto.IsEnabled, dto.TimeZoneId, utcNow, _logger, dto.JobName)`.
+   - `GetRecurringJobsListHandler.cs` line ~41-42 (inside the `foreach`): same change.
+
+6. **Seeder** (`RecurringJobSeeder.cs`): in the `RecurringJobConfiguration` object construction inside `SeedDefaultConfigurationsAsync`, insert `job.Metadata.TimeZoneId` as the new argument immediately after `job.Metadata.CronExpression`, before `job.Metadata.DefaultIsEnabled`.
+
+7. **EF Core configuration** (`RecurringJobConfigurationConfiguration.cs`): add, in the same block as the other `[MaxLength]`-backed string properties (e.g. right after the `CronExpression` property config):
+   ```csharp
+   builder.Property(e => e.TimeZoneId)
+       .HasMaxLength(100)
+       .IsRequired();
+   ```
+
+8. **EF Core migration**: after steps 1-7 compile, generate the migration from the repo root:
+   ```bash
+   cd backend && dotnet ef migrations add AddTimeZoneIdToRecurringJobConfigurations \
+     --project src/Anela.Heblo.Persistence --startup-project src/Anela.Heblo.API
+   ```
+   Verify the generated `Up`/`Down` match this shape (adjust only if the tool output differs from expectations — do not hand-edit beyond fixing an incorrect default):
+   ```csharp
+   protected override void Up(MigrationBuilder migrationBuilder)
+   {
+       migrationBuilder.AddColumn<string>(
+           name: "TimeZoneId",
+           schema: "public",
+           table: "RecurringJobConfigurations",
+           type: "character varying(100)",
+           maxLength: 100,
+           nullable: false,
+           defaultValue: "Europe/Prague");
+   }
+
+   protected override void Down(MigrationBuilder migrationBuilder)
+   {
+       migrationBuilder.DropColumn(
+           name: "TimeZoneId",
+           schema: "public",
+           table: "RecurringJobConfigurations");
+   }
+   ```
+   Confirm `ApplicationDbContextModelSnapshot.cs` was regenerated with a `b.Property<string>("TimeZoneId")...` entry in the `RecurringJobConfiguration` section. Do not hand-edit the snapshot.
+
+9. **Fix every broken call site** the compiler reports after steps 1 and 4 (constructor, `UpdateConfiguration`, and `Calculate` signature changes) across production and test code:
+   - Every `new RecurringJobConfiguration(...)` call (production: `RecurringJobSeeder.cs`, already done in step 6; test files listed above) — insert a `timeZoneId` argument (positionally after `cronExpression`). Use `"Europe/Prague"` (or `RecurringJobMetadata.DefaultTimeZoneId` if the test file already references that constant) for tests that don't care about timezone specifically; use a distinct value like `"America/New_York"` for tests that will assert timezone-aware behavior (see Tests section).
+   - Every `UpdateConfiguration(...)` call (the two known ones in `RecurringJobConfigurationRepositoryTests.cs` and `RecurringJobConfigurationTests.cs`, plus any others found by the compiler) — insert a `timeZoneId` argument after `cronExpression`.
+   - Every `RecurringJobNextRunCalculator.Calculate(...)` call in tests — insert a `timeZoneId` argument after `isEnabled`.
+   - Do a final `dotnet build` sweep to catch any call site not identified by the greps above (the greps are a starting point, not guaranteed exhaustive — trust compiler errors as the source of truth for completeness).
+
+## Tests to write/update
+
+- **Update all existing broken call sites** identified in step 9 above so the full existing suite compiles and passes unchanged in behavior (existing assertions about `NextRunAt`, cron parsing, etc. must still pass since the default `"Europe/Prague"` argument reproduces current behavior).
+- **`RecurringJobConfigurationTests.cs`**: add/update tests so:
+  - Constructing with `timeZoneId = null` or whitespace throws `ValidationException` (mirroring the existing `cronExpression` null/whitespace test).
+  - Constructing with a valid `timeZoneId` (e.g. `"America/New_York"`) sets `TimeZoneId` correctly.
+  - `UpdateConfiguration(...)` with a new `timeZoneId` updates `TimeZoneId` on the entity (mirroring the existing `cronExpression` update assertion), and with null/whitespace throws `ValidationException`.
+- **`RecurringJobNextRunCalculator` tests** (add to whichever test file currently covers `Calculate` — locate it via the existing call sites in `GetRecurringJobHandlerTests.cs`/`GetRecurringJobsListHandlerTests.cs`, or a dedicated `RecurringJobNextRunCalculatorTests.cs` if one exists; create one only if genuinely none exists and calculator logic isn't otherwise unit-tested):
+  - **New required test**: assert that `Calculate` with a non-default `timeZoneId` (e.g. `"America/New_York"`) produces a different `NextRunAt` than `Calculate` with `"Europe/Prague"` for the same cron expression and `utcNow`, proving the calculator now actually uses the passed-in timezone rather than a hardcoded default. Use a cron expression/time where the two timezones' offsets cause a different next-occurrence date (e.g. a job scheduled near local midnight, so the UTC-crossing differs) — or, simpler and robust, assert the returned `NextRunAt` values differ by the expected UTC offset delta between the two zones at that instant.
+  - Update the existing `TimeZoneNotFoundException` test (if present) to pass a bogus `timeZoneId` string directly as the parameter and assert the warning log now references that string, not `RecurringJobMetadata.DefaultTimeZoneId`.
+- **`RecurringJobSeederTests.cs`**: update/add an assertion that seeded `RecurringJobConfiguration.TimeZoneId` equals the source `IRecurringJob.Metadata.TimeZoneId` (test with a job whose metadata has a non-default `TimeZoneId` to prove it's not just defaulting).
+- **`GetRecurringJobHandlerTests.cs`** and **`GetRecurringJobsListHandlerTests.cs`**: update fixtures to include `TimeZoneId` on the underlying `RecurringJobConfiguration`/DTO, and add/update an assertion that `NextRunAt` in the response reflects the entity's own `TimeZoneId` (not the default) when a non-default value is used.
+- **`RecurringJobConfigurationRepositoryTests.cs`**: update the existing `UpdateConfiguration` call/test to pass and assert `TimeZoneId` round-trips through persistence (if this test uses an in-memory/real DB context, confirm the new EF Core column mapping works).
+- Run the full BackgroundJobs test namespace plus a full solution test run to confirm nothing else broke.
+
+## Acceptance criteria
+
+- `dotnet build` succeeds for the whole solution with no errors.
+- `dotnet format` reports no changes needed (run `dotnet format` and ensure clean diff, or that it was run and applied) on all touched files.
+- All touched/existing unit tests in `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/` pass, including the new/updated tests described above.
+- Full existing test suite (`dotnet test`) passes — no regressions outside `BackgroundJobs`.
+- `RecurringJobConfiguration` has a persisted `TimeZoneId` property (`[Required] [MaxLength(100)]`), settable via both the public constructor and `UpdateConfiguration`, with `ValidationException` on null/whitespace.
+- `RecurringJobDto` exposes `TimeZoneId` (`string`, defaults to `string.Empty`), still a class.
+- `GetRecurringJobHandler` and `GetRecurringJobsListHandler` pass `dto.TimeZoneId` into `RecurringJobNextRunCalculator.Calculate`.
+- `RecurringJobNextRunCalculator.Calculate` resolves the timezone exclusively from its `timeZoneId` parameter; `RecurringJobMetadata.DefaultTimeZoneId` no longer appears anywhere in `RecurringJobNextRunCalculator.cs`.
+- `RecurringJobSeeder` seeds new rows with `job.Metadata.TimeZoneId`.
+- A new EF Core migration (`AddTimeZoneIdToRecurringJobConfigurations`, following the `AddLotLabelDriftCorrection.cs` PascalCase/`schema: "public"` style — not the old snake_case style) adds the `TimeZoneId` column as `NOT NULL DEFAULT 'Europe/Prague'`, `maxLength: 100`; `ApplicationDbContextModelSnapshot.cs` reflects it.
+- `UpdateRecurringJobCronHandler.cs` is unmodified (verified: it calls `UpdateCronExpression`, not `UpdateConfiguration`).
+- `BackgroundJobsMappingProfile.cs` is unmodified.
+- At least one new test proves `RecurringJobNextRunCalculator.Calculate` produces a different `NextRunAt` for a non-default `timeZoneId` than for the default, demonstrating the fix actually works (not just that the code compiles).
+- For current/default-timezone data, `NextRunAt` values are unchanged from pre-change behavior (behavior-preserving for existing jobs) — covered by the existing (updated) test assertions continuing to pass with `"Europe/Prague"` as the passed-in timezone.

--- a/artifacts/feat-3687/task-plan.r1.md
+++ b/artifacts/feat-3687/task-plan.r1.md
@@ -1,0 +1,367 @@
+# Implementation Task Plan: Persist and use per-job TimeZoneId in BackgroundJobs recurring job configuration
+
+## Planning rationale
+
+This is a single, tightly-coupled change: one new property/column (`TimeZoneId`) must flow through the domain entity constructor, `UpdateConfiguration`, the DTO, the calculator signature, both GET handlers, the seeder, the EF Core configuration, a new migration, and ~30+ existing test call sites — all in one .NET solution that must build end-to-end. Splitting this into multiple tasks would leave the build broken between them (e.g. changing the entity constructor without updating every call site immediately breaks compilation). There is no independently-verifiable sub-chunk. This plan therefore defines **one task**.
+
+---
+
+### task: add-recurring-job-timezone-id
+
+## Goal
+
+Add a persisted, per-job `TimeZoneId` to `RecurringJobConfiguration` and thread it end-to-end so `RecurringJobNextRunCalculator` computes `NextRunAt` using each job's own configured timezone (as already used by Hangfire via `HangfireJobRegistrationHelper`) instead of the hardcoded `RecurringJobMetadata.DefaultTimeZoneId` ("Europe/Prague"). This closes a latent bug: today all jobs happen to use the default timezone so results are coincidentally correct, but any job configured with a non-default `TimeZoneId` would show a wrong "next run" time in the API/UI while Hangfire actually runs it correctly.
+
+## Context
+
+Background (from spec): `RecurringJobMetadata` already models `TimeZoneId` per job (default `"Europe/Prague"` via `RecurringJobMetadata.DefaultTimeZoneId`), and `HangfireJobRegistrationHelper.RegisterOrUpdate` already passes it to Hangfire correctly. The gap is entirely in the persistence/display path: `RecurringJobConfiguration` (entity), `RecurringJobDto`, `RecurringJobSeeder`, and `RecurringJobNextRunCalculator` all ignore per-job timezone today.
+
+This is a behavior-preserving change for all *current* data (every existing job uses the default timezone) — it only changes behavior once a non-default `TimeZoneId` is actually configured (e.g. `FlexiAnalyticsSyncJob`, whose timezone is config-driven via `FlexiAnalyticsSyncOptions.TimeZone` and could already differ from the default in some environment).
+
+Architecture review notes (authoritative — corrects the spec in two places):
+1. **`UpdateRecurringJobCronHandler` does NOT call `UpdateConfiguration`.** It calls a separate, narrower method `job.UpdateCronExpression(request.CronExpression, modifiedBy)` (verified at `UpdateRecurringJobCronHandler.cs:67`), which never touches `TimeZoneId` and is **not modified** by this change. `UpdateConfiguration` currently has **zero production callers** — only two unit tests call it directly (`RecurringJobConfigurationRepositoryTests.cs`, `RecurringJobConfigurationTests.cs`). Its contract is still extended for consistency, but no handler needs to change because of it.
+2. **Constructor/`UpdateConfiguration` parameter position:** insert `timeZoneId` immediately after `cronExpression`, before `isEnabled` (constructor) / before `modifiedBy` (`UpdateConfiguration`) — grouping the two schedule-related fields together, matching how `RecurringJobMetadata` treats them as a pair.
+
+Migration mechanism (from arch review, verified against `docs/development/setup.md` § "Database Migrations Runbook"): Production auto-migrates at app startup (`MigrateDatabaseAsync` in `Program.cs`). Development/Test/Staging do **not** auto-apply migrations — `dotnet ef database update` must be run manually against those environments before/along with deploying this code (same hazard as prior migrations `AddDataQualityTables` → `StandardizeTableNamingToPascalCase`). This is an operational step outside this task's scope (per CLAUDE.md, DB migrations are manual, not automated in deployment) — just generate the migration correctly.
+
+**Naming convention warning:** the live table is `"RecurringJobConfigurations"` (PascalCase, schema `public`), with PascalCase columns. The *original* migration `20260105125530_AddRecurringJobConfigurations.cs` used snake_case — that was a one-off inconsistency, later corrected by `20260424142720_StandardizeTableNamingToPascalCase.cs`. **Do not copy the snake_case style.** Copy the style of `20260715150507_AddLotLabelDriftCorrection.cs` (below), which is the current PascalCase convention.
+
+## Current code (verified by reading the files directly — use as the exact basis for diffs)
+
+### `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`
+```csharp
+public class RecurringJobConfiguration : Entity<string>
+{
+    [Required]
+    [MaxLength(100)]
+    public string JobName { get; private set; }
+    // ... DisplayName [MaxLength(200)], Description [MaxLength(500)] ...
+
+    [Required]
+    [MaxLength(50)]
+    public string CronExpression { get; private set; }
+
+    public bool IsEnabled { get; private set; }
+    public DateTime LastModifiedAt { get; private set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string LastModifiedBy { get; private set; }
+
+    // Private constructor for EF Core
+    private RecurringJobConfiguration()
+    {
+        JobName = string.Empty;
+        DisplayName = string.Empty;
+        Description = string.Empty;
+        CronExpression = string.Empty;
+        LastModifiedBy = string.Empty;
+    }
+
+    public RecurringJobConfiguration(
+        string jobName,
+        string displayName,
+        string description,
+        string cronExpression,
+        bool isEnabled,
+        string lastModifiedBy)
+    {
+        if (string.IsNullOrWhiteSpace(jobName))
+            throw new ValidationException("JobName is required");
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ValidationException("DisplayName is required");
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ValidationException("Description is required");
+        if (string.IsNullOrWhiteSpace(cronExpression))
+            throw new ValidationException("CronExpression is required");
+        if (string.IsNullOrWhiteSpace(lastModifiedBy))
+            throw new ValidationException("LastModifiedBy is required");
+
+        JobName = jobName;
+        Id = jobName; // JobName is the primary key
+        DisplayName = displayName;
+        Description = description;
+        CronExpression = cronExpression;
+        IsEnabled = isEnabled;
+        LastModifiedAt = DateTime.UtcNow;
+        LastModifiedBy = lastModifiedBy;
+    }
+
+    public void UpdateConfiguration(
+        string displayName,
+        string description,
+        string cronExpression,
+        string modifiedBy)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ValidationException("DisplayName is required");
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ValidationException("Description is required");
+        if (string.IsNullOrWhiteSpace(cronExpression))
+            throw new ValidationException("CronExpression is required");
+        if (string.IsNullOrWhiteSpace(modifiedBy))
+            throw new ValidationException("ModifiedBy is required");
+
+        DisplayName = displayName;
+        Description = description;
+        CronExpression = cronExpression;
+        LastModifiedAt = DateTime.UtcNow;
+        LastModifiedBy = modifiedBy;
+    }
+
+    public void Enable(string modifiedBy) { ... }
+    public void Disable(string modifiedBy) { ... }
+
+    public void UpdateCronExpression(string cronExpression, string modifiedBy)
+    {
+        // unchanged, unmodified by this task
+    }
+}
+```
+
+### `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs`
+```csharp
+public class RecurringJobDto
+{
+    public string JobName { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string CronExpression { get; set; } = string.Empty;
+    public bool IsEnabled { get; set; }
+    public DateTime LastModifiedAt { get; set; }
+    public string LastModifiedBy { get; set; } = string.Empty;
+    public DateTime? NextRunAt { get; set; }
+}
+```
+
+### `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs`
+```csharp
+public static class RecurringJobNextRunCalculator
+{
+    public static DateTime? Calculate(string cronExpression, bool isEnabled, DateTime utcNow, ILogger logger, string? jobName = null)
+    {
+        if (!isEnabled) return null;
+
+        TimeZoneInfo tz;
+        try
+        {
+            tz = TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId);
+        }
+        catch (TimeZoneNotFoundException ex)
+        {
+            logger.LogWarning(ex, "Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'",
+                RecurringJobMetadata.DefaultTimeZoneId, jobName);
+            return null;
+        }
+
+        try
+        {
+            var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(utcNow, tz);
+            var nextLocal = CrontabSchedule.Parse(cronExpression).GetNextOccurrence(nowLocal);
+            var nextUtc = TimeZoneInfo.ConvertTimeToUtc(
+                DateTime.SpecifyKind(nextLocal, DateTimeKind.Unspecified), tz);
+            return DateTime.SpecifyKind(nextUtc, DateTimeKind.Utc);
+        }
+        catch (CrontabException ex)
+        {
+            logger.LogWarning(ex, "Invalid CRON expression '{CronExpression}' for job '{JobName}', NextRunAt will be null",
+                cronExpression, jobName);
+            return null;
+        }
+    }
+}
+```
+`RecurringJobMetadata.DefaultTimeZoneId = "Europe/Prague"` (const) and `RecurringJobMetadata.TimeZoneId` (instance property, defaults to `DefaultTimeZoneId`) live in `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs` — **not modified** by this task.
+
+### `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+```csharp
+public async Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+{
+    var defaultConfigurations = jobs.Select(job => new RecurringJobConfiguration(
+        job.Metadata.JobName,
+        job.Metadata.DisplayName,
+        job.Metadata.Description,
+        job.Metadata.CronExpression,
+        job.Metadata.DefaultIsEnabled,
+        "System"
+    )).ToArray();
+    // ... existing add-if-not-exists loop, unchanged
+}
+```
+
+### `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`
+Configures `Id` (100), `JobName` (100), `DisplayName` (200), `Description` (500), `CronExpression` (50, note: **not** 100 — the entity's own `[MaxLength(50)]` on `CronExpression` differs from `TimeZoneId`'s planned 100), `IsEnabled`, `LastModifiedAt`, `LastModifiedBy` (100), plus two indexes (`JobName` unique, `IsEnabled`). No `TimeZoneId` entry today.
+
+### `GetRecurringJobHandler.cs` (line 47-48) and `GetRecurringJobsListHandler.cs` (line 41-42)
+Both currently call:
+```csharp
+RecurringJobNextRunCalculator.Calculate(dto.CronExpression, dto.IsEnabled, utcNow, _logger, dto.JobName)
+```
+(the list handler does this inside `foreach (var dto in jobDtos)`).
+
+### `UpdateRecurringJobCronHandler.cs`
+Calls `job.UpdateCronExpression(request.CronExpression, modifiedBy)` at line 67 — **confirmed this is NOT `UpdateConfiguration`**. Do not modify this file.
+
+### Migration style to copy — `backend/src/Anela.Heblo.Persistence/Migrations/20260715150507_AddLotLabelDriftCorrection.cs`
+```csharp
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLotLabelDriftCorrection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DriftEveryNLabels",
+                schema: "public",
+                table: "LotLabelCalibrations",
+                type: "integer",
+                nullable: false,
+                defaultValue: 3);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DriftEveryNLabels",
+                schema: "public",
+                table: "LotLabelCalibrations");
+        }
+    }
+}
+```
+This task's migration mirrors this shape but adds a `string` column with `maxLength: 100` and a string default instead of an `int` column.
+
+### Existing test call sites that will break on the constructor/`UpdateConfiguration`/`Calculate` signature changes (verified via grep, counts = number of matching lines, not necessarily distinct call sites — some are on multi-line invocations)
+All under `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/`:
+- `RecurringJobConfigurationRepositoryTests.cs` — constructs `RecurringJobConfiguration` directly (incl. one `UpdateConfiguration(...)` call around line 130 per arch review) — 7 matches
+- `RecurringJobConfigurationTests.cs` — direct entity unit tests, including one `UpdateConfiguration(...)` call around line 137 per arch review — 10 matches
+- `RecurringJobDiscoveryServiceTests.cs` — a test double's `GetAllAsync` builds a `RecurringJobConfiguration` (around line 205: `jobName: "test-async-job"`, ...) — 1 match
+- `RecurringJobSeederTests.cs` — 1 match
+- `RecurringJobStatusCheckerTests.cs` — 2 matches
+- `UpdateRecurringJobCronHandlerTests.cs` — 1 match (constructs a `RecurringJobConfiguration` as test fixture data; does not call `UpdateConfiguration` since the handler under test uses `UpdateCronExpression`)
+- `UpdateRecurringJobStatusHandlerTests.cs` — 6 matches
+- `GetRecurringJobHandlerTests.cs` — 2 matches (also likely asserts on `RecurringJobNextRunCalculator.Calculate` behavior / `dto.NextRunAt` — check for direct `Calculate(...)` calls too, not just the DTO/entity constructor)
+- `GetRecurringJobsListHandlerTests.cs` — 12 matches
+
+Also search these same test files (and any `RecurringJobNextRunCalculatorTests.cs` if it exists — check for it, it was not enumerated above but may exist) for direct calls to `RecurringJobNextRunCalculator.Calculate(...)`, which also need the new `timeZoneId` argument inserted.
+
+## Files to create/modify
+
+1. `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs`
+2. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs`
+3. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs`
+4. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJob/GetRecurringJobHandler.cs`
+5. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs`
+6. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs`
+7. `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`
+8. New file: `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_AddTimeZoneIdToRecurringJobConfigurations.cs` (+ matching `.Designer.cs`, generated by tooling)
+9. `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` (regenerated automatically — do not hand-edit)
+10. All test files listed above under `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/`: `RecurringJobConfigurationRepositoryTests.cs`, `RecurringJobConfigurationTests.cs`, `RecurringJobDiscoveryServiceTests.cs`, `RecurringJobSeederTests.cs`, `RecurringJobStatusCheckerTests.cs`, `UpdateRecurringJobCronHandlerTests.cs`, `UpdateRecurringJobStatusHandlerTests.cs`, `GetRecurringJobHandlerTests.cs`, `GetRecurringJobsListHandlerTests.cs`, plus any `RecurringJobNextRunCalculatorTests.cs` if present.
+
+**Explicitly NOT modified:** `BackgroundJobsMappingProfile.cs` (AutoMapper same-name matching handles it automatically), `UpdateRecurringJobCronHandler.cs` (`UpdateCronExpression` is untouched), `HangfireJobRegistrationHelper.cs` / `HangfireRecurringJobScheduler.cs` / `RecurringJobMetadata.cs` (already correct, out of scope).
+
+## Implementation steps
+
+1. **Domain entity** (`RecurringJobConfiguration.cs`):
+   - Add `[Required] [MaxLength(100)] public string TimeZoneId { get; private set; }` (place it after `CronExpression`, before `IsEnabled`, mirroring field grouping).
+   - In the private (EF Core) constructor, add `TimeZoneId = string.Empty;`.
+   - In the public constructor, insert `string timeZoneId` as a parameter immediately after `cronExpression`, before `isEnabled`. Add validation `if (string.IsNullOrWhiteSpace(timeZoneId)) throw new ValidationException("TimeZoneId is required");` alongside the other required-string checks, and assign `TimeZoneId = timeZoneId;` alongside the other assignments.
+   - In `UpdateConfiguration(...)`, insert `string timeZoneId` immediately after `cronExpression`, before `modifiedBy`. Add the same validation and assignment pattern used for `cronExpression`.
+   - Leave `Enable`, `Disable`, `UpdateCronExpression` untouched.
+
+2. **DTO** (`RecurringJobDto.cs`): add `public string TimeZoneId { get; set; } = string.Empty;` placed immediately after `CronExpression`. Keep as a class (never a record, per project rule).
+
+3. **Mapping**: no change needed to `BackgroundJobsMappingProfile.cs` — verify after step 1-2 that `CreateMap<RecurringJobConfiguration, RecurringJobDto>()` still compiles and picks up `TimeZoneId` (same-name auto-mapping).
+
+4. **Calculator** (`RecurringJobNextRunCalculator.cs`):
+   - Change signature to `public static DateTime? Calculate(string cronExpression, bool isEnabled, string timeZoneId, DateTime utcNow, ILogger logger, string? jobName = null)`.
+   - Replace `TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId)` with `TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)`.
+   - Update the `TimeZoneNotFoundException` catch block's log call to pass `timeZoneId` instead of `RecurringJobMetadata.DefaultTimeZoneId` as the format argument (message text can stay the same, e.g. `"Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'", timeZoneId, jobName`).
+   - Do not change the null-return-on-failure contract otherwise. Remove the now-unused `using` for `RecurringJobMetadata` if it becomes unreferenced in this file (check — it's in the same namespace `Anela.Heblo.Domain.Features.BackgroundJobs`, likely no explicit `using` needed to remove).
+
+5. **Callers**:
+   - `GetRecurringJobHandler.cs` line ~47-48: change to `RecurringJobNextRunCalculator.Calculate(dto.CronExpression, dto.IsEnabled, dto.TimeZoneId, utcNow, _logger, dto.JobName)`.
+   - `GetRecurringJobsListHandler.cs` line ~41-42 (inside the `foreach`): same change.
+
+6. **Seeder** (`RecurringJobSeeder.cs`): in the `RecurringJobConfiguration` object construction inside `SeedDefaultConfigurationsAsync`, insert `job.Metadata.TimeZoneId` as the new argument immediately after `job.Metadata.CronExpression`, before `job.Metadata.DefaultIsEnabled`.
+
+7. **EF Core configuration** (`RecurringJobConfigurationConfiguration.cs`): add, in the same block as the other `[MaxLength]`-backed string properties (e.g. right after the `CronExpression` property config):
+   ```csharp
+   builder.Property(e => e.TimeZoneId)
+       .HasMaxLength(100)
+       .IsRequired();
+   ```
+
+8. **EF Core migration**: after steps 1-7 compile, generate the migration from the repo root:
+   ```bash
+   cd backend && dotnet ef migrations add AddTimeZoneIdToRecurringJobConfigurations \
+     --project src/Anela.Heblo.Persistence --startup-project src/Anela.Heblo.API
+   ```
+   Verify the generated `Up`/`Down` match this shape (adjust only if the tool output differs from expectations — do not hand-edit beyond fixing an incorrect default):
+   ```csharp
+   protected override void Up(MigrationBuilder migrationBuilder)
+   {
+       migrationBuilder.AddColumn<string>(
+           name: "TimeZoneId",
+           schema: "public",
+           table: "RecurringJobConfigurations",
+           type: "character varying(100)",
+           maxLength: 100,
+           nullable: false,
+           defaultValue: "Europe/Prague");
+   }
+
+   protected override void Down(MigrationBuilder migrationBuilder)
+   {
+       migrationBuilder.DropColumn(
+           name: "TimeZoneId",
+           schema: "public",
+           table: "RecurringJobConfigurations");
+   }
+   ```
+   Confirm `ApplicationDbContextModelSnapshot.cs` was regenerated with a `b.Property<string>("TimeZoneId")...` entry in the `RecurringJobConfiguration` section. Do not hand-edit the snapshot.
+
+9. **Fix every broken call site** the compiler reports after steps 1 and 4 (constructor, `UpdateConfiguration`, and `Calculate` signature changes) across production and test code:
+   - Every `new RecurringJobConfiguration(...)` call (production: `RecurringJobSeeder.cs`, already done in step 6; test files listed above) — insert a `timeZoneId` argument (positionally after `cronExpression`). Use `"Europe/Prague"` (or `RecurringJobMetadata.DefaultTimeZoneId` if the test file already references that constant) for tests that don't care about timezone specifically; use a distinct value like `"America/New_York"` for tests that will assert timezone-aware behavior (see Tests section).
+   - Every `UpdateConfiguration(...)` call (the two known ones in `RecurringJobConfigurationRepositoryTests.cs` and `RecurringJobConfigurationTests.cs`, plus any others found by the compiler) — insert a `timeZoneId` argument after `cronExpression`.
+   - Every `RecurringJobNextRunCalculator.Calculate(...)` call in tests — insert a `timeZoneId` argument after `isEnabled`.
+   - Do a final `dotnet build` sweep to catch any call site not identified by the greps above (the greps are a starting point, not guaranteed exhaustive — trust compiler errors as the source of truth for completeness).
+
+## Tests to write/update
+
+- **Update all existing broken call sites** identified in step 9 above so the full existing suite compiles and passes unchanged in behavior (existing assertions about `NextRunAt`, cron parsing, etc. must still pass since the default `"Europe/Prague"` argument reproduces current behavior).
+- **`RecurringJobConfigurationTests.cs`**: add/update tests so:
+  - Constructing with `timeZoneId = null` or whitespace throws `ValidationException` (mirroring the existing `cronExpression` null/whitespace test).
+  - Constructing with a valid `timeZoneId` (e.g. `"America/New_York"`) sets `TimeZoneId` correctly.
+  - `UpdateConfiguration(...)` with a new `timeZoneId` updates `TimeZoneId` on the entity (mirroring the existing `cronExpression` update assertion), and with null/whitespace throws `ValidationException`.
+- **`RecurringJobNextRunCalculator` tests** (add to whichever test file currently covers `Calculate` — locate it via the existing call sites in `GetRecurringJobHandlerTests.cs`/`GetRecurringJobsListHandlerTests.cs`, or a dedicated `RecurringJobNextRunCalculatorTests.cs` if one exists; create one only if genuinely none exists and calculator logic isn't otherwise unit-tested):
+  - **New required test**: assert that `Calculate` with a non-default `timeZoneId` (e.g. `"America/New_York"`) produces a different `NextRunAt` than `Calculate` with `"Europe/Prague"` for the same cron expression and `utcNow`, proving the calculator now actually uses the passed-in timezone rather than a hardcoded default. Use a cron expression/time where the two timezones' offsets cause a different next-occurrence date (e.g. a job scheduled near local midnight, so the UTC-crossing differs) — or, simpler and robust, assert the returned `NextRunAt` values differ by the expected UTC offset delta between the two zones at that instant.
+  - Update the existing `TimeZoneNotFoundException` test (if present) to pass a bogus `timeZoneId` string directly as the parameter and assert the warning log now references that string, not `RecurringJobMetadata.DefaultTimeZoneId`.
+- **`RecurringJobSeederTests.cs`**: update/add an assertion that seeded `RecurringJobConfiguration.TimeZoneId` equals the source `IRecurringJob.Metadata.TimeZoneId` (test with a job whose metadata has a non-default `TimeZoneId` to prove it's not just defaulting).
+- **`GetRecurringJobHandlerTests.cs`** and **`GetRecurringJobsListHandlerTests.cs`**: update fixtures to include `TimeZoneId` on the underlying `RecurringJobConfiguration`/DTO, and add/update an assertion that `NextRunAt` in the response reflects the entity's own `TimeZoneId` (not the default) when a non-default value is used.
+- **`RecurringJobConfigurationRepositoryTests.cs`**: update the existing `UpdateConfiguration` call/test to pass and assert `TimeZoneId` round-trips through persistence (if this test uses an in-memory/real DB context, confirm the new EF Core column mapping works).
+- Run the full BackgroundJobs test namespace plus a full solution test run to confirm nothing else broke.
+
+## Acceptance criteria
+
+- `dotnet build` succeeds for the whole solution with no errors.
+- `dotnet format` reports no changes needed (run `dotnet format` and ensure clean diff, or that it was run and applied) on all touched files.
+- All touched/existing unit tests in `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/` pass, including the new/updated tests described above.
+- Full existing test suite (`dotnet test`) passes — no regressions outside `BackgroundJobs`.
+- `RecurringJobConfiguration` has a persisted `TimeZoneId` property (`[Required] [MaxLength(100)]`), settable via both the public constructor and `UpdateConfiguration`, with `ValidationException` on null/whitespace.
+- `RecurringJobDto` exposes `TimeZoneId` (`string`, defaults to `string.Empty`), still a class.
+- `GetRecurringJobHandler` and `GetRecurringJobsListHandler` pass `dto.TimeZoneId` into `RecurringJobNextRunCalculator.Calculate`.
+- `RecurringJobNextRunCalculator.Calculate` resolves the timezone exclusively from its `timeZoneId` parameter; `RecurringJobMetadata.DefaultTimeZoneId` no longer appears anywhere in `RecurringJobNextRunCalculator.cs`.
+- `RecurringJobSeeder` seeds new rows with `job.Metadata.TimeZoneId`.
+- A new EF Core migration (`AddTimeZoneIdToRecurringJobConfigurations`, following the `AddLotLabelDriftCorrection.cs` PascalCase/`schema: "public"` style — not the old snake_case style) adds the `TimeZoneId` column as `NOT NULL DEFAULT 'Europe/Prague'`, `maxLength: 100`; `ApplicationDbContextModelSnapshot.cs` reflects it.
+- `UpdateRecurringJobCronHandler.cs` is unmodified (verified: it calls `UpdateCronExpression`, not `UpdateConfiguration`).
+- `BackgroundJobsMappingProfile.cs` is unmodified.
+- At least one new test proves `RecurringJobNextRunCalculator.Calculate` produces a different `NextRunAt` for a non-default `timeZoneId` than for the default, demonstrating the fix actually works (not just that the code compiles).
+- For current/default-timezone data, `NextRunAt` values are unchanged from pre-change behavior (behavior-preserving for existing jobs) — covered by the existing (updated) test assertions continuing to pass with `"Europe/Prague"` as the passed-in timezone.

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs
@@ -6,6 +6,7 @@ public class RecurringJobDto
     public string DisplayName { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public string CronExpression { get; set; } = string.Empty;
+    public string TimeZoneId { get; set; } = string.Empty;
     public bool IsEnabled { get; set; }
     public DateTime LastModifiedAt { get; set; }
     public string LastModifiedBy { get; set; } = string.Empty;

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/RecurringJobNextRunCalculator.cs
@@ -1,4 +1,3 @@
-using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Microsoft.Extensions.Logging;
 using NCrontab.Advanced;
 using NCrontab.Advanced.Exceptions;
@@ -12,7 +11,7 @@ namespace Anela.Heblo.Application.Features.BackgroundJobs;
 /// </summary>
 public static class RecurringJobNextRunCalculator
 {
-    public static DateTime? Calculate(string cronExpression, bool isEnabled, DateTime utcNow, ILogger logger, string? jobName = null)
+    public static DateTime? Calculate(string cronExpression, bool isEnabled, string timeZoneId, DateTime utcNow, ILogger logger, string? jobName = null)
     {
         if (!isEnabled)
         {
@@ -22,12 +21,12 @@ public static class RecurringJobNextRunCalculator
         TimeZoneInfo tz;
         try
         {
-            tz = TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId);
+            tz = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
         }
         catch (TimeZoneNotFoundException ex)
         {
             logger.LogWarning(ex, "Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'",
-                RecurringJobMetadata.DefaultTimeZoneId, jobName);
+                timeZoneId, jobName);
             return null;
         }
 

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/RecurringJobSeeder.cs
@@ -25,6 +25,7 @@ public class RecurringJobSeeder : IRecurringJobSeeder
             job.Metadata.DisplayName,
             job.Metadata.Description,
             job.Metadata.CronExpression,
+            job.Metadata.TimeZoneId,
             job.Metadata.DefaultIsEnabled,
             "System"
         )).ToArray();

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJob/GetRecurringJobHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJob/GetRecurringJobHandler.cs
@@ -45,7 +45,7 @@ public class GetRecurringJobHandler : IRequestHandler<GetRecurringJobRequest, Ge
         var dto = _mapper.Map<RecurringJobDto>(job);
         var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
         dto.NextRunAt = RecurringJobNextRunCalculator.Calculate(
-            dto.CronExpression, dto.IsEnabled, utcNow, _logger, dto.JobName);
+            dto.CronExpression, dto.IsEnabled, dto.TimeZoneId, utcNow, _logger, dto.JobName);
 
         return new GetRecurringJobResponse { Job = dto };
     }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs
@@ -39,7 +39,7 @@ public class GetRecurringJobsListHandler : IRequestHandler<GetRecurringJobsListR
         foreach (var dto in jobDtos)
         {
             dto.NextRunAt = RecurringJobNextRunCalculator.Calculate(
-                dto.CronExpression, dto.IsEnabled, utcNow, _logger, dto.JobName);
+                dto.CronExpression, dto.IsEnabled, dto.TimeZoneId, utcNow, _logger, dto.JobName);
         }
 
         _logger.LogInformation("Retrieved {Count} recurring jobs", jobDtos.Count);

--- a/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobConfiguration.cs
@@ -21,6 +21,10 @@ public class RecurringJobConfiguration : Entity<string>
     [MaxLength(50)]
     public string CronExpression { get; private set; }
 
+    [Required]
+    [MaxLength(100)]
+    public string TimeZoneId { get; private set; }
+
     public bool IsEnabled { get; private set; }
 
     public DateTime LastModifiedAt { get; private set; }
@@ -36,6 +40,7 @@ public class RecurringJobConfiguration : Entity<string>
         DisplayName = string.Empty;
         Description = string.Empty;
         CronExpression = string.Empty;
+        TimeZoneId = string.Empty;
         LastModifiedBy = string.Empty;
     }
 
@@ -44,6 +49,7 @@ public class RecurringJobConfiguration : Entity<string>
         string displayName,
         string description,
         string cronExpression,
+        string timeZoneId,
         bool isEnabled,
         string lastModifiedBy)
     {
@@ -55,6 +61,8 @@ public class RecurringJobConfiguration : Entity<string>
             throw new ValidationException("Description is required");
         if (string.IsNullOrWhiteSpace(cronExpression))
             throw new ValidationException("CronExpression is required");
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+            throw new ValidationException("TimeZoneId is required");
         if (string.IsNullOrWhiteSpace(lastModifiedBy))
             throw new ValidationException("LastModifiedBy is required");
 
@@ -63,6 +71,7 @@ public class RecurringJobConfiguration : Entity<string>
         DisplayName = displayName;
         Description = description;
         CronExpression = cronExpression;
+        TimeZoneId = timeZoneId;
         IsEnabled = isEnabled;
         LastModifiedAt = DateTime.UtcNow;
         LastModifiedBy = lastModifiedBy;
@@ -72,6 +81,7 @@ public class RecurringJobConfiguration : Entity<string>
         string displayName,
         string description,
         string cronExpression,
+        string timeZoneId,
         string modifiedBy)
     {
         if (string.IsNullOrWhiteSpace(displayName))
@@ -80,12 +90,15 @@ public class RecurringJobConfiguration : Entity<string>
             throw new ValidationException("Description is required");
         if (string.IsNullOrWhiteSpace(cronExpression))
             throw new ValidationException("CronExpression is required");
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+            throw new ValidationException("TimeZoneId is required");
         if (string.IsNullOrWhiteSpace(modifiedBy))
             throw new ValidationException("ModifiedBy is required");
 
         DisplayName = displayName;
         Description = description;
         CronExpression = cronExpression;
+        TimeZoneId = timeZoneId;
         LastModifiedAt = DateTime.UtcNow;
         LastModifiedBy = modifiedBy;
     }

--- a/backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs
@@ -36,6 +36,10 @@ public class RecurringJobConfigurationConfiguration : IEntityTypeConfiguration<R
             .HasMaxLength(50)
             .IsRequired();
 
+        builder.Property(e => e.TimeZoneId)
+            .HasMaxLength(100)
+            .IsRequired();
+
         builder.Property(e => e.IsEnabled)
             .IsRequired();
 

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260718074122_AddTimeZoneIdToRecurringJobConfigurations.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260718074122_AddTimeZoneIdToRecurringJobConfigurations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718074122_AddTimeZoneIdToRecurringJobConfigurations")]
+    partial class AddTimeZoneIdToRecurringJobConfigurations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260718074122_AddTimeZoneIdToRecurringJobConfigurations.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260718074122_AddTimeZoneIdToRecurringJobConfigurations.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTimeZoneIdToRecurringJobConfigurations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TimeZoneId",
+                schema: "public",
+                table: "RecurringJobConfigurations",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "Europe/Prague");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TimeZoneId",
+                schema: "public",
+                table: "RecurringJobConfigurations");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobHandlerTests.cs
@@ -38,8 +38,8 @@ public class GetRecurringJobHandlerTests
     public async Task Handle_WhenJobExistsAndEnabled_ReturnsJobWithNextRunAt()
     {
         var request = new GetRecurringJobRequest { JobName = "print-picking-list" };
-        var job = new RecurringJobConfiguration("print-picking-list", "Print", "Desc", "0 13 * * *", true, "User1");
-        var dto = new RecurringJobDto { JobName = "print-picking-list", CronExpression = "0 13 * * *", IsEnabled = true };
+        var job = new RecurringJobConfiguration("print-picking-list", "Print", "Desc", "0 13 * * *", "Europe/Prague", true, "User1");
+        var dto = new RecurringJobDto { JobName = "print-picking-list", CronExpression = "0 13 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true };
         _repositoryMock.Setup(r => r.GetByJobNameAsync("print-picking-list", It.IsAny<CancellationToken>())).ReturnsAsync(job);
         _mapperMock.Setup(m => m.Map<RecurringJobDto>(job)).Returns(dto);
 
@@ -56,8 +56,8 @@ public class GetRecurringJobHandlerTests
     public async Task Handle_WhenJobIsDisabled_ReturnsJobWithNullNextRunAt()
     {
         var request = new GetRecurringJobRequest { JobName = "print-picking-list" };
-        var job = new RecurringJobConfiguration("print-picking-list", "Print", "Desc", "0 13 * * *", false, "User1");
-        var dto = new RecurringJobDto { JobName = "print-picking-list", CronExpression = "0 13 * * *", IsEnabled = false };
+        var job = new RecurringJobConfiguration("print-picking-list", "Print", "Desc", "0 13 * * *", "Europe/Prague", false, "User1");
+        var dto = new RecurringJobDto { JobName = "print-picking-list", CronExpression = "0 13 * * *", TimeZoneId = "Europe/Prague", IsEnabled = false };
         _repositoryMock.Setup(r => r.GetByJobNameAsync("print-picking-list", It.IsAny<CancellationToken>())).ReturnsAsync(job);
         _mapperMock.Setup(m => m.Map<RecurringJobDto>(job)).Returns(dto);
 
@@ -65,6 +65,25 @@ public class GetRecurringJobHandlerTests
 
         result.Success.Should().BeTrue();
         result.Job!.NextRunAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobHasNonDefaultTimeZone_UsesJobTimeZoneForNextRunAt()
+    {
+        var request = new GetRecurringJobRequest { JobName = "print-picking-list" };
+        var job = new RecurringJobConfiguration("print-picking-list", "Print", "Desc", "0 13 * * *", "America/New_York", true, "User1");
+        var dto = new RecurringJobDto { JobName = "print-picking-list", CronExpression = "0 13 * * *", TimeZoneId = "America/New_York", IsEnabled = true };
+        _repositoryMock.Setup(r => r.GetByJobNameAsync("print-picking-list", It.IsAny<CancellationToken>())).ReturnsAsync(job);
+        _mapperMock.Setup(m => m.Map<RecurringJobDto>(job)).Returns(dto);
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Job.Should().NotBeNull();
+        // cron "0 13 * * *" → next after 08:00 New York (EDT, UTC-4) is 2026-03-30 13:00 EDT = 17:00 UTC
+        result.Job!.NextRunAt.Should().Be(new DateTime(2026, 3, 30, 17, 0, 0, DateTimeKind.Utc));
+        // Confirms the calculator used the job's own timezone, not the Europe/Prague default
+        result.Job.NextRunAt.Should().NotBe(new DateTime(2026, 3, 31, 11, 0, 0, DateTimeKind.Utc));
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobsListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobsListHandlerTests.cs
@@ -39,13 +39,13 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job1", "Display 1", "Description 1", "0 0 * * *", true, "User1"),
-            new RecurringJobConfiguration("Job2", "Display 2", "Description 2", "0 1 * * *", false, "User2")
+            new RecurringJobConfiguration("Job1", "Display 1", "Description 1", "0 0 * * *", "Europe/Prague", true, "User1"),
+            new RecurringJobConfiguration("Job2", "Display 2", "Description 2", "0 1 * * *", "Europe/Prague", false, "User2")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "Job1", DisplayName = "Display 1", Description = "Description 1", CronExpression = "0 0 * * *", IsEnabled = true, LastModifiedBy = "User1" },
-            new RecurringJobDto { JobName = "Job2", DisplayName = "Display 2", Description = "Description 2", CronExpression = "0 1 * * *", IsEnabled = false, LastModifiedBy = "User2" }
+            new RecurringJobDto { JobName = "Job1", DisplayName = "Display 1", Description = "Description 1", CronExpression = "0 0 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true, LastModifiedBy = "User1" },
+            new RecurringJobDto { JobName = "Job2", DisplayName = "Display 2", Description = "Description 2", CronExpression = "0 1 * * *", TimeZoneId = "Europe/Prague", IsEnabled = false, LastModifiedBy = "User2" }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
@@ -95,7 +95,7 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job1", "Display 1", "Description 1", "0 0 * * *", true, "User1")
+            new RecurringJobConfiguration("Job1", "Display 1", "Description 1", "0 0 * * *", "Europe/Prague", true, "User1")
         };
         var jobDtos = new List<RecurringJobDto>();
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
@@ -112,11 +112,11 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job1", "Display 1", "Description 1", "0 0 * * *", true, "User1")
+            new RecurringJobConfiguration("Job1", "Display 1", "Description 1", "0 0 * * *", "Europe/Prague", true, "User1")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "Job1", CronExpression = "0 0 * * *", IsEnabled = true }
+            new RecurringJobDto { JobName = "Job1", CronExpression = "0 0 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
@@ -143,11 +143,11 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "0 13 * * *", true, "User1")
+            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "0 13 * * *", "Europe/Prague", true, "User1")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "Job1", CronExpression = "0 13 * * *", IsEnabled = true }
+            new RecurringJobDto { JobName = "Job1", CronExpression = "0 13 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
@@ -165,7 +165,7 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job2", "Display 2", "Desc", "0 13 * * *", false, "User1")
+            new RecurringJobConfiguration("Job2", "Display 2", "Desc", "0 13 * * *", "Europe/Prague", false, "User1")
         };
         var jobDtos = new List<RecurringJobDto>
         {
@@ -185,13 +185,13 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "0 13 * * *", true, "User1"),
-            new RecurringJobConfiguration("Job2", "Display 2", "Desc", "0 3 * * *", false, "User2")
+            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "0 13 * * *", "Europe/Prague", true, "User1"),
+            new RecurringJobConfiguration("Job2", "Display 2", "Desc", "0 3 * * *", "Europe/Prague", false, "User2")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "Job1", CronExpression = "0 13 * * *", IsEnabled = true },
-            new RecurringJobDto { JobName = "Job2", CronExpression = "0 3 * * *", IsEnabled = false }
+            new RecurringJobDto { JobName = "Job1", CronExpression = "0 13 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true },
+            new RecurringJobDto { JobName = "Job2", CronExpression = "0 3 * * *", TimeZoneId = "Europe/Prague", IsEnabled = false }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
@@ -204,17 +204,46 @@ public class GetRecurringJobsListHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenJobHasNonDefaultTimeZone_NextRunAtDiffersFromDefaultTimeZone()
+    {
+        // Fixed time is 2026-03-30 12:00:00 UTC. Same cron "0 13 * * *" evaluated in two different
+        // per-job timezones must produce two different NextRunAt values, proving the handler passes
+        // dto.TimeZoneId into the calculator instead of relying on a hardcoded default.
+        var request = new GetRecurringJobsListRequest();
+        var jobs = new List<RecurringJobConfiguration>
+        {
+            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "0 13 * * *", "Europe/Prague", true, "User1"),
+            new RecurringJobConfiguration("Job2", "Display 2", "Desc", "0 13 * * *", "America/New_York", true, "User2")
+        };
+        var jobDtos = new List<RecurringJobDto>
+        {
+            new RecurringJobDto { JobName = "Job1", CronExpression = "0 13 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true },
+            new RecurringJobDto { JobName = "Job2", CronExpression = "0 13 * * *", TimeZoneId = "America/New_York", IsEnabled = true }
+        };
+        _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
+        _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Europe/Prague: 13:00 CEST next occurrence after 14:00 local = 2026-03-31 13:00 CEST = 11:00 UTC
+        result.Jobs[0].NextRunAt.Should().Be(new DateTime(2026, 3, 31, 11, 0, 0, DateTimeKind.Utc));
+        // America/New_York (EDT, UTC-4): 08:00 local now, next occurrence 13:00 EDT same day = 17:00 UTC
+        result.Jobs[1].NextRunAt.Should().Be(new DateTime(2026, 3, 30, 17, 0, 0, DateTimeKind.Utc));
+        result.Jobs[0].NextRunAt.Should().NotBe(result.Jobs[1].NextRunAt);
+    }
+
+    [Fact]
     public async Task Handle_WhenCronExpressionIsInvalid_SetsNextRunAtToNullAndLogsWarning()
     {
         // Arrange — "NOT_A_CRON" is syntactically invalid and will cause CrontabSchedule.Parse to throw
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "NOT_A_CRON", true, "User1")
+            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "NOT_A_CRON", "Europe/Prague", true, "User1")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "Job1", CronExpression = "NOT_A_CRON", IsEnabled = true }
+            new RecurringJobDto { JobName = "Job1", CronExpression = "NOT_A_CRON", TimeZoneId = "Europe/Prague", IsEnabled = true }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
@@ -252,11 +281,11 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("czk-import", "CZK Import", "Desc", "15 4 * * *", true, "System")
+            new RecurringJobConfiguration("czk-import", "CZK Import", "Desc", "15 4 * * *", "Europe/Prague", true, "System")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "czk-import", CronExpression = "15 4 * * *", IsEnabled = true }
+            new RecurringJobDto { JobName = "czk-import", CronExpression = "15 4 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
@@ -282,11 +311,11 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("czk-import", "CZK Import", "Desc", "15 4 * * *", true, "System")
+            new RecurringJobConfiguration("czk-import", "CZK Import", "Desc", "15 4 * * *", "Europe/Prague", true, "System")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "czk-import", CronExpression = "15 4 * * *", IsEnabled = true }
+            new RecurringJobDto { JobName = "czk-import", CronExpression = "15 4 * * *", TimeZoneId = "Europe/Prague", IsEnabled = true }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
@@ -306,11 +335,11 @@ public class GetRecurringJobsListHandlerTests
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
-            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "INVALID_CRON", true, "User1")
+            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "INVALID_CRON", "Europe/Prague", true, "User1")
         };
         var jobDtos = new List<RecurringJobDto>
         {
-            new RecurringJobDto { JobName = "Job1", CronExpression = "INVALID_CRON", IsEnabled = true }
+            new RecurringJobDto { JobName = "Job1", CronExpression = "INVALID_CRON", TimeZoneId = "Europe/Prague", IsEnabled = true }
         };
         _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
         _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationRepositoryTests.cs
@@ -41,6 +41,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
             "Test Job 1",
             "Description for test job 1",
             "0 0 * * *",
+            "Europe/Prague",
             true,
             "TestUser");
 
@@ -49,6 +50,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
             "Test Job 2",
             "Description for test job 2",
             "0 12 * * *",
+            "Europe/Prague",
             false,
             "TestUser");
 
@@ -75,6 +77,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
             "Existing Job",
             "Description for existing job",
             "0 6 * * *",
+            "America/New_York",
             true,
             "TestUser");
 
@@ -90,6 +93,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
         Assert.Equal("Existing Job", result.DisplayName);
         Assert.Equal("Description for existing job", result.Description);
         Assert.Equal("0 6 * * *", result.CronExpression);
+        Assert.Equal("America/New_York", result.TimeZoneId);
         Assert.True(result.IsEnabled);
         Assert.Equal("TestUser", result.LastModifiedBy);
     }
@@ -113,6 +117,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
             "Original Display Name",
             "Original description",
             "0 8 * * *",
+            "Europe/Prague",
             true,
             "OriginalUser");
 
@@ -131,6 +136,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
             "Updated Display Name",
             "Updated description",
             "0 10 * * *",
+            "America/New_York",
             "UpdatedUser");
 
         await _repository.UpdateAsync(loadedConfig);
@@ -141,6 +147,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
         Assert.Equal("Updated Display Name", updatedConfig.DisplayName);
         Assert.Equal("Updated description", updatedConfig.Description);
         Assert.Equal("0 10 * * *", updatedConfig.CronExpression);
+        Assert.Equal("America/New_York", updatedConfig.TimeZoneId);
         Assert.Equal("UpdatedUser", updatedConfig.LastModifiedBy);
         Assert.True(updatedConfig.IsEnabled); // Should remain unchanged
     }
@@ -154,6 +161,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
             "Job to Disable",
             "Description",
             "0 8 * * *",
+            "Europe/Prague",
             true,
             "OriginalUser");
 
@@ -187,6 +195,7 @@ public class RecurringJobConfigurationRepositoryTests : IDisposable
             "New Job",
             "Description for new job",
             "0 5 * * *",
+            "Europe/Prague",
             true,
             "System");
 

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobConfigurationTests.cs
@@ -15,6 +15,7 @@ public class RecurringJobConfigurationTests
             displayName: "Purchase Price Recalculation",
             description: "Daily purchase price recalculation job",
             cronExpression: "0 2 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "system"
         );
@@ -25,8 +26,27 @@ public class RecurringJobConfigurationTests
         Assert.Equal("Purchase Price Recalculation", config.DisplayName);
         Assert.Equal("Daily purchase price recalculation job", config.Description);
         Assert.Equal("0 2 * * *", config.CronExpression);
+        Assert.Equal("Europe/Prague", config.TimeZoneId);
         Assert.True(config.IsEnabled);
         Assert.Equal("system", config.LastModifiedBy);
+    }
+
+    [Fact]
+    public void RecurringJobConfiguration_ShouldSetTimeZoneId_WhenGivenNonDefaultValue()
+    {
+        // Arrange & Act
+        var config = new RecurringJobConfiguration(
+            jobName: "test-job",
+            displayName: "Test Job",
+            description: "Test description",
+            cronExpression: "0 0 * * *",
+            timeZoneId: "America/New_York",
+            isEnabled: true,
+            lastModifiedBy: "system"
+        );
+
+        // Assert
+        Assert.Equal("America/New_York", config.TimeZoneId);
     }
 
     [Fact]
@@ -38,6 +58,7 @@ public class RecurringJobConfigurationTests
             displayName: "Test Job",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "system"
         );
@@ -59,6 +80,7 @@ public class RecurringJobConfigurationTests
             displayName: "Test Job",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "system"
         ));
@@ -73,6 +95,7 @@ public class RecurringJobConfigurationTests
             displayName: "",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "system"
         ));
@@ -87,6 +110,7 @@ public class RecurringJobConfigurationTests
             displayName: "Test Job",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: false,
             lastModifiedBy: "system"
         );
@@ -108,6 +132,7 @@ public class RecurringJobConfigurationTests
             displayName: "Test Job",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "system"
         );
@@ -129,6 +154,7 @@ public class RecurringJobConfigurationTests
             displayName: "Test Job",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "system"
         );
@@ -138,6 +164,7 @@ public class RecurringJobConfigurationTests
             displayName: "Updated Job",
             description: "Updated description",
             cronExpression: "0 2 * * *",
+            timeZoneId: "America/New_York",
             modifiedBy: "admin"
         );
 
@@ -145,7 +172,47 @@ public class RecurringJobConfigurationTests
         Assert.Equal("Updated Job", config.DisplayName);
         Assert.Equal("Updated description", config.Description);
         Assert.Equal("0 2 * * *", config.CronExpression);
+        Assert.Equal("America/New_York", config.TimeZoneId);
         Assert.Equal("admin", config.LastModifiedBy);
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowValidationException_WhenTimeZoneIdIsEmpty()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ValidationException>(() => new RecurringJobConfiguration(
+            jobName: "test-job",
+            displayName: "Test Job",
+            description: "Test description",
+            cronExpression: "0 0 * * *",
+            timeZoneId: "   ",
+            isEnabled: true,
+            lastModifiedBy: "system"
+        ));
+    }
+
+    [Fact]
+    public void UpdateConfiguration_ShouldThrowValidationException_WhenTimeZoneIdIsEmpty()
+    {
+        // Arrange
+        var config = new RecurringJobConfiguration(
+            jobName: "test-job",
+            displayName: "Test Job",
+            description: "Test description",
+            cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
+            isEnabled: true,
+            lastModifiedBy: "system"
+        );
+
+        // Act & Assert
+        Assert.Throws<ValidationException>(() => config.UpdateConfiguration(
+            displayName: "Updated Job",
+            description: "Updated description",
+            cronExpression: "0 2 * * *",
+            timeZoneId: "",
+            modifiedBy: "admin"
+        ));
     }
 
     [Fact]
@@ -157,6 +224,7 @@ public class RecurringJobConfigurationTests
             displayName: "Test Job",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: false,
             lastModifiedBy: "system"
         );
@@ -174,6 +242,7 @@ public class RecurringJobConfigurationTests
             displayName: "Test Job",
             description: "Test description",
             cronExpression: "0 0 * * *",
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "system"
         );

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobDiscoveryServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobDiscoveryServiceTests.cs
@@ -207,6 +207,7 @@ public class RecurringJobDiscoveryServiceTests : IDisposable
                 displayName: "Test Async Recurring Job",
                 description: "Test job for DB CRON path verification",
                 cronExpression: _cronExpression,
+                timeZoneId: "Europe/Prague",
                 isEnabled: true,
                 lastModifiedBy: "test");
 

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobSeederTests.cs
@@ -47,6 +47,13 @@ public class RecurringJobSeederTests : IDisposable
         Assert.Contains(configurations, c => c.JobName == "daily-invoice-import-czk");
         Assert.Contains(configurations, c => c.JobName == "daily-comgate-czk-import");
         Assert.Contains(configurations, c => c.JobName == "daily-comgate-eur-import");
+
+        // Verify TimeZoneId is seeded from job metadata, not just defaulted
+        var defaultTimeZoneJob = configurations.Single(c => c.JobName == "purchase-price-recalculation");
+        Assert.Equal(RecurringJobMetadata.DefaultTimeZoneId, defaultTimeZoneJob.TimeZoneId);
+
+        var nonDefaultTimeZoneJob = configurations.Single(c => c.JobName == "invoice-classification");
+        Assert.Equal("America/New_York", nonDefaultTimeZoneJob.TimeZoneId);
     }
 
     [Fact]
@@ -58,6 +65,7 @@ public class RecurringJobSeederTests : IDisposable
             "Purchase Price Recalculation",
             "Recalculates purchase prices for all materials and products",
             "0 2 * * *",
+            "Europe/Prague",
             true,
             "System");
 
@@ -94,7 +102,7 @@ public class RecurringJobSeederTests : IDisposable
             new MockRecurringJob("purchase-price-recalculation", "Purchase Price Recalculation", "Recalculates purchase prices for all materials and products", "0 2 * * *"),
             new MockRecurringJob("product-export-download", "Product Export Download", "Downloads product export data from external systems", "0 2 * * *"),
             new MockRecurringJob("product-weight-recalculation", "Product Weight Recalculation", "Recalculates product weights based on current material composition", "0 2 * * *"),
-            new MockRecurringJob("invoice-classification", "Invoice Classification", "Classifies and categorizes incoming invoices", "0 * * * *"),
+            new MockRecurringJob("invoice-classification", "Invoice Classification", "Classifies and categorizes incoming invoices", "0 * * * *", "America/New_York"),
             new MockRecurringJob("daily-consumption-calculation", "Daily Consumption Calculation", "Calculates daily consumption of packing materials", "0 3 * * *"),
             new MockRecurringJob("daily-invoice-import-eur", "Daily Invoice Import (EUR)", "Imports EUR invoices from Shoptet to ABRA Flexi", "0 4 * * *"),
             new MockRecurringJob("daily-invoice-import-czk", "Daily Invoice Import (CZK)", "Imports CZK invoices from Shoptet to ABRA Flexi", "15 4 * * *"),
@@ -110,7 +118,7 @@ public class RecurringJobSeederTests : IDisposable
     {
         public RecurringJobMetadata Metadata { get; }
 
-        public MockRecurringJob(string jobName, string displayName, string description, string cronExpression)
+        public MockRecurringJob(string jobName, string displayName, string description, string cronExpression, string? timeZoneId = null)
         {
             Metadata = new RecurringJobMetadata
             {
@@ -118,7 +126,8 @@ public class RecurringJobSeederTests : IDisposable
                 DisplayName = displayName,
                 Description = description,
                 CronExpression = cronExpression,
-                DefaultIsEnabled = true
+                DefaultIsEnabled = true,
+                TimeZoneId = timeZoneId ?? RecurringJobMetadata.DefaultTimeZoneId
             };
         }
 

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobStatusCheckerTests.cs
@@ -27,6 +27,7 @@ public class RecurringJobStatusCheckerTests
                 displayName: "Job A",
                 description: "Test job",
                 cronExpression: "0 * * * *",
+                timeZoneId: "Europe/Prague",
                 isEnabled: false,
                 lastModifiedBy: "test"));
         var sut = CreateSut();
@@ -49,6 +50,7 @@ public class RecurringJobStatusCheckerTests
                 displayName: "Job Enabled",
                 description: "Test job",
                 cronExpression: "0 * * * *",
+                timeZoneId: "Europe/Prague",
                 isEnabled: true,
                 lastModifiedBy: "test"));
         var sut = CreateSut();

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/UpdateRecurringJobCronHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/UpdateRecurringJobCronHandlerTests.cs
@@ -144,6 +144,7 @@ public class UpdateRecurringJobCronHandlerTests
             displayName: "Test Job",
             description: "A test job",
             cronExpression: cronExpression,
+            timeZoneId: "Europe/Prague",
             isEnabled: true,
             lastModifiedBy: "seed");
     }

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/UpdateRecurringJobStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/UpdateRecurringJobStatusHandlerTests.cs
@@ -19,6 +19,7 @@ public class UpdateRecurringJobStatusHandlerTests
     private const string ValidDisplayName = "Test Job";
     private const string ValidDescription = "Test Description";
     private const string ValidCronExpression = "0 0 * * *";
+    private const string ValidTimeZoneId = "Europe/Prague";
 
     public UpdateRecurringJobStatusHandlerTests()
     {
@@ -51,6 +52,7 @@ public class UpdateRecurringJobStatusHandlerTests
             ValidDisplayName,
             ValidDescription,
             ValidCronExpression,
+            ValidTimeZoneId,
             false,
             "System");
 
@@ -91,6 +93,7 @@ public class UpdateRecurringJobStatusHandlerTests
             ValidDisplayName,
             ValidDescription,
             ValidCronExpression,
+            ValidTimeZoneId,
             true,
             "System");
 
@@ -155,6 +158,7 @@ public class UpdateRecurringJobStatusHandlerTests
             ValidDisplayName,
             ValidDescription,
             ValidCronExpression,
+            ValidTimeZoneId,
             false,
             "System");
 
@@ -194,6 +198,7 @@ public class UpdateRecurringJobStatusHandlerTests
             ValidDisplayName,
             ValidDescription,
             ValidCronExpression,
+            ValidTimeZoneId,
             false,
             "System");
 
@@ -228,6 +233,7 @@ public class UpdateRecurringJobStatusHandlerTests
             ValidDisplayName,
             ValidDescription,
             ValidCronExpression,
+            ValidTimeZoneId,
             false,
             "System");
 
@@ -305,6 +311,7 @@ public class UpdateRecurringJobStatusHandlerTests
             ValidDisplayName,
             ValidDescription,
             ValidCronExpression,
+            ValidTimeZoneId,
             false,
             "System");
 


### PR DESCRIPTION
Closes #3687

## What the issue was

`RecurringJobMetadata` already modeled a per-job `TimeZoneId` (defaulting to `Europe/Prague`), and `HangfireJobRegistrationHelper.RegisterOrUpdate` correctly used it to schedule jobs with Hangfire. However, the *persisted* entity `RecurringJobConfiguration` and its `RecurringJobDto` had no `TimeZoneId`, so `RecurringJobNextRunCalculator` always computed "next run" using the hardcoded default timezone. This was a dormant display bug: it only ever coincidentally matched because every current job used the default timezone, but the moment a job with a different timezone was configured, the admin UI's "Next run" column would silently show a wrong time while Hangfire ran the job at the correct time.

## How it was fixed / handled

Added `TimeZoneId` to the persistence and display path and threaded it through end-to-end, per the issue's suggested fix:

- `RecurringJobConfiguration` (domain entity) — new `TimeZoneId` property, set via the constructor and `UpdateConfiguration` (positioned right after `cronExpression`), with the same required/non-empty validation as `CronExpression`.
- `RecurringJobDto` — new `TimeZoneId` field.
- `RecurringJobNextRunCalculator.Calculate(...)` — now takes a `timeZoneId` parameter and uses it instead of the hardcoded `RecurringJobMetadata.DefaultTimeZoneId`.
- `GetRecurringJobHandler` / `GetRecurringJobsListHandler` — pass `dto.TimeZoneId` into the calculator.
- `RecurringJobSeeder` — passes `job.Metadata.TimeZoneId` into the entity constructor.
- `RecurringJobConfigurationConfiguration` (EF Core) + a new migration (`AddTimeZoneIdToRecurringJobConfigurations`) — persist the column as `nvarchar(100) NOT NULL DEFAULT 'Europe/Prague'`, matching the PascalCase convention used by later migrations in this repo (not the original snake_case one).
- Updated all existing BackgroundJobs unit tests for the new constructor/method signatures, and added new tests: entity validation for `TimeZoneId`, and a handler-level test proving `Calculate` actually produces a different `NextRunAt` for a non-default timezone vs. the default.

This is behavior-preserving for all existing data (the migration backfills `'Europe/Prague'`, identical to today's hardcoded behavior) — it only changes behavior once a job is configured with a non-default timezone, and that behavior is now correct.

`dotnet build` and `dotnet format --verify-no-changes` are clean; all 95 BackgroundJobs tests pass. The full test suite has 76 pre-existing failures, all `Testcontainers`/Docker-dependent integration tests unrelated to `BackgroundJobs` (no Docker daemon in the CI sandbox used to run them here).

## Artifacts

Brief, spec, arch-review, design, task plan, impl, and review markdown are committed under `artifacts/feat-3687/` in this branch.

## Code review

The in-pipeline reviewer independently re-verified the build, formatting, and tests, and spot-checked every changed call site and the migration — result: **PASS**, no issues found.

> The implementation matches the task spec closely: `TimeZoneId` is added to `RecurringJobConfiguration` (constructor + `UpdateConfiguration`, both after `cronExpression`), threaded through `RecurringJobDto`, `RecurringJobNextRunCalculator.Calculate`, both handler call sites, the seeder, EF Core configuration, and a correctly-styled migration. Every call site of the changed signatures was updated, `dotnet build` is clean, `dotnet format --verify-no-changes` is clean, and all 95 BackgroundJobs tests plus the new required timezone-divergence test pass.
>
> No issues found. The implementation is behavior-preserving for existing data (migration default `'Europe/Prague'`) and the fix is demonstrated to actually change behavior for non-default timezones, exactly as the task intended.

## Note on manual migration

Per this repo's convention (DB migrations are manual, not auto-applied outside Production), the new migration must be applied with `dotnet ef database update` before/alongside deploying this code to Dev/Test/Staging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pg3ebrZjmaBSigMKkSB4AR)_